### PR TITLE
Update FormalFrontier templates

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,11 +4,11 @@ This repository is a formalization of a mathematics textbook using the FormalFro
 
 ## How to Work
 
-1. Read `PLAN.md` for the full pipeline description
-2. Check `PROGRESS.md` to see what stages are complete
+1. Read the most recent file in `progress/` (sorted alphabetically) — this is your onboarding document
+2. Read `PLAN.md` for the full pipeline description and stage details
 3. Work on the next incomplete stage
-4. After completing a stage, update `PROGRESS.md` with status, date, and notes
-5. For item-level progress, update `progress/items.json`
+4. For item-level progress, update `progress/items.json`
+5. At the end of every turn, write `progress/<UTC-timestamp>.md` with Accomplished, Current frontier, Overall project progress, Next step, and Blockers
 
 ## Key Principles
 
@@ -19,10 +19,10 @@ Push sorries earlier. State the theorem first, sorry the proof, then fill in. Do
 Use `sorry` placeholders with comments explaining what's needed. Never use `True` as a placeholder for propositions — it hides the actual requirements and will need a full refactor to fix.
 
 ### Discussion Blobs Are First-Class
-During structure analysis (Stage 1.4), unstructured text between numbered items must be identified and tracked just like theorems and definitions. These discussion paragraphs carry context that proofs depend on. Every byte of the book must belong to exactly one blob.
+During structure analysis (Stage 1.5), unstructured text between numbered items must be identified and tracked just like theorems and definitions. These discussion paragraphs carry context that proofs depend on. Every byte of the book must belong to exactly one blob.
 
 ### Conservative Dependencies
-Initially assume each item depends on everything before it. This is safe. We trim to actual dependencies later (Stage 3.4) once proofs exist.
+Initially assume each item depends on everything before it. This is safe. We trim to actual dependencies later (Stage 3.3) once proofs exist.
 
 ## When Stuck
 
@@ -41,7 +41,7 @@ Aristotle is an automated theorem prover. Escalate to it when Claude can't prove
 
 - A proof is beyond Claude's ability after multiple attempts
 - Standard mathematical proofs (calculus, algebra, analysis) that follow well-known patterns
-- Batch proving: after Stage 3.2 scaffolding, submit all sorry'd theorems
+- Batch proving: after Stage 3.1 scaffolding, submit all sorry'd theorems
 
 ### When NOT to use Aristotle
 
@@ -95,10 +95,66 @@ Query the extracted JSON for nodes where:
 
 These nodes are ready for formalization. Status updates are automatic — removing a `sorry` and recompiling updates the extraction output.
 
+## PR Workflow
+
+### Submitting PRs
+
+When you complete work on a formalization item, create a PR and immediately enable auto-merge so it merges to `main` without human intervention once CI passes:
+
+```bash
+gh pr create --title "Formalize <ItemID>" --body "..."
+PR_NUM=$(gh pr view --json number --jq .number)
+gh pr merge "$PR_NUM" --auto --squash
+```
+
+### Merging ready PRs (start of every planning cycle)
+
+**Before selecting new work**, merge all open PRs that are mergeable and have no failing CI checks. This unblocks downstream agents waiting on `main`.
+
+```bash
+gh pr list --state open \
+  --json number,mergeable,statusCheckRollup \
+  --jq '.[] | select(
+    .mergeable == "MERGEABLE" and
+    (.statusCheckRollup | all(.conclusion != "FAILURE" and .conclusion != "CANCELLED"))
+  ) | .number' \
+| xargs -I{} gh pr merge {} --squash --delete-branch
+```
+
+Never skip this step. Downstream agents are blocked on `main` until merged PRs land.
+
 ## Progress Tracking
 
-- Stage-level: `PROGRESS.md`
+- **Per-turn handoff files:** `progress/YYYY-MM-DDTHH-MM-SSZ.md` (UTC timestamp)
+- Stage-level summary: `PROGRESS.md` (optional, human-facing)
 - Item-level: `progress/items.json`
 - Blueprint status: automatic via LeanArchitect (sorry detection)
 - Do NOT modify `PLAN.md` — it is the reference plan
 - Blockers and discussion: GitHub issues
+
+### Writing a progress file (mandatory at end of every turn)
+
+At the end of every turn, before handing off, write `progress/<UTC-timestamp>.md` using this template:
+
+```markdown
+## Accomplished
+<!-- What was done this turn -->
+
+## Current frontier
+<!-- Where work stopped -->
+
+## Overall project progress
+<!-- High-level status (which stages are complete, how many items formalized, etc.) -->
+
+## Next step
+<!-- Concrete recommendation for the next agent -->
+
+## Blockers
+<!-- Anything blocking forward progress; empty if none -->
+```
+
+Use the current UTC time as the filename (e.g., `progress/2026-03-15T14-30-00Z.md`). Any commits made during the turn should mention the progress file in the commit message.
+
+### Starting a turn (mandatory)
+
+At the start of every turn, read the most recent file in `progress/` (sorted alphabetically = chronologically). This is your primary onboarding document. Then read `PLAN.md` for stage details as needed. If `progress/` contains only `progress/0000-init.md` (or no handoff file), the repo is freshly initialized — proceed with Stage 1.1.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,6 @@
 # FormalFrontier Formalization Plan
 
-This document describes the pipeline for formalizing a mathematics textbook into Lean 4 with Mathlib. Work through the stages in order. Record progress in `PROGRESS.md` (stage-level) and `progress/items.json` (item-level). Do not modify this file for progress tracking.
+This document describes the pipeline for formalizing a mathematics textbook into Lean 4 with Mathlib. Work through the stages in order. Record progress in per-turn files in `progress/` and item-level status in `progress/items.json`. Do not modify this file for progress tracking.
 
 ## Phase 1: Source Preparation
 
@@ -17,34 +17,111 @@ pdfseparate source/original.pdf pdf/raw-pages/%d.pdf
 
 **Verify:** The number of files in `pdf/raw-pages/` matches the page count of the original PDF.
 
-### Stage 1.2: Frontmatter Detection
+### Stage 1.2: Start Lean Build
 
-Analyze the first ~20 pages and the last ~10 pages to determine:
+The `lean/` directory was created by `ff init` using `lake init <ProjectName> math`, where `<ProjectName>` is the repository name with the `FormalFrontier-` prefix stripped (e.g., `FormalFrontier-Rudin` → `Rudin`). Start downloading Mathlib now so it is ready by the time formalization begins.
+
+```bash
+cd lean && lake build
+```
+
+This takes ~30 minutes the first time (Mathlib download and build). Start it in the background and proceed with the remaining Phase 1 stages. Having the Lean project available early allows agents to test Lean snippets while transcribing and analyzing structure.
+
+**Output:** `lean/.lake/` with compiled Mathlib artifacts.
+
+**Verify:** `cd lean && lake build` exits successfully.
+
+### Stage 1.3: Frontmatter Detection
+
+This is a **lightweight pass**. Start by examining the first ~20 pages and the last ~10 pages of `pdf/raw-pages/` — that is usually sufficient. If a book has an unusually long preface, TOC, or index, look at a few more pages until the boundary is clear. You do not need to read the entire book.
+
+Determine:
 - Where "page 1" of the book actually starts (after title page, copyright, table of contents, preface, etc.)
 - Where the backmatter begins (appendices, bibliography, index)
 
-Rename pages into `pdf/pages/` so that:
+Copy pages into `pdf/pages/` with the appropriate names. (`pdf/raw-pages/` is the untouched extraction output and must not be modified; `pdf/pages/` is the canonical input for all subsequent stages.)
 - `pdf/pages/1.pdf` corresponds to the book's actual page 1
 - Frontmatter pages become `pdf/pages/frontmatter-1.pdf`, `pdf/pages/frontmatter-2.pdf`, ...
 - Backmatter pages become `pdf/pages/backmatter-1.pdf`, `pdf/pages/backmatter-2.pdf`, ...
 
-**Output:** `pdf/pages/` directory with correctly numbered pages.
+**All pages are included** — frontmatter, main content, and backmatter all get entries in `pdf/pages/`. Nothing is discarded.
 
-**Verify:** Spot-check that page numbering matches the book's internal page numbers (printed on the pages themselves).
+After copying, write `pdf/pages/mapping.json` recording the raw-page → logical-page correspondence. This is the authoritative record of the frontmatter boundary decision; subsequent stages that need to map between raw and logical page numbers must read this file rather than reverse-engineering it from filenames.
 
-### Stage 1.3: Page Transcription
+Format:
+```json
+{
+  "frontmatter_raw_pages": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+  "backmatter_raw_pages": [298, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 312],
+  "mapping": {
+    "1": "frontmatter-1",
+    "2": "frontmatter-2",
+    "13": "1",
+    "14": "2",
+    "298": "backmatter-1",
+    "299": "backmatter-2"
+  }
+}
+```
+
+Keys in `"mapping"` are raw page numbers (as strings); values are logical page names (matching the filenames in `pdf/pages/` without the `.pdf` extension). Every raw page appears exactly once as a key; every logical page name appears exactly once as a value; and the set of values corresponds exactly to the filenames present in `pdf/pages/`. `"frontmatter_raw_pages"` and `"backmatter_raw_pages"` are convenience lists for quick range queries; use `[]` for either when the book has no frontmatter or no backmatter.
+
+**Output:** `pdf/pages/` directory with all pages from `pdf/raw-pages/`, copied and renamed. `pdf/pages/mapping.json` recording the raw-page → logical-page correspondence.
+
+**Verify:**
+- Spot-check that page numbering matches the book's internal page numbers (printed on the pages themselves).
+- Every file in `pdf/raw-pages/` maps to exactly one file in `pdf/pages/` — no raw page is missing and no extra files are present.
+- `pdf/pages/mapping.json` exists and accounts for every raw page number.
+
+> **Do not begin Stage 1.4 until this stage is complete and `pdf/pages/` is fully populated.** Stage 1.4 reads exclusively from `pdf/pages/` — never from `pdf/raw-pages/`. If you are uncertain about frontmatter boundaries after examining the boundary pages, make your best determination; do not defer this decision into the transcription loop.
+
+### Stage 1.4: Page Transcription
 
 Convert each page to markdown with LaTeX math notation.
 
-For each page in `pdf/pages/`, read the PDF and write it out as markdown. Maintain a rolling context of the book's topic and notation conventions to ensure consistency.
+Transcribe **all** pages — frontmatter, main content, and backmatter — every file in `pdf/pages/` gets a corresponding `.md` file. Read exclusively from `pdf/pages/` — never from `pdf/raw-pages/`. To look up which raw page corresponds to a given logical page (or vice versa), read `pdf/pages/mapping.json`.
 
-**Output:** `pages/1.md`, `pages/2.md`, ..., `pages/frontmatter-1.md`, etc.
+#### Setup
+
+Create one GitHub issue per page in this repo. Use `gh label create transcription --color 0075ca --description "Page transcription work item"` first (ignore error if it already exists). Each issue should:
+
+- Title: `Transcribe page N` for main-content pages; `Transcribe frontmatter-N` or `Transcribe backmatter-N` for frontmatter/backmatter pages
+- Body: list the specific input file(s) (e.g., `pdf/pages/42.pdf` or `pdf/pages/frontmatter-3.pdf`), expected output file(s) (e.g., `pages/42.md` or `pages/frontmatter-3.md`), and a dependency on the previous page's issue: `- [ ] depends on #(previous issue number)`
+- Label: `transcription`
+
+The dependency chain enforces linear processing so each agent can read the previously transcribed page for context. The first page's issue (frontmatter-1, or page 1 if there is no frontmatter) has no dependency. Order issues following the logical order already established in `pdf/pages/mapping.json`.
+
+After creating all issues, verify that every file in `pdf/pages/` is covered by exactly one issue and there are no gaps.
+
+This gives each transcription agent a single, well-scoped task and makes progress visible at page granularity. Partial failures are isolated — a missing page 47 doesn't block the rest.
+
+#### Shared notation conventions
+
+Create `pages/CONVENTIONS.md` before agents start work. Initially it may be sparse (just the book title and subject area). Each transcription agent must:
+
+1. Read `pages/CONVENTIONS.md` before transcribing
+2. After transcribing, update `pages/CONVENTIONS.md` with any notation or formatting conventions they established (e.g., how inline math is delimited, how theorem environments are marked up, abbreviations used)
+
+This file is the shared context that keeps transcriptions consistent across parallel agents. Commit it alongside the page `.md` file.
+
+#### Agent workflow
+
+Each agent assigned to a transcription issue:
+
+1. Reads `pages/CONVENTIONS.md` for established conventions
+2. Reads the previously transcribed `.md` file (if any) for style and formatting context
+3. Reads the specified PDF page(s) from `pdf/pages/`
+4. Writes the corresponding `.md` file(s) with LaTeX math notation, consistent with preceding pages
+5. Updates `pages/CONVENTIONS.md` with any new conventions introduced
+6. Commits directly to the default branch with `Fixes #N` in the commit message (which auto-closes the issue on push)
+
+**Output:** `pages/1.md`, `pages/2.md`, ..., `pages/frontmatter-1.md`, `pages/backmatter-1.md`, etc. Plus `pages/CONVENTIONS.md`.
 
 **Validation:** Consider round-tripping: render the markdown back to a visual format and compare with the original page. Flag pages where the transcription looks poor.
 
-**Verify:** One `.md` file per page in `pdf/pages/`.
+**Verify:** One `.md` file per page in `pdf/pages/`. All transcription issues are closed.
 
-### Stage 1.4: Structure Analysis
+### Stage 1.5: Structure Analysis
 
 Identify every piece of content in the book and assign it to a blob. The goal is **complete, gap-free coverage**: every character of the transcribed text belongs to exactly one blob.
 
@@ -79,14 +156,14 @@ Write `items.json` with an array of items, each having:
   "id": "Chapter3/Theorem3.1",
   "type": "theorem",
   "title": "Bolzano-Weierstrass Theorem",
-  "start_page": 45,
-  "end_page": 46,
+  "start_page": "45",
+  "end_page": "46",
   "start_line": 12,
   "end_line": 3
 }
 ```
 
-Where `start_line` and `end_line` refer to line numbers within the page markdown files.
+Where `start_line` and `end_line` refer to line numbers within the page markdown files. `start_page` and `end_page` are logical page names (strings matching the `pdf/pages/` filenames without the `.pdf` extension, e.g. `"45"`, `"frontmatter-3"`, `"backmatter-1"`).
 
 Types: `theorem`, `lemma`, `proposition`, `corollary`, `definition`, `example`, `exercise`, `remark`, `discussion`, `introduction`, `preface`, `notation`, `bibliography`, `index`
 
@@ -98,7 +175,7 @@ Types: `theorem`, `lemma`, `proposition`, `corollary`, `definition`, `example`, 
 
 **Verify:** `items.json` exists and passes the contiguity check.
 
-### Stage 1.5: Blob Extraction
+### Stage 1.6: Blob Extraction
 
 Split the page-level markdown into per-blob files, one file per item in `items.json`.
 
@@ -108,7 +185,7 @@ Split the page-level markdown into per-blob files, one file per item in `items.j
 - One blob file per item in `items.json`
 - Concatenating all blob files in order reproduces the complete transcribed text
 
-### Stage 1.6: Indexing (optional)
+### Stage 1.7: Indexing (optional)
 
 Build one-line summaries for each blob, useful for quick reference and RAG.
 
@@ -128,7 +205,7 @@ Read the text linearly, noting every internal reference:
 - **Structural declarations:** "This chapter depends only on Chapters 1 and 2", "We assume familiarity with Chapter 3"
 - **Implicit dependencies:** Uses a concept or definition from earlier without citing it
 
-**Initial assumption:** Each item depends on everything that comes before it in the book, unless the text clearly states otherwise (e.g., "this chapter is independent of chapters 4-6"). This is conservative and correct. We will trim dependencies later in Stage 3.4 once we have actual proofs.
+**Initial assumption:** Each item depends on everything that comes before it in the book, unless the text clearly states otherwise (e.g., "this chapter is independent of chapters 4-6"). This is conservative and correct. We will trim dependencies later in Stage 3.3 once we have actual proofs.
 
 **Output:** `dependencies/internal.json` — a mapping from each item ID to a list of item IDs it depends on.
 
@@ -149,7 +226,7 @@ Categorize each:
 
 Combine `items.json`, `dependencies/internal.json`, and `dependencies/external.json` into a preliminary blueprint.
 
-This is a DAG of what needs to be formalized and in what order. Because we conservatively assumed sequential dependencies, the initial DAG will be nearly linear. That is fine — it will be refined in Stage 3.4.
+This is a DAG of what needs to be formalized and in what order. Because we conservatively assumed sequential dependencies, the initial DAG will be nearly linear. That is fine — it will be refined in Stage 3.3.
 
 #### Blueprint tooling
 
@@ -167,7 +244,7 @@ The split: leanblueprint owns the full DAG (formal + non-formal nodes). LeanArch
 3. Non-formalizable items (discussion, introduction, etc.) are included as LaTeX nodes for completeness — they appear in the DAG but don't need Lean declarations.
 4. Run `leanblueprint web` to generate the HTML dependency graph.
 
-The initial blueprint is purely LaTeX-based. LeanArchitect integration happens after Stage 3.2 when Lean scaffolding is compiled — run `extract_blueprint --all --json` against the `.olean` files to get the dependency graph and formalization status.
+The initial blueprint is purely LaTeX-based. LeanArchitect integration happens after Stage 3.1 when Lean scaffolding is compiled — run `extract_blueprint --all --json` against the `.olean` files to get the dependency graph and formalization status.
 
 **Output:** `blueprint/` directory with leanblueprint LaTeX source files.
 
@@ -218,20 +295,9 @@ These files are read by formalization agents when they work on the corresponding
 
 ## Phase 3: Formalization
 
-### Stage 3.1: Lean Project Setup
+### Stage 3.1: Lean Scaffolding
 
-Create a Lean 4 project with Mathlib as a dependency. The `blueprint/` directory should already exist from Stage 2.3. LeanArchitect is **not** a dependency of the Lean project — it runs externally against the compiled `.olean` files.
-
-**Output:** `lean/` directory containing:
-- `lakefile.toml` with Mathlib dependency
-- `lean-toolchain` matching Mathlib's toolchain
-- `.gitignore` for build artifacts
-
-**Verify:** `cd lean && lake build` succeeds (empty project, just checking Mathlib dependency works).
-
-### Stage 3.2: Lean Scaffolding
-
-Create `.lean` files for each formalizable item (theorems, definitions, lemmas — not discussion blobs).
+The `lean/` project was created by `ff init` in Stage 1.2 and Mathlib was built then. Create `.lean` files for each formalizable item (theorems, definitions, lemmas — not discussion blobs).
 
 Set up the import chain:
 - Root file: `lean/{Title}.lean` importing all chapter files
@@ -259,14 +325,36 @@ Once scaffolding is complete, run `extract_blueprint single --all --json` agains
 
 **Verify:** `cd lean && lake build` succeeds (everything compiles with sorries).
 
-### Stage 3.3: Formalization Work Loop
+### Stage 3.2: Formalization Work Loop
 
 Orchestrate agents to formalize items, respecting the dependency DAG from the blueprint. Uses a tiered strategy: Claude agents first, with escalation to Aristotle (an automated theorem prover) for difficult proofs.
+
+#### PR lifecycle
+
+PRs must be merged to `main` without human intervention to avoid blocking downstream agents. Every PR should have auto-merge enabled at creation time:
+
+```bash
+gh pr create --title "Formalize <ItemID>" --body "..."
+PR_NUM=$(gh pr view --json number --jq .number)
+gh pr merge "$PR_NUM" --auto --squash
+```
+
+At the **start of every planning cycle**, before selecting new work, merge all PRs that are mergeable and have no failing CI checks:
+
+```bash
+gh pr list --state open \
+  --json number,mergeable,statusCheckRollup \
+  --jq '.[] | select(
+    .mergeable == "MERGEABLE" and
+    (.statusCheckRollup | all(.conclusion != "FAILURE" and .conclusion != "CANCELLED"))
+  ) | .number' \
+| xargs -I{} gh pr merge {} --squash --delete-branch
+```
 
 #### Agent workflow
 
 Each agent is assigned a task (an item or small group of related items). The agent either:
-1. **Submits a PR** that fully or partially resolves the task
+1. **Submits a PR** that fully or partially resolves the task (with auto-merge enabled)
 2. **Escalates by posting an issue** documenting the blockers
 
 #### Task selection
@@ -286,7 +374,7 @@ Use a tiered approach to maximize throughput:
 
 2. **Escalate to Aristotle** — When a Claude agent fails to prove a theorem after 2-3 serious attempts, escalate to Aristotle. Record the escalation in `progress/items.json` by setting `"escalated_to_aristotle": true`.
 
-3. **Aristotle batch pass** — After Stage 3.2 scaffolding is complete, submit all sorry'd theorems to Aristotle as a batch. This runs concurrently with Claude agents working on other items. Any theorems Aristotle solves reduce the workload for Claude.
+3. **Aristotle batch pass** — After Stage 3.1 scaffolding is complete, submit all sorry'd theorems to Aristotle as a batch. This runs concurrently with Claude agents working on other items. Any theorems Aristotle solves reduce the workload for Claude.
 
 #### Aristotle integration
 
@@ -298,7 +386,7 @@ For each item to submit:
 
 1. **Prepare the file.** Create a temporary copy of the item's Lean file. The file must contain exactly one `sorry` (the target theorem). Change all other `sorry` occurrences to `admit`.
 
-2. **Gather context.** Collect sorry-free local Lean files that this item depends on (from the import chain). Skip Mathlib imports — Aristotle has Mathlib built in. If no local files are sorry-free yet (e.g., during the initial batch pass after Stage 3.2), submit with no context files. Pass context via `--context-files`.
+2. **Gather context.** Collect sorry-free local Lean files that this item depends on (from the import chain). Skip Mathlib imports — Aristotle has Mathlib built in. If no local files are sorry-free yet (e.g., during the initial batch pass after Stage 3.1), submit with no context files. Pass context via `--context-files`.
 
 3. **Submit.**
    ```bash
@@ -332,7 +420,7 @@ When Aristotle returns a result:
 
 1. **Verify it compiles** against the local toolchain: copy the proof into the item's Lean file (under `lean/{Title}/...`) and run `lake build` for that module.
 2. **If it compiles clean:** Update status to `sorry_free` (if the item has no remaining sorries) or `proof_formalized`. Submit a PR.
-3. **If Aristotle reports the theorem is false:** Mark the item as `attention_needed`. Post a GitHub issue describing the counterexample Aristotle found. The formalized statement (from Stage 3.2) needs revision.
+3. **If Aristotle reports the theorem is false:** Mark the item as `attention_needed`. Post a GitHub issue describing the counterexample Aristotle found. The formalized statement (from Stage 3.1) needs revision.
 4. **If it fails to compile** (toolchain version mismatch): Mark the item as `attention_needed` for manual review.
 
 ##### Aristotle item statuses
@@ -362,7 +450,7 @@ Specialized triage agents should periodically review open issues for:
 - **Spec-driven development:** Use sorry placeholders with comments explaining what's needed, not `True` or other cheats.
 - **Pre-formalization:** For complex items, first translate the natural language blob into a pedantic, detailed version with careful references to every fact used, before attempting formalization.
 
-### Stage 3.4: Dependency Trimming (post-formalization)
+### Stage 3.3: Dependency Trimming (post-formalization)
 
 Once items have sorry-free proofs, analyze actual dependencies using both LeanArchitect's inference (for formal declarations) and manual review (for non-formal nodes).
 
@@ -381,9 +469,35 @@ This is when we learn the true dependency structure of the book, which may diffe
 
 ## Progress Tracking
 
-### Stage-level progress: `PROGRESS.md`
+### Per-turn progress files: `progress/YYYY-MM-DDTHH-MM-SSZ.md`
 
-Orchestrators update `PROGRESS.md` as stages are completed. Format:
+At the end of every agent turn, write a timestamped progress file in `progress/`. Use the current UTC time for the filename (e.g., `progress/2026-03-15T14-30-00Z.md`). This gives a full audit trail of what each agent did and decided, and reliably onboards the next agent.
+
+Template:
+```markdown
+## Accomplished
+<!-- What was done this turn -->
+
+## Current frontier
+<!-- Where work stopped -->
+
+## Overall project progress
+<!-- High-level status (which stages are complete, how many items are formalized, etc.) -->
+
+## Next step
+<!-- Concrete recommendation for the next agent -->
+
+## Blockers
+<!-- Anything blocking forward progress; empty if none -->
+```
+
+The most recent file in `progress/` (sorted alphabetically, since filenames are ISO 8601 timestamps) is the canonical handoff document for the next agent. **Always read it at the start of a turn** before checking `PLAN.md` for stage details. If `progress/` contains only `progress/0000-init.md` (or no handoff file at all), the repo is freshly initialized — proceed with Stage 1.1.
+
+Commits made during a turn should mention the corresponding progress file in the commit message (e.g., `See progress/2026-03-15T14-30-00Z.md`).
+
+### Stage-level summary: `PROGRESS.md` (optional)
+
+`PROGRESS.md` may be maintained as a human-facing summary of stage completion. It is not the primary source of truth — the per-turn files are. If kept, format:
 
 ```markdown
 ## Stage 1.1: Page Extraction
@@ -391,10 +505,15 @@ Orchestrators update `PROGRESS.md` as stages are completed. Format:
 **Date:** 2026-03-15
 **Notes:** 342 pages extracted.
 
-## Stage 1.2: Frontmatter Detection
+## Stage 1.2: Start Lean Build
 **Status:** Complete
 **Date:** 2026-03-15
-**Notes:** Page 1 starts at raw page 13. Backmatter from page 298.
+**Notes:** Mathlib downloaded and built successfully.
+
+## Stage 1.3: Frontmatter Detection
+**Status:** Complete
+**Date:** 2026-03-15
+**Notes:** Page 1 starts at raw page 13. Backmatter from raw page 298. See `pdf/pages/mapping.json` for the full raw-page → logical-page mapping.
 ```
 
 ### Item-level progress: `progress/items.json`
@@ -425,6 +544,7 @@ Items escalated to Aristotle use: `statement_formalized` → `sent_to_aristotle`
 ### Rules
 
 - **Do NOT modify PLAN.md** for progress tracking. This document is the reference plan.
-- Stage-level progress goes in `PROGRESS.md`.
+- Per-turn handoff notes go in `progress/YYYY-MM-DDTHH-MM-SSZ.md` (write one at the end of every turn).
+- Stage-level summary may be kept in `PROGRESS.md` (optional, human-facing).
 - Item-level progress goes in `progress/items.json`.
 - Blockers and discussion go in GitHub issues.


### PR DESCRIPTION
## Summary

Update template files (PLAN.md, .claude/CLAUDE.md, .gitignore) to the latest versions from the FormalFrontier pipeline.

## Changes

```diff
diff --git a/.claude/CLAUDE.md b/.claude/CLAUDE.md
index 4183c1a..1c8afcb 100644
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,11 +4,11 @@ This repository is a formalization of a mathematics textbook using the FormalFro
 
 ## How to Work
 
-1. Read `PLAN.md` for the full pipeline description
-2. Check `PROGRESS.md` to see what stages are complete
+1. Read the most recent file in `progress/` (sorted alphabetically) — this is your onboarding document
+2. Read `PLAN.md` for the full pipeline description and stage details
 3. Work on the next incomplete stage
-4. After completing a stage, update `PROGRESS.md` with status, date, and notes
-5. For item-level progress, update `progress/items.json`
+4. For item-level progress, update `progress/items.json`
+5. At the end of every turn, write `progress/<UTC-timestamp>.md` with Accomplished, Current frontier, Overall project progress, Next step, and Blockers
 
 ## Key Principles
 
@@ -19,10 +19,10 @@ Push sorries earlier. State the theorem first, sorry the proof, then fill in. Do
 Use `sorry` placeholders with comments explaining what's needed. Never use `True` as a placeholder for propositions — it hides the actual requirements and will need a full refactor to fix.
 
 ### Discussion Blobs Are First-Class
-During structure analysis (Stage 1.4), unstructured text between numbered items must be identified and tracked just like theorems and definitions. These discussion paragraphs carry context that proofs depend on. Every byte of the book must belong to exactly one blob.
+During structure analysis (Stage 1.5), unstructured text between numbered items must be identified and tracked just like theorems and definitions. These discussion paragraphs carry context that proofs depend on. Every byte of the book must belong to exactly one blob.
 
 ### Conservative Dependencies
-Initially assume each item depends on everything before it. This is safe. We trim to actual dependencies later (Stage 3.4) once proofs exist.
+Initially assume each item depends on everything before it. This is safe. We trim to actual dependencies later (Stage 3.3) once proofs exist.
 
 ## When Stuck
 
@@ -41,7 +41,7 @@ Aristotle is an automated theorem prover. Escalate to it when Claude can't prove
 
 - A proof is beyond Claude's ability after multiple attempts
 - Standard mathematical proofs (calculus, algebra, analysis) that follow well-known patterns
-- Batch proving: after Stage 3.2 scaffolding, submit all sorry'd theorems
+- Batch proving: after Stage 3.1 scaffolding, submit all sorry'd theorems
 
 ### When NOT to use Aristotle
 
@@ -95,10 +95,66 @@ Query the extracted JSON for nodes where:
 
 These nodes are ready for formalization. Status updates are automatic — removing a `sorry` and recompiling updates the extraction output.
 
+## PR Workflow
+
+### Submitting PRs
+
+When you complete work on a formalization item, create a PR and immediately enable auto-merge so it merges to `main` without human intervention once CI passes:
+
+```bash
+gh pr create --title "Formalize <ItemID>" --body "..."
+PR_NUM=$(gh pr view --json number --jq .number)
+gh pr merge "$PR_NUM" --auto --squash
+```
+
+### Merging ready PRs (start of every planning cycle)
+
+**Before selecting new work**, merge all open PRs that are mergeable and have no failing CI checks. This unblocks downstream agents waiting on `main`.
+
+```bash
+gh pr list --state open \
+  --json number,mergeable,statusCheckRollup \
+  --jq '.[] | select(
+    .mergeable == "MERGEABLE" and
+    (.statusCheckRollup | all(.conclusion != "FAILURE" and .conclusion != "CANCELLED"))
+  ) | .number' \
+| xargs -I{} gh pr merge {} --squash --delete-branch
+```
+
+Never skip this step. Downstream agents are blocked on `main` until merged PRs land.
+
 ## Progress Tracking
 
-- Stage-level: `PROGRESS.md`
+- **Per-turn handoff files:** `progress/YYYY-MM-DDTHH-MM-SSZ.md` (UTC timestamp)
+- Stage-level summary: `PROGRESS.md` (optional, human-facing)
 - Item-level: `progress/items.json`
 - Blueprint status: automatic via LeanArchitect (sorry detection)
 - Do NOT modify `PLAN.md` — it is the reference plan
 - Blockers and discussion: GitHub issues
+
+### Writing a progress file (mandatory at end of every turn)
+
+At the end of every turn, before handing off, write `progress/<UTC-timestamp>.md` using this template:
+
+```markdown
+## Accomplished
+<!-- What was done this turn -->
+
+## Current frontier
+<!-- Where work stopped -->
+
+## Overall project progress
+<!-- High-level status (which stages are complete, how many items formalized, etc.) -->
+
+## Next step
+<!-- Concrete recommendation for the next agent -->
+
+## Blockers
+<!-- Anything blocking forward progress; empty if none -->
+```
+
+Use the current UTC time as the filename (e.g., `progress/2026-03-15T14-30-00Z.md`). Any commits made during the turn should mention the progress file in the commit message.
+
+### Starting a turn (mandatory)
+
+At the start of every turn, read the most recent file in `progress/` (sorted alphabetically = chronologically). This is your primary onboarding document. Then read `PLAN.md` for stage details as needed. If `progress/` contains only `progress/0000-init.md` (or no handoff file), the repo is freshly initialized — proceed with Stage 1.1.
diff --git a/PLAN.md b/PLAN.md
index a04f9cd..1bcfea6 100644
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,6 @@
 # FormalFrontier Formalization Plan
 
-This document describes the pipeline for formalizing a mathematics textbook into Lean 4 with Mathlib. Work through the stages in order. Record progress in `PROGRESS.md` (stage-level) and `progress/items.json` (item-level). Do not modify this file for progress tracking.
+This document describes the pipeline for formalizing a mathematics textbook into Lean 4 with Mathlib. Work through the stages in order. Record progress in per-turn files in `progress/` and item-level status in `progress/items.json`. Do not modify this file for progress tracking.
 
 ## Phase 1: Source Preparation
 
@@ -17,34 +17,111 @@ pdfseparate source/original.pdf pdf/raw-pages/%d.pdf
 
 **Verify:** The number of files in `pdf/raw-pages/` matches the page count of the original PDF.
 
-### Stage 1.2: Frontmatter Detection
+### Stage 1.2: Start Lean Build
 
-Analyze the first ~20 pages and the last ~10 pages to determine:
+The `lean/` directory was created by `ff init` using `lake init <ProjectName> math`, where `<ProjectName>` is the repository name with the `FormalFrontier-` prefix stripped (e.g., `FormalFrontier-Rudin` → `Rudin`). Start downloading Mathlib now so it is ready by the time formalization begins.
+
+```bash
+cd lean && lake build
+```
+
+This takes ~30 minutes the first time (Mathlib download and build). Start it in the background and proceed with the remaining Phase 1 stages. Having the Lean project available early allows agents to test Lean snippets while transcribing and analyzing structure.
+
+**Output:** `lean/.lake/` with compiled Mathlib artifacts.
+
+**Verify:** `cd lean && lake build` exits successfully.
+
+### Stage 1.3: Frontmatter Detection
+
+This is a **lightweight pass**. Start by examining the first ~20 pages and the last ~10 pages of `pdf/raw-pages/` — that is usually sufficient. If a book has an unusually long preface, TOC, or index, look at a few more pages until the boundary is clear. You do not need to read the entire book.
+
+Determine:
 - Where "page 1" of the book actually starts (after title page, copyright, table of contents, preface, etc.)
 - Where the backmatter begins (appendices, bibliography, index)
 
-Rename pages into `pdf/pages/` so that:
+Copy pages into `pdf/pages/` with the appropriate names. (`pdf/raw-pages/` is the untouched extraction output and must not be modified; `pdf/pages/` is the canonical input for all subsequent stages.)
 - `pdf/pages/1.pdf` corresponds to the book's actual page 1
 - Frontmatter pages become `pdf/pages/frontmatter-1.pdf`, `pdf/pages/frontmatter-2.pdf`, ...
 - Backmatter pages become `pdf/pages/backmatter-1.pdf`, `pdf/pages/backmatter-2.pdf`, ...
 
-**Output:** `pdf/pages/` directory with correctly numbered pages.
+**All pages are included** — frontmatter, main content, and backmatter all get entries in `pdf/pages/`. Nothing is discarded.
+
+After copying, write `pdf/pages/mapping.json` recording the raw-page → logical-page correspondence. This is the authoritative record of the frontmatter boundary decision; subsequent stages that need to map between raw and logical page numbers must read this file rather than reverse-engineering it from filenames.
+
+Format:
+```json
+{
+  "frontmatter_raw_pages": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+  "backmatter_raw_pages": [298, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 312],
+  "mapping": {
+    "1": "frontmatter-1",
+    "2": "frontmatter-2",
+    "13": "1",
+    "14": "2",
+    "298": "backmatter-1",
+    "299": "backmatter-2"
+  }
+}
+```
 
-**Verify:** Spot-check that page numbering matches the book's internal page numbers (printed on the pages themselves).
+Keys in `"mapping"` are raw page numbers (as strings); values are logical page names (matching the filenames in `pdf/pages/` without the `.pdf` extension). Every raw page appears exactly once as a key; every logical page name appears exactly once as a value; and the set of values corresponds exactly to the filenames present in `pdf/pages/`. `"frontmatter_raw_pages"` and `"backmatter_raw_pages"` are convenience lists for quick range queries; use `[]` for either when the book has no frontmatter or no backmatter.
 
-### Stage 1.3: Page Transcription
+**Output:** `pdf/pages/` directory with all pages from `pdf/raw-pages/`, copied and renamed. `pdf/pages/mapping.json` recording the raw-page → logical-page correspondence.
+
+**Verify:**
+- Spot-check that page numbering matches the book's internal page numbers (printed on the pages themselves).
+- Every file in `pdf/raw-pages/` maps to exactly one file in `pdf/pages/` — no raw page is missing and no extra files are present.
+- `pdf/pages/mapping.json` exists and accounts for every raw page number.
+
+> **Do not begin Stage 1.4 until this stage is complete and `pdf/pages/` is fully populated.** Stage 1.4 reads exclusively from `pdf/pages/` — never from `pdf/raw-pages/`. If you are uncertain about frontmatter boundaries after examining the boundary pages, make your best determination; do not defer this decision into the transcription loop.
+
+### Stage 1.4: Page Transcription
 
 Convert each page to markdown with LaTeX math notation.
 
-For each page in `pdf/pages/`, read the PDF and write it out as markdown. Maintain a rolling context of the book's topic and notation conventions to ensure consistency.
+Transcribe **all** pages — frontmatter, main content, and backmatter — every file in `pdf/pages/` gets a corresponding `.md` file. Read exclusively from `pdf/pages/` — never from `pdf/raw-pages/`. To look up which raw page corresponds to a given logical page (or vice versa), read `pdf/pages/mapping.json`.
+
+#### Setup
+
+Create one GitHub issue per page in this repo. Use `gh label create transcription --color 0075ca --description "Page transcription work item"` first (ignore error if it already exists). Each issue should:
+
+- Title: `Transcribe page N` for main-content pages; `Transcribe frontmatter-N` or `Transcribe backmatter-N` for frontmatter/backmatter pages
+- Body: list the specific input file(s) (e.g., `pdf/pages/42.pdf` or `pdf/pages/frontmatter-3.pdf`), expected output file(s) (e.g., `pages/42.md` or `pages/frontmatter-3.md`), and a dependency on the previous page's issue: `- [ ] depends on #(previous issue number)`
+- Label: `transcription`
+
+The dependency chain enforces linear processing so each agent can read the previously transcribed page for context. The first page's issue (frontmatter-1, or page 1 if there is no frontmatter) has no dependency. Order issues following the logical order already established in `pdf/pages/mapping.json`.
 
-**Output:** `pages/1.md`, `pages/2.md`, ..., `pages/frontmatter-1.md`, etc.
+After creating all issues, verify that every file in `pdf/pages/` is covered by exactly one issue and there are no gaps.
+
+This gives each transcription agent a single, well-scoped task and makes progress visible at page granularity. Partial failures are isolated — a missing page 47 doesn't block the rest.
+
+#### Shared notation conventions
+
+Create `pages/CONVENTIONS.md` before agents start work. Initially it may be sparse (just the book title and subject area). Each transcription agent must:
+
+1. Read `pages/CONVENTIONS.md` before transcribing
+2. After transcribing, update `pages/CONVENTIONS.md` with any notation or formatting conventions they established (e.g., how inline math is delimited, how theorem environments are marked up, abbreviations used)
+
+This file is the shared context that keeps transcriptions consistent across parallel agents. Commit it alongside the page `.md` file.
+
+#### Agent workflow
+
+Each agent assigned to a transcription issue:
+
+1. Reads `pages/CONVENTIONS.md` for established conventions
+2. Reads the previously transcribed `.md` file (if any) for style and formatting context
+3. Reads the specified PDF page(s) from `pdf/pages/`
+4. Writes the corresponding `.md` file(s) with LaTeX math notation, consistent with preceding pages
+5. Updates `pages/CONVENTIONS.md` with any new conventions introduced
+6. Commits directly to the default branch with `Fixes #N` in the commit message (which auto-closes the issue on push)
+
+**Output:** `pages/1.md`, `pages/2.md`, ..., `pages/frontmatter-1.md`, `pages/backmatter-1.md`, etc. Plus `pages/CONVENTIONS.md`.
 
 **Validation:** Consider round-tripping: render the markdown back to a visual format and compare with the original page. Flag pages where the transcription looks poor.
 
-**Verify:** One `.md` file per page in `pdf/pages/`.
+**Verify:** One `.md` file per page in `pdf/pages/`. All transcription issues are closed.
 
-### Stage 1.4: Structure Analysis
+### Stage 1.5: Structure Analysis
 
 Identify every piece of content in the book and assign it to a blob. The goal is **complete, gap-free coverage**: every character of the transcribed text belongs to exactly one blob.
 
@@ -79,14 +156,14 @@ Write `items.json` with an array of items, each having:
   "id": "Chapter3/Theorem3.1",
   "type": "theorem",
   "title": "Bolzano-Weierstrass Theorem",
-  "start_page": 45,
-  "end_page": 46,
+  "start_page": "45",
+  "end_page": "46",
   "start_line": 12,
   "end_line": 3
 }
 ```
 
-Where `start_line` and `end_line` refer to line numbers within the page markdown files.
+Where `start_line` and `end_line` refer to line numbers within the page markdown files. `start_page` and `end_page` are logical page names (strings matching the `pdf/pages/` filenames without the `.pdf` extension, e.g. `"45"`, `"frontmatter-3"`, `"backmatter-1"`).
 
 Types: `theorem`, `lemma`, `proposition`, `corollary`, `definition`, `example`, `exercise`, `remark`, `discussion`, `introduction`, `preface`, `notation`, `bibliography`, `index`
 
@@ -98,7 +175,7 @@ Types: `theorem`, `lemma`, `proposition`, `corollary`, `definition`, `example`,
 
 **Verify:** `items.json` exists and passes the contiguity check.
 
-### Stage 1.5: Blob Extraction
+### Stage 1.6: Blob Extraction
 
 Split the page-level markdown into per-blob files, one file per item in `items.json`.
 
@@ -108,7 +185,7 @@ Split the page-level markdown into per-blob files, one file per item in `items.j
 - One blob file per item in `items.json`
 - Concatenating all blob files in order reproduces the complete transcribed text
 
-### Stage 1.6: Indexing (optional)
+### Stage 1.7: Indexing (optional)
 
 Build one-line summaries for each blob, useful for quick reference and RAG.
 
@@ -128,7 +205,7 @@ Read the text linearly, noting every internal reference:
 - **Structural declarations:** "This chapter depends only on Chapters 1 and 2", "We assume familiarity with Chapter 3"
 - **Implicit dependencies:** Uses a concept or definition from earlier without citing it
 
-**Initial assumption:** Each item depends on everything that comes before it in the book, unless the text clearly states otherwise (e.g., "this chapter is independent of chapters 4-6"). This is conservative and correct. We will trim dependencies later in Stage 3.4 once we have actual proofs.
+**Initial assumption:** Each item depends on everything that comes before it in the book, unless the text clearly states otherwise (e.g., "this chapter is independent of chapters 4-6"). This is conservative and correct. We will trim dependencies later in Stage 3.3 once we have actual proofs.
 
 **Output:** `dependencies/internal.json` — a mapping from each item ID to a list of item IDs it depends on.
 
@@ -149,7 +226,7 @@ Categorize each:
 
 Combine `items.json`, `dependencies/internal.json`, and `dependencies/external.json` into a preliminary blueprint.
 
-This is a DAG of what needs to be formalized and in what order. Because we conservatively assumed sequential dependencies, the initial DAG will be nearly linear. That is fine — it will be refined in Stage 3.4.
+This is a DAG of what needs to be formalized and in what order. Because we conservatively assumed sequential dependencies, the initial DAG will be nearly linear. That is fine — it will be refined in Stage 3.3.
 
 #### Blueprint tooling
 
@@ -167,7 +244,7 @@ The split: leanblueprint owns the full DAG (formal + non-formal nodes). LeanArch
 3. Non-formalizable items (discussion, introduction, etc.) are included as LaTeX nodes for completeness — they appear in the DAG but don't need Lean declarations.
 4. Run `leanblueprint web` to generate the HTML dependency graph.
 
-The initial blueprint is purely LaTeX-based. LeanArchitect integration happens after Stage 3.2 when Lean scaffolding is compiled — run `extract_blueprint --all --json` against the `.olean` files to get the dependency graph and formalization status.
+The initial blueprint is purely LaTeX-based. LeanArchitect integration happens after Stage 3.1 when Lean scaffolding is compiled — run `extract_blueprint --all --json` against the `.olean` files to get the dependency graph and formalization status.
 
 **Output:** `blueprint/` directory with leanblueprint LaTeX source files.
 
@@ -218,20 +295,9 @@ These files are read by formalization agents when they work on the corresponding
 
 ## Phase 3: Formalization
 
-### Stage 3.1: Lean Project Setup
-
-Create a Lean 4 project with Mathlib as a dependency. The `blueprint/` directory should already exist from Stage 2.3. LeanArchitect is **not** a dependency of the Lean project — it runs externally against the compiled `.olean` files.
+### Stage 3.1: Lean Scaffolding
 
-**Output:** `lean/` directory containing:
-- `lakefile.toml` with Mathlib dependency
-- `lean-toolchain` matching Mathlib's toolchain
-- `.gitignore` for build artifacts
-
-**Verify:** `cd lean && lake build` succeeds (empty project, just checking Mathlib dependency works).
-
-### Stage 3.2: Lean Scaffolding
-
-Create `.lean` files for each formalizable item (theorems, definitions, lemmas — not discussion blobs).
+The `lean/` project was created by `ff init` in Stage 1.2 and Mathlib was built then. Create `.lean` files for each formalizable item (theorems, definitions, lemmas — not discussion blobs).
 
 Set up the import chain:
 - Root file: `lean/{Title}.lean` importing all chapter files
@@ -259,14 +325,36 @@ Once scaffolding is complete, run `extract_blueprint single --all --json` agains
 
 **Verify:** `cd lean && lake build` succeeds (everything compiles with sorries).
 
-### Stage 3.3: Formalization Work Loop
+### Stage 3.2: Formalization Work Loop
 
 Orchestrate agents to formalize items, respecting the dependency DAG from the blueprint. Uses a tiered strategy: Claude agents first, with escalation to Aristotle (an automated theorem prover) for difficult proofs.
 
+#### PR lifecycle
+
+PRs must be merged to `main` without human intervention to avoid blocking downstream agents. Every PR should have auto-merge enabled at creation time:
+
+```bash
+gh pr create --title "Formalize <ItemID>" --body "..."
+PR_NUM=$(gh pr view --json number --jq .number)
+gh pr merge "$PR_NUM" --auto --squash
+```
+
+At the **start of every planning cycle**, before selecting new work, merge all PRs that are mergeable and have no failing CI checks:
+
+```bash
+gh pr list --state open \
+  --json number,mergeable,statusCheckRollup \
+  --jq '.[] | select(
+    .mergeable == "MERGEABLE" and
+    (.statusCheckRollup | all(.conclusion != "FAILURE" and .conclusion != "CANCELLED"))
+  ) | .number' \
+| xargs -I{} gh pr merge {} --squash --delete-branch
+```
+
 #### Agent workflow
 
 Each agent is assigned a task (an item or small group of related items). The agent either:
-1. **Submits a PR** that fully or partially resolves the task
+1. **Submits a PR** that fully or partially resolves the task (with auto-merge enabled)
 2. **Escalates by posting an issue** documenting the blockers
 
 #### Task selection
@@ -286,7 +374,7 @@ Use a tiered approach to maximize throughput:
 
 2. **Escalate to Aristotle** — When a Claude agent fails to prove a theorem after 2-3 serious attempts, escalate to Aristotle. Record the escalation in `progress/items.json` by setting `"escalated_to_aristotle": true`.
 
-3. **Aristotle batch pass** — After Stage 3.2 scaffolding is complete, submit all sorry'd theorems to Aristotle as a batch. This runs concurrently with Claude agents working on other items. Any theorems Aristotle solves reduce the workload for Claude.
+3. **Aristotle batch pass** — After Stage 3.1 scaffolding is complete, submit all sorry'd theorems to Aristotle as a batch. This runs concurrently with Claude agents working on other items. Any theorems Aristotle solves reduce the workload for Claude.
 
 #### Aristotle integration
 
@@ -298,7 +386,7 @@ For each item to submit:
 
 1. **Prepare the file.** Create a temporary copy of the item's Lean file. The file must contain exactly one `sorry` (the target theorem). Change all other `sorry` occurrences to `admit`.
 
-2. **Gather context.** Collect sorry-free local Lean files that this item depends on (from the import chain). Skip Mathlib imports — Aristotle has Mathlib built in. If no local files are sorry-free yet (e.g., during the initial batch pass after Stage 3.2), submit with no context files. Pass context via `--context-files`.
+2. **Gather context.** Collect sorry-free local Lean files that this item depends on (from the import chain). Skip Mathlib imports — Aristotle has Mathlib built in. If no local files are sorry-free yet (e.g., during the initial batch pass after Stage 3.1), submit with no context files. Pass context via `--context-files`.
 
 3. **Submit.**
    ```bash
@@ -332,7 +420,7 @@ When Aristotle returns a result:
 
 1. **Verify it compiles** against the local toolchain: copy the proof into the item's Lean file (under `lean/{Title}/...`) and run `lake build` for that module.
 2. **If it compiles clean:** Update status to `sorry_free` (if the item has no remaining sorries) or `proof_formalized`. Submit a PR.
-3. **If Aristotle reports the theorem is false:** Mark the item as `attention_needed`. Post a GitHub issue describing the counterexample Aristotle found. The formalized statement (from Stage 3.2) needs revision.
+3. **If Aristotle reports the theorem is false:** Mark the item as `attention_needed`. Post a GitHub issue describing the counterexample Aristotle found. The formalized statement (from Stage 3.1) needs revision.
 4. **If it fails to compile** (toolchain version mismatch): Mark the item as `attention_needed` for manual review.
 
 ##### Aristotle item statuses
@@ -362,7 +450,7 @@ Specialized triage agents should periodically review open issues for:
 - **Spec-driven development:** Use sorry placeholders with comments explaining what's needed, not `True` or other cheats.
 - **Pre-formalization:** For complex items, first translate the natural language blob into a pedantic, detailed version with careful references to every fact used, before attempting formalization.
 
-### Stage 3.4: Dependency Trimming (post-formalization)
+### Stage 3.3: Dependency Trimming (post-formalization)
 
 Once items have sorry-free proofs, analyze actual dependencies using both LeanArchitect's inference (for formal declarations) and manual review (for non-formal nodes).
 
@@ -381,9 +469,35 @@ This is when we learn the true dependency structure of the book, which may diffe
 
 ## Progress Tracking
 
-### Stage-level progress: `PROGRESS.md`
+### Per-turn progress files: `progress/YYYY-MM-DDTHH-MM-SSZ.md`
 
-Orchestrators update `PROGRESS.md` as stages are completed. Format:
+At the end of every agent turn, write a timestamped progress file in `progress/`. Use the current UTC time for the filename (e.g., `progress/2026-03-15T14-30-00Z.md`). This gives a full audit trail of what each agent did and decided, and reliably onboards the next agent.
+
+Template:
+```markdown
+## Accomplished
+<!-- What was done this turn -->
+
+## Current frontier
+<!-- Where work stopped -->
+
+## Overall project progress
+<!-- High-level status (which stages are complete, how many items are formalized, etc.) -->
+
+## Next step
+<!-- Concrete recommendation for the next agent -->
+
+## Blockers
+<!-- Anything blocking forward progress; empty if none -->
+```
+
+The most recent file in `progress/` (sorted alphabetically, since filenames are ISO 8601 timestamps) is the canonical handoff document for the next agent. **Always read it at the start of a turn** before checking `PLAN.md` for stage details. If `progress/` contains only `progress/0000-init.md` (or no handoff file at all), the repo is freshly initialized — proceed with Stage 1.1.
+
+Commits made during a turn should mention the corresponding progress file in the commit message (e.g., `See progress/2026-03-15T14-30-00Z.md`).
+
+### Stage-level summary: `PROGRESS.md` (optional)
+
+`PROGRESS.md` may be maintained as a human-facing summary of stage completion. It is not the primary source of truth — the per-turn files are. If kept, format:
 
 ```markdown
 ## Stage 1.1: Page Extraction
@@ -391,10 +505,15 @@ Orchestrators update `PROGRESS.md` as stages are completed. Format:
 **Date:** 2026-03-15
 **Notes:** 342 pages extracted.
 
-## Stage 1.2: Frontmatter Detection
+## Stage 1.2: Start Lean Build
+**Status:** Complete
+**Date:** 2026-03-15
+**Notes:** Mathlib downloaded and built successfully.
+
+## Stage 1.3: Frontmatter Detection
 **Status:** Complete
 **Date:** 2026-03-15
-**Notes:** Page 1 starts at raw page 13. Backmatter from page 298.
+**Notes:** Page 1 starts at raw page 13. Backmatter from raw page 298. See `pdf/pages/mapping.json` for the full raw-page → logical-page mapping.
 ```
 
 ### Item-level progress: `progress/items.json`
@@ -425,6 +544,7 @@ Items escalated to Aristotle use: `statement_formalized` → `sent_to_aristotle`
 ### Rules
 
 - **Do NOT modify PLAN.md** for progress tracking. This document is the reference plan.
-- Stage-level progress goes in `PROGRESS.md`.
+- Per-turn handoff notes go in `progress/YYYY-MM-DDTHH-MM-SSZ.md` (write one at the end of every turn).
+- Stage-level summary may be kept in `PROGRESS.md` (optional, human-facing).
 - Item-level progress goes in `progress/items.json`.
 - Blockers and discussion go in GitHub issues.
```

🤖 Prepared with Claude Code