### PR TITLE
## Summary

- **Proposition 5.2.4**: Algebraic integers form a ring, algebraic numbers form a field — direct application of Mathlib's `IsIntegral.add/mul` and `IsAlgebraic.add/mul`
- **Proposition 5.2.5**: A rational number is an algebraic integer iff it is an integer — uses `isIntegral_algebraMap_iff` and `IsIntegrallyClosed.isIntegral_iff`
- **Definition 5.4.1**: S₃ is solvable — proved via sign homomorphism short exact sequence (A₃ is cyclic of prime order 3, hence abelian, hence solvable)

First proofs in Chapter 5, establishing the algebraic number theory pipeline.

Closes #586

## Test plan

- [x] `lake env lean` succeeds on all three files with no errors
- [x] No `sorry` remains in any of the three files
- [x] `progress/items.json` updated with `sorry_free` status

🤖 Prepared with Claude Code

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Definition5_4_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Definition5_4_1.lean
@@ -19,4 +19,16 @@ This is `IsSolvable G` in Mathlib. (Etingof Definition 5.4.1)
 
 Example: S₃ is solvable with chain {e} ⊲ A₃ ⊲ S₃. -/
 example : IsSolvable (Equiv.Perm (Fin 3)) := by
-  sorry
+  -- S₃ is solvable with derived series S₃ ⊃ A₃ ⊃ {e}.
+  -- A₃ is commutative (order 3, cyclic), hence solvable.
+  haveI : IsSolvable (alternatingGroup (Fin 3)) := by
+    have hcard : Nat.card (alternatingGroup (Fin 3)) = 3 := by
+      rw [Nat.card_eq_fintype_card]
+      native_decide
+    haveI : Fact (Nat.Prime 3) := ⟨by norm_num⟩
+    haveI := isCyclic_of_prime_card hcard
+    exact isSolvable_of_comm (fun a b => mul_comm a b)
+  exact solvable_of_ker_le_range
+    (alternatingGroup (Fin 3)).subtype
+    (Equiv.Perm.sign)
+    (by rw [← alternatingGroup_eq_sign_ker]; exact fun x hx => ⟨⟨x, hx⟩, rfl⟩)

--- a/EtingofRepresentationTheory/Chapter5/Proposition5_2_4.lean
+++ b/EtingofRepresentationTheory/Chapter5/Proposition5_2_4.lean
@@ -19,7 +19,8 @@ theorem Etingof.Proposition5_2_4_ring :
     -- The algebraic integers form a subring of ℂ
     ∀ x y : ℂ, IsIntegral ℤ x → IsIntegral ℤ y →
       IsIntegral ℤ (x + y) ∧ IsIntegral ℤ (x * y) := by
-  sorry
+  intro x y hx hy
+  exact ⟨hx.add hy, hx.mul hy⟩
 
 /-- The set of algebraic numbers forms a subfield of ℂ (the algebraic closure of ℚ).
 (Etingof Proposition 5.2.4(ii)) -/
@@ -27,4 +28,5 @@ theorem Etingof.Proposition5_2_4_field :
     -- The algebraic numbers form a subfield of ℂ
     ∀ x y : ℂ, IsAlgebraic ℚ x → IsAlgebraic ℚ y →
       IsAlgebraic ℚ (x + y) ∧ IsAlgebraic ℚ (x * y) := by
-  sorry
+  intro x y hx hy
+  exact ⟨hx.add hy, hx.mul hy⟩

--- a/EtingofRepresentationTheory/Chapter5/Proposition5_2_5.lean
+++ b/EtingofRepresentationTheory/Chapter5/Proposition5_2_5.lean
@@ -17,4 +17,11 @@ This is `isIntegral_iff` or related results in `Mathlib.RingTheory.Algebraic`.
 Equivalently, Ā ∩ ℚ = ℤ. (Etingof Proposition 5.2.5) -/
 theorem Etingof.Proposition5_2_5 (q : ℚ) :
     IsIntegral ℤ (algebraMap ℚ ℂ q) ↔ ∃ n : ℤ, q = n := by
-  sorry
+  rw [isIntegral_algebraMap_iff (algebraMap ℚ ℂ).injective]
+  constructor
+  · intro hq
+    have := IsIntegrallyClosed.isIntegral_iff.mp hq
+    obtain ⟨r, hr⟩ := this
+    exact ⟨r, by exact_mod_cast hr.symm⟩
+  · rintro ⟨n, rfl⟩
+    exact isIntegral_algebraMap

--- a/progress/20260316T120000Z_b2163aec.md
+++ b/progress/20260316T120000Z_b2163aec.md
@@ -1,0 +1,29 @@
+## Accomplished
+
+Proved 3 Chapter 5 algebraic number theory / group theory items (issue #586):
+
+1. **Proposition 5.2.4** (ring/field closure): Algebraic integers form a ring, algebraic numbers form a field. Direct application of Mathlib's `IsIntegral.add`, `IsIntegral.mul`, `IsAlgebraic.add`, `IsAlgebraic.mul`.
+
+2. **Proposition 5.2.5** (algebraic integers in ℚ are ℤ): A rational is an algebraic integer iff it's an integer. Uses `isIntegral_algebraMap_iff` and `IsIntegrallyClosed.isIntegral_iff`.
+
+3. **Definition 5.4.1** (S₃ is solvable): Proved via the sign homomorphism short exact sequence: A₃ → S₃ → ℤ/2. A₃ has order 3 (prime), so it's cyclic hence abelian hence solvable. ℤ/2 is commutative hence solvable. Extension of solvable groups is solvable.
+
+## Current frontier
+
+All three Chapter 5 items proved and compiling. Ready for PR.
+
+## Overall project progress
+
+- **Phase 1 (Source Preparation):** Complete
+- **Phase 2 (Dependency Mapping):** Complete
+- **Phase 3 (Formalization):** Stage 3.1 complete (231 files). Stage 3.2 in progress — now 13+ items sorry_free across Chapters 2, 3, 4, and 5.
+- Chapter 5 pipeline established with first 3 proofs.
+
+## Next step
+
+- Prove remaining Chapter 5 items (5.2.4 parts about division/inverse for algebraic numbers, 5.4.3 Burnside's theorem)
+- Continue with #585 (Example 3.5.6(2) radical of upper triangular matrices)
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -65,7 +65,7 @@
   {
     "id": "Chapter2/Introduction",
     "type": "introduction",
-    "title": "Chapter 2: Basic notions of representation theory — chapter heading and Section 2.1 heading",
+    "title": "Chapter 2: Basic notions of representation theory \u2014 chapter heading and Section 2.1 heading",
     "start_page": "5",
     "end_page": "5",
     "start_line": 1,
@@ -435,7 +435,7 @@
   {
     "id": "Chapter2/Discussion_2.4_heading",
     "type": "discussion",
-    "title": "Section 2.4 Ideals — heading and definitions",
+    "title": "Section 2.4 Ideals \u2014 heading and definitions",
     "start_page": "15",
     "end_page": "15",
     "start_line": 2,
@@ -453,7 +453,7 @@
   {
     "id": "Chapter2/Discussion_2.5_heading",
     "type": "discussion",
-    "title": "Section 2.5 Quotients — heading and definition of quotient algebra",
+    "title": "Section 2.5 Quotients \u2014 heading and definition of quotient algebra",
     "start_page": "15",
     "end_page": "15",
     "start_line": 16,
@@ -498,7 +498,7 @@
   {
     "id": "Chapter2/Discussion_2.7_intro",
     "type": "discussion",
-    "title": "Section 2.7: Examples of algebras — Weyl algebra and q-Weyl algebra",
+    "title": "Section 2.7: Examples of algebras \u2014 Weyl algebra and q-Weyl algebra",
     "start_page": "17",
     "end_page": "17",
     "start_line": 5,
@@ -698,7 +698,7 @@
   {
     "id": "Chapter2/Discussion_2.9_heading",
     "type": "discussion",
-    "title": "Section 2.9: Lie algebras — heading and skew-symmetric bilinear map",
+    "title": "Section 2.9: Lie algebras \u2014 heading and skew-symmetric bilinear map",
     "start_page": "22",
     "end_page": "22",
     "start_line": 12,
@@ -874,7 +874,7 @@
   {
     "id": "Chapter2/Discussion_2.10_heading",
     "type": "discussion",
-    "title": "Section 2.10: Historical interlude — Sophus Lie's trials and transformations",
+    "title": "Section 2.10: Historical interlude \u2014 Sophus Lie's trials and transformations",
     "start_page": "26",
     "end_page": "30",
     "start_line": 7,
@@ -892,7 +892,7 @@
   {
     "id": "Chapter2/Discussion_2.11_heading",
     "type": "discussion",
-    "title": "Section 2.11: Tensor products — heading and introduction",
+    "title": "Section 2.11: Tensor products \u2014 heading and introduction",
     "start_page": "31",
     "end_page": "31",
     "start_line": 3,
@@ -991,7 +991,7 @@
   {
     "id": "Chapter2/Discussion_2.12_heading",
     "type": "discussion",
-    "title": "Section 2.12: The tensor algebra — heading and introduction",
+    "title": "Section 2.12: The tensor algebra \u2014 heading and introduction",
     "start_page": "35",
     "end_page": "35",
     "start_line": 27,
@@ -1009,7 +1009,7 @@
   {
     "id": "Chapter2/Discussion_2.13_heading",
     "type": "discussion",
-    "title": "Section 2.13: Hilbert's third problem — heading",
+    "title": "Section 2.13: Hilbert's third problem \u2014 heading",
     "start_page": "36",
     "end_page": "36",
     "start_line": 17,
@@ -1027,7 +1027,7 @@
   {
     "id": "Chapter2/Discussion_2.14_heading",
     "type": "discussion",
-    "title": "Section 2.14: Tensor products and duals of representations of Lie algebras — heading",
+    "title": "Section 2.14: Tensor products and duals of representations of Lie algebras \u2014 heading",
     "start_page": "37",
     "end_page": "37",
     "start_line": 9,
@@ -1063,7 +1063,7 @@
   {
     "id": "Chapter2/Discussion_2.15_heading",
     "type": "discussion",
-    "title": "Section 2.15: Representations of sl(2) — heading and introduction",
+    "title": "Section 2.15: Representations of sl(2) \u2014 heading and introduction",
     "start_page": "37",
     "end_page": "37",
     "start_line": 21,
@@ -1081,7 +1081,7 @@
   {
     "id": "Chapter2/Discussion_2.16_heading",
     "type": "discussion",
-    "title": "Section 2.16: Problems on Lie algebras — heading",
+    "title": "Section 2.16: Problems on Lie algebras \u2014 heading",
     "start_page": "39",
     "end_page": "39",
     "start_line": 17,
@@ -1135,7 +1135,7 @@
   {
     "id": "Chapter3/Introduction",
     "type": "introduction",
-    "title": "Chapter 3: General results of representation theory — introduction and Section 3.1 heading",
+    "title": "Chapter 3: General results of representation theory \u2014 introduction and Section 3.1 heading",
     "start_page": "43",
     "end_page": "43",
     "start_line": 1,
@@ -1226,7 +1226,7 @@
   {
     "id": "Chapter3/Introduction_to_3.2",
     "type": "introduction",
-    "title": "Section 3.2: The density theorem — heading and setup",
+    "title": "Section 3.2: The density theorem \u2014 heading and setup",
     "start_page": "45",
     "end_page": "45",
     "start_line": 23,
@@ -1256,7 +1256,7 @@
   {
     "id": "Chapter3/Introduction_to_3.3",
     "type": "introduction",
-    "title": "Section 3.3: Representations of direct sums of matrix algebras — heading and setup",
+    "title": "Section 3.3: Representations of direct sums of matrix algebras \u2014 heading and setup",
     "start_page": "47",
     "end_page": "47",
     "start_line": 1,
@@ -1319,7 +1319,7 @@
   {
     "id": "Chapter3/Introduction_to_3.4",
     "type": "introduction",
-    "title": "Section 3.4: Filtrations — heading and setup",
+    "title": "Section 3.4: Filtrations \u2014 heading and setup",
     "start_page": "49",
     "end_page": "49",
     "start_line": 3,
@@ -1347,7 +1347,7 @@
   {
     "id": "Chapter3/Introduction_to_3.5",
     "type": "introduction",
-    "title": "Section 3.5: Finite dimensional algebras — heading",
+    "title": "Section 3.5: Finite dimensional algebras \u2014 heading",
     "start_page": "49",
     "end_page": "49",
     "start_line": 13,
@@ -1431,7 +1431,7 @@
   {
     "id": "Chapter3/Introduction_to_3.6",
     "type": "introduction",
-    "title": "Section 3.6: Characters of representations — heading and character definition",
+    "title": "Section 3.6: Characters of representations \u2014 heading and character definition",
     "start_page": "52",
     "end_page": "52",
     "start_line": 3,
@@ -1458,7 +1458,7 @@
   {
     "id": "Chapter3/Introduction_to_3.7",
     "type": "introduction",
-    "title": "Section 3.7: The Jordan-Holder theorem — heading and overview",
+    "title": "Section 3.7: The Jordan-Holder theorem \u2014 heading and overview",
     "start_page": "53",
     "end_page": "53",
     "start_line": 3,
@@ -1485,7 +1485,7 @@
   {
     "id": "Chapter3/Introduction_to_3.8",
     "type": "introduction",
-    "title": "Section 3.8: The Krull-Schmidt theorem — heading",
+    "title": "Section 3.8: The Krull-Schmidt theorem \u2014 heading",
     "start_page": "54",
     "end_page": "54",
     "start_line": 9,
@@ -1558,7 +1558,7 @@
   {
     "id": "Chapter3/Introduction_to_3.9",
     "type": "introduction",
-    "title": "Section 3.9: Problems — heading",
+    "title": "Section 3.9: Problems \u2014 heading",
     "start_page": "56",
     "end_page": "56",
     "start_line": 13,
@@ -1612,7 +1612,7 @@
   {
     "id": "Chapter3/Introduction_to_3.10",
     "type": "introduction",
-    "title": "Section 3.10: Representations of tensor products — heading and setup",
+    "title": "Section 3.10: Representations of tensor products \u2014 heading and setup",
     "start_page": "59",
     "end_page": "59",
     "start_line": 5,
@@ -1666,7 +1666,7 @@
   {
     "id": "Chapter4/Introduction",
     "type": "introduction",
-    "title": "Chapter 4: Representations of finite groups: Basic results — introduction and Section 4.1 heading",
+    "title": "Chapter 4: Representations of finite groups: Basic results \u2014 introduction and Section 4.1 heading",
     "start_page": "61",
     "end_page": "61",
     "start_line": 1,
@@ -1838,7 +1838,7 @@
   {
     "id": "Chapter4/Introduction_4.5",
     "type": "introduction",
-    "title": "Section 4.5: Orthogonality of characters — Hermitian inner product on class functions",
+    "title": "Section 4.5: Orthogonality of characters \u2014 Hermitian inner product on class functions",
     "start_page": "67",
     "end_page": "68",
     "start_line": 25,
@@ -1997,7 +1997,7 @@
   {
     "id": "Chapter4/Introduction_4.8",
     "type": "introduction",
-    "title": "Section 4.8: Character tables — definition and examples of S_3, A_4",
+    "title": "Section 4.8: Character tables \u2014 definition and examples of S_3, A_4",
     "start_page": "73",
     "end_page": "74",
     "start_line": 25,
@@ -2035,7 +2035,7 @@
   {
     "id": "Chapter4/Introduction_4.10",
     "type": "introduction",
-    "title": "Section 4.10: Frobenius determinant — group determinant setup",
+    "title": "Section 4.10: Frobenius determinant \u2014 group determinant setup",
     "start_page": "78",
     "end_page": "78",
     "start_line": 1,
@@ -2101,7 +2101,7 @@
   {
     "id": "Chapter4/Discussion_4.11",
     "type": "discussion",
-    "title": "Section 4.11: Historical interlude — Georg Frobenius's Principle of Horse Trade",
+    "title": "Section 4.11: Historical interlude \u2014 Georg Frobenius's Principle of Horse Trade",
     "start_page": "79",
     "end_page": "83",
     "start_line": 21,
@@ -2218,7 +2218,7 @@
   {
     "id": "Chapter4/Discussion_4.13",
     "type": "discussion",
-    "title": "Section 4.13: Historical interlude — William Rowan Hamilton's quaternion of geometry, algebra, metaphysics, and poetry",
+    "title": "Section 4.13: Historical interlude \u2014 William Rowan Hamilton's quaternion of geometry, algebra, metaphysics, and poetry",
     "start_page": "88",
     "end_page": "92",
     "start_line": 13,
@@ -2227,7 +2227,7 @@
   {
     "id": "Chapter5/Introduction",
     "type": "introduction",
-    "title": "Chapter 5: Representations of finite groups: Further results — introduction and Section 5.1 heading",
+    "title": "Chapter 5: Representations of finite groups: Further results \u2014 introduction and Section 5.1 heading",
     "start_page": "93",
     "end_page": "93",
     "start_line": 1,
@@ -2357,7 +2357,8 @@
     "start_page": "96",
     "end_page": "97",
     "start_line": 17,
-    "end_line": 10
+    "end_line": 10,
+    "status": "sorry_free"
   },
   {
     "id": "Chapter5/Proposition5.2.5",
@@ -2366,7 +2367,8 @@
     "start_page": "97",
     "end_page": "97",
     "start_line": 11,
-    "end_line": 22
+    "end_line": 22,
+    "status": "sorry_free"
   },
   {
     "id": "Chapter5/Discussion_after_Proposition5.2.5",
@@ -2465,7 +2467,8 @@
     "start_page": "100",
     "end_page": "100",
     "start_line": 7,
-    "end_line": 12
+    "end_line": 12,
+    "status": "sorry_free"
   },
   {
     "id": "Chapter5/Remark5.4.2",
@@ -2569,7 +2572,7 @@
   {
     "id": "Chapter5/Introduction_5.5",
     "type": "introduction",
-    "title": "Section 5.5: Historical interlude — William Burnside",
+    "title": "Section 5.5: Historical interlude \u2014 William Burnside",
     "start_page": "102",
     "end_page": "102",
     "start_line": 19,
@@ -2596,7 +2599,7 @@
   {
     "id": "Chapter5/Theorem5.6.1",
     "type": "theorem",
-    "title": "Irreducible representations of G x H are tensor products V_i ⊗ W_j",
+    "title": "Irreducible representations of G x H are tensor products V_i \u2297 W_j",
     "start_page": "107",
     "end_page": "107",
     "start_line": 3,
@@ -2641,7 +2644,7 @@
   {
     "id": "Chapter5/Introduction_5.8",
     "type": "introduction",
-    "title": "Section 5.8: Induced representations — restriction and induction",
+    "title": "Section 5.8: Induced representations \u2014 restriction and induction",
     "start_page": "107",
     "end_page": "107",
     "start_line": 17,
@@ -2686,7 +2689,7 @@
   {
     "id": "Chapter5/Problem5.8.4",
     "type": "exercise",
-    "title": "Transitivity of induction: Ind_H^G Ind_K^H V ≅ Ind_K^G V",
+    "title": "Transitivity of induction: Ind_H^G Ind_K^H V \u2245 Ind_K^G V",
     "start_page": "108",
     "end_page": "108",
     "start_line": 27,
@@ -2749,7 +2752,7 @@
   {
     "id": "Chapter5/Theorem5.10.1",
     "type": "theorem",
-    "title": "Frobenius reciprocity: Hom_G(V, Ind W) ≅ Hom_H(Res V, W)",
+    "title": "Frobenius reciprocity: Hom_G(V, Ind W) \u2245 Hom_H(Res V, W)",
     "start_page": "110",
     "end_page": "110",
     "start_line": 7,
@@ -2920,7 +2923,7 @@
   {
     "id": "Chapter5/Lemma5.13.4",
     "type": "lemma",
-    "title": "Hom_A(Ae, M) ≅ eM for idempotent e (continues to missing page)",
+    "title": "Hom_A(Ae, M) \u2245 eM for idempotent e (continues to missing page)",
     "start_page": "115",
     "end_page": "115",
     "start_line": 13,
@@ -3154,7 +3157,7 @@
   {
     "id": "Chapter5/Introduction_5.18",
     "type": "introduction",
-    "title": "Section 5.18: Schur-Weyl duality for gl(V) — Double Centralizer Theorem",
+    "title": "Section 5.18: Schur-Weyl duality for gl(V) \u2014 Double Centralizer Theorem",
     "start_page": "122",
     "end_page": "122",
     "start_line": 17,
@@ -3172,7 +3175,7 @@
   {
     "id": "Chapter5/Discussion_before_Theorem5.18.2",
     "type": "discussion",
-    "title": "Application of Double Centralizer Theorem to V^{⊗n}",
+    "title": "Application of Double Centralizer Theorem to V^{\u2297n}",
     "start_page": "123",
     "end_page": "123",
     "start_line": 3,
@@ -3181,7 +3184,7 @@
   {
     "id": "Chapter5/Theorem5.18.2",
     "type": "theorem",
-    "title": "B is the image of U(gl(V)) acting on V^{⊗n}",
+    "title": "B is the image of U(gl(V)) acting on V^{\u2297n}",
     "start_page": "123",
     "end_page": "123",
     "start_line": 5,
@@ -3190,7 +3193,7 @@
   {
     "id": "Chapter5/Lemma5.18.3",
     "type": "lemma",
-    "title": "S^n U is spanned by u⊗...⊗u; S^n A is generated by Delta_n(a)",
+    "title": "S^n U is spanned by u\u2297...\u2297u; S^n A is generated by Delta_n(a)",
     "start_page": "123",
     "end_page": "123",
     "start_line": 15,
@@ -3217,7 +3220,7 @@
   {
     "id": "Chapter5/Theorem5.18.4",
     "type": "theorem",
-    "title": "Schur-Weyl duality: V^{⊗n} = ⊕ V_lambda ⊗ L_lambda",
+    "title": "Schur-Weyl duality: V^{\u2297n} = \u2295 V_lambda \u2297 L_lambda",
     "start_page": "124",
     "end_page": "124",
     "start_line": 5,
@@ -3235,7 +3238,7 @@
   {
     "id": "Chapter5/Proposition5.19.1",
     "type": "proposition",
-    "title": "Image of GL(V) in End(V^{⊗n}) spans B",
+    "title": "Image of GL(V) in End(V^{\u2297n}) spans B",
     "start_page": "124",
     "end_page": "124",
     "start_line": 21,
@@ -3255,7 +3258,7 @@
   {
     "id": "Chapter5/Example5.19.3",
     "type": "example",
-    "title": "L_lambda for partitions (n) and (1^n): S^nV and Λ^nV",
+    "title": "L_lambda for partitions (n) and (1^n): S^nV and \u039b^nV",
     "start_page": "125",
     "end_page": "125",
     "start_line": 3,
@@ -3265,7 +3268,7 @@
   {
     "id": "Chapter5/Introduction_5.20",
     "type": "introduction",
-    "title": "Section 5.20: Historical interlude — Hermann Weyl",
+    "title": "Section 5.20: Historical interlude \u2014 Hermann Weyl",
     "start_page": "125",
     "end_page": "125",
     "start_line": 5,
@@ -3367,7 +3370,7 @@
   {
     "id": "Chapter5/Proposition5.22.2",
     "type": "proposition",
-    "title": "L_{lambda+1^N} ≅ L_lambda ⊗ Λ^N V",
+    "title": "L_{lambda+1^N} \u2245 L_lambda \u2297 \u039b^N V",
     "start_page": "133",
     "end_page": "133",
     "start_line": 3,
@@ -3442,7 +3445,7 @@
   {
     "id": "Chapter5/Problem5.24.1",
     "type": "exercise",
-    "title": "V'_lambda ≅ V_lambda and V_lambda ⊗ C_- = V_{lambda*}",
+    "title": "V'_lambda \u2245 V_lambda and V_lambda \u2297 C_- = V_{lambda*}",
     "start_page": "135",
     "end_page": "135",
     "start_line": 3,
@@ -3497,7 +3500,7 @@
   {
     "id": "Chapter5/Discussion_1dim_reps",
     "type": "discussion",
-    "title": "G/[G,G] ≅ F_q^× and description of 1-dimensional representations C_xi",
+    "title": "G/[G,G] \u2245 F_q^\u00d7 and description of 1-dimensional representations C_xi",
     "start_page": "138",
     "end_page": "138",
     "start_line": 21,
@@ -3506,7 +3509,7 @@
   {
     "id": "Chapter5/Discussion_5.25.3",
     "type": "discussion",
-    "title": "Section 5.25.3: Principal series representations — setup of B, V_{lambda_1,lambda_2}",
+    "title": "Section 5.25.3: Principal series representations \u2014 setup of B, V_{lambda_1,lambda_2}",
     "start_page": "138",
     "end_page": "139",
     "start_line": 41,
@@ -3534,7 +3537,7 @@
   {
     "id": "Chapter5/Discussion_5.25.4",
     "type": "discussion",
-    "title": "Section 5.25.4: Complementary series representations — setup and character computation",
+    "title": "Section 5.25.4: Complementary series representations \u2014 setup and character computation",
     "start_page": "141",
     "end_page": "143",
     "start_line": 37,
@@ -3627,7 +3630,7 @@
   {
     "id": "Chapter5/Theorem5.27.1",
     "type": "theorem",
-    "title": "Classification of irreducible representations of semidirect products G ⋉ A",
+    "title": "Classification of irreducible representations of semidirect products G \u22c9 A",
     "start_page": "146",
     "end_page": "147",
     "start_line": 11,
@@ -4689,7 +4692,7 @@
   {
     "id": "Chapter7/Problem7.8.7",
     "type": "exercise",
-    "title": "Tensor product of complexes and Künneth formula",
+    "title": "Tensor product of complexes and K\u00fcnneth formula",
     "start_page": "193",
     "end_page": "194",
     "start_line": 23,


### PR DESCRIPTION
Closes #--title

Session: `cb73533d-98dc-4713-ae8a-e28e38f31c86`

433f1ad feat: prove Chapter 5 algebraic number foundations (5.2.4, 5.2.5, 5.4.1)

🤖 Prepared with Claude Code