### PR TITLE
feat: prove Example 7.9.6 tensor right exactness sorry-free

### DIFF
--- a/EtingofRepresentationTheory/Chapter7/Example7_9_6.lean
+++ b/EtingofRepresentationTheory/Chapter7/Example7_9_6.lean
@@ -1,5 +1,6 @@
 import Mathlib.CategoryTheory.Limits.Yoneda
 import Mathlib.CategoryTheory.Limits.Preserves.Finite
+import Mathlib.Algebra.Category.ModuleCat.Monoidal.Closed
 
 /-!
 # Example 7.9.6: Exactness Properties of Standard Functors
@@ -27,8 +28,12 @@ instance Etingof.hom_left_exact {C : Type*} [Category C] (X : C) :
     PreservesFiniteLimits (coyoneda.obj (Opposite.op X)) :=
   inferInstance
 
-/-- The tensor product functor is right exact but not necessarily left exact.
-(Etingof Example 7.9.6(iii)) -/
--- TODO: Statement formalization requires choosing a concrete category setting
--- (e.g., ModuleCat R) and expressing right exactness via PreservesFiniteColimits
-theorem Etingof.tensor_right_exact : (sorry : Prop) := by sorry
+/-- The tensor product functor `X ⊗ -` is right exact: it preserves finite colimits.
+(Etingof Example 7.9.6(iii))
+
+In Mathlib, `ModuleCat R` is a monoidal closed category, so `tensorLeft X` (the functor
+`X ⊗ -`) is a left adjoint of the internal hom functor. Left adjoints preserve all
+colimits, hence in particular finite colimits, making the tensor functor right exact. -/
+instance Etingof.tensor_right_exact {R : Type*} [CommRing R] (X : ModuleCat R) :
+    PreservesFiniteColimits (MonoidalCategory.tensorLeft X) :=
+  inferInstance

--- a/progress/2026-03-16T16-59-56Z_b2163aec.md
+++ b/progress/2026-03-16T16-59-56Z_b2163aec.md
@@ -1,0 +1,29 @@
+## Accomplished
+
+- Proved `Etingof.tensor_right_exact` in `EtingofRepresentationTheory/Chapter7/Example7_9_6.lean` (closes #673)
+- Replaced `(sorry : Prop)` placeholder with a proper `instance` declaration: `PreservesFiniteColimits (MonoidalCategory.tensorLeft X)` for `ModuleCat R`
+- Proof is `inferInstance` — Mathlib's `MonoidalClosed` structure on `ModuleCat R` provides the instance via the tensor-hom adjunction (left adjoints preserve colimits)
+- Added import `Mathlib.Algebra.Category.ModuleCat.Monoidal.Closed`
+- Updated `progress/items.json`: Chapter7/Example7.9.6 status → `sorry_free`
+- File builds cleanly with no sorries
+
+## Current frontier
+
+Chapter 7 Example 7.9.6 is fully sorry-free (both parts: hom left exact + tensor right exact).
+
+## Overall project progress
+
+- Stage 3.2 (proof filling) active
+- ~127/583 items sorry_free (~21.8%)
+- Chapter 8 fully sorry-free (9 files)
+- Chapter 7 progressing — Example 7.9.6 now complete
+
+## Next step
+
+- #678 (Infrastructure: FDRep irreducible enumeration — 4 sorries) is the highest-impact unclaimed feature, blocking the column orthogonality chain
+- #661 (Review: Chapter 5 scaffolding audit) would help plan the next wave of Ch5 proof work
+- #680 (Meditate: retrospective) for skill improvements
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -4931,9 +4931,9 @@
     "end_page": "195",
     "start_line": 13,
     "end_line": 24,
-    "status": "statement_formalized",
+    "status": "sorry_free",
     "needs_statement": false,
-    "notes": "hom_left_exact formalized and proved; tensor_right_exact still sorry"
+    "notes": "hom_left_exact via inferInstance (coyoneda); tensor_right_exact via inferInstance (MonoidalClosed left adjoint)"
   },
   {
     "id": "Chapter7/Exercise7.9.7",


### PR DESCRIPTION
Closes #673

Session: `1474c3da-3988-4e7b-922e-0f5d64b9411c`

e4c759d feat: prove Example 7.9.6 tensor right exactness sorry-free

🤖 Prepared with Claude Code