### PR TITLE
## Summary
- Eliminate all sorries in `EtingofRepresentationTheory/Chapter4/Lemma4_10_3.lean`
- Prove `rename_irreducible`: `MvPolynomial.rename` preserves irreducibility for injective functions, using vars-based argument with `exists_rename_eq_of_vars_subset_range`
- Prove `minor00_isRelPrime`: the (0,0) minor is coprime to the rest of the cofactor expansion, via an evaluation argument showing M₀₀ | M₀₁ leads to a vars contradiction
- Helper `vars_subset_vars_mul_left`: in a domain, vars of a factor are a subset of vars of the product

## Test plan
- [x] `lake env lean EtingofRepresentationTheory/Chapter4/Lemma4_10_3.lean` compiles with zero errors, zero sorries, zero warnings

Closes #679

🤖 Prepared with Claude Code

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Lemma4_10_3.lean
+++ b/EtingofRepresentationTheory/Chapter4/Lemma4_10_3.lean
@@ -106,12 +106,53 @@ This is a general fact: in MvPolynomial over a domain, if `f` is injective then
 (3) WLOG `rename g a` is a unit, (4) show `a` is a unit using `degreeOf_mul_eq` to
 establish `vars(a) ⊆ range f`, then `rename (f ∘ g) a = a`, hence `a = rename f (C c)`.
 Missing from Mathlib; see https://github.com/leanprover-community/mathlib4/issues/XXXXX -/
+private lemma vars_subset_vars_mul_left {σ : Type*} {R : Type*} [CommSemiring R]
+    [NoZeroDivisors R] {a b : MvPolynomial σ R} (ha : a ≠ 0) (hb : b ≠ 0) :
+    a.vars ⊆ (a * b).vars := by
+  classical
+  intro x hx
+  simp only [vars_def] at hx ⊢
+  rw [Multiset.mem_toFinset] at hx ⊢
+  rw [← Multiset.count_pos] at hx ⊢
+  rw [← degreeOf_def] at hx ⊢
+  have := degreeOf_mul_eq ha hb (n := x)
+  omega
+
 private lemma rename_irreducible {σ τ : Type*} [DecidableEq σ] [DecidableEq τ]
     {f : σ → τ} (hf : Function.Injective f)
     {p : MvPolynomial σ ℂ} (hp : Irreducible p) :
     Irreducible (rename f p) := by
-  sorry
+  constructor
+  · -- rename f p is not a unit
+    intro h
+    exact hp.1 ((killCompl_rename_app hf p) ▸ h.map (killCompl hf).toRingHom)
+  · -- If rename f p = a * b, then one of a, b is a unit
+    intro a b hab
+    have hne : rename f p ≠ 0 := (rename_injective f hf).ne hp.ne_zero
+    have ha : a ≠ 0 := left_ne_zero_of_mul (hab ▸ hne)
+    have hb : b ≠ 0 := right_ne_zero_of_mul (hab ▸ hne)
+    -- vars of rename f p are contained in Set.range f
+    have hvars_rfp : ∀ x ∈ (rename f p).vars, x ∈ Set.range f := by
+      intro x hx
+      obtain ⟨y, _, rfl⟩ := mem_vars_rename f p hx
+      exact Set.mem_range_self y
+    -- vars(a) ⊆ vars(a*b) = vars(rename f p) ⊆ range f
+    have hvars_a : ↑a.vars ⊆ Set.range f := by
+      intro x hx
+      exact hvars_rfp x (hab ▸ vars_subset_vars_mul_left ha hb hx)
+    have hvars_b : ↑b.vars ⊆ Set.range f := by
+      intro x hx
+      exact hvars_rfp x (hab ▸ mul_comm a b ▸ vars_subset_vars_mul_left hb ha hx)
+    -- Express a and b as renames
+    obtain ⟨a', rfl⟩ := exists_rename_eq_of_vars_subset_range a f hf hvars_a
+    obtain ⟨b', rfl⟩ := exists_rename_eq_of_vars_subset_range b f hf hvars_b
+    -- rename f p = rename f a' * rename f b' = rename f (a' * b')
+    rw [← map_mul] at hab
+    have hab' : p = a' * b' := (rename_injective f hf) hab
+    -- Since p is irreducible, one factor is a unit
+    exact (hp.isUnit_or_isUnit hab').imp (·.map (rename f).toRingHom) (·.map (rename f).toRingHom)
 
+set_option maxHeartbeats 800000 in
 /-- The (0,0) minor is coprime to the rest of the cofactor expansion. -/
 private lemma minor00_isRelPrime (n : ℕ) (ih' : Irreducible (det (genMatrix (n + 1)))) :
     IsRelPrime
@@ -127,9 +168,133 @@ private lemma minor00_isRelPrime (n : ℕ) (ih' : Irreducible (det (genMatrix (n
       ⟨Fin.succ_injective _, Fin.succ_injective _⟩) ih'
   -- Irreducible ↔ not-dvd for IsRelPrime
   rw [hf_irr.isRelPrime_iff_not_dvd]
-  -- M₀₀ doesn't divide the rest: evaluating X(0,1)→1, X(0,j)→0 for j>1
-  -- would give M₀₀ | M₀₁, but (1,1) ∈ vars(M₀₀) and (1,1) ∉ vars(M₀₁).
-  sorry
+  -- M₀₁ is also irreducible
+  have hf1_irr : Irreducible (det ((genMatrix (n + 2)).submatrix Fin.succ
+      (Fin.succAbove (1 : Fin (n + 2))))) := by
+    rw [submatrix_eq_rename]
+    exact rename_irreducible (Prod.map_injective.mpr
+      ⟨Fin.succ_injective _, Fin.succAbove_right_injective⟩) ih'
+  -- Define evaluation: X(0,1)→1, X(0,j)→0 for j≠1, X(i,j)→X(i,j) for i≥1
+  let φ : (Fin (n + 2) × Fin (n + 2)) → MvPolynomial (Fin (n + 2) × Fin (n + 2)) ℂ :=
+    fun v => if v.1 = 0 then (if v.2 = 1 then 1 else 0) else X v
+  -- aeval X is the identity
+  have aeval_X_id : ∀ (p : MvPolynomial (Fin (n + 2) × Fin (n + 2)) ℂ),
+      aeval (X : _ → MvPolynomial (Fin (n + 2) × Fin (n + 2)) ℂ) p = p := by
+    have : aeval (X : _ → MvPolynomial (Fin (n + 2) × Fin (n + 2)) ℂ) = AlgHom.id ℂ _ := by
+      ext i; simp
+    intro p; rw [this]; simp
+  -- φ fixes any submatrix minor (no row-0 variables)
+  have hφ_fix_minor : ∀ (c : Fin (n + 2)),
+      aeval φ (det ((genMatrix (n + 2)).submatrix Fin.succ (Fin.succAbove c))) =
+      det ((genMatrix (n + 2)).submatrix Fin.succ (Fin.succAbove c)) := by
+    intro c
+    have hφ_eq : ∀ v ∈ (det ((genMatrix (n + 2)).submatrix Fin.succ
+        (Fin.succAbove c))).vars, φ v = X v := by
+      intro v hv
+      simp only [φ, if_neg (submatrix_vars_fst_ne_zero n c hv)]
+    rw [show aeval φ (det ((genMatrix (n + 2)).submatrix Fin.succ (Fin.succAbove c))) =
+      aeval X (det ((genMatrix (n + 2)).submatrix Fin.succ (Fin.succAbove c))) from
+      MvPolynomial.eval₂Hom_congr' rfl (fun i hi _ => hφ_eq i hi) rfl]
+    exact aeval_X_id _
+  -- φ(X(0, j.succ)) = 1 if j = 0, else 0
+  have hφ_X : ∀ j : Fin (n + 1),
+      φ ((0 : Fin (n + 2)), j.succ) = if j = 0 then 1 else 0 := by
+    intro j
+    simp only [φ, ite_true]
+    rcases Decidable.eq_or_ne j 0 with rfl | hj
+    · simp [show Fin.succ (0 : Fin (n + 1)) = (1 : Fin (n + 2)) from rfl]
+    · simp [show Fin.succ j ≠ (1 : Fin (n + 2)) from by
+        rwa [show (1 : Fin (n + 2)) = Fin.succ 0 from rfl, Ne, Fin.succ_inj], hj]
+  -- Suppose M₀₀ | rest
+  intro ⟨q, hq⟩
+  -- Apply aeval φ: φ(rest) = -M₀₁
+  have hφ_rest : aeval φ (∑ j : Fin (n + 1),
+      (-1 : MvPolynomial (Fin (n + 2) × Fin (n + 2)) ℂ) ^ ((j : ℕ) + 1) *
+      X ((0 : Fin (n + 2)), j.succ) *
+      det ((genMatrix (n + 2)).submatrix Fin.succ (Fin.succAbove j.succ))) =
+      -det ((genMatrix (n + 2)).submatrix Fin.succ (Fin.succAbove (1 : Fin (n + 2)))) := by
+    simp only [map_sum, map_mul, map_pow, map_neg, map_one, aeval_X, hφ_fix_minor, hφ_X]
+    rw [Fin.sum_univ_succ]
+    simp
+  -- So M₀₀ | M₀₁
+  have hdvd : det ((genMatrix (n + 2)).submatrix Fin.succ (Fin.succAbove 0)) ∣
+      det ((genMatrix (n + 2)).submatrix Fin.succ (Fin.succAbove 1)) := by
+    have h1 : aeval φ (det ((genMatrix (n + 2)).submatrix Fin.succ (Fin.succAbove 0))) ∣
+        aeval φ (∑ j : Fin (n + 1),
+          (-1 : MvPolynomial (Fin (n + 2) × Fin (n + 2)) ℂ) ^ ((j : ℕ) + 1) *
+          X ((0 : Fin (n + 2)), j.succ) *
+          det ((genMatrix (n + 2)).submatrix Fin.succ (Fin.succAbove j.succ))) :=
+      (aeval φ).toRingHom.map_dvd ⟨q, hq⟩
+    rw [hφ_fix_minor 0, hφ_rest] at h1
+    exact dvd_neg.mp h1
+  -- Both are irreducible, so they must be associated
+  have hassoc := hf_irr.associated_of_dvd hf1_irr hdvd
+  -- Associated means M₀₁ = u * M₀₀ for unit u, so they have same vars
+  obtain ⟨u, hu⟩ := hassoc
+  -- Variable (1,1) is in vars(M₀₀) but not vars(M₀₁)
+  have hmem : ((1 : Fin (n + 2)), (1 : Fin (n + 2))) ∈
+      (det ((genMatrix (n + 2)).submatrix Fin.succ (Fin.succAbove 0))).vars := by
+    -- Evaluation argument: if (1,1) ∉ vars, two evaluations agree but give 1 ≠ 0
+    by_contra habs
+    let g₁ : Fin (n + 2) × Fin (n + 2) → ℂ := fun ⟨i, j⟩ => if i = j then 1 else 0
+    let g₂ : Fin (n + 2) × Fin (n + 2) → ℂ := Function.update g₁ (1, 1) 0
+    have hag : ∀ i ∈ (det ((genMatrix (n + 2)).submatrix Fin.succ
+        (Fin.succAbove 0))).vars, g₁ i = g₂ i := by
+      intro i hi
+      exact (Function.update_of_ne (ne_of_mem_of_not_mem hi habs) _ _).symm
+    -- g₁ and g₂ agree on vars of the submatrix det
+    have heq : MvPolynomial.eval g₁
+          (det ((genMatrix (n + 2)).submatrix Fin.succ (Fin.succAbove 0))) =
+        MvPolynomial.eval g₂
+          (det ((genMatrix (n + 2)).submatrix Fin.succ (Fin.succAbove 0))) :=
+      MvPolynomial.eval₂Hom_congr' rfl (fun i hi _ => hag i hi) rfl
+    -- eval g₁ gives det(I) = 1
+    have hev1 : MvPolynomial.eval g₁
+        (det ((genMatrix (n + 2)).submatrix Fin.succ (Fin.succAbove 0))) = 1 := by
+      rw [show MvPolynomial.eval g₁ (det ((genMatrix (n + 2)).submatrix Fin.succ
+        (Fin.succAbove 0))) = det ((MvPolynomial.eval g₁).mapMatrix
+        ((genMatrix (n + 2)).submatrix Fin.succ (Fin.succAbove 0))) from
+        RingHom.map_det _ _]
+      have : (MvPolynomial.eval g₁).mapMatrix
+          ((genMatrix (n + 2)).submatrix Fin.succ (Fin.succAbove 0)) =
+          (1 : Matrix (Fin (n + 1)) (Fin (n + 1)) ℂ) := by
+        ext i j
+        simp [RingHom.mapMatrix_apply, Matrix.map_apply, submatrix_apply, genMatrix_apply,
+          MvPolynomial.eval_X, g₁, Fin.succAbove_zero, Fin.succ_inj, one_apply]
+      rw [this, det_one]
+    -- eval g₂ gives 0 (first row is all zeros)
+    have hev0 : MvPolynomial.eval g₂
+        (det ((genMatrix (n + 2)).submatrix Fin.succ (Fin.succAbove 0))) = 0 := by
+      rw [show MvPolynomial.eval g₂ (det ((genMatrix (n + 2)).submatrix Fin.succ
+        (Fin.succAbove 0))) = det ((MvPolynomial.eval g₂).mapMatrix
+        ((genMatrix (n + 2)).submatrix Fin.succ (Fin.succAbove 0))) from
+        RingHom.map_det _ _]
+      apply det_eq_zero_of_row_eq_zero (0 : Fin (n + 1))
+      intro j
+      -- Entry (0, j) of the evaluated matrix is g₂(Fin.succ 0, Fin.succ j)
+      simp only [RingHom.mapMatrix_apply, Matrix.map_apply, submatrix_apply,
+        genMatrix_apply, MvPolynomial.eval_X, Fin.succAbove_zero]
+      -- g₂(1, succ j) = 0: either j=0 so g₂(1,1)=0, or j≠0 so 1≠succ j
+      simp only [g₂, g₁, Function.update_apply]
+      simp only [Prod.mk.injEq, show (1 : Fin (n + 2)) = Fin.succ 0 from rfl, Fin.succ_inj]
+      split
+      · simp
+      · next h =>
+        simp only [not_and] at h
+        simp [Ne.symm (h trivial)]
+    exact absurd (hev1.symm.trans (heq.trans hev0)) one_ne_zero
+  have hnotmem : ((1 : Fin (n + 2)), (1 : Fin (n + 2))) ∉
+      (det ((genMatrix (n + 2)).submatrix Fin.succ (Fin.succAbove (1 : Fin (n + 2))))).vars := by
+    rw [submatrix_eq_rename]
+    intro h
+    obtain ⟨⟨a, b⟩, _, hab⟩ := mem_vars_rename _ _ h
+    simp only [Prod.map, Prod.mk.injEq] at hab
+    exact absurd hab.2 (Fin.succAbove_ne 1 b)
+  -- M₀₀ * u = M₀₁, so vars(M₀₀) ⊆ vars(M₀₀ * u) = vars(M₀₁)
+  have hmem' : ((1 : Fin (n + 2)), (1 : Fin (n + 2))) ∈
+      (det ((genMatrix (n + 2)).submatrix Fin.succ (Fin.succAbove 1))).vars :=
+    hu ▸ vars_subset_vars_mul_left hf_irr.ne_zero (Units.ne_zero u) hmem
+  exact hnotmem hmem'
 
 /-- The determinant of a generic n × n matrix is an irreducible polynomial.
 (Etingof Lemma 4.10.3) -/

--- a/progress/2026-03-17T20-30-00Z.md
+++ b/progress/2026-03-17T20-30-00Z.md
@@ -1,0 +1,23 @@
+## Accomplished
+
+- Proved `rename_irreducible`: MvPolynomial.rename preserves irreducibility for injective functions. Uses vars-based argument showing factors of `rename f p` have vars in `range f`, then expresses them as renames via `exists_rename_eq_of_vars_subset_range`.
+- Proved `minor00_isRelPrime`: The (0,0) minor is coprime to the remaining cofactor sum. Uses evaluation trick: if M₀₀ | rest, then applying aeval φ (which fixes submatrix minors and evaluates row-0 X's) shows M₀₀ | M₀₁. Both are irreducible (by IH + rename), so they're associated. But (1,1) ∈ vars(M₀₀) and (1,1) ∉ vars(M₀₁) — contradiction via vars_subset_vars_mul_left.
+- Key sub-lemma: `vars_subset_vars_mul_left` — in a domain, vars of a factor are subset of vars of the product, proved via `degreeOf_mul_eq`.
+- Proved variable membership `(1,1) ∈ vars(M₀₀)` via evaluation argument: if absent, evaluating at identity (det=1) and at matrix with zero first row (det=0) would give 1=0.
+- Result: `Etingof.Lemma4_10_3` is now completely sorry-free.
+
+## Current frontier
+
+All sorries in `EtingofRepresentationTheory/Chapter4/Lemma4_10_3.lean` eliminated.
+
+## Overall project progress
+
+Stage 3.2 Chapter 4: Lemma 4.10.3 (generic determinant irreducibility) is now sorry-free. This was the last remaining sorry in the file.
+
+## Next step
+
+Create PR closing issue #679. Continue with other Stage 3.2 items.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -2134,7 +2134,7 @@
     "end_page": "78",
     "start_line": 19,
     "end_line": 22,
-    "status": "proof_formalized"
+    "status": "sorry_free"
   },
   {
     "id": "Chapter4/Discussion_proof_Theorem4.10.2",


### PR DESCRIPTION
Closes #--title

Session: `72abfaf3-6d9e-4f27-88f7-2f54963d7bb6`

9def6b5 Stage 3.2: Ch4 prove Lemma 4.10.3 sorry-free (generic determinant irreducibility)

🤖 Prepared with Claude Code