### PR TITLE
feat: complete Definition 6.6.4 (reflectionFunctorMinus cokernel)

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/Definition6_6_4.lean
+++ b/EtingofRepresentationTheory/Chapter6/Definition6_6_4.lean
@@ -2,6 +2,7 @@ import EtingofRepresentationTheory.Chapter2.Definition2_8_3
 import EtingofRepresentationTheory.Chapter6.Definition6_6_1
 import EtingofRepresentationTheory.Chapter6.Definition6_6_2
 import Mathlib.Algebra.DirectSum.Module
+import Mathlib.LinearAlgebra.Quotient.Defs
 
 /-!
 # Definition 6.6.4: Reflection Functor F⁻ᵢ (at a Source)
@@ -19,18 +20,38 @@ V_k → ⊕_{i→j} V_j with the natural quotient map ⊕_{i→j} V_j → (⊕_{
 BGP reflection functors are not in Mathlib. The cokernel-based construction uses
 `Submodule.mkQ` for quotient maps and `LinearMap.range` for image.
 
-**Note:** The cokernel construction (quotient module) requires `AddCommGroup`
-and `Ring` structure, but `QuiverRepresentation` only assumes `AddCommMonoid`
-and `CommSemiring`. A full implementation would either:
-1. Strengthen the `QuiverRepresentation` definition to use `AddCommGroup`, or
-2. Add `[Ring k]` and `[∀ v, AddCommGroup (ρ.obj v)]` hypotheses here.
-This is tracked as a design issue for the reflection functor definitions.
+The cokernel construction (quotient module) requires `AddCommGroup` and `Ring`
+structure. The definition requires `[CommRing k]` and constructs compatible
+`AddCommGroup` instances internally using scalar multiplication by `-1`.
 -/
 
 /-- The type indexing the direct sum for F⁻ᵢ: pairs (j, h) where h : i ⟶ j is an arrow
 out of the source vertex i. -/
 def Etingof.ArrowsOutOf (V : Type*) [Quiver V] (i : V) :=
   Σ (j : V), (i ⟶ j)
+
+/-- Over a commutative ring, any `AddCommMonoid` module is actually an `AddCommGroup`,
+with negation given by scalar multiplication by `-1`. The resulting `AddCommGroup`
+extends the existing `AddCommMonoid` — no diamond.
+
+This is the same construction as `addCommGroupOfField` (Proposition 6.6.5) but
+generalized to `CommRing`. -/
+private noncomputable def Etingof.addCommGroupOfRing {k : Type*} [CommRing k] {M : Type*}
+    [inst : AddCommMonoid M] [Module k M] : AddCommGroup M :=
+  { inst with
+    neg := fun x => (-1 : k) • x
+    zsmul := fun n x => (n : k) • x
+    neg_add_cancel := fun a => by
+      change (-1 : k) • a + a = 0
+      nth_rw 2 [show a = (1 : k) • a from (one_smul k a).symm]
+      rw [← add_smul, neg_add_cancel, zero_smul]
+    zsmul_zero' := fun a => by simp [zero_smul]
+    zsmul_succ' := fun n a => by
+      simp only [Nat.succ_eq_add_one, Nat.cast_add, Nat.cast_one,
+                  Int.cast_add, Int.cast_natCast, Int.cast_one, add_smul, one_smul]
+    zsmul_neg' := fun n a => by
+      simp only [Int.negSucc_eq, Nat.succ_eq_add_one, Nat.cast_add, Nat.cast_one,
+                  Int.cast_neg, smul_smul, neg_one_mul] }
 
 /-- The reflection functor F⁻ᵢ at a source vertex i, sending representations of Q
 to representations of Q̄ᵢ (the quiver with arrows at i reversed).
@@ -46,31 +67,80 @@ The linear maps in the reversed quiver Q̄ᵢ are:
 
 (Etingof Definition 6.6.4) -/
 noncomputable def Etingof.reflectionFunctorMinus
-    {k : Type*} [CommSemiring k]
-    (V : Type*) [DecidableEq V] [Quiver V]
+    {k : Type*} [CommRing k]
+    (V : Type*) [inst : DecidableEq V] [Quiver V]
     (i : V) (hi : Etingof.IsSource V i)
-    (ρ : Etingof.QuiverRepresentation k V) :
+    (ρ : Etingof.QuiverRepresentation k V)
+    [Fintype (Etingof.ArrowsOutOf V i)] :
     @Etingof.QuiverRepresentation k V _ (Etingof.reversedAtVertex V i) := by
   classical
-  -- The cokernel type at vertex i.
-  -- Mathematically: (⊕_{i→j} ρ_j) / Im(ψ) where ψ : ρ_i → ⊕_{i→j} ρ_j.
-  -- Requires AddCommGroup for quotient modules; QuiverRepresentation only has AddCommMonoid.
-  -- Using sorry as a placeholder for the cokernel type.
-  let CokerType : Type* := sorry
-  letI : AddCommMonoid CokerType := sorry
-  letI : Module k CokerType := sorry
-  -- The obj field: CokerType at vertex i, ρ.obj v elsewhere.
-  -- Same dependent type issues as F⁺ᵢ (Definition 6.6.3).
-  refine @Etingof.QuiverRepresentation.mk k V _ (Etingof.reversedAtVertex V i)
-    (fun v => if v = i then CokerType else ρ.obj v)
-    (fun v => by dsimp only; split <;> infer_instance)
-    (fun v => by exact sorry)
+  -- Upgrade vertex modules to AddCommGroup (extends existing AddCommMonoid, no diamond)
+  letI : ∀ v, AddCommGroup (ρ.obj v) := fun v => Etingof.addCommGroupOfRing (k := k)
+  -- The direct sum also gets AddCommGroup (extends its existing AddCommMonoid)
+  letI instACG_DS : AddCommGroup (DirectSum (Etingof.ArrowsOutOf V i) (fun a => ρ.obj a.1)) :=
+    Etingof.addCommGroupOfRing (k := k)
+  -- ψ : V_i → ⊕_{i→j} V_j, the canonical source map
+  let ψ : ρ.obj i →ₗ[k] DirectSum (Etingof.ArrowsOutOf V i) (fun a => ρ.obj a.1) :=
+    ∑ a : Etingof.ArrowsOutOf V i,
+      (DirectSum.lof k (Etingof.ArrowsOutOf V i) (fun a => ρ.obj a.1) a).comp (ρ.mapLinear a.2)
+  -- Cokernel type: (⊕_{i→j} V_j) / Im(ψ)
+  let CokerType := (DirectSum (Etingof.ArrowsOutOf V i) (fun a => ρ.obj a.1)) ⧸ LinearMap.range ψ
+  -- Use Decidable.casesOn with the [DecidableEq V] instance to construct
+  -- obj, AddCommMonoid, and Module coherently. All three fields share the same
+  -- Decidable instance, so the type-level case-split computes correctly.
+  let dp : ∀ v, Decidable (v = i) := fun v => inst v i
+  let objAt : ∀ v, Decidable (v = i) → Type _ :=
+    fun v d => @Decidable.casesOn _ (fun _ => Type _) d
+      (fun _ => ρ.obj v) (fun _ => CokerType)
+  let acmAt : ∀ v d, AddCommMonoid (objAt v d) :=
+    fun v d => @Decidable.casesOn _ (fun d => AddCommMonoid (objAt v d)) d
+      (fun _ => ρ.instAddCommMonoid v)
+      (fun _ => Submodule.Quotient.addCommGroup (p := LinearMap.range ψ) |>.toAddCommMonoid)
+  let modAt : ∀ v d, @Module k (objAt v d) _ (acmAt v d) :=
+    fun v d => @Decidable.casesOn _ (fun d => @Module k (objAt v d) _ (acmAt v d)) d
+      (fun _ => ρ.instModule v)
+      (fun _ => Submodule.Quotient.module (LinearMap.range ψ))
+  exact @Etingof.QuiverRepresentation.mk k V _ (Etingof.reversedAtVertex V i)
+    (fun v => objAt v (dp v))
+    (fun v => acmAt v (dp v))
+    (fun v => modAt v (dp v))
     (fun {a b} (e : Etingof.ReversedAtVertexHom V i a b) => by
-      dsimp only
-      -- Case split on whether a and b equal i:
-      -- Case a ≠ i, b ≠ i: arrow is (a ⟶ b) in Q, map is ρ.mapLinear e
-      -- Case a ≠ i, b = i: reversed arrow (i ⟶ a), map is ρ_a →ₗ ⊕ →ₗ coker(ψ)
-      --   via (Submodule.mkQ _).comp (DirectSum.lof k _ _ ⟨a, e⟩)
-      -- Case a = i, b ≠ i: arrow is (a ⟶ i) in Q; i is source, so vacuous
-      -- Case a = i, b = i: arrow is (i ⟶ i) in Q; i is source, so vacuous
-      exact sorry)
+      change Etingof.ReversedAtVertexHom V i a b at e
+      unfold Etingof.ReversedAtVertexHom at e
+      by_cases ha : a = i
+      · by_cases hb : b = i
+        · -- a = i, b = i: self-loop; vacuous since i is a source (no arrows into i)
+          simp only [ha, hb] at e; exact ((hi i).false e).elim
+        · -- a = i, b ≠ i: arrow b → i in Q; vacuous since i is a source
+          simp only [ha, hb, ite_true, ite_false] at e
+          exact ((hi b).false e).elim
+      · by_cases hb : b = i
+        · -- a ≠ i, b = i: reversed arrow (i ⟶ a in Q), map is ρ_a → ⊕ → coker(ψ)
+          simp only [ha, hb, ite_false, ite_true] at e
+          -- Beta-reduce and generalize to make Decidable.casesOn reduce
+          change objAt a (dp a) →ₗ[k] objAt b (dp b)
+          revert e
+          generalize dp a = da; generalize dp b = db
+          cases da with
+          | isTrue h => exact absurd h ha
+          | isFalse _ =>
+            cases db with
+            | isFalse h => exact absurd hb h
+            | isTrue _ =>
+              intro e
+              exact (Submodule.mkQ (LinearMap.range ψ)).comp
+                (DirectSum.lof k (Etingof.ArrowsOutOf V i)
+                  (fun a => ρ.obj a.1) ⟨a, e⟩)
+        · -- a ≠ i, b ≠ i: unchanged arrow
+          simp only [ha, hb] at e
+          change objAt a (dp a) →ₗ[k] objAt b (dp b)
+          revert e
+          generalize dp a = da; generalize dp b = db
+          cases da with
+          | isTrue h => exact absurd h ha
+          | isFalse _ =>
+            cases db with
+            | isTrue h => exact absurd h hb
+            | isFalse _ =>
+              intro e
+              exact ρ.mapLinear e)

--- a/EtingofRepresentationTheory/Chapter6/Proposition6_6_6.lean
+++ b/EtingofRepresentationTheory/Chapter6/Proposition6_6_6.lean
@@ -121,17 +121,16 @@ theorem Etingof.Proposition6_6_6_sink
     {i : Q} (hi : Etingof.IsSink Q i)
     (ρ : Etingof.QuiverRepresentation k Q)
     [∀ v, Module.Free k (ρ.obj v)] [∀ v, Module.Finite k (ρ.obj v)]
+    [Fintype (@Etingof.ArrowsOutOf Q (Etingof.reversedAtVertex Q i) i)]
     (hsurj : Function.Surjective (ρ.sinkMap i)) :
     Nonempty (Etingof.QuiverRepresentation.Iso
       (Etingof.QuiverRepresentation.transportReversedTwice
         (@Etingof.reflectionFunctorMinus k _ Q _
           (Etingof.reversedAtVertex Q i) i
           (Etingof.isSink_reversedAtVertex_isSource hi)
-          (Etingof.reflectionFunctorPlus Q i hi ρ)))
+          (Etingof.reflectionFunctorPlus Q i hi ρ) _))
       ρ) := by
-  -- BLOCKED: reflectionFunctorMinus (Definition 6.6.4) has sorry'd CokerType.
-  -- The cokernel construction needs AddCommGroup which QuiverRepresentation doesn't provide.
-  -- Once Definition 6.6.4 is fully implemented, this proof should construct the Iso by:
+  -- Now that Definition 6.6.4 is implemented, this proof should construct the Iso by:
   --   - At vertex j ≠ i: identity equivalence (both F⁺ and F⁻ leave V_j unchanged)
   --   - At vertex i: first isomorphism theorem (coker(ker φ ↪ ⊕V_j) ≅ V_i when φ surjective)
   sorry
@@ -159,8 +158,7 @@ theorem Etingof.Proposition6_6_6_source
           (Etingof.isSource_reversedAtVertex_isSink hi)
           (Etingof.reflectionFunctorMinus Q i hi ρ)))
       ρ) := by
-  -- BLOCKED: reflectionFunctorMinus (Definition 6.6.4) has sorry'd CokerType.
-  -- Once Definition 6.6.4 is fully implemented, this proof should construct the Iso by:
+  -- Now that Definition 6.6.4 is implemented, this proof should construct the Iso by:
   --   - At vertex j ≠ i: identity equivalence
   --   - At vertex i: dual of sink case (ker of map from ⊕V_j to coker(ψ) ≅ V_i when ψ injective)
   sorry

--- a/EtingofRepresentationTheory/Chapter6/Proposition6_6_7.lean
+++ b/EtingofRepresentationTheory/Chapter6/Proposition6_6_7.lean
@@ -220,6 +220,7 @@ theorem Etingof.Proposition6_6_7_source
     {i : Q} (hi : Etingof.IsSource Q i)
     (ρ : Etingof.QuiverRepresentation k Q)
     [∀ v, Module.Free k (ρ.obj v)] [∀ v, Module.Finite k (ρ.obj v)]
+    [Fintype (Etingof.ArrowsOutOf Q i)]
     (hρ : ρ.IsIndecomposable) :
     @Etingof.QuiverRepresentation.IsIndecomposable k _ Q
       (Etingof.reversedAtVertex Q i)

--- a/progress/20260318T200000Z_6cb446f9.md
+++ b/progress/20260318T200000Z_6cb446f9.md
@@ -1,0 +1,39 @@
+## Accomplished
+
+Completed issue #949: Definition 6.6.4 (reflectionFunctorMinus cokernel) — fully implemented with no sorries.
+
+1. **Implemented `reflectionFunctorMinus`** — the reflection functor F⁻ᵢ at a source vertex, using cokernel (quotient module) construction.
+   - Added `Etingof.addCommGroupOfRing` helper to construct `AddCommGroup` from `[CommRing k] [AddCommMonoid M] [Module k M]`, extending the existing `AddCommMonoid` to avoid diamond issues.
+   - Defined the source map ψ : V_i → ⊕_{i→j} V_j inline as a finite sum of `DirectSum.lof ∘ mapLinear`.
+   - Defined `CokerType` as `(⊕ V_j) ⧸ LinearMap.range ψ` using Mathlib's quotient module API.
+   - Used `Decidable.casesOn` pattern (matching Definition 6.6.3) for coherent dependent type handling.
+   - Implemented all 4 arrow cases: vacuous (a=i,b=i), vacuous (a=i,b≠i), reversed arrow via `mkQ ∘ lof` (a≠i,b=i), unchanged (a≠i,b≠i).
+
+2. **Updated callers** to accommodate new signature (`[CommRing k]`, `[Fintype (ArrowsOutOf V i)]`):
+   - Proposition 6.6.6: Added `[Fintype (@ArrowsOutOf Q (reversedAtVertex Q i) i)]` and explicit `_` for Fintype in `@` call.
+   - Proposition 6.6.7: Added `[Fintype (ArrowsOutOf Q i)]` to source version.
+   - Proposition 6.6.8: Already had `[Fintype (ArrowsOutOf V i)]`, no changes needed.
+   - Proposition 6.6.5: No changes needed (doesn't call reflectionFunctorMinus).
+
+3. **All of Chapter 6 builds successfully** — 8060 jobs, no errors.
+
+## Current frontier
+
+Definition 6.6.4 is sorry-free. The downstream proofs (Propositions 6.6.6, 6.6.7, 6.6.8) still have `sorry` but their statements now typecheck against the real definition.
+
+## Overall project progress
+
+Stage 3.2 proof filling: ~183/583 items sorry_free (~31.4%). Definition 6.6.4 was the critical blocker for the F⁻ᵢ side of reflection functor theory. Its completion unblocks:
+- Proposition 6.6.6 (reflection functor inverse) — issue #919
+- Proposition 6.6.7 (preserves indecomposability)
+- The entire Gabriel's theorem proof chain (§6.7-6.8)
+
+## Next step
+
+1. Prove Proposition 6.6.6 (issue #919) — now unblocked by Definition 6.6.4
+2. Continue Ch6 proof work: Propositions 6.6.7, 6.6.8 (source versions)
+3. Formalize Ch5 §5.21 statements (issue #946) and Ch6 §6.8 statements (issue #948)
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -65,7 +65,7 @@
   {
     "id": "Chapter2/Introduction",
     "type": "introduction",
-    "title": "Chapter 2: Basic notions of representation theory — chapter heading and Section 2.1 heading",
+    "title": "Chapter 2: Basic notions of representation theory \u2014 chapter heading and Section 2.1 heading",
     "start_page": "5",
     "end_page": "5",
     "start_line": 1,
@@ -451,7 +451,7 @@
   {
     "id": "Chapter2/Discussion_2.4_heading",
     "type": "discussion",
-    "title": "Section 2.4 Ideals — heading and definitions",
+    "title": "Section 2.4 Ideals \u2014 heading and definitions",
     "start_page": "15",
     "end_page": "15",
     "start_line": 2,
@@ -469,7 +469,7 @@
   {
     "id": "Chapter2/Discussion_2.5_heading",
     "type": "discussion",
-    "title": "Section 2.5 Quotients — heading and definition of quotient algebra",
+    "title": "Section 2.5 Quotients \u2014 heading and definition of quotient algebra",
     "start_page": "15",
     "end_page": "15",
     "start_line": 16,
@@ -514,7 +514,7 @@
   {
     "id": "Chapter2/Discussion_2.7_intro",
     "type": "discussion",
-    "title": "Section 2.7: Examples of algebras — Weyl algebra and q-Weyl algebra",
+    "title": "Section 2.7: Examples of algebras \u2014 Weyl algebra and q-Weyl algebra",
     "start_page": "17",
     "end_page": "17",
     "start_line": 5,
@@ -724,7 +724,7 @@
   {
     "id": "Chapter2/Discussion_2.9_heading",
     "type": "discussion",
-    "title": "Section 2.9: Lie algebras — heading and skew-symmetric bilinear map",
+    "title": "Section 2.9: Lie algebras \u2014 heading and skew-symmetric bilinear map",
     "start_page": "22",
     "end_page": "22",
     "start_line": 12,
@@ -904,7 +904,7 @@
   {
     "id": "Chapter2/Discussion_2.10_heading",
     "type": "discussion",
-    "title": "Section 2.10: Historical interlude — Sophus Lie's trials and transformations",
+    "title": "Section 2.10: Historical interlude \u2014 Sophus Lie's trials and transformations",
     "start_page": "26",
     "end_page": "30",
     "start_line": 7,
@@ -922,7 +922,7 @@
   {
     "id": "Chapter2/Discussion_2.11_heading",
     "type": "discussion",
-    "title": "Section 2.11: Tensor products — heading and introduction",
+    "title": "Section 2.11: Tensor products \u2014 heading and introduction",
     "start_page": "31",
     "end_page": "31",
     "start_line": 3,
@@ -1022,7 +1022,7 @@
   {
     "id": "Chapter2/Discussion_2.12_heading",
     "type": "discussion",
-    "title": "Section 2.12: The tensor algebra — heading and introduction",
+    "title": "Section 2.12: The tensor algebra \u2014 heading and introduction",
     "start_page": "35",
     "end_page": "35",
     "start_line": 27,
@@ -1041,7 +1041,7 @@
   {
     "id": "Chapter2/Discussion_2.13_heading",
     "type": "discussion",
-    "title": "Section 2.13: Hilbert's third problem — heading",
+    "title": "Section 2.13: Hilbert's third problem \u2014 heading",
     "start_page": "36",
     "end_page": "36",
     "start_line": 17,
@@ -1059,7 +1059,7 @@
   {
     "id": "Chapter2/Discussion_2.14_heading",
     "type": "discussion",
-    "title": "Section 2.14: Tensor products and duals of representations of Lie algebras — heading",
+    "title": "Section 2.14: Tensor products and duals of representations of Lie algebras \u2014 heading",
     "start_page": "37",
     "end_page": "37",
     "start_line": 9,
@@ -1097,7 +1097,7 @@
   {
     "id": "Chapter2/Discussion_2.15_heading",
     "type": "discussion",
-    "title": "Section 2.15: Representations of sl(2) — heading and introduction",
+    "title": "Section 2.15: Representations of sl(2) \u2014 heading and introduction",
     "start_page": "37",
     "end_page": "37",
     "start_line": 21,
@@ -1115,7 +1115,7 @@
   {
     "id": "Chapter2/Discussion_2.16_heading",
     "type": "discussion",
-    "title": "Section 2.16: Problems on Lie algebras — heading",
+    "title": "Section 2.16: Problems on Lie algebras \u2014 heading",
     "start_page": "39",
     "end_page": "39",
     "start_line": 17,
@@ -1169,7 +1169,7 @@
   {
     "id": "Chapter3/Introduction",
     "type": "introduction",
-    "title": "Chapter 3: General results of representation theory — introduction and Section 3.1 heading",
+    "title": "Chapter 3: General results of representation theory \u2014 introduction and Section 3.1 heading",
     "start_page": "43",
     "end_page": "43",
     "start_line": 1,
@@ -1263,7 +1263,7 @@
   {
     "id": "Chapter3/Introduction_to_3.2",
     "type": "introduction",
-    "title": "Section 3.2: The density theorem — heading and setup",
+    "title": "Section 3.2: The density theorem \u2014 heading and setup",
     "start_page": "45",
     "end_page": "45",
     "start_line": 23,
@@ -1293,7 +1293,7 @@
   {
     "id": "Chapter3/Introduction_to_3.3",
     "type": "introduction",
-    "title": "Section 3.3: Representations of direct sums of matrix algebras — heading and setup",
+    "title": "Section 3.3: Representations of direct sums of matrix algebras \u2014 heading and setup",
     "start_page": "47",
     "end_page": "47",
     "start_line": 1,
@@ -1358,7 +1358,7 @@
   {
     "id": "Chapter3/Introduction_to_3.4",
     "type": "introduction",
-    "title": "Section 3.4: Filtrations — heading and setup",
+    "title": "Section 3.4: Filtrations \u2014 heading and setup",
     "start_page": "49",
     "end_page": "49",
     "start_line": 3,
@@ -1387,7 +1387,7 @@
   {
     "id": "Chapter3/Introduction_to_3.5",
     "type": "introduction",
-    "title": "Section 3.5: Finite dimensional algebras — heading",
+    "title": "Section 3.5: Finite dimensional algebras \u2014 heading",
     "start_page": "49",
     "end_page": "49",
     "start_line": 13,
@@ -1476,7 +1476,7 @@
   {
     "id": "Chapter3/Introduction_to_3.6",
     "type": "introduction",
-    "title": "Section 3.6: Characters of representations — heading and character definition",
+    "title": "Section 3.6: Characters of representations \u2014 heading and character definition",
     "start_page": "52",
     "end_page": "52",
     "start_line": 3,
@@ -1505,7 +1505,7 @@
   {
     "id": "Chapter3/Introduction_to_3.7",
     "type": "introduction",
-    "title": "Section 3.7: The Jordan-Holder theorem — heading and overview",
+    "title": "Section 3.7: The Jordan-Holder theorem \u2014 heading and overview",
     "start_page": "53",
     "end_page": "53",
     "start_line": 3,
@@ -1533,7 +1533,7 @@
   {
     "id": "Chapter3/Introduction_to_3.8",
     "type": "introduction",
-    "title": "Section 3.8: The Krull-Schmidt theorem — heading",
+    "title": "Section 3.8: The Krull-Schmidt theorem \u2014 heading",
     "start_page": "54",
     "end_page": "54",
     "start_line": 9,
@@ -1608,7 +1608,7 @@
   {
     "id": "Chapter3/Introduction_to_3.9",
     "type": "introduction",
-    "title": "Section 3.9: Problems — heading",
+    "title": "Section 3.9: Problems \u2014 heading",
     "start_page": "56",
     "end_page": "56",
     "start_line": 13,
@@ -1662,7 +1662,7 @@
   {
     "id": "Chapter3/Introduction_to_3.10",
     "type": "introduction",
-    "title": "Section 3.10: Representations of tensor products — heading and setup",
+    "title": "Section 3.10: Representations of tensor products \u2014 heading and setup",
     "start_page": "59",
     "end_page": "59",
     "start_line": 5,
@@ -1718,7 +1718,7 @@
   {
     "id": "Chapter4/Introduction",
     "type": "introduction",
-    "title": "Chapter 4: Representations of finite groups: Basic results — introduction and Section 4.1 heading",
+    "title": "Chapter 4: Representations of finite groups: Basic results \u2014 introduction and Section 4.1 heading",
     "start_page": "61",
     "end_page": "61",
     "start_line": 1,
@@ -1892,7 +1892,7 @@
   {
     "id": "Chapter4/Introduction_4.5",
     "type": "introduction",
-    "title": "Section 4.5: Orthogonality of characters — Hermitian inner product on class functions",
+    "title": "Section 4.5: Orthogonality of characters \u2014 Hermitian inner product on class functions",
     "start_page": "67",
     "end_page": "68",
     "start_line": 25,
@@ -2051,7 +2051,7 @@
   {
     "id": "Chapter4/Introduction_4.8",
     "type": "introduction",
-    "title": "Section 4.8: Character tables — definition and examples of S_3, A_4",
+    "title": "Section 4.8: Character tables \u2014 definition and examples of S_3, A_4",
     "start_page": "73",
     "end_page": "74",
     "start_line": 25,
@@ -2089,7 +2089,7 @@
   {
     "id": "Chapter4/Introduction_4.10",
     "type": "introduction",
-    "title": "Section 4.10: Frobenius determinant — group determinant setup",
+    "title": "Section 4.10: Frobenius determinant \u2014 group determinant setup",
     "start_page": "78",
     "end_page": "78",
     "start_line": 1,
@@ -2156,7 +2156,7 @@
   {
     "id": "Chapter4/Discussion_4.11",
     "type": "discussion",
-    "title": "Section 4.11: Historical interlude — Georg Frobenius's Principle of Horse Trade",
+    "title": "Section 4.11: Historical interlude \u2014 Georg Frobenius's Principle of Horse Trade",
     "start_page": "79",
     "end_page": "83",
     "start_line": 21,
@@ -2273,7 +2273,7 @@
   {
     "id": "Chapter4/Discussion_4.13",
     "type": "discussion",
-    "title": "Section 4.13: Historical interlude — William Rowan Hamilton's quaternion of geometry, algebra, metaphysics, and poetry",
+    "title": "Section 4.13: Historical interlude \u2014 William Rowan Hamilton's quaternion of geometry, algebra, metaphysics, and poetry",
     "start_page": "88",
     "end_page": "92",
     "start_line": 13,
@@ -2282,7 +2282,7 @@
   {
     "id": "Chapter5/Introduction",
     "type": "introduction",
-    "title": "Chapter 5: Representations of finite groups: Further results — introduction and Section 5.1 heading",
+    "title": "Chapter 5: Representations of finite groups: Further results \u2014 introduction and Section 5.1 heading",
     "start_page": "93",
     "end_page": "93",
     "start_line": 1,
@@ -2645,7 +2645,7 @@
   {
     "id": "Chapter5/Introduction_5.5",
     "type": "introduction",
-    "title": "Section 5.5: Historical interlude — William Burnside",
+    "title": "Section 5.5: Historical interlude \u2014 William Burnside",
     "start_page": "102",
     "end_page": "102",
     "start_line": 19,
@@ -2672,7 +2672,7 @@
   {
     "id": "Chapter5/Theorem5.6.1",
     "type": "theorem",
-    "title": "Irreducible representations of G x H are tensor products V_i ⊗ W_j",
+    "title": "Irreducible representations of G x H are tensor products V_i \u2297 W_j",
     "start_page": "107",
     "end_page": "107",
     "start_line": 3,
@@ -2720,7 +2720,7 @@
   {
     "id": "Chapter5/Introduction_5.8",
     "type": "introduction",
-    "title": "Section 5.8: Induced representations — restriction and induction",
+    "title": "Section 5.8: Induced representations \u2014 restriction and induction",
     "start_page": "107",
     "end_page": "107",
     "start_line": 17,
@@ -2766,7 +2766,7 @@
   {
     "id": "Chapter5/Problem5.8.4",
     "type": "exercise",
-    "title": "Transitivity of induction: Ind_H^G Ind_K^H V ≅ Ind_K^G V",
+    "title": "Transitivity of induction: Ind_H^G Ind_K^H V \u2245 Ind_K^G V",
     "start_page": "108",
     "end_page": "108",
     "start_line": 27,
@@ -2830,7 +2830,7 @@
   {
     "id": "Chapter5/Theorem5.10.1",
     "type": "theorem",
-    "title": "Frobenius reciprocity: Hom_G(V, Ind W) ≅ Hom_H(Res V, W)",
+    "title": "Frobenius reciprocity: Hom_G(V, Ind W) \u2245 Hom_H(Res V, W)",
     "start_page": "110",
     "end_page": "110",
     "start_line": 7,
@@ -2922,9 +2922,9 @@
     "status": "attention_needed",
     "needs_statement": false,
     "aristotle_target": "young_symmetrizer_sq_ne_zero",
-    "aristotle_note": "Aristotle failed: couldn't load file due to namespace/axiom issues. The proof that c_λ² ≠ 0 requires showing the identity permutation has nonzero coefficient in c_λ. Previous submissions: 366668f8 (import error), 9ebaca73 (load error).",
+    "aristotle_note": "Aristotle failed: couldn't load file due to namespace/axiom issues. The proof that c_\u03bb\u00b2 \u2260 0 requires showing the identity permutation has nonzero coefficient in c_\u03bb. Previous submissions: 366668f8 (import error), 9ebaca73 (load error).",
     "aristotle_project_id": "9ebaca73-b917-472d-89bd-23a45fe94a69",
-    "notes": "All Aristotle submissions failed with import/load errors. The proof that c_λ² ≠ 0 requires showing the identity permutation has nonzero coefficient in c_λ. Need manual proof work or self-contained re-submission."
+    "notes": "All Aristotle submissions failed with import/load errors. The proof that c_\u03bb\u00b2 \u2260 0 requires showing the identity permutation has nonzero coefficient in c_\u03bb. Need manual proof work or self-contained re-submission."
   },
   {
     "id": "Chapter5/Example5.12.3",
@@ -3021,7 +3021,7 @@
   {
     "id": "Chapter5/Lemma5.13.4",
     "type": "lemma",
-    "title": "Hom_A(Ae, M) ≅ eM for idempotent e (continues to missing page)",
+    "title": "Hom_A(Ae, M) \u2245 eM for idempotent e (continues to missing page)",
     "start_page": "115",
     "end_page": "115",
     "start_line": 13,
@@ -3280,7 +3280,7 @@
   {
     "id": "Chapter5/Introduction_5.18",
     "type": "introduction",
-    "title": "Section 5.18: Schur-Weyl duality for gl(V) — Double Centralizer Theorem",
+    "title": "Section 5.18: Schur-Weyl duality for gl(V) \u2014 Double Centralizer Theorem",
     "start_page": "122",
     "end_page": "122",
     "start_line": 17,
@@ -3302,7 +3302,7 @@
   {
     "id": "Chapter5/Discussion_before_Theorem5.18.2",
     "type": "discussion",
-    "title": "Application of Double Centralizer Theorem to V^{⊗n}",
+    "title": "Application of Double Centralizer Theorem to V^{\u2297n}",
     "start_page": "123",
     "end_page": "123",
     "start_line": 3,
@@ -3311,7 +3311,7 @@
   {
     "id": "Chapter5/Theorem5.18.2",
     "type": "theorem",
-    "title": "B is the image of U(gl(V)) acting on V^{⊗n}",
+    "title": "B is the image of U(gl(V)) acting on V^{\u2297n}",
     "start_page": "123",
     "end_page": "123",
     "start_line": 5,
@@ -3322,7 +3322,7 @@
   {
     "id": "Chapter5/Lemma5.18.3",
     "type": "lemma",
-    "title": "S^n U is spanned by u⊗...⊗u; S^n A is generated by Delta_n(a)",
+    "title": "S^n U is spanned by u\u2297...\u2297u; S^n A is generated by Delta_n(a)",
     "start_page": "123",
     "end_page": "123",
     "start_line": 15,
@@ -3351,7 +3351,7 @@
   {
     "id": "Chapter5/Theorem5.18.4",
     "type": "theorem",
-    "title": "Schur-Weyl duality: V^{⊗n} = ⊕ V_lambda ⊗ L_lambda",
+    "title": "Schur-Weyl duality: V^{\u2297n} = \u2295 V_lambda \u2297 L_lambda",
     "start_page": "124",
     "end_page": "124",
     "start_line": 5,
@@ -3377,7 +3377,7 @@
   {
     "id": "Chapter5/Proposition5.19.1",
     "type": "proposition",
-    "title": "Image of GL(V) in End(V^{⊗n}) spans B",
+    "title": "Image of GL(V) in End(V^{\u2297n}) spans B",
     "start_page": "124",
     "end_page": "124",
     "start_line": 21,
@@ -3399,7 +3399,7 @@
   {
     "id": "Chapter5/Example5.19.3",
     "type": "example",
-    "title": "L_lambda for partitions (n) and (1^n): S^nV and Λ^nV",
+    "title": "L_lambda for partitions (n) and (1^n): S^nV and \u039b^nV",
     "start_page": "125",
     "end_page": "125",
     "start_line": 3,
@@ -3410,7 +3410,7 @@
   {
     "id": "Chapter5/Introduction_5.20",
     "type": "introduction",
-    "title": "Section 5.20: Historical interlude — Hermann Weyl",
+    "title": "Section 5.20: Historical interlude \u2014 Hermann Weyl",
     "start_page": "125",
     "end_page": "125",
     "start_line": 5,
@@ -3515,7 +3515,7 @@
   {
     "id": "Chapter5/Proposition5.22.2",
     "type": "proposition",
-    "title": "L_{lambda+1^N} ≅ L_lambda ⊗ Λ^N V",
+    "title": "L_{lambda+1^N} \u2245 L_lambda \u2297 \u039b^N V",
     "start_page": "133",
     "end_page": "133",
     "start_line": 3,
@@ -3592,7 +3592,7 @@
   {
     "id": "Chapter5/Problem5.24.1",
     "type": "exercise",
-    "title": "V'_lambda ≅ V_lambda and V_lambda ⊗ C_- = V_{lambda*}",
+    "title": "V'_lambda \u2245 V_lambda and V_lambda \u2297 C_- = V_{lambda*}",
     "start_page": "135",
     "end_page": "135",
     "start_line": 3,
@@ -3648,7 +3648,7 @@
   {
     "id": "Chapter5/Discussion_1dim_reps",
     "type": "discussion",
-    "title": "G/[G,G] ≅ F_q^× and description of 1-dimensional representations C_xi",
+    "title": "G/[G,G] \u2245 F_q^\u00d7 and description of 1-dimensional representations C_xi",
     "start_page": "138",
     "end_page": "138",
     "start_line": 21,
@@ -3657,7 +3657,7 @@
   {
     "id": "Chapter5/Discussion_5.25.3",
     "type": "discussion",
-    "title": "Section 5.25.3: Principal series representations — setup of B, V_{lambda_1,lambda_2}",
+    "title": "Section 5.25.3: Principal series representations \u2014 setup of B, V_{lambda_1,lambda_2}",
     "start_page": "138",
     "end_page": "139",
     "start_line": 41,
@@ -3686,7 +3686,7 @@
   {
     "id": "Chapter5/Discussion_5.25.4",
     "type": "discussion",
-    "title": "Section 5.25.4: Complementary series representations — setup and character computation",
+    "title": "Section 5.25.4: Complementary series representations \u2014 setup and character computation",
     "start_page": "141",
     "end_page": "143",
     "start_line": 37,
@@ -3782,7 +3782,7 @@
   {
     "id": "Chapter5/Theorem5.27.1",
     "type": "theorem",
-    "title": "Classification of irreducible representations of semidirect products G ⋉ A",
+    "title": "Classification of irreducible representations of semidirect products G \u22c9 A",
     "start_page": "146",
     "end_page": "147",
     "start_line": 11,
@@ -4247,7 +4247,7 @@
     "end_page": "169",
     "start_line": 3,
     "end_line": 26,
-    "status": "proof_formalized"
+    "status": "sorry_free"
   },
   {
     "id": "Chapter6/Proposition6.6.5",
@@ -4878,7 +4878,7 @@
   {
     "id": "Chapter7/Problem7.8.7",
     "type": "exercise",
-    "title": "Tensor product of complexes and Künneth formula",
+    "title": "Tensor product of complexes and K\u00fcnneth formula",
     "start_page": "193",
     "end_page": "194",
     "start_line": 23,


### PR DESCRIPTION
## Summary
- Implement the reflection functor F⁻ᵢ at a source vertex using cokernel (quotient module) construction
- Add `addCommGroupOfRing` helper to construct `AddCommGroup` from `CommRing + Module`, extending existing `AddCommMonoid` to avoid instance diamonds
- Define `CokerType` as `(⊕ V_j) ⧸ LinearMap.range ψ` using Mathlib's quotient module API
- Update callers (Propositions 6.6.6, 6.6.7) with necessary `Fintype` hypotheses

This was the critical blocker for the F⁻ᵢ side of the reflection functor theory, unblocking Proposition 6.6.6 (#919), Proposition 6.6.7, and the Gabriel's theorem proof chain (§6.7-6.8).

Closes #949

🤖 Prepared with Claude Code