### PR TITLE
## Summary
- Formalize `IsAlgebraicRepresentation` (Definition 5.23.1): a representation ρ of GL_n(k) is algebraic if its matrix coefficients (w.r.t. some basis) are polynomial functions of the matrix entries g_ij and det(g)^{-1}
- Define helper types `GLCoordVars` and `evalAtGL` for the coordinate ring infrastructure
- Corollary 5.19.2 and Example 5.19.3 were already formalized — confirmed they build cleanly
- Also closes #961 (§5.18-5.19 statements were already formalized)

## Verification
- `lake build EtingofRepresentationTheory.Chapter5.Definition5_23_1` — clean (no errors, no warnings)
- `lake build EtingofRepresentationTheory.Chapter5.Corollary5_19_2` — only `sorry` warnings
- `lake build EtingofRepresentationTheory.Chapter5.Example5_19_3` — only `sorry` warnings
- `progress/items.json` updated: Definition5.23.1 → `statement_formalized`

Closes #963

🤖 Prepared with Claude Code

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Definition5_23_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Definition5_23_1.lean
@@ -9,18 +9,43 @@ of g, g⁻¹, for g ∈ GL(V) — i.e., belong to k[gᵢⱼ][1/det(g)].
 
 ## Mathlib correspondence
 
-Not in Mathlib. Needs to be defined from scratch. Related to the regular
-representation on the coordinate ring of GL_n.
+- `Matrix.GeneralLinearGroup (Fin n) k` for GL_n(k)
+- `MvPolynomial` for multivariate polynomials over k
+- `Basis.repr` for matrix coefficients of the representation
 -/
 
-/-- A representation of GL(V) is algebraic if its matrix elements are
-polynomial functions of the matrix entries and 1/det.
-(Etingof Definition 5.23.1)
+/-- The type of variables for the coordinate ring of GL_n:
+matrix entries (Fin n × Fin n) together with one extra variable
+representing 1/det(g). -/
+abbrev Etingof.GLCoordVars (n : ℕ) := (Fin n × Fin n) ⊕ Unit
 
-TODO: Define properly once GL_n coordinate ring infrastructure exists. -/
+/-- Evaluate a polynomial in `k[Xᵢⱼ, D]` at a matrix g ∈ GL_n(k),
+substituting Xᵢⱼ ↦ gᵢⱼ and D ↦ det(g)⁻¹. -/
+noncomputable def Etingof.evalAtGL {k : Type*} [Field k] {n : ℕ}
+    (g : Matrix.GeneralLinearGroup (Fin n) k)
+    (p : MvPolynomial (Etingof.GLCoordVars n) k) : k :=
+  MvPolynomial.eval
+    (Sum.elim (fun ij : Fin n × Fin n => (g : Matrix (Fin n) (Fin n) k) ij.1 ij.2)
+              (fun _ => ((g : Matrix (Fin n) (Fin n) k).det)⁻¹))
+    p
+
+/-- A finite-dimensional representation ρ of GL_n(k) on Y is **algebraic**
+(also called rational or polynomial) if there exists a basis of Y such that
+all matrix coefficients of ρ(g) are polynomial functions of the matrix entries
+gᵢⱼ and det(g)⁻¹.
+
+Concretely: there exist polynomials Pₐ_c ∈ k[Xᵢⱼ, D] (where Xᵢⱼ are
+variables for the n² matrix entries and D represents 1/det) such that
+for all g ∈ GL_n(k), the (a,c)-th matrix coefficient of ρ(g) equals
+Pₐ_c(gᵢⱼ, det(g)⁻¹).
+
+(Etingof Definition 5.23.1) -/
 def Etingof.IsAlgebraicRepresentation
     {k : Type*} [Field k]
     (n : ℕ)
     {Y : Type*} [AddCommGroup Y] [Module k Y] [Module.Finite k Y]
-    (ρ : (Matrix.GeneralLinearGroup (Fin n) k) → Y →ₗ[k] Y) : Prop :=
-  sorry
+    (ρ : Matrix.GeneralLinearGroup (Fin n) k → Y →ₗ[k] Y) : Prop :=
+  ∃ (m : ℕ) (b : Module.Basis (Fin m) k Y)
+    (P : Fin m → Fin m → MvPolynomial (Etingof.GLCoordVars n) k),
+    ∀ (g : Matrix.GeneralLinearGroup (Fin n) k) (a c : Fin m),
+      b.repr (ρ g (b c)) a = Etingof.evalAtGL g (P a c)

--- a/progress/2026-03-17T15-23-05Z.md
+++ b/progress/2026-03-17T15-23-05Z.md
@@ -1,0 +1,27 @@
+## Accomplished
+
+1. Claimed issue #963 (formalize §5.19-5.23 statements)
+2. Found that Corollary 5.19.2 and Example 5.19.3 were already properly formalized (not `sorry : Prop` placeholders)
+3. Formalized Definition 5.23.1 (IsAlgebraicRepresentation):
+   - Defined `GLCoordVars n` as `(Fin n × Fin n) ⊕ Unit` for the coordinate ring variables
+   - Defined `evalAtGL` to evaluate polynomials at a GL_n element (substituting matrix entries and det⁻¹)
+   - Stated `IsAlgebraicRepresentation`: ρ is algebraic iff there exist basis + polynomials P_{a,c} ∈ k[X_{ij}, D] such that matrix coefficients equal P evaluated at (g_{ij}, det(g)⁻¹)
+4. All three files build cleanly (only `sorry` warnings for proofs)
+5. Also closed issue #961 (§5.18-5.19 statements) — all three items were already formalized
+
+## Current frontier
+
+Issue #963 complete. PR ready to create.
+
+## Overall project progress
+
+Stage 3.2 proof filling in progress. ~182/583 items sorry_free (31.2%). Chapter 5 statement formalization nearly complete — Definition 5.23.1 was the last remaining `sorry : Prop` placeholder in the §5.19-5.23 range.
+
+## Next step
+
+1. Create PR for #963 and enable auto-merge
+2. Tackle remaining unclaimed issues: #962 (Ch6 Gabriel theorem chain), #945 (Aristotle poll), #834 (Theorem 5.12.2 part 2)
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -65,7 +65,7 @@
   {
     "id": "Chapter2/Introduction",
     "type": "introduction",
-    "title": "Chapter 2: Basic notions of representation theory — chapter heading and Section 2.1 heading",
+    "title": "Chapter 2: Basic notions of representation theory \u2014 chapter heading and Section 2.1 heading",
     "start_page": "5",
     "end_page": "5",
     "start_line": 1,
@@ -451,7 +451,7 @@
   {
     "id": "Chapter2/Discussion_2.4_heading",
     "type": "discussion",
-    "title": "Section 2.4 Ideals — heading and definitions",
+    "title": "Section 2.4 Ideals \u2014 heading and definitions",
     "start_page": "15",
     "end_page": "15",
     "start_line": 2,
@@ -469,7 +469,7 @@
   {
     "id": "Chapter2/Discussion_2.5_heading",
     "type": "discussion",
-    "title": "Section 2.5 Quotients — heading and definition of quotient algebra",
+    "title": "Section 2.5 Quotients \u2014 heading and definition of quotient algebra",
     "start_page": "15",
     "end_page": "15",
     "start_line": 16,
@@ -514,7 +514,7 @@
   {
     "id": "Chapter2/Discussion_2.7_intro",
     "type": "discussion",
-    "title": "Section 2.7: Examples of algebras — Weyl algebra and q-Weyl algebra",
+    "title": "Section 2.7: Examples of algebras \u2014 Weyl algebra and q-Weyl algebra",
     "start_page": "17",
     "end_page": "17",
     "start_line": 5,
@@ -724,7 +724,7 @@
   {
     "id": "Chapter2/Discussion_2.9_heading",
     "type": "discussion",
-    "title": "Section 2.9: Lie algebras — heading and skew-symmetric bilinear map",
+    "title": "Section 2.9: Lie algebras \u2014 heading and skew-symmetric bilinear map",
     "start_page": "22",
     "end_page": "22",
     "start_line": 12,
@@ -904,7 +904,7 @@
   {
     "id": "Chapter2/Discussion_2.10_heading",
     "type": "discussion",
-    "title": "Section 2.10: Historical interlude — Sophus Lie's trials and transformations",
+    "title": "Section 2.10: Historical interlude \u2014 Sophus Lie's trials and transformations",
     "start_page": "26",
     "end_page": "30",
     "start_line": 7,
@@ -922,7 +922,7 @@
   {
     "id": "Chapter2/Discussion_2.11_heading",
     "type": "discussion",
-    "title": "Section 2.11: Tensor products — heading and introduction",
+    "title": "Section 2.11: Tensor products \u2014 heading and introduction",
     "start_page": "31",
     "end_page": "31",
     "start_line": 3,
@@ -1022,7 +1022,7 @@
   {
     "id": "Chapter2/Discussion_2.12_heading",
     "type": "discussion",
-    "title": "Section 2.12: The tensor algebra — heading and introduction",
+    "title": "Section 2.12: The tensor algebra \u2014 heading and introduction",
     "start_page": "35",
     "end_page": "35",
     "start_line": 27,
@@ -1041,7 +1041,7 @@
   {
     "id": "Chapter2/Discussion_2.13_heading",
     "type": "discussion",
-    "title": "Section 2.13: Hilbert's third problem — heading",
+    "title": "Section 2.13: Hilbert's third problem \u2014 heading",
     "start_page": "36",
     "end_page": "36",
     "start_line": 17,
@@ -1059,7 +1059,7 @@
   {
     "id": "Chapter2/Discussion_2.14_heading",
     "type": "discussion",
-    "title": "Section 2.14: Tensor products and duals of representations of Lie algebras — heading",
+    "title": "Section 2.14: Tensor products and duals of representations of Lie algebras \u2014 heading",
     "start_page": "37",
     "end_page": "37",
     "start_line": 9,
@@ -1097,7 +1097,7 @@
   {
     "id": "Chapter2/Discussion_2.15_heading",
     "type": "discussion",
-    "title": "Section 2.15: Representations of sl(2) — heading and introduction",
+    "title": "Section 2.15: Representations of sl(2) \u2014 heading and introduction",
     "start_page": "37",
     "end_page": "37",
     "start_line": 21,
@@ -1115,7 +1115,7 @@
   {
     "id": "Chapter2/Discussion_2.16_heading",
     "type": "discussion",
-    "title": "Section 2.16: Problems on Lie algebras — heading",
+    "title": "Section 2.16: Problems on Lie algebras \u2014 heading",
     "start_page": "39",
     "end_page": "39",
     "start_line": 17,
@@ -1169,7 +1169,7 @@
   {
     "id": "Chapter3/Introduction",
     "type": "introduction",
-    "title": "Chapter 3: General results of representation theory — introduction and Section 3.1 heading",
+    "title": "Chapter 3: General results of representation theory \u2014 introduction and Section 3.1 heading",
     "start_page": "43",
     "end_page": "43",
     "start_line": 1,
@@ -1263,7 +1263,7 @@
   {
     "id": "Chapter3/Introduction_to_3.2",
     "type": "introduction",
-    "title": "Section 3.2: The density theorem — heading and setup",
+    "title": "Section 3.2: The density theorem \u2014 heading and setup",
     "start_page": "45",
     "end_page": "45",
     "start_line": 23,
@@ -1293,7 +1293,7 @@
   {
     "id": "Chapter3/Introduction_to_3.3",
     "type": "introduction",
-    "title": "Section 3.3: Representations of direct sums of matrix algebras — heading and setup",
+    "title": "Section 3.3: Representations of direct sums of matrix algebras \u2014 heading and setup",
     "start_page": "47",
     "end_page": "47",
     "start_line": 1,
@@ -1358,7 +1358,7 @@
   {
     "id": "Chapter3/Introduction_to_3.4",
     "type": "introduction",
-    "title": "Section 3.4: Filtrations — heading and setup",
+    "title": "Section 3.4: Filtrations \u2014 heading and setup",
     "start_page": "49",
     "end_page": "49",
     "start_line": 3,
@@ -1387,7 +1387,7 @@
   {
     "id": "Chapter3/Introduction_to_3.5",
     "type": "introduction",
-    "title": "Section 3.5: Finite dimensional algebras — heading",
+    "title": "Section 3.5: Finite dimensional algebras \u2014 heading",
     "start_page": "49",
     "end_page": "49",
     "start_line": 13,
@@ -1476,7 +1476,7 @@
   {
     "id": "Chapter3/Introduction_to_3.6",
     "type": "introduction",
-    "title": "Section 3.6: Characters of representations — heading and character definition",
+    "title": "Section 3.6: Characters of representations \u2014 heading and character definition",
     "start_page": "52",
     "end_page": "52",
     "start_line": 3,
@@ -1505,7 +1505,7 @@
   {
     "id": "Chapter3/Introduction_to_3.7",
     "type": "introduction",
-    "title": "Section 3.7: The Jordan-Holder theorem — heading and overview",
+    "title": "Section 3.7: The Jordan-Holder theorem \u2014 heading and overview",
     "start_page": "53",
     "end_page": "53",
     "start_line": 3,
@@ -1533,7 +1533,7 @@
   {
     "id": "Chapter3/Introduction_to_3.8",
     "type": "introduction",
-    "title": "Section 3.8: The Krull-Schmidt theorem — heading",
+    "title": "Section 3.8: The Krull-Schmidt theorem \u2014 heading",
     "start_page": "54",
     "end_page": "54",
     "start_line": 9,
@@ -1608,7 +1608,7 @@
   {
     "id": "Chapter3/Introduction_to_3.9",
     "type": "introduction",
-    "title": "Section 3.9: Problems — heading",
+    "title": "Section 3.9: Problems \u2014 heading",
     "start_page": "56",
     "end_page": "56",
     "start_line": 13,
@@ -1662,7 +1662,7 @@
   {
     "id": "Chapter3/Introduction_to_3.10",
     "type": "introduction",
-    "title": "Section 3.10: Representations of tensor products — heading and setup",
+    "title": "Section 3.10: Representations of tensor products \u2014 heading and setup",
     "start_page": "59",
     "end_page": "59",
     "start_line": 5,
@@ -1718,7 +1718,7 @@
   {
     "id": "Chapter4/Introduction",
     "type": "introduction",
-    "title": "Chapter 4: Representations of finite groups: Basic results — introduction and Section 4.1 heading",
+    "title": "Chapter 4: Representations of finite groups: Basic results \u2014 introduction and Section 4.1 heading",
     "start_page": "61",
     "end_page": "61",
     "start_line": 1,
@@ -1892,7 +1892,7 @@
   {
     "id": "Chapter4/Introduction_4.5",
     "type": "introduction",
-    "title": "Section 4.5: Orthogonality of characters — Hermitian inner product on class functions",
+    "title": "Section 4.5: Orthogonality of characters \u2014 Hermitian inner product on class functions",
     "start_page": "67",
     "end_page": "68",
     "start_line": 25,
@@ -2051,7 +2051,7 @@
   {
     "id": "Chapter4/Introduction_4.8",
     "type": "introduction",
-    "title": "Section 4.8: Character tables — definition and examples of S_3, A_4",
+    "title": "Section 4.8: Character tables \u2014 definition and examples of S_3, A_4",
     "start_page": "73",
     "end_page": "74",
     "start_line": 25,
@@ -2089,7 +2089,7 @@
   {
     "id": "Chapter4/Introduction_4.10",
     "type": "introduction",
-    "title": "Section 4.10: Frobenius determinant — group determinant setup",
+    "title": "Section 4.10: Frobenius determinant \u2014 group determinant setup",
     "start_page": "78",
     "end_page": "78",
     "start_line": 1,
@@ -2156,7 +2156,7 @@
   {
     "id": "Chapter4/Discussion_4.11",
     "type": "discussion",
-    "title": "Section 4.11: Historical interlude — Georg Frobenius's Principle of Horse Trade",
+    "title": "Section 4.11: Historical interlude \u2014 Georg Frobenius's Principle of Horse Trade",
     "start_page": "79",
     "end_page": "83",
     "start_line": 21,
@@ -2273,7 +2273,7 @@
   {
     "id": "Chapter4/Discussion_4.13",
     "type": "discussion",
-    "title": "Section 4.13: Historical interlude — William Rowan Hamilton's quaternion of geometry, algebra, metaphysics, and poetry",
+    "title": "Section 4.13: Historical interlude \u2014 William Rowan Hamilton's quaternion of geometry, algebra, metaphysics, and poetry",
     "start_page": "88",
     "end_page": "92",
     "start_line": 13,
@@ -2282,7 +2282,7 @@
   {
     "id": "Chapter5/Introduction",
     "type": "introduction",
-    "title": "Chapter 5: Representations of finite groups: Further results — introduction and Section 5.1 heading",
+    "title": "Chapter 5: Representations of finite groups: Further results \u2014 introduction and Section 5.1 heading",
     "start_page": "93",
     "end_page": "93",
     "start_line": 1,
@@ -2645,7 +2645,7 @@
   {
     "id": "Chapter5/Introduction_5.5",
     "type": "introduction",
-    "title": "Section 5.5: Historical interlude — William Burnside",
+    "title": "Section 5.5: Historical interlude \u2014 William Burnside",
     "start_page": "102",
     "end_page": "102",
     "start_line": 19,
@@ -2672,7 +2672,7 @@
   {
     "id": "Chapter5/Theorem5.6.1",
     "type": "theorem",
-    "title": "Irreducible representations of G x H are tensor products V_i ⊗ W_j",
+    "title": "Irreducible representations of G x H are tensor products V_i \u2297 W_j",
     "start_page": "107",
     "end_page": "107",
     "start_line": 3,
@@ -2720,7 +2720,7 @@
   {
     "id": "Chapter5/Introduction_5.8",
     "type": "introduction",
-    "title": "Section 5.8: Induced representations — restriction and induction",
+    "title": "Section 5.8: Induced representations \u2014 restriction and induction",
     "start_page": "107",
     "end_page": "107",
     "start_line": 17,
@@ -2766,7 +2766,7 @@
   {
     "id": "Chapter5/Problem5.8.4",
     "type": "exercise",
-    "title": "Transitivity of induction: Ind_H^G Ind_K^H V ≅ Ind_K^G V",
+    "title": "Transitivity of induction: Ind_H^G Ind_K^H V \u2245 Ind_K^G V",
     "start_page": "108",
     "end_page": "108",
     "start_line": 27,
@@ -2830,7 +2830,7 @@
   {
     "id": "Chapter5/Theorem5.10.1",
     "type": "theorem",
-    "title": "Frobenius reciprocity: Hom_G(V, Ind W) ≅ Hom_H(Res V, W)",
+    "title": "Frobenius reciprocity: Hom_G(V, Ind W) \u2245 Hom_H(Res V, W)",
     "start_page": "110",
     "end_page": "110",
     "start_line": 7,
@@ -2922,9 +2922,9 @@
     "status": "attention_needed",
     "needs_statement": false,
     "aristotle_target": "young_symmetrizer_sq_ne_zero",
-    "aristotle_note": "Aristotle failed: couldn't load file due to namespace/axiom issues. The proof that c_λ² ≠ 0 requires showing the identity permutation has nonzero coefficient in c_λ. Previous submissions: 366668f8 (import error), 9ebaca73 (load error).",
+    "aristotle_note": "Aristotle failed: couldn't load file due to namespace/axiom issues. The proof that c_\u03bb\u00b2 \u2260 0 requires showing the identity permutation has nonzero coefficient in c_\u03bb. Previous submissions: 366668f8 (import error), 9ebaca73 (load error).",
     "aristotle_project_id": "9ebaca73-b917-472d-89bd-23a45fe94a69",
-    "notes": "All Aristotle submissions failed with import/load errors. The proof that c_λ² ≠ 0 requires showing the identity permutation has nonzero coefficient in c_λ. Need manual proof work or self-contained re-submission."
+    "notes": "All Aristotle submissions failed with import/load errors. The proof that c_\u03bb\u00b2 \u2260 0 requires showing the identity permutation has nonzero coefficient in c_\u03bb. Need manual proof work or self-contained re-submission."
   },
   {
     "id": "Chapter5/Example5.12.3",
@@ -3021,7 +3021,7 @@
   {
     "id": "Chapter5/Lemma5.13.4",
     "type": "lemma",
-    "title": "Hom_A(Ae, M) ≅ eM for idempotent e (continues to missing page)",
+    "title": "Hom_A(Ae, M) \u2245 eM for idempotent e (continues to missing page)",
     "start_page": "115",
     "end_page": "115",
     "start_line": 13,
@@ -3280,7 +3280,7 @@
   {
     "id": "Chapter5/Introduction_5.18",
     "type": "introduction",
-    "title": "Section 5.18: Schur-Weyl duality for gl(V) — Double Centralizer Theorem",
+    "title": "Section 5.18: Schur-Weyl duality for gl(V) \u2014 Double Centralizer Theorem",
     "start_page": "122",
     "end_page": "122",
     "start_line": 17,
@@ -3302,7 +3302,7 @@
   {
     "id": "Chapter5/Discussion_before_Theorem5.18.2",
     "type": "discussion",
-    "title": "Application of Double Centralizer Theorem to V^{⊗n}",
+    "title": "Application of Double Centralizer Theorem to V^{\u2297n}",
     "start_page": "123",
     "end_page": "123",
     "start_line": 3,
@@ -3311,7 +3311,7 @@
   {
     "id": "Chapter5/Theorem5.18.2",
     "type": "theorem",
-    "title": "B is the image of U(gl(V)) acting on V^{⊗n}",
+    "title": "B is the image of U(gl(V)) acting on V^{\u2297n}",
     "start_page": "123",
     "end_page": "123",
     "start_line": 5,
@@ -3322,7 +3322,7 @@
   {
     "id": "Chapter5/Lemma5.18.3",
     "type": "lemma",
-    "title": "S^n U is spanned by u⊗...⊗u; S^n A is generated by Delta_n(a)",
+    "title": "S^n U is spanned by u\u2297...\u2297u; S^n A is generated by Delta_n(a)",
     "start_page": "123",
     "end_page": "123",
     "start_line": 15,
@@ -3351,7 +3351,7 @@
   {
     "id": "Chapter5/Theorem5.18.4",
     "type": "theorem",
-    "title": "Schur-Weyl duality: V^{⊗n} = ⊕ V_lambda ⊗ L_lambda",
+    "title": "Schur-Weyl duality: V^{\u2297n} = \u2295 V_lambda \u2297 L_lambda",
     "start_page": "124",
     "end_page": "124",
     "start_line": 5,
@@ -3377,7 +3377,7 @@
   {
     "id": "Chapter5/Proposition5.19.1",
     "type": "proposition",
-    "title": "Image of GL(V) in End(V^{⊗n}) spans B",
+    "title": "Image of GL(V) in End(V^{\u2297n}) spans B",
     "start_page": "124",
     "end_page": "124",
     "start_line": 21,
@@ -3399,7 +3399,7 @@
   {
     "id": "Chapter5/Example5.19.3",
     "type": "example",
-    "title": "L_lambda for partitions (n) and (1^n): S^nV and Λ^nV",
+    "title": "L_lambda for partitions (n) and (1^n): S^nV and \u039b^nV",
     "start_page": "125",
     "end_page": "125",
     "start_line": 3,
@@ -3410,7 +3410,7 @@
   {
     "id": "Chapter5/Introduction_5.20",
     "type": "introduction",
-    "title": "Section 5.20: Historical interlude — Hermann Weyl",
+    "title": "Section 5.20: Historical interlude \u2014 Hermann Weyl",
     "start_page": "125",
     "end_page": "125",
     "start_line": 5,
@@ -3514,7 +3514,7 @@
   {
     "id": "Chapter5/Proposition5.22.2",
     "type": "proposition",
-    "title": "L_{lambda+1^N} ≅ L_lambda ⊗ Λ^N V",
+    "title": "L_{lambda+1^N} \u2245 L_lambda \u2297 \u039b^N V",
     "start_page": "133",
     "end_page": "133",
     "start_line": 3,
@@ -3538,7 +3538,8 @@
     "end_page": "133",
     "start_line": 9,
     "end_line": 10,
-    "status": "scaffolded"
+    "status": "statement_formalized",
+    "needs_statement": false
   },
   {
     "id": "Chapter5/Discussion_after_Definition5.23.1",
@@ -3590,7 +3591,7 @@
   {
     "id": "Chapter5/Problem5.24.1",
     "type": "exercise",
-    "title": "V'_lambda ≅ V_lambda and V_lambda ⊗ C_- = V_{lambda*}",
+    "title": "V'_lambda \u2245 V_lambda and V_lambda \u2297 C_- = V_{lambda*}",
     "start_page": "135",
     "end_page": "135",
     "start_line": 3,
@@ -3646,7 +3647,7 @@
   {
     "id": "Chapter5/Discussion_1dim_reps",
     "type": "discussion",
-    "title": "G/[G,G] ≅ F_q^× and description of 1-dimensional representations C_xi",
+    "title": "G/[G,G] \u2245 F_q^\u00d7 and description of 1-dimensional representations C_xi",
     "start_page": "138",
     "end_page": "138",
     "start_line": 21,
@@ -3655,7 +3656,7 @@
   {
     "id": "Chapter5/Discussion_5.25.3",
     "type": "discussion",
-    "title": "Section 5.25.3: Principal series representations — setup of B, V_{lambda_1,lambda_2}",
+    "title": "Section 5.25.3: Principal series representations \u2014 setup of B, V_{lambda_1,lambda_2}",
     "start_page": "138",
     "end_page": "139",
     "start_line": 41,
@@ -3684,7 +3685,7 @@
   {
     "id": "Chapter5/Discussion_5.25.4",
     "type": "discussion",
-    "title": "Section 5.25.4: Complementary series representations — setup and character computation",
+    "title": "Section 5.25.4: Complementary series representations \u2014 setup and character computation",
     "start_page": "141",
     "end_page": "143",
     "start_line": 37,
@@ -3780,7 +3781,7 @@
   {
     "id": "Chapter5/Theorem5.27.1",
     "type": "theorem",
-    "title": "Classification of irreducible representations of semidirect products G ⋉ A",
+    "title": "Classification of irreducible representations of semidirect products G \u22c9 A",
     "start_page": "146",
     "end_page": "147",
     "start_line": 11,
@@ -4876,7 +4877,7 @@
   {
     "id": "Chapter7/Problem7.8.7",
     "type": "exercise",
-    "title": "Tensor product of complexes and Künneth formula",
+    "title": "Tensor product of complexes and K\u00fcnneth formula",
     "start_page": "193",
     "end_page": "194",
     "start_line": 23,


### PR DESCRIPTION
Closes #--issue

Session: `5af38b7f-75a1-4633-91af-185cb5f29d8b`

a9bc41d feat: formalize Definition 5.23.1 (algebraic representation of GL(V))

🤖 Prepared with Claude Code