### PR TITLE
## Summary

- Prove E₆ has 36 positive roots, E₇ has 63, E₈ has 120 (modulo coordinate bound lemmas)
- Full infrastructure: `positiveRoots` set, `titsForm` expansion lemmas, `coordRange`/`positiveRootsFinset` finite enumeration, `native_decide` verification
- Coordinate bound lemmas (`titsForm_bound_E6/E7/E8`) are sorry'd — see #1021 for approaches

## Remaining sorry

3 coordinate bound lemmas proving that positive root coordinates are bounded (e.g., x_i ≤ 3 for E₆). These are needed to show the set of positive roots equals the finite enumeration set. The actual root counts are verified by `native_decide`.

## Test plan

- [x] `lake build EtingofRepresentationTheory.Chapter6.Example6_4_9` succeeds (with sorry warnings)
- [ ] Fill coordinate bound proofs (#1021)

🤖 Prepared with Claude Code

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/Corollary6_8_4.lean
+++ b/EtingofRepresentationTheory/Chapter6/Corollary6_8_4.lean
@@ -32,6 +32,35 @@ diagram), there is an indecomposable quiver representation whose dimension
 vector equals α. The proof uses Theorem 6.8.1 (iterated reflections reach a
 simple root) and the reflection functors (Definitions 6.6.3-6.6.4) to
 reconstruct the representation from the simple one.
+
+## Current status
+
+The proof is structured as follows:
+1. **Reduction to simple root**: By `Theorem6_8_1`, there exist vertices
+   `[v₁, ..., vₘ]` and a vertex `p` such that `sᵥₘ ∘ ⋯ ∘ sᵥ₁(α) = αₚ`.
+2. **Base case** (α is a simple root): Construct the simple representation
+   `k₍ₚ₎` (one-dimensional at `p`, zero elsewhere, all maps zero). This is
+   indecomposable with dimension vector `αₚ`.
+3. **Inductive step**: Apply inverse reflection functors `F⁻ᵥ₁ ∘ ⋯ ∘ F⁻ᵥₘ`
+   to reconstruct a representation with dimension vector `α`.
+
+### Blockers (sorry remaining)
+
+The construction is sorry'd due to several infrastructure gaps:
+- **Universe mismatch**: The `QuiverRepresentation` structure's `obj` field
+  lives in a universe variable `u₃`, but concrete constructions (e.g.,
+  `Fin m → k`) fix it to the universe of `k`. This prevents the simple
+  representation construction from type-checking against the existential.
+- **Quiver orientation**: Each reflection functor `F⁻ᵢ` changes the quiver
+  via `reversedAtVertex`, producing a representation on a different quiver
+  type. Chaining `m` reflections requires tracking `m` nested quiver
+  orientations.
+- **Q unconstrained**: The theorem statement has `{Q : Quiver (Fin n)}`
+  without requiring compatibility between `Q` and `adj`. The proof needs
+  `Q` to be an orientation of the Dynkin diagram.
+- **Prop 6.6.7 source**: The source version of indecomposability preservation
+  is sorry'd, needed for each step of the reflection functor chain.
+- **Theorem 6.8.1 sorry'd**: The reflection sequence theorem is itself sorry'd.
 -/
 
 /-- Every positive root of a Dynkin quiver is the dimension vector of some
@@ -52,5 +81,28 @@ theorem Etingof.Corollary6_8_4
       (_ : ∀ v, Module.Free k (ρ.obj v))
       (_ : ∀ v, Module.Finite k (ρ.obj v)),
       ρ.IsIndecomposable ∧
-      ∀ v, (α v : ℤ) = ↑(Module.finrank k (ρ.obj v)) :=
+      ∀ v, (α v : ℤ) = ↑(Module.finrank k (ρ.obj v)) := by
+  -- By Theorem 6.8.1, iterated simple reflections reduce α to a simple root αₚ.
+  -- This gives us the sequence of vertices [v₁, ..., vₘ] for the reflection
+  -- functor chain.
+  obtain ⟨vertices, p, hreduce⟩ := Etingof.Theorem6_8_1 hDynkin α hα.2 hα.1.1 hα.1.2
+  -- The proof proceeds by induction on `vertices.length`:
+  --
+  -- BASE CASE (vertices = []): α = simpleRoot n p.
+  --   Construct ρ with obj v = k^(δ_{v,p}) (1-dim at p, 0-dim elsewhere).
+  --   All edge maps are zero. This is indecomposable because:
+  --   - Nontrivial at p (k is nontrivial)
+  --   - Any complementary sub-reps W₁, W₂ satisfy: at v ≠ p, both are ⊥
+  --     (zero-dimensional space); at p, the space is 1-dimensional (simple),
+  --     so one of W₁ p, W₂ p must be ⊥.
+  --
+  -- INDUCTIVE STEP (vertices = i :: rest):
+  --   Let α' = sᵢ(α). By IH (on quiver reversedAtVertex Q i),
+  --   ∃ ρ' indecomposable with dim vector α'.
+  --   Apply F⁻ᵢ(ρ') to get ρ on Q with:
+  --   - dim vector = sᵢ(α') = sᵢ(sᵢ(α)) = α (reflections are involutions)
+  --     [uses Proposition 6.6.8]
+  --   - indecomposable [uses Proposition 6.6.7]
+  --
+  -- SORRY: Construction blocked — see module docstring for details.
   sorry

--- a/progress/20260317T231927Z_197bf019.md
+++ b/progress/20260317T231927Z_197bf019.md
@@ -1,0 +1,34 @@
+## Accomplished
+
+Structured the proof of Corollary 6.8.4 (every positive root is realized as a dimension vector of an indecomposable representation) — issue #1025.
+
+- Applied Theorem 6.8.1 (now sorry-free after another agent's work) to obtain the reflection sequence reducing α to a simple root αₚ
+- Documented the full proof strategy: base case (simple representation construction) and inductive step (inverse reflection functor chain)
+- Identified and documented 5 concrete blockers preventing the full proof:
+  1. Universe mismatch: `QuiverRepresentation.obj` universe variable vs concrete `Fin m → k` construction
+  2. Quiver orientation tracking through chained reflection functors
+  3. Unconstrained quiver Q in statement (needs compatibility with adj)
+  4. Proposition 6.6.7 source version sorry'd
+  5. Need proof that simple reflections preserve coordinate non-negativity
+- Build passes cleanly with only the expected sorry
+
+## Current frontier
+
+Corollary 6.8.4 has a structured sorry with proof plan. The sorry cannot be removed without addressing the infrastructure blockers listed above.
+
+## Overall project progress
+
+- ~189/583 items sorry_free (~32.4%)
+- Chapters 3 and 4: 100% complete
+- Chapters 5-6: statement formalization largely complete, proof filling active
+- Theorem 6.8.1 is now sorry-free (completed by another agent)
+- 3 unclaimed issues remain: #1017, #1025 (partial), #1026
+
+## Next step
+
+- #1017 (Artin's theorem, difficulty 3/3) or #1026 (Theorem 5.14.3, difficulty 2/3) for proof progress
+- To fully prove Corollary 6.8.4, the universe mismatch and quiver orientation tracking need infrastructure-level solutions (possibly a `SimpleQuiverRep` definition with explicit universe polymorphism, and a `ReflectionFunctorChain` that tracks quiver orientations)
+
+## Blockers
+
+None blocking other work. Corollary 6.8.4's sorry is self-contained.


### PR DESCRIPTION
Closes #--issue

Session: `14df105e-9092-4650-be31-bd5d607e2c76`

a72b43e progress: update Example6.4.9 status and write handoff
918309d feat: prove E-type root counts (E₆=36, E₇=63, E₈=120) modulo coord bounds
9fe5f02 chore: remove all Aristotle references from codebase

🤖 Prepared with Claude Code