### PR TITLE
Stage 3.2: Ch5 prove spechtModuleAction properties in Theorem5_15_1

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_15_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_15_1.lean
@@ -48,9 +48,10 @@ noncomputable def rhoShift (n : ℕ) : Fin n →₀ ℕ :=
 Since V_λ is a left ideal of ℂ[S_n], left multiplication by `of σ` preserves it. -/
 noncomputable def spechtModuleAction (n : ℕ) (la : Nat.Partition n)
     (σ : Equiv.Perm (Fin n)) : ↥(SpechtModule n la) →ₗ[ℂ] ↥(SpechtModule n la) where
-  toFun := fun ⟨m, hm⟩ => ⟨MonoidAlgebra.of ℂ _ σ * m, sorry⟩
-  map_add' := sorry
-  map_smul' := sorry
+  toFun := fun ⟨m, hm⟩ => ⟨MonoidAlgebra.of ℂ _ σ * m,
+    (SpechtModule n la).smul_mem (MonoidAlgebra.of ℂ _ σ) hm⟩
+  map_add' := fun ⟨a, _⟩ ⟨b, _⟩ => Subtype.ext (mul_add _ a b)
+  map_smul' := fun _ ⟨_, _⟩ => Subtype.ext (Algebra.mul_smul_comm _ _ _)
 
 /-- The character of the Specht module V_λ at a permutation σ ∈ S_n, defined as the
 trace of left multiplication by σ restricted to V_λ ⊆ ℂ[S_n]. -/


### PR DESCRIPTION
Closes #1105

Session: `670be5e4-643c-43a0-b35c-7f51f6e8278f`

91d5c24 feat: prove spechtModuleAction properties in Theorem5_15_1

🤖 Prepared with Claude Code