### PR TITLE
Stage 3.2: Ch5 prove finrank_spechtModule_eq_card_standardYoungTableau (dim V_λ = |SYT(λ)|)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5.lean
+++ b/EtingofRepresentationTheory/Chapter5.lean
@@ -64,6 +64,8 @@ import EtingofRepresentationTheory.Chapter5.Lemma5_15_3
 import EtingofRepresentationTheory.Chapter5.Corollary5_15_4
 
 -- Section 5.17: Hook Length Formula
+import EtingofRepresentationTheory.Chapter5.SYTFintype
+import EtingofRepresentationTheory.Chapter5.PolytabloidBasis
 import EtingofRepresentationTheory.Chapter5.Theorem5_17_1
 
 -- Section 5.18: Schur-Weyl Duality

--- a/EtingofRepresentationTheory/Chapter5/PolytabloidBasis.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolytabloidBasis.lean
@@ -1,5 +1,6 @@
 import Mathlib
-import EtingofRepresentationTheory.Chapter5.Theorem5_17_1
+import EtingofRepresentationTheory.Chapter5.SYTFintype
+import EtingofRepresentationTheory.Chapter5.Theorem5_12_2
 
 /-!
 # Polytabloid Basis Infrastructure

--- a/EtingofRepresentationTheory/Chapter5/SYTFintype.lean
+++ b/EtingofRepresentationTheory/Chapter5/SYTFintype.lean
@@ -1,0 +1,71 @@
+import Mathlib
+import EtingofRepresentationTheory.Chapter5.Definition5_12_1
+
+/-!
+# Finiteness of Standard Young Tableaux
+
+This file provides `Fintype` and `Finite` instances for `StandardYoungTableau n la`,
+extracted from Theorem5_17_1.lean to break a circular import dependency with
+PolytabloidBasis.lean.
+-/
+
+namespace Etingof
+
+/-- Each row entry of a partition's sorted parts is bounded by the total sum. -/
+private lemma getD_le_sum (l : List ℕ) (i : ℕ) : l.getD i 0 ≤ l.sum := by
+  induction l generalizing i with
+  | nil => simp [List.getD]
+  | cons a as ih =>
+    cases i with
+    | zero =>
+      show (a :: as).getD 0 0 ≤ (a :: as).sum
+      rw [List.getD_cons_zero, List.sum_cons]
+      omega
+    | succ i =>
+      simp only [List.getD_cons_succ, List.sum_cons]
+      exact le_trans (ih i) (Nat.le_add_left _ _)
+
+/-- The sorted parts of a partition of n sum to n. -/
+lemma sortedParts_sum_eq (n : ℕ) (la : Nat.Partition n) :
+    la.sortedParts.sum = n := by
+  have h := Multiset.sort_eq la.parts (· ≥ ·)
+  have : (la.sortedParts : Multiset ℕ).sum = la.parts.sum := congrArg Multiset.sum h
+  rw [Multiset.sum_coe] at this; rw [this, la.parts_sum]
+
+/-- The cell type of a Young diagram (pairs (i,j) with i < #rows, j < row_length(i))
+is finite, since all indices are bounded by n. -/
+noncomputable instance cellFintype (n : ℕ) (la : Nat.Partition n) :
+    Fintype { c : ℕ × ℕ // c.1 < la.sortedParts.length ∧ c.2 < la.sortedParts.getD c.1 0 } := by
+  haveI : Fintype { c : ℕ × ℕ //
+      c ∈ (Finset.range la.sortedParts.length ×ˢ Finset.range (n+1)) } :=
+    (Finset.range la.sortedParts.length ×ˢ Finset.range (n+1)).fintypeCoeSort
+  apply Fintype.ofInjective
+    (fun ⟨c, hc⟩ => (⟨c, by
+      simp only [Finset.mem_product, Finset.mem_range]
+      exact ⟨hc.1, by
+        have := getD_le_sum la.sortedParts c.1
+        have := sortedParts_sum_eq n la; omega⟩
+    ⟩ : { c : ℕ × ℕ //
+        c ∈ (Finset.range la.sortedParts.length ×ˢ Finset.range (n+1)) }))
+  intro ⟨a, _⟩ ⟨b, _⟩ h
+  exact Subtype.ext (Subtype.mk.inj h)
+
+/-- The type of standard Young tableaux of a given shape is finite.
+This follows from finiteness of the cell type and `Fin n`. -/
+noncomputable instance sytFintype (n : ℕ) (la : Nat.Partition n) :
+    Fintype (StandardYoungTableau n la) := by
+  unfold StandardYoungTableau
+  haveI := cellFintype n la
+  exact Subtype.fintype _
+
+/-- StandardYoungTableau is a finite type: it is a subtype of functions
+from a finite cell set to Fin n. -/
+instance standardYoungTableau_finite (n : ℕ) (la : Nat.Partition n) :
+    Finite (StandardYoungTableau n la) := by
+  classical
+  unfold StandardYoungTableau
+  change Finite { f : { c : ℕ × ℕ // c.1 < la.sortedParts.length ∧
+    c.2 < la.sortedParts.getD c.1 0 } → Fin n // _ }
+  exact Subtype.finite
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_17_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_17_1.lean
@@ -1,6 +1,6 @@
 import Mathlib
 import EtingofRepresentationTheory.Chapter5.Definition5_14_2
-import EtingofRepresentationTheory.Chapter5.Theorem5_12_2
+import EtingofRepresentationTheory.Chapter5.PolytabloidBasis
 
 /-!
 # Theorem 5.17.1: Hook Length Formula
@@ -46,92 +46,9 @@ def YoungDiagram.hookLength (μ : YoungDiagram) (i j : ℕ) : ℕ :=
 noncomputable def YoungDiagram.hookLengthProduct (μ : YoungDiagram) : ℕ :=
   μ.cells.prod (fun c => μ.hookLength c.1 c.2)
 
-/-! ## Finiteness infrastructure for StandardYoungTableau -/
-
 namespace Etingof
 
-/-- Each row entry of a partition's sorted parts is bounded by the total sum. -/
-private lemma getD_le_sum (l : List ℕ) (i : ℕ) : l.getD i 0 ≤ l.sum := by
-  induction l generalizing i with
-  | nil => simp [List.getD]
-  | cons a as ih =>
-    cases i with
-    | zero =>
-      show (a :: as).getD 0 0 ≤ (a :: as).sum
-      rw [List.getD_cons_zero, List.sum_cons]
-      omega
-    | succ i =>
-      simp only [List.getD_cons_succ, List.sum_cons]
-      exact le_trans (ih i) (Nat.le_add_left _ _)
-
-/-- The sorted parts of a partition of n sum to n. -/
-private lemma sortedParts_sum' (n : ℕ) (la : Nat.Partition n) :
-    la.sortedParts.sum = n := by
-  have h := Multiset.sort_eq la.parts (· ≥ ·)
-  have : (la.sortedParts : Multiset ℕ).sum = la.parts.sum := congrArg Multiset.sum h
-  rw [Multiset.sum_coe] at this; rw [this, la.parts_sum]
-
-/-- The cell type of a Young diagram (pairs (i,j) with i < #rows, j < row_length(i))
-is finite, since all indices are bounded by n. -/
-noncomputable instance cellFintype (n : ℕ) (la : Nat.Partition n) :
-    Fintype { c : ℕ × ℕ // c.1 < la.sortedParts.length ∧ c.2 < la.sortedParts.getD c.1 0 } := by
-  haveI : Fintype { c : ℕ × ℕ // c ∈ (Finset.range la.sortedParts.length ×ˢ Finset.range (n+1)) } :=
-    (Finset.range la.sortedParts.length ×ˢ Finset.range (n+1)).fintypeCoeSort
-  apply Fintype.ofInjective
-    (fun ⟨c, hc⟩ => (⟨c, by
-      simp only [Finset.mem_product, Finset.mem_range]
-      exact ⟨hc.1, by have := getD_le_sum la.sortedParts c.1; have := sortedParts_sum' n la; omega⟩
-    ⟩ : { c : ℕ × ℕ // c ∈ (Finset.range la.sortedParts.length ×ˢ Finset.range (n+1)) }))
-  intro ⟨a, _⟩ ⟨b, _⟩ h
-  exact Subtype.ext (Subtype.mk.inj h)
-
-/-- The type of standard Young tableaux of a given shape is finite.
-This follows from finiteness of the cell type and `Fin n`. -/
-noncomputable instance sytFintype (n : ℕ) (la : Nat.Partition n) :
-    Fintype (StandardYoungTableau n la) := by
-  unfold StandardYoungTableau
-  haveI := cellFintype n la
-  exact Subtype.fintype _
-
 noncomputable section
-
-/-- The cell type of a partition is finite: cells (i,j) with i < length, j < row width.
-Both coordinates are bounded (i < length, j < part i ≤ n), giving a finite set. -/
-noncomputable instance partitionCell_fintype (n : ℕ) (la : Nat.Partition n) :
-    Fintype { c : ℕ × ℕ // c.1 < la.sortedParts.length ∧
-      c.2 < la.sortedParts.getD c.1 0 } := by
-  classical
-  haveI : Finite { c : ℕ × ℕ // c.1 < la.sortedParts.length ∧
-      c.2 < la.sortedParts.getD c.1 0 } := by
-    refine Finite.of_injective
-      (fun (c : { c : ℕ × ℕ // c.1 < la.sortedParts.length ∧
-          c.2 < la.sortedParts.getD c.1 0 }) =>
-        show Fin la.sortedParts.length × Fin (n + 1) from
-        ⟨⟨c.1.1, c.2.1⟩, ⟨c.1.2, by
-          have hj := c.2.2
-          have hi := c.2.1
-          simp only [List.getD, List.getElem?_eq_getElem hi, Option.getD_some] at hj
-          have : la.sortedParts[c.1.1] ≤ n := by
-            calc la.sortedParts[c.1.1] ≤ la.sortedParts.sum :=
-                  List.single_le_sum (fun x _ => Nat.zero_le x) _ (List.getElem_mem hi)
-              _ = n := by
-                  unfold Nat.Partition.sortedParts
-                  rw [← Multiset.sum_coe, Multiset.sort_eq]; exact la.parts_sum
-          omega⟩⟩) ?_
-    intro ⟨⟨a1, a2⟩, ha⟩ ⟨⟨b1, b2⟩, hb⟩ h
-    simp only [Prod.mk.injEq, Fin.mk.injEq] at h
-    exact Subtype.ext (Prod.ext h.1 h.2)
-  exact Fintype.ofFinite _
-
-/-- StandardYoungTableau is a finite type: it is a subtype of functions
-from a finite cell set to Fin n. -/
-instance standardYoungTableau_finite (n : ℕ) (la : Nat.Partition n) :
-    Finite (StandardYoungTableau n la) := by
-  classical
-  unfold StandardYoungTableau
-  change Finite { f : { c : ℕ × ℕ // c.1 < la.sortedParts.length ∧
-    c.2 < la.sortedParts.getD c.1 0 } → Fin n // _ }
-  exact Subtype.finite
 
 /-- The hook length product divides n!. This is a consequence of the
 Frame–Robinson–Thrall theorem: n!/∏h(i,j) = |SYT(λ)| is a positive integer. -/
@@ -143,16 +60,14 @@ theorem hookLengthProduct_dvd_factorial (n : ℕ) (la : Nat.Partition n) :
 This is the core representation-theoretic content: the polytabloid basis of the
 Specht module is naturally indexed by SYT(λ).
 
-Proof sketch: For each standard Young tableau T, the polytabloid e_T = b_T · {T}
-(column antisymmetrizer applied to the tabloid) lies in V_λ. The set {e_T} forms
-a basis. This requires:
-- The polytabloid construction and its properties
-- Linear independence of polytabloids (via the straightening algorithm)
-- Spanning (via the Young symmetrizer generating the module) -/
+The proof delegates to `finrank_spechtModule_eq_card_syt` (which uses
+`Fintype.card`) and converts to `Nat.card`. The underlying proof constructs
+the polytabloid basis: linear independence + spanning of polytabloids. -/
 theorem finrank_spechtModule_eq_card_standardYoungTableau (n : ℕ) (la : Nat.Partition n) :
     Module.finrank ℂ (SpechtModule n la) =
       Nat.card (StandardYoungTableau n la) := by
-  sorry
+  rw [Nat.card_eq_fintype_card]
+  exact finrank_spechtModule_eq_card_syt n la
 
 /-- Frame–Robinson–Thrall theorem (1954): the number of standard Young tableaux
 of shape λ equals n! / ∏ h(i,j), where the product is over all cells of the

--- a/progress/2026-03-19T12-43-09Z_cee82ba9.md
+++ b/progress/2026-03-19T12-43-09Z_cee82ba9.md
@@ -1,0 +1,32 @@
+## Accomplished
+- Skipped issue #1206 (file split blocked by Lean elaboration context sensitivity)
+- Claimed issue #1183 (prove finrank_spechtModule_eq_card_standardYoungTableau)
+- Created `SYTFintype.lean`: extracted SYT finiteness instances (`cellFintype`, `sytFintype`, `standardYoungTableau_finite`) from `Theorem5_17_1.lean`
+- Broke circular import dependency: `PolytabloidBasis.lean` no longer imports `Theorem5_17_1.lean` (now imports `SYTFintype.lean` + `Theorem5_12_2.lean`)
+- Wired up `finrank_spechtModule_eq_card_standardYoungTableau` to delegate to `finrank_spechtModule_eq_card_syt` via `Nat.card_eq_fintype_card`
+- The direct sorry on `finrank_spechtModule_eq_card_standardYoungTableau` is eliminated; it now properly depends on the two sorry'd lemmas in `PolytabloidBasis.lean`
+- Added `SYTFintype` and `PolytabloidBasis` imports to `Chapter5.lean`
+
+## Current frontier
+- `finrank_spechtModule_eq_card_standardYoungTableau` is proved modulo two sorry'd lemmas in `PolytabloidBasis.lean`:
+  1. `polytabloid_linearIndependent` (line 194): polytabloids are linearly independent in V_λ
+  2. `perm_mul_youngSymmetrizer_mem_span_polytabloids` (line 209): straightening lemma (any σ·c_λ is in span of standard polytabloids)
+
+## Overall project progress
+- File restructuring complete: `SYTFintype.lean` → `PolytabloidBasis.lean` → `Theorem5_17_1.lean` (clean dependency chain)
+- `finrank_spechtModule_eq_card_standardYoungTableau` sorry eliminated (delegates to `finrank_spechtModule_eq_card_syt`)
+- 2 sorry's remain in `PolytabloidBasis.lean` (deep combinatorial results)
+- `polytabloid_span` and `finrank_spechtModule_eq_card_syt` are fully proved modulo these 2 sorry's
+
+## Next step
+- Prove `polytabloid_linearIndependent`: requires defining dominance order on tabloids, proving the "leading term" property of polytabloids (e_T has {T} as maximal tabloid), and a triangularity argument. Estimated 200+ lines.
+- Prove `perm_mul_youngSymmetrizer_mem_span_polytabloids`: requires Garnir relations (column transpositions that generate the column stabilizer), the straightening algorithm (rewriting non-standard tabloids), and a termination argument using a well-founded order. Estimated 200+ lines.
+- Either proof would be a substantial contribution. Both are needed for the full result.
+
+## Blockers
+- Both remaining sorry's require substantial combinatorial infrastructure not in Mathlib:
+  - **Tabloid basis**: row equivalence classes of Young tableaux, as a basis of the permutation module
+  - **Dominance order**: partial order on tabloids where {T} ≥ {T'} iff T's rows dominate T's
+  - **Garnir relations**: for adjacent column cells, the Garnir element provides rewriting rules
+  - **Straightening algorithm**: iterative application of Garnir relations with well-founded termination
+  - **Triangularity**: leading term of e_T in tabloid basis is {T}, giving upper triangular matrix → linear independence


### PR DESCRIPTION
Partial progress on #1183

Session: `3f556433-a309-4966-9b38-f2eb5218314f`

4b4d1e1 feat: wire up finrank_spechtModule_eq_card_standardYoungTableau via polytabloid basis (#1183)

🤖 Prepared with Claude Code