### PR TITLE
Stage 3.2: Ch6 prove reflFunctorPlus_mapLinear_ne_ne (Definition 6.6.3 API lemma)

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/Definition6_6_2.lean
+++ b/EtingofRepresentationTheory/Chapter6/Definition6_6_2.lean
@@ -16,14 +16,65 @@ This requires a custom definition that selectively reverses edges at a single ve
 For arrows not touching `i`, the type is unchanged. For arrows from `i` to `b` (with `b ≠ i`),
 the type is `Hom_Q(b, i)` (reversed). For arrows from `a` to `i` (with `a ≠ i`),
 the type is `Hom_Q(i, a)` (reversed). Self-loops at `i` are unchanged. -/
-def Etingof.ReversedAtVertexHom (V : Type*) [DecidableEq V] [Quiver V] (i : V)
+def Etingof.ReversedAtVertexHom (V : Type*) [inst : DecidableEq V] [Quiver V] (i : V)
     (a b : V) : Type _ :=
-  if a = i then
-    if b = i then (a ⟶ b)  -- self-loop at i: unchanged
-    else (b ⟶ i)            -- arrow from i to b: was b→i in Q
-  else
-    if b = i then (i ⟶ a)   -- arrow from a to i: was i→a in Q
-    else (a ⟶ b)             -- neither endpoint is i: unchanged
+  -- Use @Decidable.casesOn rather than ite so that matching on `inst a i` / `inst b i`
+  -- reduces both the arrow type and the object type in proofs about the reflection functor.
+  @Decidable.casesOn _ (fun _ => Type _) (inst a i)
+    (fun _ => -- a ≠ i
+      @Decidable.casesOn _ (fun _ => Type _) (inst b i)
+        (fun _ => (a ⟶ b))   -- a ≠ i, b ≠ i: unchanged
+        (fun _ => (i ⟶ a)))  -- a ≠ i, b = i: was i→a in Q
+    (fun _ => -- a = i
+      @Decidable.casesOn _ (fun _ => Type _) (inst b i)
+        (fun _ => (b ⟶ i))   -- a = i, b ≠ i: was b→i in Q
+        (fun _ => (a ⟶ b)))  -- a = i, b = i: self-loop, unchanged
+
+/-! ## API lemmas for `ReversedAtVertexHom`
+
+These reduce `ReversedAtVertexHom` to the underlying arrow type once the
+relationship between vertices `a`, `b`, and `i` is known. They avoid the need
+to `unfold` the definition and manually reduce `Decidable.casesOn`. -/
+
+theorem Etingof.ReversedAtVertexHom_ne_ne {V : Type*} [inst : DecidableEq V] [Quiver V]
+    {i a b : V} (ha : a ≠ i) (hb : b ≠ i) :
+    Etingof.ReversedAtVertexHom V i a b = (a ⟶ b) := by
+  unfold ReversedAtVertexHom
+  cases inst a i with
+  | isTrue h => exact absurd h ha
+  | isFalse _ => cases inst b i with
+    | isTrue h => exact absurd h hb
+    | isFalse _ => rfl
+
+theorem Etingof.ReversedAtVertexHom_eq_ne {V : Type*} [inst : DecidableEq V] [Quiver V]
+    {i a b : V} (ha : a = i) (hb : b ≠ i) :
+    Etingof.ReversedAtVertexHom V i a b = (b ⟶ i) := by
+  unfold ReversedAtVertexHom
+  cases inst a i with
+  | isFalse h => exact absurd ha h
+  | isTrue _ => cases inst b i with
+    | isTrue h => exact absurd h hb
+    | isFalse _ => rfl
+
+theorem Etingof.ReversedAtVertexHom_ne_eq {V : Type*} [inst : DecidableEq V] [Quiver V]
+    {i a b : V} (ha : a ≠ i) (hb : b = i) :
+    Etingof.ReversedAtVertexHom V i a b = (i ⟶ a) := by
+  unfold ReversedAtVertexHom
+  cases inst a i with
+  | isTrue h => exact absurd h ha
+  | isFalse _ => cases inst b i with
+    | isFalse h => exact absurd hb h
+    | isTrue _ => rfl
+
+theorem Etingof.ReversedAtVertexHom_eq_eq {V : Type*} [inst : DecidableEq V] [Quiver V]
+    {i a b : V} (ha : a = i) (hb : b = i) :
+    Etingof.ReversedAtVertexHom V i a b = (a ⟶ b) := by
+  unfold ReversedAtVertexHom
+  cases inst a i with
+  | isFalse h => exact absurd ha h
+  | isTrue _ => cases inst b i with
+    | isFalse h => exact absurd hb h
+    | isTrue _ => rfl
 
 /-- The quiver obtained by reversing all arrows incident to vertex `i`.
 For a sink, this reverses all incoming arrows; for a source, all outgoing arrows.

--- a/EtingofRepresentationTheory/Chapter6/Definition6_6_3.lean
+++ b/EtingofRepresentationTheory/Chapter6/Definition6_6_3.lean
@@ -73,27 +73,41 @@ noncomputable def Etingof.reflectionFunctorPlus
     (fun v => acmAt v (dp v))
     (fun v => modAt v (dp v))
     (fun {a b} (e : Etingof.ReversedAtVertexHom V i a b) => by
-      -- Use inst a i / inst b i (same Decidable instance as obj/AddCommMonoid/Module fields)
-      -- to ensure match reduces consistently across all fields.
+      -- Goal: objAt a (inst a i) →ₗ[k] objAt b (inst b i)
+      -- We use @Decidable.casesOn with EXPLICIT motives that parameterize
+      -- both the arrow type (@ite ... da ...) and objAt by the same variable da.
+      -- This ensures all ite/casesOn reduce together in each branch.
       change objAt a (inst a i) →ₗ[k] objAt b (inst b i)
       change @Etingof.ReversedAtVertexHom V inst _ i a b at e
       unfold Etingof.ReversedAtVertexHom at e
       revert e
-      -- Use match (not generalize+cases) for better definitional reduction
-      exact match inst a i, inst b i with
-      | .isTrue ha, .isTrue hb =>
-          -- a = i, b = i: vacuous since i is a sink
-          fun e => ((hi b).false (show i ⟶ b from ha ▸ e)).elim
-      | .isTrue ha, .isFalse _ =>
-          -- a = i, b ≠ i: reversed arrow, ker φ ↪ ⊕ → proj_b
-          fun e => (DirectSum.component k (Etingof.ArrowsInto V i)
-            (fun x => ρ.obj x.1) ⟨b, ha ▸ e⟩).comp (LinearMap.ker φ).subtype
-      | .isFalse _, .isTrue hb =>
-          -- a ≠ i, b = i: vacuous since i is a sink
-          fun e => ((hi a).false (hb ▸ e)).elim
-      | .isFalse _, .isFalse _ =>
-          -- a ≠ i, b ≠ i: unchanged arrow
-          fun e => ρ.mapLinear e)
+      -- Use nested @Decidable.casesOn with explicit motives that parameterize
+      -- BOTH the arrow type and objAt by the same variable (da/db).
+      -- Using Decidable.casesOn (not ite) for the arrow type ensures
+      -- the bound variable da appears in the compiled motive, enabling
+      -- definitional reduction when the proof matches on inst a i.
+      let arrowAt (da : Decidable (a = i)) (db : Decidable (b = i)) : Type _ :=
+        @Decidable.casesOn _ (fun _ => Type _) da
+          (fun _ => @Decidable.casesOn _ (fun _ => Type _) db
+            (fun _ => (a ⟶ b)) (fun _ => (i ⟶ a)))
+          (fun _ => @Decidable.casesOn _ (fun _ => Type _) db
+            (fun _ => (b ⟶ i)) (fun _ => (a ⟶ b)))
+      exact @Decidable.casesOn (a = i)
+        (fun da => arrowAt da (inst b i) → objAt a da →ₗ[k] objAt b (inst b i))
+        (inst a i)
+        (fun ha_ne => @Decidable.casesOn (b = i)
+          (fun db => arrowAt (.isFalse ha_ne) db → ρ.obj a →ₗ[k] objAt b db)
+          (inst b i)
+          (fun _hb_ne => fun e => ρ.mapLinear e)
+          (fun hb_eq => fun e => ((hi a).false e).elim))
+        (fun ha_eq => @Decidable.casesOn (b = i)
+          (fun db => arrowAt (.isTrue ha_eq) db → objAt a (.isTrue ha_eq) →ₗ[k] objAt b db)
+          (inst b i)
+          (fun _hb_ne => fun e =>
+            (DirectSum.component k (Etingof.ArrowsInto V i)
+              (fun x => ρ.obj x.1) ⟨b, e⟩).comp (LinearMap.ker φ).subtype)
+          (fun hb_eq => fun e =>
+            ((hi b).false (ha_eq ▸ e)).elim)))
 
 section ReflectionFunctorPlusAPI
 
@@ -178,7 +192,7 @@ def Etingof.reversedArrow_ne_ne
   | .isFalse _, .isTrue h => absurd h hb
   | .isFalse _, .isFalse _ => fun e => e
 
-set_option maxHeartbeats 400000 in
+set_option maxHeartbeats 1600000 in
 -- reason: unfolding reflectionFunctorPlus + equivAt_ne + match reduction
 /-- At non-sink vertices (a ≠ i, b ≠ i), the F⁺ᵢ map equals the original ρ map,
 after transport through the equivAt_ne equivalences.
@@ -200,9 +214,20 @@ theorem Etingof.reflFunctorPlus_mapLinear_ne_ne
         (Etingof.reflectionFunctorPlus Q i hi ρ) a b e w) =
     ρ.mapLinear (Etingof.reversedArrow_ne_ne ha hb e)
       ((Etingof.reflFunctorPlus_equivAt_ne hi ρ a ha) w) := by
-  -- BLOCKED: The tactic-mode `change + unfold + match` inside reflectionFunctorPlus
-  -- creates Eq.mpr wrappers that prevent rfl after unfolding. Fixing this requires
-  -- refactoring reflectionFunctorPlus to use pure term-mode case analysis.
-  sorry
+  have h_da : inst a i = .isFalse ha := by
+    cases inst a i with
+    | isTrue h => exact absurd h ha
+    | isFalse _ => rfl
+  have h_db : inst b i = .isFalse hb := by
+    cases inst b i with
+    | isTrue h => exact absurd h hb
+    | isFalse _ => rfl
+  revert e w
+  unfold Etingof.reflFunctorPlus_equivAt_ne Etingof.reversedArrow_ne_ne
+    Etingof.reflectionFunctorPlus Etingof.reversedAtVertex Etingof.ReversedAtVertexHom
+  simp only []
+  rw [h_da, h_db]
+  intro e w
+  rfl
 
 end ReflectionFunctorPlusAPI

--- a/EtingofRepresentationTheory/Chapter6/Definition6_6_4.lean
+++ b/EtingofRepresentationTheory/Chapter6/Definition6_6_4.lean
@@ -106,18 +106,17 @@ noncomputable def Etingof.reflectionFunctorMinus
     (fun v => acmAt v (dp v))
     (fun v => modAt v (dp v))
     (fun {a b} (e : Etingof.ReversedAtVertexHom V i a b) => by
-      change Etingof.ReversedAtVertexHom V i a b at e
-      unfold Etingof.ReversedAtVertexHom at e
       by_cases ha : a = i
       · by_cases hb : b = i
         · -- a = i, b = i: self-loop; vacuous since i is a source (no arrows into i)
-          simp only [ha, hb] at e; exact ((hi i).false e).elim
+          rw [Etingof.ReversedAtVertexHom_eq_eq ha hb] at e
+          exact ((hi a).false (hb ▸ e)).elim
         · -- a = i, b ≠ i: arrow b → i in Q; vacuous since i is a source
-          simp only [ha, hb, ite_true, ite_false] at e
+          rw [Etingof.ReversedAtVertexHom_eq_ne ha hb] at e
           exact ((hi b).false e).elim
       · by_cases hb : b = i
         · -- a ≠ i, b = i: reversed arrow (i ⟶ a in Q), map is ρ_a → ⊕ → coker(ψ)
-          simp only [ha, hb, ite_false, ite_true] at e
+          rw [Etingof.ReversedAtVertexHom_ne_eq ha hb] at e
           -- Beta-reduce and generalize to make Decidable.casesOn reduce
           change objAt a (dp a) →ₗ[k] objAt b (dp b)
           revert e
@@ -133,7 +132,7 @@ noncomputable def Etingof.reflectionFunctorMinus
                 (DirectSum.lof k (Etingof.ArrowsOutOf V i)
                   (fun a => ρ.obj a.1) ⟨a, e⟩)
         · -- a ≠ i, b ≠ i: unchanged arrow
-          simp only [ha, hb] at e
+          rw [Etingof.ReversedAtVertexHom_ne_ne ha hb] at e
           change objAt a (dp a) →ₗ[k] objAt b (dp b)
           revert e
           generalize dp a = da; generalize dp b = db
@@ -193,9 +192,8 @@ theorem Etingof.arrowsIntoReversed_ne
   obtain ⟨j, e⟩ := a
   intro heq; dsimp only at heq
   change Etingof.ReversedAtVertexHom Q i j i at e
-  unfold Etingof.ReversedAtVertexHom at e
-  rw [heq] at e
-  simp only [ite_true] at e; exact (hi i).false e
+  rw [Etingof.ReversedAtVertexHom_eq_eq heq rfl] at e
+  exact (hi j).false (show j ⟶ i from e)
 
 /-- Extract the original arrow i →_Q j from a reversed arrow j →_{Q̄ᵢ} i.
 When i is a source, `ReversedAtVertexHom Q i j i` with j ≠ i is just `i ⟶ j` in Q. -/
@@ -205,8 +203,7 @@ def Etingof.arrowsIntoReversed_origArrow
     (a : @Etingof.ArrowsInto Q (Etingof.reversedAtVertex Q i) i) : i ⟶ a.fst := by
   obtain ⟨j, e⟩ := a
   change Etingof.ReversedAtVertexHom Q i j i at e
-  unfold Etingof.ReversedAtVertexHom at e
   have hne := Etingof.arrowsIntoReversed_ne hi ⟨j, e⟩
-  simp only [hne, ite_false, ite_true] at e; exact e
+  rw [Etingof.ReversedAtVertexHom_ne_eq hne rfl] at e; exact e
 
 end ReflectionFunctorMinusAPI

--- a/EtingofRepresentationTheory/Chapter6/Proposition6_6_6.lean
+++ b/EtingofRepresentationTheory/Chapter6/Proposition6_6_6.lean
@@ -31,11 +31,10 @@ theorem Etingof.isSink_reversedAtVertex_isSource
   constructor
   intro e
   change Etingof.ReversedAtVertexHom Q i j i at e
-  unfold Etingof.ReversedAtVertexHom at e
   by_cases hj : j = i
-  · simp only [hj, ite_true] at e
-    exact (hi i).false e
-  · simp only [hj, ite_false, ite_true] at e
+  · rw [Etingof.ReversedAtVertexHom_eq_eq hj rfl] at e
+    rw [hj] at e; exact (hi i).false e
+  · rw [Etingof.ReversedAtVertexHom_ne_eq hj rfl] at e
     exact (hi j).false e
 
 /-- A source in Q becomes a sink in the reversed quiver Q̄ᵢ.
@@ -49,11 +48,10 @@ theorem Etingof.isSource_reversedAtVertex_isSink
   constructor
   intro e
   change Etingof.ReversedAtVertexHom Q i i j at e
-  unfold Etingof.ReversedAtVertexHom at e
   by_cases hj : j = i
-  · simp only [hj, ite_true] at e
-    exact (hi i).false e
-  · simp only [ite_true, hj, ite_false] at e
+  · rw [Etingof.ReversedAtVertexHom_eq_eq rfl hj] at e
+    rw [hj] at e; exact (hi i).false e
+  · rw [Etingof.ReversedAtVertexHom_eq_ne rfl hj] at e
     exact (hi j).false e
 
 end Reversal
@@ -86,10 +84,31 @@ private theorem Etingof.reversedAtVertex_twice
   apply Quiver.ext'
   intro a b
   change @Etingof.ReversedAtVertexHom Q _ (Etingof.reversedAtVertex Q i) i a b = (a ⟶ b)
-  unfold Etingof.ReversedAtVertexHom
-  split_ifs with ha hb hb
-  all_goals (simp only [Etingof.reversedAtVertex, Etingof.ReversedAtVertexHom])
-  all_goals (split_ifs <;> first | rfl | subst_vars <;> rfl | exact absurd rfl ‹_›)
+  -- Two-layer reduction: outer ReversedAtVertexHom uses reversed quiver,
+  -- inner uses original quiver. Use `trans` + `change` to bridge.
+  by_cases ha : a = i <;> by_cases hb : b = i
+  · -- a = i, b = i
+    trans @Quiver.Hom Q (Etingof.reversedAtVertex Q i) a b
+    · exact @Etingof.ReversedAtVertexHom_eq_eq Q _ (Etingof.reversedAtVertex Q i) i a b ha hb
+    · change Etingof.ReversedAtVertexHom Q i a b = (a ⟶ b)
+      exact Etingof.ReversedAtVertexHom_eq_eq ha hb
+  · -- a = i, b ≠ i: outer gives reversed (b ⟶ i in reversed quiver)
+    trans @Quiver.Hom Q (Etingof.reversedAtVertex Q i) b i
+    · exact @Etingof.ReversedAtVertexHom_eq_ne Q _ (Etingof.reversedAtVertex Q i) i a b ha hb
+    · change Etingof.ReversedAtVertexHom Q i b i = (a ⟶ b)
+      rw [Etingof.ReversedAtVertexHom_ne_eq hb rfl]
+      exact congrArg (· ⟶ b) ha.symm
+  · -- a ≠ i, b = i: outer gives reversed (i ⟶ a in reversed quiver)
+    trans @Quiver.Hom Q (Etingof.reversedAtVertex Q i) i a
+    · exact @Etingof.ReversedAtVertexHom_ne_eq Q _ (Etingof.reversedAtVertex Q i) i a b ha hb
+    · change Etingof.ReversedAtVertexHom Q i i a = (a ⟶ b)
+      rw [Etingof.ReversedAtVertexHom_eq_ne rfl ha]
+      exact congrArg (a ⟶ ·) hb.symm
+  · -- a ≠ i, b ≠ i: outer gives unchanged (a ⟶ b in reversed quiver)
+    trans @Quiver.Hom Q (Etingof.reversedAtVertex Q i) a b
+    · exact @Etingof.ReversedAtVertexHom_ne_ne Q _ (Etingof.reversedAtVertex Q i) i a b ha hb
+    · change Etingof.ReversedAtVertexHom Q i a b = (a ⟶ b)
+      exact Etingof.ReversedAtVertexHom_ne_ne ha hb
 
 /-- Transport a representation from the double-reversed quiver (Q̄ᵢ)̄ᵢ back to Q.
 
@@ -172,9 +191,9 @@ private theorem Etingof.arrowsOutReversed_ne
     (a : @Etingof.ArrowsOutOf Q (Etingof.reversedAtVertex Q i) i) : a.fst ≠ i := by
   obtain ⟨j, e⟩ := a
   change Etingof.ReversedAtVertexHom Q i i j at e
-  unfold Etingof.ReversedAtVertexHom at e
   by_cases hj : j = i
-  · simp only [hj, ite_true] at e; exact ((hi i).false e).elim
+  · rw [Etingof.ReversedAtVertexHom_eq_eq rfl hj] at e
+    rw [hj] at e; exact ((hi i).false e).elim
   · exact hj
 
 /-- Extract the original arrow j →_Q i from a reversed arrow i →_{Q̄ᵢ} j. -/
@@ -184,9 +203,8 @@ private def Etingof.arrowsOutReversed_origArrow
     (a : @Etingof.ArrowsOutOf Q (Etingof.reversedAtVertex Q i) i) : a.fst ⟶ i := by
   obtain ⟨j, e⟩ := a
   change Etingof.ReversedAtVertexHom Q i i j at e
-  unfold Etingof.ReversedAtVertexHom at e
   have hne := Etingof.arrowsOutReversed_ne hi ⟨j, e⟩
-  simp only [ite_true, hne, ite_false] at e; exact e
+  rw [Etingof.ReversedAtVertexHom_eq_ne rfl hne] at e; exact e
 
 /-- Map arrows into i in Q to arrows out of i in Q̄ᵢ.
 Since i is a sink (no arrows out), any arrow j → i in Q gives a reversed
@@ -200,11 +218,9 @@ private def Etingof.arrowsInto_to_arrowsOutReversed
   refine ⟨j, ?_⟩
   -- Need i →_{Q̄ᵢ} j, i.e., ReversedAtVertexHom Q i i j
   change Etingof.ReversedAtVertexHom Q i i j
-  unfold Etingof.ReversedAtVertexHom
-  -- Since i = i, first branch: if j = i then (i ⟶ i) else (j ⟶ i)
   have hji : j ≠ i := by
     intro heq; rw [heq] at e; exact (hi i).false e
-  simp only [ite_true, hji, ite_false]; exact e
+  rw [Etingof.ReversedAtVertexHom_eq_ne rfl hji]; exact e
 
 /-- The component of `arrowsInto_to_arrowsOutReversed` at j gives the original arrow j ⟶ i. -/
 private theorem Etingof.arrowsInto_to_arrowsOutReversed_fst


### PR DESCRIPTION
Closes #1228

Session: `3cbd096f-8159-402d-9977-68dd77fb9b6a`

001c596 feat: prove reflFunctorPlus_mapLinear_ne_ne and fix ReversedAtVertexHom (#1228)

🤖 Prepared with Claude Code