### PR TITLE
Stage 3.2: Ch6 prove pathQF_eq_dotProduct and An_posDef (Dynkin A_n helpers)

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/Theorem_Dynkin_classification.lean
+++ b/EtingofRepresentationTheory/Chapter6/Theorem_Dynkin_classification.lean
@@ -313,7 +313,7 @@ private lemma pathQF_eq_dotProduct (n : ℕ) (hn : 1 ≤ n) (x : Fin n → ℤ) 
         DynkinType.adj (.A (0 + 1) (by omega))) 0 0 = 2 := by
       simp [Matrix.sub_apply, Matrix.smul_apply, Matrix.one_apply, Matrix.ofNat_apply,
         smul_eq_mul, DynkinType.adj, Fin.ext_iff, Fin.val_zero]
-    rw [hmat]; ring
+    rw [hmat]; simp [Fin.ext_iff]; ring
   | succ k ih =>
     -- n = k + 2
     set ext_x : ℕ → ℤ := fun i => if h : i < k + 2 then x ⟨i, h⟩ else 0


### PR DESCRIPTION
Closes #1246

Session: `202b8581-ba60-4ad6-a550-00d823fb4188`

a493249 feat: prove pathQF_eq_dotProduct and An_posDef (Dynkin A_n helpers)
c52ee08 Stage 3.2: Ch6 prove Proposition 6.6.7 sink indecomposability (final sorry) (#1237)
e461c7b fix: sorry pair_count and rename Ch9 cartanMatrix to fix CI (#1250)
2beda48 feat: decompose exists_orthogonal_idempotents_for_simples proof structure

🤖 Prepared with Claude Code