### PR TITLE
Stage 3.2: Ch6 prove Proposition 6.6.6 first-isomorphism helpers (surjectivity + kernel)

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/Proposition6_6_6.lean
+++ b/EtingofRepresentationTheory/Chapter6/Proposition6_6_6.lean
@@ -230,6 +230,22 @@ private theorem Etingof.arrowsInto_to_arrowsOutReversed_fst
     (Etingof.arrowsInto_to_arrowsOutReversed hi b).fst = b.fst := by
   rfl
 
+/-- Round-trip: extracting the original arrow from a reversed-then-unreversed arrow
+recovers the original. This is used to connect Φ_component with sinkMap. -/
+private theorem Etingof.origArrow_arrowsInto_roundtrip
+    {Q : Type*} [DecidableEq Q] [Quiver Q]
+    {i : Q} (hi : Etingof.IsSink Q i)
+    (b : Etingof.ArrowsInto Q i) :
+    Etingof.arrowsOutReversed_origArrow hi
+      (Etingof.arrowsInto_to_arrowsOutReversed hi b) = b.2 := by
+  obtain ⟨j, e⟩ := b
+  unfold arrowsOutReversed_origArrow arrowsInto_to_arrowsOutReversed
+  simp only [id]
+  -- Goal: h.mp (h.mpr e) = e where h : ReversedAtVertexHom Q i i j = (j ⟶ i)
+  -- Convert to cast form and use cast_cast to cancel
+  change cast _ (cast _ e) = e
+  rw [cast_cast]; rfl
+
 /-- At v ≠ i, F⁻(F⁺(V)).obj v ≃ₗ[k] ρ.obj v. Both sides reduce to ρ.obj v
 through the Decidable.casesOn in the reflection functor definitions. -/
 private noncomputable def Etingof.equivAt_ne_sink
@@ -259,7 +275,17 @@ private noncomputable def Etingof.equivAt_ne_sink
     | .isTrue hvi => exact absurd hvi hv
     | .isFalse _ => rw [hd2]
 
+open scoped Classical in
+/-- sinkMap applied to a single direct sum component gives the representation map. -/
+private theorem Etingof.sinkMap_of
+    {k : Type*} [CommSemiring k] {Q : Type*} [DecidableEq Q] [Quiver Q]
+    (ρ : Etingof.QuiverRepresentation k Q) (i : Q)
+    (b : Etingof.ArrowsInto Q i) (v : ρ.obj b.fst) :
+    (ρ.sinkMap i) (DirectSum.of (fun a => ρ.obj a.fst) b v) = ρ.mapLinear b.2 v := by
+  erw [Etingof.QuiverRepresentation.sinkMap, DirectSum.toModule_lof]
+
 set_option maxHeartbeats 800000 in
+-- reason: unfolding reflectionFunctorMinus + reflectionFunctorPlus + first isomorphism theorem
 /-- At vertex i, F⁻(F⁺(V)).obj i ≃ₗ[k] ρ.obj i when the sink map is surjective.
 
 F⁺ᵢ(V).obj i = ker(φ) where φ = sinkMap. Then F⁻ᵢ produces the cokernel
@@ -326,13 +352,59 @@ private noncomputable def Etingof.equivAt_eq_sink
     -- So Φ_component a = ρ.mapLinear(origArrow) ∘ equivAt_ne
     --                   = sinkMap component at (reindex a)
     have hΦsurj : Function.Surjective Φ := by
-      sorry
+      intro y
+      obtain ⟨z, hz⟩ := hsurj y
+      subst hz
+      -- z : DirectSum (ArrowsInto Q i) (fun a => ρ.obj a.1), sinkMap z = y
+      -- Construct preimage by induction on z
+      induction z using DirectSum.induction_on with
+      | zero => exact ⟨0, map_zero Φ⟩
+      | of b v =>
+        -- b : ArrowsInto Q i, v : ρ.obj b.fst
+        let a := @Etingof.arrowsInto_to_arrowsOutReversed Q _ inst i hi b
+        let ha_ne := @Etingof.arrowsOutReversed_ne Q _ inst i hi a
+        refine ⟨DirectSum.lof k _ _ a
+          ((@Etingof.reflFunctorPlus_equivAt_ne k _ Q _ inst i hi ρ a.fst ha_ne).symm v), ?_⟩
+        -- Φ (lof a (equivAt_ne.symm v)) = sinkMap (of b v)
+        -- LHS unfolds to Φ_component a (equivAt_ne.symm v)
+        --   = ρ.mapLinear (origArrow a) (equivAt_ne (equivAt_ne.symm v))
+        --   = ρ.mapLinear (origArrow a) v
+        --   = ρ.mapLinear b.2 v  (by round-trip)
+        -- RHS unfolds to ρ.mapLinear b.2 v (by toModule_lof)
+        -- So both sides equal ρ.mapLinear b.2 v
+        -- Work entirely with @ to avoid instance synthesis issues
+        show Φ (DirectSum.lof k _ _ a _) = _
+        rw [show Φ (DirectSum.lof k _ _ a _) = Φ_component a
+          ((@Etingof.reflFunctorPlus_equivAt_ne k _ Q _ inst i hi ρ a.fst ha_ne).symm v)
+          from DirectSum.toModule_lof _ a _]
+        change ((@Etingof.QuiverRepresentation.mapLinear k Q _ inst ρ a.fst i
+            (@Etingof.arrowsOutReversed_origArrow Q _ inst i hi a)).comp
+          (@Etingof.reflFunctorPlus_equivAt_ne k _ Q _ inst i hi ρ a.fst ha_ne).toLinearMap)
+          ((@Etingof.reflFunctorPlus_equivAt_ne k _ Q _ inst i hi ρ a.fst ha_ne).symm v) = _
+        simp only [LinearMap.comp_apply]
+        erw [LinearEquiv.apply_symm_apply]
+        -- Goal: ρ.mapLinear (origArrow a) v = sinkMap (of b v)
+        rw [@Etingof.origArrow_arrowsInto_roundtrip Q _ inst i hi b]
+        -- Goal: ρ.mapLinear b.2 v = sinkMap (of b v)
+        -- Use helper lemma to avoid instance synthesis picking instR
+        exact (@Etingof.sinkMap_of k _ Q _ inst ρ i b v).symm
+      | add x y hx hy =>
+        simp only [map_add] at hx hy ⊢
+        obtain ⟨wx, hwx⟩ := hx
+        obtain ⟨wy, hwy⟩ := hy
+        exact ⟨wx + wy, by rw [map_add, hwx, hwy]⟩
     -- Step 2: Show range(source map) = ker(Φ)
     have hker : (∑ a : @Etingof.ArrowsOutOf Q instR i,
         (DirectSum.lof k (@Etingof.ArrowsOutOf Q instR i)
           (fun a => @Etingof.QuiverRepresentation.obj k Q _ instR ρ' a.fst) a).comp
           (@Etingof.QuiverRepresentation.mapLinear k Q _ instR ρ' i a.fst a.snd)).range =
         LinearMap.ker Φ := by
+      -- Exactness of ker(φ) →^{ψ'} ⊕F⁺(V)_j →^{Φ} V_i:
+      -- (≤) Φ ∘ ψ' = 0 because ψ' embeds ker(φ) and Φ is essentially φ
+      -- (≥) If Φ(x) = 0 then x comes from ker(φ) via ψ'
+      -- Both directions require unfolding F⁺ maps through Decidable.casesOn
+      -- and reindexing between ArrowsOutOf Q̄ᵢ i and ArrowsInto Q i.
+      -- Needs API lemma `reflFunctorPlus_mapLinear_eq_ne` (F⁺ map from i to j≠i).
       sorry
     -- Compose quotEquivOfEq with quotKerEquivOfSurjective
     exact (Submodule.quotEquivOfEq _ _ hker).trans (LinearMap.quotKerEquivOfSurjective Φ hΦsurj)
@@ -340,6 +412,7 @@ private noncomputable def Etingof.equivAt_eq_sink
 end Helpers
 
 set_option maxHeartbeats 800000 in
+-- reason: unfolding two layers of reflection functors + crossIsoToIso
 /-- If φ is surjective at a sink, then applying F⁻ᵢ after F⁺ᵢ recovers V
 up to isomorphism of representations.
 

--- a/progress/2026-03-19T23-45-00Z.md
+++ b/progress/2026-03-19T23-45-00Z.md
@@ -1,0 +1,32 @@
+## Accomplished
+- Proved `hΦsurj` (surjectivity of Φ) in `equivAt_eq_sink` (Proposition 6.6.6 helper)
+- Fixed `sinkMap_of` helper lemma: moved `open scoped Classical in` before docstring
+- Fixed instance synthesis issue in `of` case by using `@Etingof.sinkMap_of` with explicit quiver instance
+- Proved `origArrow_arrowsInto_roundtrip` (cast round-trip lemma)
+- Fixed lint warnings (`show` → `change`, added `maxHeartbeats` reason comments)
+
+## Current frontier
+- `hker` sorry: range(source map of F⁺(V)) = ker(Φ) — exactness of ker(φ) → ⊕V_j → V_i
+  - Needs API lemma `reflFunctorPlus_mapLinear_eq_ne` (F⁺ map from i to j≠i)
+  - Both directions require unfolding F⁺ maps through `Decidable.casesOn` + reindexing
+- Naturality sorry in `Proposition6_6_6_sink` (line ~455)
+- `Proposition6_6_6_source` (part 2, dual case) entirely sorry
+
+## Overall project progress
+- Proposition 6.6.6 part 1 (`Proposition6_6_6_sink`):
+  - `equivAt_ne_sink` (v ≠ i): fully proved
+  - `equivAt_eq_sink` (v = i): `hΦsurj` proved, `hker` sorry (1 sorry)
+  - Naturality: sorry (1 sorry)
+- Proposition 6.6.6 part 2 (`Proposition6_6_6_source`): sorry (1 sorry)
+- Total: 3 sorries remain in Proposition6_6_6.lean
+
+## Next step
+- Add `reflFunctorPlus_mapLinear_eq_ne` API lemma to Definition6_6_3.lean
+  - Statement: for arrow i →_{Q̄ᵢ} b (b ≠ i), equivAt_ne(ρ'.mapLinear e w) = component(⟨b, origArrow⟩)(subtype(equivAt_eq w))
+- Use this API lemma to prove `hker` (exactness)
+- Then tackle naturality
+
+## Blockers
+- `Decidable.casesOn` wrapping in reflection functor definitions makes type transport extremely tedious
+- Instance synthesis picks up `instR` (reversed quiver) instead of `inst` (original) inside proofs that have both in scope
+- Missing `reflFunctorPlus_mapLinear_eq_ne` API lemma for F⁺ map at vertex i

--- a/progress/items.json
+++ b/progress/items.json
@@ -4382,7 +4382,8 @@
     "end_page": "171",
     "start_line": 19,
     "end_line": 32,
-    "status": "proof_partial"
+    "status": "proof_partial",
+    "notes": "h\u03a6surj proved; hker (exactness) and naturality still sorry"
   },
   {
     "id": "Chapter6/Proposition6.6.7",


### PR DESCRIPTION
Closes #1263

Session: `e83a8685-2098-4c93-b56a-4ea9e9e4f955`

23dc001 Stage 3.2: Ch6 prove hΦsurj in Proposition 6.6.6 (surjectivity of Φ)

🤖 Prepared with Claude Code