### PR TITLE
feat: GL₂ conjugacy class partition infrastructure (definitions + partition proof)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/GL2ConjugacyClasses.lean
+++ b/EtingofRepresentationTheory/Chapter5/GL2ConjugacyClasses.lean
@@ -145,8 +145,7 @@ theorem GL2.conjugacyClass_unique (g : GL2' p n) :
              fun hss => GL2.isSplitSemisimple_not_isElliptic g hss h⟩⟩
 
 /-- The four predicates form a decidable partition: every element satisfies exactly one. -/
-theorem GL2.conjugacyClass_partition [Fintype (GaloisField p n)]
-    [DecidableEq (GaloisField p n)] (g : GL2' p n) :
+theorem GL2.conjugacyClass_partition (g : GL2' p n) :
     (GL2.IsScalar g ∧ ¬GL2.IsParabolic g ∧ ¬GL2.IsSplitSemisimple g ∧ ¬GL2.IsElliptic g) ∨
     (GL2.IsParabolic g ∧ ¬GL2.IsScalar g ∧ ¬GL2.IsSplitSemisimple g ∧ ¬GL2.IsElliptic g) ∨
     (GL2.IsSplitSemisimple g ∧ ¬GL2.IsScalar g ∧ ¬GL2.IsParabolic g ∧ ¬GL2.IsElliptic g) ∨


### PR DESCRIPTION
Partial progress on #1296

Session: `f56c87d5-2c59-4513-aeac-8264f6fac175`

e9223d9 doc: progress file for GL₂ conjugacy class partition infrastructure
ec4bf0b fix: remove unused Fintype/DecidableEq hypotheses from partition theorem
1ef1684 feat: refactor GL₂ conjugacy classes with discriminant-based partition
6bba513 feat: GL₂ conjugacy class predicates and partition infrastructure
8f25d25 progress: Theorem5_12_2 fully sorry-free (center dimension lemmas proved)
b43d591 feat: prove finrank_center_monoidAlgebra_le_card_conjClasses and finrank_center_pi_matrix
551e06e feat: prove finrank_center_pi_matrix (1/2 sorries for issue #1268)

🤖 Prepared with Claude Code