### PR TITLE
Fix PR #1315 merge conflicts (GL₂ conjugacy class partition)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/GL2ConjugacyClasses.lean
+++ b/EtingofRepresentationTheory/Chapter5/GL2ConjugacyClasses.lean
@@ -145,8 +145,7 @@ theorem GL2.conjugacyClass_unique (g : GL2' p n) :
              fun hss => GL2.isSplitSemisimple_not_isElliptic g hss h⟩⟩
 
 /-- The four predicates form a decidable partition: every element satisfies exactly one. -/
-theorem GL2.conjugacyClass_partition [Fintype (GaloisField p n)]
-    [DecidableEq (GaloisField p n)] (g : GL2' p n) :
+theorem GL2.conjugacyClass_partition (g : GL2' p n) :
     (GL2.IsScalar g ∧ ¬GL2.IsParabolic g ∧ ¬GL2.IsSplitSemisimple g ∧ ¬GL2.IsElliptic g) ∨
     (GL2.IsParabolic g ∧ ¬GL2.IsScalar g ∧ ¬GL2.IsSplitSemisimple g ∧ ¬GL2.IsElliptic g) ∨
     (GL2.IsSplitSemisimple g ∧ ¬GL2.IsScalar g ∧ ¬GL2.IsParabolic g ∧ ¬GL2.IsElliptic g) ∨


### PR DESCRIPTION
Closes #1316

Session: `42d32c59-6653-48a5-bd22-ec2bbdcfb3e6`

00a9694 fix: remove unused Fintype/DecidableEq hypotheses from partition theorem
c94351b feat: refactor GL₂ conjugacy classes with discriminant-based partition
23f8580 feat: GL₂ conjugacy class predicates and partition infrastructure

🤖 Prepared with Claude Code