### PR TITLE
fix: remove duplicate cartanMatrix_isSymm in Lemma6_7_2

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/Lemma6_7_2.lean
+++ b/EtingofRepresentationTheory/Chapter6/Lemma6_7_2.lean
@@ -32,12 +32,6 @@ variable {n : ℕ} {adj : Matrix (Fin n) (Fin n) ℤ}
 
 /-! ## B-preservation -/
 
-private lemma cartanMatrix_isSymm (hadj : adj.IsSymm) :
-    (cartanMatrix n adj).IsSymm := by
-  rw [Matrix.IsSymm]; unfold cartanMatrix
-  simp only [Matrix.transpose_sub, Matrix.transpose_smul,
-    Matrix.transpose_one]; rw [hadj.eq]
-
 private lemma cartanMatrix_diag_eq_two
     (hDynkin : IsDynkinDiagram n adj) (i : Fin n) :
     cartanMatrix n adj i i = 2 := by


### PR DESCRIPTION
## Summary

- Remove duplicate `private lemma cartanMatrix_isSymm` in `Lemma6_7_2.lean` that conflicted with the public version imported from `Theorem6_8_1.lean` via `Corollary6_8_2.lean`
- Both lemmas were identical; the imported public one is sufficient
- This fixes one of the build errors on `main`

Also created #1369 for the larger Example6_4_9 build failures (120+ errors in An/Dn files).

## Test plan

- [x] `lake build EtingofRepresentationTheory.Chapter6.Lemma6_7_2` succeeds

🤖 Prepared with Claude Code