### PR TITLE
## Summary
- Proves the characteristic 2 case in `Etingof.quadratic_one_root_zero_disc` (Lemma5_25_3.lean)
- In char 2: b² = 4ac = 0 so b = 0, equation reduces to ax² + c = 0, solved using `FiniteField.isSquare_of_char_two` (Frobenius bijectivity)
- Reduces Lemma5_25_3.lean from 3 sorries to 2

## Remaining sorries (out of scope - need separate issues)
1. `complementaryChar_parabolic_val` (line 638): Requires showing (a) conjugates of parabolic elements never land in K, and (b) charVα₁ on parabolic gives α(eigenvalue). Needs Galois theory of finite fields (Frobenius fixed points = range of algebraMap) plus principal series character computation.
2. `induced_normSq_sum_elliptic` (line 1145): The "three hardest steps" — conjugacy class decomposition, Frobenius character formula on K, and character orthogonality. Most complex sorry in the file.

## Test plan
- `lake build EtingofRepresentationTheory.Chapter5.Lemma5_25_3` succeeds (with 2 sorry warnings)

🤖 Prepared with Claude Code

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Lemma5_25_3.lean
+++ b/EtingofRepresentationTheory/Chapter5/Lemma5_25_3.lean
@@ -540,7 +540,18 @@ private lemma Etingof.quadratic_one_root_zero_disc
     -- In char 2: b² = 0, b = 0, equation is ax² + c = 0, use Frobenius for square root
     by_cases h2 : (2 : F) = 0
     · -- char 2: b = 0 (from b² = 4ac = 0), use Frobenius for square root
-      sorry
+      have h4 : (4 : F) = 0 := by linear_combination (2 : F) * h2
+      have hb_sq : b ^ 2 = 0 := by linear_combination hdisc + h4 * a * c
+      have hb : b = 0 := pow_eq_zero_iff (by omega : 2 ≠ 0) |>.mp hb_sq
+      have hringchar : ringChar F = 2 := by
+        haveI : CharP F 2 := (CharP.charP_iff_prime_eq_zero (by decide : Nat.Prime 2)).mpr h2
+        exact ringChar.eq F 2
+      obtain ⟨s, hs⟩ := FiniteField.isSquare_of_char_two hringchar (c * a⁻¹)
+      refine ⟨s, ?_⟩
+      have hsq : a * (s * s) + c = 0 := by
+        rw [← hs, mul_comm c a⁻¹, ← mul_assoc, mul_inv_cancel₀ ha, one_mul]
+        linear_combination c * h2
+      simp only [hb, zero_mul, add_zero, sq]; exact hsq
     · -- char ≠ 2: root is -b/(2a)
       have h2a : (2 * a) ≠ (0 : F) := mul_ne_zero h2 ha
       refine ⟨-b / (2 * a), ?_⟩


### PR DESCRIPTION
Closes #--title

Session: `73307e5a-0a67-4f11-929f-8320a3613c09`

d948e2b Stage 3.2: prove char 2 case in quadratic_one_root_zero_disc (#1298)

🤖 Prepared with Claude Code