### PR TITLE
feat: prove casimir_eigenspace_complement codisjoint (dimension counting)

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Theorem2_1_1.lean
+++ b/EtingofRepresentationTheory/Chapter2/Theorem2_1_1.lean
@@ -684,7 +684,26 @@ private lemma casimir_eigenspace_complement
     -- Strategy: im(C - c₀) ⊆ N (by hImg), so dim(ker(C-c₀)) ≥ dim(V) - dim(N).
     -- Since ker(C-c₀) ∩ N = 0 (disjoint) and dim(ker) ≥ dim(V)-dim(N),
     -- we get dim(ker) + dim(N) ≥ dim(V), hence ker + N = V.
-    sorry
+    rw [codisjoint_iff]
+    -- K = eigenspace c₀ = ker(C - c₀ • 1)
+    have hK_eq : K = LinearMap.ker (sl2_casimir (V := V) - c₀ • 1) :=
+      Module.End.eigenspace_def
+    -- range(C - c₀ • 1) ≤ N
+    have hRange : LinearMap.range (sl2_casimir (V := V) - c₀ • 1) ≤ N.toSubmodule := by
+      intro w hw
+      obtain ⟨v, hv⟩ := LinearMap.mem_range.mp hw
+      simp only [LinearMap.sub_apply, LinearMap.smul_apply] at hv
+      rw [← hv]
+      exact hImg v
+    -- By rank-nullity and range ≤ N, finrank V ≤ finrank N + finrank K
+    have hRN := LinearMap.finrank_range_add_finrank_ker
+      (sl2_casimir (V := V) - c₀ • 1)
+    have hRangeFinrank := Submodule.finrank_mono hRange
+    rw [← hK_eq] at hRN
+    -- N.toSubmodule ⊔ K = ⊤
+    apply Submodule.eq_top_of_disjoint N.toSubmodule K (by omega)
+    exact disjoint_iff_inf_le.mpr (fun v ⟨hvN, hvK⟩ ↦
+      hInj v hvN (Module.End.mem_eigenspace_iff.mp hvK))
 
 /-- Part (ii): Any finite-dimensional representation of sl(2, ℂ) is completely reducible.
 Every Lie submodule has a complementary Lie submodule, i.e., the lattice of Lie submodules


### PR DESCRIPTION
## Summary
- Prove the codisjoint part of `casimir_eigenspace_complement` using rank-nullity (dimension counting)
- Key insight: `range(C - c₀) ⊆ N` implies `finrank(ker(C - c₀)) ≥ finrank(V) - finrank(N)`, and combined with disjointness gives `ker ⊔ N = ⊤`
- Uses `LinearMap.finrank_range_add_finrank_ker`, `Submodule.finrank_mono`, and `Submodule.eq_top_of_disjoint`

Closes #1539

## Test plan
- [x] `lake build EtingofRepresentationTheory.Chapter2.Theorem2_1_1` succeeds
- [x] `casimir_eigenspace_complement` contains no `sorry`

🤖 Prepared with Claude Code