### PR TITLE
feat: prove exists_sink_of_dynkin_orientation counting argument (#1381)

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/Corollary6_8_3.lean
+++ b/EtingofRepresentationTheory/Chapter6/Corollary6_8_3.lean
@@ -189,17 +189,25 @@ dimension vectors transform by sᵢ, and by induction they're isomorphic on
 
 1. **Type-changing iteration**: Each reflection functor changes the quiver from Q
    to `reversedAtVertex Q i`, producing a chain of different Lean types. The
-   induction hypothesis must apply to the reversed quiver, requiring a
-   universally-quantified statement over all orientations of the same graph.
+   induction hypothesis must apply to the reversed quiver, requiring either:
+   (a) A universally-quantified auxiliary lemma with Q explicit, proved by
+       `induction vertices generalizing Q`, or
+   (b) Well-founded recursion with a bundled state type.
+   Either approach requires threading `Free`/`Finite` instances for F⁺ᵢ outputs.
 
 2. **Vertex-sink alignment**: The vertices from Theorem 6.8.1 (via `exists_good_vertex`)
    are chosen to reduce the integer dimension vector, but may not be sinks in the
    current quiver Q. The book's proof uses the Coxeter element ordering, which
    guarantees each vertex is a sink at the appropriate step. Aligning these two
-   approaches requires Coxeter element infrastructure.
+   approaches requires `admissibleOrdering_exists` (currently sorry'd in
+   `CoxeterInfrastructure.lean`). Note: `exists_sink_of_dynkin_orientation` is
+   now proved, which is the key ingredient for admissible ordering existence.
 
 3. **`Proposition6_6_7_source` (sorry'd)**: Preserving indecomposability through
-   source reflection functors is not yet proven (1 sorry in Proposition6_6_7.lean). -/
+   source reflection functors is not yet proven (1 sorry in Proposition6_6_7.lean).
+
+4. **Proposition 6.6.6 naturality**: The round-trip theorem F⁻F⁺(V) ≅ V has 2
+   remaining sorries in the naturality proof (arrow cases a≠i,b=i and a≠i,b≠i). -/
 private lemma Etingof.reflectionFunctors_reduce_and_recover
     {n : ℕ} {adj : Matrix (Fin n) (Fin n) ℤ}
     (hDynkin : Etingof.IsDynkinDiagram n adj)

--- a/EtingofRepresentationTheory/Chapter6/CoxeterInfrastructure.lean
+++ b/EtingofRepresentationTheory/Chapter6/CoxeterInfrastructure.lean
@@ -106,15 +106,85 @@ theorem exists_sink_of_dynkin_orientation
     · -- w ⟶ v: harr2 gives w ⟶ next w, and h1 : v = next w
       rw [show v = next w from h1]; exact harr2
   -- Step 4: The double sum Σ_i Σ_j adj(i,j) satisfies incompatible bounds.
-  -- Upper bound: B(1,1) > 0 means 2n - Σ adj > 0, so Σ adj < 2n.
-  -- Lower bound: the 2n distinct pairs {(v, next v)} ∪ {(next v, v)} each with adj = 1
-  --   force Σ adj ≥ 2n.
-  -- We show: for each v, adj(v, next v) ≤ Σ_j adj(v, j) (single summand of a sum of nonneg terms)
-  -- and similarly for adj(next v, v). The non-overlap condition ensures these contribute distinctly.
-  --
-  -- For now, the counting argument (injection into the double sum) is sorry'd.
-  -- The proof structure above (Steps 1-3) is complete and verified.
-  sorry
+  -- adj is nonneg
+  have hadj_nonneg : ∀ i j, (0 : ℤ) ≤ adj i j := by
+    intro i j; rcases hDynkin.2.2.1 i j with h | h <;> omega
+  -- Total sum of adj
+  set total := ∑ i : Fin n, ∑ j : Fin n, adj i j
+  -- Upper bound: positive definiteness with x = all-ones gives 2n - total > 0
+  have hone_ne : (fun (_ : Fin n) => (1 : ℤ)) ≠ 0 := by
+    intro heq; have := congr_fun heq ⟨0, hn⟩; simp at this
+  have hpos := hDynkin.2.2.2.2 (fun _ => (1 : ℤ)) hone_ne
+  -- Expand B(1,1) = 2n - total
+  have hexpand : dotProduct (fun _ => (1 : ℤ))
+      ((2 • (1 : Matrix (Fin n) (Fin n) ℤ) - adj).mulVec (fun _ => 1)) =
+      2 * (↑n : ℤ) - total := by
+    -- Row sum of (2I - adj) is 2 - row sum of adj
+    have h_row : ∀ i : Fin n,
+        ∑ j, (2 • (1 : Matrix (Fin n) (Fin n) ℤ) - adj) i j = 2 - ∑ j, adj i j := by
+      intro i
+      have h2I : ∑ j : Fin n, (2 • (1 : Matrix (Fin n) (Fin n) ℤ)) i j = 2 := by
+        simp [Matrix.smul_apply, Matrix.one_apply, Finset.mem_univ]
+      simp only [Matrix.sub_apply]
+      rw [Finset.sum_sub_distrib]
+      linarith
+    -- dotProduct 1 (M.mulVec 1) = ∑ i, ∑ j, M i j
+    have h_dot : dotProduct (fun _ => (1 : ℤ))
+        ((2 • (1 : Matrix (Fin n) (Fin n) ℤ) - adj).mulVec (fun _ => 1)) =
+        ∑ i, ∑ j, (2 • (1 : Matrix (Fin n) (Fin n) ℤ) - adj) i j := by
+      simp only [dotProduct, Matrix.mulVec, one_mul, mul_one]
+    rw [h_dot]
+    -- Now ∑ i, ∑ j, (2I - adj) i j = ∑ i, (2 - ∑ j, adj i j) = 2n - total
+    simp_rw [h_row]
+    simp only [Finset.sum_sub_distrib, Finset.sum_const, Finset.card_univ, Fintype.card_fin,
+      nsmul_eq_mul, total]
+    ring
+  have hub : total < 2 * (↑n : ℤ) := by linarith
+  -- Lower bound: 2n ≤ total via disjoint pair counting
+  -- Define forward and backward pair maps
+  have hfwd_inj : Function.Injective (fun v : Fin n => (v, next v)) :=
+    fun a b h => (Prod.mk.inj h).1
+  have hbwd_inj : Function.Injective (fun v : Fin n => (next v, v)) :=
+    fun a b h => (Prod.mk.inj h).2
+  -- The forward and backward images are disjoint (by hno_overlap)
+  have hdisjoint : Disjoint
+      (Finset.univ.image (fun v : Fin n => (v, next v)))
+      (Finset.univ.image (fun v : Fin n => (next v, v))) := by
+    rw [Finset.disjoint_left]
+    intro p hp1 hp2
+    rw [Finset.mem_image] at hp1 hp2
+    obtain ⟨v, _, hv⟩ := hp1
+    obtain ⟨w, _, hw⟩ := hp2
+    exact absurd (hv ▸ hw ▸ rfl : (v, next v) = (next w, w)) (hno_overlap v w)
+  -- Sum over forward pairs = n
+  have h_fwd_sum : ∑ p ∈ Finset.univ.image (fun v : Fin n => (v, next v)),
+      adj p.1 p.2 = ↑n := by
+    rw [Finset.sum_image (fun a _ b _ h => hfwd_inj h)]
+    simp [hadj_out, Finset.sum_const, Finset.card_univ, mul_one]
+  -- Sum over backward pairs = n
+  have h_bwd_sum : ∑ p ∈ Finset.univ.image (fun v : Fin n => (next v, v)),
+      adj p.1 p.2 = ↑n := by
+    rw [Finset.sum_image (fun a _ b _ h => hbwd_inj h)]
+    simp [hadj_in, Finset.sum_const, Finset.card_univ, mul_one]
+  -- Sum over the disjoint union = 2n
+  have h_union_sum : ∑ p ∈ (Finset.univ.image (fun v : Fin n => (v, next v)) ∪
+      Finset.univ.image (fun v : Fin n => (next v, v))),
+      adj p.1 p.2 = 2 * ↑n := by
+    rw [Finset.sum_union hdisjoint, h_fwd_sum, h_bwd_sum]; ring
+  -- The union is a subset of all pairs, and adj ≥ 0, so total ≥ 2n
+  have h_sub : Finset.univ.image (fun v : Fin n => (v, next v)) ∪
+      Finset.univ.image (fun v : Fin n => (next v, v)) ⊆
+      (Finset.univ : Finset (Fin n × Fin n)) :=
+    Finset.subset_univ _
+  have h_pair_sum : (∑ p : Fin n × Fin n, adj p.fst p.snd) = total := by
+    show (∑ p ∈ (Finset.univ : Finset (Fin n × Fin n)), adj p.fst p.snd) = total
+    rw [Finset.univ_product_univ.symm, Finset.sum_product']
+  have hlb : 2 * (↑n : ℤ) ≤ total := by
+    have := Finset.sum_le_sum_of_subset_of_nonneg h_sub
+      (fun p _ _ => hadj_nonneg p.1 p.2)
+    linarith [h_union_sum, h_pair_sum]
+  -- Contradiction: total < 2n and total ≥ 2n
+  linarith
 
 /-- Reversing at a sink makes that vertex a source in the reversed quiver. -/
 theorem reversedAtVertex_sink_becomes_source

--- a/progress/20260323T020615Z_c06a88ba.md
+++ b/progress/20260323T020615Z_c06a88ba.md
@@ -1,0 +1,41 @@
+## Accomplished
+
+Worked on issue #1381: "Stage 3.2: Ch6 prove Corollary6_8_3 helper lemmas".
+
+### Proved `exists_sink_of_dynkin_orientation` counting argument (CoxeterInfrastructure.lean)
+
+Eliminated 1 sorry by proving the combinatorial counting argument that every Dynkin orientation has a sink. The proof:
+1. Shows adj entries are nonneg (from IsDynkinDiagram: entries in {0,1})
+2. Upper bound: positive definiteness with x=all-ones gives `total < 2n`
+3. Lower bound: 2n distinct pairs from forward/backward images with disjoint union gives `2n ≤ total`
+4. Contradiction closes the case where no vertex is a sink
+
+### Verified deliverable status
+
+- `indecomposable_titsForm_le_two`: already sorry-free (delegates to `indecomposable_bilinearForm_eq_two` via `le_of_eq`)
+- `reflectionFunctors_reduce_and_recover` cons case: cannot be proved with current infrastructure due to 4 deep blockers (type-changing iteration, vertex-sink alignment, Prop 6.6.6 naturality, Free/Finite instances)
+
+### Updated documentation
+
+Updated docstring in Corollary6_8_3.lean to reflect current blocker status including that `exists_sink_of_dynkin_orientation` is now proved.
+
+## Current frontier
+
+- `reflectionFunctors_reduce_and_recover` cons case at line ~235 of Corollary6_8_3.lean still sorry'd
+- Requires: `admissibleOrdering_exists` (sorry'd), Prop 6.6.6 naturality (2 sorries), type-changing iteration infrastructure
+
+## Overall project progress
+
+- 558/583 items sorry_free (95.7%)
+- CoxeterInfrastructure.lean: reduced from 3 to 2 sorries (proved `exists_sink_of_dynkin_orientation`)
+- Ch6 total: ~28 sorries across 9 files (reduced by 1)
+
+## Next step
+
+- Prove `admissibleOrdering_exists` in CoxeterInfrastructure.lean (uses `exists_sink_of_dynkin_orientation` which is now proved)
+- Continue Prop 6.6.6 naturality (2 sorries for arrow cases)
+- These are prerequisites for the cons case of `reflectionFunctors_reduce_and_recover`
+
+## Blockers
+
+None — the remaining work requires filling in upstream infrastructure sorries.


### PR DESCRIPTION
## Summary

- Prove the combinatorial counting argument in `exists_sink_of_dynkin_orientation` (CoxeterInfrastructure.lean), eliminating 1 sorry
- The proof shows incompatible bounds on the adjacency sum: positive definiteness gives `total < 2n`, while 2n disjoint forward/backward pairs give `total >= 2n`
- Update Corollary6_8_3 docstring with current blocker analysis for the cons case

Closes #1381 (partial — proved `exists_sink_of_dynkin_orientation`; cons case of `reflectionFunctors_reduce_and_recover` remains blocked on upstream infrastructure)

🤖 Prepared with Claude Code