### PR TITLE
feat: prove frobenius_char_reciprocity and normalizer_card, eliminate 2 sorries

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/GL2NormalizerInfra.lean
+++ b/EtingofRepresentationTheory/Chapter5/GL2NormalizerInfra.lean
@@ -886,6 +886,53 @@ lemma Etingof.GL2.normalizer_card (hn : n ≠ 0) (hp2 : p ≠ 2)
     (Finset.univ.filter (fun g : GL2 p n =>
       Etingof.GL2.isInNormalizer p n g)).card =
     2 * Fintype.card ↥(Etingof.GL2.ellipticSubgroup p n) := by
-  sorry
+  classical
+  haveI : Fintype (GaloisField p n) := Fintype.ofFinite _
+  -- Split normalizer into K-part and σK-part
+  set N := Finset.univ.filter (fun g : GL2 p n => Etingof.GL2.isInNormalizer p n g)
+  set K := Finset.univ.filter (fun g : GL2 p n => g ∈ Etingof.GL2.ellipticSubgroup p n)
+  set σK := Finset.univ.filter (fun g : GL2 p n =>
+    ∃ α : (GaloisField p (2 * n))ˣ,
+      g = Etingof.GL2.frobeniusMatrix p n * Etingof.GL2.fieldExtEmbed p n α)
+  -- Show N = K ∪ σK
+  have hN_eq : N = K ∪ σK := by
+    ext g; simp only [Finset.mem_union, Finset.mem_filter, Finset.mem_univ, true_and, N, K, σK]
+    constructor
+    · intro hg
+      exact Etingof.GL2.normalizer_mem_dichotomy p n hn hp2 g hg
+    · rintro (hk | ⟨α, rfl⟩)
+      · exact Etingof.GL2.ellipticSubgroup_mem_normalizer p n g hk
+      · exact Etingof.GL2.normalizer_contains_frobeniusCoset p n hn
+          (Etingof.GL2.fieldExtEmbed p n α) ⟨α, rfl⟩
+  -- Show K and σK are disjoint
+  have hKσK_disj : Disjoint K σK := by
+    rw [Finset.disjoint_filter]
+    intro g _ hgK ⟨α, hgα⟩
+    have : Etingof.GL2.frobeniusMatrix p n ∈ Etingof.GL2.ellipticSubgroup p n := by
+      obtain ⟨β, hβ⟩ := hgK
+      rw [hgα] at hβ
+      have : Etingof.GL2.frobeniusMatrix p n =
+          Etingof.GL2.fieldExtEmbed p n β * (Etingof.GL2.fieldExtEmbed p n α)⁻¹ := by
+        rw [hβ]; group
+      rw [this]; exact ⟨β * α⁻¹, by rw [map_mul, map_inv]⟩
+    exact Etingof.GL2.frobeniusMatrix_not_in_elliptic p n hn this
+  -- |K| = Fintype.card (ellipticSubgroup)
+  have hK_card : K.card = Fintype.card ↥(Etingof.GL2.ellipticSubgroup p n) := by
+    simp only [K, ← Fintype.card_subtype]
+  -- |σK| = Fintype.card (ellipticSubgroup)
+  have hσK_card : σK.card = Fintype.card ↥(Etingof.GL2.ellipticSubgroup p n) := by
+    -- σK = image of K under left multiplication by σ
+    set σ := Etingof.GL2.frobeniusMatrix p n
+    have hσK_eq : σK = K.map ⟨(σ * ·), mul_right_injective σ⟩ := by
+      ext g; simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_map,
+        Function.Embedding.coeFn_mk, σK, K]
+      constructor
+      · rintro ⟨α, rfl⟩
+        exact ⟨Etingof.GL2.fieldExtEmbed p n α, ⟨α, rfl⟩, rfl⟩
+      · rintro ⟨k, ⟨α, rfl⟩, rfl⟩
+        exact ⟨α, rfl⟩
+    rw [hσK_eq, Finset.card_map, hK_card]
+  -- Combine
+  rw [hN_eq, Finset.card_union_of_disjoint hKσK_disj, hK_card, hσK_card, two_mul]
 
 end Normalizer

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_26_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_26_1.lean
@@ -97,7 +97,22 @@ private lemma frobenius_char_reciprocity {G : Type} [Group G] [Fintype G]
   -- then reindexing h → h⁻¹ in H converts f(↑h)⁻¹ * χ(h) to f(↑h) * χ(h⁻¹).
   -- The mathematical content is trivial; the remaining complexity is
   -- matching Lean Fintype instances between {x // x ∈ H} and ↥H.
-  sorry
+  -- Step 3: Split G-sum into H-part and complement
+  -- The G-sum with dite restricts to ↥H (complement terms are 0)
+  have h_restrict : (∑ k : G, if h_1 : k ∈ H then f k⁻¹ * χ ⟨k, h_1⟩ else 0) =
+      ∑ k : ↥H, f (↑k)⁻¹ * χ k := by
+    rw [← Fintype.sum_subtype_add_sum_subtype (· ∈ H)
+      (fun k : G => if h_1 : k ∈ H then f k⁻¹ * χ ⟨k, h_1⟩ else 0)]
+    have h_compl : (∑ k : {k : G // k ∉ H},
+        if h_1 : (↑k : G) ∈ H then f (↑k)⁻¹ * χ ⟨↑k, h_1⟩ else 0) = 0 :=
+      Finset.sum_eq_zero (fun ⟨k, hk⟩ _ => dif_neg hk)
+    rw [h_compl, add_zero]
+    congr 1; ext ⟨k, hk⟩; exact dif_pos hk
+  rw [h_restrict]
+  -- Step 4: Reindex by h ↦ h⁻¹ in the subtype sum
+  conv_lhs => rw [← Equiv.sum_comp (Equiv.inv ↥H)]
+  congr 1; ext h
+  simp only [Equiv.inv_apply, Subgroup.coe_inv, inv_inv]
 
 open Classical in
 /-- Character completeness on subgroups: if a class function f on G, when restricted to
@@ -174,9 +189,9 @@ Proof outline (Etingof, Theorem 5.26.1):
 5. By `artin_Q_span_of_induced_chars` (Remark 5.26.2): the ℚ-span of induced
    characters contains all irreducible characters.
 
-Sorry status: 3 sorry'd helpers (`frobenius_char_reciprocity` has 1 sorry in a
-subtype conversion step, `class_fun_vanishes_on_subgroup_of_orthogonal`,
-`artin_Q_span_of_induced_chars`). `covering_implies_vanishing` is fully proved.
+Sorry status: 2 sorry'd helpers (`class_fun_vanishes_on_subgroup_of_orthogonal`,
+`artin_Q_span_of_induced_chars`). `frobenius_char_reciprocity` and
+`covering_implies_vanishing` are fully proved.
 The `artin_forward` proof itself is sorry-free given the helpers. -/
 private lemma artin_forward {G : Type} [Group G] [Fintype G]
     (X : Set (Subgroup G))

--- a/progress/20260323T032234Z_791af6ba.md
+++ b/progress/20260323T032234Z_791af6ba.md
@@ -1,0 +1,42 @@
+## Accomplished
+
+### Proved `frobenius_char_reciprocity` (Theorem5_26_1.lean)
+
+Eliminated 1 sorry by proving the Frobenius character reciprocity subtype conversion step. The proof:
+1. Splits the G-sum with `dite` into H-part and complement using `Fintype.sum_subtype_add_sum_subtype`
+2. Shows complement terms are 0 via `dif_neg`, H-part simplifies via `dif_pos`
+3. Reindexes by h ↦ h⁻¹ using `Equiv.sum_comp (Equiv.inv ↥H)` and `Subgroup.coe_inv`
+
+Theorem5_26_1.lean now has 2 sorry'd helpers (down from 3).
+
+### Proved `normalizer_card` (GL2NormalizerInfra.lean)
+
+Eliminated 1 sorry by proving |N_{GL₂}(K)| = 2|K|. The proof:
+1. Decomposes normalizer filter N = K ∪ σK using `normalizer_mem_dichotomy` (forward) and `ellipticSubgroup_mem_normalizer`/`normalizer_contains_frobeniusCoset` (backward)
+2. Shows K ∩ σK = ∅: if g ∈ K ∩ σK then σ = embed(β) · embed(α)⁻¹ ∈ K, contradicting `frobeniusMatrix_not_in_elliptic`
+3. Shows |σK| = |K| by expressing σK as `K.map ⟨(σ * ·), mul_right_injective σ⟩`
+4. Combines via `Finset.card_union_of_disjoint`
+
+GL2NormalizerInfra.lean is now sorry-free (was 1 sorry).
+
+## Current frontier
+
+- Theorem5_26_1.lean: 2 sorries (`class_fun_vanishes_on_subgroup_of_orthogonal`, `artin_Q_span_of_induced_chars`)
+- All other remaining sorries are deep theorems or blocked by upstream infrastructure
+
+## Overall project progress
+
+- ~560/583 items sorry-free (~96%)
+- GL2NormalizerInfra.lean: 0 sorries (was 1)
+- Theorem5_26_1.lean: 2 sorries (was 3)
+- Total sorry count reduced by 2 this session
+
+## Next step
+
+- Prove `class_fun_vanishes_on_subgroup_of_orthogonal` in Theorem5_26_1.lean (requires characters-span-class-functions from Theorem 4.2.1)
+- Continue Chapter 6 infrastructure: `admissibleOrdering_exists`, Prop 6.6.6 naturality
+- Explore `decomp_of_ker_sum_ge_two` in Problem6_9_1.lean
+
+## Blockers
+
+None — remaining work requires filling in upstream infrastructure sorries or deep theorem proofs.


### PR DESCRIPTION
## Summary
- **Theorem5_26_1.lean**: Prove `frobenius_char_reciprocity` sorry by splitting the G-sum into H/complement parts using `Fintype.sum_subtype_add_sum_subtype`, then reindexing by inversion via `Equiv.sum_comp (Equiv.inv ↥H)`. Reduces sorry count from 3 to 2.
- **GL2NormalizerInfra.lean**: Prove `normalizer_card` (|N_{GL₂}(K)| = 2|K|) by decomposing the normalizer as K ∪ σK, proving disjointness via `frobeniusMatrix_not_in_elliptic`, and showing |σK| = |K| via `Finset.card_map`. File is now sorry-free.

## Test plan
- [x] `lake build` succeeds for both modified files
- [x] No new errors or warnings introduced

🤖 Prepared with Claude Code