### PR TITLE
## Summary

- Added detailed docstring to the `alternatingKostka_norm_sq_eq_one` sorry in `Theorem5_15_1.lean` documenting:
  - The proof outline (Etingof Theorem 5.15.1)
  - The mathematical blocker: power sum Cauchy identity
  - Three alternative approaches investigated and why they're insufficient
- Created issue #1622 for the missing infrastructure: power sum Cauchy identity `(1/n!) ∑_σ P_σ(x)P_σ(y) = [deg n of ∏_{i,j} 1/(1-xᵢyⱼ)]`

## Context

Issue #1593 asks to prove `alternatingKostka_norm_sq_eq_one` — the last sorry in the Frobenius Character Formula chain. After thorough investigation, all viable proof approaches reduce to needing the power sum Cauchy identity, which requires ~300-500 lines of new symmetric function theory (issue #1622).

This PR ships the documentation and analysis so the next agent can pick up the actual proof work.

## Test plan

- [ ] `lake build` passes (1 sorry warning expected for the target theorem)

🤖 Prepared with Claude Code

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_15_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_15_1.lean
@@ -2241,6 +2241,34 @@ private theorem cycleTypePsumProduct_inv (n : ℕ) (σ : Equiv.Perm (Fin n)) :
   unfold cycleTypePsumProduct
   rw [Equiv.Perm.cycleType_inv, Equiv.Perm.support_inv]
 
+/-- **Norm-squared identity for the alternating Kostka matrix:**
+∑_ν L²_{νλ} = 1, where L_{νλ} = ∑_π sign(π) · K(sort(λ+ρ-π(ρ)), ν).
+
+**Proof outline** (Etingof, Theorem 5.15.1):
+Define θ_λ(σ) = [x^{λ+ρ}](Δ(x) · P_σ(x)). By Young's Rule expansion,
+θ_λ = ∑_ν L_{νλ} χ_ν. Character orthonormality (`FDRep.char_orthonormal`)
+gives ⟨θ_λ, θ_λ⟩ = ∑_ν L²_{νλ}.
+
+The key step is showing ⟨θ_λ, θ_λ⟩ = 1 via Vandermonde coefficient orthogonality.
+This requires the **power sum Cauchy identity**:
+
+  (1/n!) ∑_{σ ∈ S_n} P_σ(x) P_σ(y) = [degree n of ∏_{i,j} 1/(1 - xᵢyⱼ)]
+
+Combined with the Cauchy determinant identity (Lemma 5.15.3 + Corollary 5.15.4):
+
+  det(1/(1-xᵢyⱼ)) = Δ(x)Δ(y) · ∏_{i,j} 1/(1-xᵢyⱼ)
+
+the coefficient of x^{λ+ρ}y^{λ+ρ} in the RHS is 1 (since λ+ρ has strictly
+decreasing distinct entries, only σ=id contributes).
+
+**Blocked on**: The power sum Cauchy identity is not yet formalized. This requires
+either the exponential formula for formal power series or a direct combinatorial
+argument about cycle types. See GitHub issue for details.
+
+Three alternative approaches were investigated and found insufficient:
+1. Character orthonormality alone → tautological (Parseval gives ∑L² = ⟨θ,θ⟩)
+2. Strong induction on dominance order → also tautological
+3. Sign-reversing involution → requires Gessel-Viennot / lattice path infrastructure -/
 private theorem alternatingKostka_norm_sq_eq_one {n : ℕ} (la : Nat.Partition n) :
     ∑ nu : Nat.Partition n, alternatingKostkaInt la nu ^ 2 = 1 := by
   sorry

--- a/progress/2026-03-23T05-28-35Z.md
+++ b/progress/2026-03-23T05-28-35Z.md
@@ -1,0 +1,33 @@
+## Accomplished
+
+- Investigated issue #1593: `alternatingKostka_norm_sq_eq_one` (the last sorry in the Frobenius Character Formula chain)
+- Analyzed three proof approaches and determined all reduce to the same blocker: the **power sum Cauchy identity**
+  1. Character orthonormality (Parseval) gives `⟨θ_λ, θ_λ⟩ = ∑_ν L²_{νλ}` but cannot evaluate `⟨θ_λ, θ_λ⟩ = 1` without external input
+  2. Strong induction on dominance order — tautological for the same reason
+  3. Sign-reversing involution — requires Gessel-Viennot / lattice path infrastructure not present
+- Added detailed docstring to the sorry documenting the proof outline, the blocker, and the three failed approaches
+- Created issue #1622 for the missing infrastructure: power sum Cauchy identity `(1/n!) ∑_σ P_σ(x)P_σ(y) = [deg n of ∏_{i,j} 1/(1-xᵢyⱼ)]`
+- Verified the identity computationally for n=0,1,2
+
+## Current frontier
+
+The sorry at `alternatingKostka_norm_sq_eq_one` in `Theorem5_15_1.lean` is blocked on the power sum Cauchy identity (issue #1622). The full proof chain is:
+1. Power sum Cauchy identity (NEW, ~300-500 lines) → issue #1622
+2. Coefficient extraction: `[x^{λ+ρ} y^{λ+ρ}](cauchyRHS) = 1`
+3. Vandermonde coefficient orthogonality: `(1/n!) ∑_σ θ_λ(σ)² = 1`
+4. Parseval: `∑_ν L²_{νλ} = ⟨θ_λ, θ_λ⟩ = 1`
+
+## Overall project progress
+
+- 61 sorries remain (per wave 29 audit, issue #1615)
+- The Frobenius Character Formula (`Theorem5_15_1`) has 1 sorry blocking the full chain
+- Key infrastructure in place: Cauchy determinant (Lemma 5.15.3), Cauchy identity (Corollary 5.15.4), `cycleTypePsumProduct_inv` (#1618), `spechtModuleFDRep_simple` (#1601)
+
+## Next step
+
+- Prove the power sum Cauchy identity (issue #1622) — this is the critical path item
+- Then prove coefficient extraction from `cauchyRHS` and assemble the full proof
+
+## Blockers
+
+- Issue #1622: Power sum Cauchy identity not yet formalized (~300-500 lines of symmetric function theory)


### PR DESCRIPTION
Closes #doc: document alternatingKostka_norm_sq_eq_one blocker, create issue #1622

Session: `8944a79b-5673-4ffc-8e5b-3bf72ddc02bc`

d6be646 doc: document alternatingKostka_norm_sq_eq_one blocker + create power sum Cauchy issue (#1622)

🤖 Prepared with Claude Code