### PR TITLE
doc: analyze alternatingKostka_norm_sq_eq_one blocker

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_15_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_15_1.lean
@@ -2241,34 +2241,35 @@ private theorem cycleTypePsumProduct_inv (n : ℕ) (σ : Equiv.Perm (Fin n)) :
   unfold cycleTypePsumProduct
   rw [Equiv.Perm.cycleType_inv, Equiv.Perm.support_inv]
 
-/-- **Norm-squared identity for the alternating Kostka matrix:**
-∑_ν L²_{νλ} = 1, where L_{νλ} = ∑_π sign(π) · K(sort(λ+ρ-π(ρ)), ν).
+/-- **Vandermonde coefficient orthogonality**: ∑_σ θ_λ(σ)² = n!,
+where θ_λ(σ) = [x^{λ+ρ}](Δ(x) · P_σ(x)).
 
-**Proof outline** (Etingof, Theorem 5.15.1):
-Define θ_λ(σ) = [x^{λ+ρ}](Δ(x) · P_σ(x)). By Young's Rule expansion,
-θ_λ = ∑_ν L_{νλ} χ_ν. Character orthonormality (`FDRep.char_orthonormal`)
-gives ⟨θ_λ, θ_λ⟩ = ∑_ν L²_{νλ}.
+This is equivalent to the norm-squared identity ∑_ν L²_{νλ} = 1 via
+character orthonormality (Parseval), but is stated as a combinatorial identity
+about polynomial coefficients that can be proved directly.
 
-The key step is showing ⟨θ_λ, θ_λ⟩ = 1 via Vandermonde coefficient orthogonality.
-This requires the **power sum Cauchy identity**:
+**Proof strategy** (Etingof, proof of Theorem 5.15.1):
+1. Expand θ_λ(σ)² = (∑_π sign(π) [x^{λ+ρ-e_π}](P_σ))²
+2. Sum over σ: ∑_σ c_{π,σ} c_{τ,σ} = n! · dim Hom(U_{μ_π}, U_{μ_τ})
+3. The double alternating sum gives ∑_ν L²_{νλ} (Parseval).
+4. Independently: via the power sum Cauchy identity
+   (∑_σ P_σ(x)P_σ(y) = n! · ∏_{i,j} 1/(1-x_i y_j) at degree n)
+   and the Cauchy determinant identity (Corollary 5.15.4),
+   this sum equals n! · coeff(x^{λ+ρ} y^{λ+ρ}, det(1/(1-x_i y_j))) = n! · 1.
 
-  (1/n!) ∑_{σ ∈ S_n} P_σ(x) P_σ(y) = [degree n of ∏_{i,j} 1/(1 - xᵢyⱼ)]
+**Blocked on**: The power sum Cauchy identity (GitHub issue #1622).
+The coefficient extraction coeff(x^α y^α, cauchyRHS) = 1 for distinct α
+is straightforward (only σ=id contributes when α has distinct entries),
+but connecting ∑_σ P_σ(x)P_σ(y) to ∏ 1/(1-x_i y_j) requires either
+the exponential formula for formal power series or a direct combinatorial
+argument about cycle types (estimated 300-500 lines).
 
-Combined with the Cauchy determinant identity (Lemma 5.15.3 + Corollary 5.15.4):
-
-  det(1/(1-xᵢyⱼ)) = Δ(x)Δ(y) · ∏_{i,j} 1/(1-xᵢyⱼ)
-
-the coefficient of x^{λ+ρ}y^{λ+ρ} in the RHS is 1 (since λ+ρ has strictly
-decreasing distinct entries, only σ=id contributes).
-
-**Blocked on**: The power sum Cauchy identity is not yet formalized. This requires
-either the exponential formula for formal power series or a direct combinatorial
-argument about cycle types. See GitHub issue for details.
-
-Three alternative approaches were investigated and found insufficient:
+Alternative approaches investigated and found insufficient:
 1. Character orthonormality alone → tautological (Parseval gives ∑L² = ⟨θ,θ⟩)
-2. Strong induction on dominance order → also tautological
-3. Sign-reversing involution → requires Gessel-Viennot / lattice path infrastructure -/
+2. Strong induction on dominance order → also tautological (inductive hypothesis
+   gives L_{ν,μ} = 0 for μ > λ, but doesn't constrain K(μ_π, ν) directly)
+3. Sign-reversing involution → requires Gessel-Viennot / lattice path infrastructure
+4. Matrix L^T L = I argument → needs ⟨θ_λ, θ_λ⟩ ≤ 1, same blocker -/
 private theorem alternatingKostka_norm_sq_eq_one {n : ℕ} (la : Nat.Partition n) :
     ∑ nu : Nat.Partition n, alternatingKostkaInt la nu ^ 2 = 1 := by
   sorry

--- a/progress/2026-03-23T10-45-00Z.md
+++ b/progress/2026-03-23T10-45-00Z.md
@@ -1,0 +1,56 @@
+## Accomplished
+
+- Claimed issue #1593: prove `alternatingKostka_norm_sq_eq_one` (last sorry in Theorem5_15_1.lean)
+- Deep analysis of the proof structure and all available approaches
+- Improved documentation of the sorry with detailed proof strategy, blocked dependency (#1622), and analysis of 4 investigated alternative approaches
+- Verified the file builds with the existing sorry (8039 jobs, 0 errors)
+
+## Current frontier
+
+The sorry at `alternatingKostka_norm_sq_eq_one` (line 2273 of `Theorem5_15_1.lean`) remains.
+This is the LAST sorry in the file — all other theorems (`alternatingKostka_diag`,
+`alternating_kostka_eq_zero_of_strict_dom`, `alternating_kostka_eq_delta`,
+`spechtCharacter_eq_alternating_sum_permCharacter`, `Theorem5_15_1`) are fully proved
+conditional on this one lemma.
+
+## Overall project progress
+
+- `Theorem5_15_1.lean`: 1 sorry remaining (`alternatingKostka_norm_sq_eq_one`)
+- FDRep bridge (spechtModuleRep, spechtModuleFDRep, spechtModuleFDRep_simple): fully proved
+- Vandermonde expansion, coefficient extraction, Young's Rule: fully proved
+- Diagonal identity L_{λλ} = sign(rev): fully proved
+- Alternating Kostka delta identity: fully proved modulo norm-squared identity
+- Main Frobenius formula (Theorem 5.15.1): fully proved modulo norm-squared identity
+
+## Next step
+
+The sorry is **blocked on the power sum Cauchy identity** (issue #1622):
+```
+(1/n!) ∑_{σ ∈ S_n} P_σ(x) P_σ(y) = [degree n of ∏_{i,j} 1/(1-xᵢyⱼ)]
+```
+
+To unblock:
+1. **Prove the power sum Cauchy identity** (~300-500 lines, issue #1622). This is the
+   standard approach via the exponential formula: ∏_m exp(p_m(x)p_m(y)/m) = ∏_{i,j} 1/(1-x_i y_j).
+   Alternatively, a direct combinatorial argument about cycle-type weighted sums.
+
+2. **Then prove Vandermonde coefficient orthogonality**: combine the power sum Cauchy identity
+   with the Cauchy determinant identity (Corollary 5.15.4, already proved) to show
+   ⟨θ_λ, θ_λ⟩ = coeff(x^{λ+ρ} y^{λ+ρ}, det(1/(1-x_i y_j))) = 1.
+
+3. **Connect via Parseval**: use FDRep.char_orthonormal + the expansion θ_λ = ∑_ν L_{νλ} χ_ν
+   to conclude ∑_ν L²_{νλ} = ⟨θ_λ, θ_λ⟩ = 1.
+
+The coefficient extraction step (coeff = 1 when α has distinct entries) is straightforward
+once the power sum Cauchy identity is available — only σ=id contributes.
+
+Four alternative approaches were analyzed and found insufficient:
+1. Character orthonormality alone → tautological (Parseval gives ∑L² = ⟨θ,θ⟩ but not = 1)
+2. Strong induction on dominance order → inductive hypothesis doesn't constrain L_{νλ}
+3. Sign-reversing involution → requires Gessel-Viennot / lattice path infrastructure
+4. Matrix L^T L = I argument → still needs ⟨θ_λ, θ_λ⟩ ≤ 1
+
+## Blockers
+
+- **Issue #1622** (power sum Cauchy identity) is the sole blocker for closing this sorry
+  and completing the Frobenius Character Formula (Theorem 5.15.1)


### PR DESCRIPTION
Partial progress on #1593

Session: `758587a8-cca7-4f15-92ef-7f063dad0d41`

7aef82b doc: improve alternatingKostka_norm_sq_eq_one documentation and analysis

🤖 Prepared with Claude Code