### PR TITLE
feat: prove class_fun_vanishes_on_subgroup_of_orthogonal (1/2 Artin helpers)

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Theorem4_2_1.lean
+++ b/EtingofRepresentationTheory/Chapter4/Theorem4_2_1.lean
@@ -172,6 +172,18 @@ private lemma classFunction_eq_zero_of_orthogonal_simples
 end Etingof.Theorem4_2_1_aux
 
 open Etingof.Theorem4_2_1_aux in
+/-- Character completeness: a class function orthogonal to all irreducible
+characters is zero. Public API for the internal completeness lemma. -/
+theorem Etingof.classFunction_eq_zero_of_orthogonal_simples
+    {k G : Type u} [Field k] [IsAlgClosed k] [Group G] [Fintype G]
+    [Invertible (Fintype.card G : k)]
+    (f : G → k) (hf_class : ∀ g h : G, f (h * g * h⁻¹) = f g)
+    (hf_orth : ∀ (V : FDRep k G) [Simple V], ∑ g : G, f g * V.character g⁻¹ = 0) :
+    f = 0 := by
+  classical
+  exact Etingof.Theorem4_2_1_aux.classFunction_eq_zero_of_orthogonal_simples f hf_class hf_orth
+
+open Etingof.Theorem4_2_1_aux in
 /-- Characters of irreducible representations span the space of class functions:
 every function G → k that is constant on conjugacy classes is a k-linear combination
 of characters of simple (irreducible) representations. (Etingof Theorem 4.2.1) -/

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_26_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_26_1.lean
@@ -1,4 +1,5 @@
 import Mathlib
+import EtingofRepresentationTheory.Chapter4.Theorem4_2_1
 
 /-!
 # Theorem 5.26.1: Artin's Theorem
@@ -132,7 +133,22 @@ private lemma class_fun_vanishes_on_subgroup_of_orthogonal
     (horth : ∀ (W : FDRep ℂ ↥H), CategoryTheory.Simple W →
       ∑ h : ↥H, f ↑h * W.character (h⁻¹) = 0) :
     ∀ h : ↥H, f ↑h = 0 := by
-  sorry
+  -- It suffices to show the restriction g(h) = f(↑h) is zero as a function
+  suffices hzero : (fun h : ↥H => f ↑h) = 0 by
+    intro h; exact congr_fun hzero h
+  -- |H| is invertible in ℂ (characteristic 0, |H| > 0)
+  haveI : Invertible (Fintype.card ↥H : ℂ) :=
+    invertibleOfNonzero (Nat.cast_ne_zero.mpr Fintype.card_ne_zero)
+  -- Apply character completeness on H (Theorem 4.2.1)
+  apply Etingof.classFunction_eq_zero_of_orthogonal_simples
+  · -- The restriction is a class function on H
+    intro a b
+    change f ↑(b * a * b⁻¹) = f ↑a
+    simp only [Subgroup.coe_mul, Subgroup.coe_inv]
+    exact hf_class ↑a ↑b
+  · -- The restriction is orthogonal to all irreducible characters of H
+    intro W
+    exact horth W ‹_›
 
 /-- Trivial covering argument: if f vanishes on every subgroup in X and X covers G,
 then f vanishes on all of G. -/


### PR DESCRIPTION
Partial progress on #1627

Session: `eded3756-a37e-4278-a9d9-fb633f5a37b2`

c91aed2 feat: prove class_fun_vanishes_on_subgroup_of_orthogonal (1/2 sorries eliminated)

🤖 Prepared with Claude Code