### PR TITLE
Fix main CI: Theorem_Dynkin_classification heartbeat timeouts (lines 1445, 1481)

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/Theorem_Dynkin_classification.lean
+++ b/EtingofRepresentationTheory/Chapter6/Theorem_Dynkin_classification.lean
@@ -771,6 +771,9 @@ private lemma tree_branch_iso {k : ℕ} {adj : Matrix (Fin (k + 1)) (Fin (k + 1)
     have hj_eq : j = ⟨k, by omega⟩ := Fin.ext hj_val
     rw [dif_neg hi, dif_neg hj, hi_eq, hj_eq, ht_diag_k, hdiag]
 
+-- The `split_ifs <;> omega` proofs in the D_n/E₆/E₇/E₈ cases are expensive due to
+-- many conjunctive/disjunctive conditions in the adjacency matrix definitions.
+set_option maxHeartbeats 400000 in
 /-- A tree with a degree-3 vertex (branch) and all degrees ≤ 3 has exactly one such vertex,
     three arms of lengths p ≤ q ≤ r with n = p + q + r + 1, and is uniquely determined
     (up to graph isomorphism) by its arm lengths. Given the arm-length constraint from


### PR DESCRIPTION
Closes #1652

Session: `0cce96f2-1859-4baa-aadd-b2ebaf91aefd`

9d10c11 fix: increase maxHeartbeats for branch_classification to fix CI timeout

🤖 Prepared with Claude Code