### PR TITLE
fix: replace addCommGroupOfField with addCommGroupOfRing in Proposition6_6_7

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/Proposition6_6_7.lean
+++ b/EtingofRepresentationTheory/Chapter6/Proposition6_6_7.lean
@@ -673,7 +673,7 @@ theorem Etingof.Proposition6_6_7_source
     @Etingof.QuiverRepresentation.IsZero k _ Q
       (Etingof.reversedAtVertex Q i)
       (Etingof.reflectionFunctorMinus Q i hi ρ) := by
-  letI : ∀ v, AddCommGroup (ρ.obj v) := fun v => Etingof.addCommGroupOfField (k := k)
+  letI : ∀ v, AddCommGroup (ρ.obj v) := fun v => Etingof.addCommGroupOfRing (k := k)
   rcases Etingof.Proposition6_6_5_source hi hρ with hsimple | hinj
   · -- V is simple at i → F⁻(V) is zero
     right


### PR DESCRIPTION
## Summary
- Replace `Etingof.addCommGroupOfField` (removed in #1743) with `Etingof.addCommGroupOfRing` in Proposition6_6_7.lean
- `addCommGroupOfField` was re-introduced by #1760 after being removed by the consolidation in #1743
- This fixes CI on main and unblocks PRs #1772, #1766, #1762

## Test plan
- [x] `lake build EtingofRepresentationTheory.Chapter6.Proposition6_6_7` passes

🤖 Prepared with Claude Code

Closes #1775