### PR TITLE
Stage 3.2: Prove exists_basic_morita_equivalent (basic algebra existence)

### DIFF
--- a/EtingofRepresentationTheory/Infrastructure/BasicAlgebraExistence.lean
+++ b/EtingofRepresentationTheory/Infrastructure/BasicAlgebraExistence.lean
@@ -2,6 +2,11 @@ import EtingofRepresentationTheory.Chapter9.Definition9_7_1
 import EtingofRepresentationTheory.Chapter9.Definition9_7_2
 import EtingofRepresentationTheory.Infrastructure.CornerRing
 import Mathlib.FieldTheory.IsAlgClosed.Basic
+import Mathlib.RingTheory.Artinian.Module
+import Mathlib.RingTheory.SimpleModule.IsAlgClosed
+import Mathlib.Algebra.Category.ModuleCat.Basic
+import Mathlib.CategoryTheory.Equivalence
+import Mathlib.RingTheory.Morita.Matrix
 
 /-!
 # Basic algebra existence
@@ -9,7 +14,7 @@ import Mathlib.FieldTheory.IsAlgClosed.Basic
 For a finite-dimensional algebra `A` over an algebraically closed field `k`,
 there exists a basic algebra `B` that is Morita equivalent to `A`.
 
-## Construction (sketch)
+## Construction
 
 1. `A` is Artinian, hence semiprimary: `A / rad(A)` is semisimple and `rad(A)`
    is nilpotent.
@@ -22,17 +27,69 @@ there exists a basic algebra `B` that is Morita equivalent to `A`.
    is 1-dimensional over `k`) and Morita equivalent to `A` (via the
    progenerator `Ae`).
 
-## Status
+## Decomposition
 
-The theorem is stated with `sorry` pending formalization of:
-- Extraction of primitive idempotents from the Wedderburn–Artin decomposition
-- Proof that the corner ring is basic
-- Proof of Morita equivalence via the progenerator `Ae`
+The proof is decomposed into two helper lemmas:
+
+* `exists_full_idempotent_basic_corner`: Existence of a full idempotent whose
+  corner ring is basic. This uses Wedderburn–Artin over algebraically closed
+  fields and idempotent lifting.
+
+* `morita_equiv_of_full_idempotent`: The Morita equivalence between `A` and
+  the corner ring `eAe` for a full idempotent `e` (one with `AeA = A`). This
+  is the deep part of the proof, requiring construction of the functors
+  `M ↦ eM` and `N ↦ Ae ⊗_{eAe} N` and verification they form an equivalence.
 -/
 
 universe u
 
 namespace Etingof
+
+/-! ## Full idempotent predicate -/
+
+/-- An idempotent `e` in a ring `A` is **full** if the two-sided ideal it
+generates is all of `A`, i.e., `AeA = A`. Full idempotents are precisely the
+idempotents for which the corner ring `eAe` is Morita equivalent to `A`. -/
+def IsFullIdempotent {A : Type*} [Ring A] (e : A) : Prop :=
+  IsIdempotentElem e ∧ Ideal.span {a * e * b | (a : A) (b : A)} = ⊤
+
+/-! ## Helper: Existence of full idempotent with basic corner ring
+
+For a finite-dimensional algebra `A` over an algebraically closed field `k`,
+there exists a full idempotent `e ∈ A` such that the corner ring `eAe` is basic.
+
+Construction:
+- A/Rad(A) is semisimple (Artinian + semiprimary)
+- By Wedderburn–Artin: A/Rad(A) ≅ ∏ Mat_{n_i}(k)
+- Pick one diagonal idempotent E_{11} per block → complete orthogonal system
+- Lift to A via `CompleteOrthogonalIdempotents.lift_of_isNilpotent_ker`
+- Sum of lifted idempotents gives a full idempotent e
+- eAe is basic: its simple modules correspond to k-lines (one per block) -/
+private lemma exists_full_idempotent_basic_corner
+    (k : Type u) [Field k] [IsAlgClosed k]
+    (A : Type u) [Ring A] [Algebra k A] [Module.Finite k A] :
+    ∃ (e : A) (he : IsFullIdempotent e),
+      @IsBasicAlgebra k _ (CornerRing (k := k) e) (CornerRing.instRing he.1)
+        (CornerRing.instAlgebra he.1) := by
+  sorry
+
+/-! ## Helper: Morita equivalence via full idempotent
+
+For a ring `A` and a full idempotent `e` (i.e., `AeA = A`), `A` and `eAe` are
+Morita equivalent. The equivalence is given by the functors:
+- `F : A-Mod → eAe-Mod`, `M ↦ eM` (restriction to the e-corner)
+- `G : eAe-Mod → A-Mod`, `N ↦ Ae ⊗_{eAe} N` (induction from the corner)
+
+with natural isomorphisms `FG ≅ Id` and `GF ≅ Id`.
+
+The fullness condition `AeA = A` is essential: it ensures `G` is essentially
+surjective (every A-module M satisfies AeM = M when AeA = A). -/
+private lemma morita_equiv_of_full_idempotent
+    {k : Type u} [Field k]
+    {A : Type u} [Ring A] [Algebra k A]
+    {e : A} (he : IsFullIdempotent e) :
+    @MoritaEquivalent A _ (CornerRing (k := k) e) (CornerRing.instRing he.1) := by
+  sorry
 
 /-- **Basic algebra existence**: For a finite-dimensional algebra `A` over an
 algebraically closed field `k`, there exists a basic algebra `B` (all simple
@@ -46,6 +103,14 @@ theorem exists_basic_morita_equivalent
     (A : Type u) [Ring A] [Algebra k A] [Module.Finite k A] :
     ∃ (B : Type u) (_ : Ring B) (_ : Algebra k B) (_ : Module.Finite k B),
       IsBasicAlgebra k B ∧ MoritaEquivalent A B := by
-  sorry
+  obtain ⟨e, he, hbasic⟩ := exists_full_idempotent_basic_corner k A
+  letI : Ring (CornerRing (k := k) e) := CornerRing.instRing he.1
+  letI : Algebra k (CornerRing (k := k) e) := CornerRing.instAlgebra he.1
+  exact ⟨CornerRing (k := k) e,
+    CornerRing.instRing he.1,
+    CornerRing.instAlgebra he.1,
+    CornerRing.instModuleFinite,
+    hbasic,
+    morita_equiv_of_full_idempotent he⟩
 
 end Etingof

--- a/progress/2026-03-27T04-30-00Z.md
+++ b/progress/2026-03-27T04-30-00Z.md
@@ -1,0 +1,34 @@
+## Accomplished
+
+- Decomposed `exists_basic_morita_equivalent` (1 sorry) into two well-defined helper lemmas:
+  1. `exists_full_idempotent_basic_corner` — existence of a full idempotent whose corner ring is basic (Wedderburn-Artin + idempotent lifting)
+  2. `morita_equiv_of_full_idempotent` — Morita equivalence between A and eAe for full idempotents (categorical equivalence construction)
+- Defined `IsFullIdempotent` predicate (idempotent + AeA = A)
+- Proved `exists_basic_morita_equivalent` from the two helpers (main theorem structure is complete)
+- Added imports for `Mathlib.RingTheory.Morita.Matrix`, `Mathlib.RingTheory.SimpleModule.IsAlgClosed`, `Mathlib.RingTheory.Artinian.Module`
+- Full project build passes (8297 jobs)
+
+## Current frontier
+
+`BasicAlgebraExistence.lean` has 2 sorrys (reduced from 1 monolithic sorry to 2 targeted, independently-attackable sorrys):
+
+1. **`exists_full_idempotent_basic_corner`** (line 68): Requires interfacing Wedderburn-Artin decomposition (`IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed`) with idempotent extraction from matrix blocks, then lifting via `CompleteOrthogonalIdempotents.lift_of_isNilpotent_ker`, and finally proving the resulting corner ring is basic.
+
+2. **`morita_equiv_of_full_idempotent`** (line 87): Requires constructing the functors M↦eM and N↦Ae⊗_{eAe}N and proving they form a categorical equivalence. This is NOT in Mathlib — Mathlib has `ModuleCat.matrixEquivalence` (R ≌ Mat_n(R)) but not the general corner ring Morita equivalence.
+
+## Overall project progress
+
+- Stage 3.2 formalization in progress
+- `BasicAlgebraExistence.lean`: 2 sorrys (decomposed from 1, structure complete)
+- All downstream files (`Corollary9_7_3.lean`, etc.) build successfully
+- 3 unclaimed feature issues remain: #1773, #1788, #1799 (this one now in progress)
+
+## Next step
+
+Two approaches for further progress:
+1. **Prove `morita_equiv_of_full_idempotent`**: Build the categorical equivalence from scratch. This is ~200-300 lines of Lean (functor definitions, natural transformations, unit/counit isomorphisms). The key Mathlib ingredients are `ModuleCat`, `CategoryTheory.Equivalence`, tensor products over subalgebras.
+2. **Prove `exists_full_idempotent_basic_corner`**: Use `IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed` on A/Rad(A), extract E_{11} idempotents from each matrix block, lift via Corollary 9.1.3, prove fullness and basicness.
+
+## Blockers
+
+- `morita_equiv_of_full_idempotent` requires formalizing the corner ring Morita theorem, which is a major piece of mathematics not available in Mathlib. This is the primary blocker for fully eliminating sorrys.


### PR DESCRIPTION
Partial progress on #1799

Session: `38d5d7d3-1fbf-4c86-ad64-a4725ba47e48`

e7ff7de feat: decompose exists_basic_morita_equivalent into targeted helper lemmas

🤖 Prepared with Claude Code