### PR TITLE
## Summary
- Prove `d ≫ ε = 0` for the Koszul short exact sequence using counit naturality
- Prove `Epi ε` (surjectivity of the counit: `ε(1 ⊗ m) = 1 • m = m`)
- Add `finsupp_shift_sub_mapRange_injective` auxiliary lemma (backward induction on support max) for the mono proof strategy
- Structure `ShortExact` proof via `mk'` with decomposed goals

## Remaining sorrys (2)
1. **Mono d**: `d = X•𝟙 - F.map(xAction)` injective — strategy clear via PolynomialModule iso + finsupp lemma, blocked by ModuleCat carrier type coercions
2. **Exact**: `ker ε = im d` — same type coercion blocker

## Test plan
- [x] `lake build EtingofRepresentationTheory.Chapter9.Example9_4_4` succeeds (2 sorry warnings)
- [x] No regressions in dependent files

🤖 Prepared with Claude Code

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/Example9_4_4.lean
+++ b/EtingofRepresentationTheory/Chapter9/Example9_4_4.lean
@@ -15,6 +15,7 @@ import Mathlib.Algebra.Polynomial.Inductions
 import Mathlib.Algebra.Homology.DerivedCategory.Ext.ExactSequences
 import Mathlib.Algebra.Homology.DerivedCategory.Ext.Linear
 import Mathlib.LinearAlgebra.Finsupp.VectorSpace
+import Mathlib.Algebra.Polynomial.Module.TensorProduct
 
 /-!
 # Example 9.4.4: Homological dimension of polynomial algebra (Hilbert syzygies)
@@ -151,6 +152,39 @@ private noncomputable def xActionAsRLinear {R : Type u} [CommRing R]
   (ModuleCat.restrictScalars (Polynomial.C (R := R))).map
     ((Polynomial.X : Polynomial R) • (𝟙 M))
 
+/-! ### Koszul differential on Finsupp
+
+We prove that the "shift minus action" map on `ℕ →₀ N` is injective by backward induction
+on the support. This is the key lemma for the mono part of the Koszul SES. -/
+
+/-- If `shift(f) = mapRange φ f` for all f in `ℕ →₀ N` (where shift sends `single n m` to
+`single (n+1) m`), then `f = 0`. Proof by strong induction on the maximum support index:
+the (max+1)-th coefficient of shift(f) equals `f(max)`, while `mapRange φ f` has no support
+beyond max, giving `f(max) = 0`. -/
+private theorem finsupp_shift_sub_mapRange_injective {R : Type u} [CommRing R]
+    {N : Type u} [AddCommGroup N] [Module R N] (φ : N →ₗ[R] N)
+    (f : ℕ →₀ N) (hf : Finsupp.mapDomain Nat.succ f = Finsupp.mapRange φ φ.map_zero f) :
+    f = 0 := by
+  by_contra hne
+  -- f ≠ 0, so f has nonempty support
+  have hsup : f.support.Nonempty := Finsupp.support_nonempty_iff.mpr hne
+  -- Let k be the maximum index in the support
+  set k := f.support.max' hsup
+  -- The (k+1)-th coefficient of mapDomain Nat.succ f is f(k)
+  have h_shift : (Finsupp.mapDomain Nat.succ f) (k + 1) = f k := by
+    rw [Finsupp.mapDomain_apply Nat.succ_injective]
+  -- The (k+1)-th coefficient of mapRange φ f is φ(f(k+1)) = φ(0) = 0
+  -- because k+1 is not in the support of f (k is the max)
+  have h_range : (Finsupp.mapRange φ φ.map_zero f) (k + 1) = 0 := by
+    rw [Finsupp.mapRange_apply]
+    have : f (k + 1) = 0 := by
+      by_contra hmem
+      exact absurd (f.support.le_max' (k + 1) (Finsupp.mem_support_iff.mpr hmem)) (by omega)
+    rw [this, φ.map_zero]
+  -- Combining: f(k) = 0, contradicting k ∈ support
+  have : f k = 0 := by rw [← h_shift, hf, h_range]
+  exact absurd this (Finsupp.mem_support_iff.mp (f.support.max'_mem hsup))
+
 /-- The Koszul short exact sequence for an R[X]-module M:
   0 → R[X] ⊗_R M|_R →^d R[X] ⊗_R M|_R →^ε M → 0
 where d(p ⊗ m) = Xp ⊗ m - p ⊗ (X·m) and ε(p ⊗ m) = p·m. -/
@@ -167,12 +201,28 @@ private theorem koszulSES_shortExact {R : Type u} [CommRing R]
       set adj := ModuleCat.extendRestrictScalarsAdj.{u} C
       have nat := adj.counit.naturality ((Polynomial.X : Polynomial R) • 𝟙 M)
       simp only [Functor.comp_map, Functor.id_map] at nat
-      -- d ≫ ε = 0 by counit naturality:
-      -- d = X•𝟙 - F(G(X•𝟙_M)), and by naturality of counit,
-      -- F(G(X•𝟙_M)) ≫ ε = ε ≫ X•𝟙_M = X•ε, so d ≫ ε = X•ε - X•ε = 0
-      sorry
+      -- d = X•𝟙 - F(G(X•𝟙)), ε = counit. By naturality: F(G(X•𝟙)) ≫ ε = ε ≫ X•𝟙
+      -- So d ≫ ε = (X•𝟙 - F(G(X•𝟙))) ≫ ε = X•ε - ε ≫ X•𝟙 = X•ε - X•ε = 0
+      have h1 : F.map (xActionAsRLinear M) ≫ ε = ε ≫ (Polynomial.X • 𝟙 M) := nat
+      rw [show d = (Polynomial.X : Polynomial R) • 𝟙 FGM - F.map (xActionAsRLinear M) from rfl,
+        Preadditive.sub_comp, Linear.smul_comp, Category.id_comp, h1,
+        Linear.comp_smul]
+      simp
       )).ShortExact := by
-  sorry
+  intro C F G FGM ε d
+  have hmono : Mono d := by
+    -- d = X•𝟙 - F.map(xAction) is injective.
+    -- Strategy: Under the iso R[X] ⊗_R M|_R ≃ ℕ →₀ M|_R (PolynomialModule),
+    -- d becomes shift - mapRange(X·), which is injective by backward induction
+    -- (finsupp_shift_sub_mapRange_injective).
+    sorry
+  have hepi : Epi ε := by
+    rw [ModuleCat.epi_iff_surjective]
+    intro m
+    refine ⟨(1 : Polynomial R) ⊗ₜ[R] m, ?_⟩
+    change (1 : Polynomial R) • m = m
+    exact one_smul _ _
+  exact ShortComplex.ShortExact.mk' (by sorry) hmono hepi
 
 theorem hasHomologicalDimensionLE_polynomial {R : Type u} [CommRing R] [Small.{u} R] (d : ℕ)
     (h : Etingof.HasHomologicalDimensionLE R d) :

--- a/progress/20260328T100314Z_bde03782.md
+++ b/progress/20260328T100314Z_bde03782.md
@@ -1,0 +1,27 @@
+## Accomplished
+
+- Proved `d >> epsilon = 0` for the Koszul SES using counit naturality (`Preadditive.sub_comp`, `Linear.smul_comp`, `Linear.comp_smul`)
+- Proved `Epi epsilon` (surjectivity of counit: `1 tensor m maps to 1 * m = m`)
+- Proved `finsupp_shift_sub_mapRange_injective`: if `mapDomain succ f = mapRange phi f` for a finsupp `f : N ->0 M`, then `f = 0` (backward induction on max support index)
+- Structured the `ShortExact` proof via `ShortExact.mk'` requiring: Exact, Mono, Epi
+
+## Current frontier
+
+`koszulSES_shortExact` in `Example9_4_4.lean` has 2 remaining sorrys:
+1. **Mono d** (line ~218): `d = X*1 - F.map(xAction)` is injective. Strategy is clear: transfer via `PolynomialModule` iso to `N ->0 M|_R`, then apply `finsupp_shift_sub_mapRange_injective`. Blocker: `ModuleCat` carrier type (`ExtendScalars.obj'`) does not definitionally equal `TensorProduct R (Polynomial R) M|_R`, so the type coercions between the categorical and concrete worlds are non-trivial.
+2. **Exact** (line ~225): `ker epsilon = im d`. Strategy: if `epsilon(sum X^n tensor m_n) = sum X^n * m_n = 0` in M, construct `s` with `d(s) = t` by backward recursion. Same type coercion blocker.
+
+## Overall project progress
+
+The Hilbert syzygy theorem is complete modulo `koszulSES_shortExact` (2 sorrys). All other infrastructure is in place: upper bound via induction + polynomial extension, lower bound via augmentation module argument, and the final equality `Etingof.Example_9_4_4`.
+
+## Next step
+
+- Fix the `Mono d` and `Exact` sorrys in `koszulSES_shortExact`. The key challenge is type coercion between `ModuleCat.ExtendScalars.obj'` carrier types and `TensorProduct`/`PolynomialModule` types. Options:
+  1. Build explicit `LinearEquiv` between `FGM` carrier and `PolynomialModule R M|_R`, then use `finsupp_shift_sub_mapRange_injective`
+  2. Use `ext` lemmas for `ModuleCat` to reduce to element-level proofs on the tensor product
+  3. Refactor `koszulSES_shortExact` to work directly with `PolynomialModule` instead of `ModuleCat.extendScalars`
+
+## Blockers
+
+Type coercion between `ModuleCat.ExtendScalars.obj'` and `TensorProduct`/`PolynomialModule` types prevents direct application of the finsupp injectivity lemma. The mathematical argument is fully clear (backward induction on support max), but formalizing the type transport is the main obstacle.


### PR DESCRIPTION
Closes #--title

Session: `bde03782-b1ff-440e-a34c-a8d517912245`

55aedd3 feat: prove d >> epsilon = 0 and Epi epsilon for Koszul SES (#1898)

🤖 Prepared with Claude Code