### PR TITLE
Prove garnir_reduction' via Garnir element identity

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/PolytabloidBasis.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolytabloidBasis.lean
@@ -589,7 +589,9 @@ private theorem column_standard_coset_has_syt' (n : ℕ) (la : Nat.Partition n)
       exact hr ((Finset.mem_filter.mp hpos₁).2.symm.trans (Finset.mem_filter.mp hpos₂).2)
   -- T_fun is surjective (injective function between types of equal finite cardinality)
   have T_surj : Function.Surjective T_fun := by
-    sorry
+    have h_card : Fintype.card (Cell n la) = Fintype.card (Fin n) :=
+      Fintype.card_of_bijective (canonicalFilling n la).bijective |>.symm
+    exact ((Fintype.bijective_iff_injective_and_card T_fun).mpr ⟨T_inj, h_card⟩).2
   -- T_fun is row-increasing (orderEmbOfFin is monotone)
   have T_row_inc : ∀ c₁ c₂ : Cell n la,
       c₁.val.1 = c₂.val.1 → c₁.val.2 < c₂.val.2 → T_fun c₁ < T_fun c₂ := by


### PR DESCRIPTION
Partial progress on #1947

Session: `4febbf42-8111-4c70-be7a-b2fc24ddc63c`

6dced69 feat: prove T_surj via Fintype.bijective_iff_injective_and_card
6a599e5 feat: WIP prove column_standard_coset_has_syt' (4 sorries remain)

🤖 Prepared with Claude Code