### PR TITLE
Fix reversed dominance direction in polytabloid_syt_dominance

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/TabloidModule.lean
+++ b/EtingofRepresentationTheory/Chapter5/TabloidModule.lean
@@ -857,35 +857,31 @@ private theorem tabloidCumulCount_full (σ : Equiv.Perm (Fin n)) (i : ℕ) (hn :
   · intro e _; exact σ.symm_apply_apply e
   · intro p _; exact σ.apply_symm_apply p
 
-/-- If e_{T₁}(σ_{T₂}) ≠ 0, then the tabloid of T₁ dominates the tabloid of T₂.
+/-- If e_{T₁}(σ_{T₂}) ≠ 0, then the tabloid of T₂ dominates the tabloid of T₁.
 This is the key triangularity property for polytabloid linear independence.
-
-Note: the analogous statement for arbitrary σ (not just SYT permutations) is FALSE.
-Counterexample: partition (2,2,1), SYT T=[0 3/1 4/2], q=(2,4) ∈ Q_λ gives
-σ_T * q with tabloidCumulCount(σ_T*q, 2, 2) = 3 > 2 = tabloidCumulCount(σ_T, 2, 2).
-However, σ_T * q is not the sytPerm of any SYT, so this doesn't affect the
-linear independence proof which only evaluates polytabloids at SYT permutations.
-
-The proof uses the SYT structure of both T₁ and T₂: if σ_{T₁}⁻¹ * σ_{T₂} = p * q
-with p ∈ P_λ, q ∈ Q_λ, then row_{T₂}(e) = row_{T₁}(p(q(e))). The SYT constraints
-on T₂ force the dominance inequality. This is the "dominance lemma" for standard
-Young tableaux (cf. Sagan, "The Symmetric Group").
 
 The PQ decomposition σ_{T₂} = σ_{T₁} · p · q gives row₂(e) = row₁(p(q(e))),
 where p preserves canonical rows and q preserves canonical columns. The SYT
 properties of both T₁ and T₂ constrain which (p,q) pairs are possible, ensuring
-the dominance inequality. This is a classical result in the combinatorics of
-symmetric groups (cf. James, "The Representation Theory of the Symmetric Groups",
-or Sagan, "The Symmetric Group", Theorem 2.6.5). -/
+the dominance inequality: T₂ (the "evaluated-at" SYT) is at least as dominant
+as T₁ (the polytabloid's SYT). This is the "dominance lemma" for standard
+Young tableaux (cf. James, "The Representation Theory of the Symmetric Groups",
+or Sagan, "The Symmetric Group", Theorem 2.6.5).
+
+Note on direction: T₂ dominates T₁ (not the other way around). Concretely,
+for λ=(3,2), T₁=[0 2 4/1 3], T₂=[0 1 3/2 4], we have e_{T₁}(σ_{T₂})=1≠0,
+and T₂ packs more entries into the first row (entries {0,1} both in row 0)
+than T₁ (only entry 0 in row 0 among {0,1}). -/
 theorem polytabloid_syt_dominance
     (T₁ T₂ : StandardYoungTableau n la)
     (hne : (polytabloid n la T₁ : SymGroupAlgebra n) (sytPerm n la T₂) ≠ 0) :
-    tabloidDominates la (sytPerm n la T₁) (sytPerm n la T₂) := by
+    tabloidDominates la (sytPerm n la T₂) (sytPerm n la T₁) := by
   -- Get PQ decomposition: σ_{T₂} = σ_{T₁} · p · q with p ∈ P_λ, q ∈ Q_λ
   obtain ⟨p, hp, q, hq, hσ⟩ := polytabloid_support n la T₁ (sytPerm n la T₂) hne
   -- The proof requires showing that for all k, i:
-  --   |{e ≤ k : rowOfPos(σ_{T₁}(e)) < i}| ≥ |{e ≤ k : rowOfPos(σ_{T₂}(e)) < i}|
+  --   |{e ≤ k : rowOfPos(σ_{T₂}(e)) < i}| ≥ |{e ≤ k : rowOfPos(σ_{T₁}(e)) < i}|
   -- where σ_{T₂}(e) = σ_{T₁}(p(q(e))).
+  -- Equivalently: the PQ transformation makes the tabloid MORE dominant.
   -- This is a deep combinatorial fact about standard Young tableaux and the
   -- interaction of row/column permutations with the dominance order.
   sorry
@@ -895,24 +891,25 @@ The polytabloids {e_T : T ∈ SYT(λ)} are linearly independent in V_λ.
 
 Proved via the tabloid triangularity argument:
 1. Assume Σ aₜ · eₜ = 0 with some aₜ ≠ 0.
-2. Pick T maximal (in dominance) among {T' : aₜ' ≠ 0} — exists since finite.
+2. Pick T minimal (in dominance) among {T' : aₜ' ≠ 0} — exists since finite.
 3. Evaluate at σ_T: Σ aₜ' · eₜ'(σ_T) = 0.
 4. eₜ(σ_T) = 1 by polytabloid_self_coeff.
-5. For T' ≠ T with aₜ' ≠ 0: if eₜ'(σ_T) ≠ 0, then by polytabloid_eval_implies_dominance,
-   tabloid(T') dominates tabloid(T). By maximality, tabloid(T') = tabloid(T), but then
+5. For T' ≠ T with aₜ' ≠ 0: if eₜ'(σ_T) ≠ 0, then by polytabloid_syt_dominance,
+   tabloid(T) dominates tabloid(T'). By minimality of T (it doesn't strictly
+   dominate anything with nonzero coefficient), tabloid(T') = tabloid(T), but then
    T' = T by sytToTabloid_injective — contradiction.
 6. So aₜ · 1 + Σ_{T'≠T} 0 = 0, giving aₜ = 0 — contradiction.
 -/
 
 /-- Auxiliary: if Σ f(T) e_T = 0 over a finset S, then for any T₀ ∈ S that is
-dominance-maximal among {T ∈ S : f(T) ≠ 0}, we have f(T₀) = 0. -/
-private lemma polytabloid_coeff_zero_of_maximal
+dominance-minimal among {T ∈ S : f(T) ≠ 0}, we have f(T₀) = 0. -/
+private lemma polytabloid_coeff_zero_of_minimal
     (S : Finset (StandardYoungTableau n la))
     (f : StandardYoungTableau n la → ℂ)
     (hf : ∑ t ∈ S, f t • (polytabloidInSpecht n la t : SymGroupAlgebra n) = 0)
     (T₀ : StandardYoungTableau n la) (hT₀ : T₀ ∈ S)
-    (hmax : ∀ T' ∈ S, f T' ≠ 0 →
-      tabloidDominates la (sytPerm n la T') (sytPerm n la T₀) →
+    (hmin : ∀ T' ∈ S, f T' ≠ 0 →
+      tabloidDominates la (sytPerm n la T₀) (sytPerm n la T') →
       sytToTabloid n la T' = sytToTabloid n la T₀) :
     f T₀ = 0 := by
   classical
@@ -944,62 +941,54 @@ private lemma polytabloid_coeff_zero_of_maximal
   by_cases hcoeff : (polytabloidInSpecht n la T' : SymGroupAlgebra n)
       (sytPerm n la T₀) = 0
   · rw [hcoeff, mul_zero]
-  · -- e_{T'}(σ_{T₀}) ≠ 0 implies tabloid(T') dominates tabloid(T₀)
+  · -- e_{T'}(σ_{T₀}) ≠ 0 implies tabloid(T₀) dominates tabloid(T')
     have hdom := polytabloid_syt_dominance T' T₀ hcoeff
-    -- By maximality, tabloid(T') = tabloid(T₀)
-    have htab_eq := hmax T' hT'S hfT' hdom
+    -- By minimality, tabloid(T') = tabloid(T₀)
+    have htab_eq := hmin T' hT'S hfT' hdom
     -- But different SYTs have different tabloids
     exact absurd (sytToTabloid_injective n la htab_eq) hne
 
-/-- In any finset with a dominance-like relation, a nonempty subset has a maximal
+/-- In any finset with a dominance-like relation, a nonempty subset has a minimal
 element. We use a Nat-valued measure and strong induction. -/
-private lemma exists_dominance_maximal
+private lemma exists_dominance_minimal
     (S : Finset (StandardYoungTableau n la))
     (f : StandardYoungTableau n la → ℂ) (T₀ : StandardYoungTableau n la)
     (hT₀ : T₀ ∈ S) (hfT₀ : f T₀ ≠ 0) :
     ∃ T₁ ∈ S, f T₁ ≠ 0 ∧
       ∀ T' ∈ S, f T' ≠ 0 →
-        tabloidDominates la (sytPerm n la T') (sytPerm n la T₁) →
+        tabloidDominates la (sytPerm n la T₁) (sytPerm n la T') →
         sytToTabloid n la T' = sytToTabloid n la T₁ := by
-  -- Measure: for each T, count how many other T' ∈ S with f(T') ≠ 0
-  -- have tabloid(T') strictly dominating tabloid(T). This is bounded.
-  -- Use Nat.strongRecOn on this measure.
-  -- Simpler: use well-founded induction on the subset of S that strictly
-  -- dominates T. Since S is finite, this terminates.
+  -- Measure: for each T, count how many T' ∈ S with f(T') ≠ 0 that T strictly
+  -- dominates. A minimal T has no such T', giving an empty "badSet".
   classical
-  -- Define: "badSet T" = {T' ∈ S | f(T') ≠ 0 ∧ tabloid(T') strictly dom tabloid(T)}
-  -- If badSet T₀ = ∅, T₀ is maximal. Otherwise pick T₁ ∈ badSet T₀ and recurse.
-  -- Measure: S.card - (number of SYTs whose tabloid is dominated by T)
-  -- Actually just use strong induction on |{T' ∈ S : tabloidDominates T T'}|
-  -- For a simpler proof, use the finiteness directly:
+  -- Define: "badSet T" = {T' ∈ S | f(T') ≠ 0 ∧ T strictly dominates T'}
+  -- If badSet T₀ = ∅, T₀ is minimal. Otherwise pick T₁ ∈ badSet T₀ and recurse.
   suffices hmain : ∀ (m : ℕ) (T : StandardYoungTableau n la),
       T ∈ S → f T ≠ 0 →
       (S.filter fun T' => f T' ≠ 0 ∧
-        tabloidStrictDominates la (sytPerm n la T') (sytPerm n la T)).card = m →
+        tabloidStrictDominates la (sytPerm n la T) (sytPerm n la T')).card = m →
       ∃ T₁ ∈ S, f T₁ ≠ 0 ∧ ∀ T' ∈ S, f T' ≠ 0 →
-        tabloidDominates la (sytPerm n la T') (sytPerm n la T₁) →
+        tabloidDominates la (sytPerm n la T₁) (sytPerm n la T') →
         sytToTabloid n la T' = sytToTabloid n la T₁ by
     exact hmain _ T₀ hT₀ hfT₀ rfl
   intro m
   induction m using Nat.strongRecOn with
   | ind m ih =>
   intro T hTS hfT hcard
-  -- Check if T is already maximal
-  by_cases hmax : ∀ T' ∈ S, f T' ≠ 0 →
-      tabloidDominates la (sytPerm n la T') (sytPerm n la T) →
+  -- Check if T is already minimal
+  by_cases hmin : ∀ T' ∈ S, f T' ≠ 0 →
+      tabloidDominates la (sytPerm n la T) (sytPerm n la T') →
       sytToTabloid n la T' = sytToTabloid n la T
-  · exact ⟨T, hTS, hfT, hmax⟩
-  · -- T is not maximal: there exists T' with f(T') ≠ 0 that strictly dominates T
-    push_neg at hmax
-    obtain ⟨T', hT'S, hfT', hdom, hne_tab⟩ := hmax
-    -- T' is in the badSet of T, so |badSet(T')| < |badSet(T)|
-    -- because anything strictly dominating T' also strictly dominates T (transitivity)
-    -- but T' strictly dominates T so T' ∉ badSet(T')
-    have hstrict : tabloidStrictDominates la (sytPerm n la T') (sytPerm n la T) :=
+  · exact ⟨T, hTS, hfT, hmin⟩
+  · -- T is not minimal: there exists T' with f(T') ≠ 0 that T strictly dominates
+    push_neg at hmin
+    obtain ⟨T', hT'S, hfT', hdom, hne_tab⟩ := hmin
+    -- T strictly dominates T'
+    have hstrict : tabloidStrictDominates la (sytPerm n la T) (sytPerm n la T') :=
       ⟨hdom, fun h => hne_tab (toTabloid_eq_of_tabloidRowVec_eq _ _
-        (tabloidRowVec_eq_of_toTabloid_eq _ _ h))⟩
+        (tabloidRowVec_eq_of_toTabloid_eq _ _ h.symm))⟩
     apply ih (S.filter fun T'' => f T'' ≠ 0 ∧
-        tabloidStrictDominates la (sytPerm n la T'') (sytPerm n la T')).card
+        tabloidStrictDominates la (sytPerm n la T') (sytPerm n la T'')).card
     · -- Strict decrease: badSet(T') ⊊ badSet(T)
       rw [← hcard]
       apply Finset.card_lt_card
@@ -1016,13 +1005,15 @@ private lemma exists_dominance_maximal
         intro T'' hT''
         simp only [Finset.mem_filter] at hT'' ⊢
         refine ⟨hT''.1, hT''.2.1, ?_⟩
-        exact ⟨tabloidDominates_trans hT''.2.2.1 hstrict.1,
+        exact ⟨tabloidDominates_trans hstrict.1 hT''.2.2.1,
           fun heq =>
-            -- If toTabloid(T'') = toTabloid(T), then T'' dom T' dom T and
-            -- tabloidCumulCount matches at T'' and T (same tabloid).
+            -- If toTabloid(T'') = toTabloid(T), then T dom T' dom T'' and
+            -- tabloidCumulCount matches at T and T'' (same tabloid).
             -- So T' is squeezed: all cumulative counts match, giving same tabloid.
-            hstrict.2 (tabloidDominates_antisymm_toTabloid
-              hT''.2.2.1 hstrict.1 heq)⟩
+            -- tabloidDominates_antisymm_toTabloid gives toTabloid T' = toTabloid T''
+            -- Combined with heq (toTabloid T = toTabloid T''), gives toTabloid T = toTabloid T'
+            hstrict.2 (heq.trans (tabloidDominates_antisymm_toTabloid
+              hstrict.1 hT''.2.2.1 heq).symm)⟩
     · exact hT'S
     · exact hfT'
     · rfl
@@ -1033,10 +1024,10 @@ theorem polytabloid_linearIndependent' :
   rw [linearIndependent_iff']
   intro S f hf T hT
   by_contra hfT
-  -- Find a dominance-maximal T₀ ∈ S with f(T₀) ≠ 0
-  obtain ⟨T₀, hT₀, hfT₀, hmax⟩ := exists_dominance_maximal S f T hT hfT
+  -- Find a dominance-minimal T₀ ∈ S with f(T₀) ≠ 0
+  obtain ⟨T₀, hT₀, hfT₀, hmin⟩ := exists_dominance_minimal S f T hT hfT
   -- Apply the coefficient extraction lemma to T₀
-  exact hfT₀ (polytabloid_coeff_zero_of_maximal S f hf T₀ hT₀ hmax)
+  exact hfT₀ (polytabloid_coeff_zero_of_minimal S f hf T₀ hT₀ hmin)
 
 end
 

--- a/progress/2026-03-29T18-05-45Z.md
+++ b/progress/2026-03-29T18-05-45Z.md
@@ -1,0 +1,36 @@
+## Accomplished
+
+Found and fixed a critical bug in `polytabloid_syt_dominance`: the dominance direction was reversed.
+
+**The bug**: The theorem claimed `tabloidDominates la (sytPerm T₁) (sytPerm T₂)` (T₁ dominates T₂), but the correct direction is `tabloidDominates la (sytPerm T₂) (sytPerm T₁)` (T₂ dominates T₁).
+
+**Concrete counterexample**: For λ=(3,2), T₁=[0 2 4/1 3], T₂=[0 1 3/2 4]:
+- e_{T₁}(σ_{T₂}) = 1 ≠ 0 (hypothesis satisfied)
+- tabloidCumulCount σ₂ ⟨1,_⟩ 1 = 2 > 1 = tabloidCumulCount σ₁ ⟨1,_⟩ 1
+- So T₁ does NOT dominate T₂; rather T₂ dominates T₁
+
+**Cascading fixes**:
+1. `polytabloid_syt_dominance`: flipped conclusion direction
+2. `polytabloid_coeff_zero_of_maximal` → `polytabloid_coeff_zero_of_minimal`: changed from maximality to minimality argument, flipped dominance direction in hypothesis
+3. `exists_dominance_maximal` → `exists_dominance_minimal`: flipped measure from counting strict dominators to counting strict dominatees
+4. `polytabloid_linearIndependent'`: updated to use renamed lemmas
+
+The linear independence proof structure remains sound with the corrected direction: pick a dominance-MINIMAL T₀ among nonzero-coefficient SYTs. For any T' with e_{T'}(σ_{T₀}) ≠ 0, the corrected lemma gives T₀ dominates T'. Since T₀ is minimal, this cannot be strict, so same tabloid, so T₀ = T'.
+
+## Current frontier
+
+`polytabloid_syt_dominance` still has one sorry — the core combinatorial proof. But now the STATEMENT is correct, which was not the case before. The sorry is at `TabloidModule.lean` line ~875.
+
+## Overall project progress
+
+- TabloidModule.lean: 1 sorry (correctly stated now, direction fixed)
+- PolytabloidBasis.lean: ~4-6 sorrys
+- The linear independence chain is structurally sound with the corrected direction
+
+## Next step
+
+Prove `polytabloid_syt_dominance` with the corrected direction: show that the PQ transformation σ₂ = σ₁ · p · q makes the tabloid MORE dominant (T₂ ≥ T₁). This may be easier than the old (wrong) direction since it aligns with the intuition that the SYT evaluated at (T₂) should be "more canonical" than the polytabloid's SYT (T₁).
+
+## Blockers
+
+The sorry in `polytabloid_syt_dominance` remains the key blocker for the polytabloid linear independence chain. The direction fix is a prerequisite — without it, the theorem was false and no proof could exist.


### PR DESCRIPTION
## Summary
- Found and fixed a critical bug: `polytabloid_syt_dominance` had the dominance direction reversed
- The theorem claimed T₁ dominates T₂ when `e_{T₁}(σ_{T₂}) ≠ 0`, but the correct direction is T₂ dominates T₁
- Concrete counterexample: λ=(3,2), T₁=[0 2 4/1 3], T₂=[0 1 3/2 4] gives `e_{T₁}(σ_{T₂})=1≠0` but T₂ is strictly more dominant
- Fixed cascading downstream: renamed maximal→minimal, flipped dominance directions in `polytabloid_coeff_zero_of_minimal`, `exists_dominance_minimal`, and `polytabloid_linearIndependent'`
- The sorry in `polytabloid_syt_dominance` remains, but the statement is now correct

Closes #1942

🤖 Prepared with Claude Code