### PR TITLE
fix: swap YoungSymmetrizer to b_λ·a_λ convention (#1998)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Corollary5_12_4.lean
+++ b/EtingofRepresentationTheory/Chapter5/Corollary5_12_4.lean
@@ -38,15 +38,15 @@ theorem Corollary5_12_4 (n : ℕ) (la : Nat.Partition n) :
   let b_int : MonoidAlgebra ℤ (Equiv.Perm (Fin n)) :=
     haveI : DecidablePred (· ∈ ColumnSubgroup n la) := Classical.decPred _
     ∑ g : (ColumnSubgroup n la), (Equiv.Perm.sign g.val : ℤ) • MonoidAlgebra.of ℤ _ g.val
-  use a_int * b_int
+  use b_int * a_int
   -- The ring hom φ : ℤ[Sₙ] →+* ℂ[Sₙ] preserves multiplication
-  change φ (a_int * b_int) = YoungSymmetrizer n la
+  change φ (b_int * a_int) = YoungSymmetrizer n la
   rw [map_mul]
   -- Show φ maps each factor to the corresponding ℂ-version
   -- Use ext at the Finsupp level to avoid Fintype instance issues
   suffices ha : φ a_int = RowSymmetrizer n la by
     suffices hb : φ b_int = ColumnAntisymmetrizer n la by
-      rw [ha, hb, YoungSymmetrizer]
+      rw [hb, ha, YoungSymmetrizer]
     -- Prove φ b_int = ColumnAntisymmetrizer
     simp only [b_int, φ, ColumnAntisymmetrizer, map_sum, map_zsmul,
       MonoidAlgebra.of_apply, MonoidAlgebra.mapRangeRingHom_single, map_one]

--- a/EtingofRepresentationTheory/Chapter5/Definition5_12_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Definition5_12_1.lean
@@ -13,7 +13,7 @@ A **Young tableau** of shape λ is a filling of the Young diagram with numbers 1
 The **row subgroup** P_λ ⊂ S_n consists of permutations preserving each row.
 The **column subgroup** Q_λ ⊂ S_n consists of permutations preserving each column.
 
-The **Young symmetrizer** c_λ = a_λ · b_λ where:
+The **Young symmetrizer** c_λ = b_λ · a_λ where:
 - a_λ = Σ_{g ∈ P_λ} g
 - b_λ = Σ_{g ∈ Q_λ} sign(g) · g
 
@@ -116,14 +116,20 @@ noncomputable def ColumnAntisymmetrizer (n : ℕ) (la : Nat.Partition n) :
   ∑ g : (ColumnSubgroup n la),
     ((↑(Equiv.Perm.sign g.val) : ℤ) : ℂ) • MonoidAlgebra.of ℂ _ g.val
 
-/-- The Young symmetrizer c_λ = a_λ · b_λ in the group algebra ℂ[S_n].
+/-- The Young symmetrizer c_λ = b_λ · a_λ in the group algebra ℂ[S_n].
 (Etingof Definition 5.12.1)
 
 Here a_λ = ∑_{g ∈ P_λ} g and b_λ = ∑_{g ∈ Q_λ} sign(g) · g,
-where P_λ is the row subgroup and Q_λ is the column subgroup. -/
+where P_λ is the row subgroup and Q_λ is the column subgroup.
+
+**Convention**: We use c_λ = b_λ · a_λ (column × row) rather than a_λ · b_λ.
+Both conventions generate isomorphic Specht modules, but the b_λ · a_λ convention
+is needed for the polytabloid basis theorem: the map T ↦ of(σ_T) · c_λ is injective
+on standard Young tableaux only with this ordering. See James, "The Representation
+Theory of the Symmetric Groups". -/
 noncomputable def YoungSymmetrizer (n : ℕ) (la : Nat.Partition n) :
     MonoidAlgebra ℂ (Equiv.Perm (Fin n)) :=
-  RowSymmetrizer n la * ColumnAntisymmetrizer n la
+  ColumnAntisymmetrizer n la * RowSymmetrizer n la
 
 /-! ## Helper lemmas for rowOfPos and colOfPos -/
 

--- a/EtingofRepresentationTheory/Chapter5/Lemma5_13_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Lemma5_13_1.lean
@@ -3,8 +3,9 @@ import EtingofRepresentationTheory.Chapter5.Definition5_12_1
 /-!
 # Lemma 5.13.1: Young Projector Linear Functional
 
-For x ∈ ℂ[S_n], we have a_λ · x · b_λ = ℓ_λ(x) · c_λ, where ℓ_λ is a linear
-functional on ℂ[S_n]. Here a_λ = Σ_{g ∈ P_λ} g and b_λ = Σ_{g ∈ Q_λ} sign(g) · g.
+For x ∈ ℂ[S_n], we have b_λ · x · a_λ = ℓ_λ(x) · c_λ, where ℓ_λ is a linear
+functional on ℂ[S_n]. Here a_λ = Σ_{g ∈ P_λ} g and b_λ = Σ_{g ∈ Q_λ} sign(g) · g,
+and c_λ = b_λ · a_λ is the Young symmetrizer.
 
 ## Mathlib correspondence
 
@@ -378,93 +379,117 @@ private theorem pigeonhole_transposition {n : ℕ} {la : Nat.Partition n}
     refine Set.mem_mul.mpr ⟨σ * q_perm⁻¹, hp_row, q_perm, hq_col_sub, ?_⟩
     group
 
-/-- For σ ∈ P_λ · Q_λ with σ = p · q, the sandwiched product equals sign(q) • c_λ. -/
+/-- For σ ∈ Q_λ · P_λ with σ = q · p, the sandwiched product equals sign(q) • c_λ.
+(With c_λ = b_λ · a_λ.) -/
 private theorem sandwich_mem {n : ℕ} {la : Nat.Partition n}
-    (p : Equiv.Perm (Fin n)) (hp : p ∈ RowSubgroup n la)
-    (q : Equiv.Perm (Fin n)) (hq : q ∈ ColumnSubgroup n la) :
-    RowSymmetrizer n la * MonoidAlgebra.of ℂ _ (p * q) * ColumnAntisymmetrizer n la =
+    (q : Equiv.Perm (Fin n)) (hq : q ∈ ColumnSubgroup n la)
+    (p : Equiv.Perm (Fin n)) (hp : p ∈ RowSubgroup n la) :
+    ColumnAntisymmetrizer n la * MonoidAlgebra.of ℂ _ (q * p) * RowSymmetrizer n la =
       ((↑(↑(Equiv.Perm.sign q) : ℤ) : ℂ)) • YoungSymmetrizer n la := by
-  simp only [map_mul, mul_assoc]
-  rw [← mul_assoc (RowSymmetrizer n la), RowSymmetrizer_mul_of_row p hp,
-    of_col_mul_ColumnAntisymmetrizer q hq, Algebra.mul_smul_comm]
-  rfl
+  rw [map_mul (MonoidAlgebra.of ℂ _)]
+  simp only [mul_assoc]
+  rw [of_row_mul_RowSymmetrizer p hp,
+    ← mul_assoc (ColumnAntisymmetrizer n la), ColumnAntisymmetrizer_mul_of_col q hq,
+    Algebra.smul_mul_assoc, YoungSymmetrizer]
 
 open Pointwise in
-/-- For σ ∉ P_λ · Q_λ, a sign-reversing involution shows a_λ * of(σ) * b_λ = 0. -/
+/-- For σ ∉ Q_λ · P_λ, a sign-reversing involution shows b_λ * of(σ) * a_λ = 0.
+
+The proof applies the existing pigeonhole to σ⁻¹ (since σ ∉ Q·P ↔ σ⁻¹ ∉ P·Q),
+obtaining t ∈ P_λ with u = σ·t·σ⁻¹ ∈ Q_λ. Then b·of(σ)·a = sign(u)·(b·of(σ)·a) = -y. -/
 private theorem sandwich_not_mem {n : ℕ} {la : Nat.Partition n}
     (σ : Equiv.Perm (Fin n))
-    (hσ : σ ∉ (RowSubgroup n la : Set (Equiv.Perm (Fin n))) *
-      (ColumnSubgroup n la : Set (Equiv.Perm (Fin n)))) :
-    RowSymmetrizer n la * MonoidAlgebra.of ℂ _ σ * ColumnAntisymmetrizer n la = 0 := by
+    (hσ : σ ∉ (ColumnSubgroup n la : Set (Equiv.Perm (Fin n))) *
+      (RowSubgroup n la : Set (Equiv.Perm (Fin n)))) :
+    ColumnAntisymmetrizer n la * MonoidAlgebra.of ℂ _ σ * RowSymmetrizer n la = 0 := by
   classical
-  obtain ⟨t, ht_swap, ht_row, ht_col⟩ := pigeonhole_transposition σ hσ
-  set t' := σ⁻¹ * t * σ with ht'_def
-  -- Step 1: a * of(σ) = a * of(σ) * of(t')
-  have h_absorb : RowSymmetrizer n la * MonoidAlgebra.of ℂ _ σ =
-      RowSymmetrizer n la * MonoidAlgebra.of ℂ _ σ * MonoidAlgebra.of ℂ _ t' := by
-    have htσ : t * σ = σ * t' := by simp [ht'_def]; group
-    calc RowSymmetrizer n la * MonoidAlgebra.of ℂ _ σ
-      _ = RowSymmetrizer n la * MonoidAlgebra.of ℂ _ t * MonoidAlgebra.of ℂ _ σ := by
-          rw [RowSymmetrizer_mul_of_row t ht_row]
-      _ = RowSymmetrizer n la * (MonoidAlgebra.of ℂ _ t * MonoidAlgebra.of ℂ _ σ) := by
-          rw [mul_assoc]
-      _ = RowSymmetrizer n la * MonoidAlgebra.of ℂ _ (t * σ) := by rw [map_mul]
-      _ = RowSymmetrizer n la * MonoidAlgebra.of ℂ _ (σ * t') := by rw [htσ]
-      _ = RowSymmetrizer n la * (MonoidAlgebra.of ℂ _ σ * MonoidAlgebra.of ℂ _ t') := by
-          rw [← map_mul]
-      _ = RowSymmetrizer n la * MonoidAlgebra.of ℂ _ σ * MonoidAlgebra.of ℂ _ t' := by
-          rw [← mul_assoc]
-  -- Step 2: sign(t') = -1
-  have hsign_t' : (↑(↑(Equiv.Perm.sign t') : ℤ) : ℂ) = -1 := by
+  -- σ ∉ Q·P ↔ σ⁻¹ ∉ P·Q. Apply existing pigeonhole to σ⁻¹.
+  have hσ_inv : σ⁻¹ ∉ (RowSubgroup n la : Set (Equiv.Perm (Fin n))) *
+      (ColumnSubgroup n la : Set (Equiv.Perm (Fin n))) := by
+    intro hmem
+    apply hσ
+    obtain ⟨p, hp, q, hq, hpq⟩ := Set.mem_mul.mp hmem
+    exact Set.mem_mul.mpr ⟨q⁻¹, (ColumnSubgroup n la).inv_mem hq,
+      p⁻¹, (RowSubgroup n la).inv_mem hp,
+      show q⁻¹ * p⁻¹ = σ from by rw [← mul_inv_rev, hpq, inv_inv]⟩
+  obtain ⟨t, ht_swap, ht_row, ht_col'⟩ := pigeonhole_transposition σ⁻¹ hσ_inv
+  -- ht_col' : (σ⁻¹)⁻¹ * t * σ⁻¹ = σ * t * σ⁻¹ ∈ Q_λ
+  set u := σ * t * σ⁻¹ with hu_def
+  have hu_col : u ∈ ColumnSubgroup n la := by
+    have : σ⁻¹⁻¹ = σ := inv_inv σ
+    rw [hu_def, ← this]; exact ht_col'
+  -- Key relation: σ * t = u * σ
+  have hσt : σ * t = u * σ := by simp [hu_def]; group
+  -- sign(u) = -1 (u is a conjugate of the transposition t)
+  have hsign_u : (↑(↑(Equiv.Perm.sign u) : ℤ) : ℂ) = -1 := by
     have hsign_t : Equiv.Perm.sign t = -1 := by
       obtain ⟨x, z, hxz, ht_eq⟩ := ht_swap; rw [ht_eq]; exact Equiv.Perm.sign_swap hxz
-    have : Equiv.Perm.sign t' = -1 := by
-      change Equiv.Perm.sign (σ⁻¹ * t * σ) = -1
-      rw [map_mul, map_mul, Equiv.Perm.sign_inv, hsign_t,
-        mul_comm (Equiv.Perm.sign σ) (-1 : ℤˣ), mul_assoc, Int.units_mul_self, mul_one]
+    have : Equiv.Perm.sign u = -1 := by
+      show Equiv.Perm.sign (σ * t * σ⁻¹) = -1
+      rw [map_mul, map_mul, hsign_t, Equiv.Perm.sign_inv]
+      simp [mul_comm, Int.units_mul_self]
     simp [this]
-  -- Step 3: y = -y
-  set y := RowSymmetrizer n la * MonoidAlgebra.of ℂ _ σ * ColumnAntisymmetrizer n la
-  have heq : y = -y := by
-    change RowSymmetrizer n la * MonoidAlgebra.of ℂ _ σ * ColumnAntisymmetrizer n la = -y
-    conv_lhs => rw [h_absorb, mul_assoc,
-      of_col_mul_ColumnAntisymmetrizer t' ht_col, Algebra.mul_smul_comm]
-    rw [hsign_t', neg_one_smul]
-  -- Step 4: y = -y → y = 0
-  have h2 : y + y = 0 := by nth_rw 1 [heq]; exact neg_add_cancel y
-  have h3 : (2 : ℂ) • y = 0 := by rw [two_smul]; exact h2
-  exact (smul_eq_zero.mp h3).resolve_left two_ne_zero
+  -- y = sign(u) • y, via: insert of(t) after of(σ) (absorbed by a_λ),
+  -- rewrite σ·t = u·σ, absorb of(u) into b_λ with sign.
+  -- Show: b * of(σ) * a = sign(u) • (b * of(σ) * a), then use sign(u) = -1.
+  suffices heq : ColumnAntisymmetrizer n la * MonoidAlgebra.of ℂ _ σ * RowSymmetrizer n la =
+      ((↑(↑(Equiv.Perm.sign u) : ℤ) : ℂ)) •
+        (ColumnAntisymmetrizer n la * MonoidAlgebra.of ℂ _ σ * RowSymmetrizer n la) by
+    -- x = sign(u) • x = -x, so x = 0
+    rw [hsign_u, neg_one_smul] at heq
+    -- heq : x = -x. Pointwise: x g = -(x g), so 2*(x g) = 0, so x g = 0.
+    have hg : ∀ g, (ColumnAntisymmetrizer n la * MonoidAlgebra.of ℂ _ σ *
+        RowSymmetrizer n la) g = 0 := by
+      intro g
+      have := Finsupp.ext_iff.mp heq g
+      rw [Finsupp.neg_apply] at this
+      exact (mul_eq_zero.mp (show (2 : ℂ) * _ = 0 by linear_combination this)).resolve_left (by norm_num)
+    exact Finsupp.ext hg
+  -- Proof of x = sign(u) • x:
+  -- Insert of(t) before a_λ (absorbed), combine of(σ)*of(t)=of(σ*t)=of(u*σ),
+  -- split of(u)*of(σ), absorb of(u) into b_λ with sign.
+  have h1 : ColumnAntisymmetrizer n la * MonoidAlgebra.of ℂ _ σ * RowSymmetrizer n la =
+      ColumnAntisymmetrizer n la * MonoidAlgebra.of ℂ _ (σ * t) * RowSymmetrizer n la := by
+    conv_lhs => rw [← of_row_mul_RowSymmetrizer t ht_row]
+    rw [map_mul (MonoidAlgebra.of ℂ _) σ t]
+    simp only [mul_assoc]
+  have h2 : ColumnAntisymmetrizer n la * MonoidAlgebra.of ℂ _ (u * σ) * RowSymmetrizer n la =
+      ((↑(↑(Equiv.Perm.sign u) : ℤ) : ℂ)) •
+        (ColumnAntisymmetrizer n la * MonoidAlgebra.of ℂ _ σ * RowSymmetrizer n la) := by
+    rw [map_mul (MonoidAlgebra.of ℂ _)]
+    simp only [mul_assoc]
+    rw [← mul_assoc (ColumnAntisymmetrizer n la), ColumnAntisymmetrizer_mul_of_col u hu_col,
+      Algebra.smul_mul_assoc]
+  exact h1.trans (hσt ▸ h2)
 
 end Etingof
 
 open Etingof Pointwise in
-/-- For x ∈ ℂ[S_n], a_λ · x · b_λ is a scalar multiple of c_λ = a_λ · b_λ.
+/-- For x ∈ ℂ[S_n], b_λ · x · a_λ is a scalar multiple of c_λ = b_λ · a_λ.
 More precisely, there exists a linear functional ℓ_λ on ℂ[S_n] such that
-a_λ * x * b_λ = ℓ_λ(x) • c_λ for all x.
-(Etingof Lemma 5.13.1) -/
+b_λ * x * a_λ = ℓ_λ(x) • c_λ for all x.
+(Etingof Lemma 5.13.1, adapted for c_λ = b_λ · a_λ convention) -/
 theorem Etingof.Lemma5_13_1
     (n : ℕ) (la : Nat.Partition n) :
     ∃ ℓ : MonoidAlgebra ℂ (Equiv.Perm (Fin n)) →ₗ[ℂ] ℂ,
-      ∀ x, RowSymmetrizer n la * x * ColumnAntisymmetrizer n la =
+      ∀ x, ColumnAntisymmetrizer n la * x * RowSymmetrizer n la =
         ℓ x • YoungSymmetrizer n la := by
   classical
   -- For each basis element σ, compute the coefficient
   have basis_mul : ∀ σ : Equiv.Perm (Fin n), ∃ coeff : ℂ,
-      RowSymmetrizer n la * MonoidAlgebra.of ℂ _ σ * ColumnAntisymmetrizer n la =
+      ColumnAntisymmetrizer n la * MonoidAlgebra.of ℂ _ σ * RowSymmetrizer n la =
         coeff • YoungSymmetrizer n la := by
     intro σ
-    by_cases hmem : σ ∈ (RowSubgroup n la : Set (Equiv.Perm (Fin n))) *
-        (ColumnSubgroup n la : Set (Equiv.Perm (Fin n)))
-    · obtain ⟨p, hp, q, hq, hpq⟩ := Set.mem_mul.mp hmem
-      exact ⟨↑(↑(Equiv.Perm.sign q) : ℤ), hpq ▸ sandwich_mem p hp q hq⟩
+    by_cases hmem : σ ∈ (ColumnSubgroup n la : Set (Equiv.Perm (Fin n))) *
+        (RowSubgroup n la : Set (Equiv.Perm (Fin n)))
+    · obtain ⟨q, hq, p, hp, hqp⟩ := Set.mem_mul.mp hmem
+      exact ⟨↑(↑(Equiv.Perm.sign q) : ℤ), hqp ▸ sandwich_mem q hq p hp⟩
     · exact ⟨0, by rw [zero_smul]; exact sandwich_not_mem σ hmem⟩
   -- Extract coefficient function and build linear functional
   choose f hf using basis_mul
-  -- ℓ(x) = ∑_{σ} x(σ) * f(σ), constructed via Finsupp.lsum
   let ℓ : MonoidAlgebra ℂ (Equiv.Perm (Fin n)) →ₗ[ℂ] ℂ :=
     Finsupp.lsum ℂ (fun σ => f σ • (LinearMap.id : ℂ →ₗ[ℂ] ℂ))
   refine ⟨ℓ, fun x => ?_⟩
-  -- Both sides are linear in x; check on basis elements
   induction x using Finsupp.induction_linear with
   | zero => simp
   | add x y hx hy =>

--- a/EtingofRepresentationTheory/Chapter5/Lemma5_13_3.lean
+++ b/EtingofRepresentationTheory/Chapter5/Lemma5_13_3.lean
@@ -26,9 +26,11 @@ theorem Etingof.Lemma5_13_3
     (n : ℕ) (la : Nat.Partition n) :
     ∃ α : ℂ, YoungSymmetrizer n la * YoungSymmetrizer n la =
       α • YoungSymmetrizer n la := by
-  -- c_λ² = (a_λ * b_λ) * (a_λ * b_λ) = a_λ * (b_λ * a_λ) * b_λ = ℓ(b_λ * a_λ) • c_λ
+  -- c_λ² = (b_λ * a_λ) * (b_λ * a_λ) = b_λ * (a_λ * b_λ) * a_λ = ℓ(a_λ * b_λ) • c_λ
   obtain ⟨ℓ, hℓ⟩ := Etingof.Lemma5_13_1 n la
-  exact ⟨ℓ (ColumnAntisymmetrizer n la * RowSymmetrizer n la), by
+  exact ⟨ℓ (RowSymmetrizer n la * ColumnAntisymmetrizer n la), by
     simp only [YoungSymmetrizer]
-    rw [mul_assoc, ← mul_assoc (ColumnAntisymmetrizer n la), ← mul_assoc (RowSymmetrizer n la)]
+    rw [mul_assoc (ColumnAntisymmetrizer n la) (RowSymmetrizer n la),
+      ← mul_assoc (RowSymmetrizer n la) (ColumnAntisymmetrizer n la),
+      ← mul_assoc (ColumnAntisymmetrizer n la)]
     exact hℓ _⟩

--- a/EtingofRepresentationTheory/Chapter5/PolytabloidBasis.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolytabloidBasis.lean
@@ -217,9 +217,9 @@ Uses P_λ ∩ Q_λ = {id}. -/
 private lemma youngSymmetrizer_one_coeff (n : ℕ) (la : Nat.Partition n) :
     (YoungSymmetrizer n la : SymGroupAlgebra n) 1 = 1 := by
   classical
-  simp only [YoungSymmetrizer, RowSymmetrizer, MonoidAlgebra.of_apply, Finset.sum_mul]
+  simp only [YoungSymmetrizer, RowSymmetrizer, MonoidAlgebra.of_apply, Finset.mul_sum]
   rw [Finsupp.finset_sum_apply]
-  simp only [MonoidAlgebra.single_mul_apply, one_mul, mul_one]
+  simp only [MonoidAlgebra.mul_single_apply, mul_one]
   -- Goal: ∑ p : RowSubgroup, (ColumnAntisymmetrizer)(p⁻¹) = 1
   rw [Finset.sum_eq_single (⟨1, (RowSubgroup n la).one_mem⟩ : ↑(RowSubgroup n la))]
   · -- p = 1: ColumnAntisymmetrizer(1⁻¹) = ColumnAntisymmetrizer(1)
@@ -279,13 +279,13 @@ private lemma youngSymmetrizer_rowPerm_coeff (n : ℕ) (la : Nat.Partition n)
     (p : Equiv.Perm (Fin n)) (hp : p ∈ RowSubgroup n la) :
     (YoungSymmetrizer n la : SymGroupAlgebra n) p = 1 := by
   classical
-  simp only [YoungSymmetrizer, RowSymmetrizer, MonoidAlgebra.of_apply, Finset.sum_mul]
+  simp only [YoungSymmetrizer, RowSymmetrizer, MonoidAlgebra.of_apply, Finset.mul_sum]
   rw [Finsupp.finset_sum_apply]
-  simp only [MonoidAlgebra.single_mul_apply, one_mul]
-  -- c_λ(p) = Σ_{r ∈ P_λ} b_λ(r⁻¹ * p). Only r = p contributes (giving b_λ(1) = 1).
+  simp only [MonoidAlgebra.mul_single_apply, mul_one]
+  -- c_λ(p) = Σ_{r ∈ P_λ} b_λ(p * r⁻¹). Only r = p contributes (giving b_λ(1) = 1).
   rw [Finset.sum_eq_single (⟨p, hp⟩ : ↑(RowSubgroup n la))]
-  · -- r = p: b_λ(p⁻¹ * p) = b_λ(1)
-    simp only [inv_mul_cancel]
+  · -- r = p: b_λ(p * p⁻¹) = b_λ(1)
+    simp only [mul_inv_cancel]
     simp only [ColumnAntisymmetrizer, MonoidAlgebra.of_apply]
     rw [Finsupp.finset_sum_apply]
     rw [Finset.sum_eq_single (⟨1, (ColumnSubgroup n la).one_mem⟩ : ↑(ColumnSubgroup n la))]
@@ -297,17 +297,16 @@ private lemma youngSymmetrizer_rowPerm_coeff (n : ℕ) (la : Nat.Partition n)
       have : (q : Equiv.Perm (Fin n)) ≠ 1 := fun h => hq (Subtype.ext h)
       simp [this]
     · intro h; exact absurd (Finset.mem_univ _) h
-  · -- r ≠ p: b_λ(r⁻¹ * p) = 0 because r⁻¹ * p ∉ Q_λ
+  · -- r ≠ p: b_λ(p * r⁻¹) = 0 because p * r⁻¹ ∉ Q_λ
     intro r _ hr
     have hr_ne : (r : Equiv.Perm (Fin n)) ≠ p := fun h => hr (Subtype.ext h)
     apply columnAntisymmetrizer_apply_not_mem'
     intro hcol
-    have : (r : Equiv.Perm (Fin n))⁻¹ * p = 1 := by
+    have hid : p * (r : Equiv.Perm (Fin n))⁻¹ = 1 := by
       apply row_col_inter_trivial' n la
-      · exact (RowSubgroup n la).mul_mem ((RowSubgroup n la).inv_mem r.prop) hp
+      · exact (RowSubgroup n la).mul_mem hp ((RowSubgroup n la).inv_mem r.prop)
       · exact hcol
-    exact hr_ne (mul_left_cancel (a := (r : Equiv.Perm (Fin n))⁻¹)
-      (by rw [this, inv_mul_cancel]))
+    exact hr_ne (inv_injective (mul_left_cancel (a := p) (by rw [hid, mul_inv_cancel])))
   · intro h; exact absurd (Finset.mem_univ _) h
 
 /-! ### Tabloid projection for linear independence
@@ -342,45 +341,51 @@ in both directions. The tabloid projection approach is needed instead.
 
 /-! ### Support characterization of the Young symmetrizer -/
 
-/-- The Young symmetrizer c_λ is supported on P_λ · Q_λ: if c_λ(g) ≠ 0 then g = p · q
-for some p ∈ P_λ and q ∈ Q_λ, with c_λ(g) = sign(q). -/
+/-- The Young symmetrizer c_λ is supported on Q_λ · P_λ: if c_λ(g) ≠ 0 then g = q · p
+for some q ∈ Q_λ and p ∈ P_λ, with c_λ(g) = sign(q). -/
 private theorem youngSymmetrizer_support (n : ℕ) (la : Nat.Partition n)
     (g : Equiv.Perm (Fin n))
     (hg : (YoungSymmetrizer n la : SymGroupAlgebra n) g ≠ 0) :
-    ∃ p ∈ RowSubgroup n la, ∃ q ∈ ColumnSubgroup n la,
-      g = p * q := by
+    ∃ q ∈ ColumnSubgroup n la, ∃ p ∈ RowSubgroup n la,
+      g = q * p := by
   classical
-  simp only [YoungSymmetrizer, RowSymmetrizer, MonoidAlgebra.of_apply, Finset.sum_mul] at hg
+  simp only [YoungSymmetrizer, RowSymmetrizer, MonoidAlgebra.of_apply, Finset.mul_sum] at hg
   rw [Finsupp.finset_sum_apply] at hg
-  simp only [MonoidAlgebra.single_mul_apply, one_mul] at hg
-  -- hg says ∑_{p ∈ P_λ} b_λ(p⁻¹ · g) ≠ 0, so some term is nonzero
-  obtain ⟨⟨p, hp⟩, _, hterm⟩ := Finset.exists_ne_zero_of_sum_ne_zero hg
-  -- b_λ(p⁻¹ · g) ≠ 0
+  simp only [MonoidAlgebra.mul_single_apply, mul_one] at hg
+  -- hg says ∑_{r ∈ P_λ} b_λ(g · r⁻¹) ≠ 0, so some term is nonzero
+  obtain ⟨⟨r, hr⟩, _, hterm⟩ := Finset.exists_ne_zero_of_sum_ne_zero hg
+  -- b_λ(g · r⁻¹) ≠ 0
   simp only [ColumnAntisymmetrizer, MonoidAlgebra.of_apply] at hterm
   rw [Finsupp.finset_sum_apply] at hterm
   obtain ⟨⟨q, hq⟩, _, hq_term⟩ := Finset.exists_ne_zero_of_sum_ne_zero hterm
-  -- sign(q) · δ_q(p⁻¹ · g) ≠ 0
+  -- sign(q) · δ_q(g · r⁻¹) ≠ 0
   change ((↑(↑(Equiv.Perm.sign q) : ℤ) : ℂ) •
-    (Finsupp.single q (1 : ℂ))) ((p : Equiv.Perm (Fin n))⁻¹ * g) ≠ 0 at hq_term
+    (Finsupp.single q (1 : ℂ))) (g * (r : Equiv.Perm (Fin n))⁻¹) ≠ 0 at hq_term
   rw [Finsupp.smul_apply, smul_eq_mul, Finsupp.single_apply] at hq_term
   split_ifs at hq_term with heq
-  · -- p⁻¹ · g = q, so g = p · q
-    exact ⟨p, hp, q, hq, by rw [heq, mul_inv_cancel_left]⟩
+  · -- g · r⁻¹ = q, so g = q · r
+    exact ⟨q, hq, r, hr, by
+      have : g = q * r := by
+        have h := heq.symm
+        calc g = g * r⁻¹ * r := by group
+             _ = q * r := by rw [heq]
+      exact this⟩
   · simp at hq_term
 
-/-- The coefficient of g in c_λ when g = p · q (p ∈ P_λ, q ∈ Q_λ) is sign(q). -/
+/-- The coefficient of g in c_λ when g = q · p (q ∈ Q_λ, p ∈ P_λ) is sign(q). -/
 private theorem youngSymmetrizer_pq_coeff (n : ℕ) (la : Nat.Partition n)
-    (p : Equiv.Perm (Fin n)) (hp : p ∈ RowSubgroup n la)
-    (q : Equiv.Perm (Fin n)) (hq : q ∈ ColumnSubgroup n la) :
-    (YoungSymmetrizer n la : SymGroupAlgebra n) (p * q) =
+    (q : Equiv.Perm (Fin n)) (hq : q ∈ ColumnSubgroup n la)
+    (p : Equiv.Perm (Fin n)) (hp : p ∈ RowSubgroup n la) :
+    (YoungSymmetrizer n la : SymGroupAlgebra n) (q * p) =
       (↑(↑(Equiv.Perm.sign q) : ℤ) : ℂ) := by
   classical
-  simp only [YoungSymmetrizer, RowSymmetrizer, MonoidAlgebra.of_apply, Finset.sum_mul]
+  simp only [YoungSymmetrizer, RowSymmetrizer, MonoidAlgebra.of_apply, Finset.mul_sum]
   rw [Finsupp.finset_sum_apply]
-  simp only [MonoidAlgebra.single_mul_apply, one_mul]
+  simp only [MonoidAlgebra.mul_single_apply, mul_one]
+  -- c_λ(q * p) = Σ_{r ∈ P_λ} b_λ(q * p * r⁻¹). Only r = p contributes (giving b_λ(q) = sign(q)).
   rw [Finset.sum_eq_single (⟨p, hp⟩ : ↑(RowSubgroup n la))]
-  · -- r = p: b_λ(p⁻¹ · p · q) = b_λ(q) = sign(q)
-    simp only [inv_mul_cancel_left]
+  · -- r = p: b_λ(q * p * p⁻¹) = b_λ(q) = sign(q)
+    simp only [mul_inv_cancel_right]
     simp only [ColumnAntisymmetrizer, MonoidAlgebra.of_apply]
     rw [Finsupp.finset_sum_apply]
     rw [Finset.sum_eq_single (⟨q, hq⟩ : ↑(ColumnSubgroup n la))]
@@ -394,34 +399,33 @@ private theorem youngSymmetrizer_pq_coeff (n : ℕ) (la : Nat.Partition n)
       have : (q' : Equiv.Perm (Fin n)) ≠ q := fun h => hq' (Subtype.ext h)
       simp [this]
     · intro h; exact absurd (Finset.mem_univ _) h
-  · -- r ≠ p: b_λ(r⁻¹ · p · q) = 0 because r⁻¹ · p · q ∉ Q_λ
+  · -- r ≠ p: b_λ(q * p * r⁻¹) = 0 because q * p * r⁻¹ ∉ Q_λ
     intro r _ hr
     have hr_ne : (r : Equiv.Perm (Fin n)) ≠ p := fun h => hr (Subtype.ext h)
     apply columnAntisymmetrizer_apply_not_mem'
     intro hcol
-    -- r⁻¹ · p · q ∈ Q_λ means r⁻¹ · p ∈ Q_λ · Q_λ⁻¹ = Q_λ
-    have : (r : Equiv.Perm (Fin n))⁻¹ * p ∈ ColumnSubgroup n la := by
-      have h2 := (ColumnSubgroup n la).mul_mem hcol ((ColumnSubgroup n la).inv_mem hq)
-      simp only [mul_assoc] at h2
-      rwa [mul_inv_cancel, mul_one] at h2
-    -- r⁻¹ · p ∈ P_λ ∩ Q_λ = {1}
-    have hid := row_col_inter_trivial' n la ((r : Equiv.Perm (Fin n))⁻¹ * p)
-      ((RowSubgroup n la).mul_mem ((RowSubgroup n la).inv_mem r.prop) hp)
-      this
-    exact hr_ne (mul_left_cancel (a := (r : Equiv.Perm (Fin n))⁻¹)
-      (by rw [hid, inv_mul_cancel]))
+    -- q * p * r⁻¹ ∈ Q_λ means p * r⁻¹ ∈ Q_λ⁻¹ * Q_λ = Q_λ
+    have hpr : p * (r : Equiv.Perm (Fin n))⁻¹ ∈ ColumnSubgroup n la := by
+      have h2 := (ColumnSubgroup n la).mul_mem ((ColumnSubgroup n la).inv_mem hq) hcol
+      simp only [← mul_assoc] at h2
+      rwa [inv_mul_cancel, one_mul] at h2
+    -- p * r⁻¹ ∈ P_λ ∩ Q_λ = {1}
+    have hid := row_col_inter_trivial' n la (p * (r : Equiv.Perm (Fin n))⁻¹)
+      ((RowSubgroup n la).mul_mem hp ((RowSubgroup n la).inv_mem r.prop))
+      hpr
+    exact hr_ne (inv_injective (mul_left_cancel (a := p) (by rw [hid, mul_inv_cancel])))
   · intro h; exact absurd (Finset.mem_univ _) h
 
-/-- If e_{T₂}(σ) ≠ 0, then σ ∈ σ_{T₂} · P_λ · Q_λ: there exist p ∈ P_λ and q ∈ Q_λ
-such that σ = σ_{T₂} · p · q. -/
+/-- If e_{T₂}(σ) ≠ 0, then σ ∈ σ_{T₂} · Q_λ · P_λ: there exist q ∈ Q_λ and p ∈ P_λ
+such that σ = σ_{T₂} · q · p. -/
 theorem polytabloid_support (n : ℕ) (la : Nat.Partition n)
     (T₂ : StandardYoungTableau n la) (σ : Equiv.Perm (Fin n))
     (hne : (polytabloid n la T₂ : SymGroupAlgebra n) σ ≠ 0) :
-    ∃ p ∈ RowSubgroup n la, ∃ q ∈ ColumnSubgroup n la,
-      σ = sytPerm n la T₂ * p * q := by
+    ∃ q ∈ ColumnSubgroup n la, ∃ p ∈ RowSubgroup n la,
+      σ = sytPerm n la T₂ * q * p := by
   rw [polytabloid_apply] at hne
-  obtain ⟨p, hp, q, hq, heq⟩ := youngSymmetrizer_support n la _ hne
-  refine ⟨p, hp, q, hq, ?_⟩
+  obtain ⟨q, hq, p, hp, heq⟩ := youngSymmetrizer_support n la _ hne
+  refine ⟨q, hq, p, hp, ?_⟩
   have : σ = sytPerm n la T₂ * ((sytPerm n la T₂)⁻¹ * σ) := by
     rw [mul_inv_cancel_left]
   rw [this, heq, mul_assoc]
@@ -511,13 +515,13 @@ private theorem orderEmbOfFin_lt_of_injective_lt [LinearOrder α]
 
 /-! ### Straightening infrastructure: row absorption and column inversions -/
 
-/-- Left multiplication by a row permutation is absorbed by the Young symmetrizer:
-of(p) · c_λ = c_λ for p ∈ P_λ. This follows from of(p) · a_λ = a_λ. -/
+/-- Right multiplication by a row permutation is absorbed by the Young symmetrizer:
+c_λ · of(p) = c_λ for p ∈ P_λ. This follows from a_λ · of(p) = a_λ. -/
 private theorem of_row_mul_youngSymmetrizer' (n : ℕ) (la : Nat.Partition n)
     (p : Equiv.Perm (Fin n)) (hp : p ∈ RowSubgroup n la) :
-    MonoidAlgebra.of ℂ _ p * YoungSymmetrizer n la = YoungSymmetrizer n la := by
+    YoungSymmetrizer n la * MonoidAlgebra.of ℂ _ p = YoungSymmetrizer n la := by
   unfold YoungSymmetrizer
-  rw [← mul_assoc, of_row_mul_RowSymmetrizer p hp]
+  rw [mul_assoc, RowSymmetrizer_mul_of_row p hp]
 
 /-- The number of "column inversions" in the filling defined by σ. -/
 private def columnInvCount' (n : ℕ) (la : Nat.Partition n)

--- a/EtingofRepresentationTheory/Chapter5/Proposition5_14_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Proposition5_14_1.lean
@@ -110,10 +110,10 @@ private lemma rowSymmetrizer_annihilates_specht (n : ℕ) (la mu : Nat.Partition
   rw [show v = x • YoungSymmetrizer n mu from hx.symm]
   change RowSymmetrizer n la * (x * YoungSymmetrizer n mu) = 0
   simp only [YoungSymmetrizer]
-  rw [show RowSymmetrizer n la * (x * (RowSymmetrizer n mu * ColumnAntisymmetrizer n mu)) =
-    RowSymmetrizer n la * (x * RowSymmetrizer n mu) * ColumnAntisymmetrizer n mu
+  rw [show RowSymmetrizer n la * (x * (ColumnAntisymmetrizer n mu * RowSymmetrizer n mu)) =
+    RowSymmetrizer n la * x * ColumnAntisymmetrizer n mu * RowSymmetrizer n mu
     from by simp only [mul_assoc]]
-  exact Lemma5_13_2_general n la mu h _
+  rw [Lemma5_13_2_general n la mu h x, zero_mul]
 
 end
 
@@ -226,7 +226,10 @@ private lemma row_mul_youngSymmetrizer (n : ℕ) (la : Nat.Partition n)
     (p : G' n) (hp : p ∈ RowSubgroup n la) :
     MonoidAlgebra.of ℂ _ p * YoungSymmetrizer n la = YoungSymmetrizer n la := by
   simp only [YoungSymmetrizer, ← mul_assoc]
-  rw [of_row_mul_RowSymmetrizer p hp]
+  -- TODO: with the ColumnAntisymmetrizer * RowSymmetrizer convention, this needs
+  -- of(p) * ColumnAntisymmetrizer = ColumnAntisymmetrizer for p ∈ RowSubgroup,
+  -- which is not provided by of_row_mul_RowSymmetrizer. Needs reworking.
+  sorry
 
 /-- The Young symmetrizer c_λ is nonzero. -/
 private lemma youngSymmetrizer_ne_zero (n : ℕ) (la : Nat.Partition n) :
@@ -271,8 +274,10 @@ private lemma row_invariant_is_scalar_of_youngSymmetrizer (n : ℕ) (la : Nat.Pa
   obtain ⟨ℓ, hℓ⟩ := Etingof.Lemma5_13_1 n la
   have h_sandwich : RowSymmetrizer n la * (x * YoungSymmetrizer n la) =
       ℓ (x * RowSymmetrizer n la) • YoungSymmetrizer n la := by
-    conv_lhs => rw [YoungSymmetrizer, ← mul_assoc x, ← mul_assoc]
-    exact hℓ (x * RowSymmetrizer n la)
+    -- TODO: with ColumnAntisymmetrizer * RowSymmetrizer convention, the conv_lhs rearrangement
+    -- produces RowSymmetrizer * (x * ColumnAntisymmetrizer) * RowSymmetrizer, but hℓ expects
+    -- ColumnAntisymmetrizer * (x * RowSymmetrizer) * RowSymmetrizer. Needs reworking.
+    sorry
   have h_card_ne_zero : (Fintype.card (RowSubgroup n la) : ℂ) ≠ 0 :=
     Nat.cast_ne_zero.mpr Fintype.card_pos.ne'
   rw [h_sandwich] at h_sum

--- a/EtingofRepresentationTheory/Chapter5/TabloidModule.lean
+++ b/EtingofRepresentationTheory/Chapter5/TabloidModule.lean
@@ -876,8 +876,8 @@ theorem polytabloid_syt_dominance
     (T₁ T₂ : StandardYoungTableau n la)
     (hne : (polytabloid n la T₁ : SymGroupAlgebra n) (sytPerm n la T₂) ≠ 0) :
     tabloidDominates la (sytPerm n la T₂) (sytPerm n la T₁) := by
-  -- Get PQ decomposition: σ_{T₂} = σ_{T₁} · p · q with p ∈ P_λ, q ∈ Q_λ
-  obtain ⟨p, hp, q, hq, hσ⟩ := polytabloid_support n la T₁ (sytPerm n la T₂) hne
+  -- Get QP decomposition: σ_{T₂} = σ_{T₁} · q · p with q ∈ Q_λ, p ∈ P_λ
+  obtain ⟨q, hq, p, hp, hσ⟩ := polytabloid_support n la T₁ (sytPerm n la T₂) hne
   -- The proof requires showing that for all k, i:
   --   |{e ≤ k : rowOfPos(σ_{T₂}(e)) < i}| ≥ |{e ≤ k : rowOfPos(σ_{T₁}(e)) < i}|
   -- where σ_{T₂}(e) = σ_{T₁}(p(q(e))).

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_12_2_Distinct.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_12_2_Distinct.lean
@@ -29,11 +29,11 @@ private lemma young_symmetrizer_annihilates_specht (n : ℕ) (la mu : Nat.Partit
   rw [← hx]
   change YoungSymmetrizer n la * (x * YoungSymmetrizer n mu) = 0
   simp only [YoungSymmetrizer]
-  rw [show RowSymmetrizer n la * ColumnAntisymmetrizer n la *
-    (x * (RowSymmetrizer n mu * ColumnAntisymmetrizer n mu)) =
-    RowSymmetrizer n la * (ColumnAntisymmetrizer n la * x * RowSymmetrizer n mu) *
-    ColumnAntisymmetrizer n mu from by simp only [mul_assoc]]
-  exact Lemma5_13_2_general n la mu h _
+  rw [show ColumnAntisymmetrizer n la * RowSymmetrizer n la *
+    (x * (ColumnAntisymmetrizer n mu * RowSymmetrizer n mu)) =
+    ColumnAntisymmetrizer n la * (RowSymmetrizer n la * x * ColumnAntisymmetrizer n mu) *
+    RowSymmetrizer n mu from by simp only [mul_assoc],
+    Lemma5_13_2_general n la mu h, mul_zero, zero_mul]
 
 /-- For distinct partitions λ ≠ μ, the Specht modules V_λ and V_μ are not isomorphic
 as ℂ[S_n]-modules. (Etingof Theorem 5.12.2, part 2a)

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_12_2_Irreducible.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_12_2_Irreducible.lean
@@ -42,15 +42,15 @@ private lemma sandwich_scalar (n : ℕ) (la : Nat.Partition n) :
     ∃ f : A' n →ₗ[ℂ] ℂ, ∀ x,
       YoungSymmetrizer n la * x * YoungSymmetrizer n la = f x • YoungSymmetrizer n la := by
   obtain ⟨ℓ, hℓ⟩ := Etingof.Lemma5_13_1 n la
-  refine ⟨ℓ.comp ((LinearMap.mulLeft ℂ (ColumnAntisymmetrizer n la)).comp
-    (LinearMap.mulRight ℂ (RowSymmetrizer n la))), fun x => ?_⟩
+  refine ⟨ℓ.comp ((LinearMap.mulLeft ℂ (RowSymmetrizer n la)).comp
+    (LinearMap.mulRight ℂ (ColumnAntisymmetrizer n la))), fun x => ?_⟩
   change YoungSymmetrizer n la * x * YoungSymmetrizer n la =
-    ℓ (ColumnAntisymmetrizer n la * (x * RowSymmetrizer n la)) • YoungSymmetrizer n la
+    ℓ (RowSymmetrizer n la * (x * ColumnAntisymmetrizer n la)) • YoungSymmetrizer n la
   simp only [YoungSymmetrizer]
-  have : RowSymmetrizer n la * ColumnAntisymmetrizer n la * x *
-    (RowSymmetrizer n la * ColumnAntisymmetrizer n la) =
-    RowSymmetrizer n la * (ColumnAntisymmetrizer n la * x * RowSymmetrizer n la) *
-    ColumnAntisymmetrizer n la := by simp only [mul_assoc]
+  have : ColumnAntisymmetrizer n la * RowSymmetrizer n la * x *
+    (ColumnAntisymmetrizer n la * RowSymmetrizer n la) =
+    ColumnAntisymmetrizer n la * (RowSymmetrizer n la * x * ColumnAntisymmetrizer n la) *
+    RowSymmetrizer n la := by simp only [mul_assoc]
   rw [this, hℓ]; simp only [YoungSymmetrizer, mul_assoc]
 
 /-- The trace of left multiplication by a MonoidAlgebra element in the regular
@@ -129,22 +129,39 @@ This uses the fact that P_λ ∩ Q_λ = {id}: only the pair (id, id) in P × Q
 maps to the identity permutation. -/
 private lemma youngSymmetrizer_identity_coeff (n : ℕ) (la : Nat.Partition n) :
     (YoungSymmetrizer n la : A' n) 1 = 1 := by
-  simp only [YoungSymmetrizer, RowSymmetrizer, MonoidAlgebra.of_apply, Finset.sum_mul]
+  -- (b * a)(1) = ∑_q sign(q) * a(q⁻¹). Only q = 1 contributes.
+  simp only [YoungSymmetrizer, ColumnAntisymmetrizer, MonoidAlgebra.of_apply, Finset.sum_mul]
   rw [Finsupp.finset_sum_apply]
-  simp only [MonoidAlgebra.single_mul_apply, one_mul, mul_one]
-  -- Goal: ∑ p : RowSubgroup, (ColAnti)(p⁻¹) = 1
-  rw [Finset.sum_eq_single (⟨1, (RowSubgroup n la).one_mem⟩ : ↑(RowSubgroup n la))]
-  · -- p = 1: ColAnti(1⁻¹) = ColAnti(1) = sign(1) = 1
-    simp only [Subgroup.coe_mk, inv_one]
-    rw [columnAntisymmetrizer_apply_mem n la 1 (ColumnSubgroup n la).one_mem]
-    simp [Equiv.Perm.sign_one]
-  · -- p ≠ 1: ColAnti(p⁻¹) = 0
-    intro p _ hp
-    have hp_ne : (p : G' n) ≠ 1 := fun h => hp (Subtype.ext h)
-    apply columnAntisymmetrizer_apply_not_mem
-    intro hcol
-    exact hp_ne (row_col_inter_trivial n la p.val p.prop
-      ((ColumnSubgroup n la).inv_mem_iff.mp hcol))
+  -- Rewrite each summand: (sign(q) • (single q 1 * a)) 1 = sign(q) * a(q⁻¹)
+  rw [Finset.sum_congr rfl (fun i _ => show _ = _ from by
+    rw [Algebra.smul_mul_assoc, Finsupp.smul_apply, smul_eq_mul,
+      MonoidAlgebra.single_mul_apply, one_mul, mul_one])]
+  rw [Finset.sum_eq_single (⟨1, (ColumnSubgroup n la).one_mem⟩ : ↑(ColumnSubgroup n la))]
+  · -- q = 1: sign(1) * a(1⁻¹) = 1 * a(1) = 1
+    simp only [Subgroup.coe_mk, inv_one, Equiv.Perm.sign_one, Units.val_one, Int.cast_one,
+      mul_one, one_mul]
+    -- a(1) = RowSym(1) = 1
+    simp only [RowSymmetrizer, MonoidAlgebra.of_apply]
+    rw [Finsupp.finset_sum_apply,
+      Finset.sum_eq_single (⟨1, (RowSubgroup n la).one_mem⟩ : ↑(RowSubgroup n la))]
+    · simp [Finsupp.single_apply]
+    · intro p _ hp; simp [Finsupp.single_apply, show (p : G' n) ≠ 1 from
+        fun h => hp (Subtype.ext h)]
+    · intro h; exact absurd (Finset.mem_univ _) h
+  · -- q ≠ 1: sign(q) * a(q⁻¹) = sign(q) * 0 = 0
+    intro q _ hq
+    have hq_ne : (q : G' n) ≠ 1 := fun h => hq (Subtype.ext h)
+    suffices h : (RowSymmetrizer n la : A' n) (q : G' n)⁻¹ = 0 by
+      rw [h, mul_zero]
+    simp only [RowSymmetrizer, MonoidAlgebra.of_apply]
+    rw [Finsupp.finset_sum_apply]
+    apply Finset.sum_eq_zero; intro p _
+    simp only [Finsupp.single_apply]
+    split_ifs with h
+    · exfalso; exact hq_ne (inv_eq_one.mp (row_col_inter_trivial n la (q : G' n)⁻¹
+        (h ▸ p.prop)
+        ((ColumnSubgroup n la).inv_mem q.prop)))
+    · rfl
   · intro h; exact absurd (Finset.mem_univ _) h
 
 /-- c_λ² ≠ 0. Proved via the trace argument: if c_λ² = 0 then left multiplication

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
@@ -1020,14 +1020,14 @@ private lemma mul_mem_specht_proportional' (n : ℕ) (la : Nat.Partition n)
   rw [smul_eq_mul] at ha
   obtain ⟨ℓ, hℓ⟩ := Etingof.Lemma5_13_1 n la
   have h_sandwich : ∀ x,
-      c * x * c = ℓ (ColumnAntisymmetrizer n la * (x * RowSymmetrizer n la)) • c := by
+      c * x * c = ℓ (RowSymmetrizer n la * (x * ColumnAntisymmetrizer n la)) • c := by
     intro x
-    change RowSymmetrizer n la * ColumnAntisymmetrizer n la * x *
-        (RowSymmetrizer n la * ColumnAntisymmetrizer n la) = _
-    rw [show RowSymmetrizer n la * ColumnAntisymmetrizer n la * x *
-          (RowSymmetrizer n la * ColumnAntisymmetrizer n la) =
-        RowSymmetrizer n la * (ColumnAntisymmetrizer n la * x * RowSymmetrizer n la) *
-          ColumnAntisymmetrizer n la from by simp only [mul_assoc]]
+    change ColumnAntisymmetrizer n la * RowSymmetrizer n la * x *
+        (ColumnAntisymmetrizer n la * RowSymmetrizer n la) = _
+    rw [show ColumnAntisymmetrizer n la * RowSymmetrizer n la * x *
+          (ColumnAntisymmetrizer n la * RowSymmetrizer n la) =
+        ColumnAntisymmetrizer n la * (RowSymmetrizer n la * x * ColumnAntisymmetrizer n la) *
+          RowSymmetrizer n la from by simp only [mul_assoc]]
     rw [hℓ, show c = YoungSymmetrizer n la from rfl]; simp only [YoungSymmetrizer, mul_assoc]
   have hsand := h_sandwich a
   conv_lhs at hsand => rw [mul_assoc]

--- a/progress/2026-04-02T04-17-52Z.md
+++ b/progress/2026-04-02T04-17-52Z.md
@@ -1,0 +1,31 @@
+## Accomplished
+
+Fixed issue #1998: swapped `YoungSymmetrizer` convention from `RowSymmetrizer * ColumnAntisymmetrizer` to `ColumnAntisymmetrizer * RowSymmetrizer` (b_λ · a_λ convention) and fixed all downstream breakage across 9 files:
+
+- **Definition5_12_1.lean**: Core definition swap
+- **Lemma5_13_1.lean**: Complete rewrite of sandwich lemmas (`sandwich_mem`, `sandwich_not_mem`), pigeonhole transposition on σ⁻¹, and the `y = -y → y = 0` argument via `Finsupp.ext_iff` + `linear_combination` in ℂ
+- **Lemma5_13_3.lean**: Idempotent proof — swapped scalar to `ℓ(RowSymmetrizer * ColumnAntisymmetrizer)` and fixed reassociation
+- **Corollary5_12_4.lean**: Integer lift — swapped `a_int * b_int` to `b_int * a_int`
+- **Theorem5_12_2_Irreducible.lean**: `sandwich_scalar` functional composition swap; `youngSymmetrizer_identity_coeff` fully rewritten
+- **Theorem5_12_2_Distinct.lean**: Reassociation fix + `rw [Lemma5_13_2_general ..., mul_zero, zero_mul]`
+- **PolytabloidBasis.lean**: 5 fixes across coeff/support/absorption lemmas
+- **Theorem5_22_1.lean**: `h_sandwich` change/reassociation fix for `c * x * c` expansion
+- **Proposition5_14_1.lean**: 2 new sorrys introduced (see below)
+
+Created follow-up issue #2001 for the 2 new sorrys in Proposition5_14_1.lean. These arise because `of(p) * c_λ = c_λ` (left absorption by row elements) is mathematically false with the new convention. The canonical map construction needs architectural rework.
+
+## Current frontier
+
+All files build. The only errors are pre-existing (Theorem5_22_1.lean lines 88, 134). Two new sorrys in Proposition5_14_1.lean tracked in #2001.
+
+## Overall project progress
+
+The polytabloid basis infrastructure now uses the correct convention for the James polytabloid definition, which is critical for `polytabloid_linearIndependent` and `polytabloid_span`. The Specht module dimension formula `dim V_λ = |SYT(λ)|` can now be correctly formalized.
+
+## Next step
+
+Fix issue #2001: reformulate the canonical map in Proposition5_14_1 to use right absorption (`c_λ * of(p) = c_λ`) instead of left absorption.
+
+## Blockers
+
+None — the sorrys in Proposition5_14_1 are tracked and don't block the polytabloid basis work.


### PR DESCRIPTION
## Summary

- Swaps `YoungSymmetrizer` definition from `RowSymmetrizer * ColumnAntisymmetrizer` to `ColumnAntisymmetrizer * RowSymmetrizer` (James convention `c_λ = b_λ · a_λ`)
- Fixes all 10 downstream files: sandwich lemmas, idempotent proof, integer lift, irreducibility, distinctness, polytabloid basis, tabloid module, and trace formula
- Introduces 2 new sorrys in `Proposition5_14_1.lean` where left absorption (`of(p) * c_λ = c_λ`) is now mathematically false — tracked in #2001

## Why

The polytabloid basis theorem requires `c_λ = b_λ · a_λ` so that distinct SYTs produce distinct polytabloids. With the old convention `c_λ = a_λ · b_λ`, two SYTs whose `sytPerm`s differ by a right `P_λ` element give identical polytabloids, breaking linear independence (see counterexample in #1998).

## Test plan

- [x] `lake build` passes (only pre-existing errors in Theorem5_22_1.lean lines 88, 134)
- [x] No new sorry introduced except 2 tracked in #2001
- [x] Sandwich lemma (Lemma5_13_1) fully re-proved with new convention
- [x] Idempotent property (Lemma5_13_3) re-proved
- [x] Polytabloid basis infrastructure (PolytabloidBasis.lean) builds clean

Closes #1998

🤖 Prepared with Claude Code