### PR TITLE
fix: align YoungSymmetrizerZ/K convention and eliminate titsForm timeout

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
@@ -50,9 +50,9 @@ def YoungSymmetrizerK (k : Type*) [CommRing k] (n : ℕ) (la : Nat.Partition n) 
     MonoidAlgebra k (Equiv.Perm (Fin n)) :=
   haveI : DecidablePred (· ∈ RowSubgroup n la) := Classical.decPred _
   haveI : DecidablePred (· ∈ ColumnSubgroup n la) := Classical.decPred _
-  (∑ g : (RowSubgroup n la), MonoidAlgebra.of k _ g.val) *
   (∑ g : (ColumnSubgroup n la),
-    ((↑(Equiv.Perm.sign g.val) : ℤ) : k) • MonoidAlgebra.of k _ g.val)
+    ((↑(Equiv.Perm.sign g.val) : ℤ) : k) • MonoidAlgebra.of k _ g.val) *
+  (∑ g : (RowSubgroup n la), MonoidAlgebra.of k _ g.val)
 
 /-! ### Young symmetrizer over ℤ and scalar transfer -/
 
@@ -62,9 +62,9 @@ def YoungSymmetrizerZ (n : ℕ) (la : Nat.Partition n) :
     MonoidAlgebra ℤ (Equiv.Perm (Fin n)) :=
   haveI : DecidablePred (· ∈ RowSubgroup n la) := Classical.decPred _
   haveI : DecidablePred (· ∈ ColumnSubgroup n la) := Classical.decPred _
-  (∑ g : (RowSubgroup n la), MonoidAlgebra.of ℤ _ g.val) *
   (∑ g : (ColumnSubgroup n la),
-    (↑(Equiv.Perm.sign g.val) : ℤ) • MonoidAlgebra.of ℤ _ g.val)
+    (↑(Equiv.Perm.sign g.val) : ℤ) • MonoidAlgebra.of ℤ _ g.val) *
+  (∑ g : (RowSubgroup n la), MonoidAlgebra.of ℤ _ g.val)
 
 /-- Base change maps `of ℤ g` to `of k g`. -/
 private theorem mapRange_of {G : Type*} [Monoid G] (R : Type*) [CommRing R]
@@ -131,32 +131,34 @@ theorem YoungSymmetrizerZ_apply_one (n : ℕ) (la : Nat.Partition n) :
   simp only [YoungSymmetrizer, RowSymmetrizer, ColumnAntisymmetrizer]
   -- Distribute the product of sums
   rw [Finset.sum_mul]
-  simp_rw [Finset.mul_sum, mul_smul_comm]
+  simp_rw [smul_mul_assoc, Finset.mul_sum]
   -- Unfold of to single, then simplify multiplication of singles
   have hof : ∀ (g : Equiv.Perm (Fin n)),
       (MonoidAlgebra.of ℂ _ g : MonoidAlgebra ℂ _) = Finsupp.single g 1 := fun _ => rfl
   simp_rw [hof, MonoidAlgebra.single_mul_single, mul_one]
-  -- Goal: (∑ p ∑ q, (sign q) • single (p*q) 1)(1) = 1
+  -- Push smul inside the inner sum
+  simp_rw [Finset.smul_sum]
+  -- Goal: (∑ q ∑ p, (sign q) • single (q*p) 1)(1) = 1
   rw [Finset.sum_apply']
   conv_lhs => arg 2; ext k; rw [Finset.sum_apply']
   simp only [MonoidAlgebra.smul_apply, smul_eq_mul, MonoidAlgebra.single_apply,
     mul_ite, mul_one, mul_zero]
-  -- ∑_p ∑_q, if p * q = 1 then (sign q : ℂ) else 0 = 1
-  rw [Fintype.sum_eq_single ⟨1, (RowSubgroup n la).one_mem⟩]
-  · rw [Fintype.sum_eq_single ⟨1, (ColumnSubgroup n la).one_mem⟩]
+  -- ∑_q ∑_p, if q * p = 1 then (sign q : ℂ) else 0 = 1
+  rw [Fintype.sum_eq_single ⟨1, (ColumnSubgroup n la).one_mem⟩]
+  · rw [Fintype.sum_eq_single ⟨1, (RowSubgroup n la).one_mem⟩]
     · simp [Equiv.Perm.sign_one]
-    · intro ⟨q, hq⟩ hne
+    · intro ⟨p, hp⟩ hne
       rw [if_neg]
-      intro hq1
-      exact hne (Subtype.ext (by simpa using hq1))
-  · intro ⟨p, hp⟩ hne
+      intro hp1
+      exact hne (Subtype.ext (by simpa using hp1))
+  · intro ⟨q, hq⟩ hne
     apply Fintype.sum_eq_zero
-    intro ⟨q, hq⟩
+    intro ⟨p, hp⟩
     rw [if_neg]
-    intro hpq
-    have heq : p = q⁻¹ := mul_eq_one_iff_eq_inv.mp hpq
-    have hp_in_Q : p ∈ ColumnSubgroup n la := heq ▸ (ColumnSubgroup n la).inv_mem hq
-    exact hne (Subtype.ext (row_col_preserving_eq_one n la p hp hp_in_Q))
+    intro hqp
+    have heq : q = p⁻¹ := mul_eq_one_iff_eq_inv.mp hqp
+    have hq_in_P : q ∈ RowSubgroup n la := heq ▸ (RowSubgroup n la).inv_mem hp
+    exact hne (Subtype.ext (row_col_preserving_eq_one n la q hq_in_P hq))
 
 /-- The Young symmetrizer over any CharZero ring satisfies c² = α·c for some scalar α.
 The scalar is the image of an integer, obtained by transferring the identity from ℂ

--- a/EtingofRepresentationTheory/Chapter6/Corollary6_8_3.lean
+++ b/EtingofRepresentationTheory/Chapter6/Corollary6_8_3.lean
@@ -244,70 +244,8 @@ private lemma Etingof.reflectionFunctors_reduce_and_recover
 
 end ReflectionFunctorChain
 
-section TitsFormBound
-
-/-- The Tits form of the dimension vector of an indecomposable representation of a
-Dynkin quiver satisfies B(d, d) ≤ 2.
-
-## Proof strategy (from the book)
-
-The proof uses Ringel's homological formula for hereditary algebras:
-  dim Hom(V, V) - dim Ext¹(V, V) = ½ B(d(V), d(V))
-
-For V indecomposable over an algebraically closed field k:
-  - dim End(V) = 1 by Schur's lemma (End(V) is a local algebra with
-    End(V)/rad(End(V)) ≅ k, and for finite-dimensional indecomposables
-    over algebraically closed fields, End(V) ≅ k)
-  - dim Ext¹(V, V) ≥ 0
-
-This gives ½ B(d, d) = 1 - dim Ext¹(V, V) ≤ 1, so B(d, d) ≤ 2.
-
-## Blockers
-
-1. **Ext groups**: No formalization of Ext¹ for quiver representations
-   (or more generally for modules over path algebras) exists in this project
-   or in Mathlib.
-
-2. **Homological formula**: The identity relating Hom, Ext¹, and the Euler/Tits
-   form requires the path algebra to be hereditary (global dimension ≤ 1),
-   which requires showing quivers without oriented cycles have hereditary
-   path algebras.
-
-3. **Schur's lemma variant**: While Schur's lemma for simple modules is standard,
-   the result that End(V) ≅ k for indecomposable finite-dimensional V over an
-   algebraically closed field requires the Fitting lemma / Krull-Schmidt theory.
-
-## Alternative approach (bypasses Ext entirely)
-
-The book's proof of Corollary 6.8.2 proves B(d,d) = 2 (not just ≤ 2) by a
-representation-level reduction: apply reflection functors along the Coxeter element
-until reaching a simple representation, then use `iteratedSimpleReflection_preserves_bilinearForm`
-to conclude B(d,d) = B(αₚ,αₚ) = 2. This approach requires the same Coxeter element
-infrastructure as `reflectionFunctors_reduce_and_recover` (type-changing iteration,
-vertex-sink alignment) but avoids Ext groups completely. If that infrastructure is
-built, this lemma becomes a direct corollary and can be eliminated.
-
-The Tits form of the dimension vector of an indecomposable representation of a
-Dynkin quiver satisfies B(d, d) ≤ 2.
-
-This follows from the stronger result `indecomposable_bilinearForm_eq_two` (B = 2 exactly),
-proved via representation-level Coxeter iteration in `CoxeterInfrastructure.lean`.
-The ≤ 2 form is kept for backward compatibility with the existing proof of `Corollary6_8_3`. -/
-private lemma Etingof.indecomposable_titsForm_le_two
-    {n : ℕ} {adj : Matrix (Fin n) (Fin n) ℤ}
-    (hDynkin : Etingof.IsDynkinDiagram n adj)
-    {k : Type*} [Field k]
-    {Q : Quiver (Fin n)}
-    (hOrient : Etingof.IsOrientationOf Q adj)
-    [∀ (a b : Fin n), Subsingleton (@Quiver.Hom (Fin n) Q a b)]
-    (ρ : @Etingof.QuiverRepresentation k (Fin n) _ Q)
-    [∀ v, Module.Free k (ρ.obj v)] [∀ v, Module.Finite k (ρ.obj v)]
-    (hρ : ρ.IsIndecomposable) :
-    dotProduct (fun v => (Module.finrank k (ρ.obj v) : ℤ))
-      ((Etingof.cartanMatrix n adj).mulVec (fun v => (Module.finrank k (ρ.obj v) : ℤ))) ≤ 2 :=
-  le_of_eq (Etingof.indecomposable_bilinearForm_eq_two hDynkin hOrient ρ hρ)
-
-end TitsFormBound
+-- The old `indecomposable_titsForm_le_two` lemma (≤ 2 bound) has been eliminated.
+-- `Corollary6_8_3` now uses `indecomposable_bilinearForm_eq_two` (= 2) directly.
 
 /-- Indecomposable representations of a Dynkin quiver are determined (up to isomorphism)
 by their dimension vectors.
@@ -320,7 +258,7 @@ theorem Etingof.Corollary6_8_3
     {n : ℕ} {adj : Matrix (Fin n) (Fin n) ℤ}
     (hDynkin : Etingof.IsDynkinDiagram n adj)
     {k : Type*} [Field k]
-    {Q : Quiver (Fin n)}
+    {Q : @Quiver.{0, 0} (Fin n)}
     (hOrient : Etingof.IsOrientationOf Q adj)
     [∀ (a b : Fin n), Subsingleton (@Quiver.Hom (Fin n) Q a b)]
     (ρ₁ ρ₂ : @Etingof.QuiverRepresentation k (Fin n) _ Q)
@@ -345,13 +283,8 @@ theorem Etingof.Corollary6_8_3
   -- Step 4: The dimension vector is a positive root (B(d,d) = 2)
   -- Lower bound: B(d,d) ≥ 2 from positive definiteness + evenness (Lemma 6.4.2)
   -- Upper bound: B(d,d) ≤ 2 from indecomposability (requires Ext group infrastructure)
-  have hd_root : dotProduct d ((Etingof.cartanMatrix n adj).mulVec d) = 2 := by
-    have hlb : 2 ≤ dotProduct d ((2 • (1 : Matrix (Fin n) (Fin n) ℤ) - adj).mulVec d) :=
-      Etingof.posdef_min_value hDynkin d hd_nonzero
-    have hub : dotProduct d ((Etingof.cartanMatrix n adj).mulVec d) ≤ 2 :=
-      Etingof.indecomposable_titsForm_le_two hDynkin hOrient ρ₁ h₁
-    unfold Etingof.cartanMatrix at hub ⊢
-    omega
+  have hd_root : dotProduct d ((Etingof.cartanMatrix n adj).mulVec d) = 2 :=
+    Etingof.indecomposable_bilinearForm_eq_two hDynkin hOrient ρ₁ h₁
   -- Step 5: By Theorem 6.8.1, there exists a sequence of reflections reducing d to a simple root
   obtain ⟨vertices, p, hreflect⟩ := Etingof.Theorem6_8_1 hDynkin d hd_pos hd_nonzero hd_root
   -- Step 6: Use the reflection functor chain to show ρ₁ ≅ ρ₂


### PR DESCRIPTION
## Summary

- Swap `YoungSymmetrizerZ` and `YoungSymmetrizerK` multiplication order to match the `ColumnAntisymmetrizer * RowSymmetrizer` (b_λ·a_λ) convention introduced in #2002
- Fix `YoungSymmetrizerZ_apply_one` proof for the new convention (outer sum over ColumnSubgroup, smul handling)
- Eliminate `indecomposable_titsForm_le_two` intermediate lemma that caused deterministic timeouts via expensive `le_of_eq` unification; `Corollary6_8_3` now calls `indecomposable_bilinearForm_eq_two` directly
- Fix `@Quiver.{0, 0}` universe annotation in `Corollary6_8_3` to match `CoxeterInfrastructure.lean`

These are pre-existing build failures on main that cause CI to fail on all open PRs.

Closes #2013

🤖 Prepared with Claude Code