### PR TITLE
feat: prove 3 of 5 Mackey machine sorries in Theorem5_27_1 (5→2)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_27_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_27_1.lean
@@ -1177,9 +1177,11 @@ private lemma exists_character_in_rep {G A : Type} [Group G] [CommGroup A]
   -- Get a simple ℂ[A]-submodule (exists by semisimplicity + nontriviality)
   haveI : Nontrivial ρ_A.asModule := hnt
   obtain ⟨m, hm⟩ := IsSemisimpleModule.exists_simple_submodule (MonoidAlgebra ℂ A) ρ_A.asModule
-  -- Since A is commutative, m is 1-dim (finrank_eq_one_of_isMulCommutative)
-  -- The A-action on m is by scalars → defines a character χ : A →* ℂˣ
-  -- Any nonzero v ∈ m satisfies ρ(a,1)v = χ(a)·v, so v ∈ weightSpace φ W χ
+  -- Key steps (each requires careful type class management):
+  -- 1. m is 1-dimensional over ℂ (IsSimpleModule.finrank_eq_one_of_isMulCommutative)
+  -- 2. Pick nonzero v ∈ m, then ∀ a : A, ρ(a)v = χ(a)·v for unique scalar χ(a) : ℂ
+  -- 3. χ(a) ∈ ℂˣ (since ρ(a) is invertible) and χ : A →* ℂˣ (multiplicativity)
+  -- 4. v ∈ weightSpace φ W χ, so weightSpace φ W χ ≠ ⊥
   sorry
 
 -- Helper: The weight space W_χ is invariant under G_χ


### PR DESCRIPTION
This PR reduces sorry count in `Theorem5_27_1.lean` from 5 to 2 by proving three previously-sorry'd lemmas in the Mackey machine completeness proof.

## Proved

1. **`hWχ_nz`**: `weightSpace ≠ ⊥ → ¬ IsZero (weightSpaceRep ...)` — extracts element-level info from `𝟙 = 0` via the `f.hom.hom.hom` accessor chain
2. **`exists_simple_subrep`**: Any nonzero `FDRep ℂ H` has a simple subrepresentation — proved via strong induction on finrank using Maschke's theorem (split mono from Injective) and biproduct decomposition
3. **Signature fix**: `exists_nonzero_map_from_induced` no longer has `by sorry` in its type — replaced with explicit `hχ` parameter

## Added helpers

- `finrank_iso'`: finrank invariant under iso in FDRep
- `finrank_biprod'`: finrank of biproduct = sum of finranks in FDRep

## Remaining sorries (2)

- `exists_character_in_rep` (line 1185): Extract character χ : A →* ℂˣ from 1-dim simple ℂ[A]-submodule. Strategy documented; requires careful type class plumbing for `FiniteDimensional ℂ ↥m` when `m : Submodule (MonoidAlgebra ℂ A) ρ_A.asModule`.
- `exists_nonzero_map_from_induced` (line 1389): Frobenius reciprocity — construct isomorphism `inducedRepV φ χ U ≅ W` from embedding `U ⟶ weightSpaceRep`. Hardest remaining sorry.

Closes #1782 partially (5→2 sorries).

🤖 Prepared with Claude Code