### PR TITLE
feat: fix Proposition5_14_1 convention swap regression (2→0 sorries)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Lemma5_13_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Lemma5_13_1.lean
@@ -462,6 +462,66 @@ private theorem sandwich_not_mem {n : ℕ} {la : Nat.Partition n}
       Algebra.smul_mul_assoc]
   exact h1.trans (hσt ▸ h2)
 
+/-- Dual sandwich (member case): for p ∈ P_λ, q ∈ Q_λ,
+a_λ * of(p*q) * b_λ = sign(q) • (a_λ * b_λ). -/
+private theorem dual_sandwich_mem {n : ℕ} {la : Nat.Partition n}
+    (p : Equiv.Perm (Fin n)) (hp : p ∈ RowSubgroup n la)
+    (q : Equiv.Perm (Fin n)) (hq : q ∈ ColumnSubgroup n la) :
+    RowSymmetrizer n la * MonoidAlgebra.of ℂ _ (p * q) * ColumnAntisymmetrizer n la =
+      ((↑(↑(Equiv.Perm.sign q) : ℤ) : ℂ)) •
+        (RowSymmetrizer n la * ColumnAntisymmetrizer n la) := by
+  rw [map_mul (MonoidAlgebra.of ℂ _)]
+  simp only [mul_assoc]
+  rw [of_col_mul_ColumnAntisymmetrizer q hq, Algebra.mul_smul_comm, Algebra.mul_smul_comm]
+  congr 1
+  rw [← mul_assoc, RowSymmetrizer_mul_of_row p hp]
+
+open Pointwise in
+/-- Dual sandwich (non-member case): for σ ∉ P_λ · Q_λ,
+a_λ * of(σ) * b_λ = 0. Uses the same pigeonhole argument as sandwich_not_mem. -/
+private theorem dual_sandwich_not_mem {n : ℕ} {la : Nat.Partition n}
+    (σ : Equiv.Perm (Fin n))
+    (hσ : σ ∉ (RowSubgroup n la : Set (Equiv.Perm (Fin n))) *
+      (ColumnSubgroup n la : Set (Equiv.Perm (Fin n)))) :
+    RowSymmetrizer n la * MonoidAlgebra.of ℂ _ σ * ColumnAntisymmetrizer n la = 0 := by
+  classical
+  obtain ⟨t, ht_swap, ht_row, ht_col'⟩ := pigeonhole_transposition σ hσ
+  set u := σ⁻¹ * t * σ with hu_def
+  have hu_col : u ∈ ColumnSubgroup n la := ht_col'
+  have hσt : t * σ = σ * u := by simp [hu_def]; group
+  have hsign_u : (↑(↑(Equiv.Perm.sign u) : ℤ) : ℂ) = -1 := by
+    have hsign_t : Equiv.Perm.sign t = -1 := by
+      obtain ⟨x, z, hxz, ht_eq⟩ := ht_swap; rw [ht_eq]; exact Equiv.Perm.sign_swap hxz
+    have : Equiv.Perm.sign u = -1 := by
+      show Equiv.Perm.sign (σ⁻¹ * t * σ) = -1
+      rw [map_mul, map_mul, hsign_t, Equiv.Perm.sign_inv]
+      simp [mul_comm, Int.units_mul_self]
+    simp [this]
+  suffices heq : RowSymmetrizer n la * MonoidAlgebra.of ℂ _ σ * ColumnAntisymmetrizer n la =
+      ((↑(↑(Equiv.Perm.sign u) : ℤ) : ℂ)) •
+        (RowSymmetrizer n la * MonoidAlgebra.of ℂ _ σ * ColumnAntisymmetrizer n la) by
+    rw [hsign_u, neg_one_smul] at heq
+    have hg : ∀ g, (RowSymmetrizer n la * MonoidAlgebra.of ℂ _ σ *
+        ColumnAntisymmetrizer n la) g = 0 := by
+      intro g
+      have := Finsupp.ext_iff.mp heq g
+      rw [Finsupp.neg_apply] at this
+      exact (mul_eq_zero.mp (show (2 : ℂ) * _ = 0 by linear_combination this)).resolve_left
+        (by norm_num)
+    exact Finsupp.ext hg
+  have h1 : RowSymmetrizer n la * MonoidAlgebra.of ℂ _ σ * ColumnAntisymmetrizer n la =
+      RowSymmetrizer n la * MonoidAlgebra.of ℂ _ (t * σ) * ColumnAntisymmetrizer n la := by
+    conv_lhs => rw [← RowSymmetrizer_mul_of_row t ht_row]
+    rw [map_mul (MonoidAlgebra.of ℂ _) t σ]
+    simp only [mul_assoc]
+  have h2 : RowSymmetrizer n la * MonoidAlgebra.of ℂ _ (σ * u) * ColumnAntisymmetrizer n la =
+      ((↑(↑(Equiv.Perm.sign u) : ℤ) : ℂ)) •
+        (RowSymmetrizer n la * MonoidAlgebra.of ℂ _ σ * ColumnAntisymmetrizer n la) := by
+    rw [map_mul (MonoidAlgebra.of ℂ _)]
+    simp only [mul_assoc]
+    rw [of_col_mul_ColumnAntisymmetrizer u hu_col, Algebra.mul_smul_comm, Algebra.mul_smul_comm]
+  exact h1.trans (hσt ▸ h2)
+
 end Etingof
 
 open Etingof Pointwise in
@@ -486,6 +546,45 @@ theorem Etingof.Lemma5_13_1
       exact ⟨↑(↑(Equiv.Perm.sign q) : ℤ), hqp ▸ sandwich_mem q hq p hp⟩
     · exact ⟨0, by rw [zero_smul]; exact sandwich_not_mem σ hmem⟩
   -- Extract coefficient function and build linear functional
+  choose f hf using basis_mul
+  let ℓ : MonoidAlgebra ℂ (Equiv.Perm (Fin n)) →ₗ[ℂ] ℂ :=
+    Finsupp.lsum ℂ (fun σ => f σ • (LinearMap.id : ℂ →ₗ[ℂ] ℂ))
+  refine ⟨ℓ, fun x => ?_⟩
+  induction x using Finsupp.induction_linear with
+  | zero => simp
+  | add x y hx hy =>
+    simp only [mul_add, add_mul, map_add, add_smul]
+    exact congr_arg₂ (· + ·) hx hy
+  | single σ r =>
+    have hℓ : ℓ (Finsupp.single σ r) = f σ * r := by
+      change (Finsupp.lsum ℂ (fun σ => f σ • (LinearMap.id : ℂ →ₗ[ℂ] ℂ)))
+        (Finsupp.single σ r) = f σ * r
+      rw [Finsupp.lsum_single, LinearMap.smul_apply, LinearMap.id_apply, smul_eq_mul]
+    have hsingle : (Finsupp.single σ r : MonoidAlgebra ℂ _) = r • MonoidAlgebra.of ℂ _ σ := by
+      simp [MonoidAlgebra.of_apply, mul_one]
+    conv_lhs => rw [hsingle]
+    rw [Algebra.mul_smul_comm, Algebra.smul_mul_assoc, hf, smul_smul, hℓ, mul_comm]
+
+open Etingof Pointwise in
+/-- Dual sandwich: a_λ * x * b_λ is a scalar multiple of a_λ * b_λ.
+There exists a linear functional ℓ' on ℂ[S_n] such that
+a_λ * x * b_λ = ℓ'(x) • (a_λ * b_λ) for all x.
+This is the P/Q-swapped version of Lemma 5.13.1. -/
+theorem Etingof.Lemma5_13_1_dual
+    (n : ℕ) (la : Nat.Partition n) :
+    ∃ ℓ : MonoidAlgebra ℂ (Equiv.Perm (Fin n)) →ₗ[ℂ] ℂ,
+      ∀ x, RowSymmetrizer n la * x * ColumnAntisymmetrizer n la =
+        ℓ x • (RowSymmetrizer n la * ColumnAntisymmetrizer n la) := by
+  classical
+  have basis_mul : ∀ σ : Equiv.Perm (Fin n), ∃ coeff : ℂ,
+      RowSymmetrizer n la * MonoidAlgebra.of ℂ _ σ * ColumnAntisymmetrizer n la =
+        coeff • (RowSymmetrizer n la * ColumnAntisymmetrizer n la) := by
+    intro σ
+    by_cases hmem : σ ∈ (RowSubgroup n la : Set (Equiv.Perm (Fin n))) *
+        (ColumnSubgroup n la : Set (Equiv.Perm (Fin n)))
+    · obtain ⟨p, hp, q, hq, hpq⟩ := Set.mem_mul.mp hmem
+      exact ⟨↑(↑(Equiv.Perm.sign q) : ℤ), hpq ▸ dual_sandwich_mem p hp q hq⟩
+    · exact ⟨0, by rw [zero_smul]; exact dual_sandwich_not_mem σ hmem⟩
   choose f hf using basis_mul
   let ℓ : MonoidAlgebra ℂ (Equiv.Perm (Fin n)) →ₗ[ℂ] ℂ :=
     Finsupp.lsum ℂ (fun σ => f σ • (LinearMap.id : ℂ →ₗ[ℂ] ℂ))

--- a/EtingofRepresentationTheory/Chapter5/Proposition5_14_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Proposition5_14_1.lean
@@ -221,15 +221,14 @@ noncomputable section
 set_option linter.style.openClassical false in
 open scoped Classical
 
-/-- Left multiplication by a row subgroup element fixes the Young symmetrizer. -/
-private lemma row_mul_youngSymmetrizer (n : ℕ) (la : Nat.Partition n)
+/-- Left multiplication by a row subgroup element fixes a_λ * c_λ.
+With c_λ = b_λ · a_λ, left absorption of(p) * c_λ = c_λ fails, but
+of(p) * a_λ * c_λ = a_λ * c_λ works because of(p) * a_λ = a_λ. -/
+private lemma row_mul_rowSym_youngSymmetrizer (n : ℕ) (la : Nat.Partition n)
     (p : G' n) (hp : p ∈ RowSubgroup n la) :
-    MonoidAlgebra.of ℂ _ p * YoungSymmetrizer n la = YoungSymmetrizer n la := by
-  simp only [YoungSymmetrizer, ← mul_assoc]
-  -- TODO: with the ColumnAntisymmetrizer * RowSymmetrizer convention, this needs
-  -- of(p) * ColumnAntisymmetrizer = ColumnAntisymmetrizer for p ∈ RowSubgroup,
-  -- which is not provided by of_row_mul_RowSymmetrizer. Needs reworking.
-  sorry
+    MonoidAlgebra.of ℂ _ p * (RowSymmetrizer n la * YoungSymmetrizer n la) =
+    RowSymmetrizer n la * YoungSymmetrizer n la := by
+  rw [← mul_assoc, of_row_mul_RowSymmetrizer p hp]
 
 /-- The Young symmetrizer c_λ is nonzero. -/
 private lemma youngSymmetrizer_ne_zero (n : ℕ) (la : Nat.Partition n) :
@@ -239,29 +238,43 @@ private lemma youngSymmetrizer_ne_zero (n : ℕ) (la : Nat.Partition n) :
   have hbot : SpechtModule n la = ⊥ := Submodule.span_singleton_eq_bot.mpr h
   exact (isSimpleModule_iff_isAtom.mp ‹_›).1 hbot
 
-/-- of(g) * c_λ ≠ 0 since of(g) is a unit and c_λ ≠ 0. -/
-private lemma of_mul_youngSymmetrizer_ne_zero (n : ℕ) (la : Nat.Partition n) (g : G' n) :
-    MonoidAlgebra.of ℂ _ g * YoungSymmetrizer n la ≠ 0 := by
+/-- The product a_λ * c_λ = a_λ * b_λ * a_λ is nonzero.
+If a_λ * c_λ = 0, then b_λ * (a_λ * c_λ) = c_λ² = 0, contradicting
+`young_symmetrizer_sq_ne_zero`. -/
+private lemma rowSym_youngSym_ne_zero (n : ℕ) (la : Nat.Partition n) :
+    RowSymmetrizer n la * YoungSymmetrizer n la ≠ 0 := by
   intro h
-  apply youngSymmetrizer_ne_zero n la
-  have : MonoidAlgebra.of ℂ _ g⁻¹ * (MonoidAlgebra.of ℂ _ g * YoungSymmetrizer n la) =
-      YoungSymmetrizer n la := by
+  apply young_symmetrizer_sq_ne_zero n la
+  have : ColumnAntisymmetrizer n la * (RowSymmetrizer n la * YoungSymmetrizer n la) =
+      YoungSymmetrizer n la * YoungSymmetrizer n la := by
+    simp only [YoungSymmetrizer, mul_assoc]
+  rw [h, mul_zero] at this; exact this.symm
+
+/-- of(g) * a_λ * c_λ ≠ 0 since of(g) is a unit and a_λ * c_λ ≠ 0. -/
+private lemma of_mul_rowSym_youngSymmetrizer_ne_zero (n : ℕ) (la : Nat.Partition n) (g : G' n) :
+    MonoidAlgebra.of ℂ _ g * (RowSymmetrizer n la * YoungSymmetrizer n la) ≠ 0 := by
+  intro h
+  apply rowSym_youngSym_ne_zero n la
+  have : MonoidAlgebra.of ℂ _ g⁻¹ * (MonoidAlgebra.of ℂ _ g *
+      (RowSymmetrizer n la * YoungSymmetrizer n la)) =
+      RowSymmetrizer n la * YoungSymmetrizer n la := by
     rw [← mul_assoc, ← map_mul, inv_mul_cancel, map_one, one_mul]
   rw [h, mul_zero] at this
   exact this.symm
 
-/-- Any row-invariant element of V_λ is a scalar multiple of c_λ. -/
-private lemma row_invariant_is_scalar_of_youngSymmetrizer (n : ℕ) (la : Nat.Partition n)
+/-- Any row-invariant element of V_λ is a scalar multiple of a_λ * c_λ.
+With c_λ = b_λ · a_λ, left P_λ-invariant elements are proportional to a_λ * c_λ
+(not c_λ itself, since of(p) * c_λ ≠ c_λ with the James convention). -/
+private lemma row_invariant_is_scalar_of_rowSym_youngSym (n : ℕ) (la : Nat.Partition n)
     (v : SymGroupAlgebra n) (hv : v ∈ SpechtModule n la)
     (hinv : ∀ p ∈ RowSubgroup n la,
       MonoidAlgebra.of ℂ (G' n) p * v = v) :
-    ∃ c : ℂ, v = c • YoungSymmetrizer n la := by
+    ∃ c : ℂ, v = c • (RowSymmetrizer n la * YoungSymmetrizer n la) := by
   classical
   obtain ⟨x, hx⟩ := Submodule.mem_span_singleton.mp hv
-  -- v = x * c_λ (since span is smul-span in the algebra = left multiplication)
   change x • YoungSymmetrizer n la = v at hx
   rw [hx.symm]
-  -- Sum of (of p) * v over p ∈ P_λ gives a_λ * v = |P_λ| * v
+  -- a_λ * (x * c_λ) = |P_λ| * (x * c_λ)
   have h_sum : RowSymmetrizer n la * (x * YoungSymmetrizer n la) =
       (Fintype.card (RowSubgroup n la) : ℂ) • (x * YoungSymmetrizer n la) := by
     have key : ∀ p : RowSubgroup n la,
@@ -270,47 +283,40 @@ private lemma row_invariant_is_scalar_of_youngSymmetrizer (n : ℕ) (la : Nat.Pa
       intro p; have h := hinv p.val p.prop; rwa [← hx] at h
     simp only [RowSymmetrizer, Finset.sum_mul, key, Finset.sum_const, Finset.card_univ,
       ← Nat.cast_smul_eq_nsmul ℂ]
-  -- By Lemma 5.13.1: a_λ * (x * c_λ) = a_λ * x * a_λ * b_λ = ℓ(x * a_λ) • c_λ
-  obtain ⟨ℓ, hℓ⟩ := Etingof.Lemma5_13_1 n la
+  -- By dual sandwich: a_λ * x * b_λ = ℓ'(x) • (a_λ * b_λ)
+  -- Therefore a_λ * x * c_λ = a_λ * x * b_λ * a_λ = ℓ'(x) • (a_λ * b_λ * a_λ) = ℓ'(x) • (a_λ * c_λ)
+  obtain ⟨ℓ', hℓ'⟩ := Etingof.Lemma5_13_1_dual n la
   have h_sandwich : RowSymmetrizer n la * (x * YoungSymmetrizer n la) =
-      ℓ (x * RowSymmetrizer n la) • YoungSymmetrizer n la := by
-    -- TODO: with ColumnAntisymmetrizer * RowSymmetrizer convention, the conv_lhs rearrangement
-    -- produces RowSymmetrizer * (x * ColumnAntisymmetrizer) * RowSymmetrizer, but hℓ expects
-    -- ColumnAntisymmetrizer * (x * RowSymmetrizer) * RowSymmetrizer. Needs reworking.
-    sorry
+      ℓ' x • (RowSymmetrizer n la * YoungSymmetrizer n la) := by
+    simp only [YoungSymmetrizer]
+    rw [← mul_assoc, ← mul_assoc, hℓ' x, Algebra.smul_mul_assoc, mul_assoc]
   have h_card_ne_zero : (Fintype.card (RowSubgroup n la) : ℂ) ≠ 0 :=
     Nat.cast_ne_zero.mpr Fintype.card_pos.ne'
   rw [h_sandwich] at h_sum
-  -- h_sum : ℓ(x * a_λ) • c_λ = |P_λ| • (x * c_λ)
-  -- Multiply both sides by |P_λ|⁻¹ to isolate x * c_λ
   replace h_sum := congr_arg (fun v => (Fintype.card (RowSubgroup n la) : ℂ)⁻¹ • v) h_sum.symm
   simp only [smul_smul, inv_mul_cancel₀ h_card_ne_zero, one_smul] at h_sum
-  -- h_sum : x * c_λ = (|P_λ|⁻¹ * ℓ(x * a_λ)) • c_λ
   exact ⟨_, h_sum⟩
 
-/-- Coset representative equivariance: of(out(σ·q)) * c_λ = of(σ) * of(out q) * c_λ. -/
+/-- Coset representative equivariance for a_λ * c_λ:
+of(out(σ·q)) * a_λ * c_λ = of(σ) * of(out q) * a_λ * c_λ. -/
 private lemma coset_rep_equivariance (n : ℕ) (la : Nat.Partition n)
     (σ : G' n) (q : Q n la) :
-    MonoidAlgebra.of ℂ _ (Quotient.out (σ • q)) * YoungSymmetrizer n la =
+    MonoidAlgebra.of ℂ _ (Quotient.out (σ • q)) *
+      (RowSymmetrizer n la * YoungSymmetrizer n la) =
     MonoidAlgebra.of ℂ _ σ * MonoidAlgebra.of ℂ _ (Quotient.out q) *
-      YoungSymmetrizer n la := by
-  -- out(σ·q) and σ * out(q) are in the same P_λ-coset
+      (RowSymmetrizer n la * YoungSymmetrizer n la) := by
   have h_eq : QuotientGroup.mk (Quotient.out (σ • q)) =
       (QuotientGroup.mk (σ * Quotient.out q) : Q n la) := by
     rw [QuotientGroup.out_eq']
     change σ • q = QuotientGroup.mk (σ * Quotient.out q)
     conv_lhs => rw [← QuotientGroup.out_eq' q]
     rfl
-  -- (σ * out q)⁻¹ * out(σ·q) ∈ P_λ
   have hmem := QuotientGroup.eq.mp h_eq
-  -- out(σ·q)⁻¹ * (σ * out q) ∈ P_λ (the inverse)
-  have hcoset := hmem
-  -- of(σ) * of(out q) * c_λ = of(out(σ·q)) * of(p) * c_λ = of(out(σ·q)) * c_λ
   have key : MonoidAlgebra.of ℂ _ σ * MonoidAlgebra.of ℂ _ (Quotient.out q) =
       MonoidAlgebra.of ℂ _ (Quotient.out (σ • q)) *
         MonoidAlgebra.of ℂ _ ((Quotient.out (σ • q))⁻¹ * (σ * Quotient.out q)) := by
     rw [← map_mul, ← map_mul]; congr 1; group
-  rw [key, mul_assoc, row_mul_youngSymmetrizer n la _ hcoset]
+  rw [key, mul_assoc, row_mul_rowSym_youngSymmetrizer n la _ hmem]
 
 end
 
@@ -318,10 +324,10 @@ noncomputable section
 set_option linter.style.openClassical false in
 open scoped Classical
 
-/-- Helper: the image function for the canonical map. -/
+/-- Helper: the image function for the canonical map, using a_λ * c_λ. -/
 private abbrev canonicalHom_v (n : ℕ) (la : Nat.Partition n) (q : Q n la) :
     SymGroupAlgebra n :=
-  MonoidAlgebra.of ℂ _ (Quotient.out q) * YoungSymmetrizer n la
+  MonoidAlgebra.of ℂ _ (Quotient.out q) * (RowSymmetrizer n la * YoungSymmetrizer n la)
 
 /-- The ℂ-linear version of the canonical map, using Finsupp.lift. -/
 private noncomputable def canonicalHom_ℂ (n : ℕ) (la : Nat.Partition n) :
@@ -336,7 +342,8 @@ private lemma permMod_smul_assoc (n : ℕ) (la : Nat.Partition n)
     r • ((Representation.ofMulAction ℂ (G' n) (Q n la)).asAlgebraHom a x)
   simp only [map_smul, LinearMap.smul_apply]
 
-/-- The canonical equivariant map φ : U_λ → V_λ, sending δ_{gP_λ} to of(out(gP_λ)) * c_λ. -/
+/-- The canonical equivariant map φ : U_λ → V_λ, sending δ_{gP_λ} to
+of(out(gP_λ)) * a_λ * c_λ. -/
 private noncomputable def canonicalHom (n : ℕ) (la : Nat.Partition n) :
     PermutationModule n la →ₗ[SymGroupAlgebra n] ↥(SpechtModule n la) where
   toFun x :=
@@ -344,7 +351,9 @@ private noncomputable def canonicalHom (n : ℕ) (la : Nat.Partition n) :
       simp only [canonicalHom_ℂ, Finsupp.lift_apply]
       apply Submodule.sum_mem; intro q _
       exact Submodule.smul_of_tower_mem (SpechtModule n la) (x q)
-        (Submodule.mem_span_singleton.mpr ⟨MonoidAlgebra.of ℂ _ (Quotient.out q), rfl⟩)⟩
+        (Submodule.mem_span_singleton.mpr
+          ⟨MonoidAlgebra.of ℂ _ (Quotient.out q) * RowSymmetrizer n la,
+           by rw [smul_eq_mul, mul_assoc]⟩)⟩
   map_add' x y := Subtype.ext (map_add (canonicalHom_ℂ n la) x y)
   map_smul' a x := by
     refine Subtype.ext ?_
@@ -427,18 +436,17 @@ theorem Proposition5_14_1_diagonal
     have h_val := congrArg Subtype.val h
     simp only [Submodule.coe_zero] at h_val
     rw [hφe_val, canonicalHom_v] at h_val
-    exact of_mul_youngSymmetrizer_ne_zero n la _ h_val
-  -- φ(e).val is a scalar multiple of c_λ
-  obtain ⟨c₀, hc₀⟩ := row_invariant_is_scalar_of_youngSymmetrizer n la
+    exact of_mul_rowSym_youngSymmetrizer_ne_zero n la _ h_val
+  -- φ(e).val is a scalar multiple of a_λ * c_λ
+  obtain ⟨c₀, hc₀⟩ := row_invariant_is_scalar_of_rowSym_youngSym n la
     (φ e : SymGroupAlgebra n) (φ e).prop (equivariant_map_row_invariant n la φ)
   have hc₀_ne : c₀ ≠ 0 := by
     intro h; rw [h, zero_smul] at hc₀; exact hφe_ne (Subtype.ext hc₀)
   apply finrank_eq_one (R := ℂ) (v := φ)
   · exact fun h => hφe_ne (by rw [h, LinearMap.zero_apply])
   · intro f
-    obtain ⟨c₁, hc₁⟩ := row_invariant_is_scalar_of_youngSymmetrizer n la
+    obtain ⟨c₁, hc₁⟩ := row_invariant_is_scalar_of_rowSym_youngSym n la
       (f e : SymGroupAlgebra n) (f e).prop (equivariant_map_row_invariant n la f)
-    -- f(e) = (c₁/c₀) • φ(e) as subtypes
     have h_agree : f e = (c₁ / c₀) • φ e := by
       apply Subtype.ext
       change (f e : SymGroupAlgebra n) = (c₁ / c₀) • (φ e : SymGroupAlgebra n)


### PR DESCRIPTION
## Summary
- Adds dual sandwich lemma `Lemma5_13_1_dual` (a_λ * x * b_λ = ℓ'(x) · (a_λ * b_λ)) to `Lemma5_13_1.lean`, the P/Q-swapped version of the existing sandwich formula
- Fixes `rowSym_youngSym_ne_zero` by using `young_symmetrizer_sq_ne_zero` (c_λ² ≠ 0) for direct contradiction
- Rewrites the diagonal proof in `Proposition5_14_1.lean` to use `RowSymmetrizer * YoungSymmetrizer` (= a_λ * c_λ) as the P_λ-invariant generator, since c_λ = b_λ · a_λ itself is NOT left P_λ-invariant under the James convention

Closes #2035

🤖 Prepared with Claude Code

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>