### PR TITLE
progress: garnir_identity_expansion infrastructure (#2055)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/PolytabloidBasis.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolytabloidBasis.lean
@@ -1085,21 +1085,163 @@ private theorem garnir_row_annihilates (n : ℕ) (la : Nat.Partition n)
     rw [two_smul]; exact h2
   exact (smul_eq_zero.mp h3).resolve_left (by norm_num : (2 : ℂ) ≠ 0)
 
-/-- Garnir reduction via the Garnir element identity.
+/-- swap(p₁, p₂) belongs to the column subgroup when p₁ and p₂ are in the same column. -/
+private theorem swap_mem_ColumnSubgroup' (n : ℕ) (la : Nat.Partition n)
+    (p₁ p₂ : Fin n)
+    (hcol : colOfPos la.sortedParts p₁.val = colOfPos la.sortedParts p₂.val) :
+    Equiv.swap p₁ p₂ ∈ ColumnSubgroup n la := by
+  intro k
+  simp only [Equiv.swap_apply_def]
+  split_ifs with h1 h2
+  · subst h1; exact hcol.symm
+  · subst h2; exact hcol
+  · rfl
 
-From `a_λ · G = 0`, extracting the identity term gives:
-  `a_λ = -Σ_{w ≠ id} sign(w) · a_λ · of(w)`
-Multiplying: `of(σ) · c_λ = -Σ_{w ≠ id} sign(w) · of(σ) · a_λ · of(w) · b_λ`
+/-- Left multiplication by a column subgroup element on the Young symmetrizer:
+of(q) * c_λ = sign(q) • c_λ for q ∈ Q_λ. -/
+private theorem of_col_mul_YoungSymmetrizer (n : ℕ) (la : Nat.Partition n)
+    (q : Equiv.Perm (Fin n)) (hq : q ∈ ColumnSubgroup n la) :
+    MonoidAlgebra.of ℂ _ q * YoungSymmetrizer n la =
+      ((↑(↑(Equiv.Perm.sign q) : ℤ) : ℂ)) • YoungSymmetrizer n la := by
+  show MonoidAlgebra.of ℂ _ q * (ColumnAntisymmetrizer n la * RowSymmetrizer n la) =
+    _ • (ColumnAntisymmetrizer n la * RowSymmetrizer n la)
+  rw [← mul_assoc, of_col_mul_ColumnAntisymmetrizer q hq, Algebra.smul_mul_assoc]
 
-Each non-identity w ∈ S_{A∪B} moves entries between rows r₁ and r₂,
-which reduces column inversions. Specifically:
-- The terms `of(σ) · a_λ · of(w) · b_λ` can be regrouped as
-  `Σ_τ d(τ) · of(τ) · c_λ` where each τ has fewer column inversions.
+/-- Key algebraic identity: for p₁, p₂ in the same column,
+of(σ) · c_λ = -of(σ · swap(p₁,p₂)) · c_λ.
+This follows from swap(p₁,p₂) ∈ Q_λ and the column absorption property. -/
+private theorem garnir_swap_identity (n : ℕ) (la : Nat.Partition n)
+    (σ : Equiv.Perm (Fin n)) (p₁ p₂ : Fin n)
+    (hcol : colOfPos la.sortedParts p₁.val = colOfPos la.sortedParts p₂.val)
+    (hne : p₁ ≠ p₂) :
+    MonoidAlgebra.of ℂ _ σ * YoungSymmetrizer n la =
+      (-1 : ℂ) • (MonoidAlgebra.of ℂ _ (σ * Equiv.swap p₁ p₂) *
+        YoungSymmetrizer n la) := by
+  have hswap_col := swap_mem_ColumnSubgroup' n la p₁ p₂ hcol
+  have h1 : MonoidAlgebra.of ℂ _ (Equiv.swap p₁ p₂) * YoungSymmetrizer n la =
+      (-1 : ℂ) • YoungSymmetrizer n la := by
+    rw [of_col_mul_YoungSymmetrizer n la _ hswap_col, Equiv.Perm.sign_swap hne]
+    simp [Int.cast_neg, Int.cast_one]
+  -- of(σ) * c_λ = of(σ) * of(swap)² * c_λ = of(σ*swap) * of(swap) * c_λ
+  -- = of(σ*swap) * (-1 • c_λ) = -1 • of(σ*swap) * c_λ
+  have key : MonoidAlgebra.of ℂ (Equiv.Perm (Fin n)) (σ * Equiv.swap p₁ p₂) *
+      (MonoidAlgebra.of ℂ _ (Equiv.swap p₁ p₂) * YoungSymmetrizer n la) =
+      MonoidAlgebra.of ℂ _ σ * YoungSymmetrizer n la := by
+    rw [← mul_assoc, ← map_mul, mul_assoc, Equiv.swap_mul_self, mul_one]
+  rw [h1] at key
+  rw [Algebra.mul_smul_comm] at key
+  -- key : (-1) • (of(σ*swap) * c_λ) = of(σ) * c_λ
+  exact key.symm
 
-The column inversion decrease comes from: w moves entries from the
-high-inversion row arrangement into a lower-inversion arrangement by
-"sorting" entries between adjacent rows in the same column. -/
-private theorem garnir_identity_expansion (n : ℕ) (la : Nat.Partition n)
+/-- The column inversion count is positive when there exists an inversion. -/
+private theorem columnInvCount'_pos_of_inv (n : ℕ) (la : Nat.Partition n)
+    (σ : Equiv.Perm (Fin n))
+    (p₁ p₂ : Fin n)
+    (hcol : colOfPos la.sortedParts p₁.val = colOfPos la.sortedParts p₂.val)
+    (hrow : rowOfPos la.sortedParts p₁.val < rowOfPos la.sortedParts p₂.val)
+    (hinv : σ.symm p₂ < σ.symm p₁) :
+    0 < columnInvCount' n la σ := by
+  unfold columnInvCount'
+  apply Finset.card_pos.mpr
+  exact ⟨(p₁, p₂), Finset.mem_filter.mpr ⟨Finset.mem_univ _, hcol, hrow, hinv⟩⟩
+
+/-- For a single-column partition (all parts = 1), of(σ) * c_λ = sign(σ) • c_λ.
+This gives a trivial Garnir expansion with S = {1}. -/
+private theorem single_column_garnir (n : ℕ) (la : Nat.Partition n)
+    (σ : Equiv.Perm (Fin n))
+    (h_single : ∀ i, i < la.sortedParts.length → la.sortedParts.getD i 0 = 1) :
+    MonoidAlgebra.of ℂ _ σ * YoungSymmetrizer n la =
+      ((↑(↑(Equiv.Perm.sign σ) : ℤ) : ℂ)) •
+        (MonoidAlgebra.of ℂ _ (1 : Equiv.Perm (Fin n)) * YoungSymmetrizer n la) := by
+  -- For single-column, every σ ∈ Q_λ (all positions in col 0)
+  have hσ_col : σ ∈ ColumnSubgroup n la := by
+    intro k
+    have hk := k.isLt
+    have hsum : la.sortedParts.sum = n := sortedParts_sum n la
+    have hksum : k.val < la.sortedParts.sum := by omega
+    -- Both σ k and k have colOfPos = 0 when all rows have width 1
+    have hk_col : colOfPos la.sortedParts k.val = 0 := by
+      have hrow := rowOfPos_lt_length la.sortedParts k.val hksum
+      have hw := h_single _ hrow
+      have hcol := colOfPos_lt_getD la.sortedParts k.val hksum
+      rw [hw] at hcol; omega
+    have hσk_col : colOfPos la.sortedParts (σ k).val = 0 := by
+      have hσk := (σ k).isLt
+      have hσksum : (σ k).val < la.sortedParts.sum := by omega
+      have hrow := rowOfPos_lt_length la.sortedParts (σ k).val hσksum
+      have hw := h_single _ hrow
+      have hcol := colOfPos_lt_getD la.sortedParts (σ k).val hσksum
+      rw [hw] at hcol; omega
+    rw [hk_col, hσk_col]
+  rw [of_col_mul_YoungSymmetrizer n la σ hσ_col, map_one, one_mul]
+
+/-- rowOfPos is monotone: a ≤ b implies rowOfPos a ≤ rowOfPos b. -/
+private theorem rowOfPos_mono (parts : List ℕ) (a b : ℕ)
+    (hb : b < parts.sum)
+    (hab : a ≤ b) : rowOfPos parts a ≤ rowOfPos parts b := by
+  induction parts generalizing a b with
+  | nil => simp [List.sum_nil] at hb
+  | cons p ps ih =>
+    simp only [rowOfPos]
+    split_ifs with ha hb
+    · omega
+    · omega
+    · exfalso; simp [List.sum_cons] at hb; omega
+    · have hb' : b - p < ps.sum := by simp [List.sum_cons] at hb; omega
+      have hab' : a - p ≤ b - p := Nat.sub_le_sub_right hab p
+      have := ih (a - p) (b - p) hb' hab'
+      omega
+
+/-- For the identity permutation, positions in canonical order have no column inversions:
+if rowOfPos(a) < rowOfPos(b), then a < b. -/
+private theorem rowOfPos_eq_length (parts : List ℕ) (a : ℕ) (ha : parts.sum ≤ a) :
+    rowOfPos parts a = parts.length := by
+  induction parts generalizing a with
+  | nil => simp [rowOfPos]
+  | cons p ps ih =>
+    simp only [rowOfPos, List.length_cons]
+    have : ¬(a < p) := by simp [List.sum_cons] at ha; omega
+    rw [if_neg this]
+    have : ps.sum ≤ a - p := by simp [List.sum_cons] at ha; omega
+    rw [ih _ this]; omega
+
+private theorem lt_of_lt_rowOfPos (parts : List ℕ) (a b : ℕ)
+    (hb : b < parts.sum)
+    (hrow : rowOfPos parts a < rowOfPos parts b) : a < b := by
+  by_contra h
+  push_neg at h
+  -- a ≥ b. Two cases: a < parts.sum or a ≥ parts.sum
+  by_cases ha : a < parts.sum
+  · have := rowOfPos_mono parts b a ha h
+    omega
+  · push_neg at ha
+    have := rowOfPos_eq_length parts a ha
+    have := rowOfPos_lt_length parts b hb
+    omega
+
+/-- columnInvCount' for the identity permutation is 0. -/
+private theorem columnInvCount'_one (n : ℕ) (la : Nat.Partition n) :
+    columnInvCount' n la 1 = 0 := by
+  unfold columnInvCount'
+  apply Finset.card_eq_zero.mpr
+  apply Finset.filter_eq_empty_iff.mpr
+  intro ⟨a, b⟩ _
+  simp only [Equiv.Perm.one_symm, Equiv.Perm.one_apply, not_and]
+  intro _ hrow
+  have hsum : la.sortedParts.sum = n := sortedParts_sum n la
+  have hb : b.val < la.sortedParts.sum := by omega
+  exact Nat.not_lt.mpr (Nat.le_of_lt (lt_of_lt_rowOfPos la.sortedParts a.val b.val hb hrow))
+
+/-- The column inversion count strictly decreases after applying a Garnir-type
+reduction. This is the combinatorial heart of the straightening algorithm.
+
+For a column inversion at (p₁, p₂) with hwidth (row(p₁) has width ≥ 2),
+the Garnir element produces permutations of the Garnir set that, when
+composed with σ, have strictly fewer column inversions.
+
+For the ¬hwidth case (single-column rows), a different argument based on
+the column antisymmetrizer is used. -/
+private theorem garnir_columnInvCount_decrease (n : ℕ) (la : Nat.Partition n)
     (σ : Equiv.Perm (Fin n))
     (p₁ p₂ : Fin n)
     (hcol : colOfPos la.sortedParts p₁.val = colOfPos la.sortedParts p₂.val)
@@ -1109,7 +1251,27 @@ private theorem garnir_identity_expansion (n : ℕ) (la : Nat.Partition n)
       (∀ τ ∈ S, columnInvCount' n la τ < columnInvCount' n la σ) ∧
       MonoidAlgebra.of ℂ _ σ * YoungSymmetrizer n la =
         S.sum (fun τ => c τ • (MonoidAlgebra.of ℂ _ τ * YoungSymmetrizer n la)) := by
-  sorry
+  -- Single-column case: all parts = 1
+  by_cases h_single : ∀ i, i < la.sortedParts.length → la.sortedParts.getD i 0 = 1
+  · refine ⟨{1}, fun _ => ((↑(↑(Equiv.Perm.sign σ) : ℤ) : ℂ)), ?_, ?_⟩
+    · intro τ hτ
+      rw [Finset.mem_singleton.mp hτ, columnInvCount'_one]
+      exact columnInvCount'_pos_of_inv n la σ p₁ p₂ hcol hrow hinv
+    · rw [Finset.sum_singleton, single_column_garnir n la σ h_single]
+  · -- General case: not all parts = 1, so Garnir element approach applies
+    sorry
+
+private theorem garnir_identity_expansion (n : ℕ) (la : Nat.Partition n)
+    (σ : Equiv.Perm (Fin n))
+    (p₁ p₂ : Fin n)
+    (hcol : colOfPos la.sortedParts p₁.val = colOfPos la.sortedParts p₂.val)
+    (hrow : rowOfPos la.sortedParts p₁.val < rowOfPos la.sortedParts p₂.val)
+    (hinv : σ.symm p₂ < σ.symm p₁) :
+    ∃ (S : Finset (Equiv.Perm (Fin n))) (c : Equiv.Perm (Fin n) → ℂ),
+      (∀ τ ∈ S, columnInvCount' n la τ < columnInvCount' n la σ) ∧
+      MonoidAlgebra.of ℂ _ σ * YoungSymmetrizer n la =
+        S.sum (fun τ => c τ • (MonoidAlgebra.of ℂ _ τ * YoungSymmetrizer n la)) :=
+  garnir_columnInvCount_decrease n la σ p₁ p₂ hcol hrow hinv
 
 /-- Garnir reduction: for a non-column-standard filling, of(σ) · c_λ
 can be expressed as a combination of of(τᵢ) · c_λ with fewer column inversions.

--- a/progress/20260404T062141Z_fcf92582.md
+++ b/progress/20260404T062141Z_fcf92582.md
@@ -1,0 +1,44 @@
+## Accomplished
+
+### Issue #2055: garnir_identity_expansion infrastructure (3→3 sorry, target was 3→2)
+
+Built substantial infrastructure toward proving `garnir_identity_expansion` in `PolytabloidBasis.lean` (175 insertions, 13 deletions), but the core sorry remains unproved due to a fundamental difficulty.
+
+**Proved helper lemmas:**
+- `swap_mem_ColumnSubgroup'`: positions in the same column give a column subgroup swap
+- `of_col_mul_YoungSymmetrizer`: column subgroup elements absorb into Young symmetrizer with sign
+- `garnir_swap_identity`: `of(σ) * c_λ = -of(σ*swap) * c_λ` for same-column swaps
+- `columnInvCount'_pos_of_inv`: inversions imply positive column inversion count
+- `single_column_garnir`: complete proof for single-column partitions (all parts = 1)
+- `columnInvCount'_one`: identity perm has 0 column inversions
+- `rowOfPos_mono`: monotonicity of canonical row position
+- `rowOfPos_eq_length`: row position for out-of-range indices
+- `lt_of_lt_rowOfPos`: canonical ordering respects row ordering
+
+**Proved single-column case** of `garnir_columnInvCount_decrease` — when all partition parts = 1, Q_λ = S_n so `of(σ) * c_λ = sign(σ) * c_λ` and S = {1} with 0 inversions works.
+
+**Core blocker discovered:** The simple swap approach (`σ * swap(p₁, p₂)` where p₁, p₂ are in the same column) does NOT decrease `columnInvCount'` in general. Counterexample: partition (2,2), σ = swap(1,2) has 1 inversion, but σ * swap(0,2) has 2 inversions. The Garnir straightening algorithm requires either:
+- (a) A different well-founded measure (dominance ordering on tabloids, as in James' book)
+- (b) Full Garnir element expansion with explicit combinatorial analysis showing that the *sum* decomposes into terms with lower measure
+
+This is consistent with the Wave 42 meditate finding that PolytabloidBasis has a "fundamental approach mismatch" with right-multiplication dominance.
+
+## Current frontier
+
+The sorry in `garnir_columnInvCount_decrease` for the `¬h_single` case (non-single-column partitions) remains. All infrastructure for the algebraic manipulations is in place — the gap is purely in the well-founded descent argument.
+
+## Overall project progress
+
+- **25 sorries** across 14 files (unchanged — this PR is infrastructure, not a sorry reduction)
+- **577/583 items** (98.9%) sorry-free
+- PolytabloidBasis still has 3 sorries
+
+## Next step
+
+1. Update issue #2055 with findings about the well-founded measure blocker
+2. Consider creating a design issue for switching to dominance ordering (approach a) or full Garnir expansion (approach b) — this is the same structural issue flagged in Wave 42 meditate
+3. Continue other sorry reduction work on less blocked items
+
+## Blockers
+
+- `garnir_columnInvCount_decrease` (non-single-column case) blocked by well-founded measure: `columnInvCount'` is not the right measure for the Garnir straightening algorithm. Need dominance ordering or equivalent.


### PR DESCRIPTION
## Summary

- Build infrastructure lemmas for Garnir straightening in `PolytabloidBasis.lean` (175 insertions, 13 deletions)
- Prove single-column partition case of `garnir_columnInvCount_decrease` completely
- Identify core blocker: `columnInvCount'` does not decrease under simple column swaps for non-single-column partitions (counterexample: partition (2,2))

## Findings

The Garnir straightening algorithm requires a well-founded measure where swapping column-inverted positions decreases the measure. `columnInvCount'` (number of column-inversion pairs) is NOT such a measure — a swap can increase it. The correct measure is the **dominance ordering on tabloids** (as in James' book), which is not currently formalized.

This is consistent with the Wave 42 meditate assessment that PolytabloidBasis has a "fundamental approach mismatch" with right-multiplication dominance.

Sorry count unchanged: 3→3 (target was 3→2).

## Helper lemmas added

- `swap_mem_ColumnSubgroup'`, `of_col_mul_YoungSymmetrizer`, `garnir_swap_identity`
- `columnInvCount'_pos_of_inv`, `single_column_garnir`, `columnInvCount'_one`
- `rowOfPos_mono`, `rowOfPos_eq_length`, `lt_of_lt_rowOfPos`

Refs: #2055

🤖 Prepared with Claude Code