### PR TITLE
progress: deep analysis of polytabloid cluster sorries (#2117)

### DIFF
--- a/progress/20260405T035247Z_86f675ba.md
+++ b/progress/20260405T035247Z_86f675ba.md
@@ -1,0 +1,54 @@
+## Accomplished
+
+Deep analysis of #2117 (Define tabloid dominance order for straighteningLT) and surrounding sorry landscape.
+
+### Key findings
+
+1. **#2117 is blocked on #2104**: The `straighteningLT` definition that #2117 asks to replace does not exist in the codebase. It was supposed to be introduced by #2104 (restructure straightening WF induction), which is still open. Steps 1-2 of #2117 (define dominance order, show partial order) are already complete in TabloidModule.lean.
+
+2. **The sorry at PolytabloidBasis.lean:1284 (`garnir_columnInvCount_decrease`) is on a FALSE statement**: The meditate (#2102) proved that `columnInvCount'` does not decrease pointwise under Garnir expansion for partition (2,2). The counterexample: σ.symm = [3,0,1,2] has columnInvCount'=1, and the Garnir coset representative (1,2) gives σ'.symm = [3,1,0,2] with columnInvCount'=1 (same). No ℕ-valued pointwise measure works because some Garnir terms produce the same tabloid. The fix requires multiset decrease ordering (#2104) or working at the tabloid level.
+
+3. **The sorry at PolytabloidBasis.lean:847 (`column_standard_in_span'`) is harder than #2105 claims**: Issue #2105 says it's "trivial" after the convention switch, claiming `of(p) * polytabloid(T) = polytabloid(T)` for p ∈ P_λ. This is FALSE. Concrete counterexample for partition (2,1): of((01)) * e_T₂ = -e_T₁ - e_T₂ ≠ e_T₂. The column_standard_in_span' base case requires showing of(σ) * c_λ ∈ span{e_T} when σ is column-standard but not necessarily an SYT permutation itself. With the canonical (non-T-dependent) column antisymmetrizer, row permutations do NOT fix polytabloids.
+
+4. **#2088 (`polytabloid_syt_dominance`, TabloidModule.lean:887) is now available**: The previous worker found it FALSE with the old b_λ*a_λ convention and released the claim. With the new a_λ*b_λ convention (#2103/#2116), the PQ decomposition gives sytPerm(T₂) = sytPerm(T₁) * p * q (p ∈ P_λ, q ∈ Q_λ — row first, then column). The proof requires showing tabloidDominates(σ₁, σ₁*p*q). The existing `column_perm_dominance` theorem handles q⁻¹ acting on positions (left multiplication), but the needed result has q acting on entries (right multiplication). These are genuinely different and tabloid(σ₁*p*q) ≠ tabloid(q⁻¹*σ₁) in general. The proof likely requires:
+   - A per-column analysis using both T₁ and T₂'s SYT properties
+   - The fact that σ₂ must be an SYT permutation constrains which (p,q) pairs arise
+   - Difficulty: ~7-8 (higher than the issue's claimed 5)
+
+### Existing infrastructure in TabloidModule.lean
+
+Already defined and proved:
+- `TabloidSetoid`, `Tabloid`, `toTabloid` — tabloid equivalence relation and quotient type
+- `tabloidCumulCount` — the fundamental dominance comparison function
+- `tabloidDominates`, `tabloidStrictDominates` — dominance partial order
+- `tabloidDominates_refl`, `_trans`, `_congr`, `_antisymm_toTabloid` — partial order properties
+- `tabloidRowVec` — row assignment vector for last-letter ordering
+- `column_perm_dominance` — q ∈ Q_λ ⟹ tabloid(σ_T) dominates tabloid(q⁻¹*σ_T)
+- `column_perm_strict_dominance` — strict version for q ≠ 1
+- `sytToTabloid_injective` — different SYTs give different tabloids
+
+## Current frontier
+
+The polytabloid cluster has 4 sorries:
+- PolytabloidBasis.lean:439 (`polytabloid_linearIndependent`) — blocked on #2088
+- PolytabloidBasis.lean:847 (`column_standard_in_span'`) — needs #2105 replan (issue claim is wrong about difficulty)
+- PolytabloidBasis.lean:1284 (`garnir_columnInvCount_decrease`) — FALSE statement, needs #2104
+- TabloidModule.lean:887 (`polytabloid_syt_dominance`) — available (#2088), genuinely hard
+
+## Overall project progress
+
+~12 sorries remaining. The polytabloid cluster (4 sorries) has been thoroughly analyzed but no sorry count reduction this turn. The key insight is that many of the filed issues (#2105, #2117) have incorrect dependency/difficulty assessments that need updating.
+
+## Next step
+
+1. **Replan #2105** (column_standard_in_span'): The claim that it's trivial after the convention switch is wrong. The issue needs to be updated with correct difficulty (~7) and a realistic proof strategy. Options: (a) Use T-dependent column antisymmetrizers, (b) prove directly that of(σ)*c_λ is a ℤ-linear combination of polytabloids via combinatorial argument.
+
+2. **Claim and work on #2088** (polytabloid_syt_dominance): This is the most impactful target — it unblocks polytabloid_linearIndependent. The convention switch should make the statement true. A fresh agent should attempt the proof using per-column analysis with both SYTs' properties.
+
+3. **Replan #2117**: This issue is blocked on #2104 and the dominance infrastructure it requests already exists. Consider closing as duplicate/blocked.
+
+## Blockers
+
+- #2117 blocked on #2104 (no straighteningLT to define)
+- #2105 needs replan (claimed proof strategy is wrong)
+- #2088 is the critical path item for the polytabloid cluster


### PR DESCRIPTION
## Summary

- Deep analysis of #2117 and surrounding polytabloid sorry landscape
- Found #2117 is blocked on #2104 — dominance infrastructure already exists in TabloidModule.lean
- Identified that `garnir_columnInvCount_decrease` (line 1284) is on a FALSE statement
- Identified that `column_standard_in_span'` (#2105) has incorrect difficulty/strategy assessment  
- Identified `polytabloid_syt_dominance` (#2088) as the critical path item, now available after convention switch

## Test plan

- [x] No code changes — progress/analysis only
- [x] Comments added to #2117, #2105 with findings

🤖 Prepared with Claude Code