### PR TITLE
Infrastructure: equivalence preserves Module.Finite

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/EquivFinite.lean
+++ b/EtingofRepresentationTheory/Chapter9/EquivFinite.lean
@@ -1,0 +1,94 @@
+import Mathlib.Algebra.Category.ModuleCat.Subobject
+import Mathlib.RingTheory.Artinian.Module
+import Mathlib.RingTheory.HopkinsLevitzki
+
+universe u
+
+open CategoryTheory
+
+-- An equivalence F : ModuleCat B₁ ≌ ModuleCat B₂ preserves Module.Finite for the regular module.
+theorem module_finite_of_equiv_artinian
+    {B₁ : Type u} [Ring B₁] [IsArtinianRing B₁]
+    {B₂ : Type u} [Ring B₂] [IsArtinianRing B₂]
+    (F : ModuleCat.{u} B₁ ≌ ModuleCat.{u} B₂) :
+    Module.Finite B₂ (F.functor.obj (ModuleCat.of B₁ B₁)) := by
+  set P := F.functor.obj (ModuleCat.of B₁ B₁)
+  -- The unit isomorphism: B₁ ≅ G(F(B₁)) = G(P) in ModuleCat B₁
+  set η := F.unitIso.app (ModuleCat.of B₁ B₁) with hη_def
+  -- Map: Submodule B₂ P → Submodule B₁ B₁
+  -- For N ≤ P: apply G to inclusion, compose with unit⁻¹, take preimage
+  let Φ : Submodule B₂ ↑P → Submodule B₁ B₁ := fun N =>
+    Submodule.comap η.hom.hom (LinearMap.range (F.inverse.map (ModuleCat.ofHom N.subtype)).hom)
+  -- Step 1: Φ is monotone
+  have hΦ_mono : Monotone Φ := by
+    intro N₁ N₂ h
+    apply Submodule.comap_mono
+    have h_factor : ModuleCat.ofHom N₁.subtype =
+        ModuleCat.ofHom (Submodule.inclusion h) ≫ ModuleCat.ofHom N₂.subtype := by
+      ext x; rfl
+    rw [h_factor, Functor.map_comp, ModuleCat.hom_comp]
+    exact LinearMap.range_comp_le_range _ _
+  -- Step 2: Φ is injective (uses faithfulness of equivalence)
+  have hΦ_inj : Function.Injective Φ := by
+    intro N₁ N₂ hΦ
+    -- comap η is injective since η.hom is surjective (it's an iso)
+    have hη_surj : Function.Surjective η.hom.hom :=
+      (ModuleCat.epi_iff_surjective η.hom).mp inferInstance
+    have h_range_eq : LinearMap.range (F.inverse.map (ModuleCat.ofHom N₁.subtype)).hom =
+        LinearMap.range (F.inverse.map (ModuleCat.ofHom N₂.subtype)).hom :=
+      Submodule.comap_injective_of_surjective hη_surj hΦ
+    -- Suffices to show both directions; by symmetry we prove A ≤ B from range equality
+    suffices h_le : ∀ (A B : Submodule B₂ ↑P),
+        LinearMap.range (F.inverse.map (ModuleCat.ofHom A.subtype)).hom =
+        LinearMap.range (F.inverse.map (ModuleCat.ofHom B.subtype)).hom →
+        A ≤ B from
+      le_antisymm (h_le N₁ N₂ h_range_eq) (h_le N₂ N₁ h_range_eq.symm)
+    intro A B h_rng x hx
+    -- G preserves monos, so G(ι_B) is injective
+    have h_inj_B : Function.Injective (F.inverse.map (ModuleCat.ofHom B.subtype)).hom :=
+      (ModuleCat.mono_iff_injective _).mp inferInstance
+    -- Construct σ : G(A) →ₗ[B₁] G(B) with G(ι_B) ∘ σ = G(ι_A)
+    -- Since range G(ι_A) = range G(ι_B) and G(ι_B) is injective
+    set GιA := (F.inverse.map (ModuleCat.ofHom A.subtype)).hom
+    set GιB := (F.inverse.map (ModuleCat.ofHom B.subtype)).hom
+    let σ_hom : (F.inverse.obj (ModuleCat.of B₂ ↑A) : Type u) →ₗ[B₁]
+        (F.inverse.obj (ModuleCat.of B₂ ↑B) : Type u) :=
+      (LinearEquiv.ofInjective GιB h_inj_B).symm.toLinearMap.comp
+        (GιA.codRestrict (LinearMap.range GιB) (fun a => h_rng ▸ LinearMap.mem_range_self GιA a))
+    -- Key property: G(ι_B) ∘ σ = G(ι_A)
+    have h_σ_comm : ∀ a, GιB (σ_hom a) = GιA a := by
+      intro a
+      change GιB ((LinearEquiv.ofInjective GιB h_inj_B).symm
+        ⟨GιA a, h_rng ▸ LinearMap.mem_range_self GιA a⟩) = GιA a
+      have := (LinearEquiv.ofInjective GιB h_inj_B).apply_symm_apply
+        ⟨GιA a, h_rng ▸ LinearMap.mem_range_self GιA a⟩
+      exact congr_arg Subtype.val this
+    -- Lift σ through G using full faithfulness of the inverse functor
+    let τ : ModuleCat.of B₂ ↑A ⟶ ModuleCat.of B₂ ↑B :=
+      F.fullyFaithfulInverse.preimage (ModuleCat.ofHom σ_hom)
+    -- G(τ) = σ
+    have h_G_τ : F.inverse.map τ = ModuleCat.ofHom σ_hom :=
+      F.fullyFaithfulInverse.map_preimage (ModuleCat.ofHom σ_hom)
+    -- G(τ ≫ ι_B) = G(ι_A)
+    have h_G_eq : F.inverse.map (τ ≫ ModuleCat.ofHom B.subtype) =
+        F.inverse.map (ModuleCat.ofHom A.subtype) := by
+      simp only [Functor.map_comp, h_G_τ]
+      ext a
+      exact h_σ_comm a
+    -- By faithfulness: τ ≫ ι_B = ι_A
+    have h_eq : τ ≫ ModuleCat.ofHom B.subtype = ModuleCat.ofHom A.subtype :=
+      F.inverse.map_injective h_G_eq
+    -- τ.hom(⟨x, hx⟩) ∈ B and its coercion to P equals x
+    have h_val : (τ.hom ⟨x, hx⟩ : ↑P) = x := by
+      have h1 : (τ ≫ ModuleCat.ofHom B.subtype).hom ⟨x, hx⟩ =
+          (ModuleCat.ofHom A.subtype).hom ⟨x, hx⟩ := by rw [h_eq]
+      simpa using h1
+    rw [← h_val]; exact (τ.hom ⟨x, hx⟩).2
+  -- Step 3: StrictMono from monotone + injective
+  have hΦ_strict : StrictMono Φ :=
+    hΦ_mono.strictMono_of_injective hΦ_inj
+  -- Step 4: Transfer well-foundedness via strict monotone embedding
+  haveI : IsArtinian B₂ ↑P := hΦ_strict.wellFoundedLT
+  -- Step 5: Hopkins-Levitzki: Artinian over Artinian ring → Noetherian → Module.Finite
+  haveI : IsNoetherian B₂ ↑P := IsSemiprimaryRing.isNoetherian_iff_isArtinian.mpr ‹_›
+  exact inferInstance

--- a/EtingofRepresentationTheory/Chapter9/MoritaStructural.lean
+++ b/EtingofRepresentationTheory/Chapter9/MoritaStructural.lean
@@ -3,6 +3,7 @@ import EtingofRepresentationTheory.Chapter9.Definition9_7_1
 import EtingofRepresentationTheory.Chapter9.Definition9_7_2
 import EtingofRepresentationTheory.Infrastructure.CornerRing
 import EtingofRepresentationTheory.Infrastructure.BasicAlgebraExistence
+import EtingofRepresentationTheory.Chapter9.EquivFinite
 import Mathlib.Algebra.Category.ModuleCat.Basic
 import Mathlib.Algebra.Algebra.Opposite
 import Mathlib.CategoryTheory.Equivalence
@@ -21,6 +22,7 @@ import Mathlib.RingTheory.Jacobson.Radical
 import Mathlib.RingTheory.Artinian.Module
 import Mathlib.RingTheory.HopkinsLevitzki
 import Mathlib.Algebra.Category.ModuleCat.Projective
+import Mathlib.Algebra.Category.ModuleCat.Subobject
 
 universe u v
 
@@ -308,6 +310,20 @@ private noncomputable def iso_of_surjection_with_trivial_kernel_head
        → B₂/J·B₂ through the quotient B₂ → B₂/J·B₂.
     3. By Nakayama, the lifted map is surjective (image covers B₂ mod J).
     4. Splitting (B₂ projective) gives F(B₁) ≅ B₂ ⊕ K where K/J·K = 0. -/
+-- Helper 0: An equivalence of module categories preserves finite generation of the
+-- regular module. The proof constructs a strictly monotone map from B₂-submodules
+-- of F(B₁) to B₁-submodules of B₁ using the inverse functor and the unit isomorphism,
+-- then transfers the descending chain condition.
+private theorem module_finite_equiv_image
+    (k : Type u) [Field k]
+    {B₁ : Type u} [Ring B₁] [Algebra k B₁] [Module.Finite k B₁]
+    {B₂ : Type u} [Ring B₂] [Algebra k B₂] [Module.Finite k B₂]
+    (F : ModuleCat.{u} B₁ ≌ ModuleCat.{u} B₂) :
+    Module.Finite B₂ (F.functor.obj (ModuleCat.of B₁ B₁)) := by
+  haveI : IsArtinianRing B₁ := IsArtinianRing.of_finite k B₁
+  haveI : IsArtinianRing B₂ := IsArtinianRing.of_finite k B₂
+  exact module_finite_of_equiv_artinian F
+
 -- Helper 1: An equivalence of module categories preserves projectivity.
 -- F(B₁) is projective as a B₂-module because B₁ is projective (free rank 1)
 -- and equivalences preserve projective objects.

--- a/progress/20260407T103500Z_d480dd22.md
+++ b/progress/20260407T103500Z_d480dd22.md
@@ -1,0 +1,29 @@
+## Accomplished
+
+- Proved `module_finite_of_equiv_artinian` in new file `EquivFinite.lean`: if `F : ModuleCat B₁ ≌ ModuleCat B₂` is an equivalence between module categories of Artinian rings, then `F(B₁)` is `Module.Finite B₂`
+- The proof constructs a strictly monotone map `Φ : Submodule B₂ F(B₁) → Submodule B₁ B₁` using the inverse functor and unit isomorphism, transfers DCC via `StrictMono.wellFoundedLT`, then applies Hopkins-Levitzki
+- Key technical achievement: proved injectivity of Φ using `Equivalence.fullyFaithfulInverse.preimage` to lift a linear map through the inverse functor and then applying faithfulness (`Functor.map_injective`)
+- Integrated into `MoritaStructural.lean`: replaced the sorry in `module_finite_equiv_image` with a call to the new theorem
+- Created PR #2175 closing issue #2173
+
+## Current frontier
+
+- `head_isomorphism` at MoritaStructural.lean:~490 still has 1 sorry
+- Issue #2174 covers the remaining work (semisimple module classification for head_isomorphism)
+
+## Overall project progress
+
+- **25 sorries** across the project (unchanged count — the sorry removed was in MoritaStructural.lean's `module_finite_equiv_image` but the grep count includes the same file's `head_isomorphism`)
+- **1 sorry** in MoritaStructural.lean (down from 2: `module_finite_equiv_image` now proven)
+- All other code in Chapter 9 compiles sorry-free
+
+## Next step
+
+1. Merge PR #2175 after CI passes
+2. Claim and work on #2174 (head_isomorphism via Wedderburn-Artin + semisimple module classification)
+3. After closing head_isomorphism, the full Morita structural theorem chain compiles sorry-free
+
+## Blockers
+
+- None for #2173 (completed)
+- #2174 (head_isomorphism) requires semisimple module classification infrastructure not yet in Mathlib — needs to be built from Wedderburn-Artin + idempotent decomposition


### PR DESCRIPTION
Closes #2173

Session: `d480dd22-7ea0-4ae0-a863-1d49aad42c2d`

4371749 feat: prove Module.Finite preservation for module category equivalences (#2173)

🤖 Prepared with Claude Code