### PR TITLE
## Summary

- **Problem6_9_1**: Fix 6 build errors introduced in cc25d53 (#2180):
  - `LinearMap.mul_apply` → `Module.End.mul_apply` (name was wrong)
  - `pow_succ` → `pow_succ'` (correct multiplication order for the proof)
  - Add `.symm` to `congr_arg` calls (equality direction flipped after swapOp lemma changes)

- **Theorem5_22_1**: Fix 2 build errors from YoungSymmetrizer convention mismatch (#2178):
  - `YoungSymmetrizerZ` and `YoungSymmetrizerK` still used old a·b order; updated to b·a (ColumnAntisymmetrizer * RowSymmetrizer) matching the updated `YoungSymmetrizer` definition
  - Updated `YoungSymmetrizerZ_apply_one` proof to work with new multiplication order

Fixes #2188

🤖 Prepared with Claude Code

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
@@ -45,14 +45,14 @@ def weightToPartition (N : ℕ) (lam : Fin N → ℕ) :
 
 /-! ### Young symmetrizer over a general field -/
 
-/-- The Young symmetrizer `c_λ = a_λ · b_λ` in `k[S_n]`, over a general field `k`. -/
+/-- The Young symmetrizer `c_λ = b_λ · a_λ` in `k[S_n]`, over a general field `k`. -/
 def YoungSymmetrizerK (k : Type*) [CommRing k] (n : ℕ) (la : Nat.Partition n) :
     MonoidAlgebra k (Equiv.Perm (Fin n)) :=
   haveI : DecidablePred (· ∈ RowSubgroup n la) := Classical.decPred _
   haveI : DecidablePred (· ∈ ColumnSubgroup n la) := Classical.decPred _
-  (∑ g : (RowSubgroup n la), MonoidAlgebra.of k _ g.val) *
   (∑ g : (ColumnSubgroup n la),
-    ((↑(Equiv.Perm.sign g.val) : ℤ) : k) • MonoidAlgebra.of k _ g.val)
+    ((↑(Equiv.Perm.sign g.val) : ℤ) : k) • MonoidAlgebra.of k _ g.val) *
+  (∑ g : (RowSubgroup n la), MonoidAlgebra.of k _ g.val)
 
 /-! ### Young symmetrizer over ℤ and scalar transfer -/
 
@@ -62,9 +62,9 @@ def YoungSymmetrizerZ (n : ℕ) (la : Nat.Partition n) :
     MonoidAlgebra ℤ (Equiv.Perm (Fin n)) :=
   haveI : DecidablePred (· ∈ RowSubgroup n la) := Classical.decPred _
   haveI : DecidablePred (· ∈ ColumnSubgroup n la) := Classical.decPred _
-  (∑ g : (RowSubgroup n la), MonoidAlgebra.of ℤ _ g.val) *
   (∑ g : (ColumnSubgroup n la),
-    (↑(Equiv.Perm.sign g.val) : ℤ) • MonoidAlgebra.of ℤ _ g.val)
+    (↑(Equiv.Perm.sign g.val) : ℤ) • MonoidAlgebra.of ℤ _ g.val) *
+  (∑ g : (RowSubgroup n la), MonoidAlgebra.of ℤ _ g.val)
 
 /-- Base change maps `of ℤ g` to `of k g`. -/
 private theorem mapRange_of {G : Type*} [Monoid G] (R : Type*) [CommRing R]
@@ -127,21 +127,21 @@ theorem YoungSymmetrizerZ_apply_one (n : ℕ) (la : Nat.Partition n) :
       (MonoidAlgebra.mapRangeRingHom _ (Int.castRingHom ℂ) (YoungSymmetrizerZ n la)) 1
     from (MonoidAlgebra.mapRangeRingHom_apply (Int.castRingHom ℂ) _ _).symm]
   rw [← YoungSymmetrizer_eq_mapRange, (Int.castRingHom ℂ).map_one]
-  -- YoungSymmetrizer = RowSymmetrizer * ColumnAntisymmetrizer
+  -- YoungSymmetrizer = ColumnAntisymmetrizer * RowSymmetrizer
   simp only [YoungSymmetrizer, RowSymmetrizer, ColumnAntisymmetrizer]
   -- Distribute the product of sums
-  rw [Finset.sum_mul]
-  simp_rw [Finset.mul_sum, mul_smul_comm]
+  rw [Finset.mul_sum]
+  simp_rw [Finset.sum_mul, smul_mul_assoc]
   -- Unfold of to single, then simplify multiplication of singles
   have hof : ∀ (g : Equiv.Perm (Fin n)),
       (MonoidAlgebra.of ℂ _ g : MonoidAlgebra ℂ _) = Finsupp.single g 1 := fun _ => rfl
   simp_rw [hof, MonoidAlgebra.single_mul_single, mul_one]
-  -- Goal: (∑ p ∑ q, (sign q) • single (p*q) 1)(1) = 1
+  -- Goal: (∑ p ∑ q, (sign q) • single (q*p) 1)(1) = 1
   rw [Finset.sum_apply']
   conv_lhs => arg 2; ext k; rw [Finset.sum_apply']
   simp only [MonoidAlgebra.smul_apply, smul_eq_mul, MonoidAlgebra.single_apply,
     mul_ite, mul_one, mul_zero]
-  -- ∑_p ∑_q, if p * q = 1 then (sign q : ℂ) else 0 = 1
+  -- ∑_p ∑_q, if q * p = 1 then (sign q : ℂ) else 0 = 1
   rw [Fintype.sum_eq_single ⟨1, (RowSubgroup n la).one_mem⟩]
   · rw [Fintype.sum_eq_single ⟨1, (ColumnSubgroup n la).one_mem⟩]
     · simp [Equiv.Perm.sign_one]
@@ -153,9 +153,12 @@ theorem YoungSymmetrizerZ_apply_one (n : ℕ) (la : Nat.Partition n) :
     apply Fintype.sum_eq_zero
     intro ⟨q, hq⟩
     rw [if_neg]
-    intro hpq
-    have heq : p = q⁻¹ := mul_eq_one_iff_eq_inv.mp hpq
-    have hp_in_Q : p ∈ ColumnSubgroup n la := heq ▸ (ColumnSubgroup n la).inv_mem hq
+    intro hqp
+    have heq : q = p⁻¹ := mul_eq_one_iff_eq_inv.mp hqp
+    have hp_in_Q : p ∈ ColumnSubgroup n la := by
+      have : q ∈ ColumnSubgroup n la := hq
+      rw [heq] at this
+      exact (ColumnSubgroup n la).inv_mem_iff.mp this
     exact hne (Subtype.ext (row_col_preserving_eq_one n la p hp hp_in_Q))
 
 /-- The Young symmetrizer over any CharZero ring satisfies c² = α·c for some scalar α.

--- a/EtingofRepresentationTheory/Chapter6/Problem6_9_1.lean
+++ b/EtingofRepresentationTheory/Chapter6/Problem6_9_1.lean
@@ -1184,7 +1184,7 @@ private lemma swapOp_pow_odd_fst
     (A : V →ₗ[ℂ] W) (B : W →ₗ[ℂ] V) (m : ℕ) (v : V) :
     (swapOp A B ^ (2 * m + 1)) (v, (0 : W)) =
       ((0 : V), A (((B.comp A) ^ m) v)) := by
-  rw [pow_succ, LinearMap.mul_apply, swapOp_pow_even_fst, swapOp_apply, map_zero]
+  rw [pow_succ', Module.End.mul_apply, swapOp_pow_even_fst, swapOp_apply, map_zero]
 
 /-- X^{2m}(0, w) = (0, (AB)^m w): even powers of swapOp on pure W-elements stay in {0}×W. -/
 private lemma swapOp_pow_even_snd
@@ -1201,7 +1201,7 @@ private lemma swapOp_pow_odd_snd
     (A : V →ₗ[ℂ] W) (B : W →ₗ[ℂ] V) (m : ℕ) (w : W) :
     (swapOp A B ^ (2 * m + 1)) ((0 : V), w) =
       (B (((A.comp B) ^ m) w), (0 : W)) := by
-  rw [pow_succ, LinearMap.mul_apply, swapOp_pow_even_snd, swapOp_apply, map_zero]
+  rw [pow_succ', Module.End.mul_apply, swapOp_pow_even_snd, swapOp_apply, map_zero]
 
 /-- If X^k kills (v,w), it also kills (v,0) and (0,w) separately.
 This follows because X^k(v,0) and X^k(0,w) live in complementary subspaces
@@ -1224,16 +1224,16 @@ private lemma swapOp_pow_zero_of_pure
     rw [swapOp_pow_even_fst, swapOp_pow_even_snd] at hlin ⊢
     constructor
     · exact Prod.eq_iff_fst_eq_snd_eq.mpr
-        ⟨by simpa using congr_arg Prod.fst hlin, rfl⟩
+        ⟨by simpa using (congr_arg Prod.fst hlin).symm, rfl⟩
     · exact Prod.eq_iff_fst_eq_snd_eq.mpr
-        ⟨rfl, by simpa using congr_arg Prod.snd hlin⟩
+        ⟨rfl, by simpa using (congr_arg Prod.snd hlin).symm⟩
   · -- k = 2*m+1: swapped
     rw [swapOp_pow_odd_fst, swapOp_pow_odd_snd] at hlin ⊢
     constructor
     · exact Prod.eq_iff_fst_eq_snd_eq.mpr
-        ⟨rfl, by simpa using congr_arg Prod.snd hlin⟩
+        ⟨rfl, by simpa using (congr_arg Prod.snd hlin).symm⟩
     · exact Prod.eq_iff_fst_eq_snd_eq.mpr
-        ⟨by simpa using congr_arg Prod.fst hlin, rfl⟩
+        ⟨by simpa using (congr_arg Prod.fst hlin).symm, rfl⟩
 
 /-- For (v,w) with X^{k-1}(v,w) ≠ 0, at least one of (v,0) or (0,w) also has
 X^{k-1} ≠ 0. Combined with `swapOp_pow_zero_of_pure` (both have order ≤ k),

--- a/progress/20260408T034500Z_ed6e391c.md
+++ b/progress/20260408T034500Z_ed6e391c.md
@@ -1,0 +1,31 @@
+## Accomplished
+
+- Fixed all 6 build errors in Problem6_9_1.lean:
+  - `LinearMap.mul_apply` → `Module.End.mul_apply` (constant was renamed/wrong)
+  - `pow_succ` → `pow_succ'` (needed `a * a^n` order, not `a^n * a`)
+  - Added `.symm` to 4 `congr_arg` calls (equality direction changed)
+- Fixed all 2 build errors in Theorem5_22_1.lean:
+  - Updated `YoungSymmetrizerZ` and `YoungSymmetrizerK` definitions from a·b to b·a convention (matching #2178's change to `YoungSymmetrizer`)
+  - Updated `YoungSymmetrizerZ_apply_one` proof for new multiplication order
+- Verified all downstream files build: YoungSymTraceKronecker, SpechtModuleSimple
+- Created PR #2190
+
+## Current frontier
+
+- Main CI should be green once #2190 merges
+- All other open PRs (#2183, #2175, #2168) can then be re-evaluated against a green main
+
+## Overall project progress
+
+- 14 sorry lines across project (unchanged — this was a CI fix, not new proofs)
+- Main branch was broken since ~April 4; this PR restores buildability
+
+## Next step
+
+- Merge #2190 to unblock all downstream work
+- Re-check failing CI on #2183 (YoungSymmetrizer coefficient lemmas) — may be fixed by this same convention change
+- Resume work on unclaimed issues (#2088, #2125, #2170, #2179, #2186, #2189)
+
+## Blockers
+
+None — CI fix is ready for merge.


### PR DESCRIPTION
Closes #--title

Session: `ed6e391c-3250-4fcd-92da-35fe93b6f74d`

29e3b9e fix: resolve CI breakage in Problem6_9_1 and Theorem5_22_1

🤖 Prepared with Claude Code