### PR TITLE
refactor: move polytabloid_linearIndependent to TabloidModule

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/PolytabloidBasis.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolytabloidBasis.lean
@@ -21,11 +21,13 @@ of the Specht module V_λ = ℂ[S_n] · c_λ.
 ## Main results
 
 * `Etingof.polytabloid_mem_spechtModule` — polytabloids lie in the Specht module
-* `Etingof.polytabloid_linearIndependent` — polytabloids are linearly independent (sorry)
+* `Etingof.polytabloid_linearIndependent` — polytabloids are linearly independent
+  (in `TabloidModule.lean`)
 * `Etingof.perm_mul_youngSymmetrizer_mem_span_polytabloids` — straightening lemma
   (proved via WF induction on column inversions; depends on two sorry'd helpers)
 * `Etingof.polytabloid_span` — polytabloids span the Specht module (proved from straightening)
-* `Etingof.finrank_spechtModule_eq_card_syt` — dim V_λ = |SYT(λ)| (proved from independence + span)
+* `Etingof.finrank_spechtModule_eq_card_syt` — dim V_λ = |SYT(λ)|
+  (in `TabloidModule.lean`)
 
 ## References
 
@@ -526,16 +528,6 @@ theorem polytabloid_support (n : ℕ) (la : Nat.Partition n)
   refine ⟨p', hp'_row, q, hq, ?_⟩
   -- hσ : x * p' = σ, hx_eq : y * z = x
   rw [← hσ, ← hx_eq, hy_eq, hz_eq]
-
-/-- The polytabloids {e_T : T ∈ SYT(λ)} are linearly independent in V_λ.
-
-The proof is in `TabloidModule.lean` as `polytabloid_linearIndependent'`, using
-the tabloid module infrastructure (dominance order, tabloid projections).
-This sorry is closed by that proof. -/
-theorem polytabloid_linearIndependent (n : ℕ) (la : Nat.Partition n) :
-    LinearIndependent ℂ (fun T : StandardYoungTableau n la =>
-      (polytabloidInSpecht n la T : SymGroupAlgebra n)) := by
-  sorry
 
 /-! ### Sorted comparison lemma -/
 
@@ -1471,33 +1463,12 @@ theorem polytabloid_span (n : ℕ) (la : Nat.Partition n) :
     intro σ _
     exact Submodule.smul_mem _ _ (perm_mul_youngSymmetrizer_mem_span_polytabloids n la σ)
 
-/-! ### Dimension theorem from polytabloid basis -/
+/-! ### Dimension theorem
 
-/-- The polytabloids form a basis of V_λ, so dim V_λ = |SYT(λ)|.
-
-This combines linear independence and spanning of polytabloids to
-construct an explicit basis of the Specht module indexed by standard
-Young tableaux of shape λ.
-
-This is the key infrastructure needed for the hook length formula
-(Theorem 5.17.1). -/
-theorem finrank_spechtModule_eq_card_syt (n : ℕ) (la : Nat.Partition n) :
-    Module.finrank ℂ (SpechtModule n la) =
-      Fintype.card (StandardYoungTableau n la) := by
-  -- The polytabloids are linearly independent in SymGroupAlgebra n (as a ℂ-module)
-  have hli := polytabloid_linearIndependent n la
-  -- Their ℂ-span equals V_λ (as a ℂ-submodule of SymGroupAlgebra n)
-  have hspan := polytabloid_span n la
-  -- finrank of the span of linearly independent vectors equals cardinality
-  have h1 : Module.finrank ℂ (Submodule.span ℂ (Set.range (fun T : StandardYoungTableau n la =>
-      (polytabloidInSpecht n la T : SymGroupAlgebra n)))) =
-      Fintype.card (StandardYoungTableau n la) :=
-    finrank_span_eq_card hli
-  -- The span equals V_λ.restrictScalars ℂ, so their finranks are equal
-  rw [hspan] at h1
-  -- finrank of restrictScalars = finrank of the original module
-  -- Both ↥(M.restrictScalars ℂ) and ↥M have the same ℂ-module structure
-  convert h1 using 1
+`finrank_spechtModule_eq_card_syt` and `polytabloid_linearIndependent` are proved in
+`TabloidModule.lean` (which imports this file) using the dominance-order triangularity
+argument.
+-/
 
 end
 

--- a/EtingofRepresentationTheory/Chapter5/TabloidModule.lean
+++ b/EtingofRepresentationTheory/Chapter5/TabloidModule.lean
@@ -1178,6 +1178,36 @@ theorem polytabloid_linearIndependent' :
   -- Apply the coefficient extraction lemma to T₀
   exact hfT₀ (polytabloid_coeff_zero_of_maximal S f hf T₀ hT₀ hmax)
 
+/-- The polytabloids {e_T : T ∈ SYT(λ)} are linearly independent in V_λ.
+
+Proved via the dominance-order triangularity argument in `polytabloid_linearIndependent'`. -/
+theorem polytabloid_linearIndependent (n : ℕ) (la : Nat.Partition n) :
+    LinearIndependent ℂ (fun T : StandardYoungTableau n la =>
+      (polytabloidInSpecht n la T : SymGroupAlgebra n)) :=
+  polytabloid_linearIndependent'
+
+/-! ### Dimension theorem from polytabloid basis -/
+
+/-- The polytabloids form a basis of V_λ, so dim V_λ = |SYT(λ)|.
+
+This combines linear independence and spanning of polytabloids to
+construct an explicit basis of the Specht module indexed by standard
+Young tableaux of shape λ.
+
+This is the key infrastructure needed for the hook length formula
+(Theorem 5.17.1). -/
+theorem finrank_spechtModule_eq_card_syt (n : ℕ) (la : Nat.Partition n) :
+    Module.finrank ℂ (SpechtModule n la) =
+      Fintype.card (StandardYoungTableau n la) := by
+  have hli := polytabloid_linearIndependent n la
+  have hspan := polytabloid_span n la
+  have h1 : Module.finrank ℂ (Submodule.span ℂ (Set.range (fun T : StandardYoungTableau n la =>
+      (polytabloidInSpecht n la T : SymGroupAlgebra n)))) =
+      Fintype.card (StandardYoungTableau n la) :=
+    finrank_span_eq_card hli
+  rw [hspan] at h1
+  convert h1 using 1
+
 end
 
 end Etingof

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_17_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_17_1.lean
@@ -1,6 +1,6 @@
 import Mathlib
 import EtingofRepresentationTheory.Chapter5.Definition5_14_2
-import EtingofRepresentationTheory.Chapter5.PolytabloidBasis
+import EtingofRepresentationTheory.Chapter5.TabloidModule
 import EtingofRepresentationTheory.Chapter5.FRTHelpers
 
 /-!


### PR DESCRIPTION
This PR moves `polytabloid_linearIndependent` and `finrank_spechtModule_eq_card_syt` from `PolytabloidBasis.lean` (where they were sorry'd) to `TabloidModule.lean` (where the proved `polytabloid_linearIndependent'` lives). The wrapper now delegates directly, closing the sorry. `Theorem5_17_1` import updated accordingly.

🤖 Prepared with Claude Code