### PR TITLE
feat: prove Young symmetrizer coefficient lemmas (3 sorry → 0)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/PolytabloidBasis.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolytabloidBasis.lean
@@ -266,12 +266,122 @@ private lemma rowSymmetrizer_apply_not_mem' (n : ℕ) (la : Nat.Partition n)
   · exact absurd (h ▸ p.prop) hσ
   · rfl
 
-/-- The coefficient of the identity permutation in the Young symmetrizer is 1.
-Uses P_λ ∩ Q_λ = {id}. -/
+/-! ### Support characterization of the Young symmetrizer
+
+The Young symmetrizer c_λ = b_λ · a_λ = (Σ_{q ∈ Q_λ} sign(q) · q) · (Σ_{p ∈ P_λ} p).
+Since P_λ ∩ Q_λ = {id} (proved as `row_col_inter_trivial'`), the map (q,p) ↦ q*p is
+injective from Q_λ × P_λ to S_n. Therefore:
+- c_λ(g) = 0 if g ∉ Q_λ · P_λ
+- c_λ(q*p) = sign(q) for the unique decomposition g = q*p
+
+This is the "support characterization" used in the dominance triangularity analysis.
+-/
+
+/-- The Young symmetrizer c_λ = b·a is supported on Q_λ · P_λ: if c_λ(g) ≠ 0 then g = q · p
+for some q ∈ Q_λ and p ∈ P_λ, with c_λ(g) = sign(q). -/
+private theorem youngSymmetrizer_support (n : ℕ) (la : Nat.Partition n)
+    (g : Equiv.Perm (Fin n))
+    (hg : (YoungSymmetrizer n la : SymGroupAlgebra n) g ≠ 0) :
+    ∃ q ∈ ColumnSubgroup n la, ∃ p ∈ RowSubgroup n la,
+      g = q * p := by
+  classical
+  change (ColumnAntisymmetrizer n la * RowSymmetrizer n la) g ≠ 0 at hg
+  have hmem : g ∈ (ColumnAntisymmetrizer n la * RowSymmetrizer n la).support :=
+    Finsupp.mem_support_iff.mpr hg
+  obtain ⟨q', hq'_mem, p', hp'_mem, hg_eq⟩ :=
+    Finset.mem_mul.mp (MonoidAlgebra.support_mul _ _ hmem)
+  have hq'_col : q' ∈ ColumnSubgroup n la := by
+    simp only [ColumnAntisymmetrizer, MonoidAlgebra.of_apply] at hq'_mem
+    rw [Finsupp.mem_support_iff, Finsupp.finset_sum_apply] at hq'_mem
+    by_contra h_not
+    apply hq'_mem
+    apply Finset.sum_eq_zero
+    intro ⟨r, hr⟩ _
+    rw [Finsupp.smul_apply, smul_eq_mul, Finsupp.single_apply]
+    split_ifs with heq
+    · exact absurd (heq ▸ hr) h_not
+    · ring
+  have hp'_row : p' ∈ RowSubgroup n la := by
+    simp only [RowSymmetrizer, MonoidAlgebra.of_apply] at hp'_mem
+    rw [Finsupp.mem_support_iff, Finsupp.finset_sum_apply] at hp'_mem
+    by_contra h_not
+    apply hp'_mem
+    apply Finset.sum_eq_zero
+    intro ⟨r, hr⟩ _
+    rw [Finsupp.single_apply]
+    split_ifs with heq
+    · exact absurd (heq ▸ hr) h_not
+    · rfl
+  exact ⟨q', hq'_col, p', hp'_row, hg_eq.symm⟩
+
+/-- The coefficient of g in c_λ = b·a when g = q · p (q ∈ Q_λ, p ∈ P_λ) is sign(q). -/
+private theorem youngSymmetrizer_pq_coeff (n : ℕ) (la : Nat.Partition n)
+    (q : Equiv.Perm (Fin n)) (hq : q ∈ ColumnSubgroup n la)
+    (p : Equiv.Perm (Fin n)) (hp : p ∈ RowSubgroup n la) :
+    (YoungSymmetrizer n la : SymGroupAlgebra n) (q * p) =
+      (↑(↑(Equiv.Perm.sign q) : ℤ) : ℂ) := by
+  classical
+  -- Use support_mul approach: first show q * p ∈ support implies it factors through Q_λ × P_λ
+  -- Direct evaluation via support analysis
+  change (ColumnAntisymmetrizer n la * RowSymmetrizer n la) (q * p) = _
+  -- The support of b_λ * a_λ ⊆ Q_λ * P_λ with the unique decomposition giving sign(q)
+  -- We prove this by showing: for any decomposition g = q' * p' with q' ∈ Q_λ and p' ∈ P_λ,
+  -- we must have q' = q and p' = p (by P∩Q = {1}).
+  -- Use the convolution formula: (f * g)(x) = Σ_{y} f(y) * g(y⁻¹ * x)
+  have heval : (ColumnAntisymmetrizer n la * RowSymmetrizer n la) (q * p) =
+      ∑ q' : ↥(ColumnSubgroup n la),
+        ((↑(↑(Equiv.Perm.sign q'.val) : ℤ) : ℂ) *
+          (RowSymmetrizer n la : SymGroupAlgebra n) (q'.val⁻¹ * (q * p))) := by
+    unfold ColumnAntisymmetrizer
+    simp only [MonoidAlgebra.of_apply, Finset.sum_mul]
+    rw [Finsupp.finset_sum_apply (N := ℂ)]
+    congr 1; ext ⟨q', hq'⟩
+    rw [Algebra.smul_mul_assoc, Finsupp.smul_apply, smul_eq_mul,
+        MonoidAlgebra.single_mul_apply, one_mul]
+  rw [heval]
+  -- Only q' = q contributes: q'⁻¹ * (q * p) ∈ P_λ iff q' = q
+  rw [Finset.sum_eq_single (⟨q, hq⟩ : ↥(ColumnSubgroup n la))]
+  · -- q' = q: q⁻¹ * (q * p) = p ∈ P_λ, so a_λ(p) = 1
+    simp only [inv_mul_cancel_left]
+    rw [show (RowSymmetrizer n la : SymGroupAlgebra n) p = 1 from by
+      simp only [RowSymmetrizer, MonoidAlgebra.of_apply]
+      rw [Finsupp.finset_sum_apply]
+      rw [Finset.sum_eq_single (⟨p, hp⟩ : ↥(RowSubgroup n la))]
+      · simp
+      · intro ⟨p', _⟩ _ hne
+        rw [Finsupp.single_apply, if_neg (fun h => hne (Subtype.ext h))]
+      · intro h; exact absurd (Finset.mem_univ _) h]
+    ring
+  · -- q' ≠ q: q'⁻¹ * (q * p) = (q'⁻¹ * q) * p, and a_λ at this is 0 unless q'⁻¹q ∈ P_λ
+    intro ⟨q', hq'⟩ _ hne
+    suffices h : (RowSymmetrizer n la : SymGroupAlgebra n) (q'⁻¹ * (q * p)) = 0 by
+      rw [h, mul_zero]
+    simp only [RowSymmetrizer, MonoidAlgebra.of_apply]
+    rw [Finsupp.finset_sum_apply]
+    apply Finset.sum_eq_zero
+    intro ⟨p', hp'⟩ _
+    rw [Finsupp.single_apply]
+    rw [if_neg]
+    intro heq
+    -- q'⁻¹ * q * p = p' implies q'⁻¹ * q = p' * p⁻¹ ∈ P_λ
+    have : q'⁻¹ * q = p' * p⁻¹ := by
+      have h : p' = q'⁻¹ * (q * p) := heq
+      calc q'⁻¹ * q = q'⁻¹ * (q * p) * p⁻¹ := by group
+        _ = p' * p⁻¹ := by rw [← h]
+    have hqp_row : q'⁻¹ * q ∈ RowSubgroup n la := by
+      rw [this]; exact (RowSubgroup n la).mul_mem hp' ((RowSubgroup n la).inv_mem hp)
+    have hqp_col : q'⁻¹ * q ∈ ColumnSubgroup n la :=
+      (ColumnSubgroup n la).mul_mem ((ColumnSubgroup n la).inv_mem hq') hq
+    exact hne (Subtype.ext (inv_mul_eq_one.mp
+      (row_col_inter_trivial' n la _ hqp_row hqp_col)))
+  · intro h; exact absurd (Finset.mem_univ _) h
+
+/-- The coefficient of the identity permutation in the Young symmetrizer is 1. -/
 private lemma youngSymmetrizer_one_coeff (n : ℕ) (la : Nat.Partition n) :
     (YoungSymmetrizer n la : SymGroupAlgebra n) 1 = 1 := by
-  -- c = b * a. c(1) = Σ_q sign(q) * a(q⁻¹). Only q = 1 contributes (P∩Q = {1}).
-  sorry
+  have h := youngSymmetrizer_pq_coeff n la 1 (ColumnSubgroup n la).one_mem
+    1 (RowSubgroup n la).one_mem
+  simpa [Equiv.Perm.sign_one] using h
 
 /-! ### Note on false group-algebra coefficient formulas
 
@@ -294,25 +404,12 @@ of tabloid {T} in the tabloid-module polytabloid e_T is 1. This uses
 See GitHub issue #2161 for the full analysis and counterexample.
 -/
 
-/-! ### Support characterization of the Young symmetrizer
-
-The Young symmetrizer c_λ = a_λ · b_λ = (Σ_{p ∈ P_λ} p) · (Σ_{q ∈ Q_λ} sign(q) · q).
-Since P_λ ∩ Q_λ = {id} (proved as `row_col_inter_trivial'`), the map (p,q) ↦ p*q is
-injective from P_λ × Q_λ to S_n. Therefore:
-- c_λ(g) = 0 if g ∉ P_λ · Q_λ
-- c_λ(p*q) = sign(q) for the unique decomposition g = p*q
-
-This is the "support characterization" used in the dominance triangularity analysis.
--/
-
-/-- The coefficient of p ∈ P_λ in the Young symmetrizer equals 1.
-With c = b·a, c(p) = Σ_q sign(q)·a(q⁻¹·p). Since q⁻¹·p ∈ P iff q ∈ P∩Q = {1},
-only q = 1 contributes, giving sign(1)·a(p) = 1. -/
+/-- The coefficient of p ∈ P_λ in the Young symmetrizer equals 1. -/
 private lemma youngSymmetrizer_rowPerm_coeff (n : ℕ) (la : Nat.Partition n)
     (p : Equiv.Perm (Fin n)) (hp : p ∈ RowSubgroup n la) :
     (YoungSymmetrizer n la : SymGroupAlgebra n) p = 1 := by
-  -- c = b * a. c(p) = Σ_q sign(q) * a(q⁻¹*p). Only q = 1 contributes (P∩Q = {1}).
-  sorry
+  have h := youngSymmetrizer_pq_coeff n la 1 (ColumnSubgroup n la).one_mem p hp
+  simpa [Equiv.Perm.sign_one] using h
 
 /-! ### Tabloid projection for linear independence
 
@@ -343,29 +440,6 @@ in both directions. The tabloid projection approach is needed instead.
 - For q ∈ Q_λ \ {id}: the tabloid σ · q · P_λ is strictly dominated by σ · P_λ
   (column permutations decrease dominance)
 -/
-
-/-! ### Support characterization of the Young symmetrizer -/
-
-/-- The Young symmetrizer c_λ = b·a is supported on Q_λ · P_λ: if c_λ(g) ≠ 0 then g = q · p
-for some q ∈ Q_λ and p ∈ P_λ, with c_λ(g) = sign(q). -/
-private theorem youngSymmetrizer_support (n : ℕ) (la : Nat.Partition n)
-    (g : Equiv.Perm (Fin n))
-    (hg : (YoungSymmetrizer n la : SymGroupAlgebra n) g ≠ 0) :
-    ∃ q ∈ ColumnSubgroup n la, ∃ p ∈ RowSubgroup n la,
-      g = q * p := by
-  -- c = b * a. c(g) = Σ_q sign(q) * a(q⁻¹*g). If c(g) ≠ 0, some q has a(q⁻¹*g) ≠ 0,
-  -- meaning q⁻¹*g ∈ P, so g = q*p.
-  sorry
-
-/-- The coefficient of g in c_λ = b·a when g = q · p (q ∈ Q_λ, p ∈ P_λ) is sign(q). -/
-private theorem youngSymmetrizer_pq_coeff (n : ℕ) (la : Nat.Partition n)
-    (q : Equiv.Perm (Fin n)) (hq : q ∈ ColumnSubgroup n la)
-    (p : Equiv.Perm (Fin n)) (hp : p ∈ RowSubgroup n la) :
-    (YoungSymmetrizer n la : SymGroupAlgebra n) (q * p) =
-      (↑(↑(Equiv.Perm.sign q) : ℤ) : ℂ) := by
-  -- c = b * a. c(q*p) = Σ_{q'} sign(q') * a(q'⁻¹*q*p). Only q' = q contributes
-  -- (giving a(p) = 1), since q'⁻¹*q ∈ P ∩ Q = {1}.
-  sorry
 
 /-- If e_{T₂}(σ) ≠ 0, then σ ∈ C_{T₂} · σ_{T₂} · P_λ: there exist π ��� C_{T₂}
 (entry-level column stabilizer) and p ∈ P_λ such that σ = π · σ_{T₂} · p.

--- a/progress/20260411T035718Z_8c5364fb.md
+++ b/progress/20260411T035718Z_8c5364fb.md
@@ -1,0 +1,50 @@
+## Accomplished
+
+- Proved 3 previously-sorry'd Young symmetrizer coefficient lemmas in PolytabloidBasis.lean:
+  - `youngSymmetrizer_support`: c_λ(g) ≠ 0 implies g = q·p with q ∈ Q_λ, p ∈ P_λ
+  - `youngSymmetrizer_pq_coeff`: c_λ(q·p) = sign(q) for the unique Q_λ×P_λ decomposition
+  - `youngSymmetrizer_one_coeff`: c_λ(1) = 1
+  - `youngSymmetrizer_rowPerm_coeff`: c_λ(p) = 1 for p ∈ P_λ
+- Key technique: convolution formula with `Finsupp.finset_sum_apply (N := ℂ)` (needs explicit type annotation to match MonoidAlgebra coercion), `Algebra.smul_mul_assoc` + `MonoidAlgebra.single_mul_apply` for individual terms, and `row_col_inter_trivial'` (P∩Q = {1}) for uniqueness
+- Reordered declarations so `_support` and `_pq_coeff` precede their dependents
+
+## Current frontier
+
+4 sorry's remain in PolytabloidBasis.lean (same count, but 3 previously-sorry'd helper lemmas are now proved):
+
+1. **`polytabloid_mem_spechtModule`** (line 193): e_T ∈ V_λ
+   - Non-trivial because e_T = κ_T · of(σ_T) · a_λ ≠ of(σ_T) · YS in general
+   - The T-dependent column antisymmetrizer gives κ_T = of(σ_T⁻¹) · b_λ · of(σ_T), so e_T = of(σ_T⁻¹) · b_λ · of(σ_T²) · a_λ, NOT of(σ_T) · b_λ · a_λ
+   - Needs either: (a) algebraic argument using sandwich property, or (b) showing b_λ · of(σ_T²) · a_λ ∈ A · b_λ · a_λ
+
+2. **`polytabloid_linearIndependent`** (line 519): {e_T} are ℂ-linearly independent
+   - Transfer from tabloid-level `polytabloidTab_linearIndependent` (proved in TabloidModule.lean)
+   - Requires constructing ℂ-linear map V_λ → M^λ that respects polytabloid structure
+
+3. **`column_standard_in_span'`** (line 925): column-standard σ·YS ∈ span{e_T}
+4. **`perm_mul_youngSymmetrizer_mem_span_polytabloids`** (line 1367): all σ·YS ∈ span{e_T}
+   - Both #3 and #4 are the main issue #2217 targets
+   - Garnir approach at group algebra level is a tautology (documented)
+   - Viable approaches: tabloid-level straightening + transfer, or dimension argument
+
+## Overall project progress
+
+- PolytabloidBasis.lean: 4 sorry's (was 7 before this session, 3 helpers now proved)
+- TabloidModule.lean: 0 sorry's (polytabloidTab_linearIndependent proved)
+- Problem6_9_1.lean: 4 sorry's (from previous session)
+- All other files build cleanly
+
+## Next step
+
+1. Prove `polytabloid_mem_spechtModule`: investigate whether the sandwich property YS·x·YS = f(x)·YS can be used to show e_T·YS = c·e_T, giving e_T = (1/c)·(e_T·YS) ∈ A·YS
+2. Prove `polytabloid_linearIndependent` via transfer map from group algebra to tabloid module
+3. For the spanning sorry's (#3, #4), the most promising approach is:
+   - Prove linear independence (step 2) gives dim(V_λ) ≥ |SYT(λ)|
+   - Show dim(V_λ) ≤ |SYT(λ)| via the multiplicity-1 result + tabloid module dimension
+   - dim equality + linear independence → spanning
+
+## Blockers
+
+- The T-dependent polytabloid definition `e_T = κ_T · of(σ_T) · a_λ` creates a mismatch with `of(σ_T) · YS` that makes `polytabloid_mem_spechtModule` and the transfer map non-trivial
+- The Garnir straightening approach at the group algebra level collapses to a tautology (documented in file, issue #2104)
+- Transfer map from group algebra to tabloid module needs ℂ[S_n]-action on M^λ infrastructure not yet built


### PR DESCRIPTION
## Summary

- Prove `youngSymmetrizer_support`, `youngSymmetrizer_pq_coeff`, `youngSymmetrizer_one_coeff`, and `youngSymmetrizer_rowPerm_coeff` — 3 sorry's closed
- Key result: for c_λ = b_λ · a_λ, the coefficient c_λ(q·p) = sign(q) for q ∈ Q_λ, p ∈ P_λ, using the convolution formula and P_λ ∩ Q_λ = {1}
- Reordered declarations to fix dependency ordering
- PolytabloidBasis.lean remains at 4 sorry's (the 3 helper sorry's are replaced by proofs; the 4 remaining sorry's are the harder structural ones: `polytabloid_mem_spechtModule`, `polytabloid_linearIndependent`, `column_standard_in_span'`, `perm_mul_youngSymmetrizer_mem_span_polytabloids`)

Partial progress on #2217.

🤖 Prepared with Claude Code