### PR TITLE
fix: disable GitHub Actions cache to prevent OOM

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
       - uses: leanprover/lean-action@v1
+        with:
+          use-github-cache: false


### PR DESCRIPTION
## Summary

- Disabled `use-github-cache` in lean-action — the cache save step was OOMing the ubuntu-latest runner (7GB RAM) when trying to save the multi-GB `.lake` directory after build
- Added `timeout-minutes: 30` to prevent indefinite hangs
- The Mathlib Azure cache (`lake exe cache get`) is still used automatically

This fixes the systemic exit code 143 (SIGTERM) failures blocking all CI builds on main and PR branches (#2175, #2191, #2198, #2200, #2208, #2219).

Closes #2227

🤖 Prepared with Claude Code