### PR TITLE
feat: proof skeleton for head_isomorphism (#2174)

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/MoritaStructural.lean
+++ b/EtingofRepresentationTheory/Chapter9/MoritaStructural.lean
@@ -23,6 +23,9 @@ import Mathlib.RingTheory.Artinian.Module
 import Mathlib.RingTheory.HopkinsLevitzki
 import Mathlib.Algebra.Category.ModuleCat.Projective
 import Mathlib.Algebra.Category.ModuleCat.Subobject
+import Mathlib.Algebra.Category.ModuleCat.Simple
+import Mathlib.RingTheory.SimpleModule.Isotypic
+import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 
 universe u v
 
@@ -496,10 +499,38 @@ private noncomputable def head_isomorphism [IsAlgClosed k]
   haveI : IsSemisimpleModule B₂ (Pt ⧸ JP) := h_tors_P.isSemisimpleModule_iff.mp inferInstance
   have h_tors_B := Module.isTorsionBySet_quotient_ideal_smul B₂ (Ring.jacobson B₂)
   haveI : IsSemisimpleModule B₂ (B₂ ⧸ JB) := h_tors_B.isSemisimpleModule_iff.mp inferInstance
-  -- Both are finite-dimensional over k (quotients of finite-dim modules)
-  -- The head isomorphism follows from both having the same simple multiplicities.
-  -- See the detailed proof outline above.
-  sorry
+  -- Module.Finite B₂ Pt (equivalence preserves finiteness)
+  haveI : Module.Finite B₂ Pt := module_finite_of_equiv_artinian F
+  -- Both quotients are finite over B₂
+  haveI : Module.Finite B₂ (Pt ⧸ JP) := inferInstance
+  haveI : Module.Finite B₂ (B₂ ⧸ JB) := inferInstance
+  -- Construct the isomorphism via finrank equality + surjection
+  -- Both quotients are finite-dimensional over k
+  haveI : Module.Finite k Pt := Module.Finite.trans B₂ Pt
+  haveI : Module.Finite k (Pt ⧸ JP) := Module.Finite.quotient k JP
+  haveI : Module.Finite k (B₂ ⧸ JB) := Module.Finite.quotient k JB
+  -- Key claim: finrank equality over k
+  -- Both heads have finrank_k = n (number of distinct simple B₂-modules),
+  -- because each simple appears with multiplicity 1 (basic algebras + adjunction).
+  have h_finrank : Module.finrank k (Pt ⧸ JP) = Module.finrank k (B₂ ⧸ JB) := by
+    sorry
+  -- Construct a B₂-linear surjection Pt/JP → B₂/JB
+  -- For each simple S of B₂, equiv_hom_to_simple_nonzero gives Pt → S nonzero.
+  -- This factors through Pt/JP since J₂ kills S. Assembling gives a surjection.
+  have h_surj_exists : ∃ (φ : (Pt ⧸ JP) →ₗ[B₂] (B₂ ⧸ JB)),
+      Function.Surjective φ := by
+    sorry
+  let φ := h_surj_exists.choose
+  have hφ_surj := h_surj_exists.choose_spec
+  -- Surjection + finrank equality → isomorphism
+  -- The B₂-linear map φ is also k-linear (via restriction of scalars).
+  -- By LinearMap.injective_iff_surjective_of_finrank_eq_finrank for k,
+  -- surjectivity implies injectivity (same finrank), hence bijectivity.
+  have h_inj : Function.Injective φ := by
+    have h_surj_k : Function.Surjective (φ.restrictScalars k) := hφ_surj
+    exact (LinearMap.injective_iff_surjective_of_finrank_eq_finrank
+      h_finrank).mpr h_surj_k
+  exact LinearEquiv.ofBijective φ ⟨h_inj, hφ_surj⟩
 
 private noncomputable def exists_surjection_with_trivial_kernel_head [IsAlgClosed k]
     (B₁ : Type u) [Ring B₁] [Algebra k B₁] [Module.Finite k B₁]

--- a/progress/20260411T214352Z_6d1945d1.md
+++ b/progress/20260411T214352Z_6d1945d1.md
@@ -1,0 +1,42 @@
+## Accomplished
+
+- Partially proved `head_isomorphism` in `MoritaStructural.lean` (issue #2174)
+  - Replaced the monolithic `sorry` with a verified proof skeleton
+  - Established all needed instances: `IsArtinianRing`, `IsSemisimpleModule` for both quotients, `Module.Finite B₂ Pt` (via `module_finite_of_equiv_artinian`), `Module.Finite k` for both quotients
+  - Proved the assembly step: surjection + finrank equality → injection → `LinearEquiv.ofBijective`
+  - Used `.choose`/`.choose_spec` to work around Prop→Type elimination issues
+  - Added 3 new imports: `ModuleCat.Simple`, `SimpleModule.Isotypic`, `FiniteDimensional.Lemmas`
+  - 2 remaining sorry's are cleanly-scoped Prop goals:
+    1. `h_finrank : Module.finrank k (Pt ⧸ JP) = Module.finrank k (B₂ ⧸ JB)` — both = n (number of simples), via adjunction + basic algebra dimension argument
+    2. `h_surj_exists : ∃ φ : (Pt ⧸ JP) →ₗ[B₂] (B₂ ⧸ JB), Function.Surjective φ` — construct using `equiv_hom_to_simple_nonzero` + semisimple decomposition assembly
+
+## Current frontier
+
+8 sorries across 6 files (unchanged count, but MoritaStructural sorry is now structurally decomposed):
+- PolytabloidBasis.lean: 3 (polytabloid_linearIndependent, column_standard_in_span', perm_mul_youngSymmetrizer_mem_span_polytabloids)
+- FormalCharacterIso.lean: 1 (iso_of_glWeightSpace_finrank_eq)
+- Corollary6_8_4.lean: 1 (mixed vertex case)
+- Problem6_1_5_theorem.lean: 1 (forward direction)
+- MoritaStructural.lean: 1 (head_isomorphism — now decomposed into 2 sub-goals)
+- Theorem2_1_2.lean: 1 (Gabriel's theorem)
+
+## Overall project progress
+
+- **Wave 48**: 8 sorries / 6 files
+- **Items**: 581/583 sorry-free (99.7%)
+- **Files**: 275/281 sorry-free (97.9%)
+
+## Next step
+
+1. **Close `h_finrank` sorry** (finrank equality): Apply Wedderburn-Artin `IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed` to B₂/J₂, show all block sizes = 1 via `IsBasicAlgebra`, compute finrank_k(B₂/JB) = n. For Pt/JP, use adjunction `F.toAdjunction.homEquiv` to show dim_k Hom(Pt, Sᵢ) = dim_k G(Sᵢ) = 1 (basic B₁), then Hom-multiplicity formula gives each simple appears once, so finrank = n. Estimated ~40-50 lines.
+
+2. **Close `h_surj_exists` sorry** (surjection): Decompose B₂/JB via `exists_linearEquiv_fin_dfinsupp`. For each simple component, use `equiv_hom_to_simple_nonzero` + `LinearMap.surjective_of_ne_zero` + quotient factoring through Pt/JP. Use `linearEquiv_of_ne_zero` to find matching submodules of Pt/JP, then project from Pt/JP onto these submodules and compose with component-wise isomorphisms. Estimated ~40-50 lines.
+
+3. Both sub-goals are independent and can be attacked in parallel.
+
+## Blockers
+
+- Both remaining sub-goals require infrastructure at the boundary of what Mathlib provides:
+  - **Hom-multiplicity formula**: For semisimple M = ⊕ Sᵢ^{mᵢ}, dim Hom(M, S) = mᵢ · dim End(S). Not directly in Mathlib.
+  - **Semisimple decomposition assembly**: Constructing a B₂-linear map to a DFinsupp/Pi from maps to individual components, where the source is semisimple and the maps use different summands. Requires careful handling of direct sum projections.
+  - **IsBasicAlgebra → block sizes = 1**: Connecting WA block sizes to simple module dimensions. The WA theorem gives algebra isomorphism; need to relate block sizes to finrank of simples.


### PR DESCRIPTION
## Summary

- Replaces the monolithic `sorry` in `head_isomorphism` (MoritaStructural.lean) with a verified proof skeleton
- Establishes all needed instances: `IsArtinianRing`, `IsSemisimpleModule`, `Module.Finite B₂ Pt`, `Module.Finite k` for quotients
- Proves the assembly step: surjection + finrank equality → injection → `LinearEquiv.ofBijective`
- Reduces to 2 cleanly-scoped, independently-attackable sorry sub-goals:
  1. **finrank equality**: `Module.finrank k (Pt ⧸ JP) = Module.finrank k (B₂ ⧸ JB)` — both = n via adjunction + basic algebra
  2. **surjection existence**: `∃ φ : (Pt ⧸ JP) →ₗ[B₂] (B₂ ⧸ JB), Function.Surjective φ` — via `equiv_hom_to_simple_nonzero` + assembly

Closing these 2 sub-goals completes `head_isomorphism` and makes the entire Morita structural theorem chain sorry-free.

Partial progress on #2174.

🤖 Prepared with Claude Code