### PR TITLE
feat: dim V_λ ≥ |SYT(λ)| via tabloidProjection bridge

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/TabloidModule.lean
+++ b/EtingofRepresentationTheory/Chapter5/TabloidModule.lean
@@ -1426,6 +1426,95 @@ theorem tabloidProjection_injective_on_spechtModule
   rw [hK_bot] at hv_in_K
   exact congr_arg Subtype.val ((Submodule.mem_bot _).mp hv_in_K)
 
+/-! ### Image of V_λ under tabloidProjection
+
+The key relationship: tabloidProjection maps of(σ) * c_λ to
+|P_λ| · generalizedPolytabloidTab(σ⁻¹). This connects the group-algebra
+Specht module to the tabloid-level polytabloid infrastructure. -/
+
+/-- Helper: ψ(c_λ) expressed in terms of column group sum and |P_λ|.
+This computes tabloidProjection(YoungSymmetrizer) as a scaled sum over Q_λ. -/
+private theorem tabloidProjection_youngSymmetrizer_eq :
+    tabloidProjection (n := n) (la := la) (YoungSymmetrizer n la) =
+      (Nat.card (↥(RowSubgroup n la)) : ℂ) •
+        generalizedPolytabloidTab (n := n) (la := la) 1 := by
+  classical
+  simp only [YoungSymmetrizer, ColumnAntisymmetrizer, Finset.sum_mul, map_sum,
+    smul_mul_assoc, map_smul, tabloidProjection_of_mul, tabloidProjection_RowSymmetrizer,
+    Finsupp.mapDomain_smul, Finsupp.mapDomain_single, tabloidRightMul_toTabloid, one_mul]
+  -- Goal: ∑ x, sign(x) • |P_λ| • single([x⁻¹], 1) = |P_λ| • generalizedPolytabloidTab 1
+  -- Swap the two scalars, then factor out |P_λ|
+  simp_rw [smul_comm (Equiv.Perm.sign _ : ℂ)]
+  rw [← Finset.smul_sum]
+  simp [generalizedPolytabloidTab, mul_one]
+
+theorem tabloidProjection_of_mul_youngSymmetrizer (σ : Equiv.Perm (Fin n)) :
+    tabloidProjection (n := n) (la := la)
+      (MonoidAlgebra.of ℂ _ σ * YoungSymmetrizer n la) =
+      (Nat.card (↥(RowSubgroup n la)) : ℂ) •
+        generalizedPolytabloidTab (n := n) (la := la) σ⁻¹ := by
+  classical
+  -- Step 1: ψ(of(σ) * c_λ) = mapDomain(rightMul σ⁻¹)(ψ(c_λ))
+  rw [tabloidProjection_of_mul, tabloidProjection_youngSymmetrizer_eq,
+    Finsupp.mapDomain_smul]
+  congr 1
+  -- Step 2: mapDomain(rightMul σ⁻¹)(ψ_1) = ψ_{σ⁻¹}
+  simp only [generalizedPolytabloidTab]
+  rw [Finsupp.mapDomain_finset_sum]
+  congr 1; ext ⟨q, hq⟩
+  rw [Finsupp.mapDomain_smul, Finsupp.mapDomain_single, tabloidRightMul_toTabloid, mul_one]
+
+/-- Every polytabloidTab lies in the image of V_λ under tabloidProjection.
+Specifically, polytabloidTab(T) = generalizedPolytabloidTab(σ_T) is in
+ψ(V_λ) because ψ(of(σ_T⁻¹) * c_λ) = |P_λ| · generalizedPolytabloidTab(σ_T). -/
+theorem polytabloidTab_mem_tabloidProjection_spechtModule
+    (T : StandardYoungTableau n la) :
+    polytabloidTab (n := n) (la := la) T ∈
+      Submodule.map (tabloidProjection (n := n) (la := la))
+        ((SpechtModule n la).restrictScalars ℂ) := by
+  rw [Submodule.mem_map]
+  refine ⟨(Nat.card (↥(RowSubgroup n la)) : ℂ)⁻¹ •
+    MonoidAlgebra.of ℂ _ (sytPerm n la T)⁻¹ * YoungSymmetrizer n la, ?_, ?_⟩
+  · -- This element is in V_λ (it's a scalar multiple of of(σ_T⁻¹) * c_λ)
+    change _ ∈ (SpechtModule n la).restrictScalars ℂ
+    rw [Submodule.restrictScalars_mem, SpechtModule, Submodule.mem_span_singleton]
+    exact ⟨_, rfl⟩
+  · -- Compute tabloidProjection of this element
+    simp only [map_smul, smul_mul_assoc, tabloidProjection_of_mul_youngSymmetrizer]
+    rw [smul_smul, inv_mul_cancel₀, one_smul]
+    · -- polytabloidTab(T) = generalizedPolytabloidTab(σ_T)
+      rw [inv_inv]
+      exact (generalizedPolytabloidTab_eq_polytabloidTab T).symm
+    · -- |P_λ| ≠ 0
+      exact Nat.cast_ne_zero.mpr (Nat.card_pos (α := ↥(RowSubgroup n la))).ne'
+
+/-- The image of V_λ under tabloidProjection contains all polytabloidTabs,
+hence has dimension ≥ |SYT(λ)|. Combined with injectivity on V_λ,
+this gives dim V_λ ≥ |SYT(λ)|. -/
+theorem finrank_spechtModule_ge_card_syt :
+    Fintype.card (StandardYoungTableau n la) ≤
+      Module.finrank ℂ (SpechtModule n la) := by
+  -- The polytabloidTabs are linearly independent in M^λ
+  have hli := polytabloidTab_linearIndependent (n := n) (la := la)
+  -- They all lie in ψ(V_λ)
+  have hmem : ∀ T, polytabloidTab (n := n) (la := la) T ∈
+      Submodule.map (tabloidProjection (n := n) (la := la))
+        ((SpechtModule n la).restrictScalars ℂ) :=
+    polytabloidTab_mem_tabloidProjection_spechtModule
+  -- Lift the linearly independent family into the image submodule
+  set S := Submodule.map (tabloidProjection (n := n) (la := la))
+    ((SpechtModule n la).restrictScalars ℂ)
+  have hli_sub : LinearIndependent ℂ (fun T => (⟨polytabloidTab T, hmem T⟩ : S)) := by
+    apply LinearIndependent.of_comp S.subtype
+    simpa using hli
+  -- |SYT| ≤ finrank(image)
+  have h1 := hli_sub.fintype_card_le_finrank
+  -- finrank(image) ≤ finrank(V_λ.restrictScalars ℂ)
+  have h2 := Submodule.finrank_map_le (tabloidProjection (n := n) (la := la))
+    ((SpechtModule n la).restrictScalars ℂ)
+  -- finrank(V_λ.restrictScalars ℂ) = finrank(V_λ)
+  exact h1.trans h2
+
 end
 
 end Etingof

--- a/progress/2026-04-11T22-22-10Z.md
+++ b/progress/2026-04-11T22-22-10Z.md
@@ -1,0 +1,49 @@
+## Accomplished
+
+Built the key bridge between the group-algebra Specht module V_λ and the tabloid module M^λ, proving four new theorems in `TabloidModule.lean` (no new sorries):
+
+1. **`tabloidProjection_youngSymmetrizer_eq`** (private): ψ(c_λ) = |P_λ| · generalizedPolytabloidTab(1)
+2. **`tabloidProjection_of_mul_youngSymmetrizer`**: ψ(of(σ)·c_λ) = |P_λ| · generalizedPolytabloidTab(σ⁻¹) — the master formula connecting group-algebra elements to tabloid-level polytabloids
+3. **`polytabloidTab_mem_tabloidProjection_spechtModule`**: every polytabloidTab(T) lies in the image ψ(V_λ), with explicit preimage (1/|P_λ|)·of(σ_T⁻¹)·c_λ
+4. **`finrank_spechtModule_ge_card_syt`**: |SYT(λ)| ≤ dim V_λ — the dimension lower bound, via lifting linear independence from M^λ to ψ(V_λ)
+
+## Current frontier
+
+The three pre-existing sorries in `PolytabloidBasis.lean` remain open:
+- `polytabloid_linearIndependent` (line 442)
+- `column_standard_in_span'` (line 848)
+- `perm_mul_youngSymmetrizer_mem_span_polytabloids` (line 1290)
+
+### Why these sorries couldn't be closed
+
+**Issue #2234's core theorem was never proved.** Only infrastructure was merged in PR #2243. The tabloid-level straightening lemma (every generalizedPolytabloidTab(σ) ∈ span{polytabloidTab(T) : T ∈ SYT}) is the missing piece.
+
+**For `polytabloid_linearIndependent`:** The natural approach is transfer via `LinearIndependent.of_comp` with `tabloidProjection`, but ψ(polytabloid T) = |P_λ|·generalizedPolytabloidTab((sytPerm T)⁻¹), and the dominance triangularity argument that works for `polytabloidTab_linearIndependent` (which uses sytPerm T, not its inverse) doesn't obviously extend. The column_perm_dominance lemma is specific to SYT fillings, not their inverses. Note: different SYTs DO give different inverse tabloids (proved by showing `[(sytPerm T₁)⁻¹] = [(sytPerm T₂)⁻¹] ↔ [sytPerm T₁] = [sytPerm T₂]` via P_λ being a subgroup), but the dominance direction for column permutations of inverse fillings is unproved.
+
+**For the spanning lemmas:** These require tabloid-level straightening, which is issue #2234.
+
+**Alternative route explored:** Global dimension arguments using Burnside Σ(dim V_λ)² = n! and RSK Σ|SYT(λ)|² = n!, combined with the new lower bound, would give dim = |SYT| for all λ. However, neither formula is formalized in this project or Mathlib.
+
+## Overall project progress
+
+- **TabloidModule.lean**: 0 sorries (all new theorems fully proved)
+- **PolytabloidBasis.lean**: 3 sorries (unchanged from before this session)
+- **Theorem5_17_1.lean**: Depends on `finrank_spechtModule_eq_card_syt` which uses the sorry'd lemmas
+- **FRTHelpers.lean**: Fully proved (combinatorial FRT formula)
+
+The dimension lower bound `finrank_spechtModule_ge_card_syt` is the key new result. Combined with either tabloid-level straightening OR Burnside+RSK, it would close all remaining sorries.
+
+## Next step
+
+Two approaches to close the remaining sorries:
+
+1. **Prove tabloid-level straightening** (generalizedPolytabloidTab(σ) ∈ span{polytabloidTab(T)}) — this was issue #2234's unproved core. Uses Garnir relations (already proved as `garnirAnnihilate_tabloid`) + dominance induction. Once proved, `perm_mul_youngSymmetrizer_mem_span_polytabloids` follows via `tabloidProjection_of_mul_youngSymmetrizer` + injectivity. Then `polytabloid_linearIndependent` follows from span + dimension equality.
+
+2. **Formalize Burnside's dimension formula** Σ(dim V_λ)² = |G| + RSK identity Σ|SYT(λ)|² = n!. Combined with `finrank_spechtModule_ge_card_syt`, this gives dim V_λ = |SYT(λ)| directly. Then derive independence and spanning from the dimension equality.
+
+Approach 1 is more self-contained; approach 2 requires significant new infrastructure.
+
+## Blockers
+
+- Tabloid-level straightening (issue #2234 core theorem) not yet proved
+- Neither Burnside Σ dim² = |G| nor RSK Σ |SYT|² = n! formalized


### PR DESCRIPTION
## Summary

Builds the key bridge between the group-algebra Specht module V_λ and the tabloid module M^λ, proving four new theorems in `TabloidModule.lean` with **no new sorries**:

- **`tabloidProjection_of_mul_youngSymmetrizer`**: ψ(of(σ)·c_λ) = |P_λ| · generalizedPolytabloidTab(σ⁻¹) — the master formula connecting group-algebra elements to tabloid-level polytabloids
- **`polytabloidTab_mem_tabloidProjection_spechtModule`**: every polytabloidTab(T) lies in the image ψ(V_λ)
- **`finrank_spechtModule_ge_card_syt`**: |SYT(λ)| ≤ dim V_λ — dimension lower bound via lifting linear independence from M^λ to ψ(V_λ) and applying Submodule.finrank_map_le

This is partial progress on #2235. The dimension lower bound is the key new stepping stone. Combined with tabloid-level straightening (issue #2234, whose core theorem remains unproved), it would close all remaining sorries in PolytabloidBasis.lean.

### What remains for #2235

The three pre-existing sorries in `PolytabloidBasis.lean` remain open because they require tabloid-level straightening or a global dimension argument (Burnside Σ dim² = |G| + RSK Σ |SYT|² = n!), neither of which is formalized.

🤖 Prepared with Claude Code