### PR TITLE
feat: weight decomposition infrastructure for Schur modules

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Proposition5_22_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Proposition5_22_2.lean
@@ -271,6 +271,93 @@ private theorem formalCharacter_detTwist_eq_shift (N : ℕ) (lam : Fin N → ℕ
         rw [sub_mul, one_mul, hcoord, sub_self]
       exact (mul_eq_zero.mp h_zero).elim (sub_ne_zero.mpr ht₀) hcf)
 
+/-! ### Weight decomposition for Schur modules
+
+The weight spaces of a Schur module form a direct internal decomposition.
+This is used to show `finrank(L_λ) = ∑_μ finrank(L_λ)_μ = eval₁(schurPoly)`,
+which gives the dimension equality `finrank(L_λ) = finrank(L_{λ+(1,...,1)})`. -/
+
+/-- The Young symmetrizer maps tensor basis elements to weight vectors:
+`c_λ(e_f)` has weight `tensorWeight(f)` because `c_λ` commutes with the torus. -/
+private lemma youngSym_tBasis_weightVector (N : ℕ) (lam : Fin N → ℕ)
+    (f : Fin (∑ i, lam i) → Fin N) (i : Fin N) (t : kˣ) :
+    glTensorRep k N (∑ j, lam j) (diagUnit k N i t)
+      (youngSymEndomorphism k N lam (tBasis (k := k) N (∑ j, lam j) f)) =
+    ((t : k) ^ (Finset.univ.filter (fun j => f j = i)).card) •
+      youngSymEndomorphism k N lam (tBasis (k := k) N (∑ j, lam j) f) := by
+  conv_lhs =>
+    rw [show glTensorRep k N (∑ j, lam j) (diagUnit k N i t) ∘ₗ youngSymEndomorphism k N lam =
+      youngSymEndomorphism k N lam ∘ₗ glTensorRep k N (∑ j, lam j) (diagUnit k N i t) from
+      (glTensor_comm_youngSym k N lam (diagUnit k N i t)).symm]
+  simp only [LinearMap.comp_apply, glTensorRep_diagUnit_tBasis, map_smul]
+
+/-- Every element of the Schur module is in the `iSup` of weight spaces.
+Since `L_λ = range(c_λ)` and each `c_λ(e_f)` is a weight vector, every
+element is a finite sum of weight vectors. -/
+private lemma mem_iSup_glWeightSpace_schurModule (N : ℕ) (lam : Fin N → ℕ)
+    (v : SchurModule k N lam) :
+    v ∈ ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N (SchurModule k N lam) (fun i => μ i) := by
+  -- v ∈ SchurModuleSubmodule = range(youngSymEndomorphism)
+  obtain ⟨w, rfl⟩ : (v : TensorPower k (Fin N → k) (∑ i, lam i)) ∈
+      LinearMap.range (youngSymEndomorphism k N lam) := v.property
+  -- Expand w in the tensor basis
+  set n := ∑ i, lam i
+  set b := tBasis (k := k) N n
+  rw [show w = ∑ f : Fin n → Fin N, b.repr w f • b f from (b.sum_repr w).symm]
+  simp_rw [map_sum, map_smul]
+  -- Each c_λ(e_f) is a weight vector — show the subtype is in the weight space
+  apply Submodule.sum_mem
+  intro f _
+  apply Submodule.smul_mem
+  -- Need: ⟨c_λ(e_f), _⟩ ∈ ⨆_μ glWeightSpace(L_λ, μ)
+  apply Submodule.mem_iSup_of_mem (Finsupp.equivFunOnFinite.symm
+    (fun i => (Finset.univ.filter (fun j => f j = i)).card))
+  -- Need: ⟨c_λ(e_f), _⟩ ∈ glWeightSpace(L_λ, tensorWeight(f))
+  simp only [glWeightSpace, Submodule.mem_iInf, LinearMap.mem_ker]
+  intro i t
+  -- Need: ρ(diagUnit(i,t))(c_λ(e_f)) - t^wt · c_λ(e_f) = 0
+  show (SchurModule k N lam).ρ (diagUnit k N i t)
+      ⟨youngSymEndomorphism k N lam (b f), ⟨b f, rfl⟩⟩ -
+    ((t : k) ^ (Finsupp.equivFunOnFinite.symm
+      (fun j => (Finset.univ.filter (fun l => f l = j)).card) i)) •
+      ⟨youngSymEndomorphism k N lam (b f), ⟨b f, rfl⟩⟩ = 0
+  simp only [Finsupp.equivFunOnFinite_symm_apply_toFun]
+  -- ρ on SchurModule = restriction of glTensorRep
+  have hρ : ((SchurModule k N lam).ρ (diagUnit k N i t)
+      ⟨youngSymEndomorphism k N lam (b f), ⟨b f, rfl⟩⟩ : TensorPower k (Fin N → k) n) =
+    glTensorRep k N n (diagUnit k N i t) (youngSymEndomorphism k N lam (b f)) := by
+    simp only [SchurModule, FDRep.of_ρ', schurModuleRep, LinearMap.restrict_coe_apply]
+  ext
+  simp only [Submodule.coe_sub, Submodule.coe_smul_of_tower, ZeroMemClass.coe_zero]
+  rw [hρ, youngSym_tBasis_weightVector k N lam f i t, sub_self]
+
+/-- Weight spaces of the Schur module span the entire module. -/
+private theorem glWeightSpace_schurModule_iSup_eq_top (N : ℕ) (lam : Fin N → ℕ) :
+    ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N (SchurModule k N lam) (fun i => μ i) = ⊤ := by
+  rw [eq_top_iff]
+  intro v _
+  exact mem_iSup_glWeightSpace_schurModule k N lam v
+
+/-- Weight spaces for distinct weights are disjoint: if `μ ≠ ν`, then
+`glWeightSpace(L, μ) ⊓ glWeightSpace(L, ν) = ⊥`. -/
+private theorem glWeightSpace_disjoint (N : ℕ)
+    (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
+    {μ ν : Fin N → ℕ} (hne : μ ≠ ν) :
+    Disjoint (glWeightSpace k N M μ) (glWeightSpace k N M ν) := by
+  rw [Function.ne_iff] at hne; obtain ⟨i₀, hi₀⟩ := hne
+  rw [Submodule.disjoint_def]
+  intro v hv_μ hv_ν
+  simp only [glWeightSpace, Submodule.mem_iInf, LinearMap.mem_ker] at hv_μ hv_ν
+  obtain ⟨t₀, ht₀⟩ := exists_unit_pow_ne k hi₀
+  have h1 : M.ρ (diagUnit k N i₀ t₀) v = ((t₀ : k) ^ μ i₀) • v :=
+    sub_eq_zero.mp (hv_μ i₀ t₀)
+  have h2 : M.ρ (diagUnit k N i₀ t₀) v = ((t₀ : k) ^ ν i₀) • v :=
+    sub_eq_zero.mp (hv_ν i₀ t₀)
+  have h3 : (((t₀ : k) ^ μ i₀) - ((t₀ : k) ^ ν i₀)) • v = 0 := by
+    rw [sub_smul]; exact sub_eq_zero.mpr (h1.symm.trans h2)
+  rw [smul_eq_zero, sub_eq_zero] at h3
+  exact h3.resolve_left ht₀
+
 /-- Key isomorphism: the Schur module `L_{λ+(1,…,1)}` is isomorphic (as a GL_N-representation)
 to the determinant-twisted Schur module `det ⊗ L_λ`.
 

--- a/EtingofRepresentationTheory/Chapter5/Proposition5_22_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Proposition5_22_2.lean
@@ -285,58 +285,20 @@ private lemma youngSym_tBasis_weightVector (N : ℕ) (lam : Fin N → ℕ)
       (youngSymEndomorphism k N lam (tBasis (k := k) N (∑ j, lam j) f)) =
     ((t : k) ^ (Finset.univ.filter (fun j => f j = i)).card) •
       youngSymEndomorphism k N lam (tBasis (k := k) N (∑ j, lam j) f) := by
-  conv_lhs =>
-    rw [show glTensorRep k N (∑ j, lam j) (diagUnit k N i t) ∘ₗ youngSymEndomorphism k N lam =
-      youngSymEndomorphism k N lam ∘ₗ glTensorRep k N (∑ j, lam j) (diagUnit k N i t) from
-      (glTensor_comm_youngSym k N lam (diagUnit k N i t)).symm]
-  simp only [LinearMap.comp_apply, glTensorRep_diagUnit_tBasis, map_smul]
+  change (glTensorRep k N (∑ j, lam j) (diagUnit k N i t) ∘ₗ
+    youngSymEndomorphism k N lam) (tBasis (k := k) N (∑ j, lam j) f) = _
+  rw [glTensor_comm_youngSym k N lam (diagUnit k N i t),
+    LinearMap.comp_apply, glTensorRep_diagUnit_tBasis, map_smul]
 
-/-- Every element of the Schur module is in the `iSup` of weight spaces.
-Since `L_λ = range(c_λ)` and each `c_λ(e_f)` is a weight vector, every
-element is a finite sum of weight vectors. -/
-private lemma mem_iSup_glWeightSpace_schurModule (N : ℕ) (lam : Fin N → ℕ)
-    (v : SchurModule k N lam) :
-    v ∈ ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N (SchurModule k N lam) (fun i => μ i) := by
-  -- v ∈ SchurModuleSubmodule = range(youngSymEndomorphism)
-  obtain ⟨w, rfl⟩ : (v : TensorPower k (Fin N → k) (∑ i, lam i)) ∈
-      LinearMap.range (youngSymEndomorphism k N lam) := v.property
-  -- Expand w in the tensor basis
-  set n := ∑ i, lam i
-  set b := tBasis (k := k) N n
-  rw [show w = ∑ f : Fin n → Fin N, b.repr w f • b f from (b.sum_repr w).symm]
-  simp_rw [map_sum, map_smul]
-  -- Each c_λ(e_f) is a weight vector — show the subtype is in the weight space
-  apply Submodule.sum_mem
-  intro f _
-  apply Submodule.smul_mem
-  -- Need: ⟨c_λ(e_f), _⟩ ∈ ⨆_μ glWeightSpace(L_λ, μ)
-  apply Submodule.mem_iSup_of_mem (Finsupp.equivFunOnFinite.symm
-    (fun i => (Finset.univ.filter (fun j => f j = i)).card))
-  -- Need: ⟨c_λ(e_f), _⟩ ∈ glWeightSpace(L_λ, tensorWeight(f))
-  simp only [glWeightSpace, Submodule.mem_iInf, LinearMap.mem_ker]
-  intro i t
-  -- Need: ρ(diagUnit(i,t))(c_λ(e_f)) - t^wt · c_λ(e_f) = 0
-  show (SchurModule k N lam).ρ (diagUnit k N i t)
-      ⟨youngSymEndomorphism k N lam (b f), ⟨b f, rfl⟩⟩ -
-    ((t : k) ^ (Finsupp.equivFunOnFinite.symm
-      (fun j => (Finset.univ.filter (fun l => f l = j)).card) i)) •
-      ⟨youngSymEndomorphism k N lam (b f), ⟨b f, rfl⟩⟩ = 0
-  simp only [Finsupp.equivFunOnFinite_symm_apply_toFun]
-  -- ρ on SchurModule = restriction of glTensorRep
-  have hρ : ((SchurModule k N lam).ρ (diagUnit k N i t)
-      ⟨youngSymEndomorphism k N lam (b f), ⟨b f, rfl⟩⟩ : TensorPower k (Fin N → k) n) =
-    glTensorRep k N n (diagUnit k N i t) (youngSymEndomorphism k N lam (b f)) := by
-    simp only [SchurModule, FDRep.of_ρ', schurModuleRep, LinearMap.restrict_coe_apply]
-  ext
-  simp only [Submodule.coe_sub, Submodule.coe_smul_of_tower, ZeroMemClass.coe_zero]
-  rw [hρ, youngSym_tBasis_weightVector k N lam f i t, sub_self]
-
-/-- Weight spaces of the Schur module span the entire module. -/
+/-- Weight spaces of the Schur module span the entire module.
+Every element of `L_λ = range(c_λ)` is a sum of weight vectors since each
+`c_λ(e_f)` lies in the weight space for `tensorWeight(f)` (because `c_λ`
+commutes with the torus action). -/
 private theorem glWeightSpace_schurModule_iSup_eq_top (N : ℕ) (lam : Fin N → ℕ) :
     ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N (SchurModule k N lam) (fun i => μ i) = ⊤ := by
-  rw [eq_top_iff]
-  intro v _
-  exact mem_iSup_glWeightSpace_schurModule k N lam v
+  -- Proof: v ∈ L_λ ⇒ v = ∑ cₑ · c_λ(eₑ), each c_λ(eₑ) is a weight vector
+  -- by youngSym_tBasis_weightVector + glTensor_comm_youngSym
+  sorry
 
 /-- Weight spaces for distinct weights are disjoint: if `μ ≠ ν`, then
 `glWeightSpace(L, μ) ⊓ glWeightSpace(L, ν) = ⊥`. -/

--- a/progress/20260412T081029Z_d1405920.md
+++ b/progress/20260412T081029Z_d1405920.md
@@ -1,0 +1,39 @@
+## Accomplished
+
+- **Added weight decomposition infrastructure for Schur modules** (Proposition5_22_2.lean):
+  - `youngSym_tBasis_weightVector`: Proved that Young symmetrizer maps tensor basis elements to weight vectors. Uses `glTensor_comm_youngSym` (torus commutes with Young symmetrizer) and `glTensorRep_diagUnit_tBasis`.
+  - `glWeightSpace_disjoint`: Proved that weight spaces for distinct ℕ-valued weights are disjoint for any FDRep. Uses `exists_unit_pow_ne` to find a separating torus element.
+  - `glWeightSpace_schurModule_iSup_eq_top`: Sorry'd with documented proof strategy — weight spaces span the Schur module because every element is a linear combination of `c_λ(e_f)` which are weight vectors.
+
+- **Identified key obstacles** for closing the h_dim sorry:
+  1. **FDRep coercion chain**: `SchurModule k N lam` → `FGModuleCat.of k (SchurModuleSubmodule k N lam)` → `SchurModuleSubmodule k N lam` → `TensorPower`. The multi-layer coercion causes issues with `obtain ⟨w, rfl⟩` patterns.
+  2. **iSupIndep for weight spaces**: Mathlib's `iSupIndep_iff_pairwiseDisjoint` requires `Frame` (not available for submodules). The eigenspace-style inductive proof (`iSupIndep_iff_supIndep_of_injOn`) requires `IsModularLattice` + `IsCompactlyGenerated` (both available for `Submodule`) but also an inductive disjointness argument beyond pairwise disjointness.
+  3. **finrank decomposition**: No direct Mathlib lemma for `finrank(⨆ Vᵢ) = ∑ finrank(Vᵢ)` from `iSupIndep` + `iSup = ⊤`.
+
+## Current frontier
+
+- `Proposition5_22_2.lean` has 2 sorry-using declarations (same as before):
+  - `glWeightSpace_schurModule_iSup_eq_top` (new sorry, line 297): weight spaces span
+  - `schurModule_shift_iso_detTwist` (existing sorry, line 329): uses `h_dim` and `iso_of_formalCharacter_eq_schurPoly`
+- `FormalCharacterIso.lean` has 1 sorry (unchanged): `iso_of_formalCharacter_eq_schurPoly` (line 116)
+
+## Overall project progress
+
+- **Items**: ~581/583 sorry-free (unchanged)
+- **Files**: ~275/281 sorry-free (unchanged)
+- New proved lemmas: `youngSym_tBasis_weightVector`, `glWeightSpace_disjoint`
+
+## Next step
+
+1. **Fix the spanning proof** (`glWeightSpace_schurModule_iSup_eq_top`): The proof requires careful handling of FDRep coercions. The mathematical content is clear (use `youngSym_tBasis_weightVector` + `Basis.sum_repr`), but the type coercion chain `FDRep → FGModuleCat → Submodule → TensorPower` needs explicit handling via `set vsub := (v : SchurModuleSubmodule k N lam)`.
+
+2. **Prove weight space independence** (`iSupIndep`): Use `iSupIndep_iff_supIndep_of_injOn` with `InjOn` from `glWeightSpace_finite_support` + `glWeightSpace_disjoint`. Need inductive proof that `Disjoint (glWeightSpace μ) (s.sup glWeightSpace)` for `μ ∉ s`.
+
+3. **Connect to finrank**: Use `DirectSum.IsInternal.collectedBasis` to get a basis indexed by `Σ μ, Basis(weight_space_μ)`, giving `finrank = ∑ finrank(weight spaces)`.
+
+4. **Close h_dim**: From `finrank(L_λ) = eval₁(schurPoly(λ))` and `schurPoly_shift`, get `finrank(L_λ) = finrank(L_{λ+1})`.
+
+## Blockers
+
+- Build time for Proposition5_22_2.lean is ~41 minutes (maxHeartbeats 800000), making iteration slow
+- The FDRep → FGModuleCat → Submodule coercion chain is a recurring friction point


### PR DESCRIPTION
Partial progress on #2263

Session: `d1405920-fa08-460e-9e58-974caaf67bea`

940b5b2 doc: progress file — weight decomposition infrastructure for Schur modules
4ca618e feat: weight decomposition infrastructure for Schur modules
9a7f2f8 feat: WIP weight decomposition for Schur modules (spanning + disjointness)

🤖 Prepared with Claude Code