### PR TITLE
fix: repair CI build failures in InfiniteTypeConstructions and Corollary9_7_3

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/InfiniteTypeConstructions.lean
+++ b/EtingofRepresentationTheory/Chapter6/InfiniteTypeConstructions.lean
@@ -3288,28 +3288,29 @@ theorem acyclic_deg_le_2_posdef {n : ℕ} (adj : Matrix (Fin n) (Fin n) ℤ)
       have : G.neighborFinset v = Finset.univ.filter (adj v · = 1) := by
         ext j; simp only [SimpleGraph.mem_neighborFinset, Finset.mem_filter,
           Finset.mem_univ, true_and]; exact ⟨fun h => h, fun h => h⟩
-      unfold SimpleGraph.degree; rw [this]; exact hdeg2 v
+      unfold SimpleGraph.degree; rw [this]; unfold vertexDegree at hdeg2; convert hdeg2 v
     -- G is connected
     have hG_conn : G.Connected := by
-      constructor; intro u v
-      obtain ⟨path, hhead, hlast, hedges⟩ := hconn u v
-      suffices h : ∀ (l : List (Fin n)) (a b : Fin n),
-          l.head? = some a → l.getLast? = some b →
-          (∀ m, (hm : m + 1 < l.length) →
-            adj (l.get ⟨m, by omega⟩) (l.get ⟨m + 1, hm⟩) = 1) →
-          G.Reachable a b from h path u v hhead hlast hedges
-      intro l; induction l with
-      | nil => intro a _ ha; simp at ha
-      | cons x t ih =>
-        intro a b ha hb hedges'
-        simp at ha; subst ha
-        cases t with
-        | nil => simp at hb; subst hb; exact SimpleGraph.Reachable.refl _
-        | cons y s =>
-          have hxy : G.Adj x y := hedges' 0 (by simp)
-          exact hxy.reachable.trans
-            (ih y b (by simp) hb (fun m hm => hedges' (m + 1)
-              (by simp only [List.length_cons] at hm ⊢; omega)))
+      haveI : Nonempty (Fin n) := ⟨⟨0, by omega⟩⟩
+      exact SimpleGraph.Connected.mk (fun u v => by
+        obtain ⟨path, hhead, hlast, hedges⟩ := hconn u v
+        suffices h : ∀ (l : List (Fin n)) (a b : Fin n),
+            l.head? = some a → l.getLast? = some b →
+            (∀ m, (hm : m + 1 < l.length) →
+              adj (l.get ⟨m, by omega⟩) (l.get ⟨m + 1, hm⟩) = 1) →
+            G.Reachable a b from h path u v hhead hlast hedges
+        intro l; induction l with
+        | nil => intro a _ ha; simp at ha
+        | cons x t ih =>
+          intro a b ha hb hedges'
+          simp at ha; subst ha
+          cases t with
+          | nil => simp at hb; subst hb; exact SimpleGraph.Reachable.refl _
+          | cons y s =>
+            have hxy : G.Adj x y := hedges' 0 (by simp)
+            exact hxy.reachable.trans
+              (ih y b (by simp) hb (fun m hm => hedges' (m + 1)
+                (by simp only [List.length_cons] at hm ⊢; omega))))
     -- G is acyclic (from h_acyclic): any Walk cycle → list cycle → contradiction
     have hG_acyclic : G.IsAcyclic := by
       intro v c hc
@@ -3323,33 +3324,38 @@ theorem acyclic_deg_le_2_posdef {n : ℕ} (adj : Matrix (Fin n) (Fin n) ℤ)
         exact hc.getVert_injOn' (by simp [Set.mem_setOf_eq]; omega)
           (by simp [Set.mem_setOf_eq]; omega) hveq
       -- Consecutive edges
+      have hcycle_len : cycle.length = c.length := by simp [hcycle_def]
+      have hcycle_get : ∀ (i : ℕ) (hi : i < cycle.length),
+          cycle.get ⟨i, hi⟩ = c.getVert i := by
+        intro i hi; simp [hcycle_def]
       have hcycle_edges : ∀ m, (h : m + 1 < cycle.length) →
           adj (cycle.get ⟨m, by omega⟩) (cycle.get ⟨m + 1, h⟩) = 1 := by
         intro m hm
-        simp only [hcycle_def, List.length_ofFn] at hm
-        simp only [hcycle_def, List.get_ofFn]
-        exact c.adj_getVert_succ (by omega)
+        rw [hcycle_get m (by omega), hcycle_get (m + 1) hm]
+        exact c.adj_getVert_succ (by rw [hcycle_len] at hm; omega)
       -- Closing edge: adj (getVert (length-1)) (getVert 0) = 1
-      have hcycle_close : adj (cycle.getLast (by simp; omega))
-          (cycle.get ⟨0, by simp; omega⟩) = 1 := by
-        simp only [hcycle_def]
-        obtain ⟨k, rfl⟩ : ∃ k, c.length = k + 1 := ⟨c.length - 1, by omega⟩
-        rw [List.getLast_ofFn_succ, List.get_ofFn]
-        simp only [Fin.val_last, Fin.val_zero, Fin.cast]
-        have hadj := c.adj_getVert_succ (show k < k + 1 by omega)
-        rw [show k + 1 = c.length from rfl, c.getVert_length] at hadj
-        -- hadj : G.Adj (c.getVert k) v
-        -- need: adj (c.getVert k) (c.getVert 0) = 1
-        rw [c.getVert_zero]; exact (hsymm.apply v (c.getVert k)).trans hadj
+      have hcycle_ne : cycle ≠ [] := by
+        intro h; simp [h] at hcycle_len; omega
+      have hcycle_close : adj (cycle.getLast hcycle_ne)
+          (cycle.get ⟨0, by rw [hcycle_len]; omega⟩) = 1 := by
+        have hlast : cycle.getLast hcycle_ne = c.getVert (c.length - 1) := by
+          rw [List.getLast_eq_getElem]
+          simp [hcycle_def, List.getElem_ofFn]
+        rw [hlast, hcycle_get 0 (by rw [hcycle_len]; omega)]
+        have hadj := c.adj_getVert_succ (show c.length - 1 < c.length by omega)
+        rw [show c.length - 1 + 1 = c.length from by omega, c.getVert_length] at hadj
+        -- hadj : G.Adj (c.getVert (c.length - 1)) v, i.e., adj ... = 1
+        rw [c.getVert_zero]; exact hadj
       -- Apply h_acyclic: closing edge ≠ 1
-      exact h_acyclic cycle (by simp; omega) hcycle_nodup hcycle_edges hcycle_close
+      exact h_acyclic cycle (by rw [hcycle_len]; omega) hcycle_nodup hcycle_edges hcycle_close
     -- G.IsTree: connected + acyclic
     have htree : G.IsTree := ⟨hG_conn, hG_acyclic⟩
     -- Edge count contradiction: tree has n-1 edges, but degree sum = 2n → n edges
     have h_edges := htree.card_edgeFinset
     have h_handshake := G.sum_degrees_eq_twice_card_edges
-    simp only [hG_deg, Finset.sum_const, Fintype.card_fin, smul_eq_mul] at h_handshake
-    rw [Fintype.card_fin] at h_edges
+    simp only [hG_deg, Finset.sum_const, smul_eq_mul, Finset.card_univ,
+      Fintype.card_fin] at h_handshake
+    simp only [Fintype.card_fin] at h_edges
     omega
   obtain ⟨e, he⟩ := h_has_leaf
   exact (acyclic_path_posdef_aux n adj e hsymm hdiag h01 hconn h_acyclic h_deg he).2

--- a/EtingofRepresentationTheory/Chapter9/Corollary9_7_3.lean
+++ b/EtingofRepresentationTheory/Chapter9/Corollary9_7_3.lean
@@ -155,7 +155,7 @@ theorem Etingof.Corollary_9_7_3_i_unique [IsAlgClosed k]
     (A : Type u) [Ring A] [Algebra k A] [Module.Finite k A]
     (B₁ : Type u) [Ring B₁] [Algebra k B₁] [Module.Finite k B₁]
     (B₂ : Type u) [Ring B₂] [Algebra k B₂] [Module.Finite k B₂]
-    (_hB₁ : Etingof.IsBasicAlgebra k B₁) (_hB₂ : Etingof.IsBasicAlgebra k B₂)
+    (_hB₁ : Etingof.IsBasicAlgebra.{u, u, u} k B₁) (_hB₂ : Etingof.IsBasicAlgebra.{u, u, u} k B₂)
     (h₁ : Etingof.KLinearMoritaEquivalent k A B₁)
     (h₂ : Etingof.KLinearMoritaEquivalent k A B₂) :
     Nonempty (B₁ ≃ₐ[k] B₂) := by
@@ -201,7 +201,7 @@ algebra B_A satisfies dim_k B_A ≤ dim_k A.
 theorem Etingof.Corollary_9_7_3_ii [IsAlgClosed k]
     (A : Type u) [Ring A] [Algebra k A] [Module.Finite k A]
     (B : Type u) [Ring B] [Algebra k B] [Module.Finite k B]
-    (_hB : Etingof.IsBasicAlgebra k B)
+    (_hB : Etingof.IsBasicAlgebra.{u, u, u} k B)
     (hMor : Etingof.KLinearMoritaEquivalent k A B) :
     Module.finrank k B ≤ Module.finrank k A := by
   -- By the Morita structural theorem, B ≅ eAe for some idempotent e : A.


### PR DESCRIPTION
## Summary

- Fix two independent build failures that have been breaking main CI since commit `be38a426`
- **InfiniteTypeConstructions.lean**: Fix `constructor` tactic for `SimpleGraph.Connected` (use `Connected.mk`), fix `vertexDegree` unfolding, replace deprecated `List.getLast_eq_get` with `getLast_eq_getElem`, fix dependent type issues in cycle closing edge proof, and fix `Finset.card_univ`/`Fintype.card_fin` simp usage
- **Corollary9_7_3.lean**: Add explicit universe annotations `{u, u, u}` to `IsBasicAlgebra` parameters to match `MoritaStructural`'s signature

Closes #2315

🤖 Prepared with Claude Code