### PR TITLE
fix: close 2 unprovable sorries via embed_t125_in_tree

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/InfiniteTypeConstructions.lean
+++ b/EtingofRepresentationTheory/Chapter6/InfiniteTypeConstructions.lean
@@ -4421,10 +4421,13 @@ private theorem single_branch_leaf_case {n : ℕ}
                   h_leaf_adj ha₃_adj hb₃_adj ha₂_adj hb₂_adj hc₂_adj hd₂_adj he₂_adj
                   ha₃_ne_leaf.symm ha₂_ne_leaf.symm ha₂₃.symm hb₃_ne_v₀ hb₂_ne_v₀
                   hc₂_ne_a₂ hd₂_ne_b₂ he₂_ne_c₂
-              · -- e₂ is leaf: arm2 has length exactly 5. T(1,5,2)=T(1,2,5)=E₈ → posdef → contradiction
-                exfalso
-                apply h_not_posdef
-                sorry -- T(1,5,2) = E₈ is positive definite
+              · -- e₂ is leaf: arm2 has length exactly 5. T(1,5,2)=T(1,2,5)=Ẽ₈ has infinite type.
+                -- The 9 named vertices already form T(1,2,5), so embed them directly.
+                exact embed_t125_in_tree adj hsymm hdiag h01 h_acyclic
+                  v₀ leaf a₃ b₃ a₂ b₂ c₂ d₂ e₂
+                  h_leaf_adj ha₃_adj hb₃_adj ha₂_adj hb₂_adj hc₂_adj hd₂_adj he₂_adj
+                  ha₃_ne_leaf.symm ha₂_ne_leaf.symm ha₂₃.symm hb₃_ne_v₀ hb₂_ne_v₀
+                  hc₂_ne_a₂ hd₂_ne_b₂ he₂_ne_c₂
             · -- d₂ is leaf: arm2 has length exactly 4. T(1,4,2)=T(1,2,4)=E₇ → posdef → contradiction
               exfalso
               apply h_not_posdef
@@ -4474,9 +4477,13 @@ private theorem single_branch_leaf_case {n : ℕ}
                   h_leaf_adj ha₂_adj hb₂_adj ha₃_adj hb₃_adj hc₃_adj hd₃_adj he₃_adj
                   ha₂_ne_leaf.symm ha₃_ne_leaf.symm ha₂₃ hb₂_ne_v₀ hb₃_ne_v₀
                   hc₃_ne_a₃ hd₃_ne_b₃ he₃_ne_c₃
-              · -- e₃ is leaf: arm3 length = 5. T(1,2,5) = E₈ → posdef → contradiction
-                exfalso; apply h_not_posdef
-                sorry -- T(1,2,5) = E₈ is positive definite
+              · -- e₃ is leaf: arm3 length = 5. T(1,2,5) = Ẽ₈ has infinite type.
+                -- The 9 named vertices already form T(1,2,5), so embed them directly.
+                exact embed_t125_in_tree adj hsymm hdiag h01 h_acyclic
+                  v₀ leaf a₂ b₂ a₃ b₃ c₃ d₃ e₃
+                  h_leaf_adj ha₂_adj hb₂_adj ha₃_adj hb₃_adj hc₃_adj hd₃_adj he₃_adj
+                  ha₂_ne_leaf.symm ha₃_ne_leaf.symm ha₂₃ hb₂_ne_v₀ hb₃_ne_v₀
+                  hc₃_ne_a₃ hd₃_ne_b₃ he₃_ne_c₃
             · -- d₃ is leaf: arm3 length = 4. T(1,2,4) = E₇ → posdef → contradiction
               exfalso; apply h_not_posdef
               sorry -- T(1,2,4) = E₇ is positive definite

--- a/progress/2026-04-16T20-08-59Z_f8855eb2.md
+++ b/progress/2026-04-16T20-08-59Z_f8855eb2.md
@@ -1,0 +1,62 @@
+## Accomplished
+
+Partial progress on issue #2325 (PR #2340): closed 2 of 9 sorries in
+`single_branch_leaf_case` (`InfiniteTypeConstructions.lean`).
+
+**Key discovery:** 2 sorries in the original issue were mathematically
+*unprovable as stated*:
+
+- Line 4427 claimed "T(1,5,2) = E₈ is positive definite" — but T(1,5,2)
+  has 1+5+2+1 = 9 vertices, making it affine Ẽ₈ (infinite type), not E₈.
+- Line 4479 claimed "T(1,2,5) = E₈ is positive definite" — same issue
+  (9 vertices = Ẽ₈).
+
+**Fix applied:** replaced both `exfalso; apply h_not_posdef; sorry` blocks
+with direct calls to `embed_t125_in_tree` (from the same file), which
+already produces `¬IsFiniteTypeQuiver` from the same 9 named vertices.
+No positive-definiteness claim is needed — the embedding directly
+refutes finite type.
+
+Commit: `c425de7 fix: close 2 unprovable sorries in single_branch_leaf_case via embed_t125_in_tree`
+
+## Current frontier
+
+7 sorries remain in `single_branch_leaf_case` (all **genuinely** positive
+definite cases that just need the proofs written):
+
+| Line | Case         | Vertices |
+|------|--------------|----------|
+| 4434 | T(1,4,2) = E₇ | 8        |
+| 4438 | T(1,3,2) = E₆ | 7        |
+| 4489 | T(1,2,4) = E₇ | 8        |
+| 4492 | T(1,2,3) = E₆ | 7        |
+| 4495 | T(1,2,2) = D₅ | 6        |
+| 4517 | D-type a₃ leaf | variable |
+| 4533 | D-type a₂ leaf | variable |
+
+Each proof requires (a) showing the quiver vertex set bijects with
+`Fin (rank + 1)` via connectivity, (b) building the graph isomorphism
+from the named vertices to the ADE Cartan form, (c) applying
+`Dn_posDef` / `isDynkinDiagram_of_graph_iso`. Estimated ~100 lines each
+(700+ total) — much larger than the issue's 150-200 line estimate.
+
+## Overall project progress
+
+- Stage 3 (Lean formalization): ongoing, Chapter 6 Dynkin classification
+  nearly complete except these 7 sorries plus a handful elsewhere.
+- Wave 51 summary (PR #2338) is the most recent landscape snapshot.
+
+## Next step
+
+Recommend decomposing #2325 into 7 separate issues (one per remaining
+sorry). The 5 ADE cases should share a helper lemma
+`posdef_via_dynkin_iso` that takes a graph isomorphism to a
+`DynkinType` and concludes positive definiteness. The 2 D-type cases
+need a similar setup but with variable length. Issue #2325 was marked
+`replan` by `coordination create-pr --partial`, so the next planner pass
+should produce those sub-issues.
+
+## Blockers
+
+None. The partial PR is open and auto-merge was rejected (branch
+protection not set). Maintainer will need to review/merge #2340 manually.


### PR DESCRIPTION
Partial progress on #2325

Session: `f8855eb2-964c-4008-8a38-aa0230c23b68`

c425de7 fix: close 2 unprovable sorries in single_branch_leaf_case via embed_t125_in_tree

🤖 Prepared with Claude Code