### PR TITLE
Prove iso_of_glWeightSpace_finrank_eq + Proposition5_22_2 h_dim (Ch5 Schur classification)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/FormalCharacterIso.lean
+++ b/EtingofRepresentationTheory/Chapter5/FormalCharacterIso.lean
@@ -84,6 +84,111 @@ theorem schurPoly_injective (N : ℕ) (lam₁ lam₂ : Fin N → ℕ)
 
 variable (k : Type*) [Field k] [IsAlgClosed k] [CharZero k]
 
+/-- The family of weight spaces of a `GL_N(k)`-representation is sup-independent.
+This follows from `Module.End.independent_iInf_maxGenEigenspace_of_forall_mapsTo`
+applied to the commuting family `diagUnit(i, t)`, combined with the containment
+`glWeightSpace μ ≤ ⨅ p, maxGenEigenspace(f p, χ μ p)` and injectivity of
+`χ : μ ↦ (p ↦ t^(μ i))`. -/
+theorem glWeightSpace_iSupIndep (N : ℕ)
+    (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k)) :
+    iSupIndep (fun μ : Fin N →₀ ℕ => glWeightSpace k N M (fun i => μ i)) := by
+  set f : Fin N × kˣ → Module.End k M := fun p => M.ρ (diagUnit k N p.1 p.2)
+  have h_comm : ∀ (p₁ p₂ : Fin N × kˣ), Commute (f p₁) (f p₂) :=
+    fun p₁ p₂ => rep_diagUnit_commute k N M p₁.1 p₁.2 p₂.1 p₂.2
+  have h_mapsTo : ∀ (p₁ p₂ : Fin N × kˣ) (φ : k),
+      Set.MapsTo (f p₁) ((f p₂).maxGenEigenspace φ) ((f p₂).maxGenEigenspace φ) :=
+    fun p₁ p₂ φ => Module.End.mapsTo_maxGenEigenspace_of_comm (h_comm p₂ p₁) φ
+  have h_indep := Module.End.independent_iInf_maxGenEigenspace_of_forall_mapsTo f h_mapsTo
+  -- Define eigenvalue map χ μ p = (p.2)^(μ p.1) and show injectivity
+  set χ : (Fin N →₀ ℕ) → (Fin N × kˣ → k) :=
+    fun μ p => (p.2 : k) ^ (μ p.1)
+  have h_inj : Function.Injective χ := by
+    intro μ₁ μ₂ heq
+    ext i
+    by_contra hi
+    obtain ⟨t, ht⟩ := exists_unit_pow_ne k hi
+    exact ht (congr_fun heq (i, t))
+  -- Compose with injective χ to reindex; then use mono with the containment
+  exact (h_indep.comp h_inj).mono (fun μ =>
+    le_iInf (fun p => glWeightSpace_le_maxGenEigenspace k N M (fun j => μ j) p.1 p.2))
+
+/-- For a polynomial `GL_N(k)`-representation (i.e., one where the `ℕ`-valued
+weight spaces span the whole module), the finrank equals the sum of weight space
+dimensions over the (finite) support. -/
+theorem finrank_eq_sum_glWeightSpace (N : ℕ)
+    (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
+    (h_top : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M (fun i => μ i) = ⊤) :
+    Module.finrank k M =
+      ∑ μ ∈ (glWeightSpace_finite_support k N M).toFinset,
+        Module.finrank k (glWeightSpace k N M (fun i => μ i)) := by
+  set p : (Fin N →₀ ℕ) → Submodule k M :=
+    fun μ => glWeightSpace k N M (fun i => μ i) with hp_def
+  have h_indep : iSupIndep p := glWeightSpace_iSupIndep k N M
+  have hs_fin : {μ | p μ ≠ ⊥}.Finite := glWeightSpace_finite_support k N M
+  haveI : Fintype {μ // p μ ≠ ⊥} := hs_fin.fintype
+  -- Restrict to nonzero weight spaces; still IsInternal
+  have h_internal : DirectSum.IsInternal (fun μ : {μ // p μ ≠ ⊥} => p μ.val) := by
+    rw [DirectSum.isInternal_ne_bot_iff]
+    exact (DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top _).mpr
+      ⟨h_indep, h_top⟩
+  -- Linear equivalence (⨁ μ : support, p μ) ≃ M via IsInternal
+  let e : DirectSum {μ // p μ ≠ ⊥} (fun μ => (p μ.val : Submodule k M)) ≃ₗ[k] M :=
+    LinearEquiv.ofBijective (DirectSum.coeLinearMap _) h_internal
+  rw [← LinearEquiv.finrank_eq e, Module.finrank_directSum]
+  -- Convert sum over {μ // p μ ≠ ⊥} to sum over hs_fin.toFinset
+  rw [← Finset.sum_attach hs_fin.toFinset (fun μ => Module.finrank k (p μ)),
+    show hs_fin.toFinset.attach = (Finset.univ : Finset {x // x ∈ hs_fin.toFinset})
+      from Finset.attach_eq_univ]
+  -- Now both sides are Fintype sums on subtypes; relate them via an equiv
+  refine Fintype.sum_equiv
+    ({ toFun := fun ⟨x, hx⟩ => ⟨x, (Set.Finite.mem_toFinset hs_fin).mpr hx⟩,
+       invFun := fun ⟨x, hx⟩ => ⟨x, (Set.Finite.mem_toFinset hs_fin).mp hx⟩,
+       left_inv := fun _ => rfl, right_inv := fun _ => rfl } :
+      {μ // p μ ≠ ⊥} ≃ {x // x ∈ hs_fin.toFinset})
+    (fun μ => Module.finrank k (p μ.val))
+    (fun μ => Module.finrank k (p μ.val)) (fun _ => rfl)
+
+/-- Two polynomial `GL_N(k)`-representations with the same formal character have the
+same finrank. For polynomial reps, `finrank M = ∑_μ finrank(M_μ)`, and equal characters
+imply equal weight space dimensions pointwise via `formalCharacter_coeff`. -/
+theorem finrank_eq_of_formalCharacter_eq (N : ℕ)
+    (M₁ M₂ : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
+    (h₁_top : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M₁ (fun i => μ i) = ⊤)
+    (h₂_top : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M₂ (fun i => μ i) = ⊤)
+    (h_char : formalCharacter k N M₁ = formalCharacter k N M₂) :
+    Module.finrank k M₁ = Module.finrank k M₂ := by
+  -- Pointwise equality of weight space dimensions via formalCharacter_coeff
+  have h_ptw : ∀ μ : Fin N →₀ ℕ,
+      Module.finrank k (glWeightSpace k N M₁ (fun i => μ i)) =
+      Module.finrank k (glWeightSpace k N M₂ (fun i => μ i)) := by
+    intro μ
+    have h₁ := formalCharacter_coeff k N M₁ μ
+    have h₂ := formalCharacter_coeff k N M₂ μ
+    have h_ℚ : ((Module.finrank k (glWeightSpace k N M₁ (fun i => μ i)) : ℚ) =
+        (Module.finrank k (glWeightSpace k N M₂ (fun i => μ i)) : ℚ)) := by
+      rw [← h₁, ← h₂, h_char]
+    exact_mod_cast h_ℚ
+  -- Both finranks equal sums over respective supports; extend to union of supports
+  rw [finrank_eq_sum_glWeightSpace k N M₁ h₁_top,
+      finrank_eq_sum_glWeightSpace k N M₂ h₂_top]
+  set S₁ := (glWeightSpace_finite_support k N M₁).toFinset
+  set S₂ := (glWeightSpace_finite_support k N M₂).toFinset
+  have h_extend : ∀ (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
+      (S : Finset (Fin N →₀ ℕ))
+      (hS : (glWeightSpace_finite_support k N M).toFinset ⊆ S),
+      ∑ μ ∈ (glWeightSpace_finite_support k N M).toFinset,
+          Module.finrank k (glWeightSpace k N M (fun i => μ i)) =
+        ∑ μ ∈ S, Module.finrank k (glWeightSpace k N M (fun i => μ i)) := by
+    intro M S hS
+    apply Finset.sum_subset hS
+    intro μ _ hμ
+    rw [Set.Finite.mem_toFinset] at hμ
+    simp only [Set.mem_setOf_eq, not_not] at hμ
+    rw [hμ, finrank_bot]
+  rw [h_extend M₁ (S₁ ∪ S₂) Finset.subset_union_left,
+      h_extend M₂ (S₁ ∪ S₂) Finset.subset_union_right]
+  exact Finset.sum_congr rfl (fun μ _ => h_ptw μ)
+
 /-- A `GL_N(k)`-representation whose formal character equals a Schur polynomial
 `S_λ` and whose dimension matches the Schur module is isomorphic to `L_λ`.
 

--- a/EtingofRepresentationTheory/Chapter5/Proposition5_22_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Proposition5_22_2.lean
@@ -290,16 +290,16 @@ private lemma youngSym_tBasis_weightVector (N : ℕ) (lam : Fin N → ℕ)
   rw [glTensor_comm_youngSym k N lam (diagUnit k N i t),
     LinearMap.comp_apply, glTensorRep_diagUnit_tBasis, map_smul]
 
-/-- Weight spaces of the Schur module span the entire module.
-Every element of `L_λ = range(c_λ)` is a sum of weight vectors since each
-`c_λ(e_f)` lies in the weight space for `tensorWeight(f)` (because `c_λ`
-commutes with the torus action). -/
 /-- The weight of a tensor coloring f: counts occurrences of each color. -/
 private def colorWeight (N : ℕ) {n : ℕ} (f : Fin n → Fin N) : Fin N →₀ ℕ where
   toFun i := (Finset.univ.filter (fun j => f j = i)).card
   support := Finset.univ.filter (fun i => 0 < (Finset.univ.filter (fun j => f j = i)).card)
   mem_support_toFun i := by simp [Finset.card_pos, Finset.filter_nonempty_iff]
 
+/-- Weight spaces of the Schur module span the entire module.
+Every element of `L_λ = range(c_λ)` is a sum of weight vectors since each
+`c_λ(e_f)` lies in the weight space for `tensorWeight(f)` (because `c_λ`
+commutes with the torus action). -/
 private theorem glWeightSpace_schurModule_iSup_eq_top (N : ℕ) (lam : Fin N → ℕ) :
     ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N (SchurModule k N lam) (fun i => μ i) = ⊤ := by
   set n := ∑ j, lam j
@@ -322,14 +322,13 @@ private theorem glWeightSpace_schurModule_iSup_eq_top (N : ℕ) (lam : Fin N →
   rw [eq_top_iff]
   intro v _
   obtain ⟨w, hw⟩ := v.property
-  -- v.val = c(w) = c(∑ coeff ��� B f) = ∑ coeff • c(B f)
+  -- v.val = c(w) = c(∑ coeff • B f) = ∑ coeff • c(B f)
   have hv_sum : v =
-      ∑ f ∈ (B.repr w).support,
-        (B.repr w f) • (⟨c (B f), ⟨B f, rfl⟩⟩ : ↥(SchurModuleSubmodule k N lam)) := by
+      ∑ f, (B.repr w f) • (⟨c (B f), ⟨B f, rfl⟩⟩ : ↥(SchurModuleSubmodule k N lam)) := by
     apply Subtype.ext
     simp only [Submodule.coe_sum, Submodule.coe_smul_of_tower]
-    rw [show v.val = c w from hw.symm,
-      show w = ∑ f ∈ (B.repr w).support, B.repr w f • B f from (B.sum_repr w).symm]
+    rw [show v.val = c w from hw.symm]
+    conv_lhs => rw [show w = ∑ x, B.repr w x • B x from (B.sum_repr w).symm]
     simp only [map_sum, map_smul]
   rw [hv_sum]
   exact Submodule.sum_mem S (fun f _ => Submodule.smul_mem S _ (h_gen_in_S f))
@@ -377,7 +376,31 @@ theorem schurModule_shift_iso_detTwist (N : ℕ) (lam : Fin N → ℕ) (hlam : A
   -- dim L_λ = dim L_{λ+(1,...,1)}.
   have h_dim : Module.finrank k (FDRep.of (detTwistedSchurModuleRep k N lam)) =
       Module.finrank k (SchurModule k N (fun i => lam i + 1)) := by
-    sorry
+    -- The SchurModule for λ+1 is polynomial (ℕ-valued weight spaces span).
+    have h₂_top : ⨆ (μ : Fin N →₀ ℕ),
+        glWeightSpace k N (SchurModule k N (fun i => lam i + 1)) (fun i => μ i) = ⊤ :=
+      glWeightSpace_schurModule_iSup_eq_top k N (fun i => lam i + 1)
+    -- The det-twisted rep is polynomial: its weight spaces at (μ+1) match the SchurModule's
+    -- weight spaces at μ via `glWeightSpace_detTwist_shift`, and the SchurModule is polynomial.
+    have h₁_top : ⨆ (μ : Fin N →₀ ℕ),
+        glWeightSpace k N (FDRep.of (detTwistedSchurModuleRep k N lam))
+          (fun i => μ i) = ⊤ := by
+      rw [eq_top_iff, ← glWeightSpace_schurModule_iSup_eq_top k N lam]
+      apply iSup_le
+      intro μ
+      -- Map μ to its shift (i ↦ μ i + 1) as a Fin N →₀ ℕ
+      set μ_shift : Fin N →₀ ℕ := Finsupp.equivFunOnFinite.symm (fun i => μ i + 1) with hμs
+      refine le_trans ?_ (le_iSup _ μ_shift)
+      -- glWeightSpace_detTwist_shift gives equality (M₁ at μ+1) = (SchurModule at μ)
+      have h_shift := glWeightSpace_detTwist_shift k N lam (fun i => μ i)
+      have h_apply : (fun i => μ_shift i) = (fun i => μ i + 1) := by
+        ext i; simp [μ_shift]
+      rw [h_apply, h_shift]
+    -- Formal characters agree (the det-twist shifts the character by the product of Xᵢ)
+    have h_char_eq : formalCharacter k N (FDRep.of (detTwistedSchurModuleRep k N lam)) =
+        formalCharacter k N (SchurModule k N (fun i => lam i + 1)) :=
+      formalCharacter_detTwist_eq_shift k N lam hlam
+    exact finrank_eq_of_formalCharacter_eq k N _ _ h₁_top h₂_top h_char_eq
   -- By iso_of_formalCharacter_eq_schurPoly, the det-twisted rep ≅ SchurModule k N (λ+1)
   obtain ⟨iso⟩ := iso_of_formalCharacter_eq_schurPoly k N (fun i => lam i + 1) hlam' _ h_char h_dim
   exact ⟨iso.symm⟩

--- a/progress/20260416T214216Z_78b63b6f.md
+++ b/progress/20260416T214216Z_78b63b6f.md
@@ -1,0 +1,48 @@
+## Accomplished
+
+- Claimed issue #2332 ("Prove iso_of_glWeightSpace_finrank_eq + Proposition5_22_2 h_dim (Ch5 Schur classification)")
+- **Proved `h_dim`** in `Proposition5_22_2.lean` (line 380): the det-twisted Schur module
+  `FDRep.of (detTwistedSchurModuleRep k N lam)` has the same `finrank` as
+  `SchurModule k N (fun i => lam i + 1)`. Proof strategy:
+  1. Show both reps are polynomial (weight spaces span via `iSup = top`).
+  2. Show their formal characters agree via `formalCharacter_detTwist_eq_shift`.
+  3. Conclude equal finrank via new `finrank_eq_of_formalCharacter_eq` helper.
+- **Added 3 helper theorems** to `FormalCharacterIso.lean`:
+  - `glWeightSpace_iSupIndep`: weight spaces of a GL_N-rep are sup-independent
+    (via `Module.End.independent_iInf_maxGenEigenspace_of_forall_mapsTo`)
+  - `finrank_eq_sum_glWeightSpace`: finrank equals sum of weight space dims for
+    polynomial reps (using `DirectSum.IsInternal`)
+  - `finrank_eq_of_formalCharacter_eq`: two polynomial GL_N-reps with the same
+    formal character have the same finrank
+- **Fixed 2 pre-existing build regressions** in `Proposition5_22_2.lean`:
+  - Orphaned doc comment at line 293-296 (introduced in PR #2320)
+  - `Basis.sum_repr` API change: sum over `Finset.univ` not `support`; fixed with
+    `conv_lhs` to avoid rewriting `B.repr w` on RHS
+- **Deferred `iso_of_formalCharacter_eq_schurPoly`**: requires GL_N-equivariant
+  complete reducibility (Schur-Weyl duality), which is major missing infrastructure
+  beyond this issue's scope. Left as `sorry`.
+- Build succeeds: `lake build EtingofRepresentationTheory.Chapter5.Proposition5_22_2`
+  completes with only the deferred `iso_of_formalCharacter_eq_schurPoly` sorry.
+
+## Current frontier
+
+- `iso_of_formalCharacter_eq_schurPoly` (FormalCharacterIso.lean:221) remains sorry.
+  It requires complete reducibility for GL_N polynomial representations (Schur-Weyl
+  duality), which is not yet formalized in this project.
+
+## Overall project progress
+
+- Chapter 5: `h_dim` sorry eliminated. Remaining sorries: `iso_of_formalCharacter_eq_schurPoly`
+  (deferred, needs Schur-Weyl) and `garnir_twisted_in_lower_span` (covered by #2317/#2323).
+- Net sorry change: 1 sorry eliminated in Proposition5_22_2.lean.
+
+## Next step
+
+- File a follow-up issue for `iso_of_formalCharacter_eq_schurPoly` scoped to
+  Schur-Weyl / complete reducibility infrastructure.
+- Submit partial PR for #2332 (h_dim proved, iso deferred).
+
+## Blockers
+
+- `iso_of_formalCharacter_eq_schurPoly` blocked on Schur-Weyl duality infrastructure
+  (not a blocker for this PR).


### PR DESCRIPTION
Partial progress on #2332

Session: `78b63b6f-fdca-4af5-a831-ae985cc2882a`

04f21ea feat: prove h_dim + fix pre-existing build regressions in Proposition5_22_2

🤖 Prepared with Claude Code