### PR TITLE
feat: prove T(1,2,2)=E₆ posdef in single_branch_leaf_case

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/InfiniteTypeConstructions.lean
+++ b/EtingofRepresentationTheory/Chapter6/InfiniteTypeConstructions.lean
@@ -4132,7 +4132,8 @@ private lemma tree_two_leaf_posdef {n : ℕ}
     rw [h_decomp]
     nlinarith [sq_nonneg (V - L - A), sq_nonneg (L - A)]
 
-set_option maxHeartbeats 800000 in
+set_option maxHeartbeats 6400000 in
+-- T(1,2,2) posdef proof requires large simp for QF expansion over 6 vertices
 /-- In a tree with unique degree-3 vertex, if some arm has length 1 (a leaf neighbor),
     and the Cartan form is not positive definite, the tree has infinite representation type.
     Handles T(1,q,r): embeds Ẽ₇ if q,r ≥ 3; T(1,2,5) if q=2, r≥5; ADE contradiction otherwise. -/
@@ -4684,7 +4685,393 @@ private theorem single_branch_leaf_case {n : ℕ}
             sorry -- T(1,2,3) = E₆ is positive definite
         · -- b₃ is also leaf: arm3 length = 2. T(1,2,2) = D₅ → posdef → contradiction
           exfalso; apply h_not_posdef
-          sorry -- T(1,2,2) = D₅ is positive definite
+          -- T(1,2,2) positive definiteness proof
+          -- Step 1: Establish b₃ has degree 1
+          have hb₃_deg1 : vertexDegree adj b₃ = 1 := by
+            have := h_deg_le2 b₃ hb₃_ne_v₀; omega
+          -- Step 2: Unique neighbor lists for each vertex
+          have hv₀_nbrs : ∀ j, adj v₀ j = 1 →
+              j = leaf ∨ j = a₂ ∨ j = a₃ := by
+            intro j hj
+            by_cases hjl : j = leaf
+            · exact Or.inl hjl
+            · have : j ∈ S₀.erase leaf :=
+                Finset.mem_erase.mpr
+                  ⟨hjl, Finset.mem_filter.mpr ⟨Finset.mem_univ _, hj⟩⟩
+              rw [hS₀_eq] at this
+              rcases Finset.mem_insert.mp this with rfl | hm
+              · exact Or.inr (Or.inl rfl)
+              · exact Or.inr (Or.inr (Finset.mem_singleton.mp hm))
+          have hleaf_nbrs : ∀ j, adj leaf j = 1 → j = v₀ := by
+            intro j hj; by_contra hne
+            have : 2 ≤ vertexDegree adj leaf := by
+              have h1 : v₀ ∈ Finset.univ.filter (adj leaf · = 1) :=
+                Finset.mem_filter.mpr ⟨Finset.mem_univ v₀,
+                  (adj_comm leaf v₀).trans h_leaf_adj⟩
+              have h2 : j ∈ Finset.univ.filter (adj leaf · = 1) :=
+                Finset.mem_filter.mpr ⟨Finset.mem_univ j, hj⟩
+              calc 2 = ({v₀, j} : Finset _).card :=
+                    (Finset.card_pair (Ne.symm hne)).symm
+                _ ≤ _ := Finset.card_le_card fun x hx => by
+                  simp only [Finset.mem_insert,
+                    Finset.mem_singleton] at hx
+                  rcases hx with rfl | rfl <;> assumption
+            omega
+          have ha₂_nbrs : ∀ j, adj a₂ j = 1 → j = v₀ ∨ j = b₂ := by
+            intro j hj
+            by_cases hjv : j = v₀
+            · exact Or.inl hjv
+            · right
+              have hmem : j ∈ (Finset.univ.filter
+                  (adj a₂ · = 1)).erase v₀ :=
+                Finset.mem_erase.mpr
+                  ⟨hjv, Finset.mem_filter.mpr
+                    ⟨Finset.mem_univ _, hj⟩⟩
+              rw [hb₂_eq] at hmem
+              exact Finset.mem_singleton.mp hmem
+          have hb₂_nbrs : ∀ j, adj b₂ j = 1 → j = a₂ := by
+            intro j hj; by_contra hne
+            have : 2 ≤ vertexDegree adj b₂ := by
+              have h1 : a₂ ∈ Finset.univ.filter (adj b₂ · = 1) :=
+                Finset.mem_filter.mpr ⟨Finset.mem_univ a₂,
+                  (adj_comm b₂ a₂).trans hb₂_adj⟩
+              have h2 : j ∈ Finset.univ.filter (adj b₂ · = 1) :=
+                Finset.mem_filter.mpr ⟨Finset.mem_univ j, hj⟩
+              calc 2 = ({a₂, j} : Finset _).card :=
+                    (Finset.card_pair (Ne.symm hne)).symm
+                _ ≤ _ := Finset.card_le_card fun x hx => by
+                  simp only [Finset.mem_insert,
+                    Finset.mem_singleton] at hx
+                  rcases hx with rfl | rfl <;> assumption
+            omega
+          have ha₃_nbrs : ∀ j, adj a₃ j = 1 → j = v₀ ∨ j = b₃ := by
+            intro j hj
+            by_cases hjv : j = v₀
+            · exact Or.inl hjv
+            · right
+              have hmem : j ∈ (Finset.univ.filter
+                  (adj a₃ · = 1)).erase v₀ :=
+                Finset.mem_erase.mpr
+                  ⟨hjv, Finset.mem_filter.mpr
+                    ⟨Finset.mem_univ _, hj⟩⟩
+              rw [hb₃_eq] at hmem
+              exact Finset.mem_singleton.mp hmem
+          have hb₃_nbrs : ∀ j, adj b₃ j = 1 → j = a₃ := by
+            intro j hj; by_contra hne
+            have : 2 ≤ vertexDegree adj b₃ := by
+              have h1 : a₃ ∈ Finset.univ.filter (adj b₃ · = 1) :=
+                Finset.mem_filter.mpr ⟨Finset.mem_univ a₃,
+                  (adj_comm b₃ a₃).trans hb₃_adj⟩
+              have h2 : j ∈ Finset.univ.filter (adj b₃ · = 1) :=
+                Finset.mem_filter.mpr ⟨Finset.mem_univ j, hj⟩
+              calc 2 = ({a₃, j} : Finset _).card :=
+                    (Finset.card_pair (Ne.symm hne)).symm
+                _ ≤ _ := Finset.card_le_card fun x hx => by
+                  simp only [Finset.mem_insert,
+                    Finset.mem_singleton] at hx
+                  rcases hx with rfl | rfl <;> assumption
+            omega
+          -- Step 3: Named set is closed under adjacency
+          have h_closed : ∀ i j,
+              (i = v₀ ∨ i = leaf ∨ i = a₂ ∨ i = b₂ ∨
+                i = a₃ ∨ i = b₃) →
+              adj i j = 1 →
+              (j = v₀ ∨ j = leaf ∨ j = a₂ ∨ j = b₂ ∨
+                j = a₃ ∨ j = b₃) := by
+            intro i j hi hadj
+            rcases hi with rfl | rfl | rfl | rfl | rfl | rfl
+            · rcases hv₀_nbrs j hadj with h | h | h
+              · exact Or.inr (Or.inl h)
+              · exact Or.inr (Or.inr (Or.inl h))
+              · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inl h))))
+            · exact Or.inl (hleaf_nbrs j hadj)
+            · rcases ha₂_nbrs j hadj with h | h
+              · exact Or.inl h
+              · exact Or.inr (Or.inr (Or.inr (Or.inl h)))
+            · exact Or.inr (Or.inr (Or.inl (hb₂_nbrs j hadj)))
+            · rcases ha₃_nbrs j hadj with h | h
+              · exact Or.inl h
+              · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr h))))
+            · exact .inr (.inr (.inr (.inr (.inl
+                (hb₃_nbrs j hadj)))))
+          -- Step 4: Every vertex is named
+          have h_all_named : ∀ i : Fin n,
+              i = v₀ ∨ i = leaf ∨ i = a₂ ∨ i = b₂ ∨
+                i = a₃ ∨ i = b₃ := by
+            intro i
+            obtain ⟨path, hhead, hlast, hedges⟩ := hconn v₀ i
+            have hne : path ≠ [] := by
+              intro h; rw [h] at hhead; simp at hhead
+            have hpos : 0 < path.length := by
+              cases path with
+              | nil => exact absurd rfl hne
+              | cons _ _ => simp
+            have h_elts : ∀ (k : ℕ) (hk : k < path.length),
+                path.get ⟨k, hk⟩ = v₀ ∨
+                path.get ⟨k, hk⟩ = leaf ∨
+                path.get ⟨k, hk⟩ = a₂ ∨
+                path.get ⟨k, hk⟩ = b₂ ∨
+                path.get ⟨k, hk⟩ = a₃ ∨
+                path.get ⟨k, hk⟩ = b₃ := by
+              intro k
+              induction k with
+              | zero =>
+                intro hk; left
+                cases path with
+                | nil => simp at hk
+                | cons a _ => exact Option.some.inj hhead
+              | succ k ih =>
+                intro hk
+                exact h_closed _ _
+                  (ih (by omega)) (hedges k (by omega))
+            have hlast_val : path.getLast hne = i := by
+              rw [List.getLast?_eq_some_getLast hne] at hlast
+              exact Option.some.inj hlast
+            have := h_elts (path.length - 1) (by omega)
+            rwa [show path.get ⟨path.length - 1, by omega⟩ =
+                path.getLast hne from by
+              rw [List.getLast_eq_getElem]; rfl,
+              hlast_val] at this
+          -- Step 5: Additional distinctness facts
+          have ha₂_ne_b₂ := ne_of_adj' a₂ b₂ hb₂_adj
+          have ha₃_ne_b₃ := ne_of_adj' a₃ b₃ hb₃_adj
+          have hb₂_ne_leaf : b₂ ≠ leaf := by
+            intro heq
+            have : adj leaf a₂ = 1 :=
+              heq ▸ (adj_comm b₂ a₂).trans hb₂_adj
+            exact ha₂_ne_v₀ (hleaf_nbrs a₂ this)
+          have hb₃_ne_leaf : b₃ ≠ leaf := by
+            intro heq
+            have : adj leaf a₃ = 1 :=
+              heq ▸ (adj_comm b₃ a₃).trans hb₃_adj
+            exact ha₃_ne_v₀ (hleaf_nbrs a₃ this)
+          have ha₃a₂_zero : adj a₃ a₂ = 0 :=
+            acyclic_path_nonadj adj hsymm h01 h_acyclic
+              [a₂, v₀, a₃]
+              (by simp)
+              (by simp only [List.nodup_cons, List.mem_cons,
+                    List.not_mem_nil, not_or,
+                    not_false_eq_true, List.nodup_nil,
+                    and_self, and_true]
+                  exact ⟨⟨ha₂_ne_v₀, ha₂₃⟩, Ne.symm ha₃_ne_v₀⟩)
+              (by intro k hk
+                  have hk3 : k + 1 < 3 := by
+                    simpa using hk
+                  have : k = 0 ∨ k = 1 := by omega
+                  rcases this with rfl | rfl
+                  · exact (adj_comm a₂ v₀).trans ha₂_adj
+                  · exact ha₃_adj)
+          have hb₂_ne_a₃ : b₂ ≠ a₃ := by
+            intro heq
+            have : adj a₃ a₂ = 1 :=
+              heq ▸ (adj_comm b₂ a₂).trans hb₂_adj
+            linarith [ha₃a₂_zero]
+          have ha₂_ne_b₃ : a₂ ≠ b₃ := by
+            intro heq
+            have : adj a₃ a₂ = 1 := heq ▸ hb₃_adj
+            linarith [ha₃a₂_zero]
+          have hb₂_ne_b₃ : b₂ ≠ b₃ := by
+            intro heq
+            have h1 : a₂ ∈ Finset.univ.filter
+                (adj b₂ · = 1) :=
+              Finset.mem_filter.mpr ⟨Finset.mem_univ a₂,
+                (adj_comm b₂ a₂).trans hb₂_adj⟩
+            have h2 : a₃ ∈ Finset.univ.filter
+                (adj b₂ · = 1) :=
+              Finset.mem_filter.mpr ⟨Finset.mem_univ a₃,
+                heq ▸ (adj_comm b₃ a₃).trans hb₃_adj⟩
+            have : 2 ≤ vertexDegree adj b₂ :=
+              calc 2 = ({a₂, a₃} : Finset _).card :=
+                    (Finset.card_pair ha₂₃).symm
+                _ ≤ _ := Finset.card_le_card fun x hx => by
+                  simp only [Finset.mem_insert,
+                    Finset.mem_singleton] at hx
+                  rcases hx with rfl | rfl <;> assumption
+            omega
+          -- Step 6: Finset.univ equals the 6 named vertices
+          have huniv : (Finset.univ : Finset (Fin n)) =
+              {v₀, leaf, a₂, b₂, a₃, b₃} := by
+            ext i
+            simp only [Finset.mem_univ, true_iff,
+              Finset.mem_insert, Finset.mem_singleton]
+            rcases h_all_named i with
+                rfl | rfl | rfl | rfl | rfl | rfl <;>
+              simp
+          have h_sum : ∀ f : Fin n → ℤ,
+              ∑ i, f i = f v₀ + f leaf + f a₂ +
+                f b₂ + f a₃ + f b₃ := by
+            intro f
+            change Finset.sum Finset.univ f = _
+            rw [huniv]
+            rw [Finset.sum_insert (show v₀ ∉
+                ({leaf, a₂, b₂, a₃, b₃} : Finset _) from by
+              simp only [Finset.mem_insert,
+                Finset.mem_singleton, not_or]
+              exact ⟨Ne.symm hleaf_ne_v₀,
+                Ne.symm ha₂_ne_v₀, Ne.symm hb₂_ne_v₀,
+                Ne.symm ha₃_ne_v₀, Ne.symm hb₃_ne_v₀⟩)]
+            rw [Finset.sum_insert (show leaf ∉
+                ({a₂, b₂, a₃, b₃} : Finset _) from by
+              simp only [Finset.mem_insert,
+                Finset.mem_singleton, not_or]
+              exact ⟨Ne.symm ha₂_ne_leaf,
+                Ne.symm hb₂_ne_leaf,
+                Ne.symm ha₃_ne_leaf,
+                Ne.symm hb₃_ne_leaf⟩)]
+            rw [Finset.sum_insert (show a₂ ∉
+                ({b₂, a₃, b₃} : Finset _) from by
+              simp only [Finset.mem_insert,
+                Finset.mem_singleton, not_or]
+              exact ⟨ha₂_ne_b₂, ha₂₃, ha₂_ne_b₃⟩)]
+            rw [Finset.sum_insert (show b₂ ∉
+                ({a₃, b₃} : Finset _) from by
+              simp only [Finset.mem_insert,
+                Finset.mem_singleton, not_or]
+              exact ⟨hb₂_ne_a₃, hb₂_ne_b₃⟩)]
+            rw [Finset.sum_pair ha₃_ne_b₃]
+            ring
+          -- Step 7: adj row equations
+          have hv₀_adj_eq : ∀ j,
+              adj v₀ j =
+                if j = leaf ∨ j = a₂ ∨ j = a₃
+                then 1 else 0 := by
+            intro j; split_ifs with h
+            · rcases h with rfl | rfl | rfl
+              · exact h_leaf_adj
+              · exact ha₂_adj
+              · exact ha₃_adj
+            · push_neg at h; obtain ⟨h1, h2, h3⟩ := h
+              rcases h01 v₀ j with h | h
+              · exact h
+              · exfalso
+                rcases hv₀_nbrs j h with rfl | rfl | rfl
+                · exact h1 rfl
+                · exact h2 rfl
+                · exact h3 rfl
+          have hleaf_adj_eq : ∀ j,
+              adj leaf j = if j = v₀ then 1 else 0 := by
+            intro j; split_ifs with h
+            · rw [h]
+              exact (hsymm.apply v₀ leaf).trans h_leaf_adj
+            · rcases h01 leaf j with h' | h'
+              · exact h'
+              · exact absurd (hleaf_nbrs j h') h
+          have ha₂_adj_eq : ∀ j,
+              adj a₂ j =
+                if j = v₀ ∨ j = b₂ then 1 else 0 := by
+            intro j; split_ifs with h
+            · rcases h with hj | hj
+              · rw [hj]; exact (hsymm.apply v₀ a₂).trans ha₂_adj
+              · rw [hj]; exact hb₂_adj
+            · push_neg at h; obtain ⟨h1, h2⟩ := h
+              rcases h01 a₂ j with h' | h'
+              · exact h'
+              · exfalso
+                rcases ha₂_nbrs j h' with rfl | rfl
+                · exact h1 rfl
+                · exact h2 rfl
+          have hb₂_adj_eq : ∀ j,
+              adj b₂ j = if j = a₂ then 1 else 0 := by
+            intro j; split_ifs with h
+            · rw [h]
+              exact (hsymm.apply a₂ b₂).trans hb₂_adj
+            · rcases h01 b₂ j with h' | h'
+              · exact h'
+              · exact absurd (hb₂_nbrs j h') h
+          have ha₃_adj_eq : ∀ j,
+              adj a₃ j =
+                if j = v₀ ∨ j = b₃ then 1 else 0 := by
+            intro j; split_ifs with h
+            · rcases h with hj | hj
+              · rw [hj]; exact (hsymm.apply v₀ a₃).trans ha₃_adj
+              · rw [hj]; exact hb₃_adj
+            · push_neg at h; obtain ⟨h1, h2⟩ := h
+              rcases h01 a₃ j with h' | h'
+              · exact h'
+              · exfalso
+                rcases ha₃_nbrs j h' with rfl | rfl
+                · exact h1 rfl
+                · exact h2 rfl
+          have hb₃_adj_eq : ∀ j,
+              adj b₃ j = if j = a₃ then 1 else 0 := by
+            intro j; split_ifs with h
+            · rw [h]
+              exact (hsymm.apply a₃ b₃).trans hb₃_adj
+            · rcases h01 b₃ j with h' | h'
+              · exact h'
+              · exact absurd (hb₃_nbrs j h') h
+          -- Step 8: Expand QF as polynomial
+          intro x hx
+          set V := x v₀; set L := x leaf; set A₂ := x a₂
+          set B₂ := x b₂; set A₃ := x a₃; set B₃ := x b₃
+          have h_qf : QF adj x =
+              2 * V ^ 2 + 2 * L ^ 2 + 2 * A₂ ^ 2 +
+              2 * B₂ ^ 2 + 2 * A₃ ^ 2 + 2 * B₃ ^ 2 -
+              2 * V * L - 2 * V * A₂ - 2 * A₂ * B₂ -
+              2 * V * A₃ - 2 * A₃ * B₃ := by
+            unfold QF
+            simp only [dotProduct, Matrix.mulVec, h_sum,
+              Matrix.sub_apply, Matrix.smul_apply,
+              Matrix.one_apply, hdiag,
+              hv₀_adj_eq, hleaf_adj_eq, ha₂_adj_eq,
+              hb₂_adj_eq, ha₃_adj_eq, hb₃_adj_eq,
+              eq_self_iff_true, ite_true, ite_false,
+              hleaf_ne_v₀, Ne.symm hleaf_ne_v₀,
+              ha₂_ne_v₀, Ne.symm ha₂_ne_v₀,
+              ha₃_ne_v₀, Ne.symm ha₃_ne_v₀,
+              hb₂_ne_v₀, Ne.symm hb₂_ne_v₀,
+              hb₃_ne_v₀, Ne.symm hb₃_ne_v₀,
+              ha₂_ne_leaf, Ne.symm ha₂_ne_leaf,
+              ha₃_ne_leaf, Ne.symm ha₃_ne_leaf,
+              hb₂_ne_leaf, Ne.symm hb₂_ne_leaf,
+              hb₃_ne_leaf, Ne.symm hb₃_ne_leaf,
+              ha₂₃, Ne.symm ha₂₃,
+              ha₂_ne_b₂, Ne.symm ha₂_ne_b₂,
+              ha₂_ne_b₃, Ne.symm ha₂_ne_b₃,
+              hb₂_ne_a₃, Ne.symm hb₂_ne_a₃,
+              hb₂_ne_b₃, Ne.symm hb₂_ne_b₃,
+              ha₃_ne_b₃, Ne.symm ha₃_ne_b₃,
+              ite_mul, one_mul, zero_mul,
+              true_or, or_true, false_or, or_false,
+              mul_one, mul_zero, sub_zero, zero_sub]
+            ring
+          -- Step 9: SoS positivity from LDL^T decomposition
+          rw [show dotProduct x
+              ((2 • (1 : Matrix (Fin n) (Fin n) ℤ) - adj).mulVec
+                x) = QF adj x from rfl, h_qf]
+          suffices h60 :
+              0 < 30 * (2 * V - L - A₂ - A₃) ^ 2 +
+              10 * (3 * L - A₂ - A₃) ^ 2 +
+              5 * (4 * A₂ - 3 * B₂ - 2 * A₃) ^ 2 +
+              3 * (5 * B₂ - 2 * A₃) ^ 2 +
+              3 * (4 * A₃ - 5 * B₃) ^ 2 +
+              45 * B₃ ^ 2 by nlinarith
+          by_contra h_le; push_neg at h_le
+          have h_all_zero :
+              2 * V - L - A₂ - A₃ = 0 ∧
+              3 * L - A₂ - A₃ = 0 ∧
+              4 * A₂ - 3 * B₂ - 2 * A₃ = 0 ∧
+              5 * B₂ - 2 * A₃ = 0 ∧
+              4 * A₃ - 5 * B₃ = 0 ∧ B₃ = 0 := by
+            refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩ <;>
+            nlinarith [sq_nonneg (2 * V - L - A₂ - A₃),
+              sq_nonneg (3 * L - A₂ - A₃),
+              sq_nonneg (4 * A₂ - 3 * B₂ - 2 * A₃),
+              sq_nonneg (5 * B₂ - 2 * A₃),
+              sq_nonneg (4 * A₃ - 5 * B₃),
+              sq_nonneg B₃]
+          obtain ⟨h1, h2, h3, h4, h5, h6⟩ := h_all_zero
+          have hB₃ : B₃ = 0 := h6
+          have hA₃ : A₃ = 0 := by nlinarith
+          have hB₂ : B₂ = 0 := by nlinarith
+          have hA₂ : A₂ = 0 := by nlinarith
+          have hL : L = 0 := by nlinarith
+          have hV : V = 0 := by nlinarith
+          apply hx; ext i
+          rcases h_all_named i with
+              rfl | rfl | rfl | rfl | rfl | rfl <;>
+            [exact hV; exact hL; exact hA₂;
+             exact hB₂; exact hA₃; exact hB₃]
     · -- a₃ has degree 1 (leaf): T(1,≥2,1) = D-type → positive definite → contradiction
       -- a₂ has degree 2, a₃ has degree 1.
       -- v₀ has three neighbors: leaf (deg 1), a₂ (deg 2), a₃ (deg 1).


### PR DESCRIPTION
Closes #2343

## Summary
- Replace sorry with complete proof that the Cartan form of the T(1,2,2) tree graph is positive definite
- Proof uses sum-of-squares decomposition via LDL^T factorization of the 6×6 Cartan matrix
- Establishes all 6 vertices, their adjacency/distinctness, expands QF via `dotProduct`/`mulVec`, then shows `60·QF(adj,x) = Σ squares` with equality iff x=0

🤖 Prepared with Claude Code