### PR TITLE
doc: report etilde7Rep decomposability bug (#2404)

### DIFF
--- a/progress/2026-04-18T05-30-00Z.md
+++ b/progress/2026-04-18T05-30-00Z.md
@@ -1,0 +1,32 @@
+## Accomplished
+
+- Claimed issue #2394 (Ẽ₇ nilpotent propagation, 3 sub-sorries)
+- Performed deep mathematical analysis of the Ẽ₇ representation `etilde7Rep(m)` and its arm 1 map `etilde7Arm1Embed`
+- **Discovered critical bug**: `etilde7Rep(m)` is decomposable for all m ≥ 1, making `etilde7Rep_isIndecomposable` false
+- Constructed explicit counterexample for m = 1: complementary sub-representations W₁ ⊕ W₂ where W₁(v) and W₂(v) are both non-trivial at every vertex
+- Identified root cause: arm 1 map has Block C = 0, creating structural decoupling that allows non-trivial decompositions
+- Filed bug report as #2404 with full counterexample and analysis
+- Commented on #2394 explaining why hN₁/hN₂ sorries are unprovable with current definition
+
+## Current frontier
+
+Issue #2394 is blocked on #2404 (incorrect representation definition). The proof framework (leaf containment, propagation, injectivity arguments) at lines 2654-2870 is sound and reusable — only the arm 1 map needs to be corrected.
+
+The same bug likely affects `t125Rep_isIndecomposable` (T(1,2,5) / Ẽ₈), which uses an analogous arm 1 map structure. Issue #2400 may be similarly blocked.
+
+## Overall project progress
+
+- Gabriel's theorem forward direction has critical bug in representation definitions for Ẽ₇ and likely Ẽ₈
+- `cycleRep_isIndecomposable` (extended A-type) is correct and fully proved
+- `etilde6v2Rep_isIndecomposable` (Ẽ₆) has a complete sorry for indecomposability — may or may not have the same issue
+- The downstream theorems `etilde7_not_finite_type`, `t125_not_finite_type`, and `not_posdef_infinite_type` are all affected
+
+## Next step
+
+1. **Highest priority**: Fix the arm 1 map in `etilde7Arm1Embed` (and `t125Arm1Embed`) so the representation is genuinely indecomposable. Suggested fix: `(p,q) ↦ (p+q, p, q, Nq)` (fill Block C with q). This needs validation against standard constructions for indecomposable representations of extended Dynkin quivers.
+2. After the fix, the existing proof framework (leaf containment, compl_eq_of_le, propagation) should work with minor adaptations.
+3. Then fill the hN₁, hN₂, hbot0 sorries.
+
+## Blockers
+
+- #2404: `etilde7Rep` representation definition is incorrect (decomposable). Blocks #2394 and likely #2400.


### PR DESCRIPTION
## Summary
- Found that `etilde7Rep(m)` is decomposable for all m ≥ 1, making `etilde7Rep_isIndecomposable` false
- Root cause: arm 1 map `etilde7Arm1Embed` has Block C = 0, allowing structural decoupling
- Filed detailed bug report as #2404 with concrete counterexample for m = 1
- Marked #2394 as blocked pending definition fix
- Progress file documents findings and suggests fix direction

## Test plan
- [x] No code changes, only progress documentation
- [x] Bug report filed with verification

🤖 Prepared with Claude Code