### PR TITLE
Prove etilde6v2 hbot3 (Ẽ₆ W(3)=⊥ via Γ surjectivity)

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/InfiniteTypeConstructions.lean
+++ b/EtingofRepresentationTheory/Chapter6/InfiniteTypeConstructions.lean
@@ -2497,7 +2497,84 @@ theorem etilde6v2Rep_isIndecomposable (m : ℕ) (hm : 1 ≤ m) :
     -- Proof of surjectivity: given (u, v) ∈ V(3), the preimage (v, u-v, 0) ∈ V(0)
     -- satisfies Γ(v, u-v, 0) = (v + (u-v), v + N·0) = (u, v).
     have hbot3 : W (3 : Fin 7) = ⊥ := by
-      sorry
+      -- Step 1: W'(0) = ⊤ from W(0) = ⊥ and the complement structure.
+      have hWtop0 : W' (0 : Fin 7) = ⊤ := by
+        have := (hc (0 : Fin 7)).sup_eq_top
+        rwa [hbot0, bot_sup_eq] at this
+      -- Step 2a: surjectivity of Γ on the explicit type.
+      -- Preimage of (u, v) (where u = first half of y, v = second half) is (v, u - v, 0).
+      have hΓ_surj : ∀ y : Fin (2 * (m + 1)) → ℂ,
+          ∃ z : Fin (3 * (m + 1)) → ℂ, etilde6v2Gamma m z = y := by
+        intro y
+        let z : Fin (3 * (m + 1)) → ℂ := fun i =>
+          if h1 : i.val < m + 1 then y ⟨m + 1 + i.val, by omega⟩
+          else if h2 : i.val < 2 * (m + 1) then
+            y ⟨i.val - (m + 1), by omega⟩ - y ⟨i.val, by omega⟩
+          else 0
+        -- Three accessors for the three blocks of z.
+        have z_a : ∀ (k : ℕ) (hk_bound : k < 3 * (m + 1)) (hk : k < m + 1),
+            z ⟨k, hk_bound⟩ = y ⟨m + 1 + k, by omega⟩ := by
+          intros k _ hk
+          show (if h1 : k < m + 1 then y ⟨m + 1 + k, by omega⟩
+              else if h2 : k < 2 * (m + 1) then
+                y ⟨k - (m + 1), by omega⟩ - y ⟨k, by omega⟩
+              else 0) = y ⟨m + 1 + k, by omega⟩
+          rw [dif_pos hk]
+        have z_b : ∀ (k : ℕ) (hk_bound : k < 3 * (m + 1))
+            (hk1 : ¬ k < m + 1) (hk2 : k < 2 * (m + 1)),
+            z ⟨k, hk_bound⟩ = y ⟨k - (m + 1), by omega⟩ - y ⟨k, by omega⟩ := by
+          intros k _ hk1 hk2
+          show (if h1 : k < m + 1 then y ⟨m + 1 + k, by omega⟩
+              else if h2 : k < 2 * (m + 1) then
+                y ⟨k - (m + 1), by omega⟩ - y ⟨k, by omega⟩
+              else 0) = y ⟨k - (m + 1), by omega⟩ - y ⟨k, by omega⟩
+          rw [dif_neg hk1, dif_pos hk2]
+        have z_c : ∀ (k : ℕ) (hk_bound : k < 3 * (m + 1))
+            (hk1 : ¬ k < m + 1) (hk2 : ¬ k < 2 * (m + 1)),
+            z ⟨k, hk_bound⟩ = 0 := by
+          intros k _ hk1 hk2
+          show (if h1 : k < m + 1 then y ⟨m + 1 + k, by omega⟩
+              else if h2 : k < 2 * (m + 1) then
+                y ⟨k - (m + 1), by omega⟩ - y ⟨k, by omega⟩
+              else 0) = 0
+          rw [dif_neg hk1, dif_neg hk2]
+        refine ⟨z, ?_⟩
+        ext ⟨i, hi⟩
+        simp only [etilde6v2Gamma, LinearMap.coe_mk, AddHom.coe_mk]
+        by_cases hilt : i < m + 1
+        · -- First block of Γ output at index i: z ⟨i⟩ + z ⟨m+1+i⟩.
+          rw [dif_pos hilt,
+            z_a i (by omega) hilt,
+            z_b (m + 1 + i) (by omega) (by omega) (by omega)]
+          have h_idx : (⟨m + 1 + i - (m + 1), by omega⟩ : Fin (2 * (m + 1))) =
+              ⟨i, hi⟩ := by apply Fin.ext; change m + 1 + i - (m + 1) = i; omega
+          rw [h_idx]; ring
+        · -- Second block of Γ output at index i (i ≥ m+1).
+          push_neg at hilt
+          rw [dif_neg (show ¬(i < m + 1) from by omega),
+            z_a (i - (m + 1)) (by omega) (by omega)]
+          have h_idx : (⟨m + 1 + (i - (m + 1)), by omega⟩ : Fin (2 * (m + 1))) =
+              ⟨i, hi⟩ := by
+            apply Fin.ext; change m + 1 + (i - (m + 1)) = i; omega
+          rw [h_idx]
+          split_ifs with h2
+          · -- z at index 2(m+1) + (i-(m+1)) + 1 is in c-block, so equals 0.
+            rw [z_c (2 * (m + 1) + (i - (m + 1)) + 1) (by omega) (by omega) (by omega)]
+            ring
+          · ring
+      -- Step 2b: W'(3) = ⊤.
+      have hWtop3 : W' (3 : Fin 7) = ⊤ := by
+        rw [Submodule.eq_top_iff']
+        intro y
+        obtain ⟨z, hz⟩ := hΓ_surj y
+        have hz0 : z ∈ W' (0 : Fin 7) := hWtop0 ▸ Submodule.mem_top
+        have hgz : (etilde6v2Rep m).mapLinear hom03 z ∈ W' (3 : Fin 7) :=
+          hW'_inv hom03 z hz0
+        have heq : (etilde6v2Rep m).mapLinear hom03 z = y := hz
+        rw [← heq]; exact hgz
+      -- Step 3: W(3) ⊓ W'(3) = ⊥, W'(3) = ⊤ ⇒ W(3) = ⊥.
+      have h_inf := (hc (3 : Fin 7)).inf_eq_bot
+      rwa [hWtop3, inf_top_eq] at h_inf
     fin_cases v
     · exact hbot0  -- v = 0
     · exact hbot1  -- v = 1

--- a/progress/20260423T070532Z_cd5cef42.md
+++ b/progress/20260423T070532Z_cd5cef42.md
@@ -1,0 +1,64 @@
+## Accomplished
+
+Filled the `hbot3` sub-sorry of `etilde6v2Rep_isIndecomposable` (Ẽ₆
+indecomposability framework, line 2499 of
+`EtingofRepresentationTheory/Chapter6/InfiniteTypeConstructions.lean`).
+Closes issue #2420.
+
+The proof shows that once `W(0) = ⊥` and `W(4) = ⊥` are established (via
+sibling sub-sorries `hbot0` and `h24`/`hbot`), one can conclude `W(3) = ⊥`
+by exhibiting an explicit right inverse to the coupling map
+`Γ = etilde6v2Gamma`. Given any `(u, v) ∈ V(3) = ℂ^{2(m+1)}`, the
+preimage `(v, u-v, 0) ∈ V(0) = ℂ^{3(m+1)}` satisfies
+`Γ(v, u-v, 0) = (v + (u-v), v + N·0) = (u, v)`. Combined with the
+fact that `W(0) = ⊥` forces `W'(0) = ⊤`, every element of `V(3)` lies in
+`W'(3)`, so `W'(3) = ⊤` and `W(3) = ⊥` by complementarity.
+
+Implementation notes:
+- Surjectivity is proven on the explicit type `Fin (2 * (m + 1)) → ℂ`
+  rather than `(etilde6v2Rep m).obj 3 = Fin (etilde6Dim m 3) → ℂ`, since
+  `omega` cannot unfold `etilde6Dim`. The two types are definitionally
+  equal, so the surjectivity lemma applies after `intro y`.
+- The preimage `z` is built piecewise (a-block / b-block / c-block) with
+  three named accessor lemmas (`z_a`, `z_b`, `z_c`) used in the
+  computation `Γ z = y`.
+- `Fin.ext` followed by `change` (not `show`) avoids the
+  `linter.style.show` warning when reducing Fin equality to Nat.
+
+## Current frontier
+
+`etilde6v2Rep_isIndecomposable` now has 4 remaining sub-sorries (down from
+5):
+- Line 2380 `leaf24_containment` (#2417, difficulty 7-8)
+- Line 2397 `hN₁` (#2418, difficulty 7)
+- Line 2400 `hN₂` (#2418, difficulty 7)
+- Line 2425 `hbot0` (#2419, difficulty 7)
+
+These are independent and can be worked in parallel.
+
+## Overall project progress
+
+Stage 3 (formalization) continues. Ẽ₆ indecomposability framework set
+up by PR #2414 with 5 sub-sorries; this turn closes 1 (`hbot3`). The
+companion Ẽ₇ (#2394) and T(1,2,5) (#2400) cases remain open.
+
+Ch5 straightening: PR #2421 closed the k=0 corner case;
+`garnir_twisted_in_lower_span` (#2380, difficulty 8) is the remaining
+heart of Ch5.
+
+## Next step
+
+A worker can claim any of the four remaining etilde6v2 sub-sorries
+(#2417, #2418, #2419) — they are all in scope as `sorry`'d helpers and
+can proceed without blocking on each other. `#2420` is now CLOSED via
+this turn's PR.
+
+Recommended priority: `#2419` (`hbot0`) is the prerequisite for `hbot3`'s
+premise, but since all sub-sorries are in scope as `sorry`'d helpers, any
+of them can be tackled independently. The easiest tractable one
+(after this PR) is probably `#2418` (`hN₁`/`hN₂`) — it has a clear
+algebraic structure mirroring the Ẽ₇ analogue.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2420

Session: `cd5cef42-a65d-4a72-b898-cd1c53451964`

ee18ceb feat: prove etilde6v2 hbot3 sub-sorry via Γ surjectivity (#2420)

🤖 Prepared with Claude Code