### PR TITLE
docs: progress note — counter-example refutes etilde6v2Rep_isIndecomposable (#2417 skipped)

### DIFF
--- a/progress/2026-04-23T07-56-48Z_d25b71e0.md
+++ b/progress/2026-04-23T07-56-48Z_d25b71e0.md
@@ -1,0 +1,58 @@
+## Accomplished
+
+Investigated issue #2417 (Prove etilde6v2 leaf24_containment). After extensive
+analysis I found that the parent theorem `etilde6v2Rep_isIndecomposable` (with
+`hm : 1 ≤ m`) is **still false** despite the earlier fix in #2388. Constructed
+an explicit invariant complementary decomposition for `m = 1` with both `W₁`
+and `W₂` non-trivial at every vertex, refuting indecomposability.
+
+- Posted detailed counter-example as a comment on #2417 (with full edge-by-edge
+  invariance verification of all 6 quiver arrows).
+- Skipped #2417 with `replan` label so a planner can decide how to proceed.
+
+The counter-example uses:
+- `W₁(2) = ⟨e₀⟩`, `W₁(4) = ℂ²`, `W₁(6) = ⟨e₁⟩` (and `W₁(1), W₁(3), W₁(5), W₁(0)`
+  derived to make the decomposition invariant).
+- All 6 edge invariances verified by hand: 2→1, 1→0, 0→3 (Γ), 4→3, 6→5, 5→0.
+
+The previous #2388 fix changed edge 3→4 (lossy projection) to 4→3 (starEmbed1
+embedding), but this only forces `starEmbed1(W(4)) ⊆ W(3)`, not `W(4) = W(2)`,
+so the slack remains.
+
+## Current frontier
+
+The Ẽ₆ indecomposability framework set up by PR #2414 cannot be completed as
+written. Issues #2417, #2418, #2419 (the three Ẽ₆v2 sub-sorries) and the parent
+theorem all need re-thinking. The mixed-orientation `etilde6v2Rep` is decomposable
+for `m ≥ 1`; a different representation or quiver orientation is needed.
+
+Note: the analogous Ẽ₇ (#2394) and T(1,2,5) (#2400) frameworks may have similar
+issues — they were modeled on the same #2408 zero-block fix and the same general
+structural pattern. Worth a separate investigation.
+
+## Overall project progress
+
+- Stage 3 (formalization) ongoing.
+- Six Chapter 6 indecomposability sub-issues are blocked by the apparent falsity
+  of the underlying theorem statement: #2417, #2418, #2419 (Ẽ₆v2 trio).
+- Three other open issues: #2380 (Ch5 Garnir), #2394 (Ẽ₇), #2400 (T(1,2,5)).
+
+## Next step
+
+A planner should:
+1. Re-open #2388 or open a new issue noting the decomposability of `etilde6v2Rep`
+   even after the f252f28 fix.
+2. Decide on a replacement representation/orientation for proving Ẽ₆ infinite
+   type. Options sketched in the #2417 comment: change the orientation, change
+   the maps, or pick a different rep entirely.
+3. Close (or substantially rewrite) #2417, #2418, #2419 once the new approach
+   is settled.
+4. Consider whether #2394 (Ẽ₇) and #2400 (T(1,2,5)) suffer from the same
+   structural issue and need similar review.
+
+## Blockers
+
+- Theorem `etilde6v2Rep_isIndecomposable m hm` is false for `m = 1` (and likely
+  all `m ≥ 1`). Sub-sorries cannot be filled. Needs planner triage.
+- Hit GitHub GraphQL rate limit during the session; used REST API workaround
+  to post the comment and update labels.


### PR DESCRIPTION
Documents the analysis from session `d25b71e0-c381-447f-ab43-24cb33ef5ebb` of issue #2417. Found that the parent theorem `etilde6v2Rep_isIndecomposable` is still false for m = 1 despite the #2388 fix. Posted a detailed counter-example on #2417 and skipped the issue (labels: `replan`).

This PR contains only the progress file documenting the finding — no code changes, since the issue cannot be completed as written. A planner should re-open #2388 (or open a follow-up) to decide the path forward for the Ẽ₆ indecomposability proof.

🤖 Prepared with Claude Code