### PR TITLE
chore: progress — counter-example refutes garnir_twisted_in_lower_span framework

### DIFF
--- a/progress/20260423T112112Z_9cfda69f.md
+++ b/progress/20260423T112112Z_9cfda69f.md
@@ -1,0 +1,72 @@
+## Accomplished
+
+Claimed #2425 (Garnir-term dominance fact). After careful hand-computation
+on a concrete 4-cell example (λ = (2,2), σ = swap(0,1)), refuted both the
+proposed helper `garnir_term_dominates` AND the ambient open theorem
+`garnir_twisted_in_lower_span`.
+
+Further, the same computation shows `garnir_straightening_step` itself is
+**false** for σ = swap(0, 1): the theorem's claimed span is `{ψ_id}` in this
+case, but ψ_σ = ψ_id − ψ_{swap(1,2)} (both in the SYT basis), and
+`swap(1, 2)` is not in the theorem's allowed set of τ's.
+
+Posted a detailed counter-example + analysis on #2425 and skipped the
+issue with `replan`.
+
+## Current frontier
+
+Ch5 Garnir straightening: the *framework* is unsound. The outer theorem
+`polytabloidTab_column_standard_in_span` is mathematically true (the Specht
+module has the SYT basis, that's classical), but the Garnir-based
+decomposition currently in `SpechtModuleBasis.lean` loses essential
+ψ_τ terms at lower-dominated tabloids and cannot close the sorry.
+
+Specifically, when σ has the *maximal* tabloid (under dominance) yet still
+has row inversions, no τ strictly dominates σ's tabloid, and the Garnir
+identity k·ψ_σ = −S_neither degenerates (S_neither = −k·ψ_σ, giving
+ψ_σ = ψ_σ). The "same tabloid, smaller rowInvCount'" disjunct isn't
+enough either, because the correct expansion ψ_σ = ψ_id − ψ_{T_2} uses
+a T_2 at a *different* (strictly less-dominant) tabloid class.
+
+## Overall project progress
+
+- Stage 3 (formalization) ongoing.
+- Ch5 polytabloid-basis theorem is provable in the end (the classical
+  result is true), but the current Garnir straightening *framework* needs
+  to be revisited. This unblocks dimV_λ = |SYT(λ)| only after the
+  framework is fixed.
+- All other Stage 3 work (Ch6 infinite-type, Ch2 bridges) remains at its
+  prior state.
+
+## Next step
+
+**Planner action required** — not a worker-fillable sorry. Options:
+
+1. **Reconsider the induction measure.** The classical James (Ch. 8) /
+   Fulton (Ch. 7) arguments in fact induct on the *column tableau's*
+   inversion structure, traversing tabloid classes via *column* (not
+   row) rearrangements. Port that measure.
+2. **Broaden the allowed τ set** in `garnir_straightening_step` to
+   include τ's whose tabloid is dominated by σ's (but with smaller
+   column-inversion count), and update the outer induction in
+   `polytabloidTab_column_standard_in_span` accordingly.
+3. **Add a corner case** for "maximal-tabloid, row-inverted σ": handle
+   it explicitly by column-restandardizing σ (find q₀ ∈ Q with q₀σ
+   row-standard) rather than routing through the Garnir identity.
+
+The worker who picks up the follow-up should start from the concrete
+counter-example on #2425 (σ = swap(0,1), λ = (2,2)) and verify any new
+framework works on it before scaling up.
+
+Until the framework is fixed, any *new* sub-issue that just asks "prove
+the sorry in `garnir_twisted_in_lower_span`" will fail in the same way.
+
+## Blockers
+
+- **Framework-level:** `garnir_twisted_in_lower_span` and
+  `garnir_straightening_step` both false as currently stated.
+  Blocks `polytabloidTab_column_standard_in_span` → blocks
+  `generalizedPolytabloidTab_mem_span_polytabloidTab` →
+  blocks `finrank_spechtModule_le_card_syt` →
+  blocks `finrank_spechtModule_eq_card_syt'` (Ch5 dimV_λ theorem).
+  No other downstream work depends on this, so the blockage is local.


### PR DESCRIPTION
Progress entry documenting a counter-example that refutes the framework in
`SpechtModuleBasis.lean` used by `garnir_twisted_in_lower_span` and
`garnir_straightening_step`.

## Summary

- Claimed #2425 (Garnir-term dominance fact).
- Found a concrete counter-example for λ = (2, 2), σ = swap(0, 1):
  - `garnir_term_dominates` (the proposed helper) is false.
  - `garnir_twisted_in_lower_span` (the ambient theorem) is false.
  - In fact `garnir_straightening_step` is also false as stated —
    ψ_σ = ψ_id − ψ_{swap(1,2)}, and ψ_{swap(1,2)} is not in the theorem's
    allowed span set.
- The *outer* `polytabloidTab_column_standard_in_span` is mathematically
  true (the Specht module has the SYT basis), but its Garnir decomposition
  cannot close the sorry as currently framed.
- Posted the full counter-example as a comment on #2425 and marked the
  issue `replan`.

## Changes

- Adds `progress/20260423T112112Z_9cfda69f.md` with the analysis and
  replanning recommendations. No code changes.

## Why this isn't tied to a specific issue

#2425 has been skipped (`replan`), not salvaged. A future planner will
decide whether to rewrite the Garnir induction measure, broaden the
allowed τ set, or add a corner case for maximal-tabloid row-inverted σ.
This PR just lands the shared context so the next agent can pick up from
the counter-example rather than re-deriving it.

Refs #2425.

🤖 Prepared with Claude Code