### PR TITLE
fix: flip dominance direction in Garnir straightening (Wall 3)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/SpechtModuleBasis.lean
+++ b/EtingofRepresentationTheory/Chapter5/SpechtModuleBasis.lean
@@ -857,21 +857,25 @@ private theorem twistedPolytabloid_row_eq (w : Equiv.Perm (Fin n))
   have heq : (w * q⁻¹ * σ) * (q⁻¹ * σ)⁻¹ = w := by group
   rw [heq]; exact hw
 
-/-! ### Strict-dominance rank
+/-! ### Tabloid descent rank
 
-The Garnir straightening induction runs on the strict tabloid-dominance order.
-`srRank la σ` is the count of permutations whose tabloid strictly dominates σ's
-tabloid; this is a natural-number rank that strictly decreases when we replace
-σ by a strictly dominating σ'. Within a single tabloid class (srRank fixed), a
-secondary `rowInvCount'` measure handles the `k = 0` corner case of
-`garnir_straightening_step`, where the row swap keeps the tabloid fixed. -/
+The Garnir straightening induction runs on the strict tabloid-dominance order,
+traversed *downward*: the Garnir shuffle expresses ψ_σ in terms of ψ_τ's where
+τ's tabloid is strictly dominated by σ's (classical James Ch. 8 / Fulton Ch. 7
+column-straightening; see `progress/20260423T112112Z_9cfda69f.md` for the
+counter-example that refutes the upward direction). `srRank la σ` counts
+permutations strictly dominated by σ; it strictly decreases when we pass from
+σ to a τ strictly dominated by σ. Within a single tabloid class (srRank fixed),
+a secondary `rowInvCount'` measure handles the `k = 0` corner case and the
+same-tabloid part of the Garnir expansion, where a row swap (or its
+column-restandardization) preserves the tabloid but reduces row inversions. -/
 
-/-- Number of permutations whose tabloid strictly dominates σ's tabloid. -/
+/-- Number of permutations whose tabloid is strictly dominated by σ's tabloid. -/
 private noncomputable def srRank (la : Nat.Partition n) (σ : Equiv.Perm (Fin n)) : ℕ :=
-  haveI : DecidablePred (fun τ : Equiv.Perm (Fin n) => tabloidStrictDominates la τ σ) :=
+  haveI : DecidablePred (fun τ : Equiv.Perm (Fin n) => tabloidStrictDominates la σ τ) :=
     Classical.decPred _
   (Finset.univ.filter
-      (fun τ : Equiv.Perm (Fin n) => tabloidStrictDominates la τ σ)).card
+      (fun τ : Equiv.Perm (Fin n) => tabloidStrictDominates la σ τ)).card
 
 /-- `srRank` is invariant under `toTabloid`-equivalence. -/
 private theorem srRank_eq_of_toTabloid_eq {σ₁ σ₂ : Equiv.Perm (Fin n)}
@@ -882,37 +886,39 @@ private theorem srRank_eq_of_toTabloid_eq {σ₁ σ₂ : Equiv.Perm (Fin n)}
   congr 1
   ext τ
   simp only [Finset.mem_filter, Finset.mem_univ, true_and]
-  refine ⟨fun ⟨hdom, hne⟩ => ⟨tabloidDominates_congr rfl h hdom, ?_⟩,
-          fun ⟨hdom, hne⟩ => ⟨tabloidDominates_congr rfl h.symm hdom, ?_⟩⟩
-  · intro h'; exact hne (h'.trans h.symm)
-  · intro h'; exact hne (h'.trans h)
+  refine ⟨fun ⟨hdom, hne⟩ => ⟨tabloidDominates_congr h rfl hdom, ?_⟩,
+          fun ⟨hdom, hne⟩ => ⟨tabloidDominates_congr h.symm rfl hdom, ?_⟩⟩
+  · intro h'; exact hne (h.trans h')
+  · intro h'; exact hne (h.symm.trans h')
 
-/-- If τ strictly dominates σ, then `srRank τ < srRank σ`. -/
+/-- If σ strictly dominates τ, then `srRank τ < srRank σ`. -/
 private theorem srRank_lt_of_tabloidStrictDominates
-    {τ σ : Equiv.Perm (Fin n)} (h : tabloidStrictDominates la τ σ) :
+    {σ τ : Equiv.Perm (Fin n)} (h : tabloidStrictDominates la σ τ) :
     srRank la τ < srRank la σ := by
   classical
   unfold srRank
   apply Finset.card_lt_card
   refine Finset.ssubset_iff.mpr ⟨τ, ?_, ?_⟩
-  · -- τ ∉ filter strict-dominators-of-τ (irreflexivity)
+  · -- τ ∉ filter strict-dominated-by-τ (irreflexivity)
     simp only [Finset.mem_filter, Finset.mem_univ, true_and]
     intro ⟨_, hne⟩; exact hne rfl
-  · -- insert τ (strict-dom-of-τ) ⊆ strict-dom-of-σ
+  · -- insert τ (strict-below-τ) ⊆ strict-below-σ
     intro ρ hρ
     simp only [Finset.mem_insert, Finset.mem_filter, Finset.mem_univ, true_and] at hρ ⊢
-    rcases hρ with rfl | ⟨hdom_ρτ, hne_ρτ⟩
+    rcases hρ with rfl | ⟨hdom_τρ, hne_τρ⟩
     · exact h
-    · refine ⟨tabloidDominates_trans hdom_ρτ h.1, ?_⟩
+    · refine ⟨tabloidDominates_trans h.1 hdom_τρ, ?_⟩
       intro heq
-      -- ρ dominates τ, τ dominates σ, toTab ρ = toTab σ ⟹ toTab τ = toTab σ
-      exact h.2 (tabloidDominates_antisymm_toTabloid hdom_ρτ h.1 heq)
+      -- σ dom τ, τ dom ρ, toTab σ = toTab ρ ⟹ toTab τ = toTab ρ
+      exact hne_τρ (tabloidDominates_antisymm_toTabloid h.1 hdom_τρ heq)
 
 /-- **Twisted polytabloid in lower span** (sub-sorry 2 of 2):
 For column-standard σ with row inversion, each Garnir permutation w that is
 **neither** column-preserving nor row-preserving produces a "twisted polytabloid"
-f_w(σ) that lies in the span of
-{ψ_τ : τ column-standard, `tabloidStrictDominates la τ σ`}.
+f_w(σ) = w · ψ_σ (a ℂS_n-translate of the polytabloid, hence in V^λ) that lies
+in the span of
+{ψ_τ : τ column-standard, σ's tabloid strictly dominates τ's OR τ has the same
+tabloid as σ but strictly fewer row inversions}.
 
 Both exclusions are essential to avoid circularity:
 - For w ∈ Q_λ, `twistedPolytabloid_col_eq` gives f_w(σ) = sign(w) · ψ_σ.
@@ -920,14 +926,27 @@ Both exclusions are essential to avoid circularity:
 Proving ψ_σ is in the lower span from either special case would be circular.
 The algebraic splitting of these cases is handled in `garnir_straightening_step`.
 
-The proof requires:
-1. Column-restandardize wσ: find q₀ ∈ Q_λ with q₀·w·σ column-standard.
-2. Express f_w(σ) as a ℂ-combination of standard generalized polytabloids.
-3. Use dominance theory to show the resulting tabloids strictly dominate σ's
-   tabloid (this is the classical Garnir-term dominance fact).
+**Direction**: classical Garnir-term dominance (James Ch. 7-8 / Fulton Ch. 7)
+says the Garnir expansion produces tabloids that are **strictly dominated by**
+σ's tabloid (or equal to it after column-restandardization). The previous
+formulation of this lemma had the direction reversed and was refuted at
+λ=(2,2), σ=swap(0,1) in session 9cfda69f — see
+`progress/20260423T112112Z_9cfda69f.md`. At that example, ψ_σ = ψ_id
+− ψ_{swap(1,2)}, where:
+- ψ_{swap(1,2)} has tabloid strictly dominated by σ's (first disjunct ✓);
+- ψ_id has the same tabloid as σ but rowInvCount' = 0 < 1 = rowInvCount' σ
+  (second disjunct ✓).
 
-Difficulty: 8. Combinatorial heart of the straightening theorem
-(James Ch. 7-8 / Fulton Ch. 7). -/
+The proof requires (classical Garnir-term dominance + column-restandardization):
+1. Column-restandardize each term [w q⁻¹ σ] in f_w(σ): find q_w,q ∈ Q_λ so that
+   q_w,q · w · q⁻¹ · σ is column-standard.
+2. Express f_w(σ) as a ℂ-combination of standard generalized polytabloids.
+3. Classify each resulting term by tabloid dominance vs σ's tabloid:
+   - Strictly dominated: belongs to the first disjunct.
+   - Equal tabloid: arises only when `w · q⁻¹ ∈ P_λ`; the column-restandardized
+     form has strictly smaller `rowInvCount'` (second disjunct).
+
+Difficulty: 8. Combinatorial heart of the straightening theorem. -/
 private theorem garnir_twisted_in_lower_span
     (σ : Equiv.Perm (Fin n)) (hcs : isColumnStandard' n la σ)
     (hrp : 0 < rowInvCount' (la := la) σ)
@@ -937,7 +956,10 @@ private theorem garnir_twisted_in_lower_span
     (hw_row : w ∉ RowSubgroup n la) :
     twistedPolytabloid (la := la) w σ ∈
     Submodule.span ℂ (Set.range (fun τ : {τ : Equiv.Perm (Fin n) //
-        isColumnStandard' n la τ ∧ tabloidStrictDominates la τ σ} =>
+        isColumnStandard' n la τ ∧
+          (tabloidStrictDominates la σ τ ∨
+            (toTabloid n la τ = toTabloid n la σ ∧
+              rowInvCount' (la := la) τ < rowInvCount' (la := la) σ))} =>
       generalizedPolytabloidTab (n := n) (la := la) τ.val)) := by
   sorry
 
@@ -947,15 +969,18 @@ set_option maxHeartbeats 1200000 in
 /-- **Garnir straightening step**:
 For column-standard σ with positive row inversion count, the generalized
 polytabloidTab ψ_σ lies in the ℂ-span of {ψ_{σ'} : σ' column-standard,
-(`tabloidStrictDominates la σ' σ` ∨ (`toTabloid σ' = toTabloid σ` ∧
+(`tabloidStrictDominates la σ σ'` ∨ (`toTabloid σ' = toTabloid σ` ∧
 `rowInvCount'(σ') < rowInvCount'(σ)`))}.
 
 The disjunction combines two progress modes of the classical Garnir argument:
-- The main case (k ≥ 1) produces τ whose tabloid strictly dominates σ's tabloid.
+- The main case (k ≥ 1) produces τ whose tabloid is strictly dominated by σ's
+  (classical Garnir-term dominance; direction forced by the λ=(2,2),
+  σ=swap(0,1) counter-example that refutes the opposite direction).
 - The corner case k = 0 produces σ' = t·σ with the **same** tabloid as σ but
   strictly fewer row inversions (row swap within a single row).
 Both are strictly decreasing under the lexicographic measure
-`(srRank la σ, rowInvCount' la σ)`.
+`(srRank la σ, rowInvCount' la σ)`, where `srRank` counts tabloids strictly
+**below** σ.
 
 Proof: combine `garnir_polytabloid_identity` with `garnir_twisted_in_lower_span`.
 The identity expresses ψ_σ as a negated sum of twisted polytabloids. We split
@@ -982,7 +1007,7 @@ private theorem garnir_straightening_step
     generalizedPolytabloidTab (n := n) (la := la) σ ∈
       Submodule.span ℂ (Set.range (fun τ : {τ : Equiv.Perm (Fin n) //
           isColumnStandard' n la τ ∧
-            (tabloidStrictDominates la τ σ ∨
+            (tabloidStrictDominates la σ τ ∨
               (toTabloid n la τ = toTabloid n la σ ∧
                 rowInvCount' (la := la) τ < rowInvCount' (la := la) σ))} =>
         generalizedPolytabloidTab (n := n) (la := la) τ.val)) := by
@@ -1025,19 +1050,10 @@ private theorem garnir_straightening_step
   set ψ := generalizedPolytabloidTab (n := n) (la := la) σ with hψ_def
   set L := Submodule.span ℂ (Set.range (fun τ : {τ : Equiv.Perm (Fin n) //
       isColumnStandard' n la τ ∧
-        (tabloidStrictDominates la τ σ ∨
+        (tabloidStrictDominates la σ τ ∨
           (toTabloid n la τ = toTabloid n la σ ∧
             rowInvCount' (la := la) τ < rowInvCount' (la := la) σ))} =>
     generalizedPolytabloidTab (n := n) (la := la) τ.val))
-  -- The strict-dominance span is contained in L (via `Or.inl`).
-  have h_strict_sub_L : ∀ v : TabloidRepresentation n la,
-      v ∈ Submodule.span ℂ (Set.range (fun τ : {τ : Equiv.Perm (Fin n) //
-          isColumnStandard' n la τ ∧ tabloidStrictDominates la τ σ} =>
-        generalizedPolytabloidTab (n := n) (la := la) τ.val)) → v ∈ L := by
-    intro v hv
-    refine (Submodule.span_le (R := ℂ)).mpr ?_ hv
-    rintro _ ⟨⟨τ, hτ_cs, hdom⟩, rfl⟩
-    exact Submodule.subset_span ⟨⟨τ, hτ_cs, Or.inl hdom⟩, rfl⟩
   classical
   -- Set up subtype and predicates
   set T := {w : Equiv.Perm (Fin n) // (∀ x, x ∉ G → w x = x) ∧ w ≠ 1} with hT_def
@@ -1050,7 +1066,8 @@ private theorem garnir_straightening_step
       twistedPolytabloid (la := la) w.val σ)
   -- t = swap(p₁, p₂) viewed as a T-element
   set t_elem : T := ⟨t, ht_supp, ht_ne⟩ with ht_elem_def
-  -- The "neither" sum is in L (uses fixed garnir_twisted_in_lower_span with hw_row)
+  -- The "neither" sum is in L directly (garnir_twisted_in_lower_span's conclusion
+  -- already targets this L, after the direction flip / broadening).
   have h_neither_mem :
       -(∑ w ∈ Finset.univ.filter (fun w : T => ¬p_col w ∧ ¬p_row w), f w) ∈ L := by
     apply Submodule.neg_mem
@@ -1060,8 +1077,7 @@ private theorem garnir_straightening_step
       hp_row_def] at hmem
     show f ⟨w, hw_supp, hw_ne⟩ ∈ L
     apply Submodule.smul_mem
-    exact h_strict_sub_L _
-      (garnir_twisted_in_lower_span σ hcs hrp G w hw_supp hw_ne hmem.1 hmem.2)
+    exact garnir_twisted_in_lower_span σ hcs hrp G w hw_supp hw_ne hmem.1 hmem.2
   -- The Q part: each term equals ψ (since sign(w)² = 1 and twistedPolytabloid_col_eq)
   have h_col_term : ∀ w : T, p_col w → f w = ψ := by
     intro ⟨w, hw_supp, hw_ne⟩ hw_col
@@ -1580,14 +1596,14 @@ private theorem polytabloidTab_column_standard_in_span
     -- Show the Garnir span is contained in the SYT span.
     have h_sub : Set.range (fun τ'' : {τ'' : Equiv.Perm (Fin n) //
         isColumnStandard' n la τ'' ∧
-          (tabloidStrictDominates la τ'' τ' ∨
+          (tabloidStrictDominates la τ' τ'' ∨
             (toTabloid n la τ'' = toTabloid n la τ' ∧
               rowInvCount' (la := la) τ'' < rowInvCount' (la := la) τ'))} =>
       generalizedPolytabloidTab (n := n) (la := la) τ''.val) ⊆
         ↑(Submodule.span ℂ S_syt) := by
       rintro _ ⟨⟨τ'', hτ''_cs, hor⟩, rfl⟩
       rcases hor with hdom | ⟨htab_eq, hrow_lt⟩
-      · -- Or.inl: τ'' strictly dominates τ' ⟹ srRank τ'' < srRank τ' = k.
+      · -- Or.inl: τ' strictly dominates τ'' ⟹ srRank τ'' < srRank τ' = k.
         have h_lt : srRank la τ'' < k := by
           rw [hk_τ']; exact srRank_lt_of_tabloidStrictDominates hdom
         exact ih_outer (srRank la τ'') h_lt τ'' rfl hτ''_cs

--- a/progress/20260423T133105Z_d3dde2a8.md
+++ b/progress/20260423T133105Z_d3dde2a8.md
@@ -1,0 +1,116 @@
+## Accomplished
+
+Claimed #2438 (Rewrite Garnir straightening using column-based induction) and
+implemented a **framework-level direction correction** to
+`EtingofRepresentationTheory/Chapter5/SpechtModuleBasis.lean` that brings the
+Garnir straightening theorem statements in line with the classical James
+Ch. 7-8 / Fulton Ch. 7 column-straightening result.
+
+### The fix
+
+Starting from the counter-example analysis in
+`progress/20260423T112112Z_9cfda69f.md` (λ=(2,2), σ=swap(0,1) with
+ψ_σ = ψ_id − ψ_swap(1,2)), traced through the dominance structure:
+
+- ψ_id: same tabloid as σ, rowInvCount' = 0 < 1 = rowInvCount' σ — fits the
+  existing `Or.inr` disjunct.
+- ψ_{swap(1,2)}: tabloid **strictly dominated by** σ's (σ ≻ swap(1,2).tab)
+  — does NOT fit the original `Or.inl` disjunct (`tabloidStrictDominates la τ σ`)
+  but DOES fit the direction-flipped variant (`tabloidStrictDominates la σ τ`).
+
+**Root cause**: the original theorem had the dominance direction reversed.
+The classical Garnir expansion produces tabloids that are strictly dominated
+by σ's tabloid (i.e., σ dominates them), not the other way around. This is
+consistent with the column-word lex order going **down** from σ to standard
+tableaux, which is how the classical algorithm terminates.
+
+### Changes
+
+- `srRank la σ` redefined to count permutations **strictly below** σ in
+  dominance (was: strictly above). With the new definition, srRank strictly
+  decreases when we pass from σ to a τ strictly dominated by σ.
+- `srRank_eq_of_toTabloid_eq` and `srRank_lt_of_tabloidStrictDominates`
+  updated consistently (hypothesis `σ strict dom τ` rather than `τ strict dom σ`).
+- `garnir_twisted_in_lower_span`: span broadened to
+  `{τ // τ col-std ∧ (σ strict dom τ ∨ (same tabloid ∧ rowInv τ < rowInv σ))}`.
+  Matches the `garnir_straightening_step` disjunction, which is necessary:
+  f_w(σ) for w ∈ Neither can contain same-tabloid terms (e.g., the ψ_id
+  component in the counter-example) that lie at the same tabloid class but
+  with smaller rowInv.
+- `garnir_straightening_step`: Or.inl disjunct flipped to `σ strict dom τ`.
+  The internal `h_strict_sub_L` helper is no longer needed (the broadened
+  `garnir_twisted_in_lower_span` output already lives in L).
+- `polytabloidTab_column_standard_in_span`: outer induction's Or.inl branch
+  rewritten to use `tabloidStrictDominates la τ' τ''` (τ' strictly dominates
+  τ''), matching the new `srRank_lt_of_tabloidStrictDominates`.
+
+## Current frontier
+
+`garnir_twisted_in_lower_span` (line 950 after edit) remains a **single
+sorry**, now with a **classically correct statement**. The proof is the
+classical Garnir-term dominance result (James Ch. 7-8 / Fulton Ch. 7): for
+col-std σ with row inversion and a Garnir set G, the twisted polytabloid
+f_w(σ) = w · ψ_σ decomposes as a ℂ-combination of standard polytabloids
+ψ_τ for τ col-std with tabloid ≤ σ's (strictly, or equal with smaller
+row-inversion count).
+
+### Why not filled here
+
+The combinatorial proof requires:
+1. Column-restandardization infrastructure (for each q ∈ Q_λ, express
+   [w q⁻¹ σ] as sign(q₀) · [q₀⁻¹ σ_{w,q}] for col-std σ_{w,q}).
+2. Garnir-term dominance analysis (show σ_{w,q}.tab ≤ σ.tab, with equality
+   only when w q⁻¹ ∈ P_λ and the col-restandardization yields smaller
+   rowInv).
+3. Reassembly into polytabloid basis.
+
+This is several hundred lines of new infrastructure and was out of scope
+for this session. The framework correction — flipping the direction so the
+statements are no longer refuted by the λ=(2,2), σ=swap(0,1) counter-example
+— is complete and verifiable: `lake build` passes with exactly one sorry
+(the same one), and the theorem statements now match the classical result.
+
+### Verification
+
+- `lake build EtingofRepresentationTheory.Chapter5.SpechtModuleBasis`:
+  succeeds (only sorry: line 950, `garnir_twisted_in_lower_span`).
+- `lake build` (full project): succeeds with 8307 jobs.
+- Counter-example λ=(2,2), σ=swap(0,1): both ψ_id (Or.inr, same tabloid +
+  rowInv 0 < 1) and ψ_swap(1,2) (Or.inl, σ strict dom swap(1,2).tab) now
+  lie in the theorem's span. Previously only ψ_id was reachable (via Or.inr)
+  and ψ_swap(1,2) was unreachable, making the theorem provably false at
+  this example.
+
+## Overall project progress
+
+- Stage 3 (formalization) ongoing.
+- Sorry count on branch: 1 in SpechtModuleBasis.lean (unchanged net — still
+  the same sorry, but now correctly stated instead of false).
+- Downstream theorems (`finrank_spechtModule_le_card_syt`,
+  `finrank_spechtModule_eq_card_syt'`) still depend on the (now-correct)
+  sorry, but the framework is sound: filling the classical combinatorial
+  lemma is a well-defined classical task.
+
+## Next step
+
+Fill `garnir_twisted_in_lower_span`. The statement is now classically
+correct (matching James Ch. 7 / Fulton Ch. 7), so the proof is "just" the
+Garnir-term dominance combinatorial result. Recommended sub-issues:
+
+1. **Column-restandardization lemma**: for any perm ρ, find q₀ ∈ Q_λ such
+   that q₀ ρ is col-std, and `ψ_{q₀ ρ} = sign(q₀) · ψ_ρ` (this may already
+   exist in the codebase as `generalizedPolytabloidTab_col_mul`; check).
+2. **Classical Garnir-term dominance**: for w ∈ Neither supported on a
+   Garnir set G, and any q ∈ Q_λ, the col-standardization of w q⁻¹ σ has
+   tabloid dominated by σ's tabloid, with equality only when w q⁻¹ ∈ P_λ.
+3. **Assembly**: use 1+2 to express f_w(σ) in the broadened L.
+
+Each sub-lemma is substantial (50-200 lines); the planner should split
+into separate issues.
+
+## Blockers
+
+- None for the framework direction; the fix is mathematically sound and
+  builds cleanly.
+- The classical Garnir-term dominance sorry remains; planner should
+  decompose into the three sub-lemmas above.


### PR DESCRIPTION
Partial progress on #2438

Session: `d3dde2a8-e913-41ef-8e51-c280eb295183`

21f78be fix: flip dominance direction in Garnir straightening (Wall 3)

🤖 Prepared with Claude Code