### PR TITLE
chore: progress — counter-example refutes garnir_term_sametab_rowInv_lt (#2454)

### DIFF
--- a/progress/20260423T162323Z_84b86e57.md
+++ b/progress/20260423T162323Z_84b86e57.md
@@ -1,0 +1,80 @@
+## Accomplished
+
+Claimed `feature` issue #2454 (`garnir_term_sametab_rowInv_lt` — same-tabloid
+Garnir-term has strictly smaller `rowInvCount'`). Before writing any code,
+worked through a small example to validate the proposed helper. Found a
+concrete counter-example refuting the statement:
+
+- `λ = (2, 2)`, `σ = swap 0 1` (col-std with `rowInvCount' σ = 1`).
+- `p₁ = 0, p₂ = 1` (hrow_eq, hcol_lt, hinv all hold).
+- `w = swap 1 2`, `q = q₀ = swap 1 3`.
+- Then `q₀·w·q⁻¹ = swap 2 3 ∈ P_λ` (verified with Lean `fin_cases` +
+  `simp [Equiv.swap_apply_def]`).
+- So `ρ = swap 2 3 * swap 0 1` is col-std, same tabloid as σ, and
+  `rowInvCount' ρ = 2 > 1 = rowInvCount' σ`.
+
+Posted a detailed counter-example as a comment on #2454 and skipped the
+issue with `coordination skip 2454 "..."` (routes to `replan`).
+
+### Why the sketch fails
+
+The issue's proof sketch claims `q₀·w·q⁻¹ ∈ P_λ` plus `w ∉ P_λ ∪ Q_λ`
+forces `w` to act within a single row, with `q, q₀` cleaning up column
+disorder. But `Q·P·Q` sandwich decompositions are strictly more flexible
+than this — two Q-elements can conjugate a cross-row transposition into
+a within-row one (as in the counter-example where `swap 1 3 · swap 1 2 ·
+swap 1 3 = swap 2 3`).
+
+The real issue is structural: the per-term classification
+(strict-dominates ∨ same-tabloid-smaller-rowInv) cannot capture the
+Garnir identity, because the sum `f_w(σ) = ∑_q sign(q)·[w·q⁻¹·σ]`
+makes progress via sign-cancellation across q's, not via per-term
+dominance. Same underlying issue that refuted #2425 earlier in this
+branch's history.
+
+## Current frontier
+
+- #2454 skipped (counter-example posted) — awaits planner triage.
+- #2453 (sibling — `garnir_term_tabloidDominates`) still open; my
+  counter-example doesn't directly refute it (since for λ=(2,2), σ's
+  tabloid is maximal and dominance is trivial). But the same structural
+  objection likely applies — an eventual planner should assess whether
+  the per-term classification is salvageable at all before dispatching
+  more workers to #2453.
+- Parent #2451 decomposition is almost certainly flawed; the Garnir
+  straightening proof likely needs a whole-sum (not per-term) strategy.
+
+## Overall project progress
+
+- Stage 3 (formalization) — Wall 3 (Chapter 5 Garnir straightening /
+  `dim V_λ = |SYT(λ)|`) continues to hit structural refutations as
+  sub-issues are attempted. Every decomposition of
+  `garnir_twisted_in_lower_span` into per-term claims has hit a
+  counter-example:
+  - #2425: per-term dominance — refuted
+  - #2454: per-term same-tabloid rowInv< — refuted (this session)
+  - #2453: per-term tabloid dominance — open but structurally suspect
+- Sorry count on `main`: unchanged by this session (no code landed).
+
+## Next step
+
+Planner should re-scope the parent #2451 and sibling #2453. Recommended
+path: instead of a per-term classification helper, decompose the Garnir
+proof along the whole-sum structure (e.g. recognize `f_w(σ)` as a
+conjugate polytabloid over `wQ_λw⁻¹` and relate to SYT polytabloids
+directly). This likely requires fresh planning by a human or a `/plan`
+session that reads James Ch. 7.2 more carefully than the helper sketch
+did.
+
+Short-term, a worker can claim #2453 and run the same kind of
+pre-implementation validation — either find a counter-example or
+confirm it holds as stated (the sketch for #2453 is less obviously
+flawed, since its conclusion is preserved by reflexivity in the
+same-tabloid case).
+
+## Blockers
+
+None for future sessions. This session's skip is the right outcome:
+better to leave #2454 unclaimed with a counter-example on record than
+to attempt a false theorem or to `sorry` a statement whose truth is in
+doubt.


### PR DESCRIPTION
Progress entry documenting a counter-example that refutes the helper
`garnir_term_sametab_rowInv_lt` proposed in #2454.

## Summary

- Claimed #2454 (same-tabloid Garnir-term `rowInvCount'` decrease).
- Before writing code, worked through a concrete small example and
  found the helper's conclusion is false:
  - λ = (2, 2), σ = `swap 0 1`, p₁ = 0, p₂ = 1.
  - w = `swap 1 2`, q = q₀ = `swap 1 3`.
  - Then `q₀·w·q⁻¹ = swap 2 3` (computation verified in Lean via
    `fin_cases + simp [Equiv.swap_apply_def]`).
  - ρ = `swap 2 3 · swap 0 1` is col-std, same tabloid as σ,
    `rowInvCount' ρ = 2 > 1 = rowInvCount' σ`.
- Posted the full counter-example as a comment on #2454 and skipped
  the issue (`replan`).

## Why the sketch fails

The sketch claimed `q₀·w·q⁻¹ ∈ P_λ` plus `w ∉ P_λ ∪ Q_λ` forces w to
act within a single row. But Q·P·Q sandwich decompositions are
strictly more flexible: two Q-elements can conjugate a cross-row
transposition into a within-row one (as in this counter-example).
The real issue is structural — per-term classification cannot capture
sign-cancellation in the Q-sum `f_w(σ) = Σ_q sign(q)·[w·q⁻¹·σ]`.

This is the same structural objection that refuted #2425 (see PR #2433).

## Changes

- Adds `progress/20260423T162323Z_84b86e57.md` with the analysis and
  replanning recommendations. No code changes.

## Why this isn't tied to a specific issue

#2454 has been skipped (`replan`), not salvaged. A future planner
should re-scope parent #2451 and likely also validate sibling #2453
(same structural concern, though its conclusion may hold for this
specific counter-example via tabloid reflexivity).

Refs #2454.

🤖 Prepared with Claude Code