### PR TITLE
progress: Schur-Weyl #3 blocked on bimodule foundation (#2463 filed, #2458 skipped)

### DIFF
--- a/progress/20260423T194944Z_15677def.md
+++ b/progress/20260423T194944Z_15677def.md
@@ -1,0 +1,121 @@
+## Accomplished
+
+Claimed #2458 (Schur-Weyl sub-issue #3: "identify Theorem5_18_4 L_i
+summands with SchurModule") and upon orientation discovered a
+**planning-level gap**: the premise of the issue — that
+`Theorem5_18_4_decomposition`'s `L_i` summands are non-trivial
+polynomial GL_N-reps needing character-matching to `SchurModule k N λ`
+— does not hold on the current infrastructure.
+
+### The gap
+
+`Theorem5_18_1_decomposition` (`Chapter5/Theorem5_18_1.lean:172`) claims
+in its docstring to deliver the bimodule form
+
+```
+E ≅ ⊕_i V_i ⊗ W_i,  W_i = Hom_A(V_i, E)
+```
+
+but the actual proof (line 191) sets `W_i := k`, and the theorem's
+signature only asks `AddCommGroup (W i)` and `Module k (W i)` — no
+B-module structure, no simpleness. Concretely the proof applies
+`IsSemisimpleModule.exists_linearEquiv_fin_dfinsupp` to get
+`E ≃ ⊕_{i:Fin n} S_i` (a direct sum of simple A-submodules with
+multiplicity unfolded into separate summands) and then tensors each
+`S_i` with `k` via `TensorProduct.rid`.
+
+Downstream, `Theorem5_18_4_decomposition` inherits this weakness: its
+`L_i` is literally `k`, not a non-trivial GL_N-rep. Hence #2458's
+goal "identify `L_i` with `SchurModule k N λ`" is vacuous as stated —
+`k ≇ SchurModule k N λ` in general.
+
+The scoping doc (`progress/schur-weyl-scoping.md` §5 Step C) assumed
+"existing infrastructure mostly suffices"; the detailed reading done
+in this session refutes that assumption for sub-issue #3.
+
+### Decomposition action
+
+- Filed #2463 "feat(Ch5): bimodule form of double centralizer
+  decomposition (W_i = Hom_A(V_i, E))" — the foundational upgrade.
+  Outlines two proof approaches (via Mathlib isotypic-component
+  infrastructure, or in-place strengthening of
+  `Theorem5_18_1_decomposition`).
+- Commented on #2458 with "Decomposed into #2463" breadcrumb and a
+  detailed explanation of the gap.
+- Added `depends-on: #2463` to #2458 and applied the `blocked` label
+  (auto by `coordination add-dep`).
+- Skipped #2458 (label `claimed` → `replan`), releasing the claim for
+  the planner's next triage cycle. The planner will either narrow
+  #2458 to the residual scope once #2463 lands or close it and re-file
+  sharper sub-issues.
+
+### What would be needed in #2463
+
+```
+E ≃ ⊕_{[V]} V ⊗ L_V,  where L_V = Hom_A(V, E) is a B-module (B =
+  centralizer(A))
+```
+
+- `V_i` mutually non-isomorphic as A-modules (so the direct sum is
+  grouped by isomorphism class, i.e., is the isotypic decomposition).
+- `L_i` carries the B-module action (post-composition with B ⊆ End_k E).
+- `L_i` is simple as a B-module (follows from DCT + Schur's lemma, since
+  `End_A(V_i) = k` over alg-closed k).
+- Downstream: `Theorem5_18_4_decomposition` rebuilt so `L_i` is a
+  non-trivial polynomial GL_N-rep, making #2458 feasible.
+
+### No code changes this session
+
+No `.lean` or `.md` edits in source files. Only issue management:
+created #2463, commented on #2458, changed labels. Branch
+`agent/15677def` has no commits beyond `origin/main` (besides pre-existing
+`.claude/` edits which are off-limits to agents and are unrelated).
+
+## Current frontier
+
+- #2463 (bimodule foundation) — new, unclaimed, `feature` label.
+- #2458 (original Schur-Weyl #3) — blocked on #2463, `replan` label.
+  Awaits planner triage once #2463 lands.
+- #2450 (Wall 3 Garnir straightening) — still open, two prior strategy
+  refutations, needs design work.
+- `iso_of_formalCharacter_eq_schurPoly` (the ultimate target of the
+  Schur-Weyl chain) — still sorry at `FormalCharacterIso.lean:395`.
+
+## Overall project progress
+
+- Wall 2 (D̃_n): Stage A/B/C main math merged (#2444/#2446/#2447);
+  Stage C tail (#2459) still blocked on #2447 presumed merged.
+- Wall 3 (Garnir, #2450): still open, needs design.
+- Schur-Weyl chain:
+  - #4 `schurPoly_linearIndependent` ✅ (PR #2462 merged).
+  - #1 tensor-degree homogeneity ✅ (PR #2461 merged).
+  - #3 identification of `L_i` with `SchurModule` — **blocked** on
+    bimodule foundation (#2463 filed this session).
+  - #5/#6 not yet filed.
+- Framework decision #2436 (Ẽ/T affine Dynkin) — still awaiting Kim.
+
+Sorry count on branch: unchanged at 7.
+
+## Next step
+
+**Pick up #2463** (bimodule foundation) — this is the critical-path
+prerequisite for the Schur-Weyl chain's identification step. The issue
+body outlines two concrete approaches (Mathlib isotypic components vs.
+in-place upgrade of `Theorem5_18_1_decomposition`). Approach A (isotypic
+components) is recommended as cleaner and better-aligned with Mathlib,
+but either is acceptable.
+
+After #2463 lands, a planner cycle should re-narrow #2458 to the
+now-feasible residual: identifying each (non-trivial) `L_i` with a
+concrete `SchurModule k N λ` via character matching + `schurPoly_linearIndependent`.
+
+Alternatively: #2450 (Wall 3 Garnir) is the other major open task but
+needs design work before a worker can act.
+
+## Blockers
+
+- #2458 blocked on #2463 (this session's action).
+- #2436 still blocked on human input (framework A/B/C decision).
+- #2450 not blocked in the formal sense but has two prior refutations;
+  a meditate/plan session should design the whole-sum cancellation
+  strategy before a worker attempts a third time.


### PR DESCRIPTION
Progress-only PR. No `.lean` changes.

### Summary

Upon claiming #2458 (Schur-Weyl sub-issue #3), this session discovered that its premise does not hold on the current infrastructure: `Theorem5_18_4_decomposition`'s `L_i` summands are all `k` (trivial 1-dim), not non-trivial polynomial `GL_N`-reps.

Root cause: `Theorem5_18_1_decomposition` delivers `E ≃ ⊕ V_i` (multiplicity unfolded into separate summands) with `W_i = k`, not the bimodule form `E ≃ ⊕_[V] V ⊗ Hom_A(V, E)` its docstring promises. `k ≇ SchurModule k N λ` in general, so #2458's stated deliverable is vacuous as written.

### Actions

- Filed #2463 for the foundational bimodule upgrade (two concrete proof approaches outlined).
- Commented on #2458 with a `Decomposed into #2463` breadcrumb and a detailed explanation of the gap.
- Added `depends-on: #2463` to #2458 (now `blocked`).
- Skipped #2458 to `replan`.

### Next

Pick up #2463 (bimodule foundation). After it lands, re-narrow #2458 (or re-file) to the now-feasible character-matching step.

🤖 Prepared with Claude Code