### PR TITLE
feat(Ch5): Theorem5_18_1 bimodule — isotypic decomp + Schur evaluation iso foundations

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_18_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_18_1.lean
@@ -25,6 +25,31 @@ universe u v
 
 namespace Etingof
 
+/-!
+## Helper: isotypic direct sum decomposition
+
+For a semisimple Noetherian `R`-module `M`, its isotypic components form a
+finite independent family covering all of `M`. This gives a canonical
+decomposition `M ≃[R] ⨁ c : isotypicComponents R M, c`.
+-/
+
+/-- Decomposition of a semisimple Noetherian `R`-module into its isotypic
+components. The index set `isotypicComponents R M` groups simple submodules
+by isomorphism class. -/
+noncomputable def isotypicDirectSumEquiv
+    (R : Type*) (M : Type*) [Ring R] [AddCommGroup M] [Module R M]
+    [IsSemisimpleModule R M] [IsNoetherian R M]
+    [DecidableEq (isotypicComponents R M)] :
+    (Π₀ c : isotypicComponents R M, (c.1 : Submodule R M)) ≃ₗ[R] M :=
+  let ind : iSupIndep fun c : isotypicComponents R M =>
+      (c.1 : Submodule R M) :=
+    (sSupIndep_iff _).mp (sSupIndep_isotypicComponents R M)
+  have iSup_top :
+      (⨆ c : isotypicComponents R M, (c.1 : Submodule R M)) = ⊤ := by
+    rw [← sSup_eq_iSup']
+    exact sSup_isotypicComponents R M
+  ind.linearEquiv iSup_top
+
 variable (k : Type u) [Field k]
   (E : Type v) [AddCommGroup E] [Module k E] [Module.Finite k E]
 

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_18_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_18_1.lean
@@ -50,6 +50,102 @@ noncomputable def isotypicDirectSumEquiv
     exact sSup_isotypicComponents R M
   ind.linearEquiv iSup_top
 
+/-!
+## Helper: Schur evaluation isomorphism
+
+For a simple `A`-module `V` over an algebraically closed field `k`, an
+isotypic-of-type-`V` finite-dimensional `A`-module `M` is isomorphic to
+`V ⊗[k] (V →ₗ[A] M)` via the evaluation map `v ⊗ f ↦ f v`.
+-/
+
+/-- Over an algebraically closed field, the algebra map `k → End_A V` is a
+`k`-linear equivalence when `V` is simple and finite-dimensional — Schur's
+lemma combined with alg-closedness. -/
+noncomputable def endOfSimpleEquivAlgClosed
+    (k : Type*) [Field k] [IsAlgClosed k]
+    (A : Type*) [Ring A] [Algebra k A]
+    (V : Type*) [AddCommGroup V] [Module k V] [Module A V] [IsScalarTower k A V]
+    [Module.Finite k V] [IsSimpleModule A V] :
+    k ≃ₗ[k] (V →ₗ[A] V) :=
+  LinearEquiv.ofBijective (Algebra.linearMap k (V →ₗ[A] V))
+    (IsSimpleModule.algebraMap_end_bijective_of_isAlgClosed k)
+
+/-- Post-composition equivalence: an `A`-linear equivalence of the codomain
+induces a `k`-linear equivalence of hom-spaces. This works even when `A` is
+non-commutative (where `LinearEquiv.congrRight` does not apply directly). -/
+noncomputable def homCongrRightOverSubring
+    (k : Type*) [CommSemiring k]
+    (A : Type*) [Ring A] [Algebra k A]
+    (V : Type*) [AddCommGroup V] [Module k V] [Module A V] [IsScalarTower k A V]
+    {M N : Type*}
+    [AddCommGroup M] [Module k M] [Module A M] [IsScalarTower k A M]
+    [AddCommGroup N] [Module k N] [Module A N] [IsScalarTower k A N]
+    (e : M ≃ₗ[A] N) :
+    (V →ₗ[A] M) ≃ₗ[k] (V →ₗ[A] N) where
+  toFun f := e.toLinearMap.comp f
+  invFun f := e.symm.toLinearMap.comp f
+  left_inv f := by ext; simp
+  right_inv f := by ext; simp
+  map_add' f g := by ext; simp
+  map_smul' c f := by
+    ext v
+    simp [LinearMap.smul_apply, LinearMap.comp_apply, LinearEquiv.coe_coe]
+
+/-- The curry equivalence: a map into a product of copies of `V` is the same
+as a product of maps into `V`. This is `k`-linear since `k` acts through
+either side. -/
+noncomputable def homPiCurryEquiv
+    (k : Type*) [CommSemiring k]
+    (A : Type*) [Ring A] [Algebra k A]
+    (V : Type*) [AddCommGroup V] [Module k V] [Module A V] [IsScalarTower k A V]
+    (ι : Type*) :
+    (V →ₗ[A] (ι → V)) ≃ₗ[k] (ι → V →ₗ[A] V) where
+  toFun f i := (LinearMap.proj i).comp f
+  invFun g := LinearMap.pi g
+  left_inv f := by ext v i; rfl
+  right_inv g := by funext i; ext v; rfl
+  map_add' f g := by funext i; ext v; simp
+  map_smul' c f := by funext i; ext v; simp
+
+/-- Schur evaluation isomorphism: for a simple `A`-module `V` over an
+algebraically closed field `k`, an isotypic-of-type-`V` finite-dimensional
+`A`-module `M` is isomorphic to `V ⊗[k] (V →ₗ[A] M)` as `k`-modules.
+
+The isomorphism is built by composing the multiplicity decomposition
+`M ≃[A] Fin n → V` with Schur's lemma (`End_A V ≃[k] k`) and the standard
+tensor iso `V ⊗[k] (Fin n → k) ≃[k] Fin n → V`. -/
+noncomputable def schurEvaluationEquiv
+    (k : Type*) [Field k] [IsAlgClosed k]
+    (A : Type*) [Ring A] [Algebra k A]
+    (V : Type*) [AddCommGroup V] [Module k V] [Module A V] [IsScalarTower k A V]
+    [Module.Finite k V] [IsSimpleModule A V]
+    (M : Type*) [AddCommGroup M] [Module k M] [Module A M] [IsScalarTower k A M]
+    [Module.Finite k M] [IsSemisimpleModule A M]
+    (h : IsIsotypicOfType A M V) :
+    V ⊗[k] (V →ₗ[A] M) ≃ₗ[k] M :=
+  haveI : Module.Finite A M := Module.Finite.of_restrictScalars_finite k A M
+  haveI : Nontrivial V := IsSimpleModule.nontrivial A V
+  let n : ℕ := h.linearEquiv_fun.choose
+  let e : M ≃ₗ[A] (Fin n → V) := h.linearEquiv_fun.choose_spec.some
+  -- Chain:
+  -- V ⊗[k] (V →ₗ[A] M)
+  -- ≃[k] V ⊗[k] (V →ₗ[A] Fin n → V)         -- congrRight e
+  -- ≃[k] V ⊗[k] (Fin n → V →ₗ[A] V)         -- curry
+  -- ≃[k] V ⊗[k] (Fin n → k)                 -- Schur + alg-closed
+  -- ≃[k] Fin n → V                           -- piScalarRight
+  -- ≃[k] M                                   -- e.symm
+  let e1 : (V →ₗ[A] M) ≃ₗ[k] (V →ₗ[A] (Fin n → V)) :=
+    homCongrRightOverSubring k A V e
+  let e2 : (V →ₗ[A] (Fin n → V)) ≃ₗ[k] (Fin n → V →ₗ[A] V) :=
+    homPiCurryEquiv k A V (Fin n)
+  let e3 : (Fin n → V →ₗ[A] V) ≃ₗ[k] (Fin n → k) :=
+    LinearEquiv.piCongrRight (fun _ => (endOfSimpleEquivAlgClosed k A V).symm)
+  let e4 : V ⊗[k] (Fin n → k) ≃ₗ[k] (Fin n → V) :=
+    TensorProduct.piScalarRight k k V (Fin n)
+  let e5 : (Fin n → V) ≃ₗ[k] M := e.symm.restrictScalars k
+  (TensorProduct.congr (LinearEquiv.refl k V)
+    (e1.trans (e2.trans e3))).trans (e4.trans e5)
+
 variable (k : Type u) [Field k]
   (E : Type v) [AddCommGroup E] [Module k E] [Module.Finite k E]
 

--- a/progress/2026-04-23T20-27-58Z_cabdf1b3.md
+++ b/progress/2026-04-23T20-27-58Z_cabdf1b3.md
@@ -1,0 +1,85 @@
+## Accomplished
+
+Claimed #2463 (feat: bimodule form of double centralizer decomposition,
+i.e. `Theorem5_18_1_bimodule_decomposition`). Parent is large; after
+orienting, decomposed into three workstreams and made concrete progress
+on the first two foundational pieces.
+
+**Decomposition of #2463:**
+
+- (this PR, partial): `isotypicDirectSumEquiv` helper.
+- #2465 (new sub-issue): Schur evaluation iso
+  `V ⊗[k] (V →ₗ[A] M) ≃[k] M` for isotypic-of-type-`V` `M` over alg-closed
+  `k`. **Content actually landed in this PR** — planner can either close
+  #2465 now or re-scope to "port into a dedicated helper file" if desired.
+- #2466 (new sub-issue, depends on #2465): main theorem assembly +
+  downstream `Theorem5_18_4_decomposition` upgrade (unblocks #2458).
+
+**Foundation code landed in
+`EtingofRepresentationTheory/Chapter5/Theorem5_18_1.lean`:**
+
+1. `Etingof.isotypicDirectSumEquiv` — decomposes a semisimple Noetherian
+   `R`-module `M` as a direct sum over `isotypicComponents R M`.
+   Built from Mathlib's `sSupIndep_isotypicComponents` +
+   `sSup_isotypicComponents` + `iSupIndep.linearEquiv`.
+
+2. `Etingof.endOfSimpleEquivAlgClosed` — `k ≃[k] (V →ₗ[A] V)` via
+   `IsSimpleModule.algebraMap_end_bijective_of_isAlgClosed`.
+
+3. `Etingof.homCongrRightOverSubring` — `k`-linear version of
+   `LinearEquiv.congrRight` that works when the outer ring `A` is
+   non-commutative (Mathlib's `congrRight` requires `CommSemiring`).
+
+4. `Etingof.homPiCurryEquiv` — `(V →ₗ[A] ι → V) ≃[k] (ι → V →ₗ[A] V)`.
+
+5. `Etingof.schurEvaluationEquiv` — the main Schur evaluation iso
+   (assembled as a composition of the above).
+
+Zero sorries added. `lake build EtingofRepresentationTheory.Chapter5.Theorem5_18_1`
+succeeds with only a pre-existing maxHeartbeats linter warning on the
+untouched `Theorem5_18_1_decomposition`.
+
+## Current frontier
+
+With `isotypicDirectSumEquiv` and `schurEvaluationEquiv` in place, the
+remaining work (#2466) is:
+
+- Pick a simple `V_c` submodule from each isotypic component `c` of `E`
+  (via `IsSemisimpleModule.eq_bot_or_exists_simple_le`).
+- Prove `V_c` distinct across isotypic components (simples from different
+  isotypic components are non-iso).
+- Give `L_c := V_c →ₗ[A] E` the natural `B = Subalgebra.centralizer k A`
+  action by post-composition (well-defined because `B` centralizes `A`).
+- Bridge `V_c →ₗ[A] E ≃[k] V_c →ₗ[A] c` (Hom from a simple lands in
+  its isotypic component) so `schurEvaluationEquiv` applies.
+- Compose `isotypicDirectSumEquiv` + per-summand `schurEvaluationEquiv`
+  into the full bimodule decomposition.
+- Propagate the upgrade through `Theorem5_18_4_decomposition` so `L_i`
+  carries the `GL(V)`-action for #2458.
+
+This is estimated at 200-300 lines; reachable by the next worker with
+the foundation now in place.
+
+## Overall project progress
+
+Ch5 FormalCharacterIso unchanged. Ch5 Theorem5_18_1 now has two new
+helper definitions and one non-trivial construction (`schurEvaluationEquiv`)
+that will be used by the full bimodule theorem. `Theorem5_18_1_decomposition`
+unchanged (still returns `W_i = k`); `Theorem5_18_1_bimodule_decomposition`
+is slated for #2466.
+
+Full `lake build` (Chapter5 scope) compiles.
+
+## Next step
+
+A worker should claim #2466 (main theorem assembly). #2465 can be
+triaged by a planner — the content landed here, so the planner may
+either close #2465 as covered or keep it as "port helpers to a dedicated
+file". No dependency chain change needed since #2466 only actually
+depends on the code landed in this PR, which will be on `main`.
+
+## Blockers
+
+None. #2463 was too large for one session (estimated 350-450 lines);
+decomposing into #2465 + #2466 with two foundation pieces landed is the
+normal success path per the agent-worker-flow skill.


### PR DESCRIPTION
Partial progress on #2463

Session: `cabdf1b3-c043-4061-8a1a-ec85812f7831`

2441c2a progress: Theorem5_18_1 bimodule — foundation pieces landed, #2463 decomposed into #2465 + #2466
452a858 feat(Ch5): schurEvaluationEquiv V ⊗[k] Hom_A(V,M) ≃[k] M for isotypic M over alg-closed k
aad5a4a feat(Ch5): isotypicDirectSumEquiv helper for Theorem5_18_1 bimodule

🤖 Prepared with Claude Code