### PR TITLE
feat(Ch5): bimodule helpers — centralizerToEndA, B-module on V →[A] E, range lemma (#2466 partial)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_18_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_18_1.lean
@@ -316,4 +316,111 @@ theorem Theorem5_18_1_decomposition
     ⟨(e.restrictScalars k).trans
       (DFinsupp.mapRange.linearEquiv (fun i => (TensorProduct.rid k ↥(S i)).symm))⟩⟩
 
+/-!
+## Helpers for the bimodule form of the double centralizer theorem
+
+For the bimodule decomposition `E ≃ ⨁ Vᵢ ⊗ Lᵢ`, we need:
+* The centralizer `B = centralizer(A)` acts on the Hom-space `V →ₗ[A] E`
+  by post-composition. Elements of `B` commute with `A`, hence are
+  `A`-linear maps `E → E`, which can be composed on the right of any
+  `A`-linear map out of `V`.
+* For a simple submodule `V` of an isotypic component `c`, every `A`-linear
+  map `V → E` lands inside `c` (by `Submodule.map_le_isotypicComponent`
+  combined with `c = isotypicComponent A E V`).
+-/
+
+/-- The ring homomorphism `B := centralizer(A) → End_A(E)`: every element of
+the centralizer (which commutes with `A`) is `A`-linear. -/
+noncomputable def centralizerToEndA
+    (A : Subalgebra k (Module.End k E)) :
+    (↥(Subalgebra.centralizer k (A : Set (Module.End k E)))) →+*
+      Module.End A E where
+  toFun b :=
+    { toFun := b.val
+      map_add' := b.val.map_add
+      map_smul' := fun a e => by
+        have hb := b.property
+        rw [Subalgebra.mem_centralizer_iff] at hb
+        have h := hb a.val a.property
+        -- h : b.val * a.val = a.val * b.val in End_k(E); apply to e
+        have happ := LinearMap.congr_fun h e
+        -- happ : (a.val * b.val) e = (b.val * a.val) e
+        -- i.e. a.val (b.val e) = b.val (a.val e)
+        -- Goal: b.val (a • e) = (RingHom.id A) a • b.val e
+        -- Since a • e = a.val e and a • b.val e = a.val (b.val e),
+        -- goal becomes b.val (a.val e) = a.val (b.val e), which is happ.symm.
+        exact happ.symm }
+  map_one' := by ext; rfl
+  map_mul' _ _ := by ext; rfl
+  map_zero' := by ext; rfl
+  map_add' _ _ := by ext; rfl
+
+set_option synthInstance.maxHeartbeats 400000 in
+/-- `V →ₗ[A] E` carries a `Module B`-structure (where `B = centralizer(A)`)
+via post-composition: `(b • f) v := b.val (f v)`. -/
+noncomputable instance centralizerModuleHom
+    {A : Subalgebra k (Module.End k E)}
+    {V : Type*} [AddCommGroup V] [Module k V]
+    [Module A V] [IsScalarTower k A V] :
+    Module (↥(Subalgebra.centralizer k (A : Set (Module.End k E))))
+      (V →ₗ[A] E) where
+  smul b f := (centralizerToEndA k E A b).comp f
+  one_smul f := by
+    refine LinearMap.ext fun v => ?_
+    change (centralizerToEndA k E A 1) (f v) = f v
+    rw [map_one]; rfl
+  mul_smul b₁ b₂ f := by
+    refine LinearMap.ext fun v => ?_
+    change (centralizerToEndA k E A (b₁ * b₂)) (f v) =
+      (centralizerToEndA k E A b₁)
+        ((centralizerToEndA k E A b₂) (f v))
+    rw [map_mul]; rfl
+  smul_zero b := by
+    refine LinearMap.ext fun v => ?_
+    change (centralizerToEndA k E A b) ((0 : V →ₗ[A] E) v) = 0
+    simp
+  smul_add b f g := by
+    refine LinearMap.ext fun v => ?_
+    change (centralizerToEndA k E A b) ((f + g) v) =
+      (centralizerToEndA k E A b) (f v) + (centralizerToEndA k E A b) (g v)
+    simp
+  add_smul b₁ b₂ f := by
+    refine LinearMap.ext fun v => ?_
+    change (centralizerToEndA k E A (b₁ + b₂)) (f v) =
+      (centralizerToEndA k E A b₁) (f v) + (centralizerToEndA k E A b₂) (f v)
+    rw [map_add]; rfl
+  zero_smul f := by
+    refine LinearMap.ext fun v => ?_
+    change (centralizerToEndA k E A 0) (f v) = 0
+    rw [map_zero]; rfl
+
+set_option synthInstance.maxHeartbeats 400000 in
+/-- The natural bridge: every `A`-linear map from a simple submodule `V ≤ E`
+into `E` lands in the isotypic component `isotypicComponent A E V`. -/
+theorem range_le_isotypicComponent_of_simple
+    {A : Subalgebra k (Module.End k E)}
+    (V : Submodule A E) [IsSimpleModule A V]
+    (f : V →ₗ[A] E) :
+    LinearMap.range f ≤ isotypicComponent A E V := by
+  classical
+  by_cases hf : f = 0
+  · simp [hf]
+  · -- f ≠ 0 ⇒ f injective (Schur on simple V) ⇒ range f ≃[A] V ⇒ range f
+    -- lies in the isotypic component determined by V.
+    have hker : LinearMap.ker f = ⊥ := by
+      rcases eq_bot_or_eq_top (LinearMap.ker f) with h | h
+      · exact h
+      · exfalso; apply hf
+        ext v
+        have hv : v ∈ LinearMap.ker f := h ▸ Submodule.mem_top
+        simpa [LinearMap.mem_ker] using hv
+    have hinj : Function.Injective f := LinearMap.ker_eq_bot.mp hker
+    have e : V ≃ₗ[A] LinearMap.range f := LinearEquiv.ofInjective f hinj
+    have heq : isotypicComponent A E (LinearMap.range f) = isotypicComponent A E V :=
+      e.symm.isotypicComponent_eq
+    calc LinearMap.range f
+        ≤ isotypicComponent A E (LinearMap.range f) :=
+          Submodule.le_isotypicComponent _
+      _ = isotypicComponent A E V := heq
+
 end Etingof

--- a/progress/20260423T213518Z_812af002.md
+++ b/progress/20260423T213518Z_812af002.md
@@ -1,0 +1,103 @@
+## Accomplished
+
+Worker session on #2466 (Theorem5_18_1 bimodule #2 — assembly +
+Theorem5_18_4 upgrade). Landed foundation helpers; decomposed the
+remaining work into sub-issues.
+
+### Landed (commit cb09355 on `agent/812af002`)
+
+Three helpers in `Chapter5/Theorem5_18_1.lean`:
+
+* `centralizerToEndA A : B →+* Module.End A E` — elements of
+  `B = centralizer k A` commute with `A`, hence act `A`-linearly on
+  `E`. Packaged as a `RingHom`.
+* `centralizerModuleHom` — `Module B (V →ₗ[A] E)` instance via
+  post-composition `(b • f) v := b.val (f v)`. Needs
+  `synthInstance.maxHeartbeats 400000`. Works for any `V` with scalar
+  tower.
+* `range_le_isotypicComponent_of_simple` — every `A`-linear map from a
+  simple submodule `V ≤ E` has range inside `isotypicComponent A E V`.
+  Proof: Schur splits `f = 0` vs `f` injective; in the injective case
+  `V ≃[A] range f` and `LinearEquiv.isotypicComponent_eq` closes.
+
+`lake build EtingofRepresentationTheory.Chapter5.Theorem5_18_1`
+succeeds with zero sorries.
+
+### Decomposition
+
+Filed two sub-issues and commented the breadcrumb on #2466:
+
+* **#2471** — `Theorem5_18_1_bimodule_decomposition` main assembly.
+  Detailed construction recipe included: use `Fin m`-indexed ι via
+  `Fintype.equivFin`, pick simple submodules via
+  `IsSemisimpleModule.eq_bot_or_exists_simple_le`, compose
+  `isotypicDirectSumEquiv` + `schurEvaluationEquiv` + the bridge
+  `homIsotypicBridge` (spec'd in the sub-issue) + `DFinsupp.mapRange`
+  + `DirectSum.lequivCongrLeft`.
+* **#2472** — Theorem5_18_4 upgrade (`Theorem5_18_4_bimodule_decomposition`),
+  depends on #2471, unblocks #2458.
+
+### Why decomposition
+
+Attempted the main assembly in this session. Ran into repeated
+typeclass elaboration issues composing submodules with
+`schurEvaluationEquiv`, `homIsotypicBridge`, and
+`DirectSum.lequivCongrLeft`:
+
+* `Module ↥A ↥V` for `V : Submodule A E` timing out at 20k synth
+  heartbeats, even with `synthInstance.maxHeartbeats 400000`.
+* Spurious `Field ↥V` and `Field ↥(V' c)` synthesis attempts from
+  `schurEvaluationEquiv` call site (which takes `k` as the Field,
+  suggesting elaboration order issue with section variables).
+* `DirectSum.lequivCongrLeft` direction confusion (`φ` vs `φ.symm`).
+
+Hit 3 attempts at restructuring; per `agent-worker-flow` + project
+CLAUDE.md, decomposing is the right move. The sub-issues inherit the
+cleaner helper baseline — subsequent workers don't need to rediscover
+the ring hom / module instance / range lemma.
+
+## Current frontier
+
+* **Helpers landed on `agent/812af002` commit cb09355**: usable by
+  the sub-issues directly.
+* **#2471 (assembly) unclaimed**: self-contained, has the full recipe
+  including the bridge def spec.
+* **#2472 (Theorem5_18_4 upgrade) blocked on #2471**.
+* **Parent #2466 will be closed by next planner's replan-triage** via
+  the `Decomposed into #2471, #2472` comment and the partial PR.
+
+## Overall project progress
+
+* **Wall 2 (D̃_n)**: Stage A/B/C main math merged (#2444/#2449/#2460);
+  residual Fin-transport tail in #2459 (unclaimed).
+* **Wall 3 (#2450 Garnir)**: open, unclaimed, needs design.
+* **Schur-Weyl chain**:
+  * #1 ✅ (PR #2461), #4 ✅ (PR #2462)
+  * Bimodule foundations: `isotypicDirectSumEquiv`,
+    `schurEvaluationEquiv` (PR #2467) + centralizer/bridge helpers
+    (this turn, pending PR).
+  * #2466 assembly decomposed → #2471 + #2472
+  * #2 (#2468) — unclaimed, parallel-safe
+  * #3 (#2458) — blocked transitively on #2472.
+* **Sorry count on `main`**: unchanged (this turn adds no sorries, just
+  new definitions/theorems with complete proofs).
+
+## Next step
+
+Three parallel-safe items for the next workers:
+
+1. **#2471** — Theorem5_18_1 bimodule main assembly. Highest priority
+   on the Schur-Weyl critical path. Cleaner than before because the
+   helpers are already committed.
+2. **#2468** — Schur-Weyl #2 embedding. Parallel-safe.
+3. **#2459** — Wall 2 Fin-transport tail. Low-risk mechanical work.
+
+Other options: **#2469** (wave-55 summarize), **#2450** (Wall 3
+Garnir, hardest).
+
+## Blockers
+
+* **#2472** blocked on **#2471** (dependency recorded).
+* **#2458** blocked on **#2472** (transitively on #2471).
+* **#2401** blocked on **#2436** (Ẽ/T framework, human oversight).
+* **#2436** awaits Kim's input.


### PR DESCRIPTION
Partial progress on #2466

Session: `812af002-0afa-4af4-a728-d5fe64f02c0e`

d4d04e6 progress: decompose #2466 bimodule assembly — helpers landed, filed #2471 + #2472
cb09355 feat(Ch5): helpers for bimodule decomposition — centralizerToEndA, centralizerModuleHom, range_le_isotypicComponent_of_simple

🤖 Prepared with Claude Code