### PR TITLE
doc: #2450 skip analysis — whole-sum strategy validated on λ=(2,2) counter-example

### DIFF
--- a/progress/20260424T034536Z_2a4d9cc5.md
+++ b/progress/20260424T034536Z_2a4d9cc5.md
@@ -1,0 +1,104 @@
+## Accomplished
+
+Claimed `feature` issue #2450 (`garnir_twisted_in_lower_span`) and did
+substantial mathematical validation of the whole-sum cancellation
+strategy on the counter-example λ=(2,2), σ=swap(0,1). Verified that
+the strategy closes the counter-example correctly: exhibited an
+explicit decomposition of each neither-supported `f_w(σ)` into `ψ_τ`'s
+satisfying the broadened disjunction.
+
+**Key finding.** For λ=(2,2), σ=swap(0,1), G=garnirSet(0,1)={0,1,2},
+Neither∩{G-supp}\{1} = {swap(1,2), (0,1,2), (0,2,1)} (3 elements).
+Hand-computing each `twistedPolytabloid (w, σ)`:
+
+| w          | TP(w, σ)                                                                           |
+|------------|-------------------------------------------------------------------------------------|
+| swap(1,2)  | 0 (all 4 tabloids equal — pigeonhole collapse)                                    |
+| (0,1,2)    | 0 (same pigeonhole collapse)                                                       |
+| (0,2,1)    | `ψ_τ − ψ_id` where τ=[0,2,1,3] (col-std, tabloid [{0,2}|{1,3}] strict dom σ) and id |
+
+**Both τ's lie in the broadened L** (τ via `Or.inl`; id via `Or.inr`
+same-tabloid + rowInv 0 < 1 = rowInv σ). So the lemma holds at the
+counter-example under the whole-sum strategy — the proof is not vacuous.
+
+Also verified the **Garnir identity** `ψ_σ + S_neither = 0` numerically:
+both sides expand to `[{0,1}|{2,3}] − [{0,2}|{1,3}] − [{1,3}|{0,2}] +
+[{2,3}|{0,1}]`, up to sign.
+
+**Why no code landed.** The proof is the entirety of Wall 3. Making
+the above into a Lean proof requires, in order:
+
+1. **Column-restandardization for each `w q⁻¹ σ`**: for each pair
+   `(w, q)`, find `q_{w,q} ∈ Q_λ` so that `q_{w,q} · w · q⁻¹ · σ` is
+   col-std, plus a sign tracking.
+2. **A "pigeonhole collapse" lemma**: for w supported on the Garnir
+   set G with `|col(p₁)∩G| + |col(p₂)∩G| > (#rows spanned by G)`, and
+   for q varying over some coset in Q_λ, the tabloids `[w q⁻¹ σ]` are
+   all equal (so the alternating sum is 0).
+3. **Residual-term classification**: the q's not covered by (2)
+   produce terms that resolve to ψ_τ's with τ satisfying the
+   broadened disjunction — *this is where the counter-example bites
+   the per-term approaches*, and the whole-sum is handled via grouping
+   by col-std equivalence classes in Q_λ with sign-sum coefficients.
+4. **Assembly**: combine into the final span membership.
+
+Each of (1)–(4) is a substantial lemma (~50–200 lines of Lean); total
+easily several hundred lines. Beyond a single worker session.
+
+## Current frontier
+
+`garnir_twisted_in_lower_span` (SpechtModuleBasis.lean:950) remains
+sorry'd. No code changes on this branch.
+
+## Overall project progress
+
+- Stage 3 (formalization) ongoing.
+- Sorry count on branch: **unchanged** (skipped, no code landed).
+- Wall 3 (#2450): still unclosed, but **whole-sum strategy validated**
+  against the canonical counter-example. The next session on this
+  should decompose along the (1)–(4) axes with the explicit verification
+  above as the correctness anchor.
+
+## Next step
+
+**Planner action**: decompose #2450 into the four sub-issues above.
+Each sub-issue should cite this progress entry and the explicit
+`(0,2,1)` decomposition as the validation anchor. In particular:
+
+- Sub-issue (2) (pigeonhole collapse) is the mathematical heart — and
+  is the one that the previous refuted approaches failed to isolate.
+  A good statement: "for w ∈ Neither G-supported and any q₀ ∈ Q_λ,
+  if the coset `q₀ · (Q_λ ∩ S_{w⁻¹·Y})` for appropriate Y ⊆ G collapses
+  tabloids, then the partial-sum is zero." (Exact statement needs
+  working out.)
+- Sub-issue (3) is where the Q·P·Q sandwich issue arises and needs
+  careful handling via **grouping q's that produce equivalent
+  col-restandardizations**, not via per-q classification.
+
+Each sub-issue must **verify on the counter-example** before dispatch
+(#2450's own pre-implementation requirement). This progress entry's
+computation is the verification oracle — the target of sub-issue (1)
+should reproduce `f_{(0,2,1)}(swap(0,1)) = ψ_[0,2,1,3] − ψ_id`.
+
+## Blockers
+
+None new. #2450 remains open after skip → `replan`. The framework
+direction is sound (the theorem statement is classically correct per
+wave-55 design doc); what's missing is **the 100–300 line proof
+scaffolding**, not a framework decision.
+
+## Verification of the counter-example decomposition (self-contained)
+
+Reproducing for the planner / next worker (tabloid convention: row r
+of tabloid = entries k with rowOfPos(σ(k)) = r):
+
+- `ψ_σ` (σ=swap(0,1)) = `[{0,1}|{2,3}] − [{0,2}|{1,3}] − [{1,3}|{0,2}] + [{2,3}|{0,1}]`
+- `TP(swap(1,2), σ)` = 0 (all 4 wq⁻¹σ have tabloid `[{1,2}|{0,3}]`)
+- `TP((0,1,2), σ)` = 0 (all 4 wq⁻¹σ have tabloid `[{1,2}|{0,3}]`)
+- `TP((0,2,1), σ)` = `[{0,2}|{1,3}] − [{0,1}|{2,3}] − [{2,3}|{0,1}] + [{1,3}|{0,2}]`
+- `ψ_[0,2,1,3]` = `[{0,2}|{1,3}] − [{1,2}|{0,3}] − [{0,3}|{1,2}] + [{1,3}|{0,2}]`
+- `ψ_id` = `[{0,1}|{2,3}] − [{1,2}|{0,3}] − [{0,3}|{1,2}] + [{2,3}|{0,1}]`
+- `ψ_[0,2,1,3] − ψ_id` = `[{0,2}|{1,3}] − [{0,1}|{2,3}] − [{2,3}|{0,1}] + [{1,3}|{0,2}]` = `TP((0,2,1), σ)` ✓
+
+So `f_{(0,2,1)}(σ) = ψ_[0,2,1,3] − ψ_id` lies in L under the broadened
+disjunction (Or.inl + Or.inr respectively).


### PR DESCRIPTION
## Summary

- Claimed #2450 (`garnir_twisted_in_lower_span`), verified whole-sum
  cancellation strategy closes the canonical counter-example
  λ=(2,2), σ=swap(0,1), and skipped for planner re-decomposition.
- Explicit numeric witness: `f_{(0,2,1)}(σ) = ψ_[0,2,1,3] − ψ_id`
  where both τ's lie in the broadened L (one via `Or.inl`, one via `Or.inr`).
- Progress file sketches a 4-step decomposition (col-restandardization,
  pigeonhole collapse, residual classification, assembly) for the next
  planner cycle.

## Changes

- Adds `progress/20260424T034536Z_2a4d9cc5.md` (no code changes).

## Test plan

- [x] `progress/` file only — no Lean changes, CI is informational

🤖 Prepared with Claude Code