### PR TITLE
feat(Ch5): polynomial-tensor bridge construction + injectivity (Schur-Weyl #2a, equivariance → #2496)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5.lean
+++ b/EtingofRepresentationTheory/Chapter5.lean
@@ -79,6 +79,7 @@ import EtingofRepresentationTheory.Chapter5.Theorem5_18_1
 import EtingofRepresentationTheory.Chapter5.Theorem5_18_2
 import EtingofRepresentationTheory.Chapter5.Lemma5_18_3
 import EtingofRepresentationTheory.Chapter5.Theorem5_18_4
+import EtingofRepresentationTheory.Chapter5.PolynomialTensorBridge
 
 -- Section 5.19: Schur-Weyl Duality and Schur Functors
 import EtingofRepresentationTheory.Chapter5.Proposition5_19_1

--- a/EtingofRepresentationTheory/Chapter5/PolynomialTensorBridge.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialTensorBridge.lean
@@ -40,9 +40,16 @@ zero this is an iso onto its image.
 ## Main results
 
 * `homogeneousPolyToTensor_injective` — the bridge is injective.
-* `homogeneousPolyToTensor_equivariant` — the bridge intertwines the
-  right-translation action on polynomials with the `g ↦ g^⊗n ⊗ 1`
-  action on the tensor target.
+
+## Status
+
+Equivariance of the bridge under the GL_N-right-translation action on
+polynomials vs. the `g ↦ g^⊗n ⊗ 1` action on the tensor target is the
+intended companion property. It is deferred to a sibling issue so that
+the construction and injectivity land first (injectivity is the key
+property that `#2478` consumes via the left-inverse — equivariance will
+be stated and proved alongside the final `polynomialRep_embeds_in_tensorPower`
+assembly).
 -/
 
 open scoped TensorProduct

--- a/EtingofRepresentationTheory/Chapter5/PolynomialTensorBridge.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialTensorBridge.lean
@@ -215,6 +215,70 @@ lemma prod_X_canonicalSeq (s : (Fin N × Fin N) →₀ ℕ) (hs : s.sum (fun _ =
   -- Now goal is `s.prod (fun a n => (X a) ^ n) = monomial s 1`
   exact MvPolynomial.prod_X_pow_eq_monomial
 
+/-- `tensorToPoly` applied to `multisetToTensor s` recovers the monomial `X^s`
+when `s` has the correct degree `n` (otherwise it is zero). -/
+lemma tensorToPoly_multisetToTensor (s : (Fin N × Fin N) →₀ ℕ) :
+    tensorToPoly k N n (multisetToTensor k N n s) =
+      if s.sum (fun _ => id) = n then MvPolynomial.monomial s (1 : k) else 0 := by
+  unfold multisetToTensor
+  split_ifs with hs
+  · rw [tensorToPoly_symTensor, prod_X_canonicalSeq (k := k) (N := N) (n := n) s hs]
+  · simp
+
+/-- The composition `tensorToPoly ∘ polyToTensor` is the identity on the
+degree-`n` homogeneous submodule: a homogeneous polynomial `p` recovers as
+`tensorToPoly (polyToTensor p) = p`. -/
+lemma tensorToPoly_polyToTensor_eq_self (p : MvPolynomial (Fin N × Fin N) k)
+    (hp : p.IsHomogeneous n) :
+    tensorToPoly k N n (polyToTensor k N n p) = p := by
+  classical
+  -- Expand p in the monomial basis and compute term-by-term.
+  conv_rhs => rw [p.as_sum]
+  rw [show tensorToPoly k N n (polyToTensor k N n p) =
+      tensorToPoly k N n (polyToTensor k N n
+        (∑ v ∈ p.support, MvPolynomial.monomial v (MvPolynomial.coeff v p))) from by
+    congr 2; exact p.as_sum]
+  rw [map_sum, map_sum]
+  apply Finset.sum_congr rfl
+  intro s hs
+  -- For `monomial s c`, compute polyToTensor and tensorToPoly.
+  have hcoeff_ne : MvPolynomial.coeff s p ≠ 0 := MvPolynomial.mem_support_iff.mp hs
+  -- Homogeneity: |s| = n.
+  have hsn : s.sum (fun _ => id) = n := by
+    have hw := hp hcoeff_ne  -- weight 1 s = n
+    -- weight 1 s = s.sum (fun _ => id) when s takes values in ℕ
+    rw [Finsupp.weight_apply] at hw
+    simpa using hw
+  -- Compute: monomial s c = c • monomial s 1
+  rw [show MvPolynomial.monomial s (MvPolynomial.coeff s p) =
+        MvPolynomial.coeff s p • MvPolynomial.monomial s (1 : k) from by
+    rw [MvPolynomial.smul_monomial, smul_eq_mul, mul_one]]
+  rw [LinearMap.map_smul, LinearMap.map_smul]
+  congr 1
+  -- polyToTensor (monomial s 1) = multisetToTensor s
+  rw [show polyToTensor k N n (MvPolynomial.monomial s 1) = multisetToTensor k N n s from by
+    unfold polyToTensor
+    rw [show (MvPolynomial.monomial s 1 : MvPolynomial (Fin N × Fin N) k) =
+         MvPolynomial.basisMonomials (Fin N × Fin N) k s from rfl,
+      Module.Basis.constr_basis]]
+  rw [tensorToPoly_multisetToTensor, if_pos hsn]
+
+/-- The bridge `homogeneousPolyToTensor` is injective: distinct homogeneous
+polynomials give distinct tensors. -/
+theorem homogeneousPolyToTensor_injective :
+    Function.Injective (homogeneousPolyToTensor k N n) := by
+  intro p q hpq
+  apply Subtype.ext
+  have hp := tensorToPoly_polyToTensor_eq_self k N n p.val p.property
+  have hq := tensorToPoly_polyToTensor_eq_self k N n q.val q.property
+  have heq : tensorToPoly k N n (polyToTensor k N n p.val) =
+      tensorToPoly k N n (polyToTensor k N n q.val) := by
+    unfold homogeneousPolyToTensor at hpq
+    simp only [LinearMap.comp_apply, Submodule.subtype_apply] at hpq
+    rw [hpq]
+  rw [hp, hq] at heq
+  exact heq
+
 end PolynomialTensorBridge
 
 end Etingof

--- a/EtingofRepresentationTheory/Chapter5/PolynomialTensorBridge.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialTensorBridge.lean
@@ -82,6 +82,17 @@ This depends only on the multiset of `f` (see `symTensor_comp_perm`). -/
 noncomputable def symTensor (f : Fin n → Fin N × Fin N) : PolyTensorTgt k N n :=
   (n.factorial : k)⁻¹ • ∑ σ : Equiv.Perm (Fin n), seqTensor k N n (f ∘ σ)
 
+/-- The symmetrized tensor depends only on the multiset of `f`:
+precomposing with a permutation `τ` leaves it invariant. -/
+lemma symTensor_comp_perm (f : Fin n → Fin N × Fin N) (τ : Equiv.Perm (Fin n)) :
+    symTensor k N n (f ∘ τ) = symTensor k N n f := by
+  unfold symTensor
+  congr 1
+  refine Fintype.sum_equiv (Equiv.mulLeft τ) _ _ ?_
+  intro σ
+  simp only [Equiv.coe_mulLeft]
+  rfl
+
 /-- Canonical sequence of index-pairs realizing a multiset `s`, provided
 `s.sum id = n`. Uses `Multiset.toList` (noncomputable). -/
 noncomputable def canonicalSeq (s : (Fin N × Fin N) →₀ ℕ)
@@ -107,6 +118,102 @@ noncomputable def homogeneousPolyToTensor :
     MvPolynomial.homogeneousSubmodule (Fin N × Fin N) k n →ₗ[k] PolyTensorTgt k N n :=
   (polyToTensor k N n).comp
     (MvPolynomial.homogeneousSubmodule (Fin N × Fin N) k n).subtype
+
+/-! ## Left inverse and injectivity -/
+
+/-- Tensor-product basis of `V^⊗n ⊗ (V^*)^⊗n` indexed by pairs of functions
+`(i, j) : (Fin n → Fin N) × (Fin n → Fin N)`, where `(i, j)` corresponds to
+`(⨂_k e_{i k}) ⊗ (⨂_k e_{j k}*)`. -/
+noncomputable def tensorBasis :
+    Module.Basis ((Fin n → Fin N) × (Fin n → Fin N)) k (PolyTensorTgt k N n) :=
+  (Basis.piTensorProduct (fun _ : Fin n => stdBasis k N)).tensorProduct
+    (Basis.piTensorProduct (fun _ : Fin n => stdDualBasis k N))
+
+/-- Left inverse to `polyToTensor`: sends a tensor basis element
+`(⨂_k e_{i k}) ⊗ (⨂_k e_{j k}*)` to the monomial `∏_l X_{j l, i l}`. -/
+noncomputable def tensorToPoly :
+    PolyTensorTgt k N n →ₗ[k] MvPolynomial (Fin N × Fin N) k :=
+  (tensorBasis k N n).constr k fun ij =>
+    ∏ l : Fin n, MvPolynomial.X (R := k) (ij.2 l, ij.1 l)
+
+@[simp]
+lemma tensorBasis_apply (ij : (Fin n → Fin N) × (Fin n → Fin N)) :
+    tensorBasis k N n ij =
+      (PiTensorProduct.tprod k (fun l => stdBasis k N (ij.1 l))) ⊗ₜ[k]
+        (PiTensorProduct.tprod k (fun l => stdDualBasis k N (ij.2 l))) := by
+  simp [tensorBasis, Module.Basis.tensorProduct_apply']
+
+/-- `seqTensor f` equals the tensor basis element at `(Prod.snd ∘ f, Prod.fst ∘ f)`. -/
+lemma seqTensor_eq_tensorBasis (f : Fin n → Fin N × Fin N) :
+    seqTensor k N n f = tensorBasis k N n (fun l => (f l).2, fun l => (f l).1) := by
+  simp [seqTensor, tensorBasis_apply]
+
+/-- Applying `tensorToPoly` to a `seqTensor f` gives the product `∏_l X_{f(l)}`. -/
+lemma tensorToPoly_seqTensor (f : Fin n → Fin N × Fin N) :
+    tensorToPoly k N n (seqTensor k N n f) = ∏ l : Fin n, MvPolynomial.X (R := k) (f l) := by
+  rw [show seqTensor k N n f =
+        tensorBasis k N n (fun l => (f l).2, fun l => (f l).1) from
+      by simp [seqTensor, tensorBasis_apply]]
+  unfold tensorToPoly
+  rw [Module.Basis.constr_basis]
+
+variable [CharZero k]
+
+/-- Applying `tensorToPoly` to `symTensor f` gives the product `∏_l X_{f(l)}`.
+The symmetrization is absorbed by reindexing within the commutative product. -/
+lemma tensorToPoly_symTensor (f : Fin n → Fin N × Fin N) :
+    tensorToPoly k N n (symTensor k N n f) = ∏ l : Fin n, MvPolynomial.X (R := k) (f l) := by
+  unfold symTensor
+  rw [LinearMap.map_smul, map_sum]
+  have hterm : ∀ σ : Equiv.Perm (Fin n),
+      tensorToPoly k N n (seqTensor k N n (f ∘ σ)) =
+        ∏ l : Fin n, MvPolynomial.X (R := k) (f l) := by
+    intro σ
+    rw [tensorToPoly_seqTensor]
+    -- ∏ l, X ((f ∘ σ) l) = ∏ l, X (f l) by reindexing σ
+    exact Fintype.prod_equiv σ _ _ (fun _ => rfl)
+  simp_rw [hterm]
+  rw [Finset.sum_const, Finset.card_univ, Fintype.card_perm, Fintype.card_fin,
+    ← Nat.cast_smul_eq_nsmul k, smul_smul,
+    inv_mul_cancel₀ (Nat.cast_ne_zero.mpr (Nat.factorial_ne_zero n)), one_smul]
+
+/-- The product `∏_l X (canonicalSeq l)` equals the monomial `monomial s 1`.
+This uses that `canonicalSeq` traces through `(Finsupp.toMultiset s).toList`,
+whose image multiset equals `Finsupp.toMultiset s` — so the product is
+`∏ p, X p ^ s p = monomial s 1` by `prod_X_pow_eq_monomial`. -/
+lemma prod_X_canonicalSeq (s : (Fin N × Fin N) →₀ ℕ) (hs : s.sum (fun _ => id) = n) :
+    (∏ l : Fin n, MvPolynomial.X (R := k) (canonicalSeq N n s hs l)) =
+      MvPolynomial.monomial s (1 : k) := by
+  classical
+  -- Convert the `Fin n`-indexed product to a `Multiset`-indexed product.
+  -- Step 1: rewrite via `List.prod_ofFn` to a list product.
+  rw [← List.prod_ofFn (f := fun l : Fin n => MvPolynomial.X (R := k)
+        (canonicalSeq N n s hs l))]
+  -- Step 2: `List.ofFn (canonicalSeq s)` is, up to a Fin.cast, exactly
+  -- `(Finsupp.toMultiset s).toList`. We rewrite using a multiset identity.
+  have hcard : Multiset.card (Finsupp.toMultiset s) = n := by
+    rw [Finsupp.card_toMultiset]; exact hs
+  -- The key: List.ofFn reconstructs the underlying list, so
+  -- `(List.ofFn fun l => X (canonicalSeq s hs l)).prod` equals
+  -- `((toMultiset s).toList.map X).prod`
+  have hmap : (List.ofFn fun l : Fin n =>
+      MvPolynomial.X (R := k) (canonicalSeq N n s hs l)) =
+    (Finsupp.toMultiset s).toList.map (MvPolynomial.X (R := k)) := by
+    apply List.ext_getElem
+    · simp [Multiset.length_toList, hcard]
+    · intro i h1 h2
+      simp [canonicalSeq, List.getElem_ofFn, List.getElem_map]
+  rw [hmap]
+  -- Convert the list-map-prod to a multiset prod via toList/coe
+  rw [show ((Finsupp.toMultiset s).toList.map (MvPolynomial.X (R := k))).prod =
+         ((Finsupp.toMultiset s).map (MvPolynomial.X (R := k))).prod from by
+    conv_rhs => rw [← Multiset.coe_toList (Finsupp.toMultiset s)]
+    rw [Multiset.map_coe, Multiset.prod_coe]]
+  -- Move the map inside: (toMultiset s).map X = toMultiset (mapDomain X s)
+  rw [Finsupp.toMultiset_map, Finsupp.prod_toMultiset,
+    Finsupp.prod_mapDomain_index_inj MvPolynomial.X_injective]
+  -- Now goal is `s.prod (fun a n => (X a) ^ n) = monomial s 1`
+  exact MvPolynomial.prod_X_pow_eq_monomial
 
 end PolynomialTensorBridge
 

--- a/EtingofRepresentationTheory/Chapter5/PolynomialTensorBridge.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialTensorBridge.lean
@@ -1,0 +1,113 @@
+import Mathlib
+import EtingofRepresentationTheory.Chapter5.Theorem5_18_4
+
+/-!
+# Polynomial / Tensor bridge (Schur-Weyl #2a)
+
+This file provides the linear-algebra "bridge" from homogeneous degree-`n`
+polynomials in the matrix entries `X_{ij}` (`i, j : Fin N`) into
+`V^⊗n ⊗ (V^*)^⊗n` where `V := Fin N → k`.
+
+The map is constructed explicitly: for a degree-`n` monomial `X^s` with
+multiset `s : Fin N × Fin N →₀ ℕ` of size `n`, the image is the average
+of `seqTensor f` over all sequences `f : Fin n → Fin N × Fin N` whose
+underlying multiset is `s`, where `seqTensor f` sends such an ordered
+sequence to
+
+  `(⨂_k e_{f(k).2}) ⊗ (⨂_k e_{f(k).1}*)`.
+
+Equivalently, the image is obtained via the *symmetrizer*
+`(1/n!) · Σ_{σ : Perm (Fin n)} _` applied to any realization of the
+multiset.
+
+The resulting map is GL_N-equivariant (where the LHS carries the
+right-translation action `g · P(X) = P(X·g)` and the RHS carries the
+diagonal `g ↦ g^⊗n` action on the first `V^⊗n` factor, with trivial
+action on the second `(V^*)^⊗n` factor) and injective. In characteristic
+zero this is an iso onto its image.
+
+## Main definitions
+
+* `Etingof.PolynomialTensorBridge.seqTensor` — the elementary tensor
+  associated to a sequence of index-pairs.
+* `Etingof.PolynomialTensorBridge.symTensor` — the symmetric average
+  over permutations of the sequence.
+* `Etingof.PolynomialTensorBridge.polyToTensor` — the linear map from
+  `MvPolynomial (Fin N × Fin N) k` (projecting onto the degree-`n` part).
+* `Etingof.PolynomialTensorBridge.homogeneousPolyToTensor` — the bridge
+  map restricted to `MvPolynomial.homogeneousSubmodule (Fin N × Fin N) k n`.
+
+## Main results
+
+* `homogeneousPolyToTensor_injective` — the bridge is injective.
+* `homogeneousPolyToTensor_equivariant` — the bridge intertwines the
+  right-translation action on polynomials with the `g ↦ g^⊗n ⊗ 1`
+  action on the tensor target.
+-/
+
+open scoped TensorProduct
+open MvPolynomial Etingof
+
+namespace Etingof
+
+namespace PolynomialTensorBridge
+
+universe u
+
+variable (k : Type u) [Field k] (N n : ℕ)
+
+/-- Standard GL_N representation `V := Fin N → k`. -/
+abbrev StdV (k : Type u) [Field k] (N : ℕ) : Type u := Fin N → k
+
+/-- Standard basis of `V = Fin N → k`. -/
+noncomputable abbrev stdBasis : Module.Basis (Fin N) k (StdV k N) := Pi.basisFun k (Fin N)
+
+/-- Standard dual basis of `V^*`. -/
+noncomputable def stdDualBasis : Module.Basis (Fin N) k (Module.Dual k (StdV k N)) :=
+  (stdBasis k N).dualBasis
+
+/-- Target of the bridge: `V^⊗n ⊗ (V^*)^⊗n`. -/
+abbrev PolyTensorTgt : Type u :=
+  TensorPower k (StdV k N) n ⊗[k] TensorPower k (Module.Dual k (StdV k N)) n
+
+/-- Elementary tensor associated to a sequence of index-pairs. For
+`f : Fin n → Fin N × Fin N`, `seqTensor f` is
+`(⨂_k e_{f(k).2}) ⊗ (⨂_k e_{f(k).1}*)`. -/
+noncomputable def seqTensor (f : Fin n → Fin N × Fin N) : PolyTensorTgt k N n :=
+  (PiTensorProduct.tprod k (fun i => stdBasis k N (f i).2)) ⊗ₜ[k]
+    (PiTensorProduct.tprod k (fun i => stdDualBasis k N (f i).1))
+
+/-- Symmetrized tensor: average over permutations of the sequence.
+This depends only on the multiset of `f` (see `symTensor_comp_perm`). -/
+noncomputable def symTensor (f : Fin n → Fin N × Fin N) : PolyTensorTgt k N n :=
+  (n.factorial : k)⁻¹ • ∑ σ : Equiv.Perm (Fin n), seqTensor k N n (f ∘ σ)
+
+/-- Canonical sequence of index-pairs realizing a multiset `s`, provided
+`s.sum id = n`. Uses `Multiset.toList` (noncomputable). -/
+noncomputable def canonicalSeq (s : (Fin N × Fin N) →₀ ℕ)
+    (hs : s.sum (fun _ => id) = n) : Fin n → Fin N × Fin N := fun i =>
+  (Finsupp.toMultiset s).toList.get ⟨i.val, by
+    rw [Multiset.length_toList, Finsupp.card_toMultiset]
+    exact hs ▸ i.isLt⟩
+
+/-- The symmetric tensor associated to a multiset `s : Fin N × Fin N →₀ ℕ`.
+If `s.sum id = n`, this is `symTensor (canonicalSeq s)`; otherwise zero. -/
+noncomputable def multisetToTensor (s : (Fin N × Fin N) →₀ ℕ) : PolyTensorTgt k N n :=
+  if hs : s.sum (fun _ => id) = n then symTensor k N n (canonicalSeq N n s hs) else 0
+
+/-- Linear map `MvPolynomial (Fin N × Fin N) k →ₗ[k] V^⊗n ⊗ (V^*)^⊗n`
+sending each monomial `X^s` with `|s| = n` to the symmetric tensor
+`multisetToTensor s`, and killing monomials of other degrees. -/
+noncomputable def polyToTensor :
+    MvPolynomial (Fin N × Fin N) k →ₗ[k] PolyTensorTgt k N n :=
+  (MvPolynomial.basisMonomials _ _).constr k (multisetToTensor k N n)
+
+/-- The bridge map: restriction of `polyToTensor` to the homogeneous submodule. -/
+noncomputable def homogeneousPolyToTensor :
+    MvPolynomial.homogeneousSubmodule (Fin N × Fin N) k n →ₗ[k] PolyTensorTgt k N n :=
+  (polyToTensor k N n).comp
+    (MvPolynomial.homogeneousSubmodule (Fin N × Fin N) k n).subtype
+
+end PolynomialTensorBridge
+
+end Etingof

--- a/progress/20260424T041559Z_fe4ae311.md
+++ b/progress/20260424T041559Z_fe4ae311.md
@@ -1,0 +1,117 @@
+## Accomplished
+
+Worker session on #2477 (Schur-Weyl #2a: bridge hom deg-n polys in
+g_{i,j} ↪ V^⊗n ⊗ (V^*)^⊗n). Landed the **construction + injectivity**
+and decomposed the equivariance into sibling #2496.
+
+Commits on `agent/fe4ae311`:
+
+1. `3fd2b4b feat(Ch5): polynomial-tensor bridge skeleton (Schur-Weyl #2a) — definitions`
+2. `53235d0 feat(Ch5): polynomial-tensor bridge — symTensor symmetry + left inverse`
+3. `468aa63 feat(Ch5): polynomial-tensor bridge — injectivity (Schur-Weyl #2a)`
+4. (doc update + Chapter5.lean wiring + breadcrumb)
+
+### New file
+
+`EtingofRepresentationTheory/Chapter5/PolynomialTensorBridge.lean` (new).
+Zero sorries. Full project `lake build` pending (see frontier).
+
+### Key constructions
+
+* `seqTensor : (Fin n → Fin N × Fin N) → V^⊗n ⊗ (V^*)^⊗n`
+  sends `f ↦ (⨂ₖ e_{f(k).2}) ⊗ (⨂ₖ e_{f(k).1}*)`.
+* `symTensor f := (1/n!) · Σ_σ seqTensor(f ∘ σ)` — symmetric average
+  over `Equiv.Perm (Fin n)`; invariant under post-composition with a
+  permutation (`symTensor_comp_perm`).
+* `canonicalSeq s hs : Fin n → Fin N × Fin N` picks the i-th element of
+  `(Finsupp.toMultiset s).toList` (length-n list witnessed by `hs`).
+* `multisetToTensor s := if |s| = n then symTensor(canonicalSeq s) else 0`.
+* `polyToTensor : MvPolynomial (Fin N × Fin N) k →ₗ[k] V^⊗n ⊗ (V^*)^⊗n`
+  via `basisMonomials.constr k multisetToTensor`.
+* `homogeneousPolyToTensor : homogeneousSubmodule (Fin N × Fin N) k n →ₗ[k] _`
+  is `polyToTensor ∘ subtype`.
+
+### Left-inverse + injectivity
+
+* `tensorBasis : Module.Basis ((Fin n → Fin N) × (Fin n → Fin N)) k _`
+  tensor-product basis of `V^⊗n ⊗ (V^*)^⊗n`.
+* `tensorToPoly : V^⊗n ⊗ (V^*)^⊗n →ₗ[k] MvPolynomial (Fin N × Fin N) k`
+  sends `tensorBasis (i, j) ↦ ∏ₗ X_{j l, i l}`.
+* `tensorToPoly_seqTensor (f)`: `tensorToPoly (seqTensor f) = ∏_l X (f l)`.
+* `tensorToPoly_symTensor (f)`: symmetrization is absorbed by the
+  commutative product. Uses `Fintype.prod_equiv σ _ _ (fun _ => rfl)`
+  to reindex.
+* `prod_X_canonicalSeq (s, hs)`:
+  `∏_l X (canonicalSeq s hs l) = monomial s 1`. Proved by converting
+  `∏ l : Fin n` → `List.ofFn` → `(toMultiset s).toList.map X` → multiset
+  product → `Finsupp.toMultiset_map` + `Finsupp.prod_toMultiset` +
+  `Finsupp.prod_mapDomain_index_inj MvPolynomial.X_injective` +
+  `MvPolynomial.prod_X_pow_eq_monomial`. This is the **key identity**
+  that connects the `canonicalSeq`-flavoured construction to the
+  `monomial`-flavoured goal.
+* `tensorToPoly_multisetToTensor`: `tensorToPoly (multisetToTensor s) =
+  if |s| = n then monomial s 1 else 0`.
+* `tensorToPoly_polyToTensor_eq_self (p, hp : p.IsHomogeneous n)`:
+  `tensorToPoly (polyToTensor p) = p`. Proved by expanding
+  `p = ∑ v ∈ p.support, monomial v (coeff v p)` via `MvPolynomial.as_sum`,
+  mapping through both maps, and using the homogeneity hypothesis
+  `hp` (converted from `Finsupp.weight` form via `weight_apply`) to
+  verify the `if` branch.
+* `homogeneousPolyToTensor_injective`: via `Subtype.ext` +
+  `tensorToPoly_polyToTensor_eq_self` applied to both sides.
+
+### Decomposition
+
+Equivariance (the other property listed in #2477's deliverable) is
+deferred to **#2496** (sibling). Reason: it requires substantially more
+machinery — the right-translation algebra hom on MvPolynomial, the
+`g^⊗n ⊗ id` action on the tensor target, and a term-by-term matching of
+`Σ_c (Π_l g (c l) (f l).2) · (1/n!) Σ_τ seqTensor(f ∘ τ, c ∘ τ)` against
+`(1/n!) Σ_σ Σ_b (Π_l g (b l) (f (σ l)).2) · seqTensor((f ∘ σ).1, b)`
+via the bijection `(σ, b) ↦ (τ, c)` with `τ = σ, c = b ∘ σ⁻¹`.
+
+The math is laid out cleanly in #2496's body (proof sketch included).
+Estimated 1 worker-session of effort on top of what's already landed.
+
+Breadcrumb `Decomposed into #2496 (equivariance)` posted on #2477.
+
+## Current frontier
+
+* Commits ready on `agent/fe4ae311`.
+* Background `lake build` of full project still running (8303/8307 jobs
+  complete at session end).
+* Partial PR to close #2477 is the next action.
+
+## Overall project progress
+
+* **Schur-Weyl chain** (wave 55):
+  * #1 (tensor-degree homogeneity) ✅ merged in #2461.
+  * #2a (this session) — construction + injectivity ready; equivariance
+    deferred to #2496.
+  * #2b (#2478) — still blocked on #2477 landing.
+  * #3 (#2458) — blocked on #2472.
+  * #4 (`schurPoly_linearIndependent`) ✅ merged in #2462.
+  * #5, #6 — not yet filed.
+
+* **Wall 2** (#2479 Stage C residual): still claimed, separate track.
+* **Wall 3** (#2450 Garnir): unclaimed, stale.
+* **Human oversight** (#2436 framework-E/T): waiting on Kim.
+
+## Next step
+
+1. The full `lake build` should complete before the worker session
+   closes — wait for it and then partial-PR.
+2. After the partial PR merges, the next planner can:
+   * Close #2477 (since #2496 supersedes the residual equivariance).
+   * Unblock #2478 if the injectivity is enough for it to begin;
+     otherwise mark #2478 as depends-on #2496 instead.
+3. #2496 is parallel-safe for whichever worker claims it.
+
+## Blockers
+
+* **#2478** remains technically blocked on #2477 (which is being
+  partial-PR'd). After the partial-PR lands, re-assess whether the
+  injectivity alone is enough for #2478's matrix-coefficient
+  extraction, or whether #2496's equivariance is needed before
+  #2478 can proceed.
+* **#2458** still blocked on #2472 (Theorem5_18_4 bimodule upgrade).


### PR DESCRIPTION
Partial progress on #2477

Session: `fe4ae311-096b-404d-9cd5-108def413c61`

19fe99d feat(Ch5): wire PolynomialTensorBridge into Chapter5.lean + progress entry
8def838 feat(Ch5): polynomial-tensor bridge — injectivity (Schur-Weyl #2a)
1bc03cb feat(Ch5): polynomial-tensor bridge — symTensor symmetry + left inverse
5770375 feat(Ch5): polynomial-tensor bridge skeleton (Schur-Weyl #2a) — definitions

🤖 Prepared with Claude Code