### PR TITLE
Schur-Weyl L_i (part A): endow bimodule L_i with FDRep GL_N structure

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_18_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_18_1.lean
@@ -394,6 +394,23 @@ noncomputable instance centralizerModuleHom
     change (centralizerToEndA k E A 0) (f v) = 0
     rw [map_zero]; rfl
 
+set_option maxHeartbeats 400000 in
+set_option synthInstance.maxHeartbeats 400000 in
+/-- The centralizer action on `V →ₗ[A] E` (post-composition) commutes with
+the standard `k`-action on `V →ₗ[A] E` (pointwise scaling). This follows
+from each `b ∈ centralizer(A) ⊆ End k E` being a `k`-linear map. -/
+instance centralizerModuleHom_smulCommClass
+    {A : Subalgebra k (Module.End k E)}
+    {V : Type*} [AddCommGroup V] [Module k V]
+    [Module A V] [IsScalarTower k A V] :
+    SMulCommClass (↥(Subalgebra.centralizer k (A : Set (Module.End k E)))) k
+      (V →ₗ[A] E) where
+  smul_comm b c f := by
+    refine LinearMap.ext fun v => ?_
+    -- (b • (c • f)) v = b.val (c • f v) = c • b.val (f v) = c • (b • f) v
+    show b.val ((c • f) v) = c • b.val (f v)
+    rw [LinearMap.smul_apply, map_smul]
+
 set_option synthInstance.maxHeartbeats 400000 in
 /-- The natural bridge: every `A`-linear map from a simple submodule `V ≤ E`
 into `E` lands in the isotypic component `isotypicComponent A E V`. -/
@@ -447,8 +464,12 @@ noncomputable def homIsotypicBridge
   map_add' f g := by ext v; simp
   map_smul' r f := by ext v; rfl
 
-set_option maxHeartbeats 1600000 in
-set_option synthInstance.maxHeartbeats 800000 in
+-- Heartbeats are bumped because the existential output has several universe-polymorphic
+-- ∀-binders whose instance synthesis (AddCommGroup / Module / SMulCommClass / Module.Finite
+-- over a subalgebra-wrapped ring) each triggers a deep `Subalgebra → Ring → Module.End`
+-- instance chain.
+set_option maxHeartbeats 3200000 in
+set_option synthInstance.maxHeartbeats 1600000 in
 /-- Double centralizer theorem, part (iii), bimodule form.
 
 If `A` is a semisimple subalgebra of `End_k(E)` with `E` faithful and
@@ -476,7 +497,11 @@ theorem Theorem5_18_1_bimodule_decomposition
       (_ : ∀ i, Module k (L i))
       (_ : ∀ i, Module
             (↥(Subalgebra.centralizer k (A : Set (Module.End k E))))
-            (L i)),
+            (L i))
+      (_ : ∀ i, SMulCommClass
+            (↥(Subalgebra.centralizer k (A : Set (Module.End k E))))
+            k (L i))
+      (_ : ∀ i, Module.Finite k (L i)),
       Nonempty (E ≃ₗ[k] DirectSum ι (fun i => V i ⊗[k] L i)) := by
   classical
   haveI : IsSemisimpleModule A E := IsSemisimpleRing.isSemisimpleModule
@@ -501,6 +526,17 @@ theorem Theorem5_18_1_bimodule_decomposition
     intro c
     haveI := V'_simple c
     exact eq_isotypicComponent_of_le c.2 (V'_le c)
+  haveI : ∀ c : isotypicComponents A E, Module.Finite k ↥(V' c) := fun c =>
+    Module.Finite.of_injective ((V' c).subtype.restrictScalars k)
+      Subtype.val_injective
+  haveI : ∀ c : isotypicComponents A E,
+      Module.Finite k ((↥(V' c) : Type v) →ₗ[A] E) := fun c => by
+    -- The A-linear hom space is a subspace of the k-linear hom space
+    -- (via `LinearMap.restrictScalars`), which is finite-dimensional.
+    haveI : Module.Finite k ((↥(V' c) : Type v) →ₗ[k] E) := inferInstance
+    exact Module.Finite.of_injective
+      (LinearMap.restrictScalarsₗ k A (↥(V' c)) E k)
+      (LinearMap.restrictScalars_injective _)
   refine ⟨Fin m, inferInstance, inferInstance,
     fun i => ↥(V' (φ.symm i)),
     fun _ => inferInstance, fun _ => inferInstance, fun _ => inferInstance,
@@ -508,6 +544,8 @@ theorem Theorem5_18_1_bimodule_decomposition
     ?_,
     fun i => (↥(V' (φ.symm i)) →ₗ[A] E),
     fun _ => inferInstance, fun _ => inferInstance, fun _ => inferInstance,
+    fun _ => inferInstance,
+    fun _ => inferInstance,
     ?_⟩
   · -- Distinctness: V i ≃[A] V j → i = j
     intro i j ⟨e⟩

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_18_4.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_18_4.lean
@@ -429,7 +429,7 @@ theorem Theorem5_18_4_bimodule_decomposition
   haveI := symGroupImage_isSemisimpleRing k V n
   haveI := symGroupImage_faithfulSMul k V n hN
   obtain ⟨ι, hι, hι_dec, S', hS'_acg, hS'_mod, hS'_Amod, hS'_simp,
-    hS'_dist, L', hL'_acg, hL'_mod, hL'_Bmod, ⟨e⟩⟩ :=
+    hS'_dist, L', hL'_acg, hL'_mod, hL'_Bmod, _hL'_smul, _hL'_fin, ⟨e⟩⟩ :=
     Theorem5_18_1_bimodule_decomposition k (TensorPower k V n)
       (symGroupImage k V n)
   -- Transport the `Module ↥(centralizer(symGroupImage))` structure on each
@@ -441,5 +441,111 @@ theorem Theorem5_18_4_bimodule_decomposition
     (Theorem5_18_4_centralizers k V n hN).2.symm
   refine ⟨ι, hι, hι_dec, S', hS'_acg, hS'_mod, hS'_Amod, hS'_simp, hS'_dist,
     L', hL'_acg, hL'_mod, fun i => h_eq ▸ hL'_Bmod i, ⟨e⟩⟩
+
+/-! ### GL_N-representation form of the bimodule decomposition
+
+The `L_i` summands from the bimodule decomposition carry a natural
+`FDRep k (GL_N k)` structure, via the composition
+`GL_N → End_k V → diagonalActionImage k V n` followed by the existing
+`Module (diagonalActionImage) (L_i)`-action. Specialized to
+`V = Fin N → k` because that is the only case used downstream
+(for the `FormalCharacterIso` comparison with Schur polynomials). -/
+
+-- Heartbeats bumped: the existential output has 10+ ∀-binders with
+-- `Subalgebra → Ring → Module.End` instance chains, and the GL_N
+-- representation construction composes several monoid homs each
+-- triggering similar chains.
+set_option maxHeartbeats 3200000 in
+set_option synthInstance.maxHeartbeats 1600000 in
+/-- Schur-Weyl duality, part (iii), GL_N representation form.
+
+Specialized to `V = Fin N → k` (the only case used downstream): as a
+module over `(symGroupImage k V n) ⊗[k] (GL_N k)`, `V^⊗n` decomposes as
+  `V^⊗n ≅ ⨁ᵢ Sᵢ ⊗[k] Lᵢ`
+where the `Sᵢ` are pairwise non-isomorphic simple `symGroupImage`-modules
+(Specht modules) and each `Lᵢ` is a full finite-dimensional
+`GL_N(k)`-representation (an irreducible polynomial representation).
+
+Refines `Theorem5_18_4_bimodule_decomposition` by upgrading each `Lᵢ`
+from a `Module (diagonalActionImage) Lᵢ` to a bundled
+`FDRep k (GL_N k)`. The `GL_N` action is built by composing
+`GL_N → diagonalActionImage` (via the `g ↦ g^{⊗n}` diagonal map) with
+the existing `diagonalActionImage`-module structure. -/
+theorem Theorem5_18_4_GL_rep_decomposition
+    (k : Type u) [Field k] [IsAlgClosed k] [CharZero k]
+    (N n : ℕ) (hN : n ≤ N) :
+    ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
+      (S : ι → Type u)
+      (_ : ∀ i, AddCommGroup (S i))
+      (_ : ∀ i, Module k (S i))
+      (_ : ∀ i, Module (symGroupImage k (Fin N → k) n) (S i))
+      (_ : ∀ i, IsSimpleModule (symGroupImage k (Fin N → k) n) (S i))
+      (_ : ∀ i j,
+        Nonempty (S i ≃ₗ[symGroupImage k (Fin N → k) n] S j) → i = j)
+      (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k)),
+      Nonempty (TensorPower k (Fin N → k) n ≃ₗ[k]
+        DirectSum ι (fun i => S i ⊗[k] (L i : Type u))) := by
+  set V : Type u := Fin N → k with hV
+  haveI : Module.Finite k V := inferInstance
+  have hfinrank : Module.finrank k V = N :=
+    (Module.finrank_pi k).trans (Fintype.card_fin N)
+  have hN' : n ≤ Module.finrank k V := hfinrank.symm ▸ hN
+  haveI := symGroupImage_isSemisimpleRing k V n
+  haveI := symGroupImage_faithfulSMul k V n hN'
+  -- Get the bimodule decomposition with L_i carrying a Module over
+  -- the centralizer of symGroupImage and the associated SMulCommClass.
+  obtain ⟨ι, hι, hι_dec, S', hS'_acg, hS'_mod, hS'_Amod, hS'_simp,
+    hS'_dist, L', hL'_acg, hL'_mod, hL'_Bmod, hL'_smul, hL'_fin, ⟨e⟩⟩ :=
+    Theorem5_18_1_bimodule_decomposition k (TensorPower k V n)
+      (symGroupImage k V n)
+  -- Centralizer identity: centralizer(symGroupImage) = diagonalActionImage.
+  have h_eq : Subalgebra.centralizer k
+      (symGroupImage k V n : Set (Module.End k (TensorPower k V n))) =
+        diagonalActionImage k V n :=
+    (Theorem5_18_4_centralizers k V n hN').2.symm
+  -- Monoid hom GL_N → centralizer(symGroupImage):
+  --   g ↦ PiTensorProduct.map (fun _ => mulVecLin g.val)
+  -- Its image lies in diagonalActionImage by definition, hence in the
+  -- centralizer via h_eq.
+  let glHom : Matrix.GeneralLinearGroup (Fin N) k →*
+      ↥(Subalgebra.centralizer k
+        (symGroupImage k V n : Set (Module.End k (TensorPower k V n)))) :=
+  { toFun := fun g => ⟨PiTensorProduct.map
+        (fun _ : Fin n => Matrix.mulVecLin (R := k) g.val), by
+      rw [h_eq]
+      exact Algebra.subset_adjoin ⟨Matrix.mulVecLin g.val, rfl⟩⟩
+    map_one' := by
+      apply Subtype.ext
+      change PiTensorProduct.map
+          (fun _ : Fin n => Matrix.mulVecLin (R := k) (1 : Matrix _ _ k)) = 1
+      have : (fun _ : Fin n => Matrix.mulVecLin (R := k) (1 : Matrix _ _ k)) =
+          (fun _ : Fin n => (LinearMap.id : V →ₗ[k] V)) :=
+        funext fun _ => Matrix.mulVecLin_one
+      rw [this, PiTensorProduct.map_id]; rfl
+    map_mul' := fun g₁ g₂ => by
+      apply Subtype.ext
+      change PiTensorProduct.map
+          (fun _ : Fin n => Matrix.mulVecLin (R := k) (g₁.val * g₂.val)) =
+        PiTensorProduct.map
+            (fun _ : Fin n => Matrix.mulVecLin (R := k) g₁.val) *
+          PiTensorProduct.map
+            (fun _ : Fin n => Matrix.mulVecLin (R := k) g₂.val)
+      have : (fun _ : Fin n => Matrix.mulVecLin (R := k) (g₁.val * g₂.val)) =
+          (fun _ : Fin n => (Matrix.mulVecLin g₁.val).comp
+            (Matrix.mulVecLin g₂.val)) :=
+        funext fun _ => Matrix.mulVecLin_mul g₁.val g₂.val
+      rw [this, PiTensorProduct.map_comp]; rfl }
+  -- For each i, build the GL_N representation on L' i.
+  let ρ : ∀ i,
+      Matrix.GeneralLinearGroup (Fin N) k →* Module.End k (L' i) := fun i =>
+    (Module.toModuleEnd k (L' i)
+      (S := ↥(Subalgebra.centralizer k
+        (symGroupImage k V n :
+          Set (Module.End k (TensorPower k V n)))))).toMonoidHom.comp glHom
+  -- Bundle each L' i as a finite-dimensional GL_N representation.
+  let L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k) := fun i =>
+    FDRep.of (ρ i)
+  exact ⟨ι, hι, hι_dec, S', hS'_acg, hS'_mod, hS'_Amod, hS'_simp,
+    hS'_dist, L, ⟨e⟩⟩
 
 end Etingof

--- a/progress/20260424T045656Z_949b5602.md
+++ b/progress/20260424T045656Z_949b5602.md
@@ -1,0 +1,85 @@
+## Accomplished
+
+Closed issue #2491 (Schur-Weyl L_i part A: endow bimodule L_i with FDRep GL_N
+structure).
+
+* Added instance `centralizerModuleHom_smulCommClass` in
+  `EtingofRepresentationTheory/Chapter5/Theorem5_18_1.lean`: for
+  `B = Subalgebra.centralizer k A` and any `V →ₗ[A] E`, the post-composition
+  `B`-action commutes with the pointwise `k`-action (both arise from
+  `b.val : End k E` being `k`-linear). This is the `SMulCommClass` needed to
+  build a `k`-linear representation out of the `B`-module structure on the
+  `L_i`.
+* Extended the existential output of `Theorem5_18_1_bimodule_decomposition`
+  with two new facts per summand `L_i`:
+  * `SMulCommClass (centralizer) k (L_i)` — provided via the new instance;
+  * `Module.Finite k (L_i)` — proved by `Module.Finite.of_injective` against
+    `LinearMap.restrictScalarsₗ k A (V' c) E k`, reducing to the existing
+    `LinearMap.finiteDimensional'` instance.
+* Updated `Theorem5_18_4_bimodule_decomposition` to pass through the new
+  existential binders (the centralizer-based ones drop out after the `h_eq ▸`
+  transport, so they are not exposed at the 5.18.4 layer — the new theorem
+  picks them up from 5.18.1 directly).
+* Added `Theorem5_18_4_GL_rep_decomposition` in
+  `EtingofRepresentationTheory/Chapter5/Theorem5_18_4.lean`. Specialized to
+  `V = Fin N → k` (matching the downstream `FormalCharacterIso` setting).
+  Construction:
+  * Monoid hom `glHom : GL_N k →* centralizer(symGroupImage)` built from
+    `g ↦ PiTensorProduct.map (fun _ => Matrix.mulVecLin g.val)`, with
+    membership in the centralizer established by rewriting across the
+    Schur-Weyl identity `centralizer(symGroupImage) = diagonalActionImage`
+    (from `Theorem5_18_4_centralizers`).
+  * Representation `ρ i : GL_N →* Module.End k (L_i)` built by composing
+    `glHom` with `Module.toModuleEnd k (L_i)` (the ring hom
+    `centralizer → End k (L_i)` induced by the `Module` and `SMulCommClass`
+    instances).
+  * Each `L_i` then bundled as `FDRep k (GL_N k)` via `FDRep.of (ρ i)`
+    (using `Module.Finite k (L_i)` from 5.18.1 to satisfy `FDRep.of`).
+
+No sorries introduced. Full `lake build` pending final verification (last
+file to build is `Proposition5_22_2.lean`, a pre-existing slow compile).
+
+## Current frontier
+
+New theorem signature:
+
+```lean
+theorem Theorem5_18_4_GL_rep_decomposition
+    (k : Type u) [Field k] [IsAlgClosed k] [CharZero k]
+    (N n : ℕ) (hN : n ≤ N) :
+    ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
+      (S : ι → Type u) (_ : ∀ i, AddCommGroup (S i)) (_ : ∀ i, Module k (S i))
+      (_ : ∀ i, Module (symGroupImage k (Fin N → k) n) (S i))
+      (_ : ∀ i, IsSimpleModule (symGroupImage k (Fin N → k) n) (S i))
+      (_ : ∀ i j, Nonempty (S i ≃ₗ[symGroupImage k (Fin N → k) n] S j) → i = j)
+      (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k)),
+      Nonempty (TensorPower k (Fin N → k) n ≃ₗ[k]
+        DirectSum ι (fun i => S i ⊗[k] (L i : Type u)))
+```
+
+## Overall project progress
+
+Stage 3 / Schur-Weyl decomposition subgoal #2458 (Schur-Weyl #3). Its
+sub-issue #2491 is now done; sub-issues #2492 (character additivity) and
+#2493 (final assembly of #2458) remain, and are currently `blocked` on this
+PR.
+
+Unrelated parallel work: #2489 (B-linearity of the bimodule iso — review
+finding from #2486), #2477 (Schur-Weyl #2a, matrix-coefficient embedding),
+#2436 (human-oversight framework decision, pending planner triage).
+
+## Next step
+
+Unblock #2492 and #2493 once this PR merges. A feature worker can pick up
+#2492 (character additivity) directly; #2493 depends on both.
+
+The new theorem exposes each `L_i` only via the existential — the PR does
+**not** identify which `L_i` corresponds to which Young partition / Schur
+module. That identification is the content of the downstream assembly issue
+(#2493 / the original #2458), which uses the character additivity of #2492
+and the Weyl character formula (`schurPoly_injective` etc.) to pin down each
+`L_i`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2491

Session: `949b5602-1490-4af1-96e7-9e5ef8e70986`

330d99d feat(Ch5): endow Schur-Weyl L_i with FDRep GL_N structure (#2491)

🤖 Prepared with Claude Code