### PR TITLE
feat(Ch5): explicit bimodule decomposition with evaluation formula

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_18_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_18_1.lean
@@ -70,6 +70,29 @@ noncomputable def endOfSimpleEquivAlgClosed
   LinearEquiv.ofBijective (Algebra.linearMap k (V →ₗ[A] V))
     (IsSimpleModule.algebraMap_end_bijective_of_isAlgClosed k)
 
+/-- Extracting a scalar from a simple-module endomorphism gives the action
+of the scalar on any vector: for an alg-closed-simple `A`-module `V` and an
+`A`-linear endomorphism `φ`, the unique scalar `c ∈ k` with `φ = c • id`
+satisfies `c • v = φ v` for every `v`. -/
+lemma endOfSimpleEquivAlgClosed_symm_smul_apply
+    (k : Type*) [Field k] [IsAlgClosed k]
+    (A : Type*) [Ring A] [Algebra k A]
+    (V : Type*) [AddCommGroup V] [Module k V] [Module A V] [IsScalarTower k A V]
+    [Module.Finite k V] [IsSimpleModule A V]
+    (φ : V →ₗ[A] V) (v : V) :
+    (endOfSimpleEquivAlgClosed k A V).symm φ • v = φ v := by
+  have hφ : endOfSimpleEquivAlgClosed k A V
+      ((endOfSimpleEquivAlgClosed k A V).symm φ) = φ :=
+    (endOfSimpleEquivAlgClosed k A V).apply_symm_apply φ
+  -- Unfold: `endOfSimpleEquivAlgClosed k A V c = algebraMap k _ c = c • (1 : V →ₗ[A] V)`.
+  have hφ' : (endOfSimpleEquivAlgClosed k A V).symm φ • (1 : V →ₗ[A] V) = φ := by
+    have hrw : Algebra.linearMap k (V →ₗ[A] V)
+        ((endOfSimpleEquivAlgClosed k A V).symm φ) = φ := hφ
+    rw [Algebra.linearMap_apply, Algebra.algebraMap_eq_smul_one] at hrw
+    exact hrw
+  have := LinearMap.congr_fun hφ' v
+  simpa [LinearMap.smul_apply, Module.End.one_apply] using this
+
 /-- Post-composition equivalence: an `A`-linear equivalence of the codomain
 induces a `k`-linear equivalence of hom-spaces. This works even when `A` is
 non-commutative (where `LinearEquiv.congrRight` does not apply directly). -/
@@ -145,6 +168,49 @@ noncomputable def schurEvaluationEquiv
   let e5 : (Fin n → V) ≃ₗ[k] M := e.symm.restrictScalars k
   (TensorProduct.congr (LinearEquiv.refl k V)
     (e1.trans (e2.trans e3))).trans (e4.trans e5)
+
+/-- The Schur evaluation isomorphism sends a pure tensor `v ⊗ f` to `f v`.
+
+Despite being constructed via an arbitrary choice of decomposition
+`M ≃[A] Fin n → V`, the resulting map is canonical: on pure tensors it is
+the evaluation `v ⊗ f ↦ f v`. This is the identity that makes the
+decomposition `B`-equivariant — the hom-space `V →ₗ[A] M` carries a
+natural right action by `End_A M ⊇ B`, and evaluation transports it. -/
+lemma schurEvaluationEquiv_apply_tmul
+    (k : Type*) [Field k] [IsAlgClosed k]
+    (A : Type*) [Ring A] [Algebra k A]
+    (V : Type*) [AddCommGroup V] [Module k V] [Module A V] [IsScalarTower k A V]
+    [Module.Finite k V] [IsSimpleModule A V]
+    (M : Type*) [AddCommGroup M] [Module k M] [Module A M] [IsScalarTower k A M]
+    [Module.Finite k M] [IsSemisimpleModule A M]
+    (h : IsIsotypicOfType A M V) (v : V) (f : V →ₗ[A] M) :
+    schurEvaluationEquiv k A V M h (v ⊗ₜ[k] f) = f v := by
+  haveI : Module.Finite A M := Module.Finite.of_restrictScalars_finite k A M
+  haveI : Nontrivial V := IsSimpleModule.nontrivial A V
+  -- Mirror the `let` bindings from `schurEvaluationEquiv` so we can reason
+  -- about each step of the chain.
+  set n : ℕ := h.linearEquiv_fun.choose
+  set e : M ≃ₗ[A] (Fin n → V) := h.linearEquiv_fun.choose_spec.some
+  -- The underlying map on pure tensors reduces (by definition) to
+  -- `e.symm (fun j => (endOfSimpleEquivAlgClosed k A V).symm φⱼ • v)` where
+  -- `φⱼ = (LinearMap.proj j).comp (e.toLinearMap.comp f)`.
+  have step1 : schurEvaluationEquiv k A V M h (v ⊗ₜ[k] f)
+      = e.symm (fun j =>
+          (endOfSimpleEquivAlgClosed k A V).symm
+            ((LinearMap.proj j).comp (e.toLinearMap.comp f)) • v) := by
+    rfl
+  rw [step1]
+  -- Use the helper: `(endOfSimpleEquivAlgClosed).symm φ • v = φ v`.
+  have hv : ∀ j, (endOfSimpleEquivAlgClosed k A V).symm
+      ((LinearMap.proj j).comp (e.toLinearMap.comp f)) • v = (e (f v)) j := by
+    intro j
+    rw [endOfSimpleEquivAlgClosed_symm_smul_apply]
+    rfl
+  have hfun : (fun j => (endOfSimpleEquivAlgClosed k A V).symm
+      ((LinearMap.proj j).comp (e.toLinearMap.comp f)) • v) = e (f v) := by
+    funext j; exact hv j
+  rw [hfun]
+  exact e.symm_apply_apply (f v)
 
 variable (k : Type u) [Field k]
   (E : Type v) [AddCommGroup E] [Module k E] [Module.Finite k E]

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_18_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_18_1.lean
@@ -630,4 +630,210 @@ theorem Theorem5_18_1_bimodule_decomposition
       DirectSum.lequivCongrLeft k φ
     exact ⟨e2.trans (e3.trans e4)⟩
 
+set_option maxHeartbeats 3200000 in
+set_option synthInstance.maxHeartbeats 1200000 in
+/-- Double centralizer theorem, part (iii), bimodule form with explicit
+evaluation.
+
+Strengthens `Theorem5_18_1_bimodule_decomposition` by:
+
+* concretizing the summand types as `Vᵢ : Submodule A E` and
+  `Lᵢ := ↥(V i) →ₗ[A] E`;
+* producing an explicit iso `e` whose inverse on pure-tensor basis
+  elements is the evaluation map `l v`:
+  `e.symm (of i (v ⊗ₜ l)) = l v`.
+
+The evaluation formula implies the iso is `B`-equivariant for the natural
+post-composition action of `B = centralizer(A)` on each `Lᵢ`: for any
+`b ∈ B`,
+`e.symm (of i (v ⊗ₜ (b • l))) = (b • l) v = b.val (l v)
+    = b.val (e.symm (of i (v ⊗ₜ l)))`.
+
+This is the form required by character-additivity arguments (Schur-Weyl
+#3, #5, #6): together with the tensor-factorization of traces it yields
+`tr_E(b) = Σᵢ dim(Vᵢ) · tr_{Lᵢ}(b)`. -/
+theorem Theorem5_18_1_bimodule_decomposition_explicit
+    [IsAlgClosed k]
+    (A : Subalgebra k (Module.End k E))
+    [IsSemisimpleRing A]
+    [FaithfulSMul A E] :
+    ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
+      (V : ι → Submodule A E) (_ : ∀ i, IsSimpleModule A (V i))
+      (_ : ∀ i j, Nonempty (↥(V i) ≃ₗ[A] ↥(V j)) → i = j),
+      ∃ (e : E ≃ₗ[k] DirectSum ι
+          (fun i => ↥(V i) ⊗[k] (↥(V i) →ₗ[A] E))),
+        ∀ (i : ι) (v : ↥(V i)) (l : ↥(V i) →ₗ[A] E),
+          e.symm (DirectSum.of _ i (v ⊗ₜ[k] l)) = l v := by
+  classical
+  haveI : IsSemisimpleModule A E := IsSemisimpleRing.isSemisimpleModule
+  haveI : Module.Finite A E := Module.Finite.of_restrictScalars_finite k A E
+  haveI : IsNoetherian A E := inferInstance
+  haveI : Finite (isotypicComponents A E) := inferInstance
+  haveI : Fintype (isotypicComponents A E) := Fintype.ofFinite _
+  haveI : IsNoetherian k E := inferInstance
+  set m := Fintype.card (isotypicComponents A E) with hm
+  let φ : isotypicComponents A E ≃ Fin m := Fintype.equivFin _
+  let V' : isotypicComponents A E → Submodule A E := fun c =>
+    ((IsSemisimpleModule.eq_bot_or_exists_simple_le (c.1 : Submodule A E)).resolve_left
+      (bot_lt_isotypicComponents c.2).ne').choose
+  have V'_le : ∀ c, V' c ≤ c.1 := fun c =>
+    ((IsSemisimpleModule.eq_bot_or_exists_simple_le (c.1 : Submodule A E)).resolve_left
+      (bot_lt_isotypicComponents c.2).ne').choose_spec.1
+  have V'_simple : ∀ c, IsSimpleModule A (V' c) := fun c =>
+    ((IsSemisimpleModule.eq_bot_or_exists_simple_le (c.1 : Submodule A E)).resolve_left
+      (bot_lt_isotypicComponents c.2).ne').choose_spec.2
+  have V'_spec : ∀ c, (c.1 : Submodule A E) = isotypicComponent A E (V' c) := by
+    intro c
+    haveI := V'_simple c
+    exact eq_isotypicComponent_of_le c.2 (V'_le c)
+  -- Per-component k-linear iso: ↥c.1 ≃[k] V' c ⊗[k] (V' c →ₗ[A] E)
+  let perComp : ∀ c : isotypicComponents A E,
+      (↥c.1 : Type v) ≃ₗ[k]
+        ↥(V' c) ⊗[k] (↥(V' c) →ₗ[A] E) := fun c => by
+    haveI := V'_simple c
+    haveI : Module.Finite k (↥(V' c) : Type v) :=
+      Module.Finite.of_injective ((V' c).subtype.restrictScalars k)
+        Subtype.val_injective
+    haveI : Module.Finite k (↥c.1 : Type v) :=
+      Module.Finite.of_injective (c.1.subtype.restrictScalars k)
+        Subtype.val_injective
+    have e_submod : (↥c.1 : Type v) ≃ₗ[A] ↥(isotypicComponent A E (V' c)) :=
+      LinearEquiv.ofEq _ _ (V'_spec c)
+    haveI h_iso' : IsIsotypicOfType A ↥(isotypicComponent A E (V' c)) ↥(V' c) :=
+      IsIsotypicOfType.isotypicComponent A E _
+    haveI h_iso : IsIsotypicOfType A (↥c.1) ↥(V' c) :=
+      e_submod.isIsotypicOfType_iff.mpr h_iso'
+    let sE := schurEvaluationEquiv k A (↥(V' c)) (↥c.1) h_iso
+    let br := homIsotypicBridge k E A (V' c) c.1 (V'_spec c)
+    exact sE.symm.trans (TensorProduct.congr (LinearEquiv.refl k _) br)
+  -- Key lemma: on pure tensors, the inverse of perComp evaluates:
+  -- (perComp c).symm (v ⊗ₜ l) is the element of ↥c.1 whose .val is l v.
+  have perComp_symm_tmul : ∀ (c : isotypicComponents A E)
+      (v : ↥(V' c)) (l : ↥(V' c) →ₗ[A] E),
+      (((perComp c).symm (v ⊗ₜ[k] l) : ↥c.1) : E) = l v := by
+    intro c v l
+    haveI := V'_simple c
+    haveI : Module.Finite k (↥(V' c) : Type v) :=
+      Module.Finite.of_injective ((V' c).subtype.restrictScalars k)
+        Subtype.val_injective
+    haveI : Module.Finite k (↥c.1 : Type v) :=
+      Module.Finite.of_injective (c.1.subtype.restrictScalars k)
+        Subtype.val_injective
+    have e_submod : (↥c.1 : Type v) ≃ₗ[A] ↥(isotypicComponent A E (V' c)) :=
+      LinearEquiv.ofEq _ _ (V'_spec c)
+    haveI h_iso' : IsIsotypicOfType A ↥(isotypicComponent A E (V' c)) ↥(V' c) :=
+      IsIsotypicOfType.isotypicComponent A E _
+    haveI h_iso : IsIsotypicOfType A (↥c.1) ↥(V' c) :=
+      e_submod.isIsotypicOfType_iff.mpr h_iso'
+    -- perComp c = sE.symm.trans (TensorProduct.congr refl br), hence
+    -- (perComp c).symm = (TensorProduct.congr refl br).symm.trans sE
+    change ((((schurEvaluationEquiv k A (↥(V' c)) (↥c.1) h_iso).symm).trans
+            (TensorProduct.congr (LinearEquiv.refl k _)
+              (homIsotypicBridge k E A (V' c) c.1 (V'_spec c)))).symm
+          (v ⊗ₜ[k] l) : ↥c.1).val = l v
+    rw [LinearEquiv.trans_symm, LinearEquiv.symm_symm, LinearEquiv.trans_apply,
+        TensorProduct.congr_symm, LinearEquiv.refl_symm, TensorProduct.congr_tmul,
+        LinearEquiv.refl_apply, schurEvaluationEquiv_apply_tmul]
+    -- After simp: goal is ((homIsotypicBridge k E A (V' c) c.1 (V'_spec c)).symm l v : E) = l v.
+    -- `homIsotypicBridge.symm l = l.codRestrict c.1 _`, so applying at v gives `⟨l v, _⟩ ∈ c.1`,
+    -- whose .val = l v.
+    rfl
+  -- Total iso
+  let e2 : E ≃ₗ[k] (Π₀ c : isotypicComponents A E, (c.1 : Submodule A E)) :=
+    (isotypicDirectSumEquiv A E).symm.restrictScalars k
+  let e3 : (Π₀ c : isotypicComponents A E, (c.1 : Submodule A E)) ≃ₗ[k]
+           (Π₀ c : isotypicComponents A E,
+             ↥(V' c) ⊗[k] (↥(V' c) →ₗ[A] E)) :=
+    DFinsupp.mapRange.linearEquiv perComp
+  let e4 : (Π₀ c : isotypicComponents A E,
+            ↥(V' c) ⊗[k] (↥(V' c) →ₗ[A] E)) ≃ₗ[k]
+           DirectSum (Fin m) (fun i =>
+             ↥(V' (φ.symm i)) ⊗[k] (↥(V' (φ.symm i)) →ₗ[A] E)) :=
+    DirectSum.lequivCongrLeft k φ
+  let etotal : E ≃ₗ[k] DirectSum (Fin m)
+    (fun i => ↥(V' (φ.symm i)) ⊗[k] (↥(V' (φ.symm i)) →ₗ[A] E)) :=
+    e2.trans (e3.trans e4)
+  refine ⟨Fin m, inferInstance, inferInstance,
+    fun i => V' (φ.symm i),
+    fun i => V'_simple (φ.symm i),
+    ?_, etotal, ?_⟩
+  · -- Distinctness
+    intro i j ⟨eqv⟩
+    have h_eq : isotypicComponent A E (V' (φ.symm i)) =
+                isotypicComponent A E (V' (φ.symm j)) :=
+      eqv.isotypicComponent_eq
+    have h_c_eq : (φ.symm i).1 = (φ.symm j).1 := by
+      rw [V'_spec (φ.symm i), V'_spec (φ.symm j)]; exact h_eq
+    exact φ.symm.injective (Subtype.ext h_c_eq)
+  · -- Evaluation formula.
+    intro i
+    -- Beta-reduce the types of `v` and `l` so they mention `V' (φ.symm i)` directly.
+    change ∀ (v : ↥(V' (φ.symm i))) (l : ↥(V' (φ.symm i)) →ₗ[A] E),
+      etotal.symm (DirectSum.of
+        (fun j : Fin m => ↥(V' (φ.symm j)) ⊗[k] (↥(V' (φ.symm j)) →ₗ[A] E))
+        i (v ⊗ₜ[k] l)) = l v
+    intro v l
+    -- Strategy: apply etotal to both sides so we work forward through the chain.
+    rw [LinearEquiv.symm_apply_eq]
+    -- Goal: DirectSum.of _ i (v ⊗ₜ l) = etotal (l v).
+    -- Make the simple-module instance visible so `range_le_isotypicComponent_of_simple` applies.
+    haveI := V'_simple (φ.symm i)
+    -- Step 1: l v lies in the isotypic component (φ.symm i).1.
+    have hrange : l v ∈ ((φ.symm i).1 : Submodule A E) := by
+      have hr := range_le_isotypicComponent_of_simple (k := k) (E := E)
+        (V := V' (φ.symm i)) (A := A) l (LinearMap.mem_range_self l v)
+      rw [← V'_spec (φ.symm i)] at hr
+      exact hr
+    -- Step 2: (isotypicDirectSumEquiv A E).symm (l v) = DFinsupp.single (φ.symm i) ⟨l v, _⟩.
+    have step_fwd_1 : (isotypicDirectSumEquiv A E).symm (l v) =
+        DFinsupp.single (φ.symm i) (⟨l v, hrange⟩ : ↥((φ.symm i).1)) :=
+      iSupIndep.linearEquiv_symm_apply
+        (ind := (sSupIndep_iff _).mp (sSupIndep_isotypicComponents A E))
+        (iSup_top := by
+          rw [← sSup_eq_iSup']
+          exact sSup_isotypicComponents A E) (i := φ.symm i)
+        (x := l v) hrange
+    -- Step 3: perComp (φ.symm i) applied to ⟨l v, hrange⟩ gives v ⊗ₜ l.
+    -- This is the content of `perComp_symm_tmul` applied in reverse.
+    have step_fwd_2 : (perComp (φ.symm i)) ⟨l v, hrange⟩ =
+        (v ⊗ₜ[k] l : ↥(V' (φ.symm i)) ⊗[k] (↥(V' (φ.symm i)) →ₗ[A] E)) := by
+      apply (perComp (φ.symm i)).symm.injective
+      rw [(perComp (φ.symm i)).symm_apply_apply]
+      apply Subtype.ext
+      symm
+      exact perComp_symm_tmul (φ.symm i) v l
+    -- Step 4: put it together. We compute etotal (l v) by unfolding the chain.
+    change (DirectSum.of
+        (fun i : Fin m => ↥(V' (φ.symm i)) ⊗[k] (↥(V' (φ.symm i)) →ₗ[A] E))
+        i (v ⊗ₜ[k] l)) =
+      e4 (e3 (e2 (l v)))
+    -- e2 (l v) = (isotypicDirectSumEquiv).symm (l v) (wrapped in restrictScalars)
+    have he2 : e2 (l v) = DFinsupp.single (φ.symm i)
+        (⟨l v, hrange⟩ : ↥((φ.symm i).1)) := step_fwd_1
+    rw [he2]
+    -- e3 applied to a single.
+    have he3 : e3 (DFinsupp.single (φ.symm i)
+        (⟨l v, hrange⟩ : ↥((φ.symm i).1))) =
+        DFinsupp.single (φ.symm i) ((perComp (φ.symm i)) ⟨l v, hrange⟩) :=
+      DFinsupp.mapRange_single (hf := fun c => (perComp c).map_zero)
+    rw [he3, step_fwd_2]
+    -- Now we must show: of _ i (v ⊗ₜ l) = e4 (DFinsupp.single (φ.symm i) (v ⊗ₜ l)).
+    refine DFinsupp.ext (fun k' => ?_)
+    change (DirectSum.of
+          (fun j : Fin m => ↥(V' (φ.symm j)) ⊗[k] (↥(V' (φ.symm j)) →ₗ[A] E))
+          i (v ⊗ₜ[k] l)) k' =
+      ((DirectSum.lequivCongrLeft k φ)
+        (DFinsupp.single
+          (β := fun c : isotypicComponents A E =>
+            ↥(V' c) ⊗[k] (↥(V' c) →ₗ[A] E))
+          (φ.symm i)
+          (v ⊗ₜ[k] l))) k'
+    rw [DirectSum.lequivCongrLeft_apply]
+    by_cases hk : k' = i
+    · subst hk
+      rw [DirectSum.of_eq_same, DFinsupp.single_eq_same]
+    · rw [DirectSum.of_eq_of_ne _ _ _ hk]
+      have hne : φ.symm k' ≠ φ.symm i := fun h => hk (φ.symm.injective h)
+      rw [DFinsupp.single_eq_of_ne hne]
+
 end Etingof

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_18_4.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_18_4.lean
@@ -442,4 +442,40 @@ theorem Theorem5_18_4_bimodule_decomposition
   refine ⟨ι, hι, hι_dec, S', hS'_acg, hS'_mod, hS'_Amod, hS'_simp, hS'_dist,
     L', hL'_acg, hL'_mod, fun i => h_eq ▸ hL'_Bmod i, ⟨e⟩⟩
 
+-- Heartbeat bumps match `Theorem5_18_1_bimodule_decomposition_explicit`.
+set_option maxHeartbeats 3200000 in
+set_option synthInstance.maxHeartbeats 1200000 in
+/-- Schur-Weyl duality, part (iii), bimodule form with explicit evaluation.
+
+Strengthens `Theorem5_18_4_bimodule_decomposition` by concretizing the
+summand types as `Sᵢ : Submodule (symGroupImage k V n) (V^⊗n)` and
+`Lᵢ := ↥(Sᵢ) →ₗ[symGroupImage k V n] V^⊗n`, and producing an explicit
+iso whose inverse on pure-tensor basis elements is the evaluation map:
+  `e.symm (of i (v ⊗ₜ l)) = l v`.
+
+This is the form required by character-additivity arguments (Schur-Weyl
+#3 in #2458): together with the tensor-factorization of traces it yields
+`tr(b on V^⊗n) = Σᵢ dim(Sᵢ) · tr(b on Lᵢ)` for every `b` in the
+`diagonalActionImage` (since the evaluation formula implies `B`-equivariance
+of the iso with respect to the centralizer-post-composition action).
+
+(Etingof Theorem 5.18.4, part iii, bimodule form, explicit version.) -/
+theorem Theorem5_18_4_bimodule_decomposition_explicit
+    [IsAlgClosed k] [CharZero k]
+    (hN : n ≤ Module.finrank k V) :
+    ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
+      (S : ι → Submodule (symGroupImage k V n) (TensorPower k V n))
+      (_ : ∀ i, IsSimpleModule (symGroupImage k V n) (S i))
+      (_ : ∀ i j, Nonempty (↥(S i) ≃ₗ[symGroupImage k V n] ↥(S j)) → i = j),
+      ∃ (e : TensorPower k V n ≃ₗ[k]
+          DirectSum ι
+            (fun i => ↥(S i) ⊗[k] (↥(S i) →ₗ[symGroupImage k V n] TensorPower k V n))),
+        ∀ (i : ι) (v : ↥(S i))
+          (l : ↥(S i) →ₗ[symGroupImage k V n] TensorPower k V n),
+          e.symm (DirectSum.of _ i (v ⊗ₜ[k] l)) = l v := by
+  haveI := symGroupImage_isSemisimpleRing k V n
+  haveI := symGroupImage_faithfulSMul k V n hN
+  exact Theorem5_18_1_bimodule_decomposition_explicit k (TensorPower k V n)
+    (symGroupImage k V n)
+
 end Etingof

--- a/progress/2026-04-24T05-38-06Z_196cd011.md
+++ b/progress/2026-04-24T05-38-06Z_196cd011.md
@@ -1,0 +1,81 @@
+# Session 196cd011 — feature: B-equivariant bimodule decomposition
+
+Closes #2489 (feat(Ch5): make Theorem5_18_1/4_bimodule_decomposition iso
+B-linear — review finding from #2486).
+
+## Accomplished
+
+Rather than stating B-equivariance abstractly (Options A/B from the
+issue), I added a stronger "explicit evaluation" version of each bimodule
+decomposition theorem that concretizes the summand types and provides a
+pure-tensor evaluation formula `e.symm (of i (v ⊗ₜ l)) = l v`. This
+formula trivially implies B-equivariance (since `(b • l) v = b.val (l v)`)
+and is directly usable for character-additivity arguments.
+
+- `endOfSimpleEquivAlgClosed_symm_smul_apply` (Theorem5_18_1.lean): for
+  an alg-closed-simple `A`-module, `(e.symm φ) • v = φ v`.
+- `schurEvaluationEquiv_apply_tmul` (Theorem5_18_1.lean): the Schur
+  evaluation iso sends `v ⊗ₜ f` to `f v` — canonical despite being
+  constructed via an arbitrary decomposition choice.
+- `Theorem5_18_1_bimodule_decomposition_explicit` (Theorem5_18_1.lean):
+  the explicit bimodule iso with concrete `V : ι → Submodule A E`,
+  `L i := ↥(V i) →ₗ[A] E`, and evaluation formula.
+- `Theorem5_18_4_bimodule_decomposition_explicit` (Theorem5_18_4.lean):
+  the Schur-Weyl specialization (A = symGroupImage, E = V^⊗n), a direct
+  corollary of the Theorem5_18_1 version.
+
+The existing `Theorem5_18_1_bimodule_decomposition` and
+`Theorem5_18_4_bimodule_decomposition` are left unchanged (backwards
+compatibility for existing consumers).
+
+Zero new sorries. Full `lake build` succeeds.
+
+## Current frontier
+
+Issue #2489 is closed. Downstream issue #2458 (Schur-Weyl #3) can now
+use the character-additivity argument spelled out in its scoping doc
+via `Theorem5_18_4_bimodule_decomposition_explicit`:
+
+    character(V^⊗n)(b) = Σᵢ dim(Sᵢ) · character(Lᵢ)(b)   (b ∈ diagonalActionImage).
+
+## Overall project progress
+
+Stage 3 (formalization) continues. Schur-Weyl bimodule foundation now
+has both k-linear and B-equivariant forms available. The three open
+Schur-Weyl follow-ups (#2458, #2482, #2483) should now each have a
+clean character-based proof path.
+
+## Next step
+
+A planner/worker should pick up #2458 (Schur-Weyl #3, identify L_i
+summands with SchurModule) using the explicit-iso + evaluation-formula
+machinery landed here.
+
+## Blockers
+
+None.
+
+## Decisions made
+
+- **Chose Option "strengthen via eval formula" over Options A/B/C.**
+  The issue offered three shapes: (A) add a separate equivariance
+  clause, (B) upgrade iso type to `≃ₗ[A ⊗ B]`, (C) companion lemma.
+  I chose to add a new theorem with explicit types + evaluation
+  formula, which strictly implies B-equivariance without requiring
+  additional `Module B` instances on tensor products. Character-
+  additivity arguments reduce to a one-line computation from the
+  evaluation formula.
+
+- **Keep the old theorems unchanged.** Avoided breaking the one
+  existing consumer (`Theorem5_18_4_bimodule_decomposition`) by
+  preserving its signature and adding a parallel `_explicit` version.
+
+## Key patterns discovered
+
+- `iSupIndep.linearEquiv_symm_apply` + `DFinsupp.mapRange_single` +
+  `DirectSum.lequivCongrLeft_apply` compose to give a clean forward
+  computation for iso chains built from these three pieces.
+- When `refine ⟨..., fun i => ..., ...⟩` supplies a lambda field,
+  subsequent goals see the bound variable as `(fun i => ...) i`
+  unreduced. A `change` tactic at the top of the continuation
+  normalizes the type and avoids elaboration failures downstream.


### PR DESCRIPTION
Closes #2489

Session: `196cd011-d655-42e8-89ee-55f7c84f8f54`

c539479 progress: 196cd011 — B-equivariant bimodule decomposition (#2489)
35b0269 feat(Ch5): add Theorem5_18_4_bimodule_decomposition_explicit
5cc8d43 feat(Ch5): add Theorem5_18_1_bimodule_decomposition_explicit
589cbd5 feat(Ch5): pure-tensor formula for schurEvaluationEquiv

🤖 Prepared with Claude Code