### PR TITLE
progress: /work session — decompose #2499 (Wall 3 part C) into #2519 + #2520

### DIFF
--- a/progress/20260424T060243Z_87cd98ea.md
+++ b/progress/20260424T060243Z_87cd98ea.md
@@ -1,0 +1,71 @@
+## Accomplished
+
+`/work` session picked up unclaimed `feature` issue #2499 (Wall 3 #2450
+part C — residual-term whole-sum grouping). After orienting on the
+existing Wall 3 infrastructure in
+`EtingofRepresentationTheory/Chapter5/SpechtModuleBasis.lean`
+(sibling A `garnirColReindex`, sibling B `garnir_pigeonhole_collapse`),
+concluded that the proof decomposes naturally along the axes the
+issue itself flagged as natural splits (C.1 coset partition + per-coset
+reduction, C.2 τ classification).
+
+Filed the two sub-issues:
+
+- #2519 **C.1** — express `twistedPolytabloid w σ` as ℂ-combination of
+  polytabloids ψ_τ, with a concrete Lean-statement target and the
+  counter-example `TP((0,2,1), swap(0,1)) = ψ_[0,2,1,3] − ψ_id` as
+  validation anchor.
+- #2520 **C.2** — classify each τ from C.1 into the broadened
+  disjunction (`tabloidStrictDominates ∨ same-tabloid + smaller
+  rowInv`). Depends on #2519.
+
+Then skipped #2499 with a machine-readable `Decomposed into #2519,
+#2520` breadcrumb so the next planner triage closes or narrows it.
+
+No Lean code landed this session — the decomposition is pre-implementation.
+
+## Current frontier
+
+`garnir_twisted_in_lower_span`
+(`EtingofRepresentationTheory/Chapter5/SpechtModuleBasis.lean:1101`)
+remains the single open Wall 3 sorry. Sibling A (#2497 / PR #2503) and
+sibling B (#2498 / PR #2505) are merged. Wall 3 now needs C.1 (#2519) →
+C.2 (#2520) → C (next after C.2) → D (#2500, already filed) to close.
+
+## Overall project progress
+
+- Stage 3 (formalization) ongoing.
+- Sorry count on `main`: **unchanged** (no code landed this session).
+- Wall 3 (`garnir_twisted_in_lower_span`): one step of
+  further decomposition executed. The open work is now a chain C.1 →
+  C.2 → C-assembly → D-assembly, each well-scoped for a single
+  worker session.
+- Wall 1 (Ẽ_n / T(p,q,r)): still awaiting Kim's framework decision
+  (issue #2436, `human-oversight`).
+- Wall 2 (`dTildeRep_mapLinear_transport`): merged in PR #2495; wave-55
+  resolution complete.
+
+## Next step
+
+A worker should pick up **#2519** (C.1) next. The statement in the
+issue body (`twistedPolytabloid_eq_polytabloid_combination`) gives a
+concrete Lean target, and the counter-example anchor lets the worker
+sanity-check partial progress. The step-3 algebra (expressing the
+per-q tabloid basis elements in polytabloid form via the
+`garnirColReindex` sign-tracking) is the open technical question; if
+it resists ~100 lines, a further decomposition is a legitimate
+success path.
+
+**#2520** (C.2) is blocked until C.1 lands and pins down a concrete
+output shape.
+
+Independent other worker-available issues: #2478 (Schur-Weyl #2b,
+unblocked by #2477 landing via PR #2502); #2512 (cosmetic
+`[CharZero k]` cleanup on `prod_X_canonicalSeq`).
+
+## Blockers
+
+None new. #2499 is in `replan` pending planner triage — either it will
+be closed as fully covered by #2519 + #2520, or re-scoped to whatever
+residual isn't (the assembly step). Kim-level blocker is still Wall 1
+(#2436).


### PR DESCRIPTION
## Summary

`/work` session on issue #2499 (Wall 3 part C — residual-term
whole-sum grouping) concluded with decomposition rather than
code. The combinatorial heart of `garnir_residual_in_lower_span`
splits cleanly along the (C.1) / (C.2) axes that #2499's own sizing
section flagged as natural splits:

- #2519 **C.1** — express `twistedPolytabloid w σ` as ℂ-combination of
  polytabloids ψ_τ for col-standard τ. Counter-example anchor:
  `TP((0,2,1), swap(0,1)) = ψ_[0,2,1,3] − ψ_id`.
- #2520 **C.2** — classify each τ into the broadened disjunction
  (`tabloidStrictDominates ∨ same-tabloid + smaller rowInv`). Depends on
  #2519.

#2499 was `coordination skip`'d with the standard `Decomposed into
#2519, #2520` breadcrumb for planner triage.

## Changes

- `progress/20260424T060243Z_87cd98ea.md` — progress entry.

No Lean code changes.

## Test plan

- [x] `progress/` file passes formatting
- [x] No `.lean` files modified → no build impact
- [x] Sub-issues filed with concrete Lean-statement targets and
      counter-example validation anchors

🤖 Prepared with Claude Code