### PR TITLE
progress: /work session — decompose #2519 (Wall 3 C.1) into #2522 (meditate)

### DIFF
--- a/progress/20260424T062351Z_811935af.md
+++ b/progress/20260424T062351Z_811935af.md
@@ -1,0 +1,124 @@
+## Accomplished
+
+Claimed feature issue #2519 (Wall 3 C.1 — `twistedPolytabloid w σ` as ℂ-combination
+of polytabloids ψ_τ) and did substantial mathematical validation of the planner's
+proof strategy against the counter-example λ=(2,2), σ=swap(0,1), w=(0,2,1).
+
+**Key finding (refutation of the issue's step 3).** The issue's proof strategy
+step 3 claims:
+
+> Within each fibre, the partial sum `∑_{q ∈ fibre} sign(q) • δ_{[w q⁻¹ σ]}`
+> can be expressed as a ℂ-multiple of the single polytabloid `ψ_τ`.
+
+This claim is **false** at the counter-example.
+
+For λ=(2,2), σ=(0,1), w=(0,2,1), the four `q ∈ Q_λ = {1, (0,2), (1,3), (0,2)(1,3)}`
+produce four pairwise-distinct col-std representatives `τ(q) := garnirColReindex σ w q · (w q⁻¹ σ)`:
+
+| q             | w q⁻¹ σ           | γ (unique in Q_λ)  | τ(q)                   |
+|---------------|-------------------|--------------------|------------------------|
+| 1             | (1,2)             | 1                  | [0,2,1,3]              |
+| (0,2)         | id                | 1                  | id                     |
+| (1,3)         | (0,3)(1,2)        | (0,2)(1,3)         | (0,1)(2,3) = [1,0,3,2] |
+| (0,2)(1,3)    | (0,3)             | (0,2)(1,3)         | (0,1,3,2) = [1,3,0,2]  |
+
+**All four τ(q)'s are distinct as permutations**, so every fibre of `q ↦ τ(q)` is
+a singleton. The "partial sum over the fibre" is therefore a single term
+`sign(q) · δ_{[w q⁻¹ σ]}`.
+
+Inspecting q=1: the partial sum is `+δ_{{0,2}|{1,3}}`, a **single tabloid**.
+Compare to `ψ_{[0,2,1,3]} = +δ_{{0,2}|{1,3}} − δ_{{1,2}|{0,3}} − δ_{{0,3}|{1,2}}
++ δ_{{1,3}|{0,2}}` — a sum of four tabloids with varied signs. No scalar `c ∈ ℂ`
+satisfies `+δ_{{0,2}|{1,3}} = c · ψ_{[0,2,1,3]}` (it would require `c = 1` from the
+{0,2}|{1,3} coefficient, but then the other three tabloids in ψ must vanish,
+contradicting the explicit expansion). So step 3 fails.
+
+**Naive formula verification.** The natural naive combination
+
+    TP(w,σ) =?  ∑_q sign(q · γ_{w,q}) · ψ_{τ(q)}
+
+evaluates to `ψ_[0,2,1,3] − ψ_id − ψ_[1,0,3,2] + ψ_[1,3,0,2]`, which (using
+`ψ_[1,0,3,2] = ψ_id` and `ψ_[1,3,0,2] = 0`) collapses to `ψ_[0,2,1,3] − 2·ψ_id`.
+But the actual `TP = ψ_[0,2,1,3] − ψ_id` (verified against the
+`20260424T034536Z_2a4d9cc5.md` counter-example computation). The naive formula
+is off by a factor of 2 on ψ_id.
+
+So the correct algebraic mechanism involves **cross-fibre cancellation** —
+exactly the ψ_[1,0,3,2] = ψ_id coincidence is what subtracts one copy of ψ_id.
+This is the "cross-fibre cancellation" phenomenon that the planner's step 3
+does not account for.
+
+**Evidence for the cancellation mechanism.** Two interesting coincidences
+drive the counter-example:
+
+- `ψ_{[1,0,3,2]} = ψ_id` — because `(0,1)(2,3) ∈ P_λ` (RowSubgroup) and a
+  specific interaction between the row permutation and Q_λ-conjugation. Not
+  a general rule (ψ_{pσ} ≠ ψ_σ in general for p ∈ P_λ), but it happens here.
+- `ψ_{[1,3,0,2]} = 0` — pigeonhole collapse of the polytabloid for this τ.
+
+A correct formulation must either (a) detect these coincidences and group
+fibres across ψ-equivalent τ's, or (b) avoid the per-q combinatorics entirely
+via a different algebraic identity.
+
+## Current frontier
+
+`garnir_twisted_in_lower_span` at `SpechtModuleBasis.lean:1101` remains sorry.
+No Lean code changes on this branch. Issue #2519's stated proof approach
+needs to be replaced with a correct mechanism before formalization can
+proceed.
+
+## Overall project progress
+
+- Stage 3 (formalization) ongoing.
+- Wall 3 (#2450/#2499 residual whole-sum grouping): still open with
+  C.1 blocked on the missing algebraic mechanism.
+- Siblings landed: A (#2497/PR #2503), B (#2498/PR #2505).
+- Sorry count: unchanged (no code landed).
+
+## Next step
+
+**Meditate session** to develop the correct algebraic mechanism for C.1.
+The mechanism must explain why `TP = ψ_[0,2,1,3] − ψ_id` (coefficient −1,
+not −2, on ψ_id) at the counter-example. Candidate directions:
+
+1. **Grouping fibres across ψ-equivalence**: merge fibres whose τ's give
+   equal polytabloids (ψ_{[1,0,3,2]} = ψ_id merges those two fibres; ψ_{[1,3,0,2]}
+   = 0 means that fibre contributes nothing). Study when ψ_{τ₁} = ψ_{τ₂} or
+   ψ_τ = 0 can happen and what the coefficient formula becomes.
+2. **Alternative algebraic identity**: express TP via a different formula,
+   perhaps involving the Young symmetrizer action `TP(w,σ) = w · ψ_σ` together
+   with a Q_λ-averaging, that doesn't require per-q ψ_τ decomposition.
+3. **Weaker C.1 sufficient for D**: perhaps garnir_twisted_in_lower_span can
+   be proved directly by a different structural argument (e.g., induction on
+   a different measure, direct module-theoretic reasoning) that bypasses the
+   "TP as explicit polytabloid combination" intermediate step.
+
+Each candidate should be validated on the λ=(2,2), σ=(0,1), w=(0,2,1) and
+w=swap(1,2), w=(0,1,2) cases (the three "neither" G-supported permutations)
+before committing to Lean code.
+
+## Blockers
+
+The issue #2519's proof strategy as written is mathematically incorrect
+(step 3 refuted above). Decomposing into a meditate issue for the correct
+algebraic mechanism, then a follow-up feature issue once the mechanism is
+established.
+
+## Verification of the refutation (self-contained)
+
+Using the tabloid expansions from `progress/20260424T034536Z_2a4d9cc5.md`:
+
+- `TP((0,2,1), σ)` = `+{0,2}|{1,3} − {0,1}|{2,3} − {2,3}|{0,1} + {1,3}|{0,2}`
+- `ψ_[0,2,1,3]` = `+{0,2}|{1,3} − {1,2}|{0,3} − {0,3}|{1,2} + {1,3}|{0,2}`
+- `ψ_id` = `+{0,1}|{2,3} − {1,2}|{0,3} − {0,3}|{1,2} + {2,3}|{0,1}`
+- `ψ_[1,0,3,2]` = `+{0,1}|{2,3} − {1,2}|{0,3} − {0,3}|{1,2} + {2,3}|{0,1}` = `ψ_id`
+- `ψ_[1,3,0,2]` = `+{1,3}|{0,2} − {1,3}|{0,2} − {1,3}|{0,2} + {1,3}|{0,2}` = `0`
+
+Naive q-sum: `+ψ_[0,2,1,3] − ψ_id − ψ_id + 0 = ψ_[0,2,1,3] − 2·ψ_id`
+         ≠ `TP = ψ_[0,2,1,3] − 1·ψ_id`.
+
+Single-fibre claim at q=1: `+δ_{{0,2}|{1,3}} = c · ψ_[0,2,1,3]`? The LHS is
+supported on one tabloid `{0,2}|{1,3}`; the RHS is supported on four distinct
+tabloids. For any c ≠ 0, their supports differ. Only c = 0 makes the RHS
+supported on ∅, but then LHS = 0 fails. No solution exists. So the step-3
+claim fails for q=1 regardless of the coefficient choice.


### PR DESCRIPTION
## Summary

\`/work\` session on issue #2519 (Wall 3 C.1 — \`twistedPolytabloid w σ\` as
ℂ-combination of polytabloids ψ_τ) concluded with decomposition rather than
code. The issue's proof strategy step 3 — \"within each fibre, the partial sum
equals a ℂ-multiple of ψ_τ\" — is mathematically incorrect at the canonical
counter-example.

**Refutation summary.** For λ=(2,2), σ=swap(0,1), w=(0,2,1):

- All four q ∈ Q_λ produce pairwise-distinct τ(q), so every fibre of
  \`q ↦ garnirColReindex σ w q · (w q⁻¹ σ)\` is a singleton.
- A singleton partial sum \`sign(q)·δ_{[wq⁻¹σ]}\` is a single tabloid and
  cannot equal any ℂ-multiple of the 4-tabloid polytabloid ψ_τ (supports
  differ).
- Naive formula \`∑_q sign(q·γ_{w,q})·ψ_{τ(q)}\` gives
  \`ψ_[0,2,1,3] − 2·ψ_id\`, vs. the correct
  \`TP = ψ_[0,2,1,3] − ψ_id\`. Discrepancy driven by
  \`ψ_{[1,0,3,2]} = ψ_id\` (cross-fibre cancellation across ψ-equivalent τ's).

Filed #2522 (meditate) to develop the correct algebraic identity before
formalization. #2519 \`coordination skip\`'d with \`Decomposed into #2522\`
breadcrumb for planner triage.

## Changes

- \`progress/20260424T062351Z_811935af.md\` — full refutation with the
  counter-example expansions and candidate directions for #2522.

No Lean code changes.

## Test plan

- [x] \`progress/\` file added
- [x] No \`.lean\` files modified → no build impact
- [x] Meditate issue filed with validation oracle and candidate directions

🤖 Prepared with Claude Code