### PR TITLE
feat(Ch5): polynomialRep_embeds_in_tensorPower equivariance (#2527 Part B follow-up)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/PolynomialRepEmbedding.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialRepEmbedding.lean
@@ -280,6 +280,292 @@ theorem polynomialRep_embeds_in_tensorPower_inj
   rw [hone, LinearMap.id_apply] at h
   exact h
 
+/-! ## GL_N-equivariance of the embedding -/
+
+/-- `splitDualBasis` intertwines the `g^⊗n ⊗ id` action on `V^⊗n ⊗ (V^*)^⊗n`
+with the pointwise `PiTensorProduct.map g.toLin'` action on each
+`V^⊗n`-coordinate. -/
+lemma splitDualBasis_tgtGLAction (g : Matrix (Fin N) (Fin N) k)
+    (z : PolyTensorTgt k N n) (j : Fin n → Fin N) :
+    splitDualBasis k N n (PolynomialTensorBridge.tgtGLAction k N n g z) j =
+      PiTensorProduct.map (fun _ : Fin n => Matrix.toLin' g)
+        (splitDualBasis k N n z j) := by
+  classical
+  -- Prove the underlying LinearMap equality by TensorProduct.ext.
+  suffices h :
+      ((LinearMap.proj j : ((Fin n → Fin N) → TensorPower k (StdV k N) n) →ₗ[k]
+              TensorPower k (StdV k N) n).comp
+          (splitDualBasis k N n).toLinearMap).comp
+        (PolynomialTensorBridge.tgtGLAction k N n g) =
+        (PiTensorProduct.map (fun _ : Fin n => Matrix.toLin' g)).comp
+          ((LinearMap.proj j).comp (splitDualBasis k N n).toLinearMap) by
+    have := congrArg (fun f => f z) h
+    simpa using this
+  apply TensorProduct.ext'
+  intro u v
+  simp only [LinearMap.comp_apply, splitDualBasis, PolynomialTensorBridge.tgtGLAction,
+    LinearEquiv.coe_coe, LinearEquiv.trans_apply, TensorProduct.map_tmul, LinearMap.id_coe, id_eq,
+    LinearEquiv.lTensor_tmul, TensorProduct.piScalarRight_apply,
+    TensorProduct.piScalarRightHom_tmul, LinearMap.proj_apply, map_smul]
+
+/-- **Matrix-coefficient polynomial equivariance.** Given the polynomial matrix-
+coefficient multiplicativity hypothesis `hP_mul`, the matrix-coefficient
+polynomial of `ρ g x` equals the right-translation of the matrix-coefficient
+polynomial of `x` by `g`. -/
+lemma matrixCoeffPoly_polyRightTransl {d : ℕ} (b : Module.Basis (Fin d) k M)
+    (P : Fin d → Fin d → MvPolynomial (Fin N × Fin N) k)
+    (ρ : Matrix.GeneralLinearGroup (Fin N) k →* (M →ₗ[k] M))
+    (hP : ∀ (g : Matrix.GeneralLinearGroup (Fin N) k) a c,
+      b.repr (ρ g (b c)) a =
+        MvPolynomial.eval
+          (fun ij : Fin N × Fin N => (g : Matrix (Fin N) (Fin N) k) ij.1 ij.2)
+          (P a c))
+    (hP_mul : ∀ (g : Matrix.GeneralLinearGroup (Fin N) k) a c',
+      PolynomialTensorBridge.polyRightTransl k N
+          (g : Matrix (Fin N) (Fin N) k) (P a c') =
+        ∑ c, MvPolynomial.eval
+               (fun ij : Fin N × Fin N => (g : Matrix (Fin N) (Fin N) k) ij.1 ij.2)
+               (P c c') • P a c)
+    (g : Matrix.GeneralLinearGroup (Fin N) k) (a : Fin d) (x : M) :
+    matrixCoeffPoly k N b P a (ρ g x) =
+      PolynomialTensorBridge.polyRightTransl k N
+        (g : Matrix (Fin N) (Fin N) k) (matrixCoeffPoly k N b P a x) := by
+  classical
+  -- Abbreviations.
+  set eg : MvPolynomial (Fin N × Fin N) k →ₐ[k] MvPolynomial (Fin N × Fin N) k :=
+    PolynomialTensorBridge.polyRightTransl k N (g : Matrix (Fin N) (Fin N) k) with hegd
+  set eval_g : MvPolynomial (Fin N × Fin N) k → k :=
+    fun p => MvPolynomial.eval
+      (fun ij : Fin N × Fin N => (g : Matrix (Fin N) (Fin N) k) ij.1 ij.2) p with hevalg
+  -- Key identity: b.coord c' (ρ g x) = Σ_c (b.coord c x) * eval_g (P c' c).
+  have hrepr : ∀ c' : Fin d,
+      b.coord c' (ρ g x) = ∑ c : Fin d, b.coord c x * eval_g (P c' c) := by
+    intro c'
+    have hx : x = ∑ c : Fin d, b.coord c x • b c := by
+      conv_lhs => rw [← b.sum_repr x]
+      refine Finset.sum_congr rfl (fun c _ => ?_)
+      rw [Module.Basis.coord_apply]
+    conv_lhs => rw [hx, map_sum, map_sum]
+    refine Finset.sum_congr rfl (fun c _ => ?_)
+    rw [(ρ g).map_smul, (b.coord c').map_smul, smul_eq_mul]
+    congr 1
+    have := hP g c' c
+    rwa [Module.Basis.coord_apply]
+  -- Both sides expand as Σ_c b.coord c x • eg(P a c).
+  have hLHS :
+      matrixCoeffPoly k N b P a (ρ g x) =
+        ∑ c : Fin d, b.coord c x • eg (P a c) := by
+    rw [matrixCoeffPoly_apply]
+    simp_rw [hrepr]
+    -- Σ_{c'} (Σ_c a_c * e_{c',c}) • P a c' = Σ_c a_c • (Σ_{c'} e_{c',c} • P a c')
+    have hswap :
+        (∑ c' : Fin d, (∑ c : Fin d, b.coord c x * eval_g (P c' c)) • P a c') =
+          (∑ c : Fin d, b.coord c x • (∑ c' : Fin d, eval_g (P c' c) • P a c')) := by
+      simp_rw [Finset.sum_smul]
+      rw [Finset.sum_comm]
+      refine Finset.sum_congr rfl fun c _ => ?_
+      rw [Finset.smul_sum]
+      refine Finset.sum_congr rfl fun c' _ => ?_
+      rw [← smul_smul, ← mul_smul, mul_comm]
+    rw [hswap]
+    refine Finset.sum_congr rfl fun c _ => ?_
+    congr 1
+    rw [hP_mul g a c]
+  have hRHS : eg (matrixCoeffPoly k N b P a x) =
+      ∑ c : Fin d, b.coord c x • eg (P a c) := by
+    rw [matrixCoeffPoly_apply, map_sum]
+    refine Finset.sum_congr rfl fun c _ => ?_
+    rw [map_smul]
+  rw [hLHS, hRHS]
+
+/-- Equivariance of `polyTensorRow`: right-translation on the polynomial side
+matches `tgtGLAction` on the tensor side. -/
+lemma polyTensorRow_equivariant [CharZero k] {d : ℕ}
+    (b : Module.Basis (Fin d) k M)
+    (P : Fin d → Fin d → MvPolynomial (Fin N × Fin N) k)
+    (hhom : ∀ a c, (P a c).IsHomogeneous n)
+    (ρ : Matrix.GeneralLinearGroup (Fin N) k →* (M →ₗ[k] M))
+    (hP : ∀ (g : Matrix.GeneralLinearGroup (Fin N) k) a c,
+      b.repr (ρ g (b c)) a =
+        MvPolynomial.eval
+          (fun ij : Fin N × Fin N => (g : Matrix (Fin N) (Fin N) k) ij.1 ij.2)
+          (P a c))
+    (hP_mul : ∀ (g : Matrix.GeneralLinearGroup (Fin N) k) a c',
+      PolynomialTensorBridge.polyRightTransl k N
+          (g : Matrix (Fin N) (Fin N) k) (P a c') =
+        ∑ c, MvPolynomial.eval
+               (fun ij : Fin N × Fin N => (g : Matrix (Fin N) (Fin N) k) ij.1 ij.2)
+               (P c c') • P a c)
+    (g : Matrix.GeneralLinearGroup (Fin N) k) (a : Fin d) (x : M) :
+    polyTensorRow k N n b P hhom a (ρ g x) =
+      PolynomialTensorBridge.tgtGLAction k N n (g : Matrix (Fin N) (Fin N) k)
+        (polyTensorRow k N n b P hhom a x) := by
+  unfold polyTensorRow
+  simp only [LinearMap.comp_apply]
+  -- After codRestrict, the subtypes carry matrixCoeffPoly. Push through the equality.
+  have hmc := matrixCoeffPoly_polyRightTransl k N b P ρ hP hP_mul g a x
+  have heq :
+      (LinearMap.codRestrict (MvPolynomial.homogeneousSubmodule (Fin N × Fin N) k n)
+          (matrixCoeffPoly k N b P a)
+          (matrixCoeffPoly_mem_homogeneous k N n b P hhom a)) (ρ g x) =
+      ⟨PolynomialTensorBridge.polyRightTransl k N (g : Matrix (Fin N) (Fin N) k)
+          ((LinearMap.codRestrict (MvPolynomial.homogeneousSubmodule (Fin N × Fin N) k n)
+            (matrixCoeffPoly k N b P a)
+            (matrixCoeffPoly_mem_homogeneous k N n b P hhom a)) x).val,
+       PolynomialTensorBridge.polyRightTransl_isHomogeneous (k := k) (N := N) (m := n)
+         (g : Matrix (Fin N) (Fin N) k)
+         ((LinearMap.codRestrict (MvPolynomial.homogeneousSubmodule (Fin N × Fin N) k n)
+            (matrixCoeffPoly k N b P a)
+            (matrixCoeffPoly_mem_homogeneous k N n b P hhom a)) x).property⟩ := by
+    apply Subtype.ext
+    simpa [LinearMap.codRestrict] using hmc
+  rw [heq,
+    PolynomialTensorBridge.homogeneousPolyToTensor_equivariant (k := k) (N := N) (n := n)
+      (g := (g : Matrix (Fin N) (Fin N) k))]
+
+/-- Equivariance of `polyTensorBundle` on each coordinate. -/
+lemma polyTensorBundle_equivariant [CharZero k] {d : ℕ}
+    (b : Module.Basis (Fin d) k M)
+    (P : Fin d → Fin d → MvPolynomial (Fin N × Fin N) k)
+    (hhom : ∀ a c, (P a c).IsHomogeneous n)
+    (ρ : Matrix.GeneralLinearGroup (Fin N) k →* (M →ₗ[k] M))
+    (hP : ∀ (g : Matrix.GeneralLinearGroup (Fin N) k) a c,
+      b.repr (ρ g (b c)) a =
+        MvPolynomial.eval
+          (fun ij : Fin N × Fin N => (g : Matrix (Fin N) (Fin N) k) ij.1 ij.2)
+          (P a c))
+    (hP_mul : ∀ (g : Matrix.GeneralLinearGroup (Fin N) k) a c',
+      PolynomialTensorBridge.polyRightTransl k N
+          (g : Matrix (Fin N) (Fin N) k) (P a c') =
+        ∑ c, MvPolynomial.eval
+               (fun ij : Fin N × Fin N => (g : Matrix (Fin N) (Fin N) k) ij.1 ij.2)
+               (P c c') • P a c)
+    (g : Matrix.GeneralLinearGroup (Fin N) k) (x : M)
+    (p : Fin d × (Fin n → Fin N)) :
+    polyTensorBundle k N n b P hhom (ρ g x) p =
+      PiTensorProduct.map (fun _ : Fin n => Matrix.toLin' (g : Matrix (Fin N) (Fin N) k))
+        (polyTensorBundle k N n b P hhom x p) := by
+  rw [polyTensorBundle_apply, polyTensorBundle_apply,
+    polyTensorRow_equivariant (k := k) (N := N) (n := n) b P hhom ρ hP hP_mul g p.1 x,
+    splitDualBasis_tgtGLAction k N n (g : Matrix (Fin N) (Fin N) k)
+      (polyTensorRow k N n b P hhom p.1 x) p.2]
+
+/-- **Polynomial GL_N-rep embeds equivariantly into a tensor power**
+(Etingof §5.23, Schur-Weyl #2b — full version with equivariance).
+
+The upgraded form of `polynomialRep_embeds_in_tensorPower_inj`: in addition to
+exhibiting an injective `k`-linear embedding `φ : M → (V^⊗n)^m`, the embedding
+is `GL_N`-equivariant — it intertwines the representation `ρ` on `M` with the
+tensor-power action `g ↦ PiTensorProduct.map (g^⊗n)` on each coordinate of the
+target.
+
+The equivariance requires, in addition to the matrix-coefficient evaluation
+hypothesis `hP`, the **polynomial matrix-coefficient multiplicativity**
+hypothesis `hP_mul` asserting the polynomial-level identity
+`polyRightTransl g (P a c') = Σ_c eval g (P c c') • P a c`. This identity
+holds at the evaluation level for all `g ∈ GL_N` (by `ρ.map_mul` and the
+polynomial-matrix-coefficient setup), and from `[CharZero k]` (hence
+`Infinite k`) one can derive the polynomial-level statement via the
+determinant/funext trick. We take it as a hypothesis here to keep the bundle
+focused on the equivariance assembly; the derivation is deferred to a
+follow-up.
+
+(Etingof Definition 5.23.1 + Theorem 5.23.2 setup. Issue #2537 / #2527 Part B.) -/
+theorem polynomialRep_embeds_in_tensorPower
+    [CharZero k]
+    [Module.Finite k M]
+    (ρ : Matrix.GeneralLinearGroup (Fin N) k →* (M →ₗ[k] M))
+    (_halg : IsAlgebraicRepresentation N (ρ : _ → _))
+    (hpoly : ∃ (d : ℕ) (b : Module.Basis (Fin d) k M)
+       (P : Fin d → Fin d → MvPolynomial (Fin N × Fin N) k),
+         (∀ a c, (P a c).IsHomogeneous n) ∧
+         (∀ (g : Matrix.GeneralLinearGroup (Fin N) k) a c,
+           b.repr (ρ g (b c)) a =
+             MvPolynomial.eval
+               (fun ij : Fin N × Fin N =>
+                 (g : Matrix (Fin N) (Fin N) k) ij.1 ij.2)
+               (P a c)) ∧
+         (∀ (g : Matrix.GeneralLinearGroup (Fin N) k) a c',
+           PolynomialTensorBridge.polyRightTransl k N
+               (g : Matrix (Fin N) (Fin N) k) (P a c') =
+             ∑ c, MvPolynomial.eval
+                    (fun ij : Fin N × Fin N =>
+                      (g : Matrix (Fin N) (Fin N) k) ij.1 ij.2)
+                    (P c c') • P a c)) :
+    ∃ (m : ℕ) (φ : M →ₗ[k] (Fin m → TensorPower k (StdV k N) n)),
+      Function.Injective φ ∧
+      (∀ (g : Matrix.GeneralLinearGroup (Fin N) k) (x : M) (i : Fin m),
+        φ (ρ g x) i =
+          PiTensorProduct.map
+            (fun _ : Fin n => Matrix.toLin' (g : Matrix (Fin N) (Fin N) k))
+            (φ x i)) := by
+  classical
+  obtain ⟨d, b, P, hhom, hP, hP_mul⟩ := hpoly
+  -- Unpack and keep the explicit φ so we can also state equivariance.
+  let m := Fintype.card (Fin d × (Fin n → Fin N))
+  let e : Fin d × (Fin n → Fin N) ≃ Fin m := Fintype.equivFin _
+  let reindex :
+      (Fin d × (Fin n → Fin N) → TensorPower k (StdV k N) n) ≃ₗ[k]
+        (Fin m → TensorPower k (StdV k N) n) :=
+    LinearEquiv.funCongrLeft k (TensorPower k (StdV k N) n) e.symm
+  let φ : M →ₗ[k] (Fin m → TensorPower k (StdV k N) n) :=
+    reindex.toLinearMap.comp (polyTensorBundle k N n b P hhom)
+  refine ⟨m, φ, ?_, ?_⟩
+  · -- Injectivity: identical to `polynomialRep_embeds_in_tensorPower_inj`.
+    rw [show Function.Injective φ ↔
+          Function.Injective (polyTensorBundle k N n b P hhom) from by
+      simp [φ, LinearMap.coe_comp, reindex.injective.of_comp_iff]]
+    rw [← LinearMap.ker_eq_bot, Submodule.eq_bot_iff]
+    intro x hx
+    rw [LinearMap.mem_ker] at hx
+    have hx_pt : ∀ p : Fin d × (Fin n → Fin N),
+        polyTensorBundle k N n b P hhom x p = 0 :=
+      fun p => congrFun hx p
+    have hx_split : ∀ a : Fin d,
+        (splitDualBasis k N n) (polyTensorRow k N n b P hhom a x) = 0 := by
+      intro a
+      funext j
+      have := hx_pt (a, j)
+      rw [polyTensorBundle_apply] at this
+      simpa using this
+    have hx_row : ∀ a : Fin d, polyTensorRow k N n b P hhom a x = 0 :=
+      fun a => (splitDualBasis k N n).map_eq_zero_iff.mp (hx_split a)
+    have hx_poly : ∀ a : Fin d, matrixCoeffPoly k N b P a x = 0 :=
+      fun a => (polyTensorRow_eq_zero_iff k N n b P hhom a x).mp (hx_row a)
+    have hcoord_zero : ∀ (g : Matrix.GeneralLinearGroup (Fin N) k) (a : Fin d),
+        b.coord a (ρ g x) = 0 := by
+      intro g a
+      have hP_g : ∀ a' c', b.coord a' ((ρ g) (b c')) =
+          MvPolynomial.eval
+            (fun ij : Fin N × Fin N => (g : Matrix (Fin N) (Fin N) k) ij.1 ij.2)
+            (P a' c') := by
+        intro a' c'
+        have h := hP g a' c'
+        rwa [Module.Basis.coord_apply]
+      have h := eval_matrixCoeffPoly k N b P (ρ g)
+        (fun ij => (g : Matrix (Fin N) (Fin N) k) ij.1 ij.2) hP_g a x
+      rw [hx_poly a, map_zero] at h
+      exact h.symm
+    have hρ_zero : ∀ g : Matrix.GeneralLinearGroup (Fin N) k, ρ g x = 0 := by
+      intro g
+      apply b.repr.injective
+      ext a
+      rw [LinearEquiv.map_zero, Finsupp.zero_apply]
+      have := hcoord_zero g a
+      rwa [Module.Basis.coord_apply] at this
+    have hone : ρ 1 = LinearMap.id := ρ.map_one
+    have h := hρ_zero 1
+    rw [hone, LinearMap.id_apply] at h
+    exact h
+  · -- Equivariance: φ (ρ g x) i = PiTensorProduct.map g.toLin' (φ x i).
+    intro g x i
+    -- reindex is funCongrLeft e.symm, so evaluation at i gives the value at e.symm i.
+    change polyTensorBundle k N n b P hhom (ρ g x) (e.symm i) =
+      PiTensorProduct.map (fun _ => Matrix.toLin' (g : Matrix (Fin N) (Fin N) k))
+        (polyTensorBundle k N n b P hhom x (e.symm i))
+    exact polyTensorBundle_equivariant (k := k) (N := N) (n := n) b P hhom ρ hP hP_mul
+      g x (e.symm i)
+
 end PolynomialRepEmbedding
 
 end Etingof

--- a/progress/20260424T083321Z_271cd1ab.md
+++ b/progress/20260424T083321Z_271cd1ab.md
@@ -1,0 +1,71 @@
+## Accomplished
+
+Claimed and completed feature issue #2537
+(polynomialRep_embeds_in_tensorPower equivariance — #2527 Part B follow-up).
+
+Landed the GL_N-equivariance upgrade of `polynomialRep_embeds_in_tensorPower_inj`
+in `EtingofRepresentationTheory/Chapter5/PolynomialRepEmbedding.lean` via
+**Path B** (matrix-coefficient polynomial identity taken as an explicit
+hypothesis).
+
+### New content (+286 lines, 0 sorries)
+
+- `splitDualBasis_tgtGLAction` — `splitDualBasis` intertwines the
+  `g^⊗n ⊗ id` action on `V^⊗n ⊗ (V^*)^⊗n` with the pointwise
+  `PiTensorProduct.map g.toLin'` action on each `V^⊗n`-coordinate. Proof
+  via `TensorProduct.ext'` reduction to pure tensors, then `simp`.
+- `matrixCoeffPoly_polyRightTransl` — from the hypothesized polynomial
+  multiplicativity `polyRightTransl g (P a c') = Σ_c eval g (P c c') • P a c`
+  and the matrix-coefficient hypothesis `hP`, proves
+  `matrixCoeffPoly b P a (ρ g x) = polyRightTransl g (matrixCoeffPoly b P a x)`.
+- `polyTensorRow_equivariant` — combines the previous with Part A's
+  `homogeneousPolyToTensor_equivariant`.
+- `polyTensorBundle_equivariant` — bundled equivariance at each coordinate
+  `(a, j) : Fin d × (Fin n → Fin N)`.
+- `polynomialRep_embeds_in_tensorPower` — the upgraded theorem exhibiting
+  `m`, `φ : M →ₗ[k] (Fin m → TensorPower k V n)` with both injectivity and
+  `GL_N`-equivariance: `φ (ρ g x) i = PiTensorProduct.map (g.toLin')^⊗n (φ x i)`.
+
+### Design choices
+
+- Path B over Path A: deferred the `MvPolynomial.funext` + determinant-
+  polynomial trick. The equivariance assembly is clean; the polynomial-
+  identity derivation is a separable, independent follow-up.
+- Changed the reindex LinearEquiv from `piCongrLeft` to
+  `LinearEquiv.funCongrLeft` — simpler `apply` lemma for constant-fiber
+  pi types (`funCongrLeft e x i = x (e i)`), avoiding the eqRec cast
+  that `piCongrLeft` introduces.
+- `splitDualBasis_tgtGLAction` proof uses `suffices` + `TensorProduct.ext'`
+  at the LinearMap level to avoid typeclass timeouts when inducting on
+  tensor-product elements directly.
+
+## Current frontier
+
+- Stage 3 formalization ongoing.
+- Schur-Weyl #2b (polynomial GL_N-rep embeds in tensor power) now has
+  its fully equivariant version. Ready to be consumed by Schur-Weyl #5
+  (#2482) once the polynomial matrix-coefficient multiplicativity is
+  either derived (via Path A funext/det trick) or discharged by the
+  caller from ρ.map_mul + Infinite k + polynomial funext.
+
+## Overall project progress
+
+- Stage 3 ongoing. Chapter 5 Schur-Weyl chain: #2a (bridge +
+  equivariance — merged), #2b injection (merged), #2b equivariance
+  (this PR). Wall 3 C.1 decomposed into C.1.a.i / C.1.b / C.1.c, all
+  with active feature issues; #2531 partially landed.
+- Sorry count: unchanged in this PR.
+
+## Next step
+
+- Planner: a follow-up issue to derive the polynomial multiplicativity
+  hypothesis `hP_mul` from `ρ.map_mul` and `[CharZero k]` via
+  `MvPolynomial.funext` + the generic determinant polynomial
+  (`detPoly ≠ 0` in `MvPolynomial` over a field). Then
+  `polynomialRep_embeds_in_tensorPower` can be restated with just `hP`
+  as hypothesis.
+- Downstream: Schur-Weyl #5 (#2482) can now cite this theorem.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2537

Session: `271cd1ab-56df-4143-a019-5897be40c268`

e835b1f feat(Ch5 #2537): polynomialRep_embeds_in_tensorPower equivariance (#2527 Part B)

🤖 Prepared with Claude Code