### PR TITLE
feat(Ch5 #2515 part B): character identity skeleton + sum-of-characters theorem

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/FormalCharacterIso.lean
+++ b/EtingofRepresentationTheory/Chapter5/FormalCharacterIso.lean
@@ -27,7 +27,11 @@ equal-dimensions hypothesis holds vacuously) yet are non-isomorphic.
 
 open CategoryTheory MvPolynomial
 
+open scoped TensorProduct
+
 noncomputable section
+
+universe u
 
 namespace Etingof
 
@@ -221,7 +225,7 @@ theorem schurPoly_isHomogeneous (N : ℕ) (lam : Fin N → ℕ) :
   rw [MvPolynomial.coeff_homogeneousComponent, if_pos rfl] at h_coeff_zero
   exact hd h_coeff_zero
 
-variable (k : Type*) [Field k] [IsAlgClosed k] [CharZero k]
+variable (k : Type u) [Field k] [IsAlgClosed k] [CharZero k]
 
 /-- The family of weight spaces of a `GL_N(k)`-representation is sup-independent.
 This follows from `Module.End.independent_iInf_maxGenEigenspace_of_forall_mapsTo`
@@ -727,5 +731,93 @@ theorem formalCharacter_trivialTensor (N : ℕ)
   simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin]
   -- Goal: n • char L = (n : ℚ) • char L (both on MvPolynomial (Fin N) ℚ).
   exact (Nat.cast_smul_eq_nsmul ℚ n (formalCharacter k N L)).symm
+
+/-! ### GL_N-equivariant Schur-Weyl bimodule decomposition
+
+Using the explicit evaluation formula `e.symm (of i (v ⊗ l)) = l v` from
+`Theorem5_18_1_bimodule_decomposition_explicit`, we upgrade the Schur-Weyl
+bimodule decomposition to a `GL_N(k)`-equivariant form: the iso
+`V^{⊗n} ≃ ⨁ Sᵢ ⊗ Lᵢ` intertwines the diagonal `glTensorRep` action on the
+LHS with the natural action on the RHS (trivial on each `Sᵢ`, the
+post-composition `GL_N`-action on each `Lᵢ`).
+
+This is the form required by the Schur-Weyl #3 character argument
+(`formalCharacter_tensorPower_eq_sum_character_L`).
+-/
+
+set_option maxHeartbeats 3200000 in
+set_option synthInstance.maxHeartbeats 1600000 in
+/-- **Equivariant Schur-Weyl decomposition for `V^{⊗n}`.**
+Specializing to `V = Fin N → k`, there is a finite family of Specht modules
+`S i` and polynomial `GL_N(k)`-representations `L i`, together with a
+`k`-linear equivalence
+  `V^{⊗n} ≃ₗ[k] ⨁ i, S i ⊗[k] L i`
+that is `GL_N(k)`-equivariant: it intertwines the diagonal action on the
+LHS with the action on the RHS that is trivial on each `S i` and the given
+`L i`-action on the second factor. -/
+theorem glTensorRep_equivariant_schurWeyl_decomposition
+    (N n : ℕ) (hN : n ≤ N) :
+    ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
+      (S : ι → Type u)
+      (_ : ∀ i, AddCommGroup (S i))
+      (_ : ∀ i, Module k (S i))
+      (_ : ∀ i, Module.Finite k (S i))
+      (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k)),
+      ∃ (e : TensorPower k (Fin N → k) n ≃ₗ[k]
+          (DirectSum ι (fun i => S i ⊗[k] (L i : Type u)))),
+        ∀ (g : Matrix.GeneralLinearGroup (Fin N) k)
+          (v : TensorPower k (Fin N → k) n),
+          e (glTensorRep k N n g v) =
+            Representation.directSum (fun i =>
+              (Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
+                (S i)).tprod (L i).ρ) g (e v) := by
+  sorry
+
+/-! ### Schur-Weyl character decomposition of `V^{⊗n}`
+
+Combining the Schur-Weyl bimodule decomposition (Theorem 5.18.4 part iii)
+with the direct-sum additivity and trivial-tensor multiplicativity lemmas
+above yields the main character identity used in the Schur-Weyl #3
+character argument:
+
+  `char(V^{⊗n}) = ∑ᵢ dim(Sᵢ) · char(Lᵢ)`
+
+where the sum ranges over isotypic components of the `Sₙ`-action (Specht
+modules `Sᵢ`) and each `Lᵢ` is an irreducible polynomial
+`GL_N(k)`-representation.
+-/
+
+/-- **Schur-Weyl character decomposition.** For `V = Fin N → k` and `n ≤ N`,
+the formal character of the `GL_N(k)`-representation `V^{⊗n}` decomposes as
+a sum indexed by the isotypic components of the `Sₙ`-action,
+  `char(V^{⊗n}) = ∑ᵢ dim(Sᵢ) · char(Lᵢ)`,
+where `Sᵢ` is a simple `k[Sₙ]`-module (Specht module) and `Lᵢ` is an
+irreducible polynomial `GL_N(k)`-representation. -/
+theorem formalCharacter_tensorPower_eq_sum_character_L
+    (N n : ℕ) (hN : n ≤ N) :
+    ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
+      (S : ι → Type u)
+      (_ : ∀ i, AddCommGroup (S i))
+      (_ : ∀ i, Module k (S i))
+      (_ : ∀ i, Module.Finite k (S i))
+      (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k)),
+      formalCharacter k N (FDRep.of (glTensorRep k N n)) =
+        ∑ i : ι, (Module.finrank k (S i) : ℚ) • formalCharacter k N (L i) := by
+  -- Invoke the GL_N-equivariant Schur-Weyl decomposition (Theorem 5.18.4 iii).
+  obtain ⟨ι, hιFin, hιDec, S, hS_acg, hS_mod, hS_fin, L, e, he⟩ :=
+    glTensorRep_equivariant_schurWeyl_decomposition k N n hN
+  refine ⟨ι, hιFin, hιDec, S, hS_acg, hS_mod, hS_fin, L, ?_⟩
+  -- Step 1: push char(glTensorRep) across the equivariant iso to the
+  -- direct sum of (trivial_S_i ⊗ L_i)-representations.
+  have h_iso := formalCharacter_eq_of_rep_iso k N (glTensorRep k N n)
+    (Representation.directSum (fun i =>
+      (Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
+        (S i)).tprod (L i).ρ)) e he
+  rw [h_iso]
+  -- Step 2: split the direct sum.
+  rw [formalCharacter_directSum]
+  -- Step 3: apply trivial-tensor multiplicativity summand by summand.
+  refine Finset.sum_congr rfl (fun i _ => ?_)
+  exact formalCharacter_trivialTensor k N (S i) (L i)
 
 end Etingof

--- a/progress/20260424T083947Z_3f938e3f.md
+++ b/progress/20260424T083947Z_3f938e3f.md
@@ -1,0 +1,78 @@
+## Accomplished
+
+Claimed feature issue #2515 (Schur-Weyl character identity — bimodule
+decomposition character assembly).
+
+Decomposed into two coherent parts:
+- **Character identity assembly (~80 lines)** — landed in this partial PR.
+  Theorem `formalCharacter_tensorPower_eq_sum_character_L` is **fully proved**
+  modulo the single stubbed equivariance theorem it depends on.
+- **Equivariance theorem (~150-200 lines)** — filed as sub-issue #2540.
+  Stubbed here as `glTensorRep_equivariant_schurWeyl_decomposition`.
+
+## Additions to `FormalCharacterIso.lean`
+
+- `universe u` declared (was previously using `Type*` polymorphism).
+- `variable (k : Type u)` so `k` has explicit universe.
+- `open scoped TensorProduct` so `⊗[k]` notation resolves in statements.
+- New theorem `glTensorRep_equivariant_schurWeyl_decomposition` (sorry'd) —
+  the GL_N-equivariant strengthening of the Schur-Weyl bimodule decomposition.
+  Signature states existence of Specht modules `S i`, GL_N-reps `L i`, and
+  a k-linear equivalence intertwining `glTensorRep` with the
+  directSum-of-trivial-tensor-L_i action.
+- New theorem `formalCharacter_tensorPower_eq_sum_character_L` — **fully proved**:
+  `char(V^{⊗n}) = ∑ dim(Sᵢ) · char(Lᵢ)`, using
+  `formalCharacter_eq_of_rep_iso` + `formalCharacter_directSum` +
+  `formalCharacter_trivialTensor`.
+
+## Proof sketch for #2540 (equivariance)
+
+Use `Theorem5_18_1_bimodule_decomposition_explicit` (NOT the
+non-explicit version invoked by `Theorem5_18_4_GL_rep_decomposition`),
+since the **explicit evaluation formula** `e.symm (of i (v ⊗ l)) = l v`
+makes equivariance fall out by direct computation:
+
+- LHS: `glTensorRep g (l v) = (PiTensorProduct.map (g^⊗n)) (l v)`.
+- RHS: `e.symm (of i (v ⊗ (ρ_L_i g l))) = (ρ_L_i g l) v = (map (g^⊗n) ∘ l) v
+       = (map (g^⊗n)) (l v)`.
+
+These match on basis elements; extend by linearity.
+
+`ρ_L_i : GL_N →* End(L_i)` is the composition `GL_N → B → End(L_i)` where
+`B = centralizer(A) = diagonalActionImage` and `L_i = ↥(V_i) →ₗ[A] E` has
+the post-composition `B`-module structure already given by the bimodule
+theorem.
+
+Detailed implementation plan is in the issue body of #2540.
+
+## Current frontier
+
+- `glTensorRep_equivariant_schurWeyl_decomposition` sorry'd — the
+  only remaining piece of the Schur-Weyl #3 character argument.
+- Sub-issue #2540 dispatched to the next feature worker.
+
+## Overall project progress
+
+- Stage 3 (formalization) ongoing.
+- Wall 3 (Garnir): A (#2503), B (#2505) merged. C.1.a main theorem landed
+  (#2531); C.1.a.i helper is unclaimed (#2535); C.1.b open (#2532);
+  C.2 (#2520) open.
+- Schur-Weyl #3 (character argument): #2492 parent. Direct-sum additivity
+  (#2518), trivial-tensor multiplicativity (#2534) merged. This partial PR
+  lands the final character identity (modulo #2540 equivariance).
+- Sorry count: +1 (new `glTensorRep_equivariant_schurWeyl_decomposition`),
+  scoped by #2540.
+
+## Next step
+
+Worker or planner action: dispatch a `/feature` session for #2540. The
+issue body is self-contained: implementation plan, signature, key evaluation
+formula identity, and estimated sizing (~150-200 lines).
+
+After #2540 lands, `formalCharacter_tensorPower_eq_sum_character_L` is
+automatically proof-complete. No further work needed on the character
+identity side.
+
+## Blockers
+
+None new. #2540 has no open dependencies.


### PR DESCRIPTION
Partial progress on #2515

Session: `3f938e3f-4035-4a78-bb19-0af2f20e077b`

c271774 docs: progress note for #2515 partial landing
e9d954b feat(Ch5 #2515): WIP character identity skeleton — stubbed equivariance theorem

🤖 Prepared with Claude Code