### PR TITLE
review-finding(Ch5): relax unused [CharZero k] from formalCharacter_coeff and downstream additivity / iso lemmas

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/FormalCharacterIso.lean
+++ b/EtingofRepresentationTheory/Chapter5/FormalCharacterIso.lean
@@ -458,6 +458,7 @@ Both follow from the analogous statements on weight-space finranks, combined wit
 
 open scoped DirectSum in
 open Representation in
+omit [CharZero k] in
 /-- Componentwise formula for the direct-sum representation: for `x : DirectSum ι V`,
 the `j`-th coordinate of applying `Representation.directSum ρ g` to `x` is
 `ρ j g (x j)`. -/
@@ -472,6 +473,7 @@ private lemma directSum_rep_coord (N : ℕ)
 
 open scoped DirectSum in
 open Representation in
+omit [CharZero k] in
 /-- The weight space of a direct-sum representation splits coordinate-wise: a
 vector `x` lies in the weight space iff each coordinate `x j` lies in the
 corresponding weight space of `ρ j`. -/
@@ -512,6 +514,7 @@ private lemma mem_glWeightSpace_directSum_iff (N : ℕ)
 
 open scoped DirectSum in
 open Representation in
+omit [CharZero k] in
 /-- Linear equivalence between the direct sum of weight spaces and the weight
 space of a direct-sum representation. -/
 noncomputable def glWeightSpace_directSum_equiv (N : ℕ)
@@ -560,6 +563,7 @@ noncomputable def glWeightSpace_directSum_equiv (N : ℕ)
 
 open scoped DirectSum in
 open Representation in
+omit [CharZero k] in
 /-- The finrank of the weight space of a direct-sum representation is the sum of
 finranks of the individual weight spaces. -/
 private lemma finrank_glWeightSpace_directSum (N : ℕ)
@@ -576,6 +580,7 @@ private lemma finrank_glWeightSpace_directSum (N : ℕ)
 
 open scoped DirectSum in
 open Representation in
+omit [CharZero k] in
 /-- **Direct-sum additivity of formal character.**
 For a finite family of representations `ρ i` on finite-dimensional `k`-modules,
 the formal character of the direct-sum representation equals the sum of the
@@ -627,6 +632,7 @@ private theorem glWeightSpace_map_eq_of_rep_iso (N : ℕ)
       rw [map_smul, e.apply_symm_apply]
     exact sub_eq_zero.mpr (e.injective (h1.trans h2.symm))
 
+omit [CharZero k] in
 /-- **Formal character is invariant under GL_N-equivariant isomorphism.**
 A k-linear equivalence `e : V ≃ W` that intertwines two GL_N representations induces
 equality of their formal characters. -/
@@ -647,6 +653,7 @@ theorem formalCharacter_eq_of_rep_iso (N : ℕ)
 
 open scoped DirectSum in
 open Representation in
+omit [CharZero k] in
 /-- **Trivial-tensor multiplicativity of formal character.**
 For a trivial GL_N-action on `S` tensor-producted with a representation `L`, the
 formal character is `(dim S) • formalCharacter L`. -/

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
@@ -505,6 +505,7 @@ variable (k : Type*) [Field k] [IsAlgClosed k] [CharZero k]
 
 /-! ### Coefficient extraction for formal character -/
 
+omit [CharZero k] in
 /-- The coefficient of `x^μ` in the formal character equals the dimension of the weight space. -/
 theorem formalCharacter_coeff (N : ℕ)
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))

--- a/progress/2026-04-27T14-59-30Z_e62e6ec0.md
+++ b/progress/2026-04-27T14-59-30Z_e62e6ec0.md
@@ -1,0 +1,61 @@
+# 2026-04-27 — Feature session — relax [CharZero k] from formal-character lemmas
+
+Session: feature (issue #2559)
+Branch: `agent/e62e6ec0`
+
+## Accomplished
+
+Added `omit [CharZero k] in` annotations to the formal-character
+lemmas listed in issue #2559. None of the affected proofs invoke
+`CharZero`; they were inheriting the instance via section auto-binding
+from `variable (k : Type*) [Field k] [IsAlgClosed k] [CharZero k]`.
+
+Files touched:
+- `EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean`
+  - `formalCharacter_coeff` (line 509)
+- `EtingofRepresentationTheory/Chapter5/FormalCharacterIso.lean`
+  - private helpers: `directSum_rep_coord`, `mem_glWeightSpace_directSum_iff`,
+    `finrank_glWeightSpace_directSum`
+  - public API: `glWeightSpace_directSum_equiv`,
+    `formalCharacter_directSum`, `formalCharacter_eq_of_rep_iso`,
+    `formalCharacter_trivialTensor`
+
+The `glWeightSpace_map_eq_of_rep_iso` helper at line 595 already had
+the annotation; this issue propagates the same pattern across the rest
+of the additivity / iso block.
+
+## Verification
+
+- `lake build EtingofRepresentationTheory.Chapter5.Theorem5_22_1` — pass.
+- `lake build EtingofRepresentationTheory.Chapter5.FormalCharacterIso` — pass.
+- Full `lake build` — pass (8309 jobs, no errors; warning count unchanged
+  modulo the existing pre-existing pile).
+
+## Current frontier
+
+Hypothesis-hygiene cleanups for the formal-character / Schur-Weyl
+foundations chain. Adjacent open issues #2565 and #2568 cover
+`PolynomialTensorBridge` / `PolynomialRepEmbedding` declarations.
+#2564 is a Mathlib-upstream tracker for `eq_of_eval_eq_on_gl`.
+
+## Overall project progress
+
+Stage 3 (Lean formalization) ongoing. This session is a low-risk
+hygiene cleanup; no new theorems and no proof-content changes.
+
+## Next step
+
+A follow-up worker can pick up #2565 (or #2568 once #2565 lands) to
+extend the same `omit [CharZero k]` pattern to the GL_N-equivariance
+foundations block in `PolynomialTensorBridge.lean`.
+
+The full-project build also emitted `unusedSectionVars` linter warnings
+for `[CharZero k]` on two declarations in
+`Chapter5/Proposition5_22_2.lean` (`glWeightSpace_disjoint` line 338,
+`schurModule_tensor_det_iso_detTwist` line 433). These are out of
+scope for #2559 and not blocking, but a future hygiene-cleanup planner
+cycle could fold them in.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2559

Session: `e62e6ec0-3423-42bd-98e8-ac4e0b2f4698`

efa4817 refactor(Ch5): omit [CharZero k] from formal-character additivity / iso lemmas

🤖 Prepared with Claude Code