### PR TITLE
feat(Ch5): Theorem5_18_4_GL_rep_decomposition_explicit — explicit-eval analogue for Schur-Weyl L_i

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_18_4.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_18_4.lean
@@ -584,4 +584,169 @@ theorem Theorem5_18_4_GL_rep_decomposition
   exact ⟨ι, hι, hι_dec, S', hS'_acg, hS'_mod, hS'_Amod, hS'_simp,
     hS'_dist, L, ⟨e⟩⟩
 
+-- Heartbeats bumped: the existential output has 8 ∀-binders followed by
+-- two more existentials; the GL_N representation construction composes
+-- several monoid homs each triggering deep `Subalgebra → Ring → Module.End`
+-- instance chains. Matches the bumps on `_GL_rep_decomposition`.
+set_option maxHeartbeats 3200000 in
+set_option synthInstance.maxHeartbeats 1600000 in
+/-- Schur-Weyl duality, part (iii), GL_N representation form, explicit
+version.
+
+Strengthens `Theorem5_18_4_GL_rep_decomposition` by concretizing the
+summand types and producing an explicit iso whose inverse on pure
+tensors is the evaluation map:
+
+* `S i : Submodule (symGroupImage k V n) (V^⊗n)` (Specht-module realisations
+  as concrete submodules);
+* `L i : FDRep k (GL_N k)` whose carrier is
+  `↥(S i) →ₗ[symGroupImage k V n] V^⊗n`, with the `GL_N`-action given by
+  post-composition with `g ↦ g^{⊗n}` (which lies in
+  `centralizer(symGroupImage)` by the centralizer identity);
+* a `k`-linear iso `L_carrier i : (L i : Type u) ≃ₗ[k]
+  (↥(S i) →ₗ[symGroupImage k V n] V^⊗n)` identifying the bundled FDRep
+  carrier with the explicit hom-space (it is `LinearEquiv.refl` after
+  the `FGModuleCat.of_carrier` defeq);
+* explicit iso `e : V^⊗n ≃ₗ[k] ⨁ᵢ ↥(S i) ⊗[k] (L i : Type u)` whose
+  inverse on pure tensors is the evaluation map:
+  `e.symm (of i (v ⊗ₜ l)) = (L_carrier i l) v`.
+
+The `L_carrier` clause sidesteps a defeq fragility: when stating the
+existential, `(L i : Type u)` is universally quantified and not yet
+concretised, so an `l : (L i : Type u)` cannot be applied to `v` as a
+linear map without the explicit identification with `↥(S i) →ₗ[A] E`.
+
+This is the form required by the `GL_N`-equivariance argument
+(`glTensorRep_equivariant_schurWeyl_decomposition`,
+issue #2540): the evaluation formula together with the post-composition
+`GL_N`-action on each `L i` makes equivariance computable on pure
+tensors. -/
+theorem Theorem5_18_4_GL_rep_decomposition_explicit
+    (k : Type u) [Field k] [IsAlgClosed k] [CharZero k]
+    (N n : ℕ) (hN : n ≤ N) :
+    ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
+      (S : ι → Submodule (symGroupImage k (Fin N → k) n)
+        (TensorPower k (Fin N → k) n))
+      (_ : ∀ i, IsSimpleModule (symGroupImage k (Fin N → k) n) (S i))
+      (_ : ∀ i j,
+        Nonempty (↥(S i) ≃ₗ[symGroupImage k (Fin N → k) n] ↥(S j)) → i = j)
+      (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
+      (L_carrier : ∀ i, (L i : Type u) ≃ₗ[k]
+        (↥(S i) →ₗ[symGroupImage k (Fin N → k) n]
+          TensorPower k (Fin N → k) n)),
+      ∃ (e : TensorPower k (Fin N → k) n ≃ₗ[k]
+          DirectSum ι (fun i => ↥(S i) ⊗[k] (L i : Type u))),
+        ∀ (i : ι) (v : ↥(S i)) (l : (L i : Type u)),
+          e.symm (DirectSum.of (fun i => ↥(S i) ⊗[k] (L i : Type u)) i
+              (v ⊗ₜ[k] l)) = (L_carrier i l) v := by
+  set V : Type u := Fin N → k with hV
+  haveI : Module.Finite k V := inferInstance
+  have hfinrank : Module.finrank k V = N :=
+    (Module.finrank_pi k).trans (Fintype.card_fin N)
+  have hN' : n ≤ Module.finrank k V := hfinrank.symm ▸ hN
+  haveI := symGroupImage_isSemisimpleRing k V n
+  haveI := symGroupImage_faithfulSMul k V n hN'
+  -- Get the explicit bimodule decomposition with concrete summand types
+  -- and the evaluation formula.
+  obtain ⟨ι, hι, hι_dec, S', hS'_simp, hS'_dist, e, he⟩ :=
+    Theorem5_18_4_bimodule_decomposition_explicit k V n hN'
+  -- Centralizer identity: centralizer(symGroupImage) = diagonalActionImage.
+  have h_eq : Subalgebra.centralizer k
+      (symGroupImage k V n : Set (Module.End k (TensorPower k V n))) =
+        diagonalActionImage k V n :=
+    (Theorem5_18_4_centralizers k V n hN').2.symm
+  -- Monoid hom GL_N → centralizer(symGroupImage), same as in
+  -- `_GL_rep_decomposition`.
+  let glHom : Matrix.GeneralLinearGroup (Fin N) k →*
+      ↥(Subalgebra.centralizer k
+        (symGroupImage k V n : Set (Module.End k (TensorPower k V n)))) :=
+  { toFun := fun g => ⟨PiTensorProduct.map
+        (fun _ : Fin n => Matrix.mulVecLin (R := k) g.val), by
+      rw [h_eq]
+      exact Algebra.subset_adjoin ⟨Matrix.mulVecLin g.val, rfl⟩⟩
+    map_one' := by
+      apply Subtype.ext
+      change PiTensorProduct.map
+          (fun _ : Fin n => Matrix.mulVecLin (R := k) (1 : Matrix _ _ k)) = 1
+      have : (fun _ : Fin n => Matrix.mulVecLin (R := k) (1 : Matrix _ _ k)) =
+          (fun _ : Fin n => (LinearMap.id : V →ₗ[k] V)) :=
+        funext fun _ => Matrix.mulVecLin_one
+      rw [this, PiTensorProduct.map_id]; rfl
+    map_mul' := fun g₁ g₂ => by
+      apply Subtype.ext
+      change PiTensorProduct.map
+          (fun _ : Fin n => Matrix.mulVecLin (R := k) (g₁.val * g₂.val)) =
+        PiTensorProduct.map
+            (fun _ : Fin n => Matrix.mulVecLin (R := k) g₁.val) *
+          PiTensorProduct.map
+            (fun _ : Fin n => Matrix.mulVecLin (R := k) g₂.val)
+      have : (fun _ : Fin n => Matrix.mulVecLin (R := k) (g₁.val * g₂.val)) =
+          (fun _ : Fin n => (Matrix.mulVecLin g₁.val).comp
+            (Matrix.mulVecLin g₂.val)) :=
+        funext fun _ => Matrix.mulVecLin_mul g₁.val g₂.val
+      rw [this, PiTensorProduct.map_comp]; rfl }
+  -- Each `↥(S' i)` is a finite-dimensional `k`-vector space (it injects into
+  -- the finite-dimensional `TensorPower k V n` via the subtype map).
+  haveI hSi_fin : ∀ i, Module.Finite k ((↥(S' i) : Type u)) := fun i =>
+    Module.Finite.of_injective ((S' i).subtype.restrictScalars k)
+      Subtype.val_injective
+  -- The `A`-linear hom space `↥(S' i) →ₗ[A] E` is finite-dimensional over `k`
+  -- because it injects (`k`-linearly) into the `k`-linear hom space, which has
+  -- dimension `dim(↥(S' i)) · dim(E)`. (Same derivation as in
+  -- `glTensorRep_equivariant_schurWeyl_decomposition`.)
+  haveI hLi_fin : ∀ i, Module.Finite k
+      ((↥(S' i) : Type u) →ₗ[symGroupImage k V n] TensorPower k V n) :=
+    fun i => by
+      haveI : Module.Finite k (↥(S' i) : Type u) := hSi_fin i
+      haveI : Module.Free k (↥(S' i) : Type u) :=
+        Module.Free.of_divisionRing k (↥(S' i))
+      haveI : Module.Finite k
+          ((↥(S' i) : Type u) →ₗ[k] TensorPower k V n) :=
+        Module.Finite.linearMap k k (↥(S' i)) (TensorPower k V n)
+      exact Module.Finite.of_injective
+        (LinearMap.restrictScalarsₗ k (symGroupImage k V n) (↥(S' i))
+          (TensorPower k V n) k)
+        (LinearMap.restrictScalars_injective _)
+  -- For each i, build the GL_N representation on `↥(S' i) →ₗ[A] E` directly:
+  -- `g · l := (centralizerToEndA (glHom g)).comp l`. Manual construction
+  -- bypasses an instance-synthesis diamond on the centralizer-Module
+  -- structure of the hom-space. (Same construction as in
+  -- `glTensorRep_equivariant_schurWeyl_decomposition`.)
+  let ρ : ∀ i, Matrix.GeneralLinearGroup (Fin N) k →*
+      Module.End k (↥(S' i) →ₗ[symGroupImage k V n] TensorPower k V n) := fun i =>
+  { toFun := fun g =>
+    { toFun := fun l =>
+        (centralizerToEndA k (TensorPower k V n) (symGroupImage k V n)
+          (glHom g)).comp l
+      map_add' := fun l₁ l₂ => by
+        ext v
+        simp only [LinearMap.comp_apply, LinearMap.add_apply, map_add]
+      map_smul' := fun c l => by
+        ext v
+        simp only [LinearMap.smul_apply, RingHom.id_apply,
+          LinearMap.comp_apply, LinearMap.map_smul_of_tower] }
+    map_one' := by
+      ext l v
+      simp only [LinearMap.coe_mk, AddHom.coe_mk, LinearMap.comp_apply,
+        Module.End.one_apply]
+      change (centralizerToEndA k (TensorPower k V n) (symGroupImage k V n)
+        (glHom 1)) (l v) = l v
+      rw [map_one, map_one]; rfl
+    map_mul' := fun g₁ g₂ => by
+      ext l v
+      simp only [LinearMap.coe_mk, AddHom.coe_mk, LinearMap.comp_apply,
+        Module.End.mul_apply]
+      change (centralizerToEndA k (TensorPower k V n) (symGroupImage k V n)
+          (glHom (g₁ * g₂))) (l v) = _
+      rw [map_mul, map_mul]; rfl }
+  -- Bundle each L_inner as a finite-dimensional GL_N representation.
+  let L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k) := fun i =>
+    FDRep.of (ρ i)
+  -- The carrier of `L i` is, by `FGModuleCat.of_carrier`, definitionally
+  -- the explicit hom-space `↥(S' i) →ₗ[A] E`. Hence `LinearEquiv.refl`.
+  let L_carrier : ∀ i, (L i : Type u) ≃ₗ[k]
+      (↥(S' i) →ₗ[symGroupImage k V n] TensorPower k V n) :=
+    fun i => LinearEquiv.refl k _
+  exact ⟨ι, hι, hι_dec, S', hS'_simp, hS'_dist, L, L_carrier, e, he⟩
+
 end Etingof

--- a/progress/20260427T153047Z_8e0b9c38.md
+++ b/progress/20260427T153047Z_8e0b9c38.md
@@ -1,0 +1,82 @@
+## Accomplished
+
+Feature session `8e0b9c38` — completed issue #2572: added
+`Theorem5_18_4_GL_rep_decomposition_explicit` (Schur-Weyl GL_N
+representation form, explicit version).
+
+The new theorem strengthens `Theorem5_18_4_GL_rep_decomposition` by
+providing:
+- Concrete summand types (`S i : Submodule (symGroupImage) (V^⊗n)`).
+- Each `L i : FDRep k (GL_N k)` bundled with its `GL_N` action via
+  post-composition by `g^{⊗n}`.
+- A `k`-linear iso `L_carrier i : (L i : Type u) ≃ₗ[k]
+  (↥(S i) →ₗ[A] V^⊗n)` identifying the bundled FDRep carrier with
+  the explicit hom-space (it is `LinearEquiv.refl k _` after
+  `FGModuleCat.of_carrier := rfl`).
+- Explicit iso `e : V^⊗n ≃ₗ[k] ⨁ᵢ ↥(S i) ⊗[k] (L i : Type u)` with
+  the evaluation formula `e.symm (of i (v ⊗ l)) = (L_carrier i l) v`.
+
+The `L_carrier` clause is needed because `(L i : Type u)` is
+universally quantified in the existential, so an `l : (L i : Type u)`
+cannot be applied to `v` as a linear map without the explicit
+identification.
+
+## Construction notes
+
+While I was working on this, **#2540 landed** (commit 0cc1dc7,
+`feat(Ch5): close glTensorRep_equivariant_schurWeyl_decomposition`).
+As the issue body anticipated, my work became a "refactor-extract"
+task. I copied #2540's two key technical patterns:
+
+1. **`Module.Finite k (V →ₗ[A] E)` derivation**: invoke
+   `Module.Free.of_divisionRing k (↥(V i))` and
+   `Module.Finite.linearMap k k _ _` explicitly, then
+   `Module.Finite.of_injective` via the `LinearMap.restrictScalarsₗ`
+   inclusion `(V →ₗ[A] E) ↪ (V →ₗ[k] E)`.
+
+2. **`ρ i` construction**: build each `ρ i : GL_N →* Module.End k (V →ₗ[A] E)`
+   manually as a record `{ toFun := fun g => { toFun := fun l =>
+   (centralizerToEndA (glHom g)).comp l, … }, map_one' := …,
+   map_mul' := … }`. This bypasses an instance-synthesis diamond on
+   the centralizer-Module structure
+   (`Submodule.addCommMonoid` vs `AddCommGroup.toAddCommMonoid`).
+
+Direct construction was necessary because
+`Theorem5_18_1_bimodule_decomposition_explicit` does not bundle the
+`Module ↥(centralizer A) (↥(V i) →ₗ[A] E)` instance (unlike the
+opaque `_bimodule_decomposition`). Going via `centralizerModuleHom`
++ `Module.toModuleEnd` triggers the diamond.
+
+## Current frontier
+
+- #2572 closed via this PR.
+- The unclaimed queue still has six issues (#2564, #2565, #2570,
+  #2571, #2573, #2574), all low-priority hygiene/cosmetic work.
+- The downstream consumer of #2572 was originally #2540, which
+  landed independently. The new `_explicit` theorem is now
+  available for any future consumer that needs the explicit eval
+  formula together with an `FDRep`-bundled `L i`. A natural
+  follow-up would be to refactor `glTensorRep_equivariant_schurWeyl_decomposition`
+  in `FormalCharacterIso.lean` to consume the new theorem instead
+  of duplicating the `glHom`/`ρ` chain — but that's not in scope
+  for #2572.
+
+## Overall project progress
+
+Stage 3 formalization. Schur-Weyl chain advanced: #2540 landed
+(equivariant decomposition), and #2572 (this PR) provides the
+reusable explicit-form theorem. Sorry count unchanged.
+
+## Next step
+
+- Workers: claim any of the six remaining unclaimed issues
+  (#2564 Mathlib upstream, #2565 / #2568-style CharZero hygiene
+  (already #2568 landed), #2570 doc-string fixes, #2571 doc-string,
+  #2573 Module.Finite propagation, #2574 heartbeat tightening).
+- Future work: refactor `glTensorRep_equivariant_schurWeyl_decomposition`
+  to consume `Theorem5_18_4_GL_rep_decomposition_explicit` (new
+  follow-up issue if desired).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2572

Session: `8e0b9c38-21b7-40f4-a689-7adbbecf1821`

caa5295 feat(Ch5 #2572): Theorem5_18_4_GL_rep_decomposition_explicit

🤖 Prepared with Claude Code