### PR TITLE
doc(Ch5 #2564): tracker note for upstream Mathlib PR (eq_of_eval_eq_on_gl)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/PolynomialRepEmbedding.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialRepEmbedding.lean
@@ -594,7 +594,11 @@ then `s` comes from a `GL_N`-element, so `eval s p = eval s q` by hypothesis;
 if `det s = 0`, then `eval s (det X) = 0`. In either case the product
 vanishes, so by `MvPolynomial.funext` the product is zero as a polynomial.
 The determinant polynomial is nonzero by `Matrix.det_mvPolynomialX_ne_zero`,
-and `MvPolynomial σ k` is an integral domain, so `p - q = 0`. -/
+and `MvPolynomial σ k` is an integral domain, so `p - q = 0`.
+
+Upstream Mathlib PR: https://github.com/leanprover-community/mathlib4/pull/38583
+(once it merges, replace this lemma with the upstream `MvPolynomial.eq_of_eval_eq_on_gl`
+and remove this local copy — see issue #2564). -/
 lemma eq_of_eval_eq_on_gl
     {k : Type*} [Field k] [Infinite k] {N : ℕ}
     {p q : MvPolynomial (Fin N × Fin N) k}

--- a/progress/20260427T160426Z_3e2d1cff.md
+++ b/progress/20260427T160426Z_3e2d1cff.md
@@ -1,0 +1,68 @@
+## Accomplished
+
+Feature session `3e2d1cff` — partial completion of issue #2564
+(`feat(Mathlib-upstream tracker): MvPolynomial.eq_of_eval_eq_on_gl`).
+
+**Step 1 (done)**: opened Mathlib PR
+https://github.com/leanprover-community/mathlib4/pull/38583
+adding `MvPolynomial.eq_of_eval_eq_on_gl` to a new file
+`Mathlib/LinearAlgebra/Matrix/GeneralLinearGroup/MvPolynomial.lean`.
+
+Notes:
+- The issue suggested placing the lemma in
+  `Mathlib/LinearAlgebra/Matrix/MvPolynomial.lean`. That created an
+  import cycle: `Matrix.MvPolynomial` → `GeneralLinearGroup.Defs`
+  → `NonsingularInverse` → `Adjugate` → `Matrix.MvPolynomial`.
+  Resolved by putting the lemma in a new file under
+  `GeneralLinearGroup/`, which can freely import both `Matrix.MvPolynomial`
+  and `GeneralLinearGroup.Defs`.
+- Generalized the local `Fin N` form to
+  `{m : Type*} [Fintype m] [DecidableEq m]`. The proof is otherwise
+  identical to the local copy.
+- Added a doc-comment on the local lemma (`Chapter5/PolynomialRepEmbedding.lean:598`)
+  pointing to the upstream PR for forward reference.
+
+**Step 2 (NOT done)**: removing the local copy and updating the call
+site at `Chapter5/PolynomialRepEmbedding.lean:704` to use the upstream
+form. This requires the Mathlib PR to merge first; cannot be done in
+this session.
+
+## Current frontier
+
+Issue #2564 is partially complete. The Mathlib PR is open; reviews
+and merge happen on Mathlib's timeline. Once merged, a follow-up
+session should:
+1. Bump the project's `lean-toolchain` / `lake-manifest.json` to a
+   Mathlib revision that includes the new lemma.
+2. Remove the local copy at `Chapter5/PolynomialRepEmbedding.lean:585-641`
+   (the entire `namespace MvPolynomial` block).
+3. Verify the call site at `Chapter5/PolynomialRepEmbedding.lean:704`
+   still works (the upstream signature uses `m : Type*`; the local
+   signature uses `Fin N : Type` so the call site already passes
+   `Fin N` and should resolve unchanged).
+4. Build to confirm.
+
+## Overall project progress
+
+Stage 3 formalization. No new theorems landed; this is upstream
+hygiene. The Schur-Weyl chain is unchanged.
+
+Sorry count unchanged. Build is green for the affected file
+(`EtingofRepresentationTheory.Chapter5.PolynomialRepEmbedding`).
+
+## Next step
+
+- Workers: claim any of the five remaining unclaimed issues
+  (#2570 doc-string fixes, #2571 doc-string update,
+  #2573 Module.Finite propagation, #2574 heartbeat tightening).
+  Of these, **#2573** is the highest-impact (refactor that
+  strengthens the existential output of
+  `Theorem5_18_1_bimodule_decomposition`); the others are
+  cosmetic.
+- Future: once Mathlib PR
+  https://github.com/leanprover-community/mathlib4/pull/38583
+  merges, complete step 2 of #2564.
+
+## Blockers
+
+#2564 step 2 is blocked on upstream Mathlib review/merge.


### PR DESCRIPTION
Partial progress on #2564

Session: `3e2d1cff-6a2c-4dca-9e17-ed5faf06f984`

45bd351 doc(#2564): progress note for partial completion (Mathlib PR opened)
9b60037 doc(Ch5 #2564): add upstream Mathlib PR link to eq_of_eval_eq_on_gl

🤖 Prepared with Claude Code