### PR TITLE
refactor(Ch5): omit [CharZero k] on polyRightTransl_X to relax eval_polyRightTransl/hP_mul_of_hP hypotheses

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/PolynomialRepEmbedding.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialRepEmbedding.lean
@@ -649,7 +649,7 @@ variable (k : Type u) [Field k] (N : ℕ)
 /-- Evaluating `polyRightTransl g p` at `h` coincides with evaluating `p` at
 the product matrix `h * g`. The algebra homs `eval_h ∘ polyRightTransl_g` and
 `eval_{h·g}` agree on generators `X_{ij}` (both give `(h*g)_{ij}`). -/
-lemma eval_polyRightTransl [CharZero k]
+lemma eval_polyRightTransl
     (g h : Matrix (Fin N) (Fin N) k) (p : MvPolynomial (Fin N × Fin N) k) :
     MvPolynomial.eval (fun ij : Fin N × Fin N => h ij.1 ij.2)
         (PolynomialTensorBridge.polyRightTransl k N g p) =
@@ -677,7 +677,7 @@ evaluation identity `hP`, the polynomial-level multiplicativity identity
 `hP_mul` follows from `ρ.map_mul`: both sides of `hP_mul` agree under
 evaluation at every `h ∈ GL_N` (via `MvPolynomial.eq_of_eval_eq_on_gl`),
 because `h · g ∈ GL_N` and `ρ.map_mul` gives `ρ(h·g) = ρ h ∘ ρ g`. -/
-lemma hP_mul_of_hP [CharZero k] {d : ℕ}
+lemma hP_mul_of_hP [Infinite k] {d : ℕ}
     (b : Module.Basis (Fin d) k M)
     (P : Fin d → Fin d → MvPolynomial (Fin N × Fin N) k)
     (ρ : Matrix.GeneralLinearGroup (Fin N) k →* (M →ₗ[k] M))

--- a/progress/2026-04-27T16-05-04Z_bf4de301.md
+++ b/progress/2026-04-27T16-05-04Z_bf4de301.md
@@ -1,0 +1,57 @@
+# 2026-04-27 — Feature session — relax [CharZero k] from polyRightTransl chain
+
+Session: feature (issue #2565)
+Branch: `agent/bf4de301`
+
+## Accomplished
+
+Tightened the hypothesis chain in
+`Chapter5/PolynomialRepEmbedding.lean` so that
+`eval_polyRightTransl` and `hP_mul_of_hP` no longer require
+`[CharZero k]`:
+
+- `eval_polyRightTransl` (line 652): dropped `[CharZero k]` entirely.
+  The proof rewrites with `polyRightTransl_X` (already `omit
+  [CharZero k] in`-annotated), `Matrix.mul_apply`, and the
+  `aeval`/`comp` lemmas; none of these uses `CharZero`.
+- `hP_mul_of_hP` (line 680): replaced `[CharZero k]` with
+  `[Infinite k]`. The only `CharZero`-floored call was
+  `MvPolynomial.eq_of_eval_eq_on_gl`, which itself only requires
+  `[Infinite k]`.
+
+`polyRightTransl_X` in `Chapter5/PolynomialTensorBridge.lean` already
+carried the `omit [CharZero k] in` annotation (deliverable item 1
+was a no-op).
+
+The primed wrapper `polynomialRep_embeds_in_tensorPower'`
+(`PolynomialRepEmbedding.lean:736`) still keeps `[CharZero k]`, as
+expected — it transitively needs the `(n!)⁻¹` symmetrisation factor
+of the unprimed `polynomialRep_embeds_in_tensorPower`. The internal
+call `hP_mul_of_hP k N b P ρ hP` at line 759 finds `[Infinite k]`
+via the `CharZero.infinite` instance.
+
+## Verification
+
+- `lake build EtingofRepresentationTheory.Chapter5.PolynomialRepEmbedding`
+  — pass (no errors; warnings unchanged).
+- Full `lake build` — see post-merge CI.
+
+## Current frontier
+
+Hypothesis-hygiene cleanup for the Schur-Weyl #2b polynomial
+embedding chain. Adjacent open issues #2570/#2571/#2573/#2574 cover
+doc-strings and heartbeat tightening for Theorem5_18_1/4.
+
+## Overall project progress
+
+Stage 3 (Lean formalization) ongoing. This session is a low-risk
+hygiene cleanup; no new theorems and no proof-content changes.
+
+## Next step
+
+A follow-up worker can pick up #2573 (Module.Finite k (V i)
+existential propagation) or #2574 (heartbeat tightening) next.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2565

Session: `bf4de301-8bd0-4028-a6b3-c43bb7a1206a`

437eb51 refactor(Ch5 #2565): drop [CharZero k] from eval_polyRightTransl / hP_mul_of_hP

🤖 Prepared with Claude Code