### PR TITLE
review-finding(Ch5): doc-string fixes for Theorem5_18_4_GL_rep_decomposition (irreducibility / centralizer-path)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_18_4.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_18_4.lean
@@ -501,13 +501,17 @@ module over `(symGroupImage k V n) ⊗[k] (GL_N k)`, `V^⊗n` decomposes as
   `V^⊗n ≅ ⨁ᵢ Sᵢ ⊗[k] Lᵢ`
 where the `Sᵢ` are pairwise non-isomorphic simple `symGroupImage`-modules
 (Specht modules) and each `Lᵢ` is a full finite-dimensional
-`GL_N(k)`-representation (an irreducible polynomial representation).
+`GL_N(k)`-representation, expected to be an irreducible polynomial
+representation downstream (see #2483); irreducibility is not part of
+this statement.
 
 Refines `Theorem5_18_4_bimodule_decomposition` by upgrading each `Lᵢ`
-from a `Module (diagonalActionImage) Lᵢ` to a bundled
-`FDRep k (GL_N k)`. The `GL_N` action is built by composing
-`GL_N → diagonalActionImage` (via the `g ↦ g^{⊗n}` diagonal map) with
-the existing `diagonalActionImage`-module structure. -/
+from a `Module (centralizer(symGroupImage)) Lᵢ` to a bundled
+`FDRep k (GL_N k)`. The `GL_N` action is built by composing the monoid
+hom `GL_N → centralizer(symGroupImage)` given by `g ↦ g^{⊗n}` (whose
+image lies in `diagonalActionImage` by the centralizer identity from
+`Theorem5_18_4_centralizers`) with the existing
+`centralizer(symGroupImage)`-module structure on `Lᵢ`. -/
 theorem Theorem5_18_4_GL_rep_decomposition
     (k : Type u) [Field k] [IsAlgClosed k] [CharZero k]
     (N n : ℕ) (hN : n ≤ N) :

--- a/progress/2026-04-27T16-15-55Z_1841a303.md
+++ b/progress/2026-04-27T16-15-55Z_1841a303.md
@@ -1,0 +1,42 @@
+## Accomplished
+
+- Issue #2570: doc-string fix for `Theorem5_18_4_GL_rep_decomposition`
+  in `EtingofRepresentationTheory/Chapter5/Theorem5_18_4.lean`.
+  - Removed the inaccurate "(an irreducible polynomial representation)"
+    parenthetical and replaced it with "expected to be an irreducible
+    polynomial representation downstream (see #2483); irreducibility is
+    not part of this statement." This matches what the theorem actually
+    proves.
+  - Replaced the construction-path elision "via `GL_N → diagonalActionImage`"
+    with the literal proof path: "via the monoid hom
+    `GL_N → centralizer(symGroupImage)` given by `g ↦ g^{⊗n}` (whose image
+    lies in `diagonalActionImage` by the centralizer identity from
+    `Theorem5_18_4_centralizers`) with the existing
+    `centralizer(symGroupImage)`-module structure on `Lᵢ`." Also corrected
+    "from a `Module (diagonalActionImage) Lᵢ`" to
+    "from a `Module (centralizer(symGroupImage)) Lᵢ`" — that is what the
+    bimodule decomposition actually delivers; `h_eq` only bridges to
+    `diagonalActionImage` for the centralizer-membership obligation.
+
+- Build verified: `lake build EtingofRepresentationTheory.Chapter5.Theorem5_18_4`
+  passes (warnings are pre-existing).
+
+## Current frontier
+
+Doc-string-only edit. No proof or signature changes. Ready for PR + auto-merge.
+
+## Overall project progress
+
+Chapter 5 Schur-Weyl duality work continues. This is a low-priority cosmetic
+audit cleanup (#2570) from the #2560 audit. One unclaimed feature issue remains
+(#2574: heartbeat tightening on Theorem5_18_1).
+
+## Next step
+
+Pick up #2574 (heartbeat tightening on `centralizerModuleHom_smulCommClass` and
+`Theorem5_18_1_bimodule_decomposition`) — empirical task, requires
+`lake build` of `Chapter5.Theorem5_18_1` and `Chapter5.Theorem5_18_4`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2570

Session: `1841a303-19f7-4a17-a4ad-0fcaa95a7a6a`

2215ccd doc(Ch5 #2570): correct Theorem5_18_4_GL_rep_decomposition doc-string

🤖 Prepared with Claude Code