### PR TITLE
refactor(Ch5): consume Theorem5_18_4_GL_rep_decomposition_explicit in glTensorRep_equivariant_schurWeyl_decomposition

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/FormalCharacterIso.lean
+++ b/EtingofRepresentationTheory/Chapter5/FormalCharacterIso.lean
@@ -753,12 +753,10 @@ This is the form required by the Schur-Weyl #3 character argument
 -/
 
 -- Heartbeats bumped: the existential output has 7 ∀-binders with deep
--- `Subalgebra → Ring → Module.End` instance chains, and the GL_N
--- representation construction composes several monoid homs each
--- triggering similar chains. The equivariance proof itself reduces via
--- `DirectSum.linearMap_ext` + `TensorProduct.ext'` to a
--- per-component computation that requires unfolding the chain
--- `(ρ i) g l = (centralizerToEndA (glHom g)).comp l`.
+-- `Subalgebra → Ring → Module.End` instance chains. The equivariance
+-- proof reduces via `DirectSum.linearMap_ext` + `TensorProduct.ext'` to
+-- a per-component computation that uses the action formula returned by
+-- `Theorem5_18_4_GL_rep_decomposition_explicit`.
 set_option maxHeartbeats 6400000 in
 set_option synthInstance.maxHeartbeats 1600000 in
 /-- **Equivariant Schur-Weyl decomposition for `V^{⊗n}`.**
@@ -770,12 +768,12 @@ that is `GL_N(k)`-equivariant: it intertwines the diagonal action on the
 LHS with the action on the RHS that is trivial on each `S i` and the given
 `L i`-action on the second factor.
 
-Built from `Theorem5_18_1_bimodule_decomposition_explicit`: the explicit
-evaluation formula `e.symm (of i (v ⊗ₜ l)) = l v` is the key ingredient
-that makes the equivariance argument go through directly. The `GL_N`
-action on each `Lᵢ = Sᵢ →ₗ[A] V^{⊗n}` is post-composition by
-`g^{⊗n}`, so `((L i).ρ g l) v = g^{⊗n} (l v) = glTensorRep g (l v)`,
-which intertwines with the diagonal action via the evaluation formula. -/
+Built from `Theorem5_18_4_GL_rep_decomposition_explicit`: the explicit
+evaluation formula `e.symm (of i (v ⊗ₜ l)) = (L_carrier i l) v` together
+with the action formula
+`(L_carrier i ((L i).ρ g l)) v = PiTensorProduct.map (mulVecLin g.val)
+((L_carrier i l) v)` collapse equivariance to a per-pure-tensor
+computation. -/
 theorem glTensorRep_equivariant_schurWeyl_decomposition
     (N n : ℕ) (hN : n ≤ N) :
     ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
@@ -793,159 +791,59 @@ theorem glTensorRep_equivariant_schurWeyl_decomposition
               (Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
                 (S i)).tprod (L i).ρ) g (e v) := by
   classical
-  set V : Type u := Fin N → k
-  haveI : Module.Finite k V := inferInstance
-  have hfinrank : Module.finrank k V = N :=
-    (Module.finrank_pi k).trans (Fintype.card_fin N)
-  have hN' : n ≤ Module.finrank k V := hfinrank.symm ▸ hN
-  haveI : IsSemisimpleRing (symGroupImage k V n) :=
-    symGroupImage_isSemisimpleRing k V n
-  haveI : FaithfulSMul (symGroupImage k V n) (TensorPower k V n) :=
-    symGroupImage_faithfulSMul k V n hN'
-  -- Establish IsScalarTower at the parent level (Subalgebra acts on End k V).
-  haveI : IsScalarTower k (symGroupImage k V n) (TensorPower k V n) := inferInstance
-  -- Get the explicit bimodule decomposition.
-  obtain ⟨ι, hιFin, hιDec, V', hV'_simp, hV'_dist, e, h_eval⟩ :=
-    Theorem5_18_1_bimodule_decomposition_explicit k (TensorPower k V n)
-      (symGroupImage k V n)
-  -- Centralizer identity.
-  have h_eq : Subalgebra.centralizer k
-      (symGroupImage k V n :
-        Set (Module.End k (TensorPower k V n))) =
-        diagonalActionImage k V n :=
-    (Theorem5_18_4_centralizers k V n hN').2.symm
-  -- Module.Finite k for the carriers.
-  haveI hSi_fin : ∀ i, Module.Finite k (↥(V' i) : Type u) := fun i =>
-    Module.Finite.of_injective ((V' i).subtype.restrictScalars k)
+  -- Get the explicit GL_N decomposition (issue #2572).
+  obtain ⟨ι, hιFin, hιDec, S', hS'_simp, hS'_dist, L, L_carrier, e, he, h_act⟩ :=
+    Theorem5_18_4_GL_rep_decomposition_explicit k N n hN
+  -- Each `↥(S' i)` is finite-dimensional over `k` (it injects into the
+  -- finite-dimensional ambient `TensorPower`).
+  haveI hSi_fin : ∀ i, Module.Finite k (↥(S' i) : Type u) := fun i =>
+    Module.Finite.of_injective ((S' i).subtype.restrictScalars k)
       Subtype.val_injective
-  haveI hLi_fin : ∀ i, Module.Finite k
-      ((↥(V' i) : Type u) →ₗ[symGroupImage k V n] TensorPower k V n) := fun i => by
-    haveI : Module.Finite k (↥(V' i) : Type u) := hSi_fin i
-    haveI : Module.Free k (↥(V' i) : Type u) :=
-      Module.Free.of_divisionRing k (↥(V' i))
-    haveI : Module.Finite k
-        ((↥(V' i) : Type u) →ₗ[k] TensorPower k V n) :=
-      Module.Finite.linearMap k k (↥(V' i)) (TensorPower k V n)
-    exact Module.Finite.of_injective
-      (LinearMap.restrictScalarsₗ k (symGroupImage k V n) (↥(V' i))
-        (TensorPower k V n) k)
-      (LinearMap.restrictScalars_injective _)
-  -- glHom : GL_N → centralizer(symGroupImage), via `g ↦ g^{⊗n}`.
-  let glHom : Matrix.GeneralLinearGroup (Fin N) k →*
-      ↥(Subalgebra.centralizer k
-        (symGroupImage k V n :
-          Set (Module.End k (TensorPower k V n)))) :=
-  { toFun := fun g => ⟨PiTensorProduct.map
-        (fun _ : Fin n => Matrix.mulVecLin (R := k) g.val), by
-      rw [h_eq]
-      exact Algebra.subset_adjoin ⟨Matrix.mulVecLin g.val, rfl⟩⟩
-    map_one' := by
-      apply Subtype.ext
-      change PiTensorProduct.map
-          (fun _ : Fin n => Matrix.mulVecLin (R := k) (1 : Matrix _ _ k)) = 1
-      have : (fun _ : Fin n => Matrix.mulVecLin (R := k) (1 : Matrix _ _ k)) =
-          (fun _ : Fin n => (LinearMap.id : V →ₗ[k] V)) :=
-        funext fun _ => Matrix.mulVecLin_one
-      rw [this, PiTensorProduct.map_id]; rfl
-    map_mul' := fun g₁ g₂ => by
-      apply Subtype.ext
-      change PiTensorProduct.map
-          (fun _ : Fin n => Matrix.mulVecLin (R := k) (g₁.val * g₂.val)) =
-        PiTensorProduct.map
-            (fun _ : Fin n => Matrix.mulVecLin (R := k) g₁.val) *
-          PiTensorProduct.map
-            (fun _ : Fin n => Matrix.mulVecLin (R := k) g₂.val)
-      have : (fun _ : Fin n => Matrix.mulVecLin (R := k) (g₁.val * g₂.val)) =
-          (fun _ : Fin n => (Matrix.mulVecLin g₁.val).comp
-            (Matrix.mulVecLin g₂.val)) :=
-        funext fun _ => Matrix.mulVecLin_mul g₁.val g₂.val
-      rw [this, PiTensorProduct.map_comp]; rfl }
-  -- ρ i : GL_N → End_k (Hom_A(V'_i, E)) via centralizer-action on Hom.
-  -- Built directly: g acts on l by post-composing with `(glHom g).val`,
-  -- which is `PiTensorProduct.map (mulVecLin g)` and lies in `centralizer(A)`,
-  -- so the post-composition is A-linear (hence preserves Hom_A(V'_i, E)).
-  let ρ : ∀ i, Matrix.GeneralLinearGroup (Fin N) k →*
-      Module.End k (↥(V' i) →ₗ[symGroupImage k V n] TensorPower k V n) := fun i =>
-  { toFun := fun g =>
-    { toFun := fun l =>
-        (centralizerToEndA k (TensorPower k V n) (symGroupImage k V n)
-          (glHom g)).comp l
-      map_add' := fun l₁ l₂ => by
-        ext v
-        simp only [LinearMap.comp_apply, LinearMap.add_apply, map_add]
-      map_smul' := fun c l => by
-        ext v
-        simp only [LinearMap.smul_apply, RingHom.id_apply,
-          LinearMap.comp_apply, LinearMap.map_smul_of_tower] }
-    map_one' := by
-      ext l v
-      simp only [LinearMap.coe_mk, AddHom.coe_mk, LinearMap.comp_apply,
-        Module.End.one_apply]
-      change (centralizerToEndA k (TensorPower k V n) (symGroupImage k V n)
-        (glHom 1)) (l v) = l v
-      rw [map_one, map_one]; rfl
-    map_mul' := fun g₁ g₂ => by
-      ext l v
-      simp only [LinearMap.coe_mk, AddHom.coe_mk, LinearMap.comp_apply,
-        Module.End.mul_apply]
-      change (centralizerToEndA k (TensorPower k V n) (symGroupImage k V n)
-          (glHom (g₁ * g₂))) (l v) = _
-      rw [map_mul, map_mul]; rfl }
-  let L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k) := fun i =>
-    FDRep.of (ρ i)
-  refine ⟨ι, hιFin, hιDec, fun i => ↥(V' i),
+  refine ⟨ι, hιFin, hιDec, fun i => ↥(S' i),
     fun _ => inferInstance, fun _ => inferInstance,
     fun i => hSi_fin i, L, ?_, ?_⟩
   · exact e
   intro g v
   -- Reduce equivariance to: (glTensorRep g) ∘ e.symm = e.symm ∘ directSum_action g.
-  -- We use `ρ i` directly instead of `(L i).ρ` because `e.symm` is typed
-  -- in terms of `↥(V' i) →ₗ[A] E`, not `↑(L i).V`, and the syntactic forms
-  -- must match. The two are defeq via `FDRep.of_ρ' = rfl`.
   have h_lin :
       (glTensorRep k N n g) ∘ₗ (e.symm : _ →ₗ[k] _) =
         (e.symm : _ →ₗ[k] _) ∘ₗ
           (Representation.directSum (fun i =>
             (Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
-              (↥(V' i))).tprod (ρ i)) g) := by
+              (↥(S' i))).tprod (L i).ρ) g) := by
     refine DirectSum.linearMap_ext k fun i => ?_
     apply TensorProduct.ext'
     intro s l
     change (glTensorRep k N n g) (e.symm
-        (DirectSum.lof k ι (fun i => ↥(V' i) ⊗[k]
-          (↥(V' i) →ₗ[symGroupImage k V n] TensorPower k V n)) i
+        (DirectSum.lof k ι (fun i => ↥(S' i) ⊗[k] (L i : Type u)) i
           (s ⊗ₜ[k] l))) =
       e.symm ((Representation.directSum (fun i =>
         (Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
-          (↥(V' i))).tprod (ρ i)) g)
+          (↥(S' i))).tprod (L i).ρ) g)
         (DirectSum.lof k ι _ i (s ⊗ₜ[k] l)))
-    -- LHS: e.symm (of i (s ⊗ₜ l)) = l s by h_eval.
-    rw [DirectSum.lof_eq_of, h_eval i s l]
-    -- RHS: directSum_action g (of i (s ⊗ₜ l)) = of i (s ⊗ₜ (ρ i g l))
-    -- via lmap_of + tprod_apply + map_tmul + trivial_apply, then h_eval.
+    -- LHS: e.symm (of i (s ⊗ₜ l)) = (L_carrier i l) s by `he`.
+    rw [DirectSum.lof_eq_of, he i s l]
+    -- RHS: directSum_action g (of i (s ⊗ₜ l)) = of i (s ⊗ₜ ((L i).ρ g l))
+    -- via lmap_of + tprod_apply + map_tmul + trivial_apply, then `he`.
     change _ = e.symm (DirectSum.lmap
       (fun i => ((Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
-        (↥(V' i))).tprod (ρ i)) g) (DirectSum.of _ i (s ⊗ₜ[k] l)))
+        (↥(S' i))).tprod (L i).ρ) g) (DirectSum.of _ i (s ⊗ₜ[k] l)))
     rw [DirectSum.lmap_of, Representation.tprod_apply, TensorProduct.map_tmul,
-      Representation.trivial_apply, h_eval i s ((ρ i) g l)]
-    -- Goal: glTensorRep g (l s) = ((ρ i) g l) s.
-    -- (ρ i) g l = (centralizerToEndA (glHom g)).comp l, so applied at s
-    -- gives (glHom g).val (l s) = PiTensorProduct.map (mulVecLin g) (l s).
-    rfl
-  -- Apply h_lin at z := e v.
+      Representation.trivial_apply, he i s ((L i).ρ g l)]
+    -- Goal: glTensorRep g ((L_carrier i l) s) = (L_carrier i ((L i).ρ g l)) s.
+    -- By `h_act`, RHS = PiTensorProduct.map (mulVecLin g.val) ((L_carrier i l) s),
+    -- which is `glTensorRep g ((L_carrier i l) s)` by definition of glTensorRep.
+    exact (h_act i g l s).symm
+  -- Apply h_lin at z := e v and reduce.
   have h := LinearMap.congr_fun h_lin (e v)
-  -- h : ((glTensorRep g) ∘ₗ e.symm.toLM) (e v) = (e.symm.toLM ∘ₗ ds_act) (e v).
-  -- Reduce composition + e.symm (e v) = v.
   rw [LinearMap.comp_apply, LinearMap.comp_apply] at h
   rw [show (e.symm : _ →ₗ[k] _) (e v) = v from e.symm_apply_apply v] at h
-  -- h : (glTensorRep g) v = e.symm.toLM (ds_act (e v)).
-  -- Goal: e ((glTensorRep g) v) = ds_act (e v).
   rw [show (e.symm : _ →ₗ[k] _) ((Representation.directSum (fun i =>
       (Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
-        (↥(V' i))).tprod (ρ i)) g) (e v)) =
+        (↥(S' i))).tprod (L i).ρ) g) (e v)) =
     e.symm ((Representation.directSum (fun i =>
       (Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
-        (↥(V' i))).tprod (ρ i)) g) (e v)) from rfl] at h
+        (↥(S' i))).tprod (L i).ρ) g) (e v)) from rfl] at h
   exact (LinearEquiv.eq_symm_apply e).mp h
 
 /-! ### Schur-Weyl character decomposition of `V^{⊗n}`

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_18_4.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_18_4.lean
@@ -615,7 +615,11 @@ tensors is the evaluation map:
   the `FGModuleCat.of_carrier` defeq);
 * explicit iso `e : V^⊗n ≃ₗ[k] ⨁ᵢ ↥(S i) ⊗[k] (L i : Type u)` whose
   inverse on pure tensors is the evaluation map:
-  `e.symm (of i (v ⊗ₜ l)) = (L_carrier i l) v`.
+  `e.symm (of i (v ⊗ₜ l)) = (L_carrier i l) v`;
+* the `GL_N`-action on each `L i` is, after the `L_carrier` identification,
+  post-composition by `g ↦ g^{⊗n}`:
+  `(L_carrier i ((L i).ρ g l)) v =
+   PiTensorProduct.map (fun _ ↦ mulVecLin g.val) ((L_carrier i l) v)`.
 
 The `L_carrier` clause sidesteps a defeq fragility: when stating the
 existential, `(L i : Type u)` is universally quantified and not yet
@@ -625,8 +629,7 @@ linear map without the explicit identification with `↥(S i) →ₗ[A] E`.
 This is the form required by the `GL_N`-equivariance argument
 (`glTensorRep_equivariant_schurWeyl_decomposition`,
 issue #2540): the evaluation formula together with the post-composition
-`GL_N`-action on each `L i` makes equivariance computable on pure
-tensors. -/
+`GL_N`-action formula make equivariance computable on pure tensors. -/
 theorem Theorem5_18_4_GL_rep_decomposition_explicit
     (k : Type u) [Field k] [IsAlgClosed k] [CharZero k]
     (N n : ℕ) (hN : n ≤ N) :
@@ -642,9 +645,15 @@ theorem Theorem5_18_4_GL_rep_decomposition_explicit
           TensorPower k (Fin N → k) n)),
       ∃ (e : TensorPower k (Fin N → k) n ≃ₗ[k]
           DirectSum ι (fun i => ↥(S i) ⊗[k] (L i : Type u))),
-        ∀ (i : ι) (v : ↥(S i)) (l : (L i : Type u)),
+        (∀ (i : ι) (v : ↥(S i)) (l : (L i : Type u)),
           e.symm (DirectSum.of (fun i => ↥(S i) ⊗[k] (L i : Type u)) i
-              (v ⊗ₜ[k] l)) = (L_carrier i l) v := by
+              (v ⊗ₜ[k] l)) = (L_carrier i l) v) ∧
+        (∀ (i : ι) (g : Matrix.GeneralLinearGroup (Fin N) k)
+            (l : (L i : Type u)) (v : ↥(S i)),
+          (L_carrier i ((L i).ρ g l)) v =
+            PiTensorProduct.map
+              (fun _ : Fin n => Matrix.mulVecLin (R := k) g.val)
+              ((L_carrier i l) v)) := by
   set V : Type u := Fin N → k with hV
   haveI : Module.Finite k V := inferInstance
   have hfinrank : Module.finrank k V = N :=
@@ -753,6 +762,11 @@ theorem Theorem5_18_4_GL_rep_decomposition_explicit
   let L_carrier : ∀ i, (L i : Type u) ≃ₗ[k]
       (↥(S' i) →ₗ[symGroupImage k V n] TensorPower k V n) :=
     fun i => LinearEquiv.refl k _
-  exact ⟨ι, hι, hι_dec, S', hS'_simp, hS'_dist, L, L_carrier, e, he⟩
+  -- Action formula: `((L i).ρ g l) v = PiTensorProduct.map (mulVecLin g.val) (l v)`
+  -- because `(L i).ρ = ρ i` and `ρ i g l = (centralizerToEndA (glHom g)).comp l`
+  -- whose underlying map is `PiTensorProduct.map (mulVecLin g.val)`.
+  refine ⟨ι, hι, hι_dec, S', hS'_simp, hS'_dist, L, L_carrier, e, he, ?_⟩
+  intro i g l v
+  rfl
 
 end Etingof

--- a/progress/20260427T170837Z_0243beec.md
+++ b/progress/20260427T170837Z_0243beec.md
@@ -1,0 +1,85 @@
+## Accomplished
+
+Feature session `0243beec` — landed issue #2589: refactored
+`glTensorRep_equivariant_schurWeyl_decomposition`
+(`Chapter5/FormalCharacterIso.lean`) to consume
+`Theorem5_18_4_GL_rep_decomposition_explicit` directly.
+
+Two-file change:
+
+- **`Chapter5/Theorem5_18_4.lean`** — extended the existential output of
+  `Theorem5_18_4_GL_rep_decomposition_explicit` with a second conjunct
+  exposing the GL_N-action formula:
+  `(L_carrier i ((L i).ρ g l)) v =
+   PiTensorProduct.map (fun _ ↦ mulVecLin g.val) ((L_carrier i l) v)`.
+  This is provable by `rfl` inside the proof body because `L_carrier i`
+  is `LinearEquiv.refl k _` and `(L i).ρ g l = (centralizerToEndA
+  (glHom g)).comp l` whose underlying linear map is exactly
+  `PiTensorProduct.map (mulVecLin g.val)`. Doc-string updated. Net +26 / -7
+  lines.
+- **`Chapter5/FormalCharacterIso.lean`** — rewrote
+  `glTensorRep_equivariant_schurWeyl_decomposition` to invoke the
+  enriched `_explicit` and discharge equivariance using the eval
+  formula plus the new action formula. The local manual constructions
+  (~120 lines: `Theorem5_18_1_bimodule_decomposition_explicit` call,
+  centralizer-identity hoist, `glHom`, `ρ`, `L`, `hLi_fin`) are all
+  removed; `hSi_fin` survives as a one-liner. The existential
+  signature is unchanged, so the downstream consumer
+  `formalCharacter_tensorPower_eq_sum_character_L` (line 971+) is
+  unaffected. Doc-string + heartbeat-bump comment updated. Net
+  +28 / -135 lines.
+
+Net diff across the two files: **142 deletions, 54 insertions** (≈88
+lines saved). Issue #2589 estimated ~120 line savings; the actual
+savings are smaller because adding the action formula to `_explicit`
+costs ~5 lines of statement (a bigger conjunction) plus a few lines of
+documentation, but the line of refactor is exactly as the issue
+described.
+
+Build verification:
+
+- `lake build EtingofRepresentationTheory.Chapter5.Theorem5_18_4`:
+  **PASS** (no new warnings; `rfl` discharges the new action conjunct).
+- `lake build EtingofRepresentationTheory.Chapter5.FormalCharacterIso`:
+  **PASS** (no new warnings; `formalCharacter_tensorPower_eq_sum_character_L`
+  type-checks unchanged).
+- Existing heartbeat bumps unchanged: `_explicit` keeps its 3.2M /
+  1.6M envelope, the consumer keeps its 6.4M / 1.6M envelope. The
+  consumer's bump *might* be tightenable now that the proof is
+  shorter, but that is a separate hygiene task — leaving it alone for
+  this refactor PR.
+- Sorry count unchanged: **7 across 4 files**.
+
+## Current frontier
+
+Issue #2589 closed via PR. Queue state:
+
+- **#2590** (feature): companion refactor delegating non-explicit
+  `Theorem5_18_4_GL_rep_decomposition` to `_explicit`. Still
+  unclaimed. If/when picked up, the worker should be aware that the
+  `_explicit` signature now exposes an extra ∧-conjunct (the action
+  formula) — destructure with one extra binder.
+- **#2594** (feature): claimed by another session (256a8ae3).
+- **#2591** (summarize), **#2592** (review): claimed by 7848f3c9.
+- **#2580** (Schur-Weyl C-1): in flight.
+- **#2574** (heartbeat tightening): claimed.
+- **Repair flow**: #2541 / #2550 still outstanding.
+
+## Overall project progress
+
+Stage 3 formalization. **7 sorries / 4 files** (unchanged). Schur-Weyl
+chain refactor follow-ups (the `_explicit` consumer migration) now
+half-done: #2589 landed; #2590 still pending; #2594 in flight.
+
+## Next step
+
+Workers can pick up:
+- **#2590** to complete the `_explicit` migration on the non-explicit
+  side (the `_explicit` change in this PR makes the destructure pattern
+  for `_explicit` consumers slightly different — one extra binder for
+  the new action conjunct).
+- Other unclaimed work as before.
+
+## Blockers
+
+None. PR enabled with auto-merge; once CI passes it lands on `main`.


### PR DESCRIPTION
Closes #2589

Session: `0243beec-ea5f-4b39-b415-f03214f92159`

737314f refactor(Ch5 #2589): consume Theorem5_18_4_GL_rep_decomposition_explicit in glTensorRep_equivariant_schurWeyl_decomposition

🤖 Prepared with Claude Code