### PR TITLE
Schur-Weyl L_i (part C-1): formalCharacter of glTensorRep equals (∑ Xᵢ)^n

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/FormalCharacterIso.lean
+++ b/EtingofRepresentationTheory/Chapter5/FormalCharacterIso.lean
@@ -995,4 +995,162 @@ theorem formalCharacter_tensorPower_eq_sum_character_L
   refine Finset.sum_congr rfl (fun i _ => ?_)
   exact formalCharacter_trivialTensor k N (S i) (L i)
 
+/-! ### Formal character of `V^{⊗n}` as `(∑ Xᵢ)^n`
+
+The standard tensor basis `tensorStdBasis k N n`, indexed by colorings
+`f : Fin n → Fin N`, simultaneously diagonalises the diagonal torus
+action: `(diagUnit i t)^{⊗n}` scales `B f` by `t^{tensorWeight f i}`.
+Hence the weight space at `μ : Fin N → ℕ` is exactly the span of the
+basis vectors with `tensorWeight f = μ`, and its dimension is the count
+of such colorings — which matches the multinomial coefficient extraction
+of `(X₁ + ⋯ + X_N)^n`.
+-/
+
+/-- For each coloring `f`, the standard tensor basis vector `tensorStdBasis k N n f`
+lies in the weight space of weight `tensorWeight N f`. -/
+private theorem tensorStdBasis_mem_glWeightSpace (N n : ℕ) (f : Fin n → Fin N) :
+    (tensorStdBasis k N n f) ∈
+      glWeightSpace k N (FDRep.of (glTensorRep k N n))
+        (fun i => (tensorWeight N f) i) := by
+  simp only [glWeightSpace, Submodule.mem_iInf]
+  intro i t
+  rw [LinearMap.mem_ker, LinearMap.sub_apply, LinearMap.smul_apply, sub_eq_zero]
+  change (glTensorRep k N n (diagUnit k N i t)) (tensorStdBasis k N n f) =
+      (t : k) ^ ((tensorWeight N f) i) • tensorStdBasis k N n f
+  rw [glTensorRep_diagUnit_basis k N n i t f]
+  rfl
+
+/-- The multinomial expansion: `(∑ X)^n = ∑_{f : Fin n → Fin N} ∏ j, X (f j)`. -/
+private lemma sum_X_pow_eq_sum_prod (N n : ℕ) :
+    (∑ i : Fin N, (MvPolynomial.X i : MvPolynomial (Fin N) ℚ)) ^ n =
+      ∑ f : Fin n → Fin N, ∏ j : Fin n, (MvPolynomial.X (f j) : MvPolynomial (Fin N) ℚ) := by
+  classical
+  rw [Finset.sum_pow' (s := (Finset.univ : Finset (Fin N)))
+    (f := fun i : Fin N => (MvPolynomial.X i : MvPolynomial (Fin N) ℚ)) n,
+    Fintype.piFinset_univ]
+
+/-- The expansion of `(∑ X)^n` in monomial form, indexed by tensor weights. -/
+private lemma sum_X_pow_eq_sum_monomial (N n : ℕ) :
+    (∑ i : Fin N, (MvPolynomial.X i : MvPolynomial (Fin N) ℚ)) ^ n =
+      ∑ f : Fin n → Fin N, MvPolynomial.monomial (tensorWeight N f) (1 : ℚ) := by
+  rw [sum_X_pow_eq_sum_prod]
+  exact Finset.sum_congr rfl (fun f _ => prod_X_eq_monomial_tensorWeight N f)
+
+/-- The coefficient of `monomial μ 1` in `(∑ X)^n` is the number of colorings
+`f : Fin n → Fin N` with `tensorWeight N f = μ`. -/
+private lemma sum_X_pow_coeff (N n : ℕ) (μ : Fin N →₀ ℕ) :
+    ((∑ i : Fin N, (MvPolynomial.X i : MvPolynomial (Fin N) ℚ)) ^ n).coeff μ =
+      ((Finset.univ.filter
+        fun f : Fin n → Fin N => tensorWeight N f = μ).card : ℚ) := by
+  classical
+  rw [sum_X_pow_eq_sum_monomial, MvPolynomial.coeff_sum]
+  simp_rw [MvPolynomial.coeff_monomial]
+  rw [Finset.sum_boole, Nat.cast_inj]
+
+/-- For `v` in the weight space of weight `μ`, the basis coordinate `B.repr v f`
+vanishes whenever the basis element `B f` has a different weight. -/
+private theorem tensorStdBasis_repr_eq_zero_of_ne_weight
+    (N n : ℕ) (μ : Fin N →₀ ℕ)
+    (v : TensorPower k (Fin N → k) n)
+    (hv : v ∈ glWeightSpace k N (FDRep.of (glTensorRep k N n)) (fun i => μ i))
+    (f : Fin n → Fin N) (hne : tensorWeight N f ≠ μ) :
+    (tensorStdBasis k N n).repr v f = 0 := by
+  -- Find an index `i` where the weights differ.
+  obtain ⟨i, hi⟩ : ∃ i, (tensorWeight N f) i ≠ μ i := by
+    by_contra h
+    push_neg at h
+    exact hne (Finsupp.ext h)
+  -- Pick a unit `t` with `t^(tensorWeight f i) ≠ t^(μ i)`.
+  obtain ⟨t, ht⟩ := exists_unit_pow_ne k hi
+  -- Apply membership in glWeightSpace at (i, t).
+  have hmem : v ∈ LinearMap.ker
+      ((FDRep.of (glTensorRep k N n)).ρ (diagUnit k N i t)
+        - ((t : k) ^ μ i) • LinearMap.id) := by
+    simp only [glWeightSpace, Submodule.mem_iInf] at hv
+    exact hv i t
+  rw [LinearMap.mem_ker] at hmem
+  -- The action is identified with glTensorRep via `FDRep.of_ρ` (definitional).
+  have hmem' : (glTensorRep k N n (diagUnit k N i t)) v - ((t : k) ^ μ i) • v = 0 := hmem
+  -- Apply B.repr at coordinate f.
+  have hcoord := congr_arg (fun w => (tensorStdBasis k N n).repr w f) hmem'
+  simp only [map_sub, Finsupp.sub_apply, map_zero, Finsupp.zero_apply, sub_eq_zero,
+    map_smul, Finsupp.smul_apply, smul_eq_mul] at hcoord
+  -- Apply repr_glTensorRep_diagUnit to rewrite the LHS.
+  rw [repr_glTensorRep_diagUnit k N n i t f v] at hcoord
+  -- The exponent `card{j : f j = i}` is `(tensorWeight N f) i` by definition.
+  -- hcoord : t^(tw f i) * (B.repr v f) = t^(μ i) * (B.repr v f)
+  -- so (t^(tw f i) - t^(μ i)) * (B.repr v f) = 0.
+  have hcoord' : ((t : k) ^ (tensorWeight N f) i - (t : k) ^ μ i) *
+      (tensorStdBasis k N n).repr v f = 0 := by
+    have hcw : (Finset.univ.filter (fun j : Fin n => f j = i)).card =
+        (tensorWeight N f) i := rfl
+    rw [hcw] at hcoord
+    linear_combination hcoord
+  rcases mul_eq_zero.mp hcoord' with hd | hr
+  · exact absurd (sub_eq_zero.mp hd) ht
+  · exact hr
+
+/-- The weight space of `V^⊗n` at weight `μ` is the span of the standard tensor basis
+elements indexed by colorings `f` with `tensorWeight N f = μ`. -/
+private theorem glWeightSpace_glTensorRep_eq_span (N n : ℕ) (μ : Fin N →₀ ℕ) :
+    glWeightSpace k N (FDRep.of (glTensorRep k N n)) (fun i => μ i) =
+      Submodule.span k
+        (Set.range (fun fh : {f : Fin n → Fin N // tensorWeight N f = μ} =>
+          tensorStdBasis k N n fh.val)) := by
+  classical
+  apply le_antisymm
+  · -- ⊆: any v in the weight space is a linear combination of B f for tw f = μ.
+    intro v hv
+    have hv_eq : v =
+        ((tensorStdBasis k N n).repr v).sum
+          (fun f c => c • tensorStdBasis k N n f) := by
+      conv_lhs => rw [← (tensorStdBasis k N n).linearCombination_repr v]
+      rw [Finsupp.linearCombination_apply]
+    rw [hv_eq, Finsupp.sum]
+    refine Submodule.sum_mem _ (fun f _ => ?_)
+    by_cases htw : tensorWeight N f = μ
+    · refine Submodule.smul_mem _ _ (Submodule.subset_span ?_)
+      exact ⟨⟨f, htw⟩, rfl⟩
+    · rw [tensorStdBasis_repr_eq_zero_of_ne_weight k N n μ v hv f htw, zero_smul]
+      exact Submodule.zero_mem _
+  · -- ⊇: each B f with tw f = μ is in the weight space.
+    refine Submodule.span_le.mpr ?_
+    rintro _ ⟨⟨f, hf⟩, rfl⟩
+    have hmem := tensorStdBasis_mem_glWeightSpace k N n f
+    -- hmem : B f ∈ glWeightSpace (fun i => tensorWeight N f i)
+    -- and we need: B f ∈ glWeightSpace (fun i => μ i). Use hf.
+    have heq : (fun i => (tensorWeight N f) i) = (fun i => μ i) := by
+      funext i; rw [hf]
+    rwa [heq] at hmem
+
+/-- The dimension of the weight space at `μ` in `V^⊗n` equals the number of colorings
+`f : Fin n → Fin N` with `tensorWeight N f = μ`. -/
+private theorem finrank_glWeightSpace_glTensorRep (N n : ℕ) (μ : Fin N →₀ ℕ) :
+    Module.finrank k
+        (glWeightSpace k N (FDRep.of (glTensorRep k N n)) (fun i => μ i)) =
+      Fintype.card {f : Fin n → Fin N // tensorWeight N f = μ} := by
+  classical
+  rw [glWeightSpace_glTensorRep_eq_span]
+  -- The family {B f : tw f = μ} is linearly independent (subfamily of basis B).
+  have hf_lin : LinearIndependent k
+      (fun fh : {f : Fin n → Fin N // tensorWeight N f = μ} =>
+        tensorStdBasis k N n fh.val) :=
+    (tensorStdBasis k N n).linearIndependent.comp _ Subtype.val_injective
+  exact finrank_span_eq_card hf_lin
+
+/-- **Formal character of the standard tensor power.** For `V = Fin N → k`, the formal
+character of `V^⊗n` (under the diagonal `GL_N(k)`-action `g ↦ g^{⊗n}`) is the
+multinomial expansion `(X_1 + ⋯ + X_N)^n`.
+
+This is the polynomial-side input to the Schur-Weyl character argument: combined with
+`formalCharacter_tensorPower_eq_sum_character_L`, it gives the identity
+`(∑ Xᵢ)^n = ∑ᵢ dim(Sᵢ) · char(Lᵢ)`. -/
+theorem formalCharacter_glTensorRep_eq_pow (N n : ℕ) :
+    formalCharacter k N (FDRep.of (glTensorRep k N n)) =
+      (∑ i : Fin N, MvPolynomial.X i) ^ n := by
+  classical
+  ext μ
+  rw [formalCharacter_coeff, sum_X_pow_coeff, finrank_glWeightSpace_glTensorRep,
+    Fintype.card_subtype]
+
 end Etingof

--- a/EtingofRepresentationTheory/Chapter5/Proposition5_22_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Proposition5_22_2.lean
@@ -188,8 +188,9 @@ private lemma glTensorRep_diagUnit_tBasis (N n : ℕ) (i : Fin N) (t : kˣ)
 
 omit [IsAlgClosed k] in
 /-- The f-th basis coordinate of `glTensorRep(diagUnit(i,t))` applied to `v` equals
-`t^(count f i) * (f-th coordinate of v)`. -/
-private lemma repr_glTensorRep_diagUnit (N n : ℕ) (i : Fin N) (t : kˣ)
+`t^(count f i) * (f-th coordinate of v)`. Local copy specialised to `tBasis`; the
+`tensorStdBasis`-version is exposed publicly in `Theorem5_22_1.lean`. -/
+private lemma repr_glTensorRep_diagUnit_local (N n : ℕ) (i : Fin N) (t : kˣ)
     (v : TensorPower k (Fin N → k) n) (f : Fin n → Fin N) :
     (tBasis (k := k) N n).repr ((glTensorRep k N n (diagUnit k N i t)) v) f =
       ((t : k) ^ (Finset.univ.filter (fun j => f j = i)).card) *
@@ -264,7 +265,7 @@ private theorem formalCharacter_detTwist_eq_shift (N : ℕ) (lam : Fin N → ℕ
       have hcoord : (t₀ : k) ^ (m + 1) * b.repr vt f = b.repr vt f := by
         have h1 := congr_arg (fun w => b.repr w f) hfix_val
         simp only [map_smul, Finsupp.smul_apply, smul_eq_mul] at h1
-        rw [repr_glTensorRep_diagUnit, ← mul_assoc, ← pow_succ'] at h1
+        rw [repr_glTensorRep_diagUnit_local, ← mul_assoc, ← pow_succ'] at h1
         exact h1
       -- (t₀^(m+1) - 1) * c_f = 0, contradicting both ≠ 0
       have h_zero : ((t₀ : k) ^ (m + 1) - 1) * b.repr vt f = 0 := by

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
@@ -709,13 +709,13 @@ private theorem trace_normalized_youngSym_eq_finrank
 
 /-- The weight of a tensor basis element `f : Fin n → Fin N`: counts how many times
 each color `i : Fin N` appears in the coloring `f`. -/
-private def tensorWeight (N : ℕ) {n : ℕ} (f : Fin n → Fin N) : Fin N →₀ ℕ where
+def tensorWeight (N : ℕ) {n : ℕ} (f : Fin n → Fin N) : Fin N →₀ ℕ where
   toFun i := (Finset.univ.filter (fun j => f j = i)).card
   support := Finset.univ.filter (fun i => 0 < (Finset.univ.filter (fun j => f j = i)).card)
   mem_support_toFun i := by simp [Finset.card_pos, Finset.filter_nonempty_iff]
 
 /-- The monomial `∏_j X_{f(j)}` equals `X^{tensorWeight f}`. -/
-private lemma prod_X_eq_monomial_tensorWeight (N : ℕ) {n : ℕ} (f : Fin n → Fin N) :
+lemma prod_X_eq_monomial_tensorWeight (N : ℕ) {n : ℕ} (f : Fin n → Fin N) :
     ∏ j : Fin n, (MvPolynomial.X (f j) : MvPolynomial (Fin N) ℚ) =
       MvPolynomial.monomial (tensorWeight N f) 1 := by
   -- ∏_j X_{f(j)} = ∏_{i : Fin N} X_i ^ #{j : f(j) = i}
@@ -757,7 +757,7 @@ private lemma permTracePoly_coeff_eq_card (N : ℕ) {n : ℕ}
   rw [Finset.filter_filter]
 
 /-- The standard tensor basis for `V^{⊗n}` over `k'`, indexed by colorings `f : Fin n → Fin N`. -/
-private noncomputable abbrev tensorStdBasis (k' : Type*) [Field k'] (N n : ℕ) :=
+noncomputable abbrev tensorStdBasis (k' : Type*) [Field k'] (N n : ℕ) :=
   (_root_.Basis.piTensorProduct (R := k') (fun _ : Fin n => Pi.basisFun k' (Fin N)))
 
 /-- A permutation σ ∈ S_n acts on the standard tensor basis by reindexing:
@@ -840,7 +840,7 @@ private lemma diagUnit_mulVecLin_basisFun (N : ℕ) (i : Fin N) (t : kˣ)
   simp only [Pi.smul_apply, smul_eq_mul]
   by_cases hm : m = i <;> by_cases hx : x = m <;> simp_all [Pi.single_apply]
 
-private lemma glTensorRep_diagUnit_basis (N n : ℕ) (i : Fin N) (t : kˣ)
+lemma glTensorRep_diagUnit_basis (N n : ℕ) (i : Fin N) (t : kˣ)
     (f : Fin n → Fin N) :
     (glTensorRep k N n (diagUnit k N i t)) (tensorStdBasis k N n f) =
       ((t : k) ^ (Finset.univ.filter (fun j => f j = i)).card) •
@@ -945,7 +945,7 @@ private lemma weight_restricted_diag_sum (N : ℕ) (lam : Fin N → ℕ) (μ : F
 
 /-- The basis repr coordinate of a diagonal torus action is multiplicative:
 `B.repr(ρ(diag(i,t))(v))(g) = t^(wt(g)(i)) * B.repr(v)(g)`. -/
-private lemma repr_glTensorRep_diagUnit (N n : ℕ) (i : Fin N) (t : kˣ)
+lemma repr_glTensorRep_diagUnit (N n : ℕ) (i : Fin N) (t : kˣ)
     (g : Fin n → Fin N) (v : TensorPower k (Fin N → k) n) :
     (tensorStdBasis k N n).repr (glTensorRep k N n (diagUnit k N i t) v) g =
     ((t : k) ^ (Finset.univ.filter (fun j => g j = i)).card) *

--- a/progress/2026-04-27T16-54-10Z_867022a2.md
+++ b/progress/2026-04-27T16-54-10Z_867022a2.md
@@ -1,0 +1,62 @@
+## Accomplished
+
+* **Decomposed #2493** (Schur-Weyl L_i part C: final assembly) into four
+  self-contained sub-issues (#2580, #2581, #2582, #2583). The original
+  parent required four foundational pieces — formal character of `V^⊗n`,
+  Schur-Weyl polynomial identity, irreducibility of `L_i`, irreducibility
+  of `SchurModule` — none of which existed. Marked the parent `replan`
+  with a `Decomposed into …` breadcrumb for the next planner cycle.
+* **Closed sub-issue #2580** (formal character of `glTensorRep` =
+  `(∑ Xᵢ)^n`) with a full proof in `Chapter5/FormalCharacterIso.lean`.
+  The proof shows that the standard tensor basis is a weight basis, the
+  weight space at `μ` is the span of basis vectors with
+  `tensorWeight = μ`, and dimension matching follows via
+  `finrank_span_eq_card`. Polynomial-side expansion uses
+  `Finset.sum_pow'` + `prod_X_eq_monomial_tensorWeight`.
+* Exposed five previously private helpers in `Chapter5/Theorem5_22_1.lean`
+  (`tensorWeight`, `prod_X_eq_monomial_tensorWeight`, `tensorStdBasis`,
+  `glTensorRep_diagUnit_basis`, `repr_glTensorRep_diagUnit`), since they
+  are the canonical weight-basis API for `V^⊗n` and are now used
+  outside the Weyl-character-formula trace argument.
+
+## Current frontier
+
+* `formalCharacter_glTensorRep_eq_pow` (the new theorem) is sorry-free
+  and downstream-ready. The remaining three sub-issues for the Schur-Weyl
+  L_i final-assembly chain are open and unblocked-or-blocked-on-#2580:
+  - #2581 (`(∑ Xᵢ)^n = ∑ dim(Specht) · schurPoly_λ`, derived from
+    Proposition 5.21.1) — depends on #2580.
+  - #2582 (irreducibility of `L_i` from Theorem 5.18.4) — depends on
+    #2580 (ordering hint only; mathematically independent).
+  - #2583 (irreducibility of `SchurModule k N λ`) — depends on #2580
+    (ordering hint only).
+
+## Overall project progress
+
+* Stage 3 (formalization) continues. PR queue for Schur-Weyl block:
+  recent merges include #2540 (equivariant bimodule decomposition),
+  #2572 (`Theorem5_18_4_GL_rep_decomposition_explicit`), #2576/#2577
+  (CharZero hygiene cleanup), #2575/#2579 (review docs).
+* The Schur-Weyl L_i character chain (issues #2491, #2492, #2515) is
+  fully landed; the path to closing the original sorry at
+  `FormalCharacterIso.lean:399`
+  (`iso_of_formalCharacter_eq_schurPoly`) now goes through the four
+  sub-issues created in this turn.
+
+## Next step
+
+* A planner cycle should triage the parent #2493 (close it with a
+  forward link to #2580–#2583, or narrow it to "final-assembly only").
+* The next worker can claim either #2581 (Schur-Weyl polynomial
+  identity, mostly polynomial work using Proposition 5.21.1) or
+  one of the irreducibility sub-issues (#2582 / #2583), independently of
+  the others.
+
+## Blockers
+
+None. Sub-issue #2580 is fully closed by this PR; the three siblings
+have ordering hints only.
+
+## Commits
+
+* `feat(Ch5 #2580): formalCharacter_glTensorRep_eq_pow`


### PR DESCRIPTION
Closes #2580

Session: `867022a2-8944-4e3f-ab6c-a6720ea62fb9`

1e2f1a6 fix(Ch5 #2580): rename Proposition5_22_2 local helper to avoid collision
b01dfba feat(Ch5 #2580): formalCharacter_glTensorRep_eq_pow

🤖 Prepared with Claude Code