### PR TITLE
refactor(Ch5): propagate Module.Finite k (V i / S i) into _explicit bimodule chain existentials

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/FormalCharacterIso.lean
+++ b/EtingofRepresentationTheory/Chapter5/FormalCharacterIso.lean
@@ -792,13 +792,9 @@ theorem glTensorRep_equivariant_schurWeyl_decomposition
                 (S i)).tprod (L i).ρ) g (e v) := by
   classical
   -- Get the explicit GL_N decomposition (issue #2572).
-  obtain ⟨ι, hιFin, hιDec, S', hS'_simp, hS'_dist, L, L_carrier, e, he, h_act⟩ :=
+  obtain ⟨ι, hιFin, hιDec, S', hS'_simp, hS'_dist, hSi_fin, L, L_carrier, e, he,
+      h_act⟩ :=
     Theorem5_18_4_GL_rep_decomposition_explicit k N n hN
-  -- Each `↥(S' i)` is finite-dimensional over `k` (it injects into the
-  -- finite-dimensional ambient `TensorPower`).
-  haveI hSi_fin : ∀ i, Module.Finite k (↥(S' i) : Type u) := fun i =>
-    Module.Finite.of_injective ((S' i).subtype.restrictScalars k)
-      Subtype.val_injective
   refine ⟨ι, hιFin, hιDec, fun i => ↥(S' i),
     fun _ => inferInstance, fun _ => inferInstance,
     fun i => hSi_fin i, L, ?_, ?_⟩

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_18_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_18_1.lean
@@ -715,7 +715,8 @@ theorem Theorem5_18_1_bimodule_decomposition_explicit
     [FaithfulSMul A E] :
     ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
       (V : ι → Submodule A E) (_ : ∀ i, IsSimpleModule A (V i))
-      (_ : ∀ i j, Nonempty (↥(V i) ≃ₗ[A] ↥(V j)) → i = j),
+      (_ : ∀ i j, Nonempty (↥(V i) ≃ₗ[A] ↥(V j)) → i = j)
+      (_ : ∀ i, Module.Finite k ↥(V i)),
       ∃ (e : E ≃ₗ[k] DirectSum ι
           (fun i => ↥(V i) ⊗[k] (↥(V i) →ₗ[A] E))),
         ∀ (i : ι) (v : ↥(V i)) (l : ↥(V i) →ₗ[A] E),
@@ -742,14 +743,18 @@ theorem Theorem5_18_1_bimodule_decomposition_explicit
     intro c
     haveI := V'_simple c
     exact eq_isotypicComponent_of_le c.2 (V'_le c)
+  -- Each `↥(V' c)` is finite-dimensional over `k` (it injects into the
+  -- finite-dimensional ambient `E`). Hoisted to top-level so the existential
+  -- output can advertise `Module.Finite k ↥(V i)` directly.
+  haveI hV'_fin : ∀ c : isotypicComponents A E,
+      Module.Finite k ((↥(V' c) : Type v)) := fun c =>
+    Module.Finite.of_injective ((V' c).subtype.restrictScalars k)
+      Subtype.val_injective
   -- Per-component k-linear iso: ↥c.1 ≃[k] V' c ⊗[k] (V' c →ₗ[A] E)
   let perComp : ∀ c : isotypicComponents A E,
       (↥c.1 : Type v) ≃ₗ[k]
         ↥(V' c) ⊗[k] (↥(V' c) →ₗ[A] E) := fun c => by
     haveI := V'_simple c
-    haveI : Module.Finite k (↥(V' c) : Type v) :=
-      Module.Finite.of_injective ((V' c).subtype.restrictScalars k)
-        Subtype.val_injective
     haveI : Module.Finite k (↥c.1 : Type v) :=
       Module.Finite.of_injective (c.1.subtype.restrictScalars k)
         Subtype.val_injective
@@ -769,9 +774,6 @@ theorem Theorem5_18_1_bimodule_decomposition_explicit
       (((perComp c).symm (v ⊗ₜ[k] l) : ↥c.1) : E) = l v := by
     intro c v l
     haveI := V'_simple c
-    haveI : Module.Finite k (↥(V' c) : Type v) :=
-      Module.Finite.of_injective ((V' c).subtype.restrictScalars k)
-        Subtype.val_injective
     haveI : Module.Finite k (↥c.1 : Type v) :=
       Module.Finite.of_injective (c.1.subtype.restrictScalars k)
         Subtype.val_injective
@@ -812,7 +814,7 @@ theorem Theorem5_18_1_bimodule_decomposition_explicit
   refine ⟨Fin m, inferInstance, inferInstance,
     fun i => V' (φ.symm i),
     fun i => V'_simple (φ.symm i),
-    ?_, etotal, ?_⟩
+    ?_, fun i => hV'_fin (φ.symm i), etotal, ?_⟩
   · -- Distinctness
     intro i j ⟨eqv⟩
     have h_eq : isotypicComponent A E (V' (φ.symm i)) =

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_18_4.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_18_4.lean
@@ -467,7 +467,8 @@ theorem Theorem5_18_4_bimodule_decomposition_explicit
     ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
       (S : ι → Submodule (symGroupImage k V n) (TensorPower k V n))
       (_ : ∀ i, IsSimpleModule (symGroupImage k V n) (S i))
-      (_ : ∀ i j, Nonempty (↥(S i) ≃ₗ[symGroupImage k V n] ↥(S j)) → i = j),
+      (_ : ∀ i j, Nonempty (↥(S i) ≃ₗ[symGroupImage k V n] ↥(S j)) → i = j)
+      (_ : ∀ i, Module.Finite k ↥(S i)),
       ∃ (e : TensorPower k V n ≃ₗ[k]
           DirectSum ι
             (fun i => ↥(S i) ⊗[k] (↥(S i) →ₗ[symGroupImage k V n] TensorPower k V n))),
@@ -639,6 +640,7 @@ theorem Theorem5_18_4_GL_rep_decomposition_explicit
       (_ : ∀ i, IsSimpleModule (symGroupImage k (Fin N → k) n) (S i))
       (_ : ∀ i j,
         Nonempty (↥(S i) ≃ₗ[symGroupImage k (Fin N → k) n] ↥(S j)) → i = j)
+      (_ : ∀ i, Module.Finite k ↥(S i))
       (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
       (L_carrier : ∀ i, (L i : Type u) ≃ₗ[k]
         (↥(S i) →ₗ[symGroupImage k (Fin N → k) n]
@@ -663,7 +665,7 @@ theorem Theorem5_18_4_GL_rep_decomposition_explicit
   haveI := symGroupImage_faithfulSMul k V n hN'
   -- Get the explicit bimodule decomposition with concrete summand types
   -- and the evaluation formula.
-  obtain ⟨ι, hι, hι_dec, S', hS'_simp, hS'_dist, e, he⟩ :=
+  obtain ⟨ι, hι, hι_dec, S', hS'_simp, hS'_dist, hS'_fin, e, he⟩ :=
     Theorem5_18_4_bimodule_decomposition_explicit k V n hN'
   -- Centralizer identity: centralizer(symGroupImage) = diagonalActionImage.
   have h_eq : Subalgebra.centralizer k
@@ -700,19 +702,15 @@ theorem Theorem5_18_4_GL_rep_decomposition_explicit
             (Matrix.mulVecLin g₂.val)) :=
         funext fun _ => Matrix.mulVecLin_mul g₁.val g₂.val
       rw [this, PiTensorProduct.map_comp]; rfl }
-  -- Each `↥(S' i)` is a finite-dimensional `k`-vector space (it injects into
-  -- the finite-dimensional `TensorPower k V n` via the subtype map).
-  haveI hSi_fin : ∀ i, Module.Finite k ((↥(S' i) : Type u)) := fun i =>
-    Module.Finite.of_injective ((S' i).subtype.restrictScalars k)
-      Subtype.val_injective
   -- The `A`-linear hom space `↥(S' i) →ₗ[A] E` is finite-dimensional over `k`
   -- because it injects (`k`-linearly) into the `k`-linear hom space, which has
-  -- dimension `dim(↥(S' i)) · dim(E)`. (Same derivation as in
-  -- `glTensorRep_equivariant_schurWeyl_decomposition`.)
+  -- dimension `dim(↥(S' i)) · dim(E)`. (`Module.Finite k ↥(S' i)` is now
+  -- propagated from `Theorem5_18_4_bimodule_decomposition_explicit` as
+  -- `hS'_fin`.)
   haveI hLi_fin : ∀ i, Module.Finite k
       ((↥(S' i) : Type u) →ₗ[symGroupImage k V n] TensorPower k V n) :=
     fun i => by
-      haveI : Module.Finite k (↥(S' i) : Type u) := hSi_fin i
+      haveI : Module.Finite k (↥(S' i) : Type u) := hS'_fin i
       haveI : Module.Free k (↥(S' i) : Type u) :=
         Module.Free.of_divisionRing k (↥(S' i))
       haveI : Module.Finite k
@@ -765,7 +763,7 @@ theorem Theorem5_18_4_GL_rep_decomposition_explicit
   -- Action formula: `((L i).ρ g l) v = PiTensorProduct.map (mulVecLin g.val) (l v)`
   -- because `(L i).ρ = ρ i` and `ρ i g l = (centralizerToEndA (glHom g)).comp l`
   -- whose underlying map is `PiTensorProduct.map (mulVecLin g.val)`.
-  refine ⟨ι, hι, hι_dec, S', hS'_simp, hS'_dist, L, L_carrier, e, he, ?_⟩
+  refine ⟨ι, hι, hι_dec, S', hS'_simp, hS'_dist, hS'_fin, L, L_carrier, e, he, ?_⟩
   intro i g l v
   rfl
 

--- a/progress/2026-04-27T17-36-52Z_bc0ef21b.md
+++ b/progress/2026-04-27T17-36-52Z_bc0ef21b.md
@@ -1,0 +1,46 @@
+## Accomplished
+
+Closed feature issue #2594 — propagated `Module.Finite k ↥(V i)` /
+`Module.Finite k ↥(S i)` through the `_explicit` bimodule chain in
+Chapter 5:
+
+- `Theorem5_18_1_bimodule_decomposition_explicit`
+  (`Chapter5/Theorem5_18_1.lean:711`): added
+  `(_ : ∀ i, Module.Finite k ↥(V i))` to the existential. The witness
+  was already constructed inside `perComp` and `perComp_symm_tmul` via
+  `Module.Finite.of_injective`; hoisted to a top-level `hV'_fin` and
+  threaded through the final `refine`.
+- `Theorem5_18_4_bimodule_decomposition_explicit`
+  (`Chapter5/Theorem5_18_4.lean:464`): added the same clause; body
+  delegates to upstream so the new clause flows through unchanged.
+- `Theorem5_18_4_GL_rep_decomposition_explicit`
+  (`Chapter5/Theorem5_18_4.lean:633`): added the same clause; obtain
+  pattern absorbs `hS'_fin` from upstream and threads it into the final
+  `refine`. The local `hSi_fin` derivation is now redundant and removed
+  in favor of the propagated witness.
+- `glTensorRep_equivariant_schurWeyl_decomposition`
+  (`Chapter5/FormalCharacterIso.lean:792-804`): obtain pattern
+  extended to absorb the new clause via local name `hSi_fin`; the
+  local `Module.Finite.of_injective` derivation is removed.
+
+## Current frontier
+
+PR #2594 created and queued for auto-merge. Build is green
+(`lake build` at 8309 jobs).
+
+## Overall project progress
+
+Stage 3 (formalization) — ongoing chain of refactors landing the
+explicit Schur-Weyl bimodule decomposition. With this PR the explicit
+chain (`_explicit` variants) now ships every clause the non-explicit
+chain ships; consumers (`#2589`, future `#2482`/`#2483`) no longer need
+to re-derive `Module.Finite k ↥(S i)` via `of_injective`.
+
+## Next step
+
+Pick up `#2590` (delegate `Theorem5_18_4_GL_rep_decomposition` to
+`_explicit`); the two refactors are independent.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2594

Session: `bc0ef21b-a9e7-40fb-83fa-2cca774e8fc3`

9017790 progress: refactor #2594 — Module.Finite propagation through _explicit bimodule chain
2388934 refactor(Ch5 #2594): propagate Module.Finite k (V/S i) through _explicit bimodule chain

🤖 Prepared with Claude Code