### PR TITLE
Schur-Weyl L_i (part C-2): polynomial identity (∑ Xᵢ)^n = ∑ dim(Specht)·schurPoly

### DIFF
--- a/EtingofRepresentationTheory/Chapter5.lean
+++ b/EtingofRepresentationTheory/Chapter5.lean
@@ -95,6 +95,7 @@ import EtingofRepresentationTheory.Chapter5.Proposition5_21_2
 import EtingofRepresentationTheory.Chapter5.PermDiagonalTrace
 import EtingofRepresentationTheory.Chapter5.Theorem5_22_1
 import EtingofRepresentationTheory.Chapter5.Proposition5_22_2
+import EtingofRepresentationTheory.Chapter5.SchurWeylPolynomialIdentity
 
 -- Section 5.23: Algebraic Representations of GL(V)
 import EtingofRepresentationTheory.Chapter5.Definition5_23_1

--- a/EtingofRepresentationTheory/Chapter5/Proposition5_21_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Proposition5_21_1.lean
@@ -565,13 +565,15 @@ theorem exists_bp_of_strictAnti_sum {N n : ℕ}
     simp only [vandermondeExps] at hsum; omega
   · funext j; simp only [shiftedExps, parts]; exact Nat.sub_add_cancel (hge j)
 
-theorem Proposition5_21_1
+/-- **Frobenius character formula (universe form).** Stronger version of
+`Proposition5_21_1` where the indexing finset is `Finset.univ`: every
+power-sum partition expands as a sum over *all* bounded partitions, with
+coefficients given by `charValue`. -/
+theorem Proposition5_21_1_univ
     {n : ℕ} (N : ℕ) (μ : n.Partition) :
-    ∃ (lams : Finset (BoundedPartition N n)),
-      (MvPolynomial.psumPart (Fin N) ℚ μ : MvPolynomial (Fin N) ℚ) =
-        ∑ lam ∈ lams,
-          (charValue N lam μ : ℚ) • schurPoly N lam.parts := by
-  use Finset.univ
+    (MvPolynomial.psumPart (Fin N) ℚ μ : MvPolynomial (Fin N) ℚ) =
+      ∑ lam : BoundedPartition N n,
+        (charValue N lam μ : ℚ) • schurPoly N lam.parts := by
   -- Step 1: Cancel the Vandermonde determinant Δ from both sides (integral domain)
   have hΔ : (alternantMatrix N (vandermondeExps N)).det ≠ 0 := by
     obtain ⟨u, hu⟩ := alternant_det_associated_prod N
@@ -652,5 +654,19 @@ theorem Proposition5_21_1
     · -- Matching partition exists, card = 1
       have : filt.card = 1 := by omega
       rw [this, one_nsmul]
+
+/-- **Proposition 5.21.1** (Etingof). Every power-sum partition decomposes
+as a sum of Schur polynomials weighted by character values: there exists
+a finset of bounded partitions over which the expansion holds.
+
+This is the existential form; for the universe form (which fixes the
+indexing finset to `Finset.univ`), see `Proposition5_21_1_univ`. -/
+theorem Proposition5_21_1
+    {n : ℕ} (N : ℕ) (μ : n.Partition) :
+    ∃ (lams : Finset (BoundedPartition N n)),
+      (MvPolynomial.psumPart (Fin N) ℚ μ : MvPolynomial (Fin N) ℚ) =
+        ∑ lam ∈ lams,
+          (charValue N lam μ : ℚ) • schurPoly N lam.parts :=
+  ⟨Finset.univ, Proposition5_21_1_univ N μ⟩
 
 end Etingof

--- a/EtingofRepresentationTheory/Chapter5/SchurWeylPolynomialIdentity.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurWeylPolynomialIdentity.lean
@@ -1,0 +1,110 @@
+import Mathlib
+import EtingofRepresentationTheory.Chapter5.Proposition5_21_1
+import EtingofRepresentationTheory.Chapter5.Theorem5_22_1
+
+/-!
+# Schur-Weyl Polynomial Identity
+
+The closed-form expansion of `(∑ Xᵢ)^n` against the Schur basis,
+specialising the Frobenius character formula `Proposition5_21_1_univ`
+to the trivial cycle type `(1, 1, …, 1)`.
+
+## Main results
+
+* `trivialCycleType n` — the partition of `n` consisting of `n` parts of size `1`
+  (the cycle type of the identity permutation in `Sₙ`).
+* `psumPart_trivialCycleType` — `psumPart (Fin N) ℚ (trivialCycleType n) = (∑ Xᵢ)^n`.
+* `sum_X_pow_eq_sum_charValue_smul_schurPoly` — the Schur-Weyl polynomial identity:
+  `(∑ Xᵢ)^n = ∑_{λ} charValue N λ (trivialCycleType n) • schurPoly N λ.parts`,
+  where the sum runs over `λ : BoundedPartition N n`.
+
+The coefficient `charValue N λ (trivialCycleType n)` equals the dimension of the
+Specht module `Sₙ`-irrep `Sλ` (Frobenius character at the identity), bridging the
+polynomial identity to a Specht-multiplicity statement.
+-/
+
+open MvPolynomial Finset
+
+noncomputable section
+
+namespace Etingof
+
+/-- The trivial cycle-type partition: `n` parts each equal to `1`.
+This is the cycle type of the identity permutation in `Sₙ`. -/
+def trivialCycleType (n : ℕ) : Nat.Partition n where
+  parts := Multiset.replicate n 1
+  parts_pos hi := by
+    rw [Multiset.mem_replicate] at hi; omega
+  parts_sum := by
+    rw [Multiset.sum_replicate]; simp
+
+/-- The power-sum partition for the trivial cycle type collapses to `(∑ Xᵢ)^n`. -/
+theorem psumPart_trivialCycleType (N n : ℕ) :
+    MvPolynomial.psumPart (Fin N) ℚ (trivialCycleType n) =
+      (∑ i : Fin N, (MvPolynomial.X i : MvPolynomial (Fin N) ℚ)) ^ n := by
+  unfold MvPolynomial.psumPart
+  change (Multiset.map (MvPolynomial.psum (Fin N) ℚ) (Multiset.replicate n 1)).prod = _
+  rw [Multiset.map_replicate, Multiset.prod_replicate, MvPolynomial.psum_one]
+
+/-- **Schur-Weyl polynomial identity.**
+
+The `n`-th power of the standard character `∑ᵢ Xᵢ` decomposes as a sum
+of Schur polynomials weighted by character values at the identity:
+
+`(∑ᵢ Xᵢ)ⁿ = ∑_{λ ∈ BoundedPartition N n} χ_λ(1) • s_λ(X)`,
+
+where `χ_λ(1) = charValue N λ (trivialCycleType n)` is the Frobenius character
+value at the identity (equivalently: the dimension of the Specht module `Sλ`).
+
+This is the polynomial-side ingredient of Schur-Weyl duality (Etingof Theorem
+5.18.4): combined with the formal-character identity for `glTensorRep`
+(`formalCharacter_glTensorRep_eq_pow`), it yields the multiplicity formula for the
+GL_N-irreducible summands of `V^⊗n`. -/
+theorem sum_X_pow_eq_sum_charValue_smul_schurPoly (N n : ℕ) :
+    (∑ i : Fin N, (MvPolynomial.X i : MvPolynomial (Fin N) ℚ)) ^ n =
+      ∑ lam : BoundedPartition N n,
+        charValue N lam (trivialCycleType n) • schurPoly N lam.parts := by
+  rw [← psumPart_trivialCycleType N n]
+  exact Proposition5_21_1_univ N (trivialCycleType n)
+
+/-! ## Bridge to Specht module dimensions
+
+The character value `charValue N λ (trivialCycleType n)` evaluates the Frobenius
+character at the identity, hence equals the dimension of the Specht module `Sλ`.
+This bridges the polynomial identity above to a multiplicity statement involving
+explicit Specht-module dimensions, as needed by the Schur-Weyl final assembly. -/
+
+/-- The cycle type of the identity permutation in `Sₙ` is the trivial cycle type
+(`n` parts of size `1`). -/
+theorem fullCycleTypePartition_one (n : ℕ) :
+    fullCycleTypePartition (1 : Equiv.Perm (Fin n)) = trivialCycleType n := by
+  apply Nat.Partition.ext
+  change fullCycleType n 1 = Multiset.replicate n 1
+  unfold fullCycleType
+  rw [Equiv.Perm.cycleType_one, Equiv.Perm.support_one,
+    Finset.card_empty, Nat.sub_zero, zero_add]
+
+/-- The Frobenius character at the identity equals the dimension of the Specht module. -/
+theorem spechtModuleCharacter_one (n : ℕ) (la : Nat.Partition n) :
+    spechtModuleCharacter n la 1 = (Module.finrank ℂ (SpechtModule n la) : ℂ) := by
+  unfold spechtModuleCharacter
+  rw [show (spechtModuleAction n la 1) = (1 : Module.End ℂ ↥(SpechtModule n la)) from
+        map_one (spechtModuleRep n la),
+      LinearMap.trace_one]
+
+/-- **Specht-dimension bridge.** The character value at the trivial cycle type
+equals the dimension of the corresponding Specht module (cast to `ℂ`):
+
+`(charValue N λ (trivialCycleType n) : ℂ) = dim_ℂ (Sλ)`.
+
+This is the polynomial-identity counterpart of "trace at identity = dimension". -/
+theorem charValue_trivialCycleType_eq_spechtFinrank
+    (N : ℕ) {n : ℕ} (lam : BoundedPartition N n) :
+    (charValue N lam (trivialCycleType n) : ℂ) =
+      (Module.finrank ℂ
+        (SpechtModule n (lam.sum_eq ▸ weightToPartition N lam.parts)) : ℂ) := by
+  rw [← fullCycleTypePartition_one n,
+      charValue_eq_spechtModuleCharacter N n lam 1,
+      spechtModuleCharacter_one]
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
@@ -2484,7 +2484,7 @@ private lemma charValue_stability
 the Weyl character formula with the trace definition used in Specht module theory.
 
 For general N, this reduces to the N = n case via `charValue_stability`. -/
-private lemma charValue_eq_spechtModuleCharacter
+theorem charValue_eq_spechtModuleCharacter
     (N : ℕ) (n : ℕ) (lam' : BoundedPartition N n) (σ : Equiv.Perm (Fin n)) :
     (charValue N lam' (fullCycleTypePartition σ) : ℂ) =
       spechtModuleCharacter n (lam'.sum_eq ▸ weightToPartition N lam'.parts) σ := by

--- a/progress/2026-04-27T17-49-32Z_7d00dd75.md
+++ b/progress/2026-04-27T17-49-32Z_7d00dd75.md
@@ -1,0 +1,83 @@
+# Schur-Weyl polynomial identity (#2581) — feature session 7d00dd75
+
+## Accomplished
+
+Implemented the Schur-Weyl polynomial identity from issue #2581 (part C-2 of the
+Schur-Weyl L_i critical path):
+
+`(∑ᵢ Xᵢ)ⁿ = ∑_{λ : BoundedPartition N n} χ_λ(1) · s_λ(X)`,
+
+with the explicit identification `χ_λ(1) = dim_ℂ(Sλ)` (Frobenius character at the
+identity equals Specht-module dimension).
+
+Concretely:
+
+1. **`Proposition5_21_1` refactor**
+   (`EtingofRepresentationTheory/Chapter5/Proposition5_21_1.lean`).
+   Split the existing `∃ lams, …` statement into:
+   - `Proposition5_21_1_univ` (universe form, `lams = Finset.univ`, the actual
+     content of the proof).
+   - `Proposition5_21_1` as a 3-line existential wrapper (preserves the
+     existing public API).
+
+2. **Made `charValue_eq_spechtModuleCharacter` public**
+   (`EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean:2487`). Removed the
+   `private` keyword so the Frobenius character bridge can be invoked from
+   outside the file. No callers were affected.
+
+3. **New file `Chapter5/SchurWeylPolynomialIdentity.lean`**:
+   - `trivialCycleType n : Nat.Partition n` — the cycle type `(1, 1, …, 1)`.
+   - `psumPart_trivialCycleType` — `psumPart trivialCycleType = (∑ᵢ Xᵢ)ⁿ`.
+   - **`sum_X_pow_eq_sum_charValue_smul_schurPoly`** — the polynomial identity
+     itself, derived as a one-line corollary of `Proposition5_21_1_univ`.
+   - `fullCycleTypePartition_one` — `1 ∈ Sₙ` has cycle type `trivialCycleType n`.
+   - `spechtModuleCharacter_one` — `χ_Sλ(1) = dim_ℂ(Sλ)` (trace of identity =
+     dimension via `LinearMap.trace_one`).
+   - **`charValue_trivialCycleType_eq_spechtFinrank`** — the Specht-dimension
+     bridge, casting `charValue` to `ℂ` and matching against `Module.finrank ℂ`.
+
+4. Added the new file to `Chapter5.lean`'s import list.
+
+Build: `lake build EtingofRepresentationTheory.Chapter5.SchurWeylPolynomialIdentity`
+passes (zero `sorry` placeholders, two style-only warnings cleaned).
+
+## Current frontier
+
+Schur-Weyl part-C critical path:
+
+- ✅ #2580 — `formalCharacter glTensorRep = (∑ X)ⁿ` (already merged)
+- ✅ **#2581 — polynomial identity (∑ X)ⁿ = ∑ χ_λ(1)·s_λ** (this PR)
+- 🟡 #2582 — irreducibility of L_i in `Theorem5_18_4_GL_rep_decomposition`
+- 🟡 #2583 — irreducibility of `SchurModule k N λ` as GL_N-rep
+
+Once #2582 and #2583 land, the final assembly #2493 can match characters
+between the two decompositions of `V^⊗n` and conclude Schur-Weyl part (iii):
+`L_i ≅ SchurModule k N λ_i`.
+
+## Overall project progress
+
+Stage 3 (formalization) continues to drive down the Schur-Weyl wall:
+
+- Proposition 5.21.1 now exposes both an existential and a strong universe form.
+- The Frobenius character bridge (`charValue ↔ spechtModuleCharacter`) is now
+  publicly callable, unlocking downstream work that needs to convert between
+  the polynomial-side `charValue` and trace-side `spechtModuleCharacter`.
+- The polynomial identity `(∑ X)ⁿ = ∑ dim(Sλ) • s_λ` is now formalised,
+  closing a foundational gap in the Schur-Weyl assembly.
+
+## Next step
+
+The natural follow-on is **#2582** (irreducibility of `L_i` in
+`Theorem5_18_4_GL_rep_decomposition`). It hinges on the bimodule structure
+exposed by `Theorem5_18_1_bimodule_decomposition_explicit` — Schur's-lemma
+applied to simple `S i ⊗ L i` summands transfers simplicity to `L_i`. The
+new public `charValue_eq_spechtModuleCharacter` may help bridge dimension
+arguments if needed.
+
+Alternative: **#2583** (irreducibility of `SchurModule k N λ` as GL_N-rep)
+is mathematically harder (idempotent-image-simple lemma) and may itself need
+decomposition.
+
+## Blockers
+
+None for this work item.


### PR DESCRIPTION
Closes #2581

Session: `7d00dd75-44d8-4970-a46d-f0de9d908989`

6fc9c4c feat(Ch5 #2581): Schur-Weyl polynomial identity (∑Xᵢ)ⁿ = ∑ χ_λ(1)·s_λ

🤖 Prepared with Claude Code