### PR TITLE
feat(Ch5): combined dimension-form Schur-Weyl polynomial identity (∑ Xᵢ)^n = ∑ dim(Specht) • schurPoly

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/SchurWeylPolynomialIdentity.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurWeylPolynomialIdentity.lean
@@ -107,4 +107,38 @@ theorem charValue_trivialCycleType_eq_spechtFinrank
       charValue_eq_spechtModuleCharacter N n lam 1,
       spechtModuleCharacter_one]
 
+/-- **Specht-dimension bridge over `ℚ`.** Stronger form of
+`charValue_trivialCycleType_eq_spechtFinrank`: the rational character value at
+the trivial cycle type already equals the natural-number dimension of the
+Specht module (cast to `ℚ`). Obtained from the `ℂ`-form by injectivity of
+`Rat.cast : ℚ → ℂ`. -/
+theorem charValue_trivialCycleType_eq_spechtFinrank_rat
+    (N : ℕ) {n : ℕ} (lam : BoundedPartition N n) :
+    charValue N lam (trivialCycleType n) =
+      (Module.finrank ℂ
+        (SpechtModule n (lam.sum_eq ▸ weightToPartition N lam.parts)) : ℚ) := by
+  apply (Rat.cast_injective (α := ℂ))
+  rw [Rat.cast_natCast]
+  exact charValue_trivialCycleType_eq_spechtFinrank N lam
+
+/-- **Schur-Weyl polynomial identity in dimension form.**
+
+The `n`-th power of the standard character `∑ᵢ Xᵢ` decomposes as a sum of
+Schur polynomials weighted by Specht-module dimensions:
+
+`(∑ᵢ Xᵢ)ⁿ = ∑_{λ ∈ BoundedPartition N n} dim_ℂ(Sλ) • s_λ(X)`.
+
+This is the dimension-form combination of `sum_X_pow_eq_sum_charValue_smul_schurPoly`
+and `charValue_trivialCycleType_eq_spechtFinrank_rat`, ready for direct use by
+the Schur-Weyl L_i final assembly. -/
+theorem sum_X_pow_eq_sum_finrank_smul_schurPoly (N n : ℕ) :
+    (∑ i : Fin N, (MvPolynomial.X i : MvPolynomial (Fin N) ℚ)) ^ n =
+      ∑ lam : BoundedPartition N n,
+        (Module.finrank ℂ (SpechtModule n
+          (lam.sum_eq ▸ weightToPartition N lam.parts)) : ℚ) •
+        schurPoly N lam.parts := by
+  rw [sum_X_pow_eq_sum_charValue_smul_schurPoly]
+  refine Finset.sum_congr rfl (fun lam _ => ?_)
+  rw [charValue_trivialCycleType_eq_spechtFinrank_rat]
+
 end Etingof

--- a/progress/2026-04-27T20-18-17Z_fa4c1756.md
+++ b/progress/2026-04-27T20-18-17Z_fa4c1756.md
@@ -1,0 +1,41 @@
+## Accomplished
+
+Closed #2630 (combined dimension-form Schur-Weyl polynomial identity).
+
+Added two theorems to `Chapter5/SchurWeylPolynomialIdentity.lean`:
+
+1. `charValue_trivialCycleType_eq_spechtFinrank_rat` — `ℚ`-form of the
+   Specht-dimension bridge (Option B from the issue): obtained from the
+   existing `ℂ`-form by `Rat.cast_injective`. Statement:
+   `charValue N lam (trivialCycleType n) =
+      (Module.finrank ℂ (SpechtModule n …) : ℚ)`.
+2. `sum_X_pow_eq_sum_finrank_smul_schurPoly` — the combined dimension-form
+   polynomial identity in one rewrite step:
+   `(∑ Xᵢ)^n = ∑_{λ ∈ BoundedPartition N n} dim_ℂ(Sλ) • schurPoly N λ.parts`,
+   stated entirely in `MvPolynomial (Fin N) ℚ`.
+
+Proof of (1) is 3 lines (`Rat.cast_injective` + `Rat.cast_natCast` +
+existing bridge). Proof of (2) is 3 lines (`Finset.sum_congr` over the
+existing `charValue` form). No new infrastructure, no signature changes.
+
+## Current frontier
+
+PR open. Module compiles cleanly (32s incremental). The dimension-form
+identity is now a single-rewrite reduction for the Schur-Weyl L_i final
+assembly (#2493).
+
+## Overall project progress
+
+Stage 3 (formalization). Chapter 5 Schur-Weyl pipeline continues to
+consolidate: `Theorem5_18_4_GL_rep_decomposition_explicit` provides the
+representation-theoretic side and `SchurWeylPolynomialIdentity` now
+provides the polynomial side directly in dimension form.
+
+## Next step
+
+Pick up #2601 (heartbeat tightening) or #2602 (helper extraction, now
+unblocked since #2590 has landed). Both are hygiene work.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2630

Session: `fa4c1756-8321-4057-9a6d-672e4d1c6fec`

64f049c feat(Ch5 #2630): combined dimension-form Schur-Weyl polynomial identity

🤖 Prepared with Claude Code