### PR TITLE
chore(progress): decompose #2643 (Schur-Weyl C-4a-i) into sub-α/β/γ

### DIFF
--- a/progress/20260503T081523Z_a74a22df.md
+++ b/progress/20260503T081523Z_a74a22df.md
@@ -1,0 +1,103 @@
+## Accomplished
+
+Worker session `a74a22df` claimed parent issue #2643
+(`youngSymEndomorphism_specht_action` — c_λ acts as scalar α on
+S_λ block and zero on other Specht blocks), assessed scope, and
+**decomposed it into three session-sized sub-issues**, then skipped
+the parent for planner triage.
+
+**Decomposition rationale**: the deliverable signature
+```
+∃ (i_λ : ι),
+  (∀ i ≠ i_λ, c_λ-restricted-to-Sᵢ-block = 0) ∧
+  c_λ-restricted-to-S_{i_λ}-block = α • <rank-1 projection>
+```
+requires three independent technical pieces, each a session in itself:
+
+1. **#2655 (sub-α)** — Block factorization via A-equivariance of the
+   bimodule iso. The action of `youngSymEndomorphism k N lam` on each
+   block `S_i ⊗ L_i` of `Theorem5_18_4_bimodule_decomposition_explicit`
+   factors as `(c_λ · -) ⊗ id_{L_i}`. Provable from the existing
+   evaluation formula `e.symm (of i (v ⊗ₜ l)) = l v` plus A-linearity
+   of `l : S_i →ₗ[A] V^⊗n`. Sized ~150-250 lines.
+2. **#2656 (sub-β)** — Off-block vanishing via character
+   orthogonality. Combines bimodule trace decomposition with the
+   existing `youngSym_charValue_orthogonality:2565` and
+   `monoidAlgebra_trace_mulLeft_eq':1424` to deduce `f_i = 0` for all
+   blocks except a unique `i_λ`. Depends on sub-α. Sized ~200-300
+   lines.
+3. **#2657 (sub-γ)** — Rank-1 scaled projection on the special block.
+   On the unique non-vanishing block, `f_{i_λ} = α • π_{i_λ}` for a
+   rank-1 projection `π_{i_λ}`. Combines `c_λ² = α c_λ` (idempotent
+   up to scalar) with a trace/dimension argument via the bimodule
+   decomp and weight-multiplicity formula. Depends on sub-α + sub-β.
+   Sized ~150-250 lines.
+
+Parent #2643 marked `replan` via `coordination skip` with the
+breadcrumb `Decomposed into #2655, #2656, #2657 — see comment`. The
+next planner cycle will close it with a forward link.
+
+**Sub-issue independence note**: per agent-worker-flow guidance, the
+three sub-issues do NOT depend on `#2643` directly (the parent is
+being superseded). Sub-β and sub-γ depend on sub-α (block
+factorization is the foundation); sub-γ also depends on sub-β.
+
+## Current frontier
+
+- **#2643 (parent) skipped** — awaiting planner triage to close.
+- **#2655 (sub-α) actionable** — first claimable.
+- **#2656 (sub-β) blocked on #2655**.
+- **#2657 (sub-γ) blocked on #2655 + #2656**.
+
+The Schur-Weyl L_i critical path remains:
+- **#2610 (parent C-4a)** consumes #2643's full deliverable; landing
+  all three sub-issues α/β/γ unblocks #2610.
+- **#2644 (C-4a-ii)** consumes the same per-block-action data; takes
+  it as a hypothesis. Could land in parallel with #2643's
+  decomposition (no actual data dependency until final assembly).
+- **#2612 (C-4c, final assembly)** depends on #2610.
+
+## Overall project progress
+
+Stage 3 formalization. **Sorry count: 7 leaves / 4 files** (unchanged
+this session).
+
+This session produced no code; it is a pure decomposition / scope
+adjustment. The parent issue's anticipated 3-way decomposition was
+realized, with each sub-issue clearly scoped, dependency-ordered,
+and pointed at the right existing infrastructure
+(`youngSym_charValue_orthogonality`, `youngSymEndomorphism_sq_scalar`,
+`Theorem5_18_4_bimodule_decomposition_explicit`).
+
+Critical paths:
+- **Wall 1** (Ch6): blocked on #2436 human-oversight (replan).
+- **Wall 3** (Ch5 SpechtModuleBasis): #2605 critical path; #2652
+  claimed (`garnir_twisted_in_lower_span_aux`); #2649 (sub-B
+  packed-induction) blocked on #2652.
+- **Schur-Weyl L_i chain**: #2610 (C-4a) decomposed into #2655 / #2656
+  / #2657; #2611 also pending. Final assembly #2612 → #2493.
+- **Theorem 2.1.2** (Ch2): blocked on Wall 1.
+
+## Next step
+
+**Workers** (priority order):
+1. **#2655 (sub-α)** — block factorization. Highest-priority on the
+   Schur-Weyl L_i chain. Self-contained; uses only the evaluation
+   formula from `Theorem5_18_4_bimodule_decomposition_explicit`.
+2. **#2602** — `glHom` helper extraction (refactor, low priority).
+3. **#2629** — CharZero hygiene fix (claimed 5d ago — likely stale).
+4. **#2644 (C-4a-ii)** — abstract idempotent simplicity. Already
+   posted; could land in parallel since it takes the per-block-action
+   structure as a hypothesis without depending on a specific α/β/γ
+   shape until final assembly.
+
+**Planner**:
+- Triage parent **#2643** (now in `replan`): close with forward link
+  to #2655, #2656, #2657, since the decomposition fully covers the
+  original scope.
+
+## Blockers
+
+None for this session. Decomposition is the standard success path
+when the parent scope exceeds one session, per agent-worker-flow
+Step 4b. No code touched; no PR created.


### PR DESCRIPTION
This PR records the decomposition of #2643 (`youngSymEndomorphism_specht_action`) into three session-sized sub-issues. No code was touched.

The parent issue's deliverable requires three independent technical pieces, each a session in itself:

- **#2655 (sub-α)** — block factorization of c_λ on each `S_i ⊗ L_i` block via A-equivariance of the bimodule iso (provable from the existing evaluation formula).
- **#2656 (sub-β)** — off-block vanishing via character orthogonality (uses existing `youngSym_charValue_orthogonality` + bimodule trace decomposition).
- **#2657 (sub-γ)** — rank-1 scaled projection on the unique special block (idempotent + dimension/trace argument).

Sub-issues are dependency-ordered: sub-β depends on sub-α; sub-γ depends on sub-α + sub-β. The parent #2643 was marked `replan` via `coordination skip` with a `Decomposed into #2655, #2656, #2657` breadcrumb for planner triage.

The decomposition follows the explicit 3-way split anticipated in the parent issue's "Notes" section.

🤖 Prepared with Claude Code