### PR TITLE
feat(Ch5 hygiene): omit [CharZero k] from formalCharacter_glTensorRep_eq_pow and supporting lemmas

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/FormalCharacterIso.lean
+++ b/EtingofRepresentationTheory/Chapter5/FormalCharacterIso.lean
@@ -897,6 +897,7 @@ of such colorings — which matches the multinomial coefficient extraction
 of `(X₁ + ⋯ + X_N)^n`.
 -/
 
+omit [CharZero k] in
 /-- For each coloring `f`, the standard tensor basis vector `tensorStdBasis k N n f`
 lies in the weight space of weight `tensorWeight N f`. -/
 private theorem tensorStdBasis_mem_glWeightSpace (N n : ℕ) (f : Fin n → Fin N) :
@@ -938,6 +939,7 @@ private lemma sum_X_pow_coeff (N n : ℕ) (μ : Fin N →₀ ℕ) :
   simp_rw [MvPolynomial.coeff_monomial]
   rw [Finset.sum_boole, Nat.cast_inj]
 
+omit [CharZero k] in
 /-- For `v` in the weight space of weight `μ`, the basis coordinate `B.repr v f`
 vanishes whenever the basis element `B f` has a different weight. -/
 private theorem tensorStdBasis_repr_eq_zero_of_ne_weight
@@ -981,6 +983,7 @@ private theorem tensorStdBasis_repr_eq_zero_of_ne_weight
   · exact absurd (sub_eq_zero.mp hd) ht
   · exact hr
 
+omit [CharZero k] in
 /-- The weight space of `V^⊗n` at weight `μ` is the span of the standard tensor basis
 elements indexed by colorings `f` with `tensorWeight N f = μ`. -/
 private theorem glWeightSpace_glTensorRep_eq_span (N n : ℕ) (μ : Fin N →₀ ℕ) :
@@ -1014,6 +1017,7 @@ private theorem glWeightSpace_glTensorRep_eq_span (N n : ℕ) (μ : Fin N →₀
       funext i; rw [hf]
     rwa [heq] at hmem
 
+omit [CharZero k] in
 /-- The dimension of the weight space at `μ` in `V^⊗n` equals the number of colorings
 `f : Fin n → Fin N` with `tensorWeight N f = μ`. -/
 private theorem finrank_glWeightSpace_glTensorRep (N n : ℕ) (μ : Fin N →₀ ℕ) :
@@ -1029,6 +1033,7 @@ private theorem finrank_glWeightSpace_glTensorRep (N n : ℕ) (μ : Fin N →₀
     (tensorStdBasis k N n).linearIndependent.comp _ Subtype.val_injective
   exact finrank_span_eq_card hf_lin
 
+omit [CharZero k] in
 /-- **Formal character of the standard tensor power.** For `V = Fin N → k`, the formal
 character of `V^⊗n` (under the diagonal `GL_N(k)`-action `g ↦ g^{⊗n}`) is the
 multinomial expansion `(X_1 + ⋯ + X_N)^n`.

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
@@ -826,6 +826,7 @@ private lemma youngSym_diagonal_entry (k' : Type*) [Field k'] (N : ℕ) (lam : F
     simp only [Finsupp.mem_support_iff, not_not] at hmem
     simp [hmem]
 
+omit [CharZero k] in
 /-- The `diagUnit(i,t)` action on a standard tensor basis element multiplies by `t` raised
 to the number of times color `i` appears in `f`. -/
 private lemma diagUnit_mulVecLin_basisFun (N : ℕ) (i : Fin N) (t : kˣ)
@@ -840,6 +841,7 @@ private lemma diagUnit_mulVecLin_basisFun (N : ℕ) (i : Fin N) (t : kˣ)
   simp only [Pi.smul_apply, smul_eq_mul]
   by_cases hm : m = i <;> by_cases hx : x = m <;> simp_all [Pi.single_apply]
 
+omit [CharZero k] in
 lemma glTensorRep_diagUnit_basis (N n : ℕ) (i : Fin N) (t : kˣ)
     (f : Fin n → Fin N) :
     (glTensorRep k N n (diagUnit k N i t)) (tensorStdBasis k N n f) =
@@ -943,6 +945,7 @@ private lemma weight_restricted_diag_sum (N : ℕ) (lam : Fin N → ℕ) (μ : F
   intro f _
   exact youngSym_diagonal_entry ℚ N lam f
 
+omit [CharZero k] in
 /-- The basis repr coordinate of a diagonal torus action is multiplicative:
 `B.repr(ρ(diag(i,t))(v))(g) = t^(wt(g)(i)) * B.repr(v)(g)`. -/
 lemma repr_glTensorRep_diagUnit (N n : ℕ) (i : Fin N) (t : kˣ)

--- a/progress/2026-05-03T08-29-57Z_4c9d6e87.md
+++ b/progress/2026-05-03T08-29-57Z_4c9d6e87.md
@@ -1,0 +1,44 @@
+## Accomplished
+
+Issue #2629 (hygiene): wrapped five lemmas in `omit [CharZero k] in` so that
+`formalCharacter_glTensorRep_eq_pow` and its supporting helpers no longer
+carry `[CharZero k]` in their public signatures. Confirmed via `#check` that
+the public theorem now requires only `[Field k] [IsAlgClosed k]`.
+
+Files touched:
+
+- `EtingofRepresentationTheory/Chapter5/FormalCharacterIso.lean`: 5 omits
+  (the originally requested set).
+- `EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean`: 3 additional
+  omits (`diagUnit_mulVecLin_basisFun`, `glTensorRep_diagUnit_basis`,
+  `repr_glTensorRep_diagUnit`) — these helpers are called by the wrapped
+  FormalCharacterIso lemmas and themselves inherit `[CharZero k]` from
+  Theorem5_22_1's file-scope `variable` at line 504. The audit in #2629
+  missed this transitive carry; without these three additional omits the
+  build fails with "failed to synthesize CharZero k". All three helper
+  proofs are pure tensor / matrix algebra with no actual CharZero use.
+
+No proof modifications. Sorry count unchanged.
+
+## Current frontier
+
+Schur-Weyl L_i program: same as before; this PR does not unblock
+anything new (every downstream consumer already carries `[CharZero k]`
+for orthogonality reasons). Audit hygiene parity restored.
+
+## Overall project progress
+
+Stage 3 formalisation continuing. Open feature queue: #2602
+(refactor — glHom helpers, depends-on-now-merged #2590), #2643
+(Schur-Weyl L_i C-4a-i character-theoretic Specht block scalar action),
+#2652 (claimed). #2629 closing as `has-pr` once CI passes.
+
+## Next step
+
+Pick up #2602 (pure refactor, ~80-line cleanup) or #2643 (substantial
+mathematical content, decomposable along the (a)/(b)/(c) lines spelled
+out in the issue body). #2602 is the lower-risk follow-up.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2629

Session: `4c9d6e87-b549-46b0-b672-490d1f28f0cc`

5c7c778 feat(Ch5 #2629 hygiene): omit [CharZero k] from formalCharacter_glTensorRep_eq_pow chain

🤖 Prepared with Claude Code