### PR TITLE
progress: planner cycle bab8e3ff — file #2708 (C-4a aggregation) + harness counter bug report

### DIFF
--- a/plans/bab8e3ff-1.md
+++ b/plans/bab8e3ff-1.md
@@ -1,0 +1,114 @@
+## Current state
+
+PR #2706 (Schur-Weyl L_i part C-4c, `schurModule_isSimple`) merged on
+2026-05-04 as a `--partial` PR carrying one well-localised sorry at
+`EtingofRepresentationTheory/Chapter5/SchurModuleSimple.lean:148`:
+
+```lean
+theorem schurModuleSubmodule_isSimple_centralizer
+    (N : ℕ) (lam : Fin N → ℕ) (_hlam : Antitone lam) (_hN : (∑ i, lam i) ≤ N) :
+    IsSimpleModule
+      (↥(diagonalActionImage k (Fin N → k) (∑ i, lam i)))
+      (SchurModuleSubmodule k N lam) := by
+  sorry
+```
+
+This is the **C-4a aggregation** referenced in the worker progress note
+`progress/20260504T082119Z_a1a48844.md`: the single discharge that
+combines the now-landed/in-flight C-4a sub-pieces — `sub-α`, `sub-β`
+(β.1 #2682 merged, β.2 #2683 merged via PR #2697, β.3 #2684 in flight),
+`sub-γ` (γ.A #2694 PR in repair, γ.B #2693 blocked on β.3), and
+`C-4a-ii` `image_of_primitive_idempotent_isSimple_centralizer`
+(`PrimitiveIdempotentSimplicity.lean:220`, merged via PR #2698) — into
+the single `IsSimpleModule` conclusion above.
+
+Once γ.A + γ.B + β.3 all land, the discharge is mechanical glue: thread
+the `Theorem5_18_4_bimodule_decomposition_explicit` decomposition
+(sub-α, already merged) into the `e : E ≃ₗ[k] ⨁ᵢ ↥(S i) ⊗[k] L i`
+hypothesis of `image_of_primitive_idempotent_isSimple_centralizer`, then
+read off `f i = 0` for `i ≠ iLam` from β.3 and `f iLam = α • π` for a
+rank-1 idempotent `π` from γ.A + γ.B.
+
+## Deliverables
+
+Replace the sorry at `SchurModuleSimple.lean:148` with the full proof of
+`schurModuleSubmodule_isSimple_centralizer`. **Single deliverable, one
+file touched.**
+
+## Context
+
+- **Parent**: closes the last sorry introduced by PR #2706 (#2612). With
+  this sorry discharged, the C-4c critical-path entry of
+  `Theorem 5.22.1` is fully proven.
+- **Files**: `EtingofRepresentationTheory/Chapter5/SchurModuleSimple.lean`
+  (the only file touched). Likely net ≤ 50 lines of glue code; if it
+  grows past ~150 lines, decompose via `coordination skip`.
+- **Helpers to use**:
+  - `image_of_primitive_idempotent_isSimple_centralizer`
+    (`PrimitiveIdempotentSimplicity.lean:220`) — the aggregation
+    interface. Consumes a bimodule decomposition `e`, the simplicity of
+    `S iLam`, and per-block action hypotheses `hf_block`, `hf_zero`,
+    `hπ_idem`, `hπ_rank`, `hπ_special`. Outputs `IsSimpleModule
+    centralizer ↥(imageSubmoduleB c)`.
+  - `Theorem5_18_4_bimodule_decomposition_explicit`
+    (`Theorem5_18_4.lean`) — supplies the `e` (bimodule
+    decomposition of `V^⊗n` indexed by partitions of `n` ≤ N).
+  - `Theorem5_18_4_centralizers` (`Theorem5_18_4.lean:268`) —
+    identifies the centralizer of `symGroupImage` with
+    `diagonalActionImage` (needed to match the conclusion's module
+    structure). Requires `n ≤ N`.
+  - **β.3 output** (from #2684, when it lands): `hf_zero` — the
+    off-block vanishing `f i = 0` for `i ≠ iLam`.
+  - **γ.A output** (from PR #2694, when it lands): the scaled-projection
+    structure on the iLam block, giving the rank-1 idempotent `π` and
+    scalar `α` such that `f iLam = α • π`.
+  - **γ.B output** (from #2693, when it lands): rank-1 dim count
+    `Module.finrank k (LinearMap.range π) = 1` (= `hπ_rank` in the
+    aggregation interface).
+  - **β.2 output** (PR #2697 merged): simplicity of the special Specht
+    block, supplies `hSiLam_simple : IsSimpleModule A ↥(S iLam)`.
+
+## Proof outline
+
+```lean
+theorem schurModuleSubmodule_isSimple_centralizer
+    (N : ℕ) (lam : Fin N → ℕ) (hlam : Antitone lam) (hN : (∑ i, lam i) ≤ N) :
+    IsSimpleModule (↥(diagonalActionImage k (Fin N → k) (∑ i, lam i)))
+      (SchurModuleSubmodule k N lam) := by
+  -- 1. Identify diagonalActionImage with centralizer(symGroupImage)
+  --    via Theorem5_18_4_centralizers (needs hN).
+  -- 2. The Schur module submodule equals `range (c_λ : V^⊗n →ₗ V^⊗n)`
+  --    where `c_λ` is the Young symmetrizer — i.e. it IS an
+  --    `imageSubmoduleB c_λ` for `c = c_λ`.
+  -- 3. Feed the per-block data from β.3 + γ.A + γ.B into
+  --    `image_of_primitive_idempotent_isSimple_centralizer`:
+  --    - `e` from `Theorem5_18_4_bimodule_decomposition_explicit`
+  --    - `hSiLam_simple` from β.2 (merged)
+  --    - `hf_zero` from β.3
+  --    - `hπ_idem`, `hπ_rank` from γ.B
+  --    - `hπ_special` (the rank-1 idempotent structure) from γ.A
+  -- 4. Transport simplicity via the centralizer identification (step 1).
+  sorry  -- ≤ 50 lines of glue
+```
+
+## Stalls and pivots
+
+If the per-block data from γ.A + γ.B + β.3 doesn't match the
+`image_of_primitive_idempotent_isSimple_centralizer` interface
+verbatim (mismatched indexing, scalar bookkeeping, or DirectSum
+mismatches), do NOT force-close with a new sorry. Instead, file a
+follow-up issue identifying the specific interface mismatch and leave
+the existing sorry in place. The discharge is purely mechanical glue —
+any non-trivial obstacle is a sign that one of the upstream pieces
+needs sharpening before aggregation.
+
+## Verification
+
+- `lake build EtingofRepresentationTheory.Chapter5.SchurModuleSimple` passes
+- Zero sorries remain in `SchurModuleSimple.lean`
+- `lake build EtingofRepresentationTheory.Chapter5` passes end-to-end
+- Sorry-count delta: **−1 leaf in 1 file**
+
+depends-on: #2684
+depends-on: #2693
+depends-on: #2694

--- a/progress/20260517T050030Z_bab8e3ff.md
+++ b/progress/20260517T050030Z_bab8e3ff.md
@@ -1,0 +1,188 @@
+## Accomplished
+
+Planner cycle `bab8e3ff`. **Real-world queue is healthy** (5 unclaimed
+unblocked work items + 2 PRs already in the repair queue); harness
+counter is broken (see Blockers).
+
+### Merged ready PRs
+
+None. Both open PRs (#2694 γ.A, #2550 Wall 3 C.1.a.ii pigeonhole_pair)
+are `CONFLICTING` and already in `coordination list-pr-repair` —
+repair-agent dispatch will pick them up.
+
+### New work — one issue filed
+
+- **#2708** (`feature`, `blocked` on #2684 + #2693 + #2694) — C-4a
+  aggregation discharge. Closes the well-localised sorry at
+  `SchurModuleSimple.lean:148` introduced by PR #2706 (#2612 partial).
+  Glues `Theorem5_18_4_bimodule_decomposition_explicit` (sub-α,
+  merged) + β.2 (#2683, merged via #2697) + β.3 (#2684) + γ.A
+  (#2694) + γ.B (#2693) + C-4a-ii (#2698 merged) into a single
+  `IsSimpleModule (↥(diagonalActionImage k V n)) (SchurModuleSubmodule
+  k N λ)` discharge via `image_of_primitive_idempotent_isSimple_centralizer`
+  (`PrimitiveIdempotentSimplicity.lean:220`).
+
+  Filed as `blocked` because the per-block hypotheses `hf_zero`,
+  `hf_block`, `hπ_idem`, `hπ_rank`, `hπ_special` come from work that
+  hasn't landed yet (γ.A still in repair, γ.B blocked on β.3, β.3
+  still unclaimed). Once those three land, #2708 auto-unblocks via
+  `coordination check-blocked` and becomes mechanical glue (≤50 lines).
+
+### Why only one issue this cycle
+
+POD_QUEUE_DEFICIT=3 (advisory). I did not file three issues because:
+
+1. **The real-world queue is healthy.** Filtering by labels directly
+   via `gh issue list`, there are **5 unclaimed unblocked** issues:
+   - #2702 R2.b (Wall 3 — combinatorial heart, the next implementation
+     step after #2707 merged); auto-unblocked when R2.a landed.
+   - #2684 β.3 (Schur-Weyl L_i off-block vanishing).
+   - #2705 review (audit β.2 + C-4a-ii merges).
+   - #2564 Mathlib upstream tracker.
+   - #2401 Theorem 2.1.2 bridges.
+2. **Real deficit is 0.** Per the planner instructions ("If the deficit
+   is 0 or negative, create no new issues and exit"), filing additional
+   work would just pad the queue with low-value items.
+3. **The single new issue (#2708) is genuinely missing work** flagged
+   multiple times in recent progress notes (`97b07e3d`, `a1a48844`):
+   "Once γ.B + γ.A both merge, file the C-4a aggregation issue."
+   Filing it now as `blocked` makes the upcoming work tracked rather
+   than implicit; it doesn't compete with active claims.
+
+## Current frontier
+
+Unclaimed unblocked (5):
+- **#2702** Wall 3 R2.b (the queue head — Wall 3 critical path).
+- **#2684** Schur-Weyl L_i β.3.
+- **#2705** review (audit β.2 + C-4a-ii).
+- **#2564** Mathlib upstream tracker.
+- **#2401** Theorem 2.1.2 bridges (NB: progress notes say this is
+  transitively blocked on Wall 1; not currently labelled `blocked`,
+  but worker should re-check before claiming).
+
+Claimed (0). The C-4c claim by `a1a48844` was published via PR #2706,
+which merged. The remaining sorry is now tracked by #2708.
+
+Blocked (6 feature + 1 human-oversight):
+- **#2703** R2.c — blocked on #2702.
+- **#2693** γ.B — blocked on #2684.
+- **#2708** C-4a aggregation — blocked on #2684, #2693, #2694 (filed
+  this cycle).
+- **#2493**, **#2483**, **#2482** — Schur-Weyl L_i top-of-chain.
+- **#2436** — `human-oversight + replan`, framework decision.
+
+Replan-labelled (1, excluding human-oversight):
+- **#2612** — C-4c with partial PR #2706 merged. The next /replan
+  cycle should close this as **superseded** by #2708 (the remaining
+  sorry tracker). Could not be triaged this cycle: see Blockers.
+
+PR repair queue (2, will be picked up by repair-agent dispatch):
+- **PR #2694** γ.A — CONFLICTING.
+- **PR #2550** Wall 3 C.1.a.ii pigeonhole_pair — CONFLICTING (10 days).
+
+Issues with open PRs (1):
+- **#2543** / PR **#2550** — same as above.
+
+## Overall project progress
+
+Stage 3 formalisation. Sorry-count delta this cycle: **0** (planning
+cycle, no code changes). State at start = end:
+
+- `SchurModuleSimple.lean:148` — 1 sorry (`schurModuleSubmodule_isSimple_centralizer`).
+- Wall 1 (Ch6, 3 sorries): blocked on #2436 human-oversight, sixth
+  wave stale.
+- Wall 3 (Ch5 SpechtModuleBasis): 2 sorries — `garnir_twisted_in_lower_span`
+  (R2.c discharge target) + `twistedPolytabloid_pigeonhole_pair`
+  (PR #2550 target, in repair queue).
+- Theorem 2.1.2 (Ch2, 1 sorry): blocked on Wall 1.
+- Schur-Weyl L_i chain: only #2708 C-4a aggregation, plus the
+  already-tracked γ.A (#2694), γ.B (#2693), β.3 (#2684) sub-pieces.
+
+Critical paths:
+- **Wall 1**: unchanged — blocked on #2436.
+- **Wall 3**: R2.b (#2702) is queue head. R2.c (#2703) auto-unblocks
+  when R2.b lands.
+- **Schur-Weyl L_i**: β.3 (#2684) is queue head; landing it unblocks
+  γ.B (#2693); landing γ.A (PR #2694 in repair) + γ.B unblocks the
+  new #2708 (C-4a aggregation); landing #2708 unblocks the
+  top-of-chain #2493 → #2482 → #2483.
+
+## Next step
+
+**Workers** (priority order):
+1. **#2702** R2.b — Wall 3 combinatorial heart. The hardest open
+   feature; ~150–200 lines; may escalate to R3-bis meditate per
+   `progress/q-high-involution.md` §5.
+2. **#2684** β.3 — Schur-Weyl L_i critical path; unblocks γ.B (#2693)
+   and #2708 once landed.
+3. **#2705** review — audit β.2 + C-4a-ii (PR #2697 + #2698) merges.
+4. **#2401** — only if Wall 1 has actually unblocked; otherwise leave
+   it on the floor.
+
+**Repair**:
+- **PR #2694** (γ.A) and **PR #2550** (pigeonhole_pair) — both in the
+  repair queue.
+
+**Planner** (next cycle):
+- Once **β.3 #2684** lands: γ.B (#2693) auto-unblocks; consider whether
+  #2708 (C-4a aggregation) is now closer to unblocked.
+- Once **R2.b #2702** lands: R2.c (#2703) auto-unblocks.
+- Triage #2612 replan: the partial PR #2706 merged with a tracked
+  follow-up (#2708) for the remaining sorry; safe to close #2612 as
+  superseded by #2708.
+
+## Blockers
+
+### Harness bug: `coordination list-unclaimed` and `list-replan` return 0
+
+`coordination list-unclaimed`, `coordination queue-depth`, and
+`coordination list-replan` all return empty/0 in this worktree. Root
+cause: this worktree has local modifications to `.claude/commands/plan.md`
+(template divergence), which causes `pod _filter-trusted-issues` to
+emit a leading non-JSON warning line on stdout:
+
+```
+pod: 1 project-customised file(s) differ from pod template: commands/plan.md
+[...the JSON array...]
+```
+
+The python helper `_safe_json` falls back to `default=[]` when parsing
+fails on the prefix, so `_unclaimed_filter` sees an empty input. This
+means **POD_QUEUE_DEPTH=0 and the implied POD_QUEUE_DEFICIT=3 are not
+reflecting the real queue** (which contains 5 unclaimed unblocked
+issues, well above POD_MIN_QUEUE=3).
+
+The dispatcher will likely keep firing `/plan` on every cycle until the
+template divergence is resolved, because it sees the queue as empty.
+Two cleanups would each fix it:
+
+1. **Recommended**: have `_filter_trusted_issues` strip the leading
+   `pod: …` template-divergence warning from its captured stdout
+   before passing to `_safe_json`. The warning is logically stderr-only
+   diagnostics; it's bleeding into stdout because `pod`'s top-level
+   shim emits it unconditionally before any subcommand runs.
+
+2. **Workaround**: realign `.claude/commands/plan.md` with the pod
+   template (revert the local mod). I did NOT do this myself: agents
+   are forbidden from modifying `.claude/commands/plan.md` per
+   `.claude/CLAUDE.md` ("Agents must not modify the project's top-level
+   CLAUDE.md or roadmap file"), and `commands/plan.md` is in a similar
+   protected category — touching it would put the operator's local
+   edits at risk.
+
+The operator should pick one of these resolutions; in the meantime,
+this planner session relied on direct `gh issue list` filtering
+rather than the broken `coordination` queue helpers.
+
+### #2612 still has `replan` label
+
+The partial PR #2706 closed `schurModule_isSimple` modulo the now-tracked
+sorry (#2708). Either:
+- `/replan` should close #2612 as superseded by #2708, or
+- The `replan` label should be removed and #2612 left open as a
+  long-running "tracks the C-4c final state" pointer until #2708 closes.
+
+I could not triage this myself — the planner is instructed not to
+duplicate `/replan` work. The harness bug above (`list-replan` returning
+0) may also explain why `/replan` did not run before this `/plan`
+invocation.


### PR DESCRIPTION
This PR captures the planner-cycle progress note and plan body for the single new issue filed this cycle.

Filed:
- #2708 (`feature`, blocked on #2684 + #2693 + #2694) — Schur-Weyl L_i C-4a aggregation discharge. Closes the well-localised sorry at `SchurModuleSimple.lean:148` introduced by PR #2706. Glues sub-α + sub-β.{1,2,3} + sub-γ.{A,B} + C-4a-ii into a single `IsSimpleModule (↥(diagonalActionImage k V n)) (SchurModuleSubmodule k N λ)` discharge via `image_of_primitive_idempotent_isSimple_centralizer`.

Only one issue this cycle: the real-world queue has 5 unclaimed unblocked items (well above `POD_MIN_QUEUE=3`), so real deficit is 0. `POD_QUEUE_DEFICIT=3` is artifactual — the progress note diagnoses a `pod _filter-trusted-issues` stdout pollution bug that breaks the `coordination list-unclaimed` / `queue-depth` / `list-replan` helpers in this worktree (template divergence on `commands/plan.md` causes `pod:` warning to bleed into the JSON payload). Workaround in this cycle was to use direct `gh issue list` filtering; the operator should either teach `_filter_trusted_issues` to strip the leading warning, or realign the template.

Also notes (in the progress file) that #2612 remains `replan`-labelled with PR #2706 merged; next `/replan` cycle should close it as superseded by #2708.

🤖 Prepared with Claude Code