### PR TITLE
progress: planner cycle cd84b957 — 8th cycle, queue healthy (7 unblocked), harness bug persists

### DIFF
--- a/progress/20260517T052846Z_cd84b957.md
+++ b/progress/20260517T052846Z_cd84b957.md
@@ -1,0 +1,175 @@
+## Accomplished
+
+Planner cycle `cd84b957`. **No new work filed; real-world queue
+remains healthy (7 unclaimed unblocked items).** Eighth consecutive
+cycle with the same state. Harness bug from cycles `bab8e3ff`,
+`b21cabb0`, `cf33db8a`, `603f8386`, `30ac6478`, `ef84083b`, and
+`88b15ba5` continues to fire the dispatcher at
+`POD_QUEUE_DEFICIT=3` while the actual queue is well above
+`POD_MIN_QUEUE=3`.
+
+### Merged ready PRs
+
+None. Both open PRs are CONFLICTING and already on
+`coordination list-pr-repair`:
+- **PR #2694** Schur-Weyl L_i γ.A — CONFLICTING (CI green).
+- **PR #2550** Wall 3 C.1.a.ii pigeonhole_pair — CONFLICTING
+  (23+ days, CI green).
+
+### No new issues filed — rationale
+
+`POD_QUEUE_DEFICIT=3` (advisory, harness counter broken).
+`coordination list-unclaimed` and `coordination list-replan` both
+return empty due to the bug; `coordination list-pr-repair` works
+and correctly reports both broken PRs. Direct
+`gh issue list --label agent-plan --state open` confirms **7
+unclaimed unblocked work items**, unchanged from cycles `88b15ba5`,
+`ef84083b`, `30ac6478`, `603f8386`, `cf33db8a`, and `b21cabb0`:
+
+- #2702 Wall 3 R2.b — combinatorial heart, queue head.
+- #2684 Schur-Weyl L_i β.3 — Schur-Weyl critical path head.
+- #2710 review — audit C-4c transfer (PR #2706).
+- #2711 review — audit Wall 3 R2.a (PR #2707).
+- #2705 review — audit β.2 + C-4a-ii (PR #2697 + #2698).
+- #2564 Mathlib upstream tracker.
+- #2401 Theorem 2.1.2 bridges.
+
+That is well above `POD_MIN_QUEUE=3`. Per planner instructions
+*"If the deficit is 0 or negative, create no new issues and exit"*,
+the real deficit is negative.
+
+All recent merges already covered: PR #2697 + #2698 → #2705;
+PR #2706 → #2710; PR #2707 → #2711; `SchurModuleSimple.lean:148`
+sorry → #2708 (blocked). No new substantive feature PRs have
+merged since 2026-05-04 — all merges in the last 13 days are
+planner-cycle progress notes (#2704, #2709, #2712, #2713, #2714,
+#2715, #2716, #2717).
+
+### Summarize check
+
+Wave-58 (#2681) closed 2026-05-03. Since then **4** substantive
+PRs have merged (#2697 β.2, #2698 C-4a-ii, #2706 C-4c,
+#2707 R2.a). Below the 10+ threshold for filing wave-59
+summarize. Next planner cycle should re-check once 6 more
+feature PRs land.
+
+### Replan triage
+
+`#2612` still carries the `replan` label and should be closed
+as superseded by `#2708`. `coordination list-replan` returns
+empty due to the harness bug, presumably why `/replan` is not
+firing. Per planner instructions, replan triage belongs to
+`/replan` and `/plan` must not duplicate it — so this stays
+unhandled until either the harness bug is fixed or the operator
+intervenes.
+
+### Why I did NOT call `set-target`
+
+Active development continues (Wall 3 R2.b and Schur-Weyl β.3
+critical paths both have unclaimed queue heads). Per planner
+instructions, leave `set-target` alone outside the converged /
+tail cases.
+
+## Current frontier
+
+Unclaimed unblocked (7): unchanged from cycles `88b15ba5`,
+`ef84083b`, `30ac6478`, `603f8386`, `cf33db8a`, and `b21cabb0`.
+
+Claimed (0).
+
+Blocked (6 feature + 1 human-oversight):
+- #2703 R2.c — blocked on #2702.
+- #2693 γ.B — blocked on #2684.
+- #2708 C-4a aggregation — blocked on #2684, #2693, #2694.
+- #2493, #2483, #2482 — Schur-Weyl L_i top-of-chain.
+- #2436 — `human-oversight + replan`, framework decision.
+
+Replan-labelled (1 excluding human-oversight): #2612.
+
+PR repair queue (2): PR #2694 γ.A and PR #2550 pigeonhole_pair,
+both CONFLICTING.
+
+Issues with open PRs (1): #2543 / PR #2550.
+
+## Overall project progress
+
+Stage 3 formalisation. Sorry-count delta this cycle: **0**
+(planning cycle, no code changes). Inventory unchanged from
+cycles `bab8e3ff`, `b21cabb0`, `cf33db8a`, `603f8386`,
+`30ac6478`, `ef84083b`, and `88b15ba5`:
+
+- `SchurModuleSimple.lean:148` — 1 sorry (tracked by #2708).
+- Wall 1 (Ch6, 3 sorries) — blocked on #2436.
+- Wall 3 (Ch5 SpechtModuleBasis, 2 sorries) —
+  `garnir_twisted_in_lower_span` (R2.c target) +
+  `twistedPolytabloid_pigeonhole_pair` (PR #2550 in repair).
+- Theorem 2.1.2 (Ch2, 1 sorry) — blocked on Wall 1.
+
+Critical paths:
+- Wall 1: blocked on #2436.
+- Wall 3: R2.b (#2702) is queue head; landing it auto-unblocks
+  R2.c (#2703).
+- Schur-Weyl L_i: β.3 (#2684) is queue head; landing it unblocks
+  γ.B (#2693); landing γ.A (PR #2694, in repair) + γ.B unblocks
+  #2708 (C-4a aggregation); landing #2708 unblocks #2493 →
+  #2482 → #2483.
+
+## Next step
+
+**Workers** (priority order, unchanged):
+1. #2702 R2.b — Wall 3 combinatorial heart, hardest open feature
+   (~150–200 lines, may escalate per `q-high-involution.md` §5).
+2. #2684 β.3 — Schur-Weyl L_i critical path; unblocks #2693 and
+   feeds #2708.
+3. #2710 / #2711 / #2705 reviews — mechanical audits of the
+   recent Schur-Weyl + Wall 3 merges (~30–60 min each).
+4. #2401 — only if Wall 1 has actually unblocked.
+
+**Repair**:
+- PR #2694 (γ.A) CONFLICTING.
+- PR #2550 (pigeonhole_pair) CONFLICTING (23+ days; abandonment
+  candidate if next repair attempt also fails).
+
+**Planner** (next cycle):
+- Wait for either a review issue or a feature issue to land.
+  If #2702 lands, file the next Wall 3 follow-up (sorry-closure
+  audit for R2.c-ready state). If #2684 lands, file the audit
+  issue for the β.3 merge.
+- If feature merges accumulate, file wave-59 summarize once 10+
+  PRs land since #2681.
+
+**Operator action requested** (eighth cycle in a row):
+- `coordination list-unclaimed` / `queue-depth` / `list-replan`
+  harness bug. Source: this worktree's `.claude/commands/plan.md`
+  diverges from the pod template (84 insertions / 62 deletions),
+  causing `pod _filter-trusted-issues` to emit a leading
+  non-JSON warning that breaks `_safe_json` parsing. The
+  dispatcher reads `POD_QUEUE_DEPTH=0` and fires `/plan` every
+  cycle even though the real queue has 7 unblocked items.
+  Two fixes documented in cycle `bab8e3ff`'s progress note:
+  (a) patch `_filter-trusted-issues` to strip the warning from
+  stdout, or (b) realign `.claude/commands/plan.md` with the
+  upstream template. Agents will not fix this themselves:
+  `commands/plan.md` carries the operator's local customisations
+  and reverting them autonomously could destroy intentional work.
+
+## Blockers
+
+### Harness bug: `coordination` queue helpers return 0
+
+Unchanged for eight consecutive cycles. See "Operator action
+requested" above. This planner cycle again relied on direct
+`gh issue list --label …` filtering rather than the broken
+`coordination` queue helpers. Verified again this cycle:
+`coordination list-pr-repair` works (returns both broken PRs)
+but `coordination list-unclaimed` returns empty,
+`coordination list-replan` returns empty, and
+`coordination queue-depth` returns 0 despite a real queue of
+7+ items and #2612 carrying the `replan` label.
+
+### #2612 still has `replan` label
+
+Unchanged for eight consecutive cycles. `/replan` should close
+it as superseded by #2708 but is not firing, likely because of
+the harness bug above. Planner cannot triage replan-labelled
+issues per the `/plan` command instructions.


### PR DESCRIPTION
This PR records the planner cycle cd84b957 progress note. Eighth
consecutive cycle reporting the same state:

- Real queue has 7 unclaimed unblocked items (well above
  `POD_MIN_QUEUE=3`)
- `POD_QUEUE_DEFICIT=3` advisory is wrong due to harness bug in
  `pod _filter-trusted-issues`
- 2 broken PRs (#2694, #2550) on `coordination list-pr-repair`
- #2612 still carries `replan` label, `/replan` not firing
- No substantive merges in 13 days (only planner-cycle progress
  notes)

No new issues filed per planner instructions ("If deficit is 0 or
negative, create no new issues and exit"). Operator action
requested to fix the harness bug — eighth cycle in a row.

🤖 Prepared with Claude Code