### PR TITLE
progress: worker d361fdf5 — decompose #2401 forward bridge into #2773 + #2774

### DIFF
--- a/progress/2026-05-17T08-37-31Z_d361fdf5.md
+++ b/progress/2026-05-17T08-37-31Z_d361fdf5.md
@@ -1,0 +1,29 @@
+## Accomplished
+
+Session `d361fdf5` claimed worker issue **#2401** (Theorem2_1_2 forward bridge), assessed scope, and decomposed it.
+
+After tracing the forward-bridge sorry at `Chapter2/Theorem2_1_2.lean:173` (`not_posdef_not_HasFiniteRepresentationType`), the gap is the same one already documented in closed issue #2255: every existing infinite-type theorem in `Chapter6/InfiniteTypeConstructions.lean` is wrapped as `¬ IsFiniteTypeQuiver n adj`, which is `∃ k₀ Q₀ infinite indec` (existential), but the bridge needs **∀ k ∀ Q** infinite indec for the given k and Q. PR #2328 already attempted this and only landed the cycle case as field-generic (still existential over orientation Q). The remaining work is ~800-1200 LOC across 6 ℂ-specific base cases plus per-(k,Q) subgraph transfer plus bridge wiring — clearly multi-session.
+
+Decomposition filed:
+- **#2773** `feat(Ch6): per-(field, orientation) infinite-type for forbidden subgraphs` — bundles the 6 base cases (cycle, K_{1,4}, D̃₅, Ẽ₆, Ẽ₇, T(1,2,5)) refactored to per-(F, Q) form. Mutually independent; the issue body invites a worker to further decompose into 6 sub-issues if needed.
+- **#2774** `feat(Ch2): per-(k,Q) subgraph transfer + assembly into not_posdef_not_HasFiniteRepresentationType bridge` — covers the per-(k,Q) restriction of `subgraph_infinite_type_transfer`, the per-(k,Q) case-analysis assembly of `not_posdef_infinite_type`, and the wiring into `not_posdef_not_HasFiniteRepresentationType` (closes #2401). `depends-on: #2773` (auto-detected, `blocked` label applied).
+
+Parent #2401 marked `replan` via `coordination skip` with `Decomposed into #2773, #2774` breadcrumb.
+
+## Current frontier
+
+- **Forward bridge of Theorem 2.1.2** (Gabriel's theorem): blocked on the per-(field, orientation) refactor of Chapter 6's six forbidden-subgraph infinite-type theorems.
+- **Backward bridge** (`isDynkinDiagram_HasFiniteRepresentationType`): already proved in PR #2403, no remaining work.
+
+## Overall project progress
+
+Forward-direction sorry count in `Theorem2_1_2.lean` unchanged (still 1 sorry at line 173). No code changes this session — pure planning/decomposition. The decomposition unblocks 7+ sessions of parallelizable per-base-case work in Chapter 6 (worker may further decompose #2773 by case).
+
+## Next step
+
+A planner cycle should close #2401 (the breadcrumb satisfies the `Decomposed into #X, #Y` replan-triage pattern). A worker can then claim #2773; the 6 base cases inside are mutually independent and can be tackled either as a bundle or as 6 sub-issues. #2774 unblocks once #2773 closes.
+
+## Blockers
+
+- #2773 is large enough (~600-800 LOC, 6 sub-tasks) that the first worker to claim it may itself decide to decompose into 6 per-case sub-issues. The issue body explicitly invites this.
+- The per-(F, Q) generalisation requires deep linear-algebra work (per-base-case indecomposability proofs over arbitrary fields and arbitrary orientations). `compl_le_forces_eq` and `nilpotent_invariant_compl_trivial_gen` in `FieldGenericInfiniteType.lean` are the orientation-invariance / kernel-condition primitives a worker should lean on.


### PR DESCRIPTION
This PR records the decomposition of the Theorem 2.1.2 forward bridge issue (#2401) into two sub-issues per the parent's explicit decomposition fallback.

Worker session \`d361fdf5\` claimed #2401, traced the forward-bridge sorry at \`Chapter2/Theorem2_1_2.lean:173\` (\`not_posdef_not_HasFiniteRepresentationType\`), and confirmed the gap is exactly what closed issue #2255 documented and PR #2328 partially addressed: every infinite-type theorem in \`Chapter6/InfiniteTypeConstructions.lean\` is wrapped as \`¬ IsFiniteTypeQuiver n adj\`, which is existential over (k, Q), but the bridge needs the universal form for the given k and Q. PR #2328 confirmed the cycle base case alone took ~324 LOC. Estimated remaining work: ~800-1200 LOC across 6 ℂ-specific base cases plus per-(k,Q) subgraph transfer plus bridge wiring — clearly multi-session.

Decomposition:

- #2773 \`feat(Ch6): per-(field, orientation) infinite-type for forbidden subgraphs\` — bundles 6 base cases (cycle, K_{1,4}, D̃₅, Ẽ₆, Ẽ₇, T(1,2,5)) refactored to per-(F, Q) form. Mutually independent; invites further per-case decomposition by the first worker if needed.
- #2774 \`feat(Ch2): per-(k,Q) subgraph transfer + assembly into not_posdef_not_HasFiniteRepresentationType bridge\` — covers per-(k,Q) restriction of \`subgraph_infinite_type_transfer\`, per-(k,Q) case-analysis assembly of \`not_posdef_infinite_type\`, and the bridge wiring (closes #2401). \`depends-on: #2773\`.

Parent #2401 was \`coordination skip\`'d with a \`Decomposed into #2773, #2774\` breadcrumb for the next planner's replan-triage cycle.

No Lean code changes; sorry-count delta is 0.

🤖 Prepared with Claude Code