### PR TITLE
feat(Ch5): lint cleanup in β.2 Specht bridge section (Theorem5_22_1.lean lines 879-1075)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
@@ -880,12 +880,6 @@ section SpechtBridge
 
 variable {N n : ℕ}
 
--- The `IsScalarTower ℂ ↥(symGroupImage) V^⊗n` instance is needed for several
--- definitions in this section; its synthesis traverses a deep
--- `Subalgebra → Subsemiring → Module` chain that exceeds the default 20000
--- heartbeats.
-set_option synthInstance.maxHeartbeats 800000
-
 /-- Codomain-restricted version of `symGroupAlgHom`, landing in `symGroupImage`.
 This is a surjection `ℂ[S_n] →ₐ[ℂ] symGroupImage`. -/
 private noncomputable def symGroupAlgHomToImage :
@@ -912,11 +906,15 @@ private theorem symGroupAlgHomToImage_of (σ : Equiv.Perm (Fin n)) :
       ⟨(symGroupAction ℂ (Fin N → ℂ) n σ).toLinearMap,
         Algebra.subset_adjoin ⟨σ, rfl⟩⟩ := by
   apply Subtype.ext
-  show (symGroupAlgHom ℂ (Fin N → ℂ) n) (MonoidAlgebra.of ℂ _ σ) = _
+  change (symGroupAlgHom ℂ (Fin N → ℂ) n) (MonoidAlgebra.of ℂ _ σ) = _
   unfold symGroupAlgHom
   rw [MonoidAlgebra.lift_of]
   rfl
 
+set_option synthInstance.maxHeartbeats 200000 in
+-- `Module.compHom` synthesises a `Module (symGroupImage) ↥(S.restrictScalars ℂ)`
+-- instance, traversing a deep `Subalgebra → Subsemiring → Module` chain that
+-- exceeds the default 20000 heartbeats.
 /-- The `SymGroupAlgebra n`-module structure on `↥(S.restrictScalars ℂ)`
 induced from the `symGroupImage`-module structure on `↥S` via
 `symGroupAlgHomToImage`. -/
@@ -926,6 +924,10 @@ private noncomputable def submoduleAsSymGroupAlgebraModule
     Module (SymGroupAlgebra n) ↥(S.restrictScalars ℂ) :=
   Module.compHom _ (symGroupAlgHomToImage (N := N) (n := n)).toRingHom
 
+set_option synthInstance.maxHeartbeats 200000 in
+-- The `letI := submoduleAsSymGroupAlgebraModule S` in the type forces
+-- elaboration of the `Module (SymGroupAlgebra n) ↥(S.restrictScalars ℂ)`
+-- instance, traversing the `Subalgebra → Subsemiring → Module` chain.
 /-- The smul of `submoduleAsSymGroupAlgebraModule` agrees with applying
 `symGroupAlgHomToImage(a)` (an element of `↥(symGroupImage)`) to the carrier. -/
 private theorem submoduleAsSymGroupAlgebraModule_smul_def
@@ -935,6 +937,10 @@ private theorem submoduleAsSymGroupAlgebraModule_smul_def
     letI := submoduleAsSymGroupAlgebraModule S
     (a • v).val = (symGroupAlgHom ℂ (Fin N → ℂ) n) a v.val := rfl
 
+set_option synthInstance.maxHeartbeats 200000 in
+-- The `IsScalarTower ℂ ↥(symGroupImage) V^⊗n` instance is needed to
+-- elaborate the scalar-tower hypothesis; its synthesis traverses the same
+-- deep `Subalgebra → Subsemiring → Module` chain.
 /-- Scalar tower: `(c • a) • v = c • (a • v)` for `c : ℂ`,
 `a : SymGroupAlgebra n`, `v : ↥(S.restrictScalars ℂ)`. -/
 private theorem submoduleAsSymGroupAlgebra_isScalarTower
@@ -948,6 +954,10 @@ private theorem submoduleAsSymGroupAlgebra_isScalarTower
   rw [submoduleAsSymGroupAlgebraModule_smul_def, map_smul]
   rfl
 
+set_option synthInstance.maxHeartbeats 200000 in
+-- Constructing a semilinear map between the two carriers requires elaborating
+-- both `Module` instances on `↥(S.restrictScalars ℂ)` (over ℂ and over
+-- `SymGroupAlgebra n`), each via the same deep instance chain.
 /-- The identity-on-carrier `↥(S.restrictScalars ℂ) → ↥S`, semilinear over the
 surjective ring hom `symGroupAlgHomToImage`. -/
 private noncomputable def submoduleSemilinearId
@@ -960,6 +970,8 @@ private noncomputable def submoduleSemilinearId
     map_add' := fun _ _ => rfl
     map_smul' := fun _ _ => rfl }
 
+set_option synthInstance.maxHeartbeats 200000 in
+-- Same instance chain as `submoduleSemilinearId`.
 private theorem submoduleSemilinearId_bijective
     (S : Submodule (symGroupImage ℂ (Fin N → ℂ) n)
       (TensorPower ℂ (Fin N → ℂ) n)) :
@@ -972,6 +984,11 @@ private theorem submoduleSemilinearId_bijective
     exact Subtype.ext_iff.mp h
   · rintro ⟨w, hw⟩; exact ⟨⟨w, hw⟩, rfl⟩
 
+set_option synthInstance.maxHeartbeats 200000 in
+-- The `RingHomSurjective` instance for `symGroupAlgHomToImage.toRingHom` and
+-- the bijective-semilinear-map transfer both invoke `Module` instance
+-- synthesis on the `S.restrictScalars ℂ` carrier, traversing the deep
+-- `Subalgebra → Subsemiring → Module` chain.
 /-- Simplicity of `↥S` as a `↥(symGroupImage)`-module transfers to simplicity
 of `↥(S.restrictScalars ℂ)` as a `SymGroupAlgebra n`-module. -/
 private theorem submoduleAsSymGroupAlgebra_isSimpleModule
@@ -997,9 +1014,10 @@ private theorem spechtModule_smul_of
   apply Subtype.ext
   rfl
 
+set_option maxHeartbeats 400000 in
 -- Bumped: the Specht-bridge construction unfolds Module.compHom, traverses a
 -- `Subalgebra → Subsemiring → Module` chain, and applies trace conjugation.
-set_option maxHeartbeats 1600000 in
+set_option synthInstance.maxHeartbeats 200000 in
 /-- **Specht bridge** (β.2). Every simple `symGroupImage`-submodule `S ≤ V^⊗n`
 admits a partition `la'` such that the trace of every `σ`-permutation operator
 restricted to `S` equals `spechtModuleCharacter n la' σ`.
@@ -1043,7 +1061,7 @@ theorem trace_symGroupAction_eq_spechtModuleCharacter
     have h_lhs : (MonoidAlgebra.of ℂ _ σ : SymGroupAlgebra n) • v =
         restrictedAction v := by
       apply Subtype.ext
-      show (symGroupAlgHom ℂ (Fin N → ℂ) n) (MonoidAlgebra.of ℂ _ σ) v.val =
+      change (symGroupAlgHom ℂ (Fin N → ℂ) n) (MonoidAlgebra.of ℂ _ σ) v.val =
         (symGroupAction ℂ (Fin N → ℂ) n σ).toLinearMap v.val
       unfold symGroupAlgHom
       rw [MonoidAlgebra.lift_of]
@@ -1056,7 +1074,7 @@ theorem trace_symGroupAction_eq_spechtModuleCharacter
       (spechtModuleAction n la' σ) ∘ₗ eℂ.toLinearMap := by
     apply LinearMap.ext
     intro v
-    show restrictedAction v = eℂ.symm (spechtModuleAction n la' σ (eℂ v))
+    change restrictedAction v = eℂ.symm (spechtModuleAction n la' σ (eℂ v))
     rw [← h_intertwine v, eℂ.symm_apply_apply]
   rw [h_eq]
   -- Trace conjugation: tr(eℂ.symm ∘ T ∘ eℂ) = tr(T) for ℂ-linear T.

--- a/progress/20260517T093421Z_c17a305a.md
+++ b/progress/20260517T093421Z_c17a305a.md
@@ -1,0 +1,59 @@
+# Feature session — issue #2780 (β.2 Specht bridge lint cleanup)
+
+Session: `c17a305a-009f-4128-ae2c-41adfc7545a8` · Branch: `agent/c17a305a`
+
+## Accomplished
+
+Closed the four janitorial issues in the β.2 Specht-bridge section of
+`EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean`:
+
+1. **Scoped the section-level `synthInstance.maxHeartbeats` bump.** Replaced
+   the unscoped `set_option synthInstance.maxHeartbeats 800000` (former
+   line 887) with per-declaration `set_option synthInstance.maxHeartbeats
+   200000 in` on the seven declarations that need it:
+   `submoduleAsSymGroupAlgebraModule`,
+   `submoduleAsSymGroupAlgebraModule_smul_def`,
+   `submoduleAsSymGroupAlgebra_isScalarTower`,
+   `submoduleSemilinearId`,
+   `submoduleSemilinearId_bijective`,
+   `submoduleAsSymGroupAlgebra_isSimpleModule`,
+   `trace_symGroupAction_eq_spechtModuleCharacter`. The issue listed four
+   declarations; three more (`*_smul_def`, `submoduleSemilinearId`, and
+   its `_bijective` companion) also need the bump — discovered by build
+   failure on `IsScalarTower ℂ ↥(symGroupImage) V^⊗n` synthesis. Each
+   per-declaration bump carries its own one-line explanatory comment.
+2. **Moved the bridge-theorem heartbeat-bump comment** between
+   `set_option maxHeartbeats 400000 in` and the following
+   `set_option synthInstance.maxHeartbeats 200000 in` (linter wants the
+   comment immediately after the `maxHeartbeats` bump).
+3. **Replaced three `show → change`** at the three flagged sites in
+   `symGroupAlgHomToImage_of` and the bridge theorem's
+   `h_intertwine`/`h_eq` sub-proofs.
+4. **Tightened heartbeat bumps** to `maxHeartbeats 400000` /
+   `synthInstance.maxHeartbeats 200000` (down from `1600000` / `800000`),
+   matching the audit's recommended values.
+
+## Verification
+
+`lake build EtingofRepresentationTheory.Chapter5.Theorem5_22_1` passes.
+Per-file warning count for `Theorem5_22_1.lean` drops 62 → 57 (no new
+warnings introduced). The five cleared warnings are exactly the four
+deliverables (the third deliverable covered three `show`-tactic sites).
+
+## Current frontier
+
+Issue #2780 deliverables complete; no residual scope.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. This is a hygiene PR — no new
+mathematical content, no sorry-count change.
+
+## Next step
+
+Merge PR and let the audit-tracker close out the #2705 cleanup
+backlog item.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2780

Session: `c17a305a-009f-4128-ae2c-41adfc7545a8`

347cca6 style(Ch5 #2780): lint cleanup in β.2 Specht bridge section

🤖 Prepared with Claude Code