### PR TITLE
Schur-Weyl L_i (β.3): off-block vanishing assembly from β.1 + β.2 + character orthogonality

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
@@ -2082,6 +2082,160 @@ private theorem youngSym_trace_kronecker' (n : ℕ) (la la' : Nat.Partition n)
   · subst h; exact trace_mulLeft_youngSym_eq' n la (α : ℂ) hα_ne hα_ℂ
   · rw [mulLeft_youngSym_zero_of_ne' n la la' h, map_zero]
 
+/-! #### β.3 Off-block vanishing: `youngSymEndomorphism` vanishes on simple
+`symGroupImage`-submodules whose Specht-module label differs from
+`weightToPartition N lam`
+
+Assembles β.1 (`trace_youngSymEndomorphism_restrict_eq_sum`), β.2
+(`trace_symGroupAction_eq_spechtModuleCharacter`), the character-orthogonality
+identity (`youngSym_trace_kronecker'`), and the idempotent-up-to-scalar
+identity (`youngSymEndomorphism_restrict_sq_scalar`).
+
+The "trace-zero idempotent ⟹ zero" step is encapsulated as a small
+characteristic-zero linear-algebra lemma (`isIdempotentElem_eq_zero_of_trace_eq_zero`).
+-/
+
+/-- An idempotent endomorphism of a finite-dimensional vector space over a
+characteristic-zero field with vanishing trace is the zero map.
+
+The trace of an idempotent equals the cast of the rank of its range
+(`LinearMap.IsProj.trace`). Over a characteristic-zero field, vanishing trace
+forces the rank to be zero, hence the range is `⊥` and the endomorphism
+vanishes. -/
+private theorem isIdempotentElem_eq_zero_of_trace_eq_zero
+    {K : Type*} [Field K] [CharZero K]
+    {V : Type*} [AddCommGroup V] [Module K V] [Module.Finite K V]
+    {e : V →ₗ[K] V} (he : IsIdempotentElem e)
+    (htr : LinearMap.trace K V e = 0) :
+    e = 0 := by
+  have hproj : LinearMap.IsProj (LinearMap.range e) e :=
+    LinearMap.IsIdempotentElem.isProj_range _ he
+  have htr_eq : LinearMap.trace K V e = (Module.finrank K (LinearMap.range e) : K) :=
+    hproj.trace
+  rw [htr] at htr_eq
+  have hfinrank_zero : Module.finrank K (LinearMap.range e) = 0 := by
+    have h : ((Module.finrank K (LinearMap.range e) : ℕ) : K) = 0 := htr_eq.symm
+    exact_mod_cast h
+  rw [← LinearMap.range_eq_bot, ← Submodule.finrank_eq_zero]
+  exact hfinrank_zero
+
+/-- `YoungSymmetrizerK ℂ n la = YoungSymmetrizer n la`: both are the image of
+the universal ℤ Young symmetrizer under base change `ℤ → ℂ`. -/
+private lemma youngSymmetrizerK_complex_eq (n : ℕ) (la : Nat.Partition n) :
+    YoungSymmetrizerK ℂ n la = YoungSymmetrizer n la := by
+  rw [YoungSymmetrizerK_eq_mapRange ℂ n la, YoungSymmetrizer_eq_mapRange n la]
+
+set_option maxHeartbeats 800000 in
+-- Bumped: applying β.1 (`trace_youngSymEndomorphism_restrict_eq_sum`) and
+-- β.2 (`trace_symGroupAction_eq_spechtModuleCharacter`) traverses the deep
+-- `Subalgebra → Subsemiring → Module → IsScalarTower` synthesis chain for
+-- `S.restrictScalars ℂ`, which exceeds the default 20000 heartbeats.
+set_option synthInstance.maxHeartbeats 800000 in
+/-- **β.3 Off-block vanishing.** When the simple `symGroupImage`-submodule
+`S ≤ V^⊗n` has Specht-module label `la' ≠ weightToPartition N lam`, the Young
+symmetrizer endomorphism `c_λ` vanishes when restricted to `S`.
+
+The proof assembles four pieces:
+* β.1 (`trace_youngSymEndomorphism_restrict_eq_sum`): the trace of `c_λ` on
+  `S` equals `∑_σ c_λ(σ) · tr(σ on S)`.
+* β.2 (`trace_symGroupAction_eq_spechtModuleCharacter`, encoded via the
+  `h_label` hypothesis): `tr(σ on S) = spechtModuleCharacter n la' σ`.
+* `youngSym_trace_kronecker'` (character orthogonality): when `la ≠ la'`
+  the orthogonality sum vanishes, so the trace of `c_λ` on `S` is zero.
+* `youngSymEndomorphism_restrict_sq_scalar`: the restriction of `c_λ`
+  satisfies `f² = α · f` for the same scalar `α ≠ 0`. Normalising by
+  `α⁻¹` produces an idempotent of vanishing trace; over a characteristic-zero
+  field such an idempotent is the zero map.
+
+The `h_label` hypothesis encodes β.2's witness for this particular `S`; the
+typical caller obtains it by destructuring the existential in
+`trace_symGroupAction_eq_spechtModuleCharacter`. -/
+theorem youngSym_action_vanishes_off_block
+    (N : ℕ) (lam : Fin N → ℕ)
+    (S : Submodule (symGroupImage ℂ (Fin N → ℂ) (∑ i, lam i))
+      (TensorPower ℂ (Fin N → ℂ) (∑ i, lam i)))
+    [Module.Finite ℂ ↥(S.restrictScalars ℂ)]
+    (la' : Nat.Partition (∑ i, lam i))
+    (h_label : ∀ σ : Equiv.Perm (Fin (∑ i, lam i)),
+        LinearMap.trace ℂ ↥(S.restrictScalars ℂ)
+            ((symGroupAction ℂ (Fin N → ℂ) (∑ i, lam i) σ).toLinearMap.restrict
+              (p := S.restrictScalars ℂ) (q := S.restrictScalars ℂ)
+              (fun _ hv =>
+                symGroupAction_mem_of_symGroupImage_submodule S σ hv)) =
+          spechtModuleCharacter (∑ i, lam i) la' σ)
+    (h_ne : la' ≠ weightToPartition N lam) :
+    (youngSymEndomorphism ℂ N lam).restrict
+        (p := S.restrictScalars ℂ) (q := S.restrictScalars ℂ)
+        (fun _ hv =>
+          youngSymEndomorphism_mem_of_symGroupImage_submodule lam S hv) = 0 := by
+  -- Abbreviation: `f` is the restriction of `c_λ` to `S`.
+  let f : ↥(S.restrictScalars ℂ) →ₗ[ℂ] ↥(S.restrictScalars ℂ) :=
+    (youngSymEndomorphism ℂ N lam).restrict
+      (p := S.restrictScalars ℂ) (q := S.restrictScalars ℂ)
+      (fun _ hv =>
+        youngSymEndomorphism_mem_of_symGroupImage_submodule lam S hv)
+  change f = 0
+  -- Scalar α (≠ 0) from `c_λ² = α · c_λ` over ℚ, transferred to ℂ.
+  obtain ⟨α, hα_sq⟩ :=
+    YoungSymmetrizerK_sq_scalar ℚ (∑ i, lam i) (weightToPartition N lam)
+  have hα_ne : α ≠ 0 :=
+    YoungSymmetrizerK_sq_scalar_ne_zero _ (weightToPartition N lam) α hα_sq
+  have hα_ℂ_ne : (α : ℂ) ≠ 0 := by exact_mod_cast hα_ne
+  have hα_sq_ℂ :
+      YoungSymmetrizerK ℂ (∑ i, lam i) (weightToPartition N lam) *
+        YoungSymmetrizerK ℂ (∑ i, lam i) (weightToPartition N lam) =
+      (α : ℂ) • YoungSymmetrizerK ℂ (∑ i, lam i) (weightToPartition N lam) := by
+    rw [youngSymmetrizerK_complex_eq]
+    exact youngSym_sq_ℂ' _ _ α hα_sq
+  -- β.1: trace of `f` is the weighted sum over σ of traces of σ on S.
+  have h_trace_f : LinearMap.trace ℂ _ f =
+      ∑ σ : Equiv.Perm (Fin (∑ i, lam i)),
+        (YoungSymmetrizerK ℂ (∑ i, lam i) (weightToPartition N lam) σ) *
+        LinearMap.trace ℂ _
+          ((symGroupAction ℂ (Fin N → ℂ) (∑ i, lam i) σ).toLinearMap.restrict
+            (p := S.restrictScalars ℂ) (q := S.restrictScalars ℂ)
+            (fun _ hv => symGroupAction_mem_of_symGroupImage_submodule S σ hv)) :=
+    trace_youngSymEndomorphism_restrict_eq_sum N lam S
+  -- β.2 (via `h_label`): substitute the Specht character.
+  have h_trace_eq_sum : LinearMap.trace ℂ _ f =
+      ∑ σ : Equiv.Perm (Fin (∑ i, lam i)),
+        (YoungSymmetrizerK ℂ (∑ i, lam i) (weightToPartition N lam) σ) *
+          spechtModuleCharacter (∑ i, lam i) la' σ := by
+    rw [h_trace_f]
+    exact Finset.sum_congr rfl fun σ _ => by rw [h_label σ]
+  -- Character orthogonality: the trace is 0 because `weightToPartition N lam ≠ la'`.
+  have h_trace_zero : LinearMap.trace ℂ _ f = 0 := by
+    have h_coef_cast : ∀ σ : Equiv.Perm (Fin (∑ i, lam i)),
+        (YoungSymmetrizerK ℂ (∑ i, lam i) (weightToPartition N lam) σ : ℂ) =
+          ((YoungSymmetrizerK ℚ (∑ i, lam i) (weightToPartition N lam) σ : ℚ) : ℂ) := by
+      intro σ
+      rw [youngSym_coeff_cast', ← youngSymmetrizerK_complex_eq]
+    rw [h_trace_eq_sum]
+    conv_lhs => arg 2; ext σ; rw [h_coef_cast σ]
+    rw [youngSym_trace_kronecker' _ (weightToPartition N lam) la' α hα_sq,
+        if_neg (fun h => h_ne h.symm)]
+  -- f² = α • f.
+  have hf_sq : f * f = (α : ℂ) • f :=
+    youngSymEndomorphism_restrict_sq_scalar N lam S (α : ℂ) hα_sq_ℂ
+  -- g := α⁻¹ • f is an idempotent endomorphism of `S`.
+  let g : ↥(S.restrictScalars ℂ) →ₗ[ℂ] ↥(S.restrictScalars ℂ) := (α : ℂ)⁻¹ • f
+  have hg_idem : IsIdempotentElem g := by
+    change ((α : ℂ)⁻¹ • f) * ((α : ℂ)⁻¹ • f) = (α : ℂ)⁻¹ • f
+    rw [smul_mul_smul_comm, hf_sq, smul_smul]
+    congr 1
+    rw [mul_assoc, inv_mul_cancel₀ hα_ℂ_ne, mul_one]
+  -- Trace of g vanishes.
+  have hg_tr_zero : LinearMap.trace ℂ _ g = 0 := by
+    change LinearMap.trace ℂ _ ((α : ℂ)⁻¹ • f) = 0
+    rw [LinearMap.map_smul, h_trace_zero, smul_zero]
+  -- A trace-zero idempotent over a characteristic-zero field is the zero map.
+  have hg_zero : g = 0 := isIdempotentElem_eq_zero_of_trace_eq_zero hg_idem hg_tr_zero
+  -- Therefore f = α • g = 0.
+  have hf_eq_smul_g : f = (α : ℂ) • g := by
+    change f = (α : ℂ) • ((α : ℂ)⁻¹ • f)
+    rw [smul_smul, mul_inv_cancel₀ hα_ℂ_ne, one_smul]
+  rw [hf_eq_smul_g, hg_zero, smul_zero]
+
 /-! #### Bridge: charValue ↔ spechtModuleCharacter
 
 The Frobenius character formula (Theorem 5.15.1) connects the polynomial

--- a/progress/20260517T102026Z_da0a10c6.md
+++ b/progress/20260517T102026Z_da0a10c6.md
@@ -1,0 +1,84 @@
+## Accomplished
+
+Implemented β.3 of the Schur-Weyl L_i C-4a-i sub-β chain (#2684):
+off-block vanishing of the Young symmetrizer action on simple
+`symGroupImage`-submodules whose Specht-module label differs from
+`weightToPartition N lam`.
+
+Added to `EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean`
+(154 insertions, 0 deletions):
+
+1. **`isIdempotentElem_eq_zero_of_trace_eq_zero`** — a small
+   characteristic-zero linear-algebra lemma: an idempotent endomorphism of
+   a finite-dimensional vector space over a `CharZero` field with vanishing
+   trace is the zero map. Proof uses `LinearMap.IsIdempotentElem.isProj_range`
+   to obtain an `IsProj` witness, then `IsProj.trace` to read off
+   `tr(e) = (finrank(range e) : K)`. Combined with `CharZero` and
+   `Submodule.finrank_eq_zero`, the range collapses to `⊥` and
+   `LinearMap.range_eq_bot` gives `e = 0`.
+
+2. **`youngSymmetrizerK_complex_eq`** — bridges `YoungSymmetrizerK ℂ` and
+   `YoungSymmetrizer` (both are the image of `YoungSymmetrizerZ` under base
+   change ℤ → ℂ).
+
+3. **`youngSym_action_vanishes_off_block`** — the main β.3 deliverable.
+   Combines:
+   * β.1 (`trace_youngSymEndomorphism_restrict_eq_sum`): the trace of `c_λ`
+     on `S` equals the weighted sum `∑_σ c_λ(σ) · tr(σ on S)`.
+   * β.2 (encoded via the `h_label` hypothesis from
+     `trace_symGroupAction_eq_spechtModuleCharacter`):
+     `tr(σ on S) = spechtModuleCharacter n la' σ`.
+   * `youngSym_trace_kronecker'` (character orthogonality): when
+     `weightToPartition N lam ≠ la'`, the orthogonality sum vanishes.
+   * `youngSymEndomorphism_restrict_sq_scalar`: the restricted endomorphism
+     satisfies `f² = (α : ℂ) • f`. Normalising by `α⁻¹` produces an
+     idempotent `g`; combined with `tr(f) = 0`, the helper lemma gives
+     `g = 0`, hence `f = α • g = 0`.
+
+Build: `lake build EtingofRepresentationTheory.Chapter5.Theorem5_22_1`
+passes (8050 jobs); zero sorries; no new warnings inside the added section.
+
+Heartbeat bumps: `maxHeartbeats 800000` and `synthInstance.maxHeartbeats 800000`
+on the main theorem (the β.1 application traverses the same deep
+`Subalgebra → Subsemiring → Module → IsScalarTower` synthesis chain as the
+β.1 / β.2 statements themselves).
+
+## Current frontier
+
+#2684 is fully implemented locally; full repository `lake build` running
+to verify no downstream regressions.
+
+The interface accepts a partition `la'` and the β.2 trace identity for that
+`la'` as a hypothesis (`h_label`); the typical caller destructures the
+existential from `trace_symGroupAction_eq_spechtModuleCharacter`. This
+matches the issue's suggested shape ("the exact shape depends on β.2's
+interface — likely the `la'` argument is replaced by an `∃ la', ...` or by
+a direct hypothesis"). The `h_label` form is the cleanest contract: it
+exposes only what's needed to instantiate `youngSym_trace_kronecker'`.
+
+## Overall project progress
+
+Stage 3 formalisation. Sorry-count delta this turn: **0** (the project
+already had zero sorries in `Theorem5_22_1.lean`; #2684 added new theorems
+without introducing any).
+
+Schur-Weyl L_i C-4a-i sub-β chain now has all three pieces:
+* β.1 `trace_youngSymEndomorphism_restrict_eq_sum` (closed via #2655 deps).
+* β.2 `trace_symGroupAction_eq_spechtModuleCharacter` (#2683, closed).
+* β.3 `youngSym_action_vanishes_off_block` (this PR).
+
+This unblocks #2693 (sub-γ rank-1 on the special block) and feeds #2708
+(C-4a-ii abstract idempotent simplicity).
+
+## Next step
+
+Once the PR merges:
+* #2693 (sub-γ): the rank-1-on-special-block analysis can claim. The
+  combination of β.3 (off-block vanishing) and sub-γ (rank-1 on the
+  matching block) gives the Schur-Weyl `L_i` simplicity statement at the
+  level of `youngSymEndomorphism` applied to `S`.
+* #2708 (C-4a-ii): downstream consumer of the C-4a-i decomposition.
+
+## Blockers
+
+None. All deps closed; PR ready.


### PR DESCRIPTION
Closes #2684

Session: `da0a10c6-a254-408c-90f7-2780398ad6e1`

65322ce feat(Ch5 #2684): β.3 off-block vanishing of Young symmetrizer action

🤖 Prepared with Claude Code