### PR TITLE
chore(Ch6): rename cycleRepGen_kQ → cycleRep_kQ for naming consistency

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/FieldGenericInfiniteType.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericInfiniteType.lean
@@ -654,7 +654,7 @@ the forbidden-subgraph constructions: identity arrows force subspace
 equality regardless of arrow direction.
 
 The four submodules are passed explicitly: when the carrier `V` arises as
-`(cycleRepGen_kQ …).obj a` (a struct projection that does not always
+`(cycleRep_kQ …).obj a` (a struct projection that does not always
 reduce), implicit-argument inference cannot align them across the two
 complementary-pair hypotheses. -/
 theorem compl_le_forces_eq
@@ -685,7 +685,7 @@ carries the nilpotent shift; all other arrows carry the identity. The
 closing edge is detected from the pair `{a.val, b.val}`, not the arrow
 direction, so the construction works for any orientation `Q` of the cycle
 adjacency matrix `cycleAdj k hk`. -/
-noncomputable def cycleRepGen_kQ
+noncomputable def cycleRep_kQ
     (F : Type) [Field F] (k : ℕ) (hk : 3 ≤ k)
     (Q : @Quiver.{0, 0} (Fin k))
     [∀ a b, Subsingleton (@Quiver.Hom (Fin k) Q a b)]
@@ -702,13 +702,13 @@ noncomputable def cycleRepGen_kQ
 
 attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
   CategoryTheory.ReflQuiver.toQuiver in
-theorem cycleRepGen_kQ_isIndecomposable
+theorem cycleRep_kQ_isIndecomposable
     (F : Type) [Field F] (k : ℕ) (hk : 3 ≤ k)
     (Q : @Quiver.{0, 0} (Fin k))
     [∀ a b, Subsingleton (@Quiver.Hom (Fin k) Q a b)]
     (hOrient : @Etingof.IsOrientationOf k Q (cycleAdj k hk))
     (m : ℕ) :
-    (cycleRepGen_kQ F k hk Q hOrient m).IsIndecomposable := by
+    (cycleRep_kQ F k hk Q hOrient m).IsIndecomposable := by
   obtain ⟨_, hOrient_edge, _⟩ := hOrient
   constructor
   · refine ⟨⟨0, by omega⟩, ?_⟩
@@ -743,11 +743,11 @@ theorem cycleRepGen_kQ_isIndecomposable
         obtain ⟨e⟩ := hQab
         have h_inv₁ : W₁ a ≤ W₁ b := fun x hx => by
           have h := hW₁_inv e x hx
-          simp only [cycleRepGen_kQ, if_neg h_not_closing_ab, LinearMap.id_coe, id_eq] at h
+          simp only [cycleRep_kQ, if_neg h_not_closing_ab, LinearMap.id_coe, id_eq] at h
           exact h
         have h_inv₂ : W₂ a ≤ W₂ b := fun x hx => by
           have h := hW₂_inv e x hx
-          simp only [cycleRepGen_kQ, if_neg h_not_closing_ab, LinearMap.id_coe, id_eq] at h
+          simp only [cycleRep_kQ, if_neg h_not_closing_ab, LinearMap.id_coe, id_eq] at h
           exact h
         exact compl_le_forces_eq (V := Fin (m + 1) → F) (W₁ a) (W₂ a) (W₁ b) (W₂ b)
           (hcompl a) (hcompl b) h_inv₁ h_inv₂
@@ -755,11 +755,11 @@ theorem cycleRepGen_kQ_isIndecomposable
         obtain ⟨e⟩ := hQba
         have h_inv₁ : W₁ b ≤ W₁ a := fun x hx => by
           have h := hW₁_inv e x hx
-          simp only [cycleRepGen_kQ, if_neg h_not_closing_ba, LinearMap.id_coe, id_eq] at h
+          simp only [cycleRep_kQ, if_neg h_not_closing_ba, LinearMap.id_coe, id_eq] at h
           exact h
         have h_inv₂ : W₂ b ≤ W₂ a := fun x hx => by
           have h := hW₂_inv e x hx
-          simp only [cycleRepGen_kQ, if_neg h_not_closing_ba, LinearMap.id_coe, id_eq] at h
+          simp only [cycleRep_kQ, if_neg h_not_closing_ba, LinearMap.id_coe, id_eq] at h
           exact h
         have ⟨h1, h2⟩ := compl_le_forces_eq (V := Fin (m + 1) → F)
           (W₁ b) (W₂ b) (W₁ a) (W₂ a)
@@ -795,13 +795,13 @@ theorem cycleRepGen_kQ_isIndecomposable
       have h_shift₁ : ∀ x ∈ W₁ z, nilpotentShiftLinGen F m x ∈ W₁ z := by
         intro x hx
         have h := hW₁_inv e x hx
-        simp only [cycleRepGen_kQ, if_pos h_close_zl] at h
+        simp only [cycleRep_kQ, if_pos h_close_zl] at h
         rw [(h_const last).1] at h
         exact h
       have h_shift₂ : ∀ x ∈ W₂ z, nilpotentShiftLinGen F m x ∈ W₂ z := by
         intro x hx
         have h := hW₂_inv e x hx
-        simp only [cycleRepGen_kQ, if_pos h_close_zl] at h
+        simp only [cycleRep_kQ, if_pos h_close_zl] at h
         rw [(h_const last).2] at h
         exact h
       have hres := nilpotent_invariant_compl_trivial_gen
@@ -820,13 +820,13 @@ theorem cycleRepGen_kQ_isIndecomposable
         intro x hx
         rw [(h_const last).1.symm] at hx
         have h := hW₁_inv e x hx
-        simp only [cycleRepGen_kQ, if_pos h_close_lz] at h
+        simp only [cycleRep_kQ, if_pos h_close_lz] at h
         exact h
       have h_shift₂ : ∀ x ∈ W₂ z, nilpotentShiftLinGen F m x ∈ W₂ z := by
         intro x hx
         rw [(h_const last).2.symm] at hx
         have h := hW₂_inv e x hx
-        simp only [cycleRepGen_kQ, if_pos h_close_lz] at h
+        simp only [cycleRep_kQ, if_pos h_close_lz] at h
         exact h
       have hres := nilpotent_invariant_compl_trivial_gen
         (nilpotentShiftLinGen F m) (nilpotentShiftLinGen_nilpotent F m)
@@ -838,14 +838,14 @@ theorem cycleRepGen_kQ_isIndecomposable
 
 attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
   CategoryTheory.ReflQuiver.toQuiver in
-theorem cycleRepGen_kQ_dimVec
+theorem cycleRep_kQ_dimVec
     (F : Type) [Field F] (k : ℕ) (hk : 3 ≤ k)
     (Q : @Quiver.{0, 0} (Fin k))
     [∀ a b, Subsingleton (@Quiver.Hom (Fin k) Q a b)]
     (hOrient : @Etingof.IsOrientationOf k Q (cycleAdj k hk))
     (m : ℕ) (v : Fin k) :
     Nonempty (@Etingof.QuiverRepresentation.obj F (Fin k) _
-      Q (cycleRepGen_kQ F k hk Q hOrient m) v ≃ₗ[F] (Fin (m + 1) → F)) :=
+      Q (cycleRep_kQ F k hk Q hOrient m) v ≃ₗ[F] (Fin (m + 1) → F)) :=
   ⟨LinearEquiv.refl F _⟩
 
 attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
@@ -869,9 +869,9 @@ theorem cycle_not_finite_type_per_kQ
         ∃ V : @Etingof.QuiverRepresentation.{0,0,0,0} F (Fin k) _ Q,
           V.IsIndecomposable ∧ ∀ v, Nonempty (V.obj v ≃ₗ[F] (Fin (d v) → F))} := by
     intro m
-    exact ⟨cycleRepGen_kQ F k hk Q hOrient m,
-      cycleRepGen_kQ_isIndecomposable F k hk Q hOrient m,
-      cycleRepGen_kQ_dimVec F k hk Q hOrient m⟩
+    exact ⟨cycleRep_kQ F k hk Q hOrient m,
+      cycleRep_kQ_isIndecomposable F k hk Q hOrient m,
+      cycleRep_kQ_dimVec F k hk Q hOrient m⟩
   have hinj : Function.Injective (fun m : ℕ => (fun (_ : Fin k) => m + 1)) := by
     intro m₁ m₂ h
     have : m₁ + 1 = m₂ + 1 := congr_fun h ⟨0, by omega⟩

--- a/progress/2026-05-17T17-03-13Z_27185a5d.md
+++ b/progress/2026-05-17T17-03-13Z_27185a5d.md
@@ -1,0 +1,57 @@
+## Accomplished
+
+Closed issue #2824 — renamed the per-(F, Q) cycle representation
+identifiers in
+`EtingofRepresentationTheory/Chapter6/FieldGenericInfiniteType.lean`
+to follow the wave-58 `_kQ` convention:
+
+- `cycleRepGen_kQ` → `cycleRep_kQ`
+- `cycleRepGen_kQ_isIndecomposable` → `cycleRep_kQ_isIndecomposable`
+- `cycleRepGen_kQ_dimVec` → `cycleRep_kQ_dimVec`
+
+The dropped `Gen` suffix matches the naming used by the Ẽ₆/Ẽ₇
+analogues (`etilde6Rep_kQ`, `etilde7Rep_kQ`): `_kQ` already means
+"per-(F, Q)", and F-genericity is implicit in abstracting over `F`.
+
+No external file referenced the old identifiers (verified by
+`grep -rn cycleRepGen_kQ`). All call sites are inside the same file,
+in the body of `cycle_not_finite_type_per_kQ` and in `simp only`
+hypotheses inside `cycleRep_kQ_isIndecomposable`.
+
+Build: `lake build EtingofRepresentationTheory.Chapter6` passes
+(8076 jobs, no new errors or sorries).
+
+Commit: 3a04b6f.
+
+## Current frontier
+
+Naming convention now consistent across all per-(F, Q) wave-58
+declarations. This unblocks #2819 (which documents the
+`_F` / `_kQ` / `_per_kQ` convention in the module docstring) —
+that issue can now be implemented without having to call out a
+`cycleRepGen_kQ` exception.
+
+## Overall project progress
+
+Chapter 6 per-(F, Q) infrastructure refactor wave continues. Recent
+landings: #2820, #2817, #2812, #2809, #2810. Open in this wave:
+
+- #2818 (remove dead `_adj`/`_adj_sub` parameters from
+  `subgraph_infinite_type_transfer_per_kQ`) — independent.
+- #2819 (document `_kQ` / `_per_kQ` / `_F` convention) — now ready.
+- #2822 (generalize prefix-block embed/projection across
+  FieldGenericETilde{6,7}) — independent.
+- #2825 (split FieldGenericInfiniteType.lean) — best after #2802 /
+  #2801 land.
+- #2564 (Mathlib upstream tracker) — blocked on external Mathlib PR
+  https://github.com/leanprover-community/mathlib4/pull/38583.
+
+## Next step
+
+A `/feature` agent should claim #2818 (small, independent chore) or
+#2819 (docstring-only, now unblocked by this rename).
+
+## Blockers
+
+None for this issue. #2825 (file split) remains coordinated with
+#2802 / #2801 per its issue body.


### PR DESCRIPTION
Closes #2824

Session: `27185a5d-a8dd-4a5c-80de-dce11b35b4e0`

a6a9755 progress: rename session 27185a5d — #2824 cycleRep_kQ
3a04b6f chore(Ch6 #2824): rename cycleRepGen_kQ → cycleRep_kQ

🤖 Prepared with Claude Code