### PR TITLE
refactor(Ch6 #2822): generalize prefix-block embed/proj across FieldGenericETilde{6,7}

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/FieldGenericETilde6.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericETilde6.lean
@@ -32,22 +32,42 @@ open scoped Matrix
 
 namespace Etingof
 
+/-! ## Section 0: Shared prefix-block primitives
+
+Two-parameter families that subsume the prefix-block embed / projection
+pairs used in both Ẽ₆ and Ẽ₇. The Ẽ₆ rep uses `prefixBlockEmbed_F 2 3`
+(zero-extension `F^{2(m+1)} → F^{3(m+1)}`) and `prefixBlockProj_F 2 3 _`;
+the Ẽ₇ rep additionally uses the `3 → 4` instances.
+-/
+
+/-- F-generic zero-extension `F^{a(m+1)} → F^{b(m+1)}` along the first
+`a` blocks: `x ↦ (x, 0, …, 0)`. When `a > b` the output is zero
+everywhere (no values fit), but the typical use case has `a ≤ b`. -/
+noncomputable def prefixBlockEmbed_F (F : Type) [Field F]
+    (a b m : ℕ) :
+    (Fin (a * (m + 1)) → F) →ₗ[F] (Fin (b * (m + 1)) → F) where
+  toFun x i := if h : i.val < a * (m + 1) then x ⟨i.val, h⟩ else 0
+  map_add' x y := by ext i; simp only [Pi.add_apply]; split_ifs <;> ring
+  map_smul' c x := by
+    ext i; simp only [Pi.smul_apply, smul_eq_mul, RingHom.id_apply]; split_ifs <;> ring
+
+/-- F-generic first-`a`-blocks projection `F^{b(m+1)} → F^{a(m+1)}`:
+`w ↦ (w₀, …, w_{a(m+1)-1})`. Requires `a ≤ b` so the domain index
+remains in range. -/
+noncomputable def prefixBlockProj_F (F : Type) [Field F]
+    (a b m : ℕ) (hab : a ≤ b) :
+    (Fin (b * (m + 1)) → F) →ₗ[F] (Fin (a * (m + 1)) → F) where
+  toFun w i :=
+    w ⟨i.val, Nat.lt_of_lt_of_le i.isLt (Nat.mul_le_mul_right _ hab)⟩
+  map_add' _ _ := by ext; simp
+  map_smul' _ _ := by ext; simp
+
 /-! ## Section 1: F-generic forward maps for Ẽ₆
 
 F-generic versions of the ℂ-specific maps used in `etilde6v2RepMap`
 (`InfiniteTypeConstructions.lean:3282-3294`). The bodies are
 copy-paste of the ℂ versions with `ℂ` replaced by `F`.
 -/
-
-/-- F-generic embedding from a 2-block space into the first two blocks of a
-3-block space: `(a, b) ↦ (a, b, 0)`. Mirror of `embed2to3_AB`
-(`InfiniteTypeConstructions.lean:1518`). -/
-noncomputable def embed2to3_AB_F (F : Type) [Field F] (m : ℕ) :
-    (Fin (2 * (m + 1)) → F) →ₗ[F] (Fin (3 * (m + 1)) → F) where
-  toFun x i := if h : i.val < 2 * (m + 1) then x ⟨i.val, h⟩ else 0
-  map_add' x y := by ext i; simp only [Pi.add_apply]; split_ifs <;> ring
-  map_smul' c x := by
-    ext i; simp only [Pi.smul_apply, smul_eq_mul, RingHom.id_apply]; split_ifs <;> ring
 
 /-- F-generic embedding from a 2-block space into blocks (C, _, A) of a
 3-block space: `(a, b) ↦ (b, 0, a)` (first component to block C, second
@@ -88,8 +108,8 @@ For an arbitrary orientation `Q` of `etilde6Adj`, each edge may point the
 opposite way from `etilde6v2Quiver`. The reverse maps below are linear
 maps in the opposite direction:
 
-- `embed2to3_AB_reverse_F`: left inverse of `embed2to3_AB_F`, sending
-  `(a, b, c) ↦ (a, b)` (first two blocks).
+- The reverse of `prefixBlockEmbed_F 2 3` is `prefixBlockProj_F 2 3 _`
+  (defined in Section 0), sending `(a, b, c) ↦ (a, b)`.
 - `embed2to3_CA_reverse_F`: left inverse of `embed2to3_CA_F`, sending
   `(a, b, c) ↦ (c, a)` (block C to first half, block A to second half).
 - `etilde6GammaInv_F`: right section of `etilde6Gamma_F`. The map
@@ -102,15 +122,6 @@ maps in the opposite direction:
   `starEmbedNilp_F` (since `starEmbedNilp_F x = (x, Nx)`). Used for the
   three reversed-leaf-edge cases.
 -/
-
-/-- Reverse map for the `embed2to3_AB_F` edge: `(a, b, c) ↦ (a, b)`,
-which is the first-two-blocks projection. Left inverse of
-`embed2to3_AB_F`. -/
-noncomputable def embed2to3_AB_reverse_F (F : Type) [Field F] (m : ℕ) :
-    (Fin (3 * (m + 1)) → F) →ₗ[F] (Fin (2 * (m + 1)) → F) where
-  toFun w i := w ⟨i.val, by omega⟩
-  map_add' _ _ := by ext; simp
-  map_smul' _ _ := by ext; simp
 
 /-- Reverse map for the `embed2to3_CA_F` edge: `(a', b', c') ↦ (c', a')`,
 sending block C to the first half and block A to the second half. Left
@@ -173,8 +184,8 @@ private noncomputable def etilde6RepMap_kQ (F : Type) [Field F] (m : ℕ) (a b :
   | ⟨2, _⟩, ⟨1, _⟩ => starEmbed1_F F m
   | ⟨1, _⟩, ⟨2, _⟩ => etilde6LeafProj_F F m
   -- Edge {0, 1}
-  | ⟨1, _⟩, ⟨0, _⟩ => embed2to3_AB_F F m
-  | ⟨0, _⟩, ⟨1, _⟩ => embed2to3_AB_reverse_F F m
+  | ⟨1, _⟩, ⟨0, _⟩ => prefixBlockEmbed_F F 2 3 m
+  | ⟨0, _⟩, ⟨1, _⟩ => prefixBlockProj_F F 2 3 m (by omega)
   -- Edge {0, 3}
   | ⟨0, _⟩, ⟨3, _⟩ => etilde6Gamma_F F m
   | ⟨3, _⟩, ⟨0, _⟩ => etilde6GammaInv_F F m

--- a/EtingofRepresentationTheory/Chapter6/FieldGenericETilde7.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericETilde7.lean
@@ -44,18 +44,11 @@ F-generic versions of the ℂ-specific maps used in `etilde7RepMap`
 (`InfiniteTypeConstructions.lean:3559`). The bodies are copy-paste of
 the ℂ versions with `ℂ` replaced by `F`. The maps reused from existing
 files are `starEmbed1_F` (from `FieldGenericInfiniteType.lean`) and
-`embed2to3_AB_F` (from `FieldGenericETilde6.lean`).
+`prefixBlockEmbed_F 2 3` (from `FieldGenericETilde6.lean`, used for
+edges {2,3} and {5,6} where the arrow goes leaf → arm-internal vertex).
+The `3 → 4` prefix-block embedding for edges {0,2} and (via the dual)
+{0,5} comes from the same `prefixBlockEmbed_F` family.
 -/
-
-/-- F-generic embedding from a 3-block space into the first three blocks of a
-4-block space: `(x, y, z) ↦ (x, y, z, 0)`. Mirror of `embed3to4_ABC`
-(`InfiniteTypeConstructions.lean:3508`). -/
-noncomputable def embed3to4_ABC_F (F : Type) [Field F] (m : ℕ) :
-    (Fin (3 * (m + 1)) → F) →ₗ[F] (Fin (4 * (m + 1)) → F) where
-  toFun x i := if h : i.val < 3 * (m + 1) then x ⟨i.val, h⟩ else 0
-  map_add' x y := by ext i; simp only [Pi.add_apply]; split_ifs <;> ring
-  map_smul' c x := by
-    ext i; simp only [Pi.smul_apply, smul_eq_mul, RingHom.id_apply]; split_ifs <;> ring
 
 /-- F-generic embedding from a 3-block space into blocks (A, _, C, D) of a
 4-block space: `(x, y, z) ↦ (x, 0, y, z)`. Mirror of `embed3to4_ACD`
@@ -100,8 +93,8 @@ For an arbitrary orientation `Q` of `etilde7Adj`, each edge may point
 the opposite way from `etilde7Quiver`. The reverse maps below are
 linear maps in the opposite direction:
 
-- `embed3to4_ABC_reverse_F`: left inverse of `embed3to4_ABC_F`,
-  sending `(a, b, c, d) ↦ (a, b, c)` (first three blocks).
+- The reverse of `prefixBlockEmbed_F 3 4` is `prefixBlockProj_F 3 4 _`
+  (from `FieldGenericETilde6.lean`), sending `(a, b, c, d) ↦ (a, b, c)`.
 - `embed3to4_ACD_reverse_F`: left inverse of `embed3to4_ACD_F`,
   sending `(a, b, c, d) ↦ (a, c, d)` (blocks A, C, D extracted).
 - `etilde7Arm1Embed_reverse_F`: a right section of `etilde7Arm1Embed_F`,
@@ -114,18 +107,9 @@ linear maps in the opposite direction:
 
 The leaf-edge reverses (for edges `{3, 4}` and `{6, 7}`) reuse
 `etilde6LeafProj_F` from `FieldGenericETilde6.lean`; the arm-internal
-reverses (for edges `{2, 3}` and `{5, 6}`) reuse
-`embed2to3_AB_reverse_F` from the same file.
+reverses (for edges `{2, 3}` and `{5, 6}`) use
+`prefixBlockProj_F 2 3 _` from the same file.
 -/
-
-/-- Reverse map for the `embed3to4_ABC_F` edge: `(a, b, c, d) ↦ (a, b, c)`,
-which is the first-three-blocks projection. Left inverse of
-`embed3to4_ABC_F`. -/
-noncomputable def embed3to4_ABC_reverse_F (F : Type) [Field F] (m : ℕ) :
-    (Fin (4 * (m + 1)) → F) →ₗ[F] (Fin (3 * (m + 1)) → F) where
-  toFun w i := w ⟨i.val, by omega⟩
-  map_add' _ _ := by ext; simp
-  map_smul' _ _ := by ext; simp
 
 /-- Reverse map for the `embed3to4_ACD_F` edge: `(a, b, c, d) ↦ (a, c, d)`,
 sending block A to the first third, then blocks C, D to the last two
@@ -180,17 +164,17 @@ private noncomputable def etilde7RepMap_kQ (F : Type) [Field F] (m : ℕ) (a b :
   | ⟨4, _⟩, ⟨3, _⟩ => starEmbed1_F F m
   | ⟨3, _⟩, ⟨4, _⟩ => etilde6LeafProj_F F m
   -- Arm 2: edge {2, 3}
-  | ⟨3, _⟩, ⟨2, _⟩ => embed2to3_AB_F F m
-  | ⟨2, _⟩, ⟨3, _⟩ => embed2to3_AB_reverse_F F m
+  | ⟨3, _⟩, ⟨2, _⟩ => prefixBlockEmbed_F F 2 3 m
+  | ⟨2, _⟩, ⟨3, _⟩ => prefixBlockProj_F F 2 3 m (by omega)
   -- Arm 2: edge {0, 2}
-  | ⟨2, _⟩, ⟨0, _⟩ => embed3to4_ABC_F F m
-  | ⟨0, _⟩, ⟨2, _⟩ => embed3to4_ABC_reverse_F F m
+  | ⟨2, _⟩, ⟨0, _⟩ => prefixBlockEmbed_F F 3 4 m
+  | ⟨0, _⟩, ⟨2, _⟩ => prefixBlockProj_F F 3 4 m (by omega)
   -- Arm 3: edge {6, 7}
   | ⟨7, _⟩, ⟨6, _⟩ => starEmbed1_F F m
   | ⟨6, _⟩, ⟨7, _⟩ => etilde6LeafProj_F F m
   -- Arm 3: edge {5, 6}
-  | ⟨6, _⟩, ⟨5, _⟩ => embed2to3_AB_F F m
-  | ⟨5, _⟩, ⟨6, _⟩ => embed2to3_AB_reverse_F F m
+  | ⟨6, _⟩, ⟨5, _⟩ => prefixBlockEmbed_F F 2 3 m
+  | ⟨5, _⟩, ⟨6, _⟩ => prefixBlockProj_F F 2 3 m (by omega)
   -- Arm 3: edge {0, 5}
   | ⟨5, _⟩, ⟨0, _⟩ => embed3to4_ACD_F F m
   | ⟨0, _⟩, ⟨5, _⟩ => embed3to4_ACD_reverse_F F m

--- a/progress/2026-05-17T17-20-51Z_ac4fd6d2.md
+++ b/progress/2026-05-17T17-20-51Z_ac4fd6d2.md
@@ -1,0 +1,45 @@
+## Accomplished
+
+Refactored four near-duplicate prefix-block definitions in
+`FieldGenericETilde{6,7}.lean` into a two-parameter family. Closes #2822.
+
+Added to `FieldGenericETilde6.lean` (new Section 0: Shared prefix-block primitives):
+- `prefixBlockEmbed_F (a b m : ℕ)` — zero-extension `F^{a(m+1)} → F^{b(m+1)}`
+- `prefixBlockProj_F (a b m : ℕ) (hab : a ≤ b)` — first-`a`-blocks projection
+  `F^{b(m+1)} → F^{a(m+1)}`
+
+Removed the four specialised definitions and rewired six call sites:
+- `embed2to3_AB_F` (ETilde6) → `prefixBlockEmbed_F F 2 3`
+- `embed2to3_AB_reverse_F` (ETilde6) → `prefixBlockProj_F F 2 3 m (by omega)`
+- `embed3to4_ABC_F` (ETilde7) → `prefixBlockEmbed_F F 3 4`
+- `embed3to4_ABC_reverse_F` (ETilde7) → `prefixBlockProj_F F 3 4 m (by omega)`
+
+Call sites: 2 in `etilde6RepMap_kQ` (edge {0,1}), 4 in `etilde7RepMap_kQ`
+(edges {2,3}, {0,2}, {5,6}). The asymmetric maps (`embed2to3_CA_F`,
+`embed3to4_ACD_F` and their reverses) are intentionally untouched per
+the issue's out-of-scope note — they skip blocks rather than
+zero-extending a contiguous prefix.
+
+Build passes for both modules (`lake build EtingofRepresentationTheory.Chapter6.FieldGenericETilde6 EtingofRepresentationTheory.Chapter6.FieldGenericETilde7`).
+
+## Current frontier
+
+`FieldGenericETilde{6,7}.lean` now share a generic prefix-block API; a
+future `FieldGenericDTilde5.lean` (blocked on #2813) can use the same
+family without introducing a third copy.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. Per-(F, Q) wave for Chapter 6 continues
+in parallel — this PR is API hygiene that lands ahead of the next
+per-graph file.
+
+## Next step
+
+After merge, downstream per-graph files (`FieldGenericDTilde5.lean`,
+`FieldGenericT125.lean`) should reuse `prefixBlockEmbed_F` /
+`prefixBlockProj_F` instead of introducing new specialised pairs.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2822

Session: `ac4fd6d2-7e37-43c9-b158-b719b22808f2`

a20f740 refactor(Ch6 #2822): generalize prefix-block embed/proj across FieldGenericETilde{6,7}

🤖 Prepared with Claude Code