### PR TITLE
doc(Ch6): document _kQ / _per_kQ / _F naming convention in FieldGenericInfiniteType module docstring

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/FieldGenericETilde6.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericETilde6.lean
@@ -26,6 +26,10 @@ choices below are left inverses (for embeddings) or a right section
 (for `etilde6Gamma_F`, which is not injective). Sub B may revisit the
 section choice if it turns out indecomposability requires a different
 one.
+
+See the "Naming conventions" section of
+`Chapter6/FieldGenericInfiniteType.lean` for the meaning of the
+`_F` / `_kQ` / `_per_kQ` suffixes used throughout this file.
 -/
 
 open scoped Matrix

--- a/EtingofRepresentationTheory/Chapter6/FieldGenericETilde7.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericETilde7.lean
@@ -32,6 +32,10 @@ Indecomposability inherits the same wave-54 framework wall as the
 ℂ-specific source `etilde7Rep_isIndecomposable`
 (`InfiniteTypeConstructions.lean:3588`); the stub here carries the
 same `sorry` with a docstring tying it to the wall.
+
+See the "Naming conventions" section of
+`Chapter6/FieldGenericInfiniteType.lean` for the meaning of the
+`_F` / `_kQ` / `_per_kQ` suffixes used throughout this file.
 -/
 
 open scoped Matrix

--- a/EtingofRepresentationTheory/Chapter6/FieldGenericInfiniteType.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericInfiniteType.lean
@@ -14,6 +14,42 @@ any field F (or any algebraically closed field when needed).
 The key insight: all the indecomposability proofs use only linear algebra
 (nilpotent maps, kernel dimension, complementary subspaces). None of this
 requires ℂ specifically.
+
+## Naming conventions
+
+The Chapter 6 "field-generic" / "orientation-generic" wave introduces three
+suffix conventions side-by-side with the original ℂ-only names. Four
+categories are in use across this file,
+`Chapter6/FieldGenericETilde6.lean`, and `Chapter6/FieldGenericETilde7.lean`:
+
+* `_F` / `_gen` — **field-generic only.** Construction or theorem
+  parametrised by an arbitrary field `F` (often algebraically closed),
+  but specialised to the canonical orientation of the graph.
+  Representative examples: `cycleRepGen`, `cycleRepGen_dimVec`,
+  `cycle_not_finite_type_gen`, `starRepGen`, `starEmbed1_F`,
+  `starEmbedNilp_F`, `star_not_finite_type_F`.
+
+* `_kQ` — **data, parametrised by both `(F, Q)`.** A representation or
+  structure over any field `F` and any orientation `Q` of the underlying
+  graph. The `Q` argument selects per-edge directions, so each edge map
+  is built from forward/reverse maps depending on `Q`'s choice.
+  Representative examples: `cycleRep_kQ`, `etilde6Rep_kQ`,
+  `etilde7Rep_kQ`, `etilde6RepMap_kQ`, `etilde7RepMap_kQ`.
+
+* `_per_kQ` — **theorem stating a per-`(F, Q)` conclusion.** Typically
+  an infinite-type or indecomposability statement applied to the
+  `_kQ` data. Representative examples: `cycle_not_finite_type_per_kQ`,
+  `etilde6_not_finite_type_per_kQ`, `subgraph_infinite_type_transfer_per_kQ`.
+
+* (no suffix) — **original ℂ-only construction** living in
+  `Chapter6/InfiniteTypeConstructions.lean`. Representative examples:
+  `cycleRep`, `etilde6Rep`, `etilde7Rep`, `cycle_not_finite_type`,
+  `etilde6_not_finite_type`.
+
+When introducing a new item, pick the suffix matching what is actually
+generic: `_F`/`_gen` when only the field is generic, `_kQ` for `(F, Q)`
+data, `_per_kQ` for `(F, Q)`-quantified theorems, and no suffix for
+ℂ-only code in `InfiniteTypeConstructions.lean`.
 -/
 
 open scoped Matrix

--- a/progress/2026-05-17T18-04-50Z_b5154fb5.md
+++ b/progress/2026-05-17T18-04-50Z_b5154fb5.md
@@ -1,0 +1,37 @@
+## Accomplished
+
+Documented the Chapter 6 per-(field, orientation) wave naming
+conventions (`_F` / `_gen`, `_kQ`, `_per_kQ`, no suffix) in the
+top-of-file docstring of
+`EtingofRepresentationTheory/Chapter6/FieldGenericInfiniteType.lean`,
+with one representative example per suffix and guidance for new items.
+Added short cross-references at the top of
+`FieldGenericETilde6.lean` and `FieldGenericETilde7.lean` pointing to
+that section. No code changes — docstring only. Closes issue #2819.
+
+`lake build` of all three modified modules passes; pre-existing
+warnings and `sorry`s are unchanged.
+
+## Current frontier
+
+Wave-58 per-(F, Q) generalisations of Chapter 6 — same as before.
+The naming conventions are now codified before the API ossifies under
+landing of #2802 / #2801 (K_{1,4}) and the D̃₅ / T(1,2,5) work.
+
+## Overall project progress
+
+Chapter 6 per-(field, orientation) wave continues: cycle / Ẽ₆ / Ẽ₇
+per-(F, Q) data and infinite-type theorems are in; K_{1,4} (#2801),
+D̃₅ Sub B (#2804/#2813), T(1,2,5) (#2793) still ahead. Deliverable-2
+assembly tracked in #2774. Module-split refactor (#2825) deferred
+until #2802 / #2801 land.
+
+## Next step
+
+A planner can claim #2825 (FieldGenericInfiniteType.lean split) once
+PR #2802 lands and before #2801 grows the file by 400–600 lines.
+Otherwise: pick up the next wave-58 feature issue from the queue.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2819

Session: `b5154fb5-c1e6-4e22-9a7c-edd17c364691`

2e5d6a9 doc(Ch6 #2819): document _F / _kQ / _per_kQ naming convention in FieldGenericInfiniteType module docstring

🤖 Prepared with Claude Code