### PR TITLE
refactor(Ch5 Theorem5_22_1): reduce `youngSym_action_vanishes_off_block` heartbeat bumps from 800000/800000 to 400000/200000

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
@@ -2125,12 +2125,12 @@ private lemma youngSymmetrizerK_complex_eq (n : ℕ) (la : Nat.Partition n) :
     YoungSymmetrizerK ℂ n la = YoungSymmetrizer n la := by
   rw [YoungSymmetrizerK_eq_mapRange ℂ n la, YoungSymmetrizer_eq_mapRange n la]
 
-set_option maxHeartbeats 800000 in
+set_option maxHeartbeats 400000 in
 -- Bumped: applying β.1 (`trace_youngSymEndomorphism_restrict_eq_sum`) and
 -- β.2 (`trace_symGroupAction_eq_spechtModuleCharacter`) traverses the deep
 -- `Subalgebra → Subsemiring → Module → IsScalarTower` synthesis chain for
 -- `S.restrictScalars ℂ`, which exceeds the default 20000 heartbeats.
-set_option synthInstance.maxHeartbeats 800000 in
+set_option synthInstance.maxHeartbeats 200000 in
 /-- **β.3 Off-block vanishing.** When the simple `symGroupImage`-submodule
 `S ≤ V^⊗n` has Specht-module label `la' ≠ weightToPartition N lam`, the Young
 symmetrizer endomorphism `c_λ` vanishes when restricted to `S`.

--- a/progress/2026-05-17T18-51-42Z_8079006b.md
+++ b/progress/2026-05-17T18-51-42Z_8079006b.md
@@ -1,0 +1,38 @@
+# Worker session 8079006b — Ch5 Theorem5_22_1 heartbeat reduction (#2840)
+
+## Accomplished
+
+- Claimed #2840 and reduced the heartbeat bumps on
+  `youngSym_action_vanishes_off_block`
+  (`EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean:2128–2133`)
+  from `maxHeartbeats 800000` / `synthInstance.maxHeartbeats 800000`
+  to `400000` / `200000` — the targets recommended by the
+  #2832 review based on empirical probing (minima 300000 / 32000).
+- `lake build EtingofRepresentationTheory.Chapter5.Theorem5_22_1`
+  passes at the new values (0 errors; only pre-existing linter
+  warnings elsewhere in the file).
+- The comment between the two `set_option` lines is unchanged (it
+  already explained the underlying synthesis cost, which still
+  motivates the remaining bumps).
+
+## Current frontier
+
+PR ready to create on branch `agent/8079006b` closing #2840.
+
+## Overall project progress
+
+Routine Ch5 polish. The β-chain (`trace_youngSymEndomorphism_restrict_eq_sum`,
+`trace_symGroupAction_eq_spechtModuleCharacter`,
+`youngSym_action_vanishes_off_block`) remains intact; this change
+only tightens β.3's elaboration budget to roughly match β.2's
+profile (which uses similar bumps for its own non-trivial elaboration).
+
+## Next step
+
+After CI passes and the PR merges, the open companion #2841
+(upstream tracker for `LinearMap.IsIdempotentElem.eq_zero_of_trace_eq_zero`)
+remains the natural next Ch5 polish item.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #2840

Session: `8079006b-f6f3-471c-8c2e-db66fc3bf785`

1164346 refactor(Ch5 #2840): reduce youngSym_action_vanishes_off_block heartbeat bumps to 400000/200000

🤖 Prepared with Claude Code