### PR TITLE
progress: worker 5b8dd06f — skip #2823, file critical fix #2846 for broken main

### DIFF
--- a/progress/20260517T203455Z_5b8dd06f.md
+++ b/progress/20260517T203455Z_5b8dd06f.md
@@ -1,0 +1,95 @@
+# Progress — worker session 5b8dd06f (feature)
+
+## Accomplished
+
+Claimed #2823 (bridge `starRep_kQ` ↔ `starRepGen`). On attempting to
+build `FieldGenericStar.lean` with the bridge added, discovered that
+**main is broken**: `lake build EtingofRepresentationTheory.Chapter6.FieldGenericInfiniteType`
+fails with ~25 "Unknown identifier `starEmbed1_F`/`starEmbed2_F`/
+`starEmbedDiag_F`/`starEmbedNilp_F`" errors at lines 635–703.
+
+Root cause: PR #2802 (`227dab6`, "direction-aware projections +
+starRep_kQ + dim vec") was branched off `cbcc552`, before the file
+split #2844 (`463d92a`, "split FieldGenericInfiniteType.lean"). The
+PR added 164 lines to `FieldGenericInfiniteType.lean` referencing
+`starEmbed*_F`, which the split had moved to `FieldGenericStar.lean`.
+The squash-merge to main went through textually but left the file
+referencing identifiers it can no longer see. The PR's "SUCCESS" CI
+status reflects the pre-rebase state.
+
+Secondary issue surfaced (latent until the move-back is done): PR #2802
+also added `Etingof.starProj1_F`/`starProj2_F` (the "complemented"
+projections, `(a,b)↦a-b` and `(a,b)↦b-N(a)`), which collide with PR
+#2813's same-named `Etingof.starProj1_F`/`starProj2_F` in
+`FieldGenericD5Tilde.lean` (the *simple* `(a,b)↦a` and `(a,b)↦b`).
+
+Filed **#2846** describing the breakage with the recommended fix
+(move the post-line-577 content to `FieldGenericStar.lean` per its
+existing module docstring, and resolve the `starProj1_F`/`starProj2_F`
+collision via dedupe or rename). Skipped #2823 (now marked `replan`)
+and added `depends-on: #2846` so it stays blocked until the repair
+lands.
+
+The bridge proof was drafted before discovering the breakage; the
+intended proof structure is
+
+```lean
+theorem starRep_kQ_canonical_eq_starRepGen
+    (F : Type) [Field F] (m : ℕ)
+    (hOrient : @Etingof.IsOrientationOf 5 starQuiver starAdj) :
+    starRep_kQ F starQuiver hOrient m = starRepGen F m := by
+  letI := starQuiver
+  unfold starRep_kQ starRepGen
+  congr 1
+  funext a b e
+  obtain ⟨ha, hb⟩ := e.down
+  fin_cases a <;> fin_cases b <;> first | rfl | (exfalso; omega)
+```
+
+with a one-line corollary deriving `starRep_kQ_canonical_isIndecomposable`
+via `rw [starRep_kQ_canonical_eq_starRepGen]; exact starRepGen_isIndecomposable F m`.
+This was not committed because the file does not build. Recorded
+here so the next worker can pick it up directly after #2846 lands.
+
+## Current frontier
+
+- **#2846** (newly filed) — repair main, prerequisite for the entire
+  K_{1,4}/D̃₅ per-(F, Q) chain (#2823, #2801, and downstream).
+- **#2823** — now `blocked` on #2846.
+- The same breakage transitively blocks #2801 (orientation-generic
+  K_{1,4} indecomposability) and any downstream Ch6 work that
+  imports `FieldGenericInfiniteType.lean` cleanly.
+
+## Overall project progress
+
+Stage 3 (Lean formalisation). No code changes this turn. Sorry-count
+delta: **0**. Queue delta: +1 unclaimed feature (#2846), one issue
+moved from `claimed` to `replan/blocked` (#2823).
+
+## Next step
+
+A pr-repair or feature worker should claim #2846 and execute the
+file-move + collision resolution. Recommended sequence:
+
+1. Move lines 578–742 of `FieldGenericInfiniteType.lean`
+   (Section 7 leaf projections, Section 8 `starRep_kQ` +
+   `starRep_kQ_dimVec`) verbatim into `FieldGenericStar.lean` after
+   `star_not_finite_type_F`. They will resolve `starEmbed*_F` from
+   the same file.
+2. Resolve the `starProj1_F`/`starProj2_F` collision with
+   `FieldGenericD5Tilde.lean`. Preferred: delete D̃₅'s
+   re-definitions and update its callers
+   (`d5tildeRepMap_kQ`, `d5tildeGammaInv_F`,
+   `cumTailSumLin_eq_decomp`-style lemmas) to use the K_{1,4} names
+   `starFirst_F` / `starSecond_F` — which are the same underlying
+   maps. This also partially addresses #2821 (dedupe pattern).
+3. `lake build EtingofRepresentationTheory.Chapter6.FieldGenericD5Tilde`
+   passes.
+
+Once #2846 lands, #2823 becomes the natural next pick — the bridge
+proof above should drop in directly.
+
+## Blockers
+
+#2846 blocks the entire K_{1,4}/D̃₅ per-(F, Q) chain. No PR fix is
+available without it.


### PR DESCRIPTION
This PR records a worker session that discovered main is broken and filed a critical fix issue, then skipped the original claim. No code change beyond the progress entry — the work for #2823 cannot proceed until #2846 lands.

Discovered while attempting bridge work for #2823 that
\`lake build EtingofRepresentationTheory.Chapter6.FieldGenericInfiniteType\`
fails on main with ~25 \"Unknown identifier \`starEmbed*_F\`\" errors. Root cause: PR #2802 was branched off pre-#2844 main, and the squash-merge to post-#2844 main left references in \`FieldGenericInfiniteType.lean\` that point to identifiers now in \`FieldGenericStar.lean\`. Secondary latent issue: name collision between PR #2802's \`starProj1_F\`/\`starProj2_F\` and PR #2813's same-named defs in \`FieldGenericD5Tilde.lean\`.

Filed #2846 with the recommended fix, skipped #2823 (now blocked on #2846), and recorded the drafted bridge proof in the progress entry so the next worker can drop it in after #2846 lands.

🤖 Prepared with Claude Code