### PR TITLE
progress: close #2869 (γ⁻¹-coupled containment doesn't factor)

### DIFF
--- a/progress/2026-05-18T09-04-43Z_bcc5a2ad.md
+++ b/progress/2026-05-18T09-04-43Z_bcc5a2ad.md
@@ -1,0 +1,59 @@
+## Accomplished
+
+Claimed and closed #2869 (γ⁻¹-coupled sibling lemma
+`d5tilde_gamma_containment_F_inv` for the e23-reversed central edge)
+without code changes, taking the escape hatch documented in the issue
+body. Posted a detailed analysis comment explaining why the naive
+γ-push ↦ γ⁻¹-pull swap does **not** factor cleanly as a direct analog
+of `d5tilde_gamma_containment_F`.
+
+## Current frontier
+
+The structural finding: closed-form `γ⁻¹(starEmbed1_F y)` and
+`γ⁻¹(starEmbed2_F y)` produce M-factored decompositions (M =
+cumTailSumLin), so the natural inv-direction containments from
+`d5tilde_core_F` are `y ∈ Wmain ⟨4⟩ → (y − M y, M y) ∈ (Wmain ⟨0⟩,
+Wmain ⟨1⟩)` etc. Recovering a clean `Wmain ⟨4⟩ → Wmain ⟨0⟩` would
+require knowing `Wmain ⟨0⟩ = Wmain ⟨1⟩` already — circular at the
+lemma level. The alternative routing via
+`gammaInv_embed1_plus_embed2_F` is conditional (`x ∈ Wmain ⟨4⟩ ∩
+Wmain ⟨5⟩ → x ∈ Wmain ⟨0⟩`), also not the mirror shape.
+
+Concretely: #2853 was already planning (per #2850's strategy notes)
+to "use the closed-form γ⁻¹ identities ... to bridge vertex 2 and
+vertex 3" inline. Pre-staging adds no leverage.
+
+## Overall project progress
+
+Stage 3 (Lean formalization) ongoing. Chapter 6 D̃₅ work item queue:
+- #2839 (D̃₅ orientation-generic indecomposability, parent of #2850).
+- #2850 (sub A leaf-equality derivation, in `replan`).
+- #2853 (sub A2: 31 non-canonical orientation sub-cases of
+  `d5tildeRep_kQ_leaf_equalities`), blocked on #2850.
+- #2869 (this issue, e23-reversed pre-staging) — closed without code.
+- #2868 projection-based sibling pre-staging — landed in PR #2871
+  (7f67ca2).
+
+Open queue after this cycle: #2564 (low-priority Mathlib-upstream
+tracker, blocked on external merge). Active formalization queue is
+effectively empty pending planner re-triage of #2850.
+
+## Next step
+
+Planner should:
+1. Re-triage #2850 (which has `replan`), now armed with the finding
+   that the inv-direction reasoning will inline in #2853 rather than
+   factor as a sibling lemma. Consider whether #2853 still needs
+   further decomposition (its sizing estimate is 600–900 lines for
+   31 sub-cases; 4 sub-issues by orientation class is a natural
+   split).
+2. The projection-based sibling lemmas from #2871
+   (`d5tilde_core_F_proj1/2`, `d5tilde_core3_F_proj1/2`) cover the
+   reversed-leaf-edge half of mixed sub-cases. Combined with inline
+   `gammaInv_embed*_F` usage for the e23-reversed cases, #2853's 31
+   sub-cases should have all primitives in place.
+
+## Blockers
+
+None for the planner. #2564 remains blocked on external Mathlib PR
+merge (https://github.com/leanprover-community/mathlib4/pull/38583).


### PR DESCRIPTION
This PR lands the progress entry for session `bcc5a2ad`, which claimed and then closed #2869 without code changes per the escape hatch documented in the issue body.

The structural finding (full analysis in https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/issues/2869#issuecomment-4476072991): the naive γ-push ↦ γ⁻¹-pull swap does not factor cleanly as a direct analog of \`d5tilde_gamma_containment_F\`. Closed-form \`γ⁻¹(starEmbed1_F y)\` and \`γ⁻¹(starEmbed2_F y)\` produce M-factored decompositions (M = cumTailSumLin), so the natural inv-direction containments have \`y − M y\` and \`M y\` shapes that don't mirror the canonical \`Wmain ⟨0⟩ → Wmain ⟨4⟩\` conclusion. Recovering the clean shape would require \`Wmain ⟨0⟩ = Wmain ⟨1⟩\` (circular at the lemma level).

#2853 already plans (per #2850's strategy notes) to inline the closed-form γ⁻¹ identities directly; pre-staging adds no leverage.

🤖 Prepared with Claude Code