### PR TITLE
progress: planner cycle 183960dd — file #2875 (#2774 deliverables 2 + 3)

### DIFF
--- a/plans/183960dd-1.md
+++ b/plans/183960dd-1.md
@@ -1,0 +1,102 @@
+## Current state
+
+`Chapter2/Theorem2_1_2.lean:173` still has `not_posdef_not_HasFiniteRepresentationType` as `sorry`. This is the forward bridge of Theorem 2.1.2 (Gabriel).
+
+Parent issue #2774 split this work into three deliverables:
+
+1. **Per-(k, Q) subgraph transfer** — `subgraph_infinite_type_transfer_per_kQ` in `Chapter6/FieldGenericInfiniteType.lean:374`. **LANDED PR #2805 (wave 59).**
+2. **Per-(k, Q) assembly** `not_posdef_infinite_type_per_kQ` — mirrors the case-analysis of `not_posdef_infinite_type` (`Chapter6/InfiniteTypeConstructions.lean:10661`), dispatching each case to a per-(F, Q) base theorem. **UNFILED since wave 59.**
+3. **Wire into `Theorem2_1_2.lean`** — convert `h_not_posdef` to the negated form expected by deliverable 2, apply, and combine with `HasFiniteRepresentationType.finite_dimVectors` (`Chapter2/Theorem2_1_2.lean:111`). **UNFILED since wave 59.**
+
+Both wave-59 and wave-60 summaries flagged deliverables 2 + 3 as unfiled (`progress/sorry-landscape.md` priority 5).
+
+### Base-case readiness (per-(F, Q) theorems for the 6 forbidden subgraphs)
+
+| Subgraph | Per-(F, Q) theorem name | Status on `main` |
+|---|---|---|
+| Cycle | `cycle_not_finite_type_per_kQ` (`FieldGenericCycle.lean:326`) | LIVE |
+| K_{1,4} (D̃₄) | `star_not_finite_type_per_kQ` | **MISSING — must be introduced as an API stub** |
+| D̃₅ | `d5tilde_not_finite_type_per_kQ` (`FieldGenericD5Tilde.lean:999`) | LIVE (body sorry-propagates from `d5tildeRep_kQ_isIndecomposable`, tracked by #2851/#2853) |
+| Ẽ₆ | `etilde6_not_finite_type_per_kQ` (`FieldGenericETilde6.lean:319`) | LIVE (Wall-1 sorry inside) |
+| Ẽ₇ | `etilde7_not_finite_type_per_kQ` (`FieldGenericETilde7.lean:301`) | LIVE (Wall-1 sorry inside) |
+| T(1,2,5) | `t125_not_finite_type_per_kQ` | **MISSING — must be introduced as an API stub** |
+
+Sorry-propagating dependencies are fine per "spec-driven development" (project CLAUDE.md). Missing theorem **statements** are not: the assembly cannot dispatch to a name that does not exist.
+
+## Deliverables
+
+### D1. Introduce the two missing per-(F, Q) API stubs
+
+Add `theorem` signatures (not `def` — bodies may be `sorry`):
+
+- `star_not_finite_type_per_kQ` in `Chapter6/FieldGenericStar.lean`. Mirror the shape of `etilde6_not_finite_type_per_kQ` (size 5, adjacency `starAdj`).
+- `t125_not_finite_type_per_kQ` in a new file `Chapter6/FieldGenericT125.lean` (mirror the per-graph file pattern; size 8, adjacency `t125Adj`). The new file imports `FieldGenericInfiniteType` and `InfiniteTypeConstructions` (for `t125Adj`).
+
+Both stubs have `by sorry` bodies. They exist solely so the assembly in D2 can dispatch by name; the actual proofs are tracked by #2789 / #2801 (K_{1,4}) and #2793 (T(1,2,5)).
+
+### D2. Per-(k, Q) assembly `not_posdef_infinite_type_per_kQ`
+
+In `Chapter6/FieldGenericInfiniteType.lean`, add:
+
+```lean
+theorem not_posdef_infinite_type_per_kQ
+    {n : ℕ} (adj : Matrix (Fin n) (Fin n) ℤ)
+    (hn : 1 ≤ n)
+    (hsymm : adj.IsSymm) (hdiag : ∀ i, adj i i = 0)
+    (h01 : ∀ i j, adj i j = 0 ∨ adj i j = 1)
+    (hconn : ∀ i j : Fin n, ∃ path : List (Fin n), …)   -- same shape as not_posdef_infinite_type
+    (h_not_posdef : ¬ ∀ x : Fin n → ℤ, x ≠ 0 →
+      0 < dotProduct x ((2 • (1 : Matrix (Fin n) (Fin n) ℤ) - adj).mulVec x))
+    (F : Type) [Field F] [IsAlgClosed F]
+    (Q : @Quiver.{0, 0} (Fin n))
+    [∀ a b, Subsingleton (@Quiver.Hom (Fin n) Q a b)]
+    (hOrient : @Etingof.IsOrientationOf n Q adj) :
+    ¬ Set.Finite
+      {d : Fin n → ℕ |
+        ∃ V : @Etingof.QuiverRepresentation.{0,0,0,0} F (Fin n) _ Q,
+          V.IsIndecomposable ∧ ∀ v, Nonempty (V.obj v ≃ₗ[F] (Fin (d v) → F))}
+```
+
+Mirror the case-analysis tree of `not_posdef_infinite_type` (`InfiniteTypeConstructions.lean:10661-10714`):
+
+1. `degree ≥ 4` (currently dispatches to `degree_ge_4_infinite_type`, line 4064) — for the per-(k, Q) version, locate the K_{1,4} subgraph and dispatch to `star_not_finite_type_per_kQ` via `subgraph_infinite_type_transfer_per_kQ`.
+2. Contains list cycle (currently `graph_with_list_cycle_infinite_type`, line 3910) — dispatch to `cycle_not_finite_type_per_kQ` via the same transfer.
+3. Acyclic with a degree-3 vertex — `acyclic_branch_not_posdef_infinite_type` (line 10609) splits into:
+   - 3a. Adjacent branches: dispatch to D̃₅ (per `adjacent_branches_infinite_type` line 4764).
+   - 3b. Non-adjacent branches: dispatch to Ẽ₆ / Ẽ₇ / D̃₅ depending on branch geometry (per `non_adjacent_branches_infinite_type` line 9682).
+   - 3c. Single branch (T(p,q,r) family): dispatch to T(1,2,5) (per `single_branch_not_posdef_infinite_type` line 8401).
+4. All degrees ≤ 2: closes by contradiction via `acyclic_deg_le_2_posdef`.
+
+Each dispatch uses `subgraph_infinite_type_transfer_per_kQ` with the restriction `restrictOrientationViaEmb φ Q` of the ambient orientation to the subgraph.
+
+### D3. Close `not_posdef_not_HasFiniteRepresentationType`
+
+In `Chapter2/Theorem2_1_2.lean`, replace the `sorry` at line 173 with a proof that:
+
+1. Specializes `not_posdef_infinite_type_per_kQ` with `adj := quiverUndirectedAdj n`, the given `k`, and the ambient `Quiver (Fin n)` instance.
+2. Establishes `h_not_posdef` from the given `∃ x ≠ 0, ¬(0 < …)` by `push_neg` / `Classical.not_forall`.
+3. Combines with the contrapositive of `HasFiniteRepresentationType.finite_dimVectors` (`Theorem2_1_2.lean:111`).
+
+The proof should be ~30-60 lines. No new helpers needed.
+
+## Verification
+
+- `lake build EtingofRepresentationTheory.Chapter2.Theorem2_1_2` passes.
+- `not_posdef_not_HasFiniteRepresentationType` carries no sorries of its own; the remaining sorry chain is the (preexisting) bodies inside the per-(F, Q) base cases.
+- `Chapter2/Theorem2_1_2.lean:173` is no longer `sorry`.
+- New stubs `star_not_finite_type_per_kQ` and `t125_not_finite_type_per_kQ` have correct `IsOrientationOf` premises and the same conclusion shape as `d5tilde_not_finite_type_per_kQ`.
+
+## Context
+
+- Parent: #2774 (which closes on completion of all three deliverables).
+- Closes: contributes the final step toward #2401 (Theorem 2.1.2 forward bridge); #2401 itself stays open until all per-(F, Q) sorry chains close.
+- Sibling sub: deliverable 1 already landed PR #2805 (wave 59).
+- The two API stubs introduced here will have their bodies filled by #2789 / #2801 (K_{1,4} D̃₄ canonical / Q-extension) and #2793 (T(1,2,5)); both of those issues are in `replan`. Filing the stubs unblocks D2/D3 without waiting on those proof-level chains.
+- Files touched: `Chapter6/FieldGenericStar.lean` (+stub, ~30 lines); new `Chapter6/FieldGenericT125.lean` (~30 lines); `Chapter6/FieldGenericInfiniteType.lean` (+assembly, ~150-200 lines); `Chapter2/Theorem2_1_2.lean` (~50 lines). Add the new file to the relevant `lakefile.lean` / module manifest if required.
+- Estimated total: ~250-310 lines across 4 files.
+
+## Sizing note
+
+This issue is at the upper end of the planner sizing target (3 deliverables, 4 files, ~300 lines). The three deliverables are tightly coupled (each depends on the previous), so splitting now would create a 2-3 issue chain where each blocks the next on the same session window. If the claiming worker finds the scope unmanageable in a single session, they should follow the `agent-worker-flow` "Assess Scope" path and decompose into:
+- one sub-issue for D1 (API stubs, ~60 lines, 2 files);
+- one sub-issue for D2 + D3 (assembly + bridge, ~200-250 lines, 2 files).

--- a/progress/2026-05-18T09-26-04Z_183960dd.md
+++ b/progress/2026-05-18T09-26-04Z_183960dd.md
@@ -1,0 +1,87 @@
+# Planner cycle 183960dd
+
+## Accomplished
+
+Planner cycle (`/plan`). Queue state on entry: `POD_MIN_QUEUE=3`,
+`POD_QUEUE_DEPTH=2`, `POD_QUEUE_DEFICIT=1`. Unclaimed at entry:
+#2564 (Mathlib-upstream tracker, blocked on external Mathlib PR) and
+#2873 (Ch6 sibling-lemma review). No directives open. No mergeable
+PRs with passing CI. Three PRs are in the PR-repair queue (#2849
+CI FAILED, #2694 / #2550 CONFLICTING) — pod's `/repair` dispatch
+owns those; no plan-side fix issues needed.
+
+Refilled the queue by **+1 atomic feature issue**, matching the
+deficit and the priority-5 callout in `progress/sorry-landscape.md`
+(wave 60): **#2875** —
+`feat(Ch2 #2774): close not_posdef_not_HasFiniteRepresentationType
+— per-(k,Q) assembly + Theorem 2.1.2 bridge`. This covers
+deliverables 2 + 3 of parent #2774, which the wave-59 and wave-60
+summaries both flagged as unfiled for ~14 days. Three deliverables:
+
+- D1 introduces the two missing per-(F, Q) API stubs
+  `star_not_finite_type_per_kQ` (in `FieldGenericStar.lean`) and
+  `t125_not_finite_type_per_kQ` (in a new `FieldGenericT125.lean`).
+  Both are theorem-with-sorry-body stubs, whose proofs are tracked
+  by #2789 / #2801 (K_{1,4}) and #2793 (T(1,2,5)). This decouples
+  the assembly from those proof-level chains.
+- D2 adds `not_posdef_infinite_type_per_kQ` in
+  `FieldGenericInfiniteType.lean`, mirroring the case-analysis of
+  `not_posdef_infinite_type` (`InfiniteTypeConstructions.lean:10661`)
+  and dispatching each case to a per-(F, Q) base theorem via
+  `subgraph_infinite_type_transfer_per_kQ` (deliverable 1 of #2774,
+  PR #2805 wave 59).
+- D3 closes `not_posdef_not_HasFiniteRepresentationType` at
+  `Chapter2/Theorem2_1_2.lean:173`.
+
+Estimated 250-310 lines across 4 files; sizing notes in the issue
+body invite worker-led decomposition into (D1) + (D2+D3) if the
+combined scope doesn't fit one session.
+
+## Current frontier
+
+Plan-queue: #2564 (external-blocked), #2873 (review), #2875
+(new feature). Three workers can productively claim from the
+queue; one feature, one review, one external-blocked tracker.
+
+D̃₅ Sub B cascade remains the most active in-flight chain
+(#2853, #2851, blocked on #2850 which is in `replan`).
+`/replan` will triage #2850 next cycle armed with the finding
+from #2872 that γ⁻¹-coupled containment doesn't factor as a
+sibling lemma (inv-direction reasoning inlines in #2853).
+
+## Overall project progress
+
+Stage 3 (Lean formalization) ongoing. 16 sorries / 8 files as of
+wave-60 (PRs since the snapshot have not changed the count).
+582/583 items sorry-free; 0 definition-level sorries.
+
+Active per-(F, Q) chain coverage after this cycle:
+- 4 of 6 forbidden-subgraph per-(F, Q) theorems live on `main`
+  (cycle ✅, D̃₅ ✅ with sorry chain, Ẽ₆ ✅ with Wall-1 sorry,
+  Ẽ₇ ✅ with Wall-1 sorry).
+- 2 missing names (K_{1,4} `star_not_finite_type_per_kQ`, T(1,2,5)
+  `t125_not_finite_type_per_kQ`) will be introduced as API stubs
+  by #2875.
+- The Theorem 2.1.2 forward bridge (`Theorem2_1_2.lean:173`)
+  closes once #2875 lands; remaining sorry chain transitively
+  depends on Wall 1 (#2436), D̃₅ Sub B cascade (#2853 + #2851),
+  K_{1,4} indecomposability (#2789 + #2801), and T(1,2,5)
+  proof (#2793).
+
+## Next step
+
+- A `/feature` worker can claim #2875. The body is self-contained
+  with explicit file paths, line numbers for the case-analysis
+  template in `not_posdef_infinite_type`, and decomposition
+  guidance if scope exceeds one session.
+- `/replan` cycles continue to triage the existing `replan` queue
+  (notably #2850 for the D̃₅ Sub B chain, #2789 / #2801 / #2793
+  for the K_{1,4} / T(1,2,5) per-(F, Q) proofs which #2875's
+  stubs depend on for body-filling).
+- `/repair` cycles continue on #2849, #2694, #2550 (~24-day,
+  ~15-day, fresh-CI-fail respectively).
+
+## Blockers
+
+None for the planner. #2564 stays blocked on
+https://github.com/leanprover-community/mathlib4/pull/38583 .


### PR DESCRIPTION
This PR records the planner cycle 183960dd progress note and the plan body for the new feature issue.

Filed #2875 (feature): close `not_posdef_not_HasFiniteRepresentationType` at `Chapter2/Theorem2_1_2.lean:173` via per-(k, Q) assembly. Covers deliverables 2 + 3 of parent #2774 (deliverable 1 landed PR #2805 wave 59). Three deliverables: (D1) introduce missing per-(F, Q) API stubs `star_not_finite_type_per_kQ` and `t125_not_finite_type_per_kQ`; (D2) `not_posdef_infinite_type_per_kQ` assembly in `Chapter6/FieldGenericInfiniteType.lean` mirroring the case-analysis of `not_posdef_infinite_type` (line 10661); (D3) Theorem 2.1.2 bridge wiring. Estimated 250-310 lines across 4 files; body invites worker-led decomposition into (D1) + (D2+D3) if the combined scope doesn't fit one session.

Queue refilled to depth 3 (`POD_MIN_QUEUE`, was 2) — matches `POD_QUEUE_DEFICIT=1`.

No merge sweep this cycle — all open PRs (#2849, #2694, #2550) are in pr-repair territory. No directives open. No additional planner-side fix issues needed for the broken PRs (`coordination list-pr-repair` already has them).

🤖 Prepared with Claude Code