### PR TITLE
progress: planner cycle a204bae4 — pre-step #2877 subgraph dispatch wrappers (#2880)

### DIFF
--- a/plans/a204bae4-1.md
+++ b/plans/a204bae4-1.md
@@ -1,0 +1,176 @@
+## Current state
+
+Pre-step decomposition for **#2877** (`not_posdef_infinite_type_per_kQ`
+assembly + Theorem 2.1.2 bridge). #2877 enumerates 6 sub-deliverables
+mirroring the case-analysis tree of `not_posdef_infinite_type`
+(`InfiniteTypeConstructions.lean:10661-10714`). Three of those
+sub-deliverables (D2.degree4, D2.cycle, the bigger ones) consume small
+per-(F, Q) subgraph-transfer wrappers that currently **do not exist**
+on `main`:
+
+| `_kQ`-side wrapper | `kQ`-free counterpart | Lines | Used by |
+|---|---|---|---|
+| `star_subgraph_not_finite_type_per_kQ` | `star_subgraph_not_finite_type` (`InfiniteTypeConstructions.lean:1133-1183`) | ~50 | #2877 D2.degree4 (K_{1,4} branch) |
+| `triangle_infinite_type_per_kQ` | `triangle_infinite_type` (`InfiniteTypeConstructions.lean:3880-3902`) | ~25 | #2877 D2.degree4 (3-cycle branch) |
+| `chordless_cycle_infinite_type_per_kQ` | `chordless_cycle_infinite_type` (`InfiniteTypeConstructions.lean:4112-4120`) | ~15 | #2877 D2.cycle |
+
+Each `_kQ`-free counterpart on `main` is a thin wrapper around
+`subgraph_infinite_type_transfer` + the corresponding leaf theorem
+(`star_not_finite_type`, `cycle_not_finite_type k hk` at `k=3`,
+`cycle_not_finite_type k hk`).
+
+The per-(F, Q) transfer (`subgraph_infinite_type_transfer_per_kQ`,
+`FieldGenericInfiniteType.lean:374`) and both leaf theorems
+(`star_not_finite_type_per_kQ` in `FieldGenericStar.lean:542`,
+sorry-bodied per #2789/#2801; `cycle_not_finite_type_per_kQ` in
+`FieldGenericCycle.lean:326`, fully proven) are all on `main`. The only
+missing pieces are the three transfer-wrapped dispatch helpers above.
+
+Filing them as one atomic feature pre-step shrinks #2877.D2.degree4
+from ~150 lines (with inlined wrappers) to ~50 lines (pure outer
+case-split) and #2877.D2.cycle from ~150 lines to ~135 lines. More
+importantly, it mirrors the existing structural pattern in
+`InfiniteTypeConstructions.lean` (named one-liner wrappers around
+`subgraph_infinite_type_transfer`), keeping the per-(F, Q) side
+isomorphic to the `_kQ`-free side.
+
+This is the same shape as the wave-60 pre-step pattern (#2868 / #2869
+pre-stepped #2853): infrastructure helpers extracted into their own
+unblocked sub-issue while the parent is in `replan`-or-blocked
+territory.
+
+## Deliverables
+
+Add three top-level theorems to
+`EtingofRepresentationTheory/Chapter6/FieldGenericInfiniteType.lean`
+(near the existing `subgraph_infinite_type_transfer_per_kQ` at line
+374). All three are pure mechanical mirrors of their `_kQ`-free
+counterparts: replace `subgraph_infinite_type_transfer` with
+`subgraph_infinite_type_transfer_per_kQ`, swap the leaf theorem for
+its `_per_kQ` analog, and thread the `(F, Q, hOrient)` triple plus
+the restricted orientation
+(`restrictOrientationViaEmb φ Q` +
+`restrictOrientationViaEmb_isOrientationOf` at line 345) through.
+
+### D1. `chordless_cycle_infinite_type_per_kQ` (~15 lines)
+
+Mirror `InfiniteTypeConstructions.lean:4112-4120`. Signature:
+
+```lean
+theorem chordless_cycle_infinite_type_per_kQ {n k : ℕ}
+    (adj : Matrix (Fin n) (Fin n) ℤ)
+    (hsymm : adj.IsSymm)
+    (hdiag : ∀ i, adj i i = 0)
+    (hk : 3 ≤ k)
+    (φ : Fin k ↪ Fin n)
+    (hembed : ∀ i j, cycleAdj k hk i j = adj (φ i) (φ j))
+    (F : Type) [Field F]
+    (Q : @Quiver.{0, 0} (Fin n))
+    [∀ a b, Subsingleton (@Quiver.Hom (Fin n) Q a b)]
+    (hOrient : @Etingof.IsOrientationOf n Q adj) :
+    ¬ Set.Finite
+      {d : Fin n → ℕ |
+        ∃ V : @Etingof.QuiverRepresentation.{0,0,0,0} F (Fin n) _ Q,
+          V.IsIndecomposable ∧ ∀ v, Nonempty (V.obj v ≃ₗ[F] (Fin (d v) → F))} := by
+  exact subgraph_infinite_type_transfer_per_kQ φ F Q
+    (cycle_not_finite_type_per_kQ F k hk
+      (restrictOrientationViaEmb φ Q)
+      (restrictOrientationViaEmb_isOrientationOf φ hembed hOrient))
+```
+
+(Subsingleton instance for the restricted quiver is already provided
+by `restrictOrientationViaEmb` typeclass synthesis — see existing
+proof in `subgraph_infinite_type_transfer_per_kQ` at line 390-393.)
+
+### D2. `triangle_infinite_type_per_kQ` (~25 lines)
+
+Mirror `InfiniteTypeConstructions.lean:3880-3902`. Constructs the
+3-cycle embedding `φ : Fin 3 ↪ Fin n` mapping `0 ↦ a, 1 ↦ b, 2 ↦ c`,
+verifies `hembed : ∀ i j, cycleAdj 3 _ i j = adj (φ i) (φ j)` using
+the symmetry hypotheses, then dispatches to D1 (or directly to
+`subgraph_infinite_type_transfer_per_kQ` + `cycle_not_finite_type_per_kQ`).
+
+### D3. `star_subgraph_not_finite_type_per_kQ` (~50 lines)
+
+Mirror `InfiniteTypeConstructions.lean:1133-1183`. Constructs the
+embedding `φ : Fin 5 ↪ Fin n` (center at 0, leaves at 1-4), verifies
+`hembed : ∀ i j, starAdj i j = adj (φ i) (φ j)` from the
+`hadj_diag` / `hadj_edge` / `hadj_indep` hypotheses (case-split on
+whether each index is 0 or non-zero), then dispatches to
+`subgraph_infinite_type_transfer_per_kQ` + `star_not_finite_type_per_kQ`.
+
+Add the `[IsAlgClosed F]` requirement to the signature only if
+`star_not_finite_type_per_kQ` (`FieldGenericStar.lean:542`) requires
+it. (It does — its signature carries `[Field F] [IsAlgClosed F]`.
+D3 must inherit this.)
+
+## Strategy notes
+
+- All three are body-isomorphic to their `_kQ`-free counterparts modulo
+  the `(F, Q, hOrient)` plumbing. The `restrictOrientationViaEmb φ Q`
+  is the orientation that gets passed to the leaf-theorem call, and
+  `restrictOrientationViaEmb_isOrientationOf` proves it actually
+  orients the restricted adjacency.
+- D1 and D2 are independent (D2 could be written as a body-inline of
+  the 3-cycle embedding, or compose D1 with `k = 3`). Either is fine
+  — prefer the clearer.
+- D3 is the largest (~50 lines) because the K_{1,4}-style embedding
+  needs the if-on-`i.val=0` case-split on `φ_fun`. Cribbed from
+  `star_subgraph_not_finite_type:1144-1183` mostly verbatim.
+
+## Context
+
+- Parent: #2877 (per-(F, Q) Ch2 assembly + Theorem 2.1.2 bridge).
+- Sibling pre-step pattern: #2868 / #2869 → #2853 (D̃₅ Sub B).
+- Wrapper transfer: `subgraph_infinite_type_transfer_per_kQ`
+  (`FieldGenericInfiniteType.lean:374`).
+- Restricted orientation: `restrictOrientationViaEmb_isOrientationOf`
+  (`FieldGenericInfiniteType.lean:345`).
+- Leaf theorems on `main`:
+  - `star_not_finite_type_per_kQ` (`FieldGenericStar.lean:542`) —
+    sorry-bodied per #2789/#2801, name exists.
+  - `cycle_not_finite_type_per_kQ` (`FieldGenericCycle.lean:326`) —
+    fully proven.
+- `_kQ`-free counterparts to mirror: lines 1133-1183, 3880-3902,
+  4112-4120 of `InfiniteTypeConstructions.lean`.
+- The new wrappers' bodies inherit any sorry chain from their leaf
+  theorems (D2.degree4 K_{1,4} branch transitively depends on
+  #2789/#2801 because `star_not_finite_type_per_kQ` has a `sorry`
+  body — this is fine per "spec-driven development").
+
+## Verification
+
+- `lake build EtingofRepresentationTheory.Chapter6.FieldGenericInfiniteType`
+  passes.
+- Three new top-level theorems (`chordless_cycle_infinite_type_per_kQ`,
+  `triangle_infinite_type_per_kQ`, `star_subgraph_not_finite_type_per_kQ`)
+  are visible in `FieldGenericInfiniteType.lean`.
+- No new `sorry` placeholders introduced by this PR (the wrappers
+  themselves are sorry-free; any sorries reachable through their
+  bodies were already on `main` via `star_not_finite_type_per_kQ`).
+- Net sorry-count delta: **0** raw `sorry`s; **0** sorry'd
+  declarations.
+
+## Sizing
+
+Small-to-medium (~90-130 lines, 1 file, 3 deliverables). Comfortably
+within the planner sizing target (max 3 deliverables, ~2 files,
+~200 lines).
+
+## Notes for the worker
+
+- The three deliverables can land in any order in the same PR — they
+  share no dependencies among themselves.
+- If you find the wrappers are clean enough that
+  `triangle_infinite_type_per_kQ` becomes a 5-line composition of
+  D1 with `k = 3`, prefer the composition over a fresh embedding —
+  but only if the resulting statement matches the `_kQ`-free
+  counterpart's shape (three vertices `a`, `b`, `c` with pairwise
+  adjacencies).
+- The `attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
+  CategoryTheory.ReflQuiver.toQuiver in` line in the `_kQ`-free
+  counterparts is needed to avoid quiver-instance ambiguity; the
+  per-(F, Q) wrappers should follow the same pattern (the existing
+  `subgraph_infinite_type_transfer_per_kQ` does).
+- Do not attempt to fill `star_not_finite_type_per_kQ`'s body — that
+  is #2789/#2801's scope.

--- a/progress/2026-05-18T10-19-20Z_a204bae4.md
+++ b/progress/2026-05-18T10-19-20Z_a204bae4.md
@@ -1,0 +1,163 @@
+# Progress — planner session a204bae4
+
+## Accomplished
+
+Planner cycle. Queue state on entry: `POD_QUEUE_DEPTH=2`,
+`POD_MIN_QUEUE=3`, `POD_QUEUE_DEFICIT=1`.
+
+Pre-plan checks:
+
+- **Directives**: none open (`directive` label query empty).
+- **Merge sweep**: no PRs satisfied the mergeable + non-failing
+  predicate. Three open PRs all in pr-repair territory:
+  - **#2849** (chore: dedupe `etilde6LeafProj_F` / `starFirst_F`):
+    MERGEABLE but CI FAILURE.
+  - **#2694** (Schur-Weyl γ.A): CONFLICTING.
+  - **#2550** (Wall 3 C.1.a.ii): CONFLICTING (~24 days static).
+- **Replan triage**: handled by `/replan` — out of scope here.
+
+Substantive PR motion since cycle e3149b7f:
+
+- PR **#2871** merged (closes #2868) — four proj-sibling lemmas
+  for D̃₅ reversed leaf edges, landed earlier this cycle window.
+- PR **#2878** merged (closes #2875 D1) — per-(F, Q) API stubs
+  `star_not_finite_type_per_kQ` (in `FieldGenericStar.lean:542`,
+  sorry-bodied per #2789/#2801) and `t125_not_finite_type_per_kQ`
+  (in new `FieldGenericT125.lean`, sorry-bodied per #2793).
+- PR **#2879** merged (closes #2873) — proj-sibling lemma audit,
+  PASS verdict, no follow-up sub-issues filed.
+
+Step 4 overlap audit: re-read all open `agent-plan` issue titles
+plus the bodies of #2877, #2875, #2853, and the wave-60 audit
+notes. The three new transfer-wrapped dispatch wrappers proposed
+this cycle (`chordless_cycle_infinite_type_per_kQ`,
+`triangle_infinite_type_per_kQ`,
+`star_subgraph_not_finite_type_per_kQ`) are *not* explicitly
+enumerated in #2877's deliverable list; #2877 implicitly inlines
+them inside D2.degree4 / D2.cycle. The pre-step extraction is
+strictly orthogonal and produces named helpers that mirror the
+`_kQ`-free structural pattern.
+
+Created one new feature issue, fully consuming the deficit:
+
+- **#2880** — `feat(Ch6 #2877 pre-step): per-(F, Q) subgraph
+  dispatch wrappers (star / triangle / chordless_cycle)`. Three
+  thin transfer-wrapped helpers in
+  `FieldGenericInfiniteType.lean` mirroring lines 1133-1183 / 3880-3902 /
+  4112-4120 of `InfiniteTypeConstructions.lean`. Each is a
+  mechanical wrap of `subgraph_infinite_type_transfer_per_kQ` +
+  the appropriate leaf theorem (`star_not_finite_type_per_kQ`
+  sorry-bodied; `cycle_not_finite_type_per_kQ` fully proven).
+  Total ~90 lines, 1 file, 0 new sorries. Pre-staging shrinks
+  #2877.D2.degree4 from ~150 to ~50 lines and #2877.D2.cycle
+  from ~150 to ~135 lines once #2880 lands.
+
+Wave-61 summarize NOT filed this cycle: substantive PRs merged
+since wave-60 (#2857 at 2026-05-18T02:25Z) currently total
+**8** — below the documented 10+ trigger. List: #2861, #2862,
+#2863, #2866, #2867, #2871, #2878, #2879. Next planner cycle
+will likely cross threshold.
+
+Other options ruled out:
+
+- **Decompose #2877 D2.degree4 / D2.cycle directly**: would create
+  larger sub-issues that still need the missing wrapper helpers
+  inlined. Filing the wrappers separately (this cycle) lets
+  D2.degree4 / D2.cycle be filed cleanly as outer case-splits
+  next cycle.
+- **K_{1,4} / Schur-Weyl pre-staging**: K_{1,4} chain (#2789,
+  #2801, #2823) all in `replan`, no obvious pre-staging target
+  that isn't gated by #2789/#2801's `starRep_kQ` indecomposability
+  proof. Schur-Weyl γ.A (#2694) in pr-repair queue.
+- **Audit/review of #2878**: the two API stubs are 30-line
+  sorry-bodied theorems that mirror `etilde6_not_finite_type_per_kQ`
+  byte-for-byte modulo size constants — the value of an audit is
+  low. Recent audits (#2858, #2864, #2873/#2879) have all
+  delivered PASS verdicts; a fourth in a row would over-index on
+  review work relative to the 2:1 feature:review target during
+  implementation phase.
+- **#2877 D2.outer + D3 bridge**: depends on D2.degree4 / cycle /
+  adjacent / single / nonadj all landing first; not actionable
+  this cycle.
+
+Queue depth post-planning: **3** actionable issues = `POD_MIN_QUEUE`.
+Composition:
+
+- **#2880** (new feature, just filed) — per-(F, Q) subgraph
+  dispatch wrappers pre-step for #2877.
+- **#2877** — per-(F, Q) Ch2 assembly + Theorem 2.1.2 bridge.
+- **#2564** — Mathlib upstream tracker, external-blocked.
+
+`coordination set-target` not called — active development phase,
+operator-configured pool size stands.
+
+## Current frontier
+
+Unclaimed actionable issues:
+
+- **#2880** — per-(F, Q) subgraph dispatch wrappers (just filed).
+- **#2877** — Ch2 assembly + Theorem 2.1.2 bridge.
+- **#2564** — Mathlib upstream tracker, external-blocked.
+
+Active in-flight PRs (all in pr-repair territory): #2849 (#2821
+dedupe, CI FAILURE), #2694 (Schur-Weyl γ.A, CONFLICTING — ~15
+days static), #2550 (Wall 3 C.1.a.ii, CONFLICTING — ~24 days
+static).
+
+Per-(F, Q) Ch6 refactor scoreboard:
+- Cycle / K_{1,4} canonical / D̃₅ Sub A / Ẽ₆ Sub A+B / Ẽ₇: done.
+- K_{1,4} per-(F, Q) indecomposability: #2801 — `replan`.
+- K_{1,4} bridge `starRep_kQ ↔ starRepGen` canonical: #2823 —
+  `replan`.
+- D̃₅ Sub B: helpers + γ⁻¹ identities + canonical leaf-equality
+  case + wave-60 cleanup hoists + proj-sibling pre-steps all
+  landed. #2839 / #2850 / #2853 / #2851 still in chain (all
+  `replan`/`blocked`).
+- T(1,2,5): #2793 still `replan`. Subgraph transfer: D1 landed
+  (#2805), D2+D3 now in **#2877** + pre-step **#2880**.
+- Theorem 2.1.2 forward bridge (`Theorem2_1_2.lean:173`): closes
+  once #2877 + #2880 both land (sorry chain remains
+  transitively through Wall 1, D̃₅ Sub B, K_{1,4}, T(1,2,5)).
+
+Schur-Weyl L_i C-tier chain: γ.A (#2694) still CONFLICTING, all
+downstream items (γ.B, C-4a aggregation, C-4c, Schur-Weyl #5/#6)
+still blocked.
+
+## Overall project progress
+
+Stage 3 (Lean formalisation). Per-(F, Q) Ch2 assembly chain is
+the next active critical path now that all D̃₅ Sub B pre-staging
+(#2871) and Ch2 D1 (#2878) have landed. The remaining `_per_kQ`
+infrastructure gap is the three subgraph-transfer dispatch
+wrappers filed as #2880.
+
+Substantive PRs since wave-60 summarize (#2857 at 2026-05-18T02:25Z):
+**8** (below 10+ trigger): #2861, #2862, #2863, #2866, #2867,
+#2871, #2878, #2879. Wave-61 summarize likely triggered next
+cycle.
+
+Sorry-count delta this turn: **0** (planner cycle, no code
+changes). Expected sorry delta once #2880 lands: **0** (three
+new wrapper theorems with sorry-free bodies).
+
+## Next step
+
+- Dispatcher will run `/replan` first (sizeable queue including
+  #2850, the key D̃₅ Sub B gate), then pr-repair on #2849 /
+  #2694 / #2550, then claim a worker on the unclaimed queue.
+  **#2880** is the natural pick for a fresh feature slot
+  (~90 lines, mechanical mirroring, 1 file).
+- After #2880 lands, the next planner cycle should: (a) consider
+  wave-61 summarize (likely past the 10+ trigger by then);
+  (b) decompose #2877 into D2.degree4 / D2.cycle as separate
+  sub-issues (the now-available wrappers make these clean
+  ~50-line outer-dispatch issues); (c) re-evaluate #2789 /
+  #2801 / #2793 `replan` resolutions.
+
+## Blockers
+
+None for the planner work itself. Standing constraints unchanged:
+framework-wall decision (#2436) gates the inherited sorries in
+the per-(F, Q) and ℂ-side indecomposability proofs; the three
+static pr-repair PRs (#2849 / #2694 / #2550) remain in `/repair`
+territory.


### PR DESCRIPTION
This PR records the planner cycle a204bae4 progress note and the plan body for the new feature issue filed this cycle.

Filed #2880 (feature, pre-step for #2877): three per-(F, Q) subgraph-transfer dispatch wrappers (`chordless_cycle_infinite_type_per_kQ`, `triangle_infinite_type_per_kQ`, `star_subgraph_not_finite_type_per_kQ`) in `Chapter6/FieldGenericInfiniteType.lean`. Each is a thin mechanical mirror of an existing `_kQ`-free wrapper in `Chapter6/InfiniteTypeConstructions.lean` (lines 1133-1183, 3880-3902, 4112-4120). Total ~90 lines, 1 file, 0 new sorries. Pre-staging shrinks #2877.D2.degree4 from ~150 to ~50 lines and #2877.D2.cycle from ~150 to ~135 lines once #2880 lands.

Queue refilled to depth 3 (`POD_MIN_QUEUE`, was 2) — matches `POD_QUEUE_DEFICIT=1`.

No merge sweep this cycle — all open PRs (#2849, #2694, #2550) are in pr-repair territory. No directives open. Wave-61 summarize not filed: 8 substantive PRs merged since wave-60 (#2857 at 2026-05-18T02:25Z), below the 10+ trigger.

🤖 Prepared with Claude Code