### PR TITLE
feat(Ch6 #2877 pre-step): per-(F, Q) subgraph dispatch wrappers (star / triangle / chordless_cycle)

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/FieldGenericCycle.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericCycle.lean
@@ -348,4 +348,83 @@ theorem cycle_not_finite_type_per_kQ
   exact (Set.infinite_range_of_injective hinj |>.mono
     (Set.range_subset_iff.mpr hmem)).not_finite hfin
 
+/-! ## Section: Per-(F, Q) subgraph dispatch wrappers for cycle subgraphs
+
+Mirrors `chordless_cycle_infinite_type` (`InfiniteTypeConstructions.lean:4112`)
+and `triangle_infinite_type` (`InfiniteTypeConstructions.lean:3880`): given
+an embedding witnessing that `Q` contains a cycle (or a triangle), conclude
+that the per-(F, Q) representation set of indecomposable dimension vectors
+is infinite. Body-isomorphic to the kQ-free counterparts modulo plumbing
+through `(F, Q, hOrient)` via `subgraph_infinite_type_transfer_per_kQ` and
+the restricted orientation.
+
+The wrappers are placed here (rather than in `FieldGenericInfiniteType.lean`
+next to `subgraph_infinite_type_transfer_per_kQ`) because they depend on
+`cycle_not_finite_type_per_kQ`, which lives in this file; the import graph
+runs `FieldGenericInfiniteType → FieldGenericCycle`, not the reverse.
+-/
+
+attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
+  CategoryTheory.ReflQuiver.toQuiver in
+/-- Per-(F, Q) version of `chordless_cycle_infinite_type`: a graph
+containing a chordless cycle of length `k ≥ 3` (witnessed by an embedding
+`φ : Fin k ↪ Fin n` exactly preserving the cycle adjacency) has infinite
+representation type for every orientation `Q`. -/
+theorem chordless_cycle_infinite_type_per_kQ {n k : ℕ}
+    (adj : Matrix (Fin n) (Fin n) ℤ)
+    (_hsymm : adj.IsSymm)
+    (_hdiag : ∀ i, adj i i = 0)
+    (hk : 3 ≤ k)
+    (φ : Fin k ↪ Fin n)
+    (hembed : ∀ i j, cycleAdj k hk i j = adj (φ i) (φ j))
+    (F : Type) [Field F]
+    (Q : @Quiver.{0, 0} (Fin n))
+    [∀ a b, Subsingleton (@Quiver.Hom (Fin n) Q a b)]
+    (hOrient : @Etingof.IsOrientationOf n Q adj) :
+    ¬ Set.Finite
+      {d : Fin n → ℕ |
+        ∃ V : @Etingof.QuiverRepresentation.{0,0,0,0} F (Fin n) _ Q,
+          V.IsIndecomposable ∧ ∀ v, Nonempty (V.obj v ≃ₗ[F] (Fin (d v) → F))} :=
+  subgraph_infinite_type_transfer_per_kQ φ F Q
+    (cycle_not_finite_type_per_kQ F k hk (restrictOrientationViaEmb φ Q)
+      (restrictOrientationViaEmb_isOrientationOf φ hembed hOrient))
+
+attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
+  CategoryTheory.ReflQuiver.toQuiver in
+/-- Per-(F, Q) version of `triangle_infinite_type`: a graph containing a
+triangle (three pairwise-adjacent distinct vertices) has infinite
+representation type for every orientation `Q`. Built as the `k = 3`
+specialisation of `chordless_cycle_infinite_type_per_kQ`. -/
+theorem triangle_infinite_type_per_kQ {n : ℕ}
+    (adj : Matrix (Fin n) (Fin n) ℤ)
+    (hsymm : adj.IsSymm)
+    (hdiag : ∀ i, adj i i = 0)
+    (_h01 : ∀ i j, adj i j = 0 ∨ adj i j = 1)
+    (a b c : Fin n) (hab : a ≠ b) (hbc : b ≠ c) (hac : a ≠ c)
+    (h_ab : adj a b = 1) (h_bc : adj b c = 1) (h_ac : adj a c = 1)
+    (F : Type) [Field F]
+    (Q : @Quiver.{0, 0} (Fin n))
+    [∀ a b, Subsingleton (@Quiver.Hom (Fin n) Q a b)]
+    (hOrient : @Etingof.IsOrientationOf n Q adj) :
+    ¬ Set.Finite
+      {d : Fin n → ℕ |
+        ∃ V : @Etingof.QuiverRepresentation.{0,0,0,0} F (Fin n) _ Q,
+          V.IsIndecomposable ∧ ∀ v, Nonempty (V.obj v ≃ₗ[F] (Fin (d v) → F))} := by
+  -- Construct embedding φ : Fin 3 ↪ Fin n mapping 0 ↦ a, 1 ↦ b, 2 ↦ c.
+  let φ_fun : Fin 3 → Fin n := ![a, b, c]
+  have hφ_inj : Function.Injective φ_fun := by
+    intro x y h
+    fin_cases x <;> fin_cases y <;> simp_all [φ_fun, Matrix.cons_val_zero,
+      Matrix.cons_val_one]
+  let φ : Fin 3 ↪ Fin n := ⟨φ_fun, hφ_inj⟩
+  have hembed : ∀ i j, cycleAdj 3 (by omega) i j = adj (φ i) (φ j) := by
+    intro i j
+    have h_ba := (hsymm.apply a b).trans h_ab
+    have h_cb := (hsymm.apply b c).trans h_bc
+    have h_ca := (hsymm.apply a c).trans h_ac
+    fin_cases i <;> fin_cases j <;> simp [cycleAdj, φ, φ_fun, Matrix.cons_val_zero,
+      Matrix.cons_val_one, hdiag, h_ab, h_bc, h_ac, h_ba, h_cb, h_ca]
+  exact chordless_cycle_infinite_type_per_kQ adj hsymm hdiag (by omega) φ hembed
+    F Q hOrient
+
 end Etingof

--- a/EtingofRepresentationTheory/Chapter6/FieldGenericStar.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericStar.lean
@@ -555,4 +555,84 @@ theorem star_not_finite_type_per_kQ
   let _ := hOrient
   sorry
 
+/-! ## Section: Per-(F, Q) subgraph dispatch wrapper for K_{1,4}
+
+Mirrors `star_subgraph_not_finite_type` (`InfiniteTypeConstructions.lean:1133`):
+given a center vertex and four pairwise non-adjacent leaves, conclude that
+the per-(F, Q) representation set of indecomposable dimension vectors is
+infinite. Inherits the `sorry` chain of `star_not_finite_type_per_kQ`
+(tracked by #2789 / #2801).
+
+Placed here (rather than in `FieldGenericInfiniteType.lean` next to
+`subgraph_infinite_type_transfer_per_kQ`) because it depends on
+`star_not_finite_type_per_kQ`, which lives in this file; the import graph
+runs `FieldGenericInfiniteType → FieldGenericStar`, not the reverse.
+-/
+
+attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
+  CategoryTheory.ReflQuiver.toQuiver in
+/-- Per-(F, Q) version of `star_subgraph_not_finite_type`: a graph
+containing a `K_{1,4}` subgraph (a center vertex with four pairwise
+non-adjacent leaves) has infinite representation type for every
+algebraically closed `F` and every orientation `Q`. -/
+theorem star_subgraph_not_finite_type_per_kQ {n : ℕ}
+    (adj : Matrix (Fin n) (Fin n) ℤ)
+    (hadj_symm : adj.IsSymm)
+    (hadj_diag : ∀ v, adj v v = 0)
+    (center : Fin n) (leaves : Fin 4 ↪ Fin n)
+    (hleaves_ne : ∀ i, leaves i ≠ center)
+    (hadj_edge : ∀ i, adj center (leaves i) = 1)
+    (hadj_indep : ∀ i j, adj (leaves i) (leaves j) = 0)
+    (F : Type) [Field F] [IsAlgClosed F]
+    (Q : @Quiver.{0, 0} (Fin n))
+    [∀ a b, Subsingleton (@Quiver.Hom (Fin n) Q a b)]
+    (hOrient : @Etingof.IsOrientationOf n Q adj) :
+    ¬ Set.Finite
+      {d : Fin n → ℕ |
+        ∃ V : @Etingof.QuiverRepresentation.{0,0,0,0} F (Fin n) _ Q,
+          V.IsIndecomposable ∧ ∀ v, Nonempty (V.obj v ≃ₗ[F] (Fin (d v) → F))} := by
+  -- Construct embedding φ : Fin 5 ↪ Fin n mapping 0 ↦ center, k+1 ↦ leaves k.
+  have h_leaf (i : Fin 5) (h : i.val ≠ 0) : i.val - 1 < 4 := by omega
+  let φ_fun : Fin 5 → Fin n := fun i =>
+    if h : i.val = 0 then center
+    else leaves ⟨i.val - 1, h_leaf i h⟩
+  have hφ_inj : Function.Injective φ_fun := by
+    intro a b hab
+    simp only [φ_fun] at hab
+    by_cases ha0 : a.val = 0 <;> by_cases hb0 : b.val = 0
+    · exact Fin.ext (by omega)
+    · exfalso; rw [dif_pos ha0, dif_neg hb0] at hab; exact hleaves_ne _ hab.symm
+    · exfalso; rw [dif_neg ha0, dif_pos hb0] at hab; exact hleaves_ne _ hab
+    · rw [dif_neg ha0, dif_neg hb0] at hab
+      have h := congr_arg Fin.val (leaves.injective hab)
+      simp at h
+      exact Fin.ext (by omega)
+  let φ : Fin 5 ↪ Fin n := ⟨φ_fun, hφ_inj⟩
+  -- Verify adjacency embedding condition: starAdj i j = adj (φ i) (φ j).
+  have hembed : ∀ i j, starAdj i j = adj (φ i) (φ j) := by
+    intro i j
+    change (if (i.val = 0 ∧ j.val ≠ 0) ∨ (i.val ≠ 0 ∧ j.val = 0) then (1 : ℤ) else 0) =
+      adj (φ_fun i) (φ_fun j)
+    by_cases hi0 : i.val = 0 <;> by_cases hj0 : j.val = 0
+    · -- center-center
+      rw [if_neg (by rintro (⟨-, h⟩ | ⟨h, -⟩) <;> contradiction)]
+      simp only [φ_fun, dif_pos hi0, dif_pos hj0]
+      exact (hadj_diag center).symm
+    · -- center-leaf
+      rw [if_pos (Or.inl ⟨hi0, hj0⟩)]
+      simp only [φ_fun, dif_pos hi0, dif_neg hj0]
+      exact (hadj_edge ⟨j.val - 1, h_leaf j hj0⟩).symm
+    · -- leaf-center
+      rw [if_pos (Or.inr ⟨hi0, hj0⟩)]
+      simp only [φ_fun, dif_neg hi0, dif_pos hj0]
+      exact ((hadj_symm.apply center (leaves ⟨i.val - 1, h_leaf i hi0⟩)).trans
+        (hadj_edge ⟨i.val - 1, h_leaf i hi0⟩)).symm
+    · -- leaf-leaf
+      rw [if_neg (by rintro (⟨h, -⟩ | ⟨-, h⟩) <;> contradiction)]
+      simp only [φ_fun, dif_neg hi0, dif_neg hj0]
+      exact (hadj_indep ⟨i.val - 1, h_leaf i hi0⟩ ⟨j.val - 1, h_leaf j hj0⟩).symm
+  exact subgraph_infinite_type_transfer_per_kQ φ F Q
+    (star_not_finite_type_per_kQ F (restrictOrientationViaEmb φ Q)
+      (restrictOrientationViaEmb_isOrientationOf φ hembed hOrient))
+
 end Etingof

--- a/progress/2026-05-18T10-37-56Z_37f21857.md
+++ b/progress/2026-05-18T10-37-56Z_37f21857.md
@@ -1,0 +1,73 @@
+## Accomplished
+
+Closed pre-step issue #2880 (per-(F, Q) subgraph dispatch wrappers,
+pre-step for #2877). Added three top-level wrappers that mirror the
+`_kQ`-free counterparts in `InfiniteTypeConstructions.lean`:
+
+- `chordless_cycle_infinite_type_per_kQ` (in
+  `Chapter6/FieldGenericCycle.lean`, ~22 lines) — mirrors
+  `chordless_cycle_infinite_type` (`InfiniteTypeConstructions.lean:4112`).
+- `triangle_infinite_type_per_kQ` (in
+  `Chapter6/FieldGenericCycle.lean`, ~30 lines) — mirrors
+  `triangle_infinite_type` (`InfiniteTypeConstructions.lean:3880`).
+  Implemented as a `k = 3` specialisation of
+  `chordless_cycle_infinite_type_per_kQ` per the issue's
+  "5-line composition" suggestion (plus the embedding boilerplate).
+- `star_subgraph_not_finite_type_per_kQ` (in
+  `Chapter6/FieldGenericStar.lean`, ~55 lines) — mirrors
+  `star_subgraph_not_finite_type` (`InfiniteTypeConstructions.lean:1133`).
+  Inherits the `sorry` chain of `star_not_finite_type_per_kQ` per
+  #2789 / #2801 (no new `sorry`s introduced here).
+
+## Decisions
+
+**File placement diverges from the issue spec.** The issue requested
+placing all three wrappers in
+`Chapter6/FieldGenericInfiniteType.lean` near
+`subgraph_infinite_type_transfer_per_kQ` (line 374). That is not
+viable because `FieldGenericCycle.lean` and `FieldGenericStar.lean`
+both `import FieldGenericInfiniteType`, so the wrappers (which call
+the leaf theorems `cycle_not_finite_type_per_kQ` and
+`star_not_finite_type_per_kQ`) cannot live upstream of those
+imports. The cycle wrappers go in `FieldGenericCycle.lean`; the star
+wrapper goes in `FieldGenericStar.lean`. Each new section header in
+those files documents the placement rationale.
+
+**`adj_symm_of_isSymm` is private** in
+`InfiniteTypeConstructions.lean`. In the star wrapper's leaf-center
+case I used `hadj_symm.apply` directly (the `Matrix.IsSymm.apply`
+lemma) to compose with `hadj_edge`, mirroring the same idiom used
+elsewhere (e.g. `triangle_infinite_type` line 3896).
+
+**`_hsymm` / `_hdiag` are underscored** in
+`chordless_cycle_infinite_type_per_kQ` since they are present only
+for API parity with the kQ-free counterpart — the body does not use
+them (the symmetry and diagonal info flow through `hOrient`).
+`triangle_infinite_type_per_kQ` does use both, so they are not
+underscored there.
+
+## Current frontier
+
+PR for #2880 about to be created.
+
+## Overall project progress
+
+After this lands, all three subgraph-dispatch wrappers required by
+#2877's D2.degree4 and D2.cycle sub-deliverables exist on `main`,
+shrinking those sub-issues per the sizing notes in #2880. The
+larger #2877 assembly remains unclaimed and is still recommended
+for further decomposition before any worker claims it.
+
+## Next step
+
+Planner picks up #2877 / decomposes further into D2.cycle,
+D2.degree4, etc. with the new wrappers available, or a worker
+claims a freshly-decomposed sub-issue. Mathlib upstream tracker
+#2564 remains blocked on
+https://github.com/leanprover-community/mathlib4/pull/38583.
+
+## Blockers
+
+None for this pre-step. The pre-existing `sorry` chain reachable
+through `star_not_finite_type_per_kQ` (issues #2789 and #2801) is
+inherited unchanged.


### PR DESCRIPTION
Closes #2880

Session: `37f21857-cd34-4f55-b048-a08ff06ae2ed`

a625cfb feat(Ch6 #2880): per-(F, Q) subgraph dispatch wrappers (star / triangle / chordless_cycle)

🤖 Prepared with Claude Code