### PR TITLE
progress: planner cycle 9938ed64 — split D2.degree4 (#2889) from #2877

### DIFF
--- a/plans/9938ed64-1.md
+++ b/plans/9938ed64-1.md
@@ -1,0 +1,107 @@
+## Current state
+
+Sub of #2877 (`not_posdef_infinite_type_per_kQ` assembly + Theorem
+2.1.2 bridge), pre-split by planner cycle `9938ed64` to feed
+parallel workers. This issue covers **D2.degree4** — the smallest
+and most independent of the six sub-deliverables enumerated in
+#2877's body.
+
+The audit at #2885 explicitly confirmed D2.degree4 is worker-ready
+with no missing primitives:
+
+> The `_kQ`-free proof calls exactly two leaf functions:
+> 1. `star_subgraph_not_finite_type` (when 4 neighbors are pairwise
+>    non-adjacent) — wrapper `star_subgraph_not_finite_type_per_kQ`
+>    exists with matching arity (PR #2882,
+>    `FieldGenericStar.lean:578`).
+> 2. `triangle_infinite_type` (when two neighbors are adjacent) —
+>    wrapper `triangle_infinite_type_per_kQ` exists with matching
+>    arity (PR #2882, `FieldGenericCycle.lean:398`).
+>
+> Both wrappers add `(F, Q, hOrient)` at the end of the argument
+> list; the rest of the per-(F, Q) `degree_ge_4_infinite_type_per_kQ`
+> proof is identical plumbing. **Worker-ready, ~50 lines.**
+
+The `_kQ`-free original lives at
+`Chapter6/InfiniteTypeConstructions.lean:4064-4101` (38 lines of
+proof body). Per-(F, Q) version threads `(F, Q, hOrient)` through
+the two dispatch calls and is otherwise identical plumbing.
+
+## Deliverables
+
+1. **`degree_ge_4_infinite_type_per_kQ`** in Chapter 6. Mirror
+   `degree_ge_4_infinite_type`
+   (`Chapter6/InfiniteTypeConstructions.lean:4064-4101`) with the
+   per-(F, Q) signature pattern (add `(F : Type) [Field F]`,
+   `(Q : Quiver (Fin n))`,
+   `[∀ a b, Subsingleton (Q.Hom a b)]`,
+   `(hOrient : IsOrientationOf Q adj)` at the end of the argument
+   list, and `[IsAlgClosed F]` if and only if the dispatch path
+   requires it — note that `star_subgraph_not_finite_type_per_kQ`
+   at `FieldGenericStar.lean:586` carries `[IsAlgClosed F]`, so
+   the `star_subgraph_*` branch will need that constraint
+   propagated). Conclusion uses the canonical per-(F, Q) shape
+   `¬ Set.Finite {d : Fin n → ℕ | ∃ V : QuiverRepresentation F (Fin n) Q,
+       V.IsIndecomposable ∧ ∀ v, Nonempty (V.obj v ≃ₗ[F] (Fin (d v) → F))}`.
+   Body is structurally identical to the `_kQ`-free original — the
+   only deltas are (a) `[IsAlgClosed F]` propagation, and (b)
+   `(F, Q, hOrient)` appended to the final `star_subgraph_*_per_kQ`
+   and `triangle_*_per_kQ` calls.
+
+## Context
+
+- **Parent**: #2877 (covers D2.cycle, D2.adjacent, D2.single,
+  D2.nonadj, D2.outer + D3 after this issue lands).
+- **Audit confirming worker-readiness**: #2885 deliverable 3.
+- **Per-(F, Q) leaf wrappers** (both already on `main`):
+  - `star_subgraph_not_finite_type_per_kQ`
+    (`Chapter6/FieldGenericStar.lean:578`, PR #2882).
+  - `triangle_infinite_type_per_kQ`
+    (`Chapter6/FieldGenericCycle.lean:398`, PR #2882).
+- **Per-(F, Q) leaf API reference**:
+  `etilde6_not_finite_type_per_kQ`
+  (`Chapter6/FieldGenericETilde6.lean:319`) is the canonical
+  shape — same `(F, Q, hOrient)` ordering and same conclusion
+  type.
+
+### Placement options
+
+Neither `FieldGenericStar.lean` nor `FieldGenericCycle.lean`
+imports the other (both import `FieldGenericInfiniteType` only —
+verified by `grep '^import' Chapter6/FieldGeneric*.lean`).
+`degree_ge_4_infinite_type_per_kQ` calls both `star_subgraph_*` and
+`triangle_*`, so the worker must either:
+
+- add `import EtingofRepresentationTheory.Chapter6.FieldGenericCycle`
+  to `FieldGenericStar.lean` and place the wrapper there, or
+- add `import EtingofRepresentationTheory.Chapter6.FieldGenericStar`
+  to `FieldGenericCycle.lean` and place the wrapper there, or
+- create a new file `Chapter6/FieldGenericDegree4.lean` that
+  imports both and place the wrapper there, then add the new file
+  to `EtingofRepresentationTheory/Chapter6.lean` (the per-file
+  registry already contains the existing FieldGeneric* files —
+  `grep FieldGeneric EtingofRepresentationTheory/Chapter6.lean`).
+
+Either of the first two options is preferred (smaller diff). The
+choice may be driven by where `degree_ge_4_infinite_type_per_kQ`'s
+consumer (`acyclic_branch_not_posdef_infinite_type_per_kQ`, part
+of #2877 D2.outer) will eventually live — both consumers are
+naturally `FieldGenericInfiniteType.lean`-adjacent, so neither
+host file has a clear advantage. Worker's call.
+
+### Out of scope
+
+- D2.cycle (`graph_with_list_cycle_infinite_type_per_kQ`, ~150
+  lines) — remains in #2877.
+- D2.adjacent / D2.single / D2.nonadj / D2.outer / D3 — all
+  remain in #2877.
+
+## Verification
+
+- `lake build EtingofRepresentationTheory.Chapter6` passes (no
+  net `sorry` change — the new theorem has a real proof body).
+- New theorem builds with no `sorry` in its body (it threads
+  through `star_subgraph_*_per_kQ` and `triangle_*_per_kQ`; both
+  exist on `main` with the right arity per audit #2885).
+- A `lake exe cache get` before the first build avoids a
+  Mathlib rebuild (per project CLAUDE.md).

--- a/progress/20260518T112428Z_9938ed64.md
+++ b/progress/20260518T112428Z_9938ed64.md
@@ -1,0 +1,188 @@
+# Progress — planner session 9938ed64
+
+## Accomplished
+
+Planner cycle. Queue state on entry: `POD_QUEUE_DEPTH=2`,
+`POD_MIN_QUEUE=3`, `POD_QUEUE_DEFICIT=1`.
+
+Pre-plan checks:
+
+- **Directives**: none open.
+- **Merge sweep**: zero PRs satisfied the mergeable + non-failing
+  predicate. Same three open PRs all in pr-repair territory
+  (unchanged from cycle c8d09742):
+  - **#2849** (chore dedupe): MERGEABLE but CI FAILURE.
+  - **#2694** (Schur-Weyl γ.A): CONFLICTING (~16 days static).
+  - **#2550** (Wall 3 C.1.a.ii): CONFLICTING (~24 days static).
+- **Replan triage**: handled by `/replan` — out of scope here.
+
+Recent `main` movement since cycle c8d09742 (d2aeebf):
+
+- PR **#2888** merged (closes #2886) — wave-61 sorry-landscape
+  summarize + design-walls refresh. Documentation-only. Brought
+  `progress/sorry-landscape.md` and `progress/design-walls-wave61.md`
+  to current. Confirmed sorry count on `main` = 18 (Ch2 1, Ch5
+  4, Ch6 13). Confirmed the per-(F, Q) ↔ Theorem 2.1.2 bridge
+  scoreboard: all six leaves and all three dispatch wrappers in
+  place; outer assembly (#2877) is the only remaining gap.
+
+Wave-62 baseline (post-#2888 close): substantive non-summarize
+PRs since wave-61 close = 0. Next summarize trigger at +10.
+
+Step 4 overlap audit: re-read all open `agent-plan` titles plus
+the bodies of #2877 (umbrella for D2 + D3) and #2885 (the audit
+verdict that confirmed D2.degree4 and D2.cycle are worker-ready).
+No overlap with any open feature/review/summarize issue.
+
+**Decision: planner-led split of D2.degree4 from #2877.**
+
+The prior planner (c8d09742) explicitly considered and ruled out a
+planner-led decomposition of #2877, citing "no cross-issue
+coordination warrants planner-led decomposition here" and
+preferring worker-led decomposition by default. That cycle chose
+the wave-61 summarize as its refill issue instead. Now that the
+summarize has landed (#2888 / #2886 closed), the deficit has
+re-opened and the natural refill target is the highest-impact
+parallel work available.
+
+The arguments that flipped the call this cycle:
+
+1. **Two of three unclaimed issues are not actionable.** #2564
+   (Mathlib upstream tracker) is external-blocked on Mathlib PR
+   38583 (no movement since wave 60). #2877 is large and
+   recommends worker-self-decomposition — but a worker claiming
+   #2877 will, per its body, file 5 new sub-issues then exit (or
+   tackle one and PR it). Either pattern leaves a window where
+   no other worker has a parallel unit to pick up.
+2. **D2.degree4 is the cleanest possible split.** Audit #2885
+   confirmed it is ~50 lines, depends only on two dispatch
+   wrappers (`star_subgraph_not_finite_type_per_kQ` /
+   `triangle_infinite_type_per_kQ`) that exist on `main`, and
+   identifies no missing primitives. It is independent of the
+   other five sub-deliverables. The `_kQ`-free original at
+   `InfiniteTypeConstructions.lean:4064-4101` is 38 lines of body
+   with two case-split branches.
+3. **Filing D2.degree4 separately enables one extra parallel
+   worker right now.** The dispatcher will be able to assign one
+   worker to #2877 (start with D2.cycle ~150 lines per #2885)
+   and another worker to #2889 (D2.degree4) in the same cycle.
+
+Created one new feature issue:
+
+- **#2889** — `feat(Ch6 #2877 sub D2.degree4):
+  degree_ge_4_infinite_type_per_kQ — per-(F, Q) wrapper`. Single
+  deliverable (~50 lines). Body cites the `_kQ`-free source range
+  (`InfiniteTypeConstructions.lean:4064-4101`), the two existing
+  per-(F, Q) wrapper call targets (`FieldGenericStar.lean:578` +
+  `FieldGenericCycle.lean:398`), the canonical per-(F, Q) shape
+  reference (`FieldGenericETilde6.lean:319`), and three placement
+  options for the worker to choose between (since neither
+  `FieldGenericStar` nor `FieldGenericCycle` currently imports
+  the other — confirmed by `grep '^import'`). Notes `[IsAlgClosed F]`
+  must be propagated because `star_subgraph_not_finite_type_per_kQ`
+  carries it.
+
+Posted a comment on #2877 noting the D2.degree4 split, listing
+the five remaining sub-deliverables (D2.cycle / D2.adjacent /
+D2.single / D2.nonadj / D2.outer + D3), and instructing the
+claimant to start with D2.cycle (also worker-ready per #2885).
+
+**Second issue not filed.** Considered but ruled out:
+
+- **Further #2877 pre-splits (D2.cycle, D2.adjacent, …)**:
+  unnecessary at this queue depth. After #2889 lands, queue depth
+  hits `POD_MIN_QUEUE` (3); no further deficit to refill. Pre-splitting
+  more sub-deliverables now would risk over-decomposition before
+  the first sub-PR clarifies the structural choices (placement
+  file, refactor-vs-mirror approach). The next planner cycle can
+  pre-split D2.cycle if the dispatch on #2889 / #2877 is slow.
+- **Wave-62 summarize**: 0 substantive PRs since wave-61 close;
+  way below the 10-PR trigger.
+- **Mathlib upstream trackers**: #2564 and #2841 remain
+  external-blocked.
+- **New review issue**: no fresh feature PR has landed since the
+  PASS audit chain closed (#2861, #2866, #2879, #2885). The next
+  natural review target is the first #2877 / #2889 sub-PR.
+
+Queue depth post-planning: **3** actionable issues
+(= `POD_MIN_QUEUE`). Composition:
+
+- **#2889** (new feature, just filed) — D2.degree4 per-(F, Q)
+  wrapper, ~50 lines, worker-ready.
+- **#2877** — umbrella for D2.cycle + D2.adjacent + D2.single +
+  D2.nonadj + D2.outer + D3 (worker self-decomposes per body).
+- **#2564** — Mathlib upstream tracker, external-blocked.
+
+Deficit fully refilled (1 of 1). `coordination set-target` not
+called — active development phase, operator-configured pool size
+stands.
+
+## Current frontier
+
+Unclaimed actionable issues:
+
+- **#2889** — D2.degree4 per-(F, Q) wrapper (just filed). Smallest
+  worker-ready unit on the per-(F, Q) Theorem 2.1.2 bridge.
+- **#2877** — outer assembly umbrella (D2.cycle / D2.adjacent /
+  D2.single / D2.nonadj / D2.outer + D3). Worker-self-decomposes.
+- **#2564** — Mathlib upstream tracker, external-blocked.
+
+Active in-flight PRs (all in pr-repair territory, unchanged):
+#2849 (CI FAILURE), #2694 (CONFLICTING — ~16 days static), #2550
+(CONFLICTING — ~24 days static).
+
+Per-(F, Q) ↔ Theorem 2.1.2 bridge scoreboard (unchanged from
+wave-61 summarize):
+
+- All six per-(F, Q) forbidden-subgraph leaves exist on `main`
+  (4 proven, 2 stubbed pending #2789/#2801/#2793).
+- All three per-(F, Q) subgraph dispatch wrappers exist on `main`
+  (PR #2882).
+- Outer case-analysis assembly `not_posdef_infinite_type_per_kQ`
+  + D3 bridge tracked by #2877 + #2889. Theorem 2.1.2 closes
+  once both land (transitively conditional on Wall 1 + the
+  K_{1,4} / T(1,2,5) / D̃₅ replan chain).
+
+## Overall project progress
+
+Stage 3 (Lean formalisation). Wave 62 baseline: 0 substantive PRs
+since #2888 landed. The planner-led split (#2889) prepares the
+ground for two parallel feature workers on the outer assembly.
+
+Sorry count on `main`: 18 (Ch2 1, Ch5 4, Ch6 13). No change from
+wave-61 close. Expected delta from #2889 if it lands: **0** (the
+new theorem has a real proof body; D2.degree4 is the no-sorry
+plumbing case).
+
+Sorry-count delta this turn: **0** (planner cycle, no code
+changes).
+
+## Next step
+
+- Dispatcher should run `/replan` first (substantial replan queue
+  unchanged), then pr-repair on the three static broken PRs, then
+  claim workers on the queue. **#2889** is the natural pick for a
+  fast feature slot (~50 lines, worker-ready, low-risk).
+  **#2877** is the natural pick for a second feature slot (worker
+  self-decomposes starting with D2.cycle ~150 lines per #2885).
+- Next planner cycle should re-evaluate:
+  (a) status of #2889 (landed? if so, will it have triggered any
+      structural decisions that affect the remaining D2 sub-splits
+      — e.g., placement file, `[IsAlgClosed F]` propagation
+      pattern?);
+  (b) state of #2877 self-decomposition (sub-issues filed? how
+      scoped?);
+  (c) whether a follow-up review issue on #2889's PR is warranted
+      (probably yes if it lands cleanly — the same style of light
+      audit as #2885);
+  (d) wave-62 substantive-PR count (currently 0; trigger at +10);
+  (e) `replan` resolutions on the D̃₅ Sub B and K_{1,4}/T(1,2,5)
+      per-(F, Q) chains.
+
+## Blockers
+
+None for the planner work itself. Standing constraints unchanged:
+framework wall #2436 gates the inherited sorries in the per-(F, Q)
+indecomposability proofs (#2789, #2793, #2801, #2839); the three
+static pr-repair PRs (#2849 / #2694 / #2550) remain in `/repair`
+territory.


### PR DESCRIPTION
This PR files the planner-cycle progress notes for session
9938ed64.

Queue state on entry: `POD_QUEUE_DEPTH=2`, `POD_MIN_QUEUE=3`,
`POD_QUEUE_DEFICIT=1`. Filed exactly one issue to refill the
deficit:

- **#2889** — `feat(Ch6 #2877 sub D2.degree4):
  degree_ge_4_infinite_type_per_kQ — per-(F, Q) wrapper`.
  Planner-led split of the smallest worker-ready sub-deliverable
  enumerated in #2877's body. Audit #2885 confirmed
  `degree_ge_4_infinite_type_per_kQ` is ~50 lines, depends only
  on `star_subgraph_not_finite_type_per_kQ` and
  `triangle_infinite_type_per_kQ` (both on `main` via PR #2882),
  and identifies no missing primitives. Filing it as a standalone
  issue lets the dispatcher run two parallel feature workers
  (D2.degree4 in #2889, the remaining five sub-deliverables in
  #2877 starting with D2.cycle).

Posted a comment on #2877 noting the split and listing the
remaining sub-deliverables (D2.cycle / D2.adjacent / D2.single /
D2.nonadj / D2.outer + D3).

Sorry count on `main`: 18 (unchanged from wave-61 close — the
wave-61 summarize at #2888 was documentation-only). Expected
delta from #2889 if it lands: **0** (the new theorem has a real
proof body; D2.degree4 is the no-sorry plumbing case).

Queue post-planning: #2889 (new feature, ~50 lines worker-ready),
#2877 (umbrella for the other five D2 sub-deliverables, worker
self-decomposes), #2564 (Mathlib upstream tracker,
external-blocked).

🤖 Prepared with Claude Code