### PR TITLE
feat(Ch6 #2908 partial): single_branch_leaf_both_extend_b3leaf_per_kQ — c₂-leaf E₇ + d₂-leaf E₈ posdef cases (T(1, q, 2) sub-B)

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/FieldGenericTpqr.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericTpqr.lean
@@ -490,14 +490,129 @@ theorem single_branch_leaf_both_extend_t122_per_kQ {n : ℕ}
     [exact hV; exact hL; exact hA₂;
      exact hB₂; exact hA₃; exact hB₃]
 
+set_option maxHeartbeats 6400000 in
+-- reason: T(1, q, 2) case-split mirrors `InfiniteTypeConstructions.lean:7325-7639`
+-- (~315 lines of port plus an inlined T(1, 2, 5) embedding); the
+-- 81-case `fin_cases` adjacency proof through the `Fin 9 ↪ Fin n` embedding
+-- and the bundle of `acyclic_path_nonadj`/`Finset.sum_insert` reasoning push
+-- elaboration past the default budget. Same setting as on the sub-D helper
+-- and on `single_branch_leaf_case` in the original source.
+attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
+  CategoryTheory.ReflQuiver.toQuiver in
+/-- Per-(F, Q) version of the `(b₂ degree 2, b₃ degree 1)` sub-case of the
+"both arms extend" branch of `single_branch_leaf_case`
+(`InfiniteTypeConstructions.lean:7325-7639`): the T(1, q, 2) configuration
+with q ≥ 3 (i.e. `b₂` extends to a longer arm and `b₃` is a leaf).
+Case-splits on whether `c₂`, `d₂`, `e₂` extend:
+
+* `c₂` is a leaf (arm2 length = 3) → T(1, 3, 2) = E₇ is positive definite,
+  contradicting `h_not_posdef` via `e7_tree_posdef`.
+* `d₂` is a leaf (arm2 length = 4) → T(1, 4, 2) = E₈ is positive definite,
+  contradicting `h_not_posdef` via `e8_posdef`.
+* `d₂` extends (arm2 length ≥ 5) → the 9 vertices
+  `{v₀, leaf, a₃, b₃, a₂, b₂, c₂, d₂, e₂}` form a T(1, 2, 5) = Ẽ₈ subgraph;
+  dispatch to `t125_not_finite_type_per_kQ` via
+  `subgraph_infinite_type_transfer_per_kQ`. -/
+theorem single_branch_leaf_both_extend_b3leaf_per_kQ {n : ℕ}
+    (adj : Matrix (Fin n) (Fin n) ℤ)
+    (hsymm : adj.IsSymm)
+    (hdiag : ∀ i, adj i i = 0)
+    (h01 : ∀ i j, adj i j = 0 ∨ adj i j = 1)
+    (hconn : ∀ i j : Fin n, ∃ path : List (Fin n),
+      path.head? = some i ∧ path.getLast? = some j ∧
+      ∀ k, (h : k + 1 < path.length) →
+        adj (path.get ⟨k, by omega⟩) (path.get ⟨k + 1, h⟩) = 1)
+    (h_acyclic : ∀ (cycle : List (Fin n)) (hclen : 3 ≤ cycle.length), cycle.Nodup →
+      (∀ k, (h : k + 1 < cycle.length) →
+        adj (cycle.get ⟨k, by omega⟩) (cycle.get ⟨k + 1, h⟩) = 1) →
+      adj (cycle.getLast (List.ne_nil_of_length_pos (by omega)))
+        (cycle.get ⟨0, by omega⟩) ≠ 1)
+    (h_deg : ∀ v, vertexDegree adj v < 4)
+    (v₀ : Fin n) (hv₀ : vertexDegree adj v₀ = 3)
+    (h_unique : ∀ w, vertexDegree adj w = 3 → w = v₀)
+    (h_not_posdef : ¬ ∀ x : Fin n → ℤ, x ≠ 0 →
+      0 < dotProduct x ((2 • (1 : Matrix (Fin n) (Fin n) ℤ) - adj).mulVec x))
+    (leaf a₂ a₃ b₂ b₃ : Fin n)
+    (h_leaf_adj : adj v₀ leaf = 1)
+    (ha₂_adj : adj v₀ a₂ = 1) (ha₃_adj : adj v₀ a₃ = 1)
+    (hb₂_adj : adj a₂ b₂ = 1) (hb₃_adj : adj a₃ b₃ = 1)
+    (h_leaf_deg : vertexDegree adj leaf = 1)
+    (h_a2_ext : vertexDegree adj a₂ = 2) (h_a3_ext : vertexDegree adj a₃ = 2)
+    (h_b2_ext : vertexDegree adj b₂ = 2)
+    (hb₃_deg1 : vertexDegree adj b₃ = 1)
+    (ha₂₃ : a₂ ≠ a₃)
+    (ha₂_ne_leaf : a₂ ≠ leaf) (ha₃_ne_leaf : a₃ ≠ leaf)
+    (hb₂_ne_v₀ : b₂ ≠ v₀) (hb₃_ne_v₀ : b₃ ≠ v₀)
+    (hS₀_eq : (Finset.univ.filter (adj v₀ · = 1)).erase leaf = {a₂, a₃})
+    (hb₂_eq : (Finset.univ.filter (adj a₂ · = 1)).erase v₀ = {b₂})
+    (hb₃_eq : (Finset.univ.filter (adj a₃ · = 1)).erase v₀ = {b₃})
+    (F : Type) [Field F] [IsAlgClosed F]
+    (Q : @Quiver.{0, 0} (Fin n))
+    [∀ a b, Subsingleton (@Quiver.Hom (Fin n) Q a b)]
+    (hOrient : @Etingof.IsOrientationOf n Q adj) :
+    ¬ Set.Finite
+      {d : Fin n → ℕ |
+        ∃ V : @Etingof.QuiverRepresentation.{0,0,0,0} F (Fin n) _ Q,
+          V.IsIndecomposable ∧ ∀ v, Nonempty (V.obj v ≃ₗ[F] (Fin (d v) → F))} := by
+  have adj_comm : ∀ i j, adj i j = adj j i := fun i j => hsymm.apply j i
+  have ne_of_adj' : ∀ a b, adj a b = 1 → a ≠ b := fun a b h hab => by
+    rw [hab, hdiag] at h; exact one_ne_zero h.symm
+  have h_deg_le2 : ∀ v, v ≠ v₀ → vertexDegree adj v ≤ 2 := by
+    intro v hv; have h3 := h_deg v
+    by_contra h; push_neg at h; exact hv (h_unique v (by omega))
+  have hleaf_ne_v₀ : leaf ≠ v₀ := (ne_of_adj' v₀ leaf h_leaf_adj).symm
+  have ha₂_ne_v₀ : a₂ ≠ v₀ := (ne_of_adj' v₀ a₂ ha₂_adj).symm
+  have ha₃_ne_v₀ : a₃ ≠ v₀ := (ne_of_adj' v₀ a₃ ha₃_adj).symm
+  have ha₂_ne_b₂ : a₂ ≠ b₂ := ne_of_adj' a₂ b₂ hb₂_adj
+  have ha₃_ne_b₃ : a₃ ≠ b₃ := ne_of_adj' a₃ b₃ hb₃_adj
+  set S₀ := Finset.univ.filter (fun j => adj v₀ j = 1) with hS₀_def
+  -- Extract c₂: the neighbour of b₂ other than a₂
+  have extract_other := fun (v u : Fin n) (hvu : adj v u = 1)
+      (hdeg2 : vertexDegree adj v = 2) =>
+    let Sv := Finset.univ.filter (fun j => adj v j = 1)
+    have hcard : Sv.card = 2 := hdeg2
+    have hu_mem : u ∈ Sv :=
+      Finset.mem_filter.mpr ⟨Finset.mem_univ _, hvu⟩
+    Finset.card_eq_one.mp (by rw [Finset.card_erase_of_mem hu_mem, hcard])
+  obtain ⟨c₂, hc₂_eq⟩ := extract_other b₂ a₂
+    ((adj_comm b₂ a₂).trans hb₂_adj) h_b2_ext
+  have hc₂_mem : c₂ ∈ (Finset.univ.filter (adj b₂ · = 1)).erase a₂ :=
+    hc₂_eq ▸ Finset.mem_singleton_self c₂
+  have hc₂_adj : adj b₂ c₂ = 1 :=
+    (Finset.mem_filter.mp (Finset.mem_of_mem_erase hc₂_mem)).2
+  have hc₂_ne_a₂ : c₂ ≠ a₂ := Finset.ne_of_mem_erase hc₂_mem
+  have hb₂_ne_c₂ : b₂ ≠ c₂ := ne_of_adj' b₂ c₂ hc₂_adj
+  by_cases h_c2_ext : vertexDegree adj c₂ = 2
+  · -- c₂ extends (arm2 length ≥ 4): extract d₂
+    obtain ⟨d₂, hd₂_eq⟩ := extract_other c₂ b₂
+      ((adj_comm c₂ b₂).trans hc₂_adj) h_c2_ext
+    have hd₂_mem : d₂ ∈ (Finset.univ.filter (adj c₂ · = 1)).erase b₂ :=
+      hd₂_eq ▸ Finset.mem_singleton_self d₂
+    have hd₂_adj : adj c₂ d₂ = 1 :=
+      (Finset.mem_filter.mp (Finset.mem_of_mem_erase hd₂_mem)).2
+    have hd₂_ne_b₂ : d₂ ≠ b₂ := Finset.ne_of_mem_erase hd₂_mem
+    have hc₂_ne_d₂ : c₂ ≠ d₂ := ne_of_adj' c₂ d₂ hd₂_adj
+    by_cases h_d2_ext : vertexDegree adj d₂ = 2
+    · -- d₂ extends (arm2 length ≥ 5): extract e₂, embed T(1, 2, 5)
+      obtain ⟨e₂, he₂_eq⟩ := extract_other d₂ c₂
+        ((adj_comm d₂ c₂).trans hd₂_adj) h_d2_ext
+      have he₂_mem : e₂ ∈ (Finset.univ.filter (adj d₂ · = 1)).erase c₂ :=
+        he₂_eq ▸ Finset.mem_singleton_self e₂
+      have _he₂_adj : adj d₂ e₂ = 1 :=
+        (Finset.mem_filter.mp (Finset.mem_of_mem_erase he₂_mem)).2
+      have _he₂_ne_c₂ : e₂ ≠ c₂ := Finset.ne_of_mem_erase he₂_mem
+      let _ := h_a3_ext  -- silenced until d₂-extends body is implemented
+      sorry  -- T(1, 2, 5) embedding for d₂-extends arm
+    · -- d₂ is a leaf (arm2 length = 4): e8_posdef contradiction
+      sorry  -- E₈ posdef contradiction for T(1, 4, 2)
+  · -- c₂ is a leaf (arm2 length = 3): e7_tree_posdef contradiction
+    sorry  -- E₇ posdef contradiction for T(1, 3, 2)
+
 attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
   CategoryTheory.ReflQuiver.toQuiver in
 /-- Per-(F, Q) version of the "both arms extend" branch of
 `single_branch_leaf_case` (`InfiniteTypeConstructions.lean:6981-8352`):
 given the T(1, q, r) configuration where both of `v₀`'s non-leaf
-neighbours `a₂` and `a₃` have degree 2 (i.e. q, r ≥ 2), the quiver has
-infinite representation type for every algebraically closed `F` and every
-orientation `Q`.
 
 API stub: the body is `sorry`, tracked by a follow-up sub-issue. The real
 proof mirrors the `_kQ`-free original — further case-splits on whether

--- a/EtingofRepresentationTheory/Chapter6/FieldGenericTpqr.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericTpqr.lean
@@ -603,10 +603,251 @@ theorem single_branch_leaf_both_extend_b3leaf_per_kQ {n : ℕ}
       have _he₂_ne_c₂ : e₂ ≠ c₂ := Finset.ne_of_mem_erase he₂_mem
       let _ := h_a3_ext  -- silenced until d₂-extends body is implemented
       sorry  -- T(1, 2, 5) embedding for d₂-extends arm
-    · -- d₂ is a leaf (arm2 length = 4): e8_posdef contradiction
-      sorry  -- E₈ posdef contradiction for T(1, 4, 2)
-  · -- c₂ is a leaf (arm2 length = 3): e7_tree_posdef contradiction
-    sorry  -- E₇ posdef contradiction for T(1, 3, 2)
+    · -- d₂ is a leaf (arm2 length = 4): T(1, 4, 2) = E₈ posdef contradiction.
+      -- The 8 named vertices {v₀, leaf, a₂, b₂, c₂, d₂, a₃, b₃} form an E₈ tree
+      -- whose Cartan form is positive definite — contradicting `h_not_posdef`.
+      exfalso
+      apply h_not_posdef
+      have hd₂_ne_v₀ : d₂ ≠ v₀ := by
+        intro h
+        have ha₂_ne_b₂' : a₂ ≠ b₂ := ne_of_adj' a₂ b₂ hb₂_adj
+        have hb₂_ne_c₂' : b₂ ≠ c₂ := ne_of_adj' b₂ c₂ hc₂_adj
+        have hv₀_ne_b₂ : v₀ ≠ b₂ := hb₂_ne_v₀.symm
+        have hv₀_ne_c₂ : v₀ ≠ c₂ := by
+          intro heq; rw [h, heq] at hd₂_adj; linarith [hdiag c₂]
+        have ha₂_ne_c₂ : a₂ ≠ c₂ := hc₂_ne_a₂.symm
+        have h_nonadj : adj c₂ v₀ = 0 := acyclic_path_nonadj adj hsymm h01 h_acyclic
+          [v₀, a₂, b₂, c₂] (by simp)
+          (by simp only [List.nodup_cons, List.mem_cons, List.not_mem_nil,
+              not_or, not_false_eq_true, List.nodup_nil, and_self, and_true]
+              exact ⟨⟨ha₂_ne_v₀.symm, hv₀_ne_b₂, hv₀_ne_c₂⟩, ⟨ha₂_ne_b₂', ha₂_ne_c₂⟩, hb₂_ne_c₂'⟩)
+          (by intro k hk
+              have : k + 1 < 4 := by simpa using hk
+              have : k = 0 ∨ k = 1 ∨ k = 2 := by omega
+              rcases this with rfl | rfl | rfl
+              · exact ha₂_adj
+              · exact hb₂_adj
+              · exact hc₂_adj)
+        have hcv : adj c₂ v₀ = 1 := by rw [← h]; exact hd₂_adj
+        linarith [hcv, h_nonadj]
+      have hd₂_deg_ge1 : 1 ≤ vertexDegree adj d₂ :=
+        Finset.card_pos.mpr ⟨c₂, Finset.mem_filter.mpr
+          ⟨Finset.mem_univ _, (adj_comm d₂ c₂).trans hd₂_adj⟩⟩
+      have hd₂_deg1 : vertexDegree adj d₂ = 1 := by
+        have hle := h_deg_le2 d₂ hd₂_ne_v₀; omega
+      -- "only" facts for each named vertex (8 vertices)
+      have hv₀_only : ∀ w, adj v₀ w = 1 → w = leaf ∨ w = a₂ ∨ w = a₃ := by
+        intro w hw
+        have hw_mem : w ∈ S₀ := Finset.mem_filter.mpr ⟨Finset.mem_univ _, hw⟩
+        by_cases hwl : w = leaf
+        · left; exact hwl
+        have hw_mem' : w ∈ S₀.erase leaf := Finset.mem_erase.mpr ⟨hwl, hw_mem⟩
+        rw [hS₀_eq] at hw_mem'
+        rcases Finset.mem_insert.mp hw_mem' with h | h
+        · right; left; exact h
+        · right; right; exact Finset.mem_singleton.mp h
+      have hleaf_only : ∀ w, adj leaf w = 1 → w = v₀ := by
+        intro w hw; by_contra hne
+        have h2 : 2 ≤ vertexDegree adj leaf := by
+          change 2 ≤ (Finset.univ.filter (fun j => adj leaf j = 1)).card
+          have hv₀_in : v₀ ∈ Finset.univ.filter (fun j => adj leaf j = 1) :=
+            Finset.mem_filter.mpr ⟨Finset.mem_univ _, (adj_comm leaf v₀).trans h_leaf_adj⟩
+          have hw_in : w ∈ Finset.univ.filter (fun j => adj leaf j = 1) :=
+            Finset.mem_filter.mpr ⟨Finset.mem_univ _, hw⟩
+          calc 2 = ({v₀, w} : Finset _).card := by rw [Finset.card_pair (Ne.symm hne)]
+            _ ≤ _ := Finset.card_le_card (fun x hx => by
+                simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+                rcases hx with rfl | rfl <;> assumption)
+        omega
+      have ha₂_only : ∀ w, adj a₂ w = 1 → w = v₀ ∨ w = b₂ := by
+        intro w hw
+        have hw_mem : w ∈ Finset.univ.filter (fun j => adj a₂ j = 1) :=
+          Finset.mem_filter.mpr ⟨Finset.mem_univ _, hw⟩
+        by_cases hwv : w = v₀
+        · left; exact hwv
+        right
+        have hw' : w ∈ (Finset.univ.filter (fun j => adj a₂ j = 1)).erase v₀ :=
+          Finset.mem_erase.mpr ⟨hwv, hw_mem⟩
+        rw [hb₂_eq] at hw'; exact Finset.mem_singleton.mp hw'
+      have hb₂_only : ∀ w, adj b₂ w = 1 → w = a₂ ∨ w = c₂ := by
+        intro w hw
+        have hw_mem : w ∈ Finset.univ.filter (fun j => adj b₂ j = 1) :=
+          Finset.mem_filter.mpr ⟨Finset.mem_univ _, hw⟩
+        by_cases hwa : w = a₂
+        · left; exact hwa
+        right
+        have hw' : w ∈ (Finset.univ.filter (fun j => adj b₂ j = 1)).erase a₂ :=
+          Finset.mem_erase.mpr ⟨hwa, hw_mem⟩
+        rw [hc₂_eq] at hw'; exact Finset.mem_singleton.mp hw'
+      have hc₂_only : ∀ w, adj c₂ w = 1 → w = b₂ ∨ w = d₂ := by
+        intro w hw
+        have hw_mem : w ∈ Finset.univ.filter (fun j => adj c₂ j = 1) :=
+          Finset.mem_filter.mpr ⟨Finset.mem_univ _, hw⟩
+        by_cases hwb : w = b₂
+        · left; exact hwb
+        right
+        have hw' : w ∈ (Finset.univ.filter (fun j => adj c₂ j = 1)).erase b₂ :=
+          Finset.mem_erase.mpr ⟨hwb, hw_mem⟩
+        rw [hd₂_eq] at hw'; exact Finset.mem_singleton.mp hw'
+      have hd₂_only : ∀ w, adj d₂ w = 1 → w = c₂ := by
+        intro w hw; by_contra hne
+        have h2 : 2 ≤ vertexDegree adj d₂ := by
+          change 2 ≤ (Finset.univ.filter (fun j => adj d₂ j = 1)).card
+          have hc₂_in : c₂ ∈ Finset.univ.filter (fun j => adj d₂ j = 1) :=
+            Finset.mem_filter.mpr ⟨Finset.mem_univ _, (adj_comm d₂ c₂).trans hd₂_adj⟩
+          have hw_in : w ∈ Finset.univ.filter (fun j => adj d₂ j = 1) :=
+            Finset.mem_filter.mpr ⟨Finset.mem_univ _, hw⟩
+          calc 2 = ({c₂, w} : Finset _).card := by rw [Finset.card_pair (Ne.symm hne)]
+            _ ≤ _ := Finset.card_le_card (fun x hx => by
+                simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+                rcases hx with rfl | rfl <;> assumption)
+        omega
+      have ha₃_only : ∀ w, adj a₃ w = 1 → w = v₀ ∨ w = b₃ := by
+        intro w hw
+        have hw_mem : w ∈ Finset.univ.filter (fun j => adj a₃ j = 1) :=
+          Finset.mem_filter.mpr ⟨Finset.mem_univ _, hw⟩
+        by_cases hwv : w = v₀
+        · left; exact hwv
+        right
+        have hw' : w ∈ (Finset.univ.filter (fun j => adj a₃ j = 1)).erase v₀ :=
+          Finset.mem_erase.mpr ⟨hwv, hw_mem⟩
+        rw [hb₃_eq] at hw'; exact Finset.mem_singleton.mp hw'
+      have hb₃_only : ∀ w, adj b₃ w = 1 → w = a₃ := by
+        intro w hw; by_contra hne
+        have h2 : 2 ≤ vertexDegree adj b₃ := by
+          change 2 ≤ (Finset.univ.filter (fun j => adj b₃ j = 1)).card
+          have ha₃_in : a₃ ∈ Finset.univ.filter (fun j => adj b₃ j = 1) :=
+            Finset.mem_filter.mpr ⟨Finset.mem_univ _, (adj_comm b₃ a₃).trans hb₃_adj⟩
+          have hw_in : w ∈ Finset.univ.filter (fun j => adj b₃ j = 1) :=
+            Finset.mem_filter.mpr ⟨Finset.mem_univ _, hw⟩
+          calc 2 = ({a₃, w} : Finset _).card := by rw [Finset.card_pair (Ne.symm hne)]
+            _ ≤ _ := Finset.card_le_card (fun x hx => by
+                simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+                rcases hx with rfl | rfl <;> assumption)
+        omega
+      have h_all_named : ∀ w : Fin n,
+          w = v₀ ∨ w = leaf ∨ w = a₂ ∨ w = b₂ ∨ w = c₂ ∨ w = d₂ ∨
+          w = a₃ ∨ w = b₃ := by
+        apply connected_closed_set_is_all adj hconn
+          (fun w => w = v₀ ∨ w = leaf ∨ w = a₂ ∨ w = b₂ ∨ w = c₂ ∨ w = d₂ ∨
+            w = a₃ ∨ w = b₃) v₀ (Or.inl rfl)
+        intro v w hv hvw
+        rcases hv with rfl | rfl | rfl | rfl | rfl | rfl | rfl | rfl
+        · rcases hv₀_only w hvw with rfl | rfl | rfl
+          · exact Or.inr (Or.inl rfl)
+          · exact Or.inr (Or.inr (Or.inl rfl))
+          · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl rfl))))))
+        · rcases hleaf_only w hvw with rfl
+          exact Or.inl rfl
+        · rcases ha₂_only w hvw with rfl | rfl
+          · exact Or.inl rfl
+          · exact Or.inr (Or.inr (Or.inr (Or.inl rfl)))
+        · rcases hb₂_only w hvw with rfl | rfl
+          · exact Or.inr (Or.inr (Or.inl rfl))
+          · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inl rfl))))
+        · rcases hc₂_only w hvw with rfl | rfl
+          · exact Or.inr (Or.inr (Or.inr (Or.inl rfl)))
+          · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl rfl)))))
+        · rcases hd₂_only w hvw with rfl
+          exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inl rfl))))
+        · rcases ha₃_only w hvw with rfl | rfl
+          · exact Or.inl rfl
+          · exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr rfl))))))
+        · rcases hb₃_only w hvw with rfl
+          exact Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inr (Or.inl rfl))))))
+      have hd_e8 : E8Distinct v₀ leaf a₂ b₂ c₂ d₂ a₃ b₃ := by
+        refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_,
+                ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+        · exact ne_of_adj' v₀ leaf h_leaf_adj
+        · exact ne_of_adj' v₀ a₂ ha₂_adj
+        · intro h; subst h
+          rcases hb₂_only leaf h_leaf_adj with rfl | rfl
+          · linarith [h_leaf_deg, h_a2_ext]
+          · linarith [h_leaf_deg, h_c2_ext]
+        · intro h; subst h
+          rcases hc₂_only a₂ ha₂_adj with rfl | rfl
+          · linarith [hdiag a₂, hb₂_adj]
+          · linarith [h_a2_ext, hd₂_deg1]
+        · intro h; subst h; exact absurd rfl hd₂_ne_v₀
+        · exact ne_of_adj' v₀ a₃ ha₃_adj
+        · intro heq; linarith [hv₀, heq ▸ hb₃_deg1]
+        · exact ha₂_ne_leaf.symm
+        · intro h; linarith [h_leaf_deg, h ▸ h_b2_ext]
+        · intro h; linarith [h_leaf_deg, h ▸ h_c2_ext]
+        · intro h; subst h
+          have hca : c₂ = v₀ := hleaf_only c₂ ((adj_comm leaf c₂).trans hd₂_adj)
+          subst hca; linarith [hv₀, h_c2_ext]
+        · exact ha₃_ne_leaf.symm
+        · intro h; subst h
+          have haa : a₃ = v₀ := hleaf_only a₃ ((adj_comm leaf a₃).trans hb₃_adj)
+          subst haa; linarith [hv₀, h_a3_ext]
+        · exact ne_of_adj' a₂ b₂ hb₂_adj
+        · intro h; subst h
+          rcases ha₂_only d₂ hd₂_adj with rfl | rfl
+          · linarith [hv₀, hd₂_deg1]
+          · linarith [h_b2_ext, hd₂_deg1]
+        · intro h; linarith [h_a2_ext, h ▸ hd₂_deg1]
+        · exact ha₂₃
+        · intro h; linarith [h_a2_ext, h ▸ hb₃_deg1]
+        · exact ne_of_adj' b₂ c₂ hc₂_adj
+        · intro h; linarith [h_b2_ext, h ▸ hd₂_deg1]
+        · intro h
+          rw [h] at hb₂_only
+          rcases hb₂_only v₀ ((adj_comm a₃ v₀).trans ha₃_adj) with rfl | rfl
+          · linarith [hv₀, h_a2_ext]
+          · linarith [hv₀, h_c2_ext]
+        · intro h; linarith [h_b2_ext, h ▸ hb₃_deg1]
+        · exact ne_of_adj' c₂ d₂ hd₂_adj
+        · intro h
+          rw [h] at hc₂_only
+          rcases hc₂_only v₀ ((adj_comm a₃ v₀).trans ha₃_adj) with rfl | rfl
+          · linarith [hv₀, h_b2_ext]
+          · linarith [hv₀, hd₂_deg1]
+        · intro h; linarith [h_c2_ext, h ▸ hb₃_deg1]
+        · intro h; linarith [hd₂_deg1, h ▸ h_a3_ext]
+        · intro h; subst h
+          have ha₃_eq_c₂ := hd₂_only a₃ ((adj_comm d₂ a₃).trans hb₃_adj)
+          rcases hc₂_only v₀ (ha₃_eq_c₂ ▸ (adj_comm a₃ v₀).trans ha₃_adj) with rfl | rfl
+          · linarith [hv₀, h_b2_ext]
+          · linarith [hv₀, hd₂_deg1]
+        · exact ne_of_adj' a₃ b₃ hb₃_adj
+      intro x hx
+      exact e8_posdef adj hsymm hdiag h01 v₀ leaf a₂ b₂ c₂ d₂ a₃ b₃ hd_e8
+        h_leaf_adj ha₂_adj hb₂_adj hc₂_adj hd₂_adj ha₃_adj hb₃_adj
+        hv₀_only hleaf_only ha₂_only hb₂_only hc₂_only hd₂_only
+        ha₃_only hb₃_only h_all_named x hx
+  · -- c₂ is a leaf (arm2 length = 3): e7_tree_posdef contradiction.
+    -- The 7 named vertices {v₀, leaf, a₂, b₂, c₂, a₃, b₃} form T(1, 3, 2) = E₇,
+    -- whose Cartan form is positive definite — contradicting `h_not_posdef`.
+    exfalso
+    apply h_not_posdef
+    have hc₂_ne_v₀ : c₂ ≠ v₀ := by
+      intro heq
+      have hb₂v₀ : adj v₀ b₂ = 1 := by
+        rw [adj_comm]; rw [heq] at hc₂_adj; exact hc₂_adj
+      have hv₀_nbrs := deg3_three_neighbors h_leaf_adj ha₂_adj
+        ha₃_adj ha₂_ne_leaf.symm ha₃_ne_leaf.symm ha₂₃ hv₀
+      rcases hv₀_nbrs b₂ hb₂v₀ with h_eq | h_eq | h_eq
+      · rw [h_eq] at h_b2_ext; omega
+      · rw [h_eq] at hb₂_adj; have := hdiag a₂; omega
+      · rw [h_eq] at hb₂_adj
+        have ha₃_nbrs := deg2_two_neighbors
+          ((adj_comm a₃ v₀).trans ha₃_adj)
+          hb₃_adj hb₃_ne_v₀.symm h_a3_ext
+        rcases ha₃_nbrs a₂
+          ((adj_comm a₃ a₂).trans hb₂_adj) with h' | h'
+        · exact ha₂_ne_v₀ h'
+        · rw [h'] at h_a2_ext; omega
+    have hc₂_deg_ge1 : 1 ≤ vertexDegree adj c₂ :=
+      Finset.card_pos.mpr ⟨b₂, Finset.mem_filter.mpr
+        ⟨Finset.mem_univ _, (adj_comm c₂ b₂).trans hc₂_adj⟩⟩
+    have hc₂_deg1 : vertexDegree adj c₂ = 1 := by
+      have hle := h_deg_le2 c₂ hc₂_ne_v₀; omega
+    exact e7_tree_posdef adj hsymm hdiag h01 hconn h_acyclic
+      v₀ leaf a₂ b₂ c₂ a₃ b₃
+      h_leaf_adj ha₂_adj ha₃_adj hb₂_adj hc₂_adj hb₃_adj
+      hv₀ h_leaf_deg h_a2_ext h_a3_ext h_b2_ext
+      hc₂_deg1 hb₃_deg1
 
 attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
   CategoryTheory.ReflQuiver.toQuiver in

--- a/EtingofRepresentationTheory/Chapter6/FieldGenericTpqr.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericTpqr.lean
@@ -593,7 +593,15 @@ theorem single_branch_leaf_both_extend_b3leaf_per_kQ {n : ℕ}
     have hd₂_ne_b₂ : d₂ ≠ b₂ := Finset.ne_of_mem_erase hd₂_mem
     have hc₂_ne_d₂ : c₂ ≠ d₂ := ne_of_adj' c₂ d₂ hd₂_adj
     by_cases h_d2_ext : vertexDegree adj d₂ = 2
-    · -- d₂ extends (arm2 length ≥ 5): extract e₂, embed T(1, 2, 5)
+    · -- d₂ extends (arm2 length ≥ 5): extract e₂, embed T(1, 2, 5) and
+      -- dispatch to `t125_not_finite_type_per_kQ` via
+      -- `subgraph_infinite_type_transfer_per_kQ`. Tracked by follow-up
+      -- sub-issue: this case requires ~250 lines of distinctness/non-edge
+      -- derivations across 9 vertices plus the φ + hembed construction,
+      -- mirroring `embed_t125_in_tree`
+      -- (`InfiniteTypeConstructions.lean:4918-5279`) with renaming
+      -- (v₀, u₁, p₁, p₂, q₁, q₂, q₃, q₄, q₅) ↦
+      -- (v₀, leaf, a₃, b₃, a₂, b₂, c₂, d₂, e₂).
       obtain ⟨e₂, he₂_eq⟩ := extract_other d₂ c₂
         ((adj_comm d₂ c₂).trans hd₂_adj) h_d2_ext
       have he₂_mem : e₂ ∈ (Finset.univ.filter (adj d₂ · = 1)).erase c₂ :=
@@ -601,8 +609,8 @@ theorem single_branch_leaf_both_extend_b3leaf_per_kQ {n : ℕ}
       have _he₂_adj : adj d₂ e₂ = 1 :=
         (Finset.mem_filter.mp (Finset.mem_of_mem_erase he₂_mem)).2
       have _he₂_ne_c₂ : e₂ ≠ c₂ := Finset.ne_of_mem_erase he₂_mem
-      let _ := h_a3_ext  -- silenced until d₂-extends body is implemented
-      sorry  -- T(1, 2, 5) embedding for d₂-extends arm
+      let _ := h_a3_ext  -- absorbed in the embedded subgraph
+      sorry
     · -- d₂ is a leaf (arm2 length = 4): T(1, 4, 2) = E₈ posdef contradiction.
       -- The 8 named vertices {v₀, leaf, a₂, b₂, c₂, d₂, a₃, b₃} form an E₈ tree
       -- whose Cartan form is positive definite — contradicting `h_not_posdef`.

--- a/EtingofRepresentationTheory/Chapter6/InfiniteTypeConstructions.lean
+++ b/EtingofRepresentationTheory/Chapter6/InfiniteTypeConstructions.lean
@@ -5997,7 +5997,7 @@ set_option maxHeartbeats 6400000 in
 /-- E₇ tree T(1,3,2) has positive definite Cartan form.
     Given 7 named vertices forming the E₇ tree in a connected acyclic graph,
     the Cartan quadratic form is positive definite. -/
-private lemma e7_tree_posdef {n : ℕ}
+lemma e7_tree_posdef {n : ℕ}
     (adj : Matrix (Fin n) (Fin n) ℤ)
     (hsymm : adj.IsSymm) (hdiag : ∀ i, adj i i = 0)
     (h01 : ∀ i j, adj i j = 0 ∨ adj i j = 1)
@@ -6486,7 +6486,7 @@ private lemma e8_arm_a (v a b c d : ℤ) :
              sq_nonneg (c-d), sq_nonneg d]
 
 -- All 28 pairs distinct, bundled as a structure
-private structure E8Distinct {n : ℕ} (v₀ l a b c d p q : Fin n) : Prop where
+structure E8Distinct {n : ℕ} (v₀ l a b c d p q : Fin n) : Prop where
   ne_v₀l : v₀ ≠ l
   ne_v₀a : v₀ ≠ a
   ne_v₀b : v₀ ≠ b
@@ -6620,7 +6620,7 @@ set_option maxHeartbeats 3200000 in
 /-- E₈ positive definiteness for an abstract graph with 8 named vertices.
     v₀ (center, degree 3), l (leaf), a,b,c,d (arm of length 4), p,q (arm of length 2).
     Edges: v₀-l, v₀-a, a-b, b-c, c-d, v₀-p, p-q. -/
-private theorem e8_posdef {n : ℕ}
+theorem e8_posdef {n : ℕ}
     (adj : Matrix (Fin n) (Fin n) ℤ)
     (hsymm : adj.IsSymm)
     (hdiag : ∀ i, adj i i = 0)

--- a/EtingofRepresentationTheory/Chapter6/InfiniteTypeConstructions.lean
+++ b/EtingofRepresentationTheory/Chapter6/InfiniteTypeConstructions.lean
@@ -5928,7 +5928,7 @@ private lemma deg1_unique_neighbor {n : ℕ} {adj : Matrix (Fin n) (Fin n) ℤ}
   omega
 
 -- Helper: if a vertex has degree 2 with two known distinct neighbors, any neighbor is one of them.
-private lemma deg2_two_neighbors {n : ℕ} {adj : Matrix (Fin n) (Fin n) ℤ}
+lemma deg2_two_neighbors {n : ℕ} {adj : Matrix (Fin n) (Fin n) ℤ}
     {v w₁ w₂ : Fin n} (h1 : adj v w₁ = 1) (h2 : adj v w₂ = 1) (hne : w₁ ≠ w₂)
     (hdeg : vertexDegree adj v = 2) :
     ∀ j, adj v j = 1 → j = w₁ ∨ j = w₂ := by
@@ -5944,7 +5944,7 @@ private lemma deg2_two_neighbors {n : ℕ} {adj : Matrix (Fin n) (Fin n) ℤ}
   omega
 
 -- Helper: if a vertex has degree 3 with three known distinct neighbors, any neighbor is one of them.
-private lemma deg3_three_neighbors {n : ℕ} {adj : Matrix (Fin n) (Fin n) ℤ}
+lemma deg3_three_neighbors {n : ℕ} {adj : Matrix (Fin n) (Fin n) ℤ}
     {v w₁ w₂ w₃ : Fin n} (h1 : adj v w₁ = 1) (h2 : adj v w₂ = 1) (h3 : adj v w₃ = 1)
     (hne12 : w₁ ≠ w₂) (hne13 : w₁ ≠ w₃) (hne23 : w₂ ≠ w₃)
     (hdeg : vertexDegree adj v = 3) :
@@ -6426,7 +6426,7 @@ lemma e7_tree_posdef {n : ℕ}
 
 /-- In a connected graph, if a predicate S holds for a vertex v₀ and is closed
     under adjacency (S v ∧ adj v w = 1 → S w), then S holds for all vertices. -/
-private lemma connected_closed_set_is_all {n : ℕ}
+lemma connected_closed_set_is_all {n : ℕ}
     (adj : Matrix (Fin n) (Fin n) ℤ)
     (hconn : ∀ i j : Fin n, ∃ path : List (Fin n),
       path.head? = some i ∧ path.getLast? = some j ∧

--- a/progress/2026-05-18T16-09-09Z_f7e8a56b.md
+++ b/progress/2026-05-18T16-09-09Z_f7e8a56b.md
@@ -1,0 +1,93 @@
+# Progress — feature session f7e8a56b (#2908 partial)
+
+## Accomplished
+
+Claimed and partially executed #2908 (sub-B of #2905): the
+`(b₂ degree 2, b₃ degree 1)` sub-case of the "both arms extend" branch
+in `single_branch_leaf_case_both_extend_per_kQ`.
+
+In `EtingofRepresentationTheory/Chapter6/InfiniteTypeConstructions.lean`,
+de-privatised six helpers used by the sub-B port (sibling precedent
+set by #2900 / #2906 for `tree_two_leaf_posdef`):
+
+- `e7_tree_posdef` (lemma)
+- `e8_posdef` (theorem)
+- `E8Distinct` (structure)
+- `deg2_two_neighbors` (lemma)
+- `deg3_three_neighbors` (lemma)
+- `connected_closed_set_is_all` (lemma)
+
+In `EtingofRepresentationTheory/Chapter6/FieldGenericTpqr.lean`, added
+the new helper `single_branch_leaf_both_extend_b3leaf_per_kQ` with the
+signature mirroring the dispatch site inside
+`single_branch_leaf_case_both_extend_per_kQ` (`h_b2_ext = 2`,
+`hb₃_deg1 = 1`). The body case-splits on whether `c₂`, `d₂` extend:
+
+- **c₂ leaf (arm2 = 3)** → `e7_tree_posdef` posdef contradiction ✅
+- **d₂ leaf (arm2 = 4)** → `e8_posdef` posdef contradiction with the
+  full `E8Distinct` witness, 8 'only' adjacency facts, and `h_all_named`
+  built in-line, mirroring source `InfiniteTypeConstructions.lean:7385-7607` ✅
+- **d₂ extends (arm2 ≥ 5)** → embed T(1, 2, 5) — **left as `sorry`** ⏳
+
+The `e₂` vertex is still extracted at the top of the d₂-extends branch
+so the follow-up has all 9 named vertices in scope. Created
+follow-up sub-issue #2913 covering the remaining ~250-line T(1, 2, 5)
+inline embed (it cannot reuse `embed_t125_in_tree` because that returns
+`¬ IsFiniteTypeQuiver`, which is strictly weaker than the per-(F, Q)
+shape this helper requires).
+
+`lake build EtingofRepresentationTheory.Chapter6.FieldGenericTpqr` passes.
+
+## Current frontier
+
+Partial PR for sub-B (#2908) ready to push, with 1 `sorry` inside the
+new helper for the d₂-extends T(1, 2, 5) embed (tracked by #2913).
+
+`single_branch_leaf_case_both_extend_per_kQ` dispatch chain remaining
+sub-issues:
+
+- sub-A (#2907) Ẽ₇ embed (q, r ≥ 3) — has-pr (#2911) [conflicts].
+- sub-B (#2908) T(1, q, 2), q ≥ 3 — partial this PR; sorry tracked by
+  follow-up #2913.
+- sub-C (#2909) T(1, 2, r), r ≥ 3 — unclaimed.
+- sub-D (#2910) T(1, 2, 2) = D₅ — landed on `main` (PR #2912).
+- Final D2 (wire all four into `single_branch_leaf_case_both_extend_per_kQ`):
+  belongs to whichever sub-issue lands last.
+
+Chapter 6 per-(F, Q) ↔ Theorem 2.1.2 bridge scoreboard (#2877):
+
+- D2.degree4 on `main` (PR #2891).
+- D2.cycle on `main` (PR #2897).
+- D2.adjacent on `main` (PR #2900).
+- D2.single on `main` (PR #2903).
+- D2.single follow-up #2904 partial on `main` (PR #2906).
+- D2.single follow-up #2905 sub-A: has-pr #2911 (conflicts).
+- D2.single follow-up #2905 sub-D: on `main` (PR #2912).
+- D2.single follow-up #2905 sub-B: partial via this PR; remainder #2913.
+- **Pending**: D2.single follow-up #2905 sub-C, sub-B follow-up #2913,
+  then final wiring; plus D2.nonadj, D2.outer + D3 (still under #2877).
+
+## Overall project progress
+
+Stage 3 (Lean formalisation). Sorry count on `main` post-#2912: 69.
+This PR is sorry-positive: net +1 (the d₂-extends placeholder).
+Post-merge sorry count: 70. Sub-issue #2913 will return it to 69.
+
+## Next step
+
+- Next workers should claim #2909 (T(1, 2, r) sub-C; symmetric to
+  this sub-B) or #2913 (this PR's follow-up: d₂-extends T(1, 2, 5)
+  embed).
+- Whichever PR lands last among #2907 / #2908+#2913 / #2909 / #2912
+  should do the final D2 wiring step that replaces the
+  `single_branch_leaf_case_both_extend_per_kQ` sorry body with the
+  four-way dispatch.
+- Parent #2877 still has D2.nonadj (~900 lines, decomposition candidate)
+  and D2.outer + D3 (~150 lines) outstanding.
+
+## Blockers
+
+None for this worker. Standing constraints unchanged: framework wall
+#2436 gates the inherited sorries in the per-(F, Q) indecomposability
+proofs; the static pr-repair PRs (#2849 / #2694 / #2550) remain in
+`/repair` territory.


### PR DESCRIPTION
Partial progress on #2908

Session: `f7e8a56b-dfaf-4900-b5b4-26dcc4549121`

6208a12 progress: feature session f7e8a56b — partial #2908 (sub-B), follow-up #2913
d9e9850 feat(Ch6 #2908): leave d₂-extends T(1, 2, 5) embed as sorry for follow-up
8284608 feat(Ch6 #2908): fill c₂-leaf (E₇) and d₂-leaf (E₈) posdef cases
b047f20 feat(Ch6 #2908): de-privatize e7_tree_posdef/e8_posdef/E8Distinct + skeleton for single_branch_leaf_both_extend_b3leaf_per_kQ

🤖 Prepared with Claude Code