### PR TITLE
feat(Ch6 #2919 sub-A2): non_adjacent_branches_infinite_type_per_kQ outer assembly — neighbour extraction, dispatch, Ẽ₆ all-deg-2 case

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/FieldGenericAssembly.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericAssembly.lean
@@ -1,5 +1,6 @@
 import EtingofRepresentationTheory.Chapter6.FieldGenericTpqr
 import EtingofRepresentationTheory.Chapter6.FieldGenericD5Tilde
+import EtingofRepresentationTheory.Chapter6.FieldGenericNonAdjacentBranches
 
 /-!
 # Per-(F, Q) outer assembly: `not_posdef_infinite_type_per_kQ`
@@ -47,6 +48,12 @@ open Matrix
 
 namespace Etingof
 
+set_option maxHeartbeats 6400000 in
+-- reason: mirrors the budget on the universal
+-- `non_adjacent_branches_infinite_type`
+-- (`InfiniteTypeConstructions.lean:9678`); the all-deg-2 case verifies
+-- the 49-pair `etilde6Adj`/host adjacency table via `fin_cases` +
+-- `linarith` and pushes past the default budget.
 attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
   CategoryTheory.ReflQuiver.toQuiver in
 /-- Per-(F, Q) version of `non_adjacent_branches_infinite_type`
@@ -56,11 +63,14 @@ A connected acyclic simple graph with all degrees ≤ 3 and two
 non-adjacent degree-3 vertices `v₀` and `w` has infinite representation
 type for every algebraically closed `F` and every orientation `Q`.
 
-The proof (universal version) embeds either D̃ₖ (when both branch points
-have two leaf neighbours), Ẽ₇ (when arms extend appropriately), or
-T(1, 2, 5) (when one arm is long) via
-`subgraph_infinite_type_transfer_per_kQ`. Body is `sorry`; mirror tracked
-by #2919. -/
+The proof mirrors the universal version. After dispatching to
+`adjacent_branches_infinite_type_per_kQ` when any pair of branch points
+turns out to be adjacent, we extract `v₀`'s three neighbours and case
+split: if any neighbour is a leaf we delegate to
+`non_adjacent_branches_leaf_case_per_kQ`; otherwise all three have
+degree 2 and we embed `Ẽ₆ = T(2, 2, 2)` via
+`subgraph_infinite_type_transfer_per_kQ` and
+`etilde6_not_finite_type_per_kQ`. -/
 theorem non_adjacent_branches_infinite_type_per_kQ {n : ℕ}
     (adj : Matrix (Fin n) (Fin n) ℤ)
     (hn : 1 ≤ n) (hsymm : adj.IsSymm)
@@ -87,13 +97,279 @@ theorem non_adjacent_branches_infinite_type_per_kQ {n : ℕ}
         ∃ V : @Etingof.QuiverRepresentation.{0,0,0,0} F (Fin n) _ Q,
           V.IsIndecomposable ∧
           ∀ v, Nonempty (V.obj v ≃ₗ[F] (Fin (d v) → F))} := by
-  -- TODO (#2919): mirror `non_adjacent_branches_infinite_type` at
-  -- `Chapter6/InfiniteTypeConstructions.lean:9682-10608` line-for-line,
-  -- swapping each leaf dispatch for its per-(F, Q) variant
-  -- (`adjacent_branches_infinite_type_per_kQ`, `d5tilde_not_finite_type_per_kQ`,
-  -- `etilde7_not_finite_type_per_kQ`, `t125_not_finite_type_per_kQ`).
-  let _ := hOrient
-  sorry
+  -- Case 1: If some pair of branch points is adjacent somewhere, use that directly
+  by_cases h_adj_exists : ∃ x y, adj x y = 1 ∧ vertexDegree adj x = 3 ∧ vertexDegree adj y = 3
+  · obtain ⟨x, y, hxy, hx, hy⟩ := h_adj_exists
+    exact adjacent_branches_infinite_type_per_kQ adj hsymm hdiag h01 h_acyclic x y hx hy
+      hxy F Q hOrient
+  · -- Case 2: All branch points are pairwise non-adjacent
+    push_neg at h_adj_exists
+    have adj_comm : ∀ i j, adj i j = adj j i := fun i j => hsymm.apply j i
+    have ne_of_adj : ∀ a b, adj a b = 1 → a ≠ b := fun a b h hab => by
+      rw [hab, hdiag] at h; exact one_ne_zero h.symm
+    -- Extract v₀'s 3 neighbors
+    set S₀ := Finset.univ.filter (fun j => adj v₀ j = 1) with hS₀_def
+    have hS₀_card : S₀.card = 3 := hv₀
+    have hS₀_ne : S₀.Nonempty := by
+      rw [Finset.nonempty_iff_ne_empty]; intro h; simp [h] at hS₀_card
+    obtain ⟨u₃, hu₃_mem⟩ := hS₀_ne
+    have hu₃_adj : adj v₀ u₃ = 1 := (Finset.mem_filter.mp hu₃_mem).2
+    have hS₀_erase : (S₀.erase u₃).card = 2 := by
+      rw [Finset.card_erase_of_mem hu₃_mem, hS₀_card]
+    obtain ⟨u₁, u₂, hu₁₂, hS₀_eq⟩ := Finset.card_eq_two.mp hS₀_erase
+    have hu₁_mem : u₁ ∈ S₀.erase u₃ := hS₀_eq ▸ Finset.mem_insert_self u₁ _
+    have hu₂_mem : u₂ ∈ S₀.erase u₃ := hS₀_eq ▸ Finset.mem_insert.mpr
+      (Or.inr (Finset.mem_singleton_self u₂))
+    have hu₁_adj : adj v₀ u₁ = 1 :=
+      (Finset.mem_filter.mp (Finset.mem_of_mem_erase hu₁_mem)).2
+    have hu₂_adj : adj v₀ u₂ = 1 :=
+      (Finset.mem_filter.mp (Finset.mem_of_mem_erase hu₂_mem)).2
+    have hu₁_ne_u₃ : u₁ ≠ u₃ := Finset.ne_of_mem_erase hu₁_mem
+    have hu₂_ne_u₃ : u₂ ≠ u₃ := Finset.ne_of_mem_erase hu₂_mem
+    have hu₁_deg : vertexDegree adj u₁ < 3 := h_no_adj_branch u₁ hu₁_adj
+    have hu₂_deg : vertexDegree adj u₂ < 3 := h_no_adj_branch u₂ hu₂_adj
+    have hu₃_deg : vertexDegree adj u₃ < 3 := h_no_adj_branch u₃ hu₃_adj
+    have hu₁_ne_v₀ : u₁ ≠ v₀ := (ne_of_adj v₀ u₁ hu₁_adj).symm
+    have hu₂_ne_v₀ : u₂ ≠ v₀ := (ne_of_adj v₀ u₂ hu₂_adj).symm
+    have hu₃_ne_v₀ : u₃ ≠ v₀ := (ne_of_adj v₀ u₃ hu₃_adj).symm
+    have hu₁_v₀ : adj u₁ v₀ = 1 := (adj_comm u₁ v₀).trans hu₁_adj
+    have hu₂_v₀ : adj u₂ v₀ = 1 := (adj_comm u₂ v₀).trans hu₂_adj
+    have hu₃_v₀ : adj u₃ v₀ = 1 := (adj_comm u₃ v₀).trans hu₃_adj
+    have hu₁_deg_ge : 1 ≤ vertexDegree adj u₁ :=
+      Finset.card_pos.mpr ⟨v₀, Finset.mem_filter.mpr ⟨Finset.mem_univ _, hu₁_v₀⟩⟩
+    have hu₂_deg_ge : 1 ≤ vertexDegree adj u₂ :=
+      Finset.card_pos.mpr ⟨v₀, Finset.mem_filter.mpr ⟨Finset.mem_univ _, hu₂_v₀⟩⟩
+    have hu₃_deg_ge : 1 ≤ vertexDegree adj u₃ :=
+      Finset.card_pos.mpr ⟨v₀, Finset.mem_filter.mpr ⟨Finset.mem_univ _, hu₃_v₀⟩⟩
+    -- v₀ and w are not adjacent (no adjacent degree-3 pair exists)
+    have h_v₀w_nonadj : adj v₀ w ≠ 1 := by
+      intro hadj
+      have := h_adj_exists v₀ w hadj
+      simp [hv₀, hw] at this
+    -- Leaf-case dispatch via Sub-A1 helper (`non_adjacent_branches_leaf_case_per_kQ`).
+    by_cases hu₁_leaf : vertexDegree adj u₁ = 1
+    · exact non_adjacent_branches_leaf_case_per_kQ adj hn hsymm hdiag h01 hconn h_acyclic
+        h_deg v₀ w hv₀ hw hne h_no_adj_branch h_v₀w_nonadj u₁ hu₁_adj hu₁_leaf F Q hOrient
+    · by_cases hu₂_leaf : vertexDegree adj u₂ = 1
+      · exact non_adjacent_branches_leaf_case_per_kQ adj hn hsymm hdiag h01 hconn h_acyclic
+          h_deg v₀ w hv₀ hw hne h_no_adj_branch h_v₀w_nonadj u₂ hu₂_adj hu₂_leaf F Q hOrient
+      · by_cases hu₃_leaf : vertexDegree adj u₃ = 1
+        · exact non_adjacent_branches_leaf_case_per_kQ adj hn hsymm hdiag h01 hconn h_acyclic
+            h_deg v₀ w hv₀ hw hne h_no_adj_branch h_v₀w_nonadj u₃ hu₃_adj hu₃_leaf F Q hOrient
+        · -- All 3 neighbors have degree = 2. Embed Ẽ₆ = T(2, 2, 2).
+          have hu₁_deg2 : vertexDegree adj u₁ = 2 := by omega
+          have hu₂_deg2 : vertexDegree adj u₂ = 2 := by omega
+          have hu₃_deg2 : vertexDegree adj u₃ = 2 := by omega
+          -- u₁'s other neighbor
+          set Su₁ := Finset.univ.filter (fun j => adj u₁ j = 1)
+          have hSu₁_card : Su₁.card = 2 := hu₁_deg2
+          have hv₀_in_Su₁ : v₀ ∈ Su₁ :=
+            Finset.mem_filter.mpr ⟨Finset.mem_univ _, hu₁_v₀⟩
+          obtain ⟨u₁', hu₁'_eq⟩ := Finset.card_eq_one.mp (by
+            rw [Finset.card_erase_of_mem hv₀_in_Su₁, hSu₁_card])
+          have hu₁'_mem : u₁' ∈ Su₁.erase v₀ := hu₁'_eq ▸ Finset.mem_singleton_self u₁'
+          have hu₁'_adj : adj u₁ u₁' = 1 :=
+            (Finset.mem_filter.mp (Finset.mem_of_mem_erase hu₁'_mem)).2
+          have hu₁'_ne_v₀ : u₁' ≠ v₀ := Finset.ne_of_mem_erase hu₁'_mem
+          -- u₂'s other neighbor
+          set Su₂ := Finset.univ.filter (fun j => adj u₂ j = 1)
+          have hSu₂_card : Su₂.card = 2 := hu₂_deg2
+          have hv₀_in_Su₂ : v₀ ∈ Su₂ :=
+            Finset.mem_filter.mpr ⟨Finset.mem_univ _, hu₂_v₀⟩
+          obtain ⟨u₂', hu₂'_eq⟩ := Finset.card_eq_one.mp (by
+            rw [Finset.card_erase_of_mem hv₀_in_Su₂, hSu₂_card])
+          have hu₂'_mem : u₂' ∈ Su₂.erase v₀ := hu₂'_eq ▸ Finset.mem_singleton_self u₂'
+          have hu₂'_adj : adj u₂ u₂' = 1 :=
+            (Finset.mem_filter.mp (Finset.mem_of_mem_erase hu₂'_mem)).2
+          have hu₂'_ne_v₀ : u₂' ≠ v₀ := Finset.ne_of_mem_erase hu₂'_mem
+          -- u₃'s other neighbor
+          set Su₃ := Finset.univ.filter (fun j => adj u₃ j = 1)
+          have hSu₃_card : Su₃.card = 2 := hu₃_deg2
+          have hv₀_in_Su₃ : v₀ ∈ Su₃ :=
+            Finset.mem_filter.mpr ⟨Finset.mem_univ _, hu₃_v₀⟩
+          obtain ⟨u₃', hu₃'_eq⟩ := Finset.card_eq_one.mp (by
+            rw [Finset.card_erase_of_mem hv₀_in_Su₃, hSu₃_card])
+          have hu₃'_mem : u₃' ∈ Su₃.erase v₀ := hu₃'_eq ▸ Finset.mem_singleton_self u₃'
+          have hu₃'_adj : adj u₃ u₃' = 1 :=
+            (Finset.mem_filter.mp (Finset.mem_of_mem_erase hu₃'_mem)).2
+          have hu₃'_ne_v₀ : u₃' ≠ v₀ := Finset.ne_of_mem_erase hu₃'_mem
+          -- Reverse adjacencies for u_i'
+          have hu₁'_u₁ : adj u₁' u₁ = 1 := (adj_comm u₁' u₁).trans hu₁'_adj
+          have hu₂'_u₂ : adj u₂' u₂ = 1 := (adj_comm u₂' u₂).trans hu₂'_adj
+          have hu₃'_u₃ : adj u₃' u₃ = 1 := (adj_comm u₃' u₃).trans hu₃'_adj
+          -- u_i' ≠ u_i (from adjacency)
+          have hu₁'_ne_u₁ : u₁' ≠ u₁ := (ne_of_adj u₁ u₁' hu₁'_adj).symm
+          have hu₂'_ne_u₂ : u₂' ≠ u₂ := (ne_of_adj u₂ u₂' hu₂'_adj).symm
+          have hu₃'_ne_u₃ : u₃' ≠ u₃ := (ne_of_adj u₃ u₃' hu₃'_adj).symm
+          -- Non-edges via acyclic_no_triangle
+          have hu₁u₂ : adj u₁ u₂ = 0 :=
+            acyclic_no_triangle adj hsymm h01 h_acyclic v₀ u₁ u₂
+              hu₁₂ hu₁_ne_v₀ hu₂_ne_v₀ hu₁_adj hu₂_adj
+          have hu₁u₃ : adj u₁ u₃ = 0 :=
+            acyclic_no_triangle adj hsymm h01 h_acyclic v₀ u₁ u₃
+              hu₁_ne_u₃ hu₁_ne_v₀ hu₃_ne_v₀ hu₁_adj hu₃_adj
+          have hu₂u₃ : adj u₂ u₃ = 0 :=
+            acyclic_no_triangle adj hsymm h01 h_acyclic v₀ u₂ u₃
+              hu₂_ne_u₃ hu₂_ne_v₀ hu₃_ne_v₀ hu₂_adj hu₃_adj
+          have hv₀_u₁' : adj v₀ u₁' = 0 :=
+            acyclic_no_triangle adj hsymm h01 h_acyclic u₁ v₀ u₁'
+              hu₁'_ne_v₀.symm (ne_of_adj v₀ u₁ hu₁_adj) hu₁'_ne_u₁ hu₁_v₀ hu₁'_adj
+          have hv₀_u₂' : adj v₀ u₂' = 0 :=
+            acyclic_no_triangle adj hsymm h01 h_acyclic u₂ v₀ u₂'
+              hu₂'_ne_v₀.symm (ne_of_adj v₀ u₂ hu₂_adj) hu₂'_ne_u₂ hu₂_v₀ hu₂'_adj
+          have hv₀_u₃' : adj v₀ u₃' = 0 :=
+            acyclic_no_triangle adj hsymm h01 h_acyclic u₃ v₀ u₃'
+              hu₃'_ne_v₀.symm (ne_of_adj v₀ u₃ hu₃_adj) hu₃'_ne_u₃ hu₃_v₀ hu₃'_adj
+          -- Distinctness: u_i' ≠ u_j
+          have hu₁'_ne_u₂ : u₁' ≠ u₂ := by intro h; rw [h] at hv₀_u₁'; linarith
+          have hu₁'_ne_u₃ : u₁' ≠ u₃ := by intro h; rw [h] at hv₀_u₁'; linarith
+          have hu₂'_ne_u₁ : u₂' ≠ u₁ := by intro h; rw [h] at hv₀_u₂'; linarith
+          have hu₂'_ne_u₃ : u₂' ≠ u₃ := by intro h; rw [h] at hv₀_u₂'; linarith
+          have hu₃'_ne_u₁ : u₃' ≠ u₁ := by intro h; rw [h] at hv₀_u₃'; linarith
+          have hu₃'_ne_u₂ : u₃' ≠ u₂ := by intro h; rw [h] at hv₀_u₃'; linarith
+          -- Cross-arm non-adjacency via 4-vertex paths
+          have path_nodup4 : ∀ (a b c d : Fin n),
+              a ≠ b → a ≠ c → a ≠ d → b ≠ c → b ≠ d → c ≠ d → [a, b, c, d].Nodup := by
+            intro a b c d hab hac had hbc hbd hcd
+            simp only [List.nodup_cons, List.mem_cons,
+              List.not_mem_nil, not_or, not_false_eq_true, List.nodup_nil, and_self, and_true]
+            exact ⟨⟨hab, hac, had⟩, ⟨hbc, hbd⟩, hcd⟩
+          have path_edges4 : ∀ (a b c d : Fin n),
+              adj a b = 1 → adj b c = 1 → adj c d = 1 →
+              ∀ k, (hk : k + 1 < [a, b, c, d].length) →
+                adj ([a, b, c, d].get ⟨k, by omega⟩) ([a, b, c, d].get ⟨k + 1, hk⟩) = 1 := by
+            intro a b c d h₁ h₂ h₃ k hk
+            have : k + 1 < 4 := by simpa using hk
+            have : k = 0 ∨ k = 1 ∨ k = 2 := by omega
+            rcases this with rfl | rfl | rfl <;> assumption
+          have hu₁'_u₂_nonadj : adj u₁' u₂ = 0 :=
+            acyclic_path_nonadj adj hsymm h01 h_acyclic [u₂, v₀, u₁, u₁'] (by simp)
+              (path_nodup4 u₂ v₀ u₁ u₁' hu₂_ne_v₀ hu₁₂.symm hu₁'_ne_u₂.symm
+                hu₁_ne_v₀.symm hu₁'_ne_v₀.symm hu₁'_ne_u₁.symm)
+              (path_edges4 u₂ v₀ u₁ u₁' (adj_comm u₂ v₀ |>.trans hu₂_adj)
+                hu₁_adj hu₁'_adj)
+          have hu₁'_u₃_nonadj : adj u₁' u₃ = 0 :=
+            acyclic_path_nonadj adj hsymm h01 h_acyclic [u₃, v₀, u₁, u₁'] (by simp)
+              (path_nodup4 u₃ v₀ u₁ u₁' hu₃_ne_v₀ hu₁_ne_u₃.symm hu₁'_ne_u₃.symm
+                hu₁_ne_v₀.symm hu₁'_ne_v₀.symm hu₁'_ne_u₁.symm)
+              (path_edges4 u₃ v₀ u₁ u₁' (adj_comm u₃ v₀ |>.trans hu₃_adj)
+                hu₁_adj hu₁'_adj)
+          have hu₂'_u₁_nonadj : adj u₂' u₁ = 0 :=
+            acyclic_path_nonadj adj hsymm h01 h_acyclic [u₁, v₀, u₂, u₂'] (by simp)
+              (path_nodup4 u₁ v₀ u₂ u₂' hu₁_ne_v₀ hu₁₂ hu₂'_ne_u₁.symm
+                hu₂_ne_v₀.symm hu₂'_ne_v₀.symm hu₂'_ne_u₂.symm)
+              (path_edges4 u₁ v₀ u₂ u₂' (adj_comm u₁ v₀ |>.trans hu₁_adj)
+                hu₂_adj hu₂'_adj)
+          have hu₂'_u₃_nonadj : adj u₂' u₃ = 0 :=
+            acyclic_path_nonadj adj hsymm h01 h_acyclic [u₃, v₀, u₂, u₂'] (by simp)
+              (path_nodup4 u₃ v₀ u₂ u₂' hu₃_ne_v₀ hu₂_ne_u₃.symm hu₂'_ne_u₃.symm
+                hu₂_ne_v₀.symm hu₂'_ne_v₀.symm hu₂'_ne_u₂.symm)
+              (path_edges4 u₃ v₀ u₂ u₂' (adj_comm u₃ v₀ |>.trans hu₃_adj)
+                hu₂_adj hu₂'_adj)
+          have hu₃'_u₁_nonadj : adj u₃' u₁ = 0 :=
+            acyclic_path_nonadj adj hsymm h01 h_acyclic [u₁, v₀, u₃, u₃'] (by simp)
+              (path_nodup4 u₁ v₀ u₃ u₃' hu₁_ne_v₀ hu₁_ne_u₃ hu₃'_ne_u₁.symm
+                hu₃_ne_v₀.symm hu₃'_ne_v₀.symm hu₃'_ne_u₃.symm)
+              (path_edges4 u₁ v₀ u₃ u₃' (adj_comm u₁ v₀ |>.trans hu₁_adj)
+                hu₃_adj hu₃'_adj)
+          have hu₃'_u₂_nonadj : adj u₃' u₂ = 0 :=
+            acyclic_path_nonadj adj hsymm h01 h_acyclic [u₂, v₀, u₃, u₃'] (by simp)
+              (path_nodup4 u₂ v₀ u₃ u₃' hu₂_ne_v₀ hu₂_ne_u₃ hu₃'_ne_u₂.symm
+                hu₃_ne_v₀.symm hu₃'_ne_v₀.symm hu₃'_ne_u₃.symm)
+              (path_edges4 u₂ v₀ u₃ u₃' (adj_comm u₂ v₀ |>.trans hu₂_adj)
+                hu₃_adj hu₃'_adj)
+          -- 5-vertex paths for extension-vertex non-adjacencies
+          have path_nodup5 : ∀ (a b c d e : Fin n),
+              a ≠ b → a ≠ c → a ≠ d → a ≠ e →
+              b ≠ c → b ≠ d → b ≠ e →
+              c ≠ d → c ≠ e → d ≠ e → [a, b, c, d, e].Nodup := by
+            intro a b c d e hab hac had hae hbc hbd hbe hcd hce hde
+            simp only [List.nodup_cons, List.mem_cons,
+              List.not_mem_nil, not_or, not_false_eq_true, List.nodup_nil, and_self, and_true]
+            exact ⟨⟨hab, hac, had, hae⟩, ⟨hbc, hbd, hbe⟩, ⟨hcd, hce⟩, hde⟩
+          have path_edges5 : ∀ (a b c d e : Fin n),
+              adj a b = 1 → adj b c = 1 → adj c d = 1 → adj d e = 1 →
+              ∀ k, (hk : k + 1 < [a, b, c, d, e].length) →
+                adj ([a, b, c, d, e].get ⟨k, by omega⟩)
+                    ([a, b, c, d, e].get ⟨k + 1, hk⟩) = 1 := by
+            intro a b c d e h₁ h₂ h₃ h₄ k hk
+            have : k + 1 < 5 := by simpa using hk
+            have : k = 0 ∨ k = 1 ∨ k = 2 ∨ k = 3 := by omega
+            rcases this with rfl | rfl | rfl | rfl <;> assumption
+          have hu₁'_ne_u₂' : u₁' ≠ u₂' := by
+            intro h; rw [h] at hu₁'_u₂_nonadj
+            linarith [adj_comm u₂' u₂, hu₂'_u₂]
+          have hu₁'_ne_u₃' : u₁' ≠ u₃' := by
+            intro h; rw [h] at hu₁'_u₃_nonadj
+            linarith [adj_comm u₃' u₃, hu₃'_u₃]
+          have hu₂'_ne_u₃' : u₂' ≠ u₃' := by
+            intro h; rw [h] at hu₂'_u₃_nonadj
+            linarith [adj_comm u₃' u₃, hu₃'_u₃]
+          have hu₁'_u₂'_nonadj : adj u₁' u₂' = 0 :=
+            acyclic_path_nonadj adj hsymm h01 h_acyclic [u₂', u₂, v₀, u₁, u₁'] (by simp)
+              (path_nodup5 u₂' u₂ v₀ u₁ u₁'
+                hu₂'_ne_u₂ hu₂'_ne_v₀ hu₂'_ne_u₁ hu₁'_ne_u₂'.symm
+                hu₂_ne_v₀ hu₁₂.symm hu₁'_ne_u₂.symm
+                hu₁_ne_v₀.symm hu₁'_ne_v₀.symm hu₁'_ne_u₁.symm)
+              (path_edges5 u₂' u₂ v₀ u₁ u₁' hu₂'_u₂
+                (adj_comm u₂ v₀ |>.trans hu₂_adj) hu₁_adj hu₁'_adj)
+          have hu₁'_u₃'_nonadj : adj u₁' u₃' = 0 :=
+            acyclic_path_nonadj adj hsymm h01 h_acyclic [u₃', u₃, v₀, u₁, u₁'] (by simp)
+              (path_nodup5 u₃' u₃ v₀ u₁ u₁'
+                hu₃'_ne_u₃ hu₃'_ne_v₀ hu₃'_ne_u₁ hu₁'_ne_u₃'.symm
+                hu₃_ne_v₀ hu₁_ne_u₃.symm hu₁'_ne_u₃.symm
+                hu₁_ne_v₀.symm hu₁'_ne_v₀.symm hu₁'_ne_u₁.symm)
+              (path_edges5 u₃' u₃ v₀ u₁ u₁' hu₃'_u₃
+                (adj_comm u₃ v₀ |>.trans hu₃_adj) hu₁_adj hu₁'_adj)
+          have hu₂'_u₃'_nonadj : adj u₂' u₃' = 0 :=
+            acyclic_path_nonadj adj hsymm h01 h_acyclic [u₃', u₃, v₀, u₂, u₂'] (by simp)
+              (path_nodup5 u₃' u₃ v₀ u₂ u₂'
+                hu₃'_ne_u₃ hu₃'_ne_v₀ hu₃'_ne_u₂ hu₂'_ne_u₃'.symm
+                hu₃_ne_v₀ hu₂_ne_u₃.symm hu₂'_ne_u₃.symm
+                hu₂_ne_v₀.symm hu₂'_ne_v₀.symm hu₂'_ne_u₂.symm)
+              (path_edges5 u₃' u₃ v₀ u₂ u₂' hu₃'_u₃
+                (adj_comm u₃ v₀ |>.trans hu₃_adj) hu₂_adj hu₂'_adj)
+          have hu₁_u₃'_nonadj : adj u₁ u₃' = 0 :=
+            acyclic_path_nonadj adj hsymm h01 h_acyclic [u₃', u₃, v₀, u₁] (by simp)
+              (path_nodup4 u₃' u₃ v₀ u₁
+                hu₃'_ne_u₃ hu₃'_ne_v₀ hu₃'_ne_u₁
+                hu₃_ne_v₀ hu₁_ne_u₃.symm hu₁_ne_v₀.symm)
+              (path_edges4 u₃' u₃ v₀ u₁ hu₃'_u₃
+                (adj_comm u₃ v₀ |>.trans hu₃_adj) hu₁_adj)
+          have hu₂_u₃'_nonadj : adj u₂ u₃' = 0 :=
+            acyclic_path_nonadj adj hsymm h01 h_acyclic [u₃', u₃, v₀, u₂] (by simp)
+              (path_nodup4 u₃' u₃ v₀ u₂
+                hu₃'_ne_u₃ hu₃'_ne_v₀ hu₃'_ne_u₂
+                hu₃_ne_v₀ hu₂_ne_u₃.symm hu₂_ne_v₀.symm)
+              (path_edges4 u₃' u₃ v₀ u₂ hu₃'_u₃
+                (adj_comm u₃ v₀ |>.trans hu₃_adj) hu₂_adj)
+          -- Embedding φ : Fin 7 → Fin n
+          let φ_fun : Fin 7 → Fin n := fun i =>
+            match i with
+            | ⟨0, _⟩ => v₀  | ⟨1, _⟩ => u₁  | ⟨2, _⟩ => u₁'
+            | ⟨3, _⟩ => u₂  | ⟨4, _⟩ => u₂' | ⟨5, _⟩ => u₃ | ⟨6, _⟩ => u₃'
+          have φ_inj : Function.Injective φ_fun := by
+            intro i j hij; simp only [φ_fun] at hij
+            fin_cases i <;> fin_cases j <;>
+              first | rfl | (exact absurd hij ‹_›) | (exact absurd hij.symm ‹_›)
+          let φ : Fin 7 ↪ Fin n := ⟨φ_fun, φ_inj⟩
+          have hembed : ∀ i j, etilde6Adj i j = adj (φ i) (φ j) := by
+            intro i j
+            fin_cases i <;> fin_cases j <;>
+              simp only [etilde6Adj, φ, φ_fun] <;> norm_num <;>
+              linarith [hdiag v₀, hdiag u₁, hdiag u₁', hdiag u₂, hdiag u₂',
+                        hdiag u₃, hdiag u₃',
+                        adj_comm v₀ u₁, adj_comm v₀ u₂, adj_comm v₀ u₃,
+                        adj_comm u₁ u₁', adj_comm u₂ u₂', adj_comm u₃ u₃',
+                        adj_comm u₁ u₂, adj_comm u₁ u₃, adj_comm u₂ u₃,
+                        adj_comm v₀ u₁', adj_comm v₀ u₂', adj_comm v₀ u₃',
+                        adj_comm u₁' u₂, adj_comm u₁' u₃, adj_comm u₂' u₁,
+                        adj_comm u₂' u₃, adj_comm u₃' u₁, adj_comm u₃' u₂,
+                        adj_comm u₁' u₂', adj_comm u₁' u₃', adj_comm u₂' u₃',
+                        adj_comm u₁ u₃', adj_comm u₂ u₃']
+          exact subgraph_infinite_type_transfer_per_kQ φ F Q
+            (etilde6_not_finite_type_per_kQ F (restrictOrientationViaEmb φ Q)
+              (restrictOrientationViaEmb_isOrientationOf φ hembed hOrient))
 
 attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
   CategoryTheory.ReflQuiver.toQuiver in

--- a/progress/20260519T000720Z_356f1e39.md
+++ b/progress/20260519T000720Z_356f1e39.md
@@ -1,0 +1,89 @@
+# Per-(F, Q) non-adjacent branches outer assembly filled (#2923)
+
+## Accomplished
+
+Closed issue #2923 — Sub-A2 of #2919 / D2-non-adj of #2877. Filled the
+body of `non_adjacent_branches_infinite_type_per_kQ`
+(`Chapter6/FieldGenericAssembly.lean:64`), removing its `sorry`.
+
+Mirrors the universal
+`non_adjacent_branches_infinite_type`
+(`Chapter6/InfiniteTypeConstructions.lean:9682-10597`) line-by-line:
+
+1. **Adjacent-pair fallback** — when `∃ x y, adj x y = 1 ∧
+   vertexDegree adj x = 3 ∧ vertexDegree adj y = 3`, dispatch to
+   `adjacent_branches_infinite_type_per_kQ`.
+2. **Neighbour extraction** — set up `u₁, u₂, u₃` as the three
+   neighbours of `v₀` via the standard `Finset.card_eq_two` /
+   `Finset.card_eq_one` peeling, plus the degree-`<3`,
+   reverse-adjacency, and `≠ v₀` facts.
+3. **Non-adjacency derivation** — `h_v₀w_nonadj : adj v₀ w ≠ 1`
+   from the negated `h_adj_exists` and `hv₀, hw`.
+4. **Leaf dispatch** — three nested `by_cases` on `vertexDegree adj
+   u_i = 1` each routing into the Sub-A1 helper
+   `non_adjacent_branches_leaf_case_per_kQ`
+   (`Chapter6/FieldGenericNonAdjacentBranches.lean:79`, sorry-bodied
+   pending #2939).
+5. **All-deg-2 case** — mechanical mirror of universal lines
+   10324-10597: extract `u_i'` (each `u_i`'s second neighbour),
+   derive the cross-arm non-adjacencies via `acyclic_no_triangle` (for
+   triangle-free pairs at `v₀` or `u_i`) and `acyclic_path_nonadj`
+   (for distance-≥2 pairs via 4- and 5-vertex paths), build
+   `φ : Fin 7 ↪ Fin n` with map `0 → v₀, 1 → u₁, 2 → u₁', 3 → u₂,
+   4 → u₂', 5 → u₃, 6 → u₃'`, verify the 49-pair `etilde6Adj`
+   adjacency table via `fin_cases` + `linarith`, and close via
+   `subgraph_infinite_type_transfer_per_kQ φ F Q
+   (etilde6_not_finite_type_per_kQ F (restrictOrientationViaEmb φ Q)
+     (restrictOrientationViaEmb_isOrientationOf φ hembed hOrient))`.
+
+Required `set_option maxHeartbeats 6400000 in` (matches the universal
+budget) to handle the all-deg-2 case's adjacency-table verification.
+Added an import for `FieldGenericNonAdjacentBranches` (Sub-A1 helper).
+
+Build status: `lake build EtingofRepresentationTheory` completes
+successfully (8048 jobs). The only remaining sorry on the call chain
+is `non_adjacent_branches_leaf_case_per_kQ` itself (#2939).
+
+## Current frontier
+
+The outer dispatcher
+`acyclic_branch_not_posdef_infinite_type_per_kQ`
+(`Chapter6/FieldGenericAssembly.lean:113`) now compiles cleanly — it
+dispatches to `adjacent_branches_infinite_type_per_kQ`,
+`single_branch_not_posdef_infinite_type_per_kQ`, and
+`non_adjacent_branches_infinite_type_per_kQ` without a `sorry` at the
+dispatcher level.
+
+`not_posdef_infinite_type_per_kQ`
+(`Chapter6/FieldGenericAssembly.lean:177`) — the outer assembly
+Chapter 2 calls — is now sorry-free at the dispatcher level (modulo
+helper-internal sorries tracked by the wave-62 plan).
+
+## Overall project progress
+
+- Stage 3 / Chapter 6 outer per-(F, Q) assembly tree is fully wired
+  from `not_posdef_infinite_type_per_kQ` down through the four leaf
+  cases (`degree_ge_4`, `graph_with_list_cycle`,
+  `acyclic_branch_not_posdef` → `{adjacent_branches,
+  single_branch_not_posdef, non_adjacent_branches}`).
+- The remaining sorries on this chain are all in deeper helpers
+  tracked by separate wave-62 issues: `t125_not_finite_type_per_kQ`
+  body (#2793), `non_adjacent_branches_leaf_case_per_kQ` body (#2939
+  blocked on #2937/#2938), `single_branch_leaf_both_extend_per_kQ`
+  dispatcher (#2905 chain).
+
+## Next step
+
+Pick up an unclaimed `feature` issue:
+
+- #2937 `embed_etilde6_in_tree_per_kQ` body (T(2, 2, 2) embedding).
+- #2938 `embed_etilde7_in_tree_per_kQ` body (T(1, 3, 3) embedding).
+
+Both unblock #2939 (`non_adjacent_branches_leaf_case_per_kQ` body),
+which is the last sorry on the call chain this PR opens up.
+
+## Blockers
+
+None for this PR. Sub-A1 helper still has a `sorry` body, but that's
+tracked by #2939 and does not block this PR's completion or downstream
+dispatcher compilation.


### PR DESCRIPTION
Closes #2923

Session: `356f1e39-3d97-4270-ac67-a60e45359222`

f231879 feat(Ch6 #2919 sub-A2): non_adjacent_branches_infinite_type_per_kQ outer assembly

🤖 Prepared with Claude Code