### PR TITLE
feat(Ch6 #2932 sub-1): embed_etilde6_in_tree_per_kQ body — T(2,2,2) embedding

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/FieldGenericETilde6.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericETilde6.lean
@@ -362,13 +362,13 @@ Mirrors the pattern of `embed_t125_in_tree_per_kQ`
 Embedding map: `0→v₀, 1→c₁, 2→d₁, 3→c₂, 4→d₂, 5→c₃, 6→d₃`.
 
 Shared helper introduced for the non-adjacent-branches leaf case
-(issue #2932). The body is currently `sorry` pending the proof
-tracked by a follow-up sub-issue of #2932; the full implementation
-mirrors `embed_t125_in_tree_per_kQ` (build the distinctness lattice
-via `acyclic_no_triangle` and `acyclic_path_nonadj`, define a
-`Fin 7 ↪ Fin n` embedding, verify `etilde6Adj i j = adj (φ i) (φ j)`
-by case analysis, then dispatch via
-`subgraph_infinite_type_transfer_per_kQ`). -/
+(issue #2932). Body filled in #2937 following the
+`embed_t125_in_tree_per_kQ` pattern: build the distinctness lattice
+via `acyclic_no_triangle` (six triangle non-edges) and
+`acyclic_path_nonadj` (six distance-3 and three distance-4 non-edges),
+define a `Fin 7 ↪ Fin n` embedding, verify
+`etilde6Adj i j = adj (φ i) (φ j)` by case analysis, then dispatch
+via `subgraph_infinite_type_transfer_per_kQ`. -/
 theorem embed_etilde6_in_tree_per_kQ {n : ℕ}
     (adj : Matrix (Fin n) (Fin n) ℤ)
     (hsymm : adj.IsSymm)
@@ -393,13 +393,169 @@ theorem embed_etilde6_in_tree_per_kQ {n : ℕ}
       {d : Fin n → ℕ |
         ∃ V : @Etingof.QuiverRepresentation.{0,0,0,0} F (Fin n) _ Q,
           V.IsIndecomposable ∧ ∀ v, Nonempty (V.obj v ≃ₗ[F] (Fin (d v) → F))} := by
-  -- TODO (sub-issue of #2932): port the body from the
-  -- `embed_t125_in_tree_per_kQ` pattern (`FieldGenericT125.lean:71`).
-  let _ := hsymm; let _ := hdiag; let _ := h01; let _ := h_acyclic
-  let _ := hc₁; let _ := hd₁; let _ := hc₂; let _ := hd₂; let _ := hc₃; let _ := hd₃
-  let _ := hc₁_ne_c₂; let _ := hc₁_ne_c₃; let _ := hc₂_ne_c₃
-  let _ := hd₁_ne_v₀; let _ := hd₂_ne_v₀; let _ := hd₃_ne_v₀
-  let _ := hOrient
-  sorry
+  have adj_comm : ∀ i j, adj i j = adj j i := fun i j => hsymm.apply j i
+  have ne_of_adj' : ∀ a b, adj a b = 1 → a ≠ b := fun a b h hab => by
+    rw [hab, hdiag] at h; exact one_ne_zero h.symm
+  -- Same-arm distinctness (from adjacency)
+  have hv₀_ne_c₁ := ne_of_adj' v₀ c₁ hc₁
+  have hv₀_ne_c₂ := ne_of_adj' v₀ c₂ hc₂
+  have hv₀_ne_c₃ := ne_of_adj' v₀ c₃ hc₃
+  have hc₁_ne_d₁ := ne_of_adj' c₁ d₁ hd₁
+  have hc₂_ne_d₂ := ne_of_adj' c₂ d₂ hd₂
+  have hc₃_ne_d₃ := ne_of_adj' c₃ d₃ hd₃
+  -- Reversed edges
+  have hc₁_v₀ : adj c₁ v₀ = 1 := (adj_comm c₁ v₀).trans hc₁
+  have hc₂_v₀ : adj c₂ v₀ = 1 := (adj_comm c₂ v₀).trans hc₂
+  have hc₃_v₀ : adj c₃ v₀ = 1 := (adj_comm c₃ v₀).trans hc₃
+  have hd₁_c₁ : adj d₁ c₁ = 1 := (adj_comm d₁ c₁).trans hd₁
+  have hd₂_c₂ : adj d₂ c₂ = 1 := (adj_comm d₂ c₂).trans hd₂
+  have hd₃_c₃ : adj d₃ c₃ = 1 := (adj_comm d₃ c₃).trans hd₃
+  -- Triangle non-edges (acyclic_no_triangle): v₀-dᵢ via apex cᵢ
+  have hv₀d₁ : adj v₀ d₁ = 0 :=
+    acyclic_no_triangle adj hsymm h01 h_acyclic c₁ v₀ d₁
+      hd₁_ne_v₀.symm hv₀_ne_c₁ hc₁_ne_d₁.symm hc₁_v₀ hd₁
+  have hv₀d₂ : adj v₀ d₂ = 0 :=
+    acyclic_no_triangle adj hsymm h01 h_acyclic c₂ v₀ d₂
+      hd₂_ne_v₀.symm hv₀_ne_c₂ hc₂_ne_d₂.symm hc₂_v₀ hd₂
+  have hv₀d₃ : adj v₀ d₃ = 0 :=
+    acyclic_no_triangle adj hsymm h01 h_acyclic c₃ v₀ d₃
+      hd₃_ne_v₀.symm hv₀_ne_c₃ hc₃_ne_d₃.symm hc₃_v₀ hd₃
+  -- Triangle non-edges: cᵢ-cⱼ via apex v₀
+  have hc₁c₂ : adj c₁ c₂ = 0 :=
+    acyclic_no_triangle adj hsymm h01 h_acyclic v₀ c₁ c₂
+      hc₁_ne_c₂ hv₀_ne_c₁.symm hv₀_ne_c₂.symm hc₁ hc₂
+  have hc₁c₃ : adj c₁ c₃ = 0 :=
+    acyclic_no_triangle adj hsymm h01 h_acyclic v₀ c₁ c₃
+      hc₁_ne_c₃ hv₀_ne_c₁.symm hv₀_ne_c₃.symm hc₁ hc₃
+  have hc₂c₃ : adj c₂ c₃ = 0 :=
+    acyclic_no_triangle adj hsymm h01 h_acyclic v₀ c₂ c₃
+      hc₂_ne_c₃ hv₀_ne_c₂.symm hv₀_ne_c₃.symm hc₂ hc₃
+  -- Cross-arm ne (level 1): cᵢ ≠ dⱼ for i ≠ j (from triangle non-edges)
+  have hc₁_ne_d₂ : c₁ ≠ d₂ := by intro h; rw [h] at hc₁; linarith [hv₀d₂]
+  have hc₁_ne_d₃ : c₁ ≠ d₃ := by intro h; rw [h] at hc₁; linarith [hv₀d₃]
+  have hc₂_ne_d₁ : c₂ ≠ d₁ := by intro h; rw [h] at hc₂; linarith [hv₀d₁]
+  have hc₂_ne_d₃ : c₂ ≠ d₃ := by intro h; rw [h] at hc₂; linarith [hv₀d₃]
+  have hc₃_ne_d₁ : c₃ ≠ d₁ := by intro h; rw [h] at hc₃; linarith [hv₀d₁]
+  have hc₃_ne_d₂ : c₃ ≠ d₂ := by intro h; rw [h] at hc₃; linarith [hv₀d₂]
+  -- Path nodup helpers
+  have path_nodup4 : ∀ (a b c d : Fin n),
+      a ≠ b → a ≠ c → a ≠ d → b ≠ c → b ≠ d → c ≠ d → [a, b, c, d].Nodup := by
+    intro a b c d hab hac had hbc hbd hcd
+    simp only [List.nodup_cons, List.mem_cons, List.not_mem_nil,
+      not_or, not_false_eq_true, List.nodup_nil, and_self, and_true]
+    exact ⟨⟨hab, hac, had⟩, ⟨hbc, hbd⟩, hcd⟩
+  have path_nodup5 : ∀ (a b c d e : Fin n),
+      a ≠ b → a ≠ c → a ≠ d → a ≠ e →
+      b ≠ c → b ≠ d → b ≠ e → c ≠ d → c ≠ e → d ≠ e →
+      [a, b, c, d, e].Nodup := by
+    intro a b c d e hab hac had hae hbc hbd hbe hcd hce hde
+    simp only [List.nodup_cons, List.mem_cons, List.not_mem_nil,
+      not_or, not_false_eq_true, List.nodup_nil, and_self, and_true]
+    exact ⟨⟨hab, hac, had, hae⟩, ⟨hbc, hbd, hbe⟩, ⟨hcd, hce⟩, hde⟩
+  -- Path edges helpers
+  have path_edges4 : ∀ (a b c d : Fin n),
+      adj a b = 1 → adj b c = 1 → adj c d = 1 →
+      ∀ k, (hk : k + 1 < [a, b, c, d].length) →
+        adj ([a, b, c, d].get ⟨k, by omega⟩)
+          ([a, b, c, d].get ⟨k + 1, hk⟩) = 1 := by
+    intro a b c d h₁ h₂ h₃ k hk
+    have : k + 1 < 4 := by simpa using hk
+    have : k = 0 ∨ k = 1 ∨ k = 2 := by omega
+    rcases this with rfl | rfl | rfl <;> assumption
+  have path_edges5 : ∀ (a b c d e : Fin n),
+      adj a b = 1 → adj b c = 1 → adj c d = 1 → adj d e = 1 →
+      ∀ k, (hk : k + 1 < [a, b, c, d, e].length) →
+        adj ([a, b, c, d, e].get ⟨k, by omega⟩)
+          ([a, b, c, d, e].get ⟨k + 1, hk⟩) = 1 := by
+    intro a b c d e h₁ h₂ h₃ h₄ k hk
+    have : k + 1 < 5 := by simpa using hk
+    have : k = 0 ∨ k = 1 ∨ k = 2 ∨ k = 3 := by omega
+    rcases this with rfl | rfl | rfl | rfl <;> assumption
+  -- Distance-3 non-edges (4-vertex paths): cᵢ-dⱼ for i ≠ j
+  have hc₁d₂ : adj c₁ d₂ = 0 :=
+    acyclic_path_nonadj adj hsymm h01 h_acyclic [d₂, c₂, v₀, c₁] (by simp)
+      (path_nodup4 _ _ _ _ hc₂_ne_d₂.symm hd₂_ne_v₀ hc₁_ne_d₂.symm
+        hv₀_ne_c₂.symm hc₁_ne_c₂.symm hv₀_ne_c₁)
+      (path_edges4 _ _ _ _ hd₂_c₂ hc₂_v₀ hc₁)
+  have hc₁d₃ : adj c₁ d₃ = 0 :=
+    acyclic_path_nonadj adj hsymm h01 h_acyclic [d₃, c₃, v₀, c₁] (by simp)
+      (path_nodup4 _ _ _ _ hc₃_ne_d₃.symm hd₃_ne_v₀ hc₁_ne_d₃.symm
+        hv₀_ne_c₃.symm hc₁_ne_c₃.symm hv₀_ne_c₁)
+      (path_edges4 _ _ _ _ hd₃_c₃ hc₃_v₀ hc₁)
+  have hc₂d₁ : adj c₂ d₁ = 0 :=
+    acyclic_path_nonadj adj hsymm h01 h_acyclic [d₁, c₁, v₀, c₂] (by simp)
+      (path_nodup4 _ _ _ _ hc₁_ne_d₁.symm hd₁_ne_v₀ hc₂_ne_d₁.symm
+        hv₀_ne_c₁.symm hc₁_ne_c₂ hv₀_ne_c₂)
+      (path_edges4 _ _ _ _ hd₁_c₁ hc₁_v₀ hc₂)
+  have hc₂d₃ : adj c₂ d₃ = 0 :=
+    acyclic_path_nonadj adj hsymm h01 h_acyclic [d₃, c₃, v₀, c₂] (by simp)
+      (path_nodup4 _ _ _ _ hc₃_ne_d₃.symm hd₃_ne_v₀ hc₂_ne_d₃.symm
+        hv₀_ne_c₃.symm hc₂_ne_c₃.symm hv₀_ne_c₂)
+      (path_edges4 _ _ _ _ hd₃_c₃ hc₃_v₀ hc₂)
+  have hc₃d₁ : adj c₃ d₁ = 0 :=
+    acyclic_path_nonadj adj hsymm h01 h_acyclic [d₁, c₁, v₀, c₃] (by simp)
+      (path_nodup4 _ _ _ _ hc₁_ne_d₁.symm hd₁_ne_v₀ hc₃_ne_d₁.symm
+        hv₀_ne_c₁.symm hc₁_ne_c₃ hv₀_ne_c₃)
+      (path_edges4 _ _ _ _ hd₁_c₁ hc₁_v₀ hc₃)
+  have hc₃d₂ : adj c₃ d₂ = 0 :=
+    acyclic_path_nonadj adj hsymm h01 h_acyclic [d₂, c₂, v₀, c₃] (by simp)
+      (path_nodup4 _ _ _ _ hc₂_ne_d₂.symm hd₂_ne_v₀ hc₃_ne_d₂.symm
+        hv₀_ne_c₂.symm hc₂_ne_c₃ hv₀_ne_c₃)
+      (path_edges4 _ _ _ _ hd₂_c₂ hc₂_v₀ hc₃)
+  -- Cross-arm ne (level 2): dᵢ ≠ dⱼ for i ≠ j (from distance-3 non-edges)
+  have hd₁_ne_d₂ : d₁ ≠ d₂ := by intro h; rw [h] at hd₁; linarith [hc₁d₂]
+  have hd₁_ne_d₃ : d₁ ≠ d₃ := by intro h; rw [h] at hd₁; linarith [hc₁d₃]
+  have hd₂_ne_d₃ : d₂ ≠ d₃ := by intro h; rw [h] at hd₂; linarith [hc₂d₃]
+  -- Distance-4 non-edges (5-vertex paths): dᵢ-dⱼ for i ≠ j
+  have hd₁d₂ : adj d₁ d₂ = 0 :=
+    acyclic_path_nonadj adj hsymm h01 h_acyclic [d₂, c₂, v₀, c₁, d₁] (by simp)
+      (path_nodup5 _ _ _ _ _ hc₂_ne_d₂.symm hd₂_ne_v₀ hc₁_ne_d₂.symm hd₁_ne_d₂.symm
+        hv₀_ne_c₂.symm hc₁_ne_c₂.symm hc₂_ne_d₁ hv₀_ne_c₁ hd₁_ne_v₀.symm hc₁_ne_d₁)
+      (path_edges5 _ _ _ _ _ hd₂_c₂ hc₂_v₀ hc₁ hd₁)
+  have hd₁d₃ : adj d₁ d₃ = 0 :=
+    acyclic_path_nonadj adj hsymm h01 h_acyclic [d₃, c₃, v₀, c₁, d₁] (by simp)
+      (path_nodup5 _ _ _ _ _ hc₃_ne_d₃.symm hd₃_ne_v₀ hc₁_ne_d₃.symm hd₁_ne_d₃.symm
+        hv₀_ne_c₃.symm hc₁_ne_c₃.symm hc₃_ne_d₁ hv₀_ne_c₁ hd₁_ne_v₀.symm hc₁_ne_d₁)
+      (path_edges5 _ _ _ _ _ hd₃_c₃ hc₃_v₀ hc₁ hd₁)
+  have hd₂d₃ : adj d₂ d₃ = 0 :=
+    acyclic_path_nonadj adj hsymm h01 h_acyclic [d₃, c₃, v₀, c₂, d₂] (by simp)
+      (path_nodup5 _ _ _ _ _ hc₃_ne_d₃.symm hd₃_ne_v₀ hc₂_ne_d₃.symm hd₂_ne_d₃.symm
+        hv₀_ne_c₃.symm hc₂_ne_c₃.symm hc₃_ne_d₂ hv₀_ne_c₂ hd₂_ne_v₀.symm hc₂_ne_d₂)
+      (path_edges5 _ _ _ _ _ hd₃_c₃ hc₃_v₀ hc₂ hd₂)
+  -- Construct the embedding φ : Fin 7 ↪ Fin n for T(2, 2, 2)
+  -- Map: 0→v₀, 1→c₁, 2→d₁, 3→c₂, 4→d₂, 5→c₃, 6→d₃
+  let φ_fun : Fin 7 → Fin n := fun i =>
+    match i with
+    | ⟨0, _⟩ => v₀  | ⟨1, _⟩ => c₁  | ⟨2, _⟩ => d₁
+    | ⟨3, _⟩ => c₂  | ⟨4, _⟩ => d₂  | ⟨5, _⟩ => c₃
+    | ⟨6, _⟩ => d₃
+  have φ_inj : Function.Injective φ_fun := by
+    intro i j hij; simp only [φ_fun] at hij
+    fin_cases i <;> fin_cases j <;> first
+      | rfl
+      | (exact absurd hij ‹_›)
+      | (exact absurd hij.symm ‹_›)
+  let φ : Fin 7 ↪ Fin n := ⟨φ_fun, φ_inj⟩
+  have hembed : ∀ i j, etilde6Adj i j = adj (φ i) (φ j) := by
+    intro i j
+    fin_cases i <;> fin_cases j <;>
+      simp only [etilde6Adj, φ, φ_fun] <;> norm_num <;>
+      linarith [hdiag v₀, hdiag c₁, hdiag d₁,
+        hdiag c₂, hdiag d₂, hdiag c₃, hdiag d₃,
+        hc₁, hd₁, hc₂, hd₂, hc₃, hd₃,
+        adj_comm v₀ c₁, adj_comm v₀ d₁, adj_comm v₀ c₂, adj_comm v₀ d₂,
+        adj_comm v₀ c₃, adj_comm v₀ d₃,
+        adj_comm c₁ d₁, adj_comm c₁ c₂, adj_comm c₁ d₂,
+        adj_comm c₁ c₃, adj_comm c₁ d₃,
+        adj_comm d₁ c₂, adj_comm d₁ d₂, adj_comm d₁ c₃, adj_comm d₁ d₃,
+        adj_comm c₂ d₂, adj_comm c₂ c₃, adj_comm c₂ d₃,
+        adj_comm d₂ c₃, adj_comm d₂ d₃,
+        adj_comm c₃ d₃,
+        hv₀d₁, hv₀d₂, hv₀d₃, hc₁c₂, hc₁c₃, hc₂c₃,
+        hc₁d₂, hc₁d₃, hc₂d₁, hc₂d₃, hc₃d₁, hc₃d₂,
+        hd₁d₂, hd₁d₃, hd₂d₃]
+  exact subgraph_infinite_type_transfer_per_kQ φ F Q
+    (etilde6_not_finite_type_per_kQ F (restrictOrientationViaEmb φ Q)
+      (restrictOrientationViaEmb_isOrientationOf φ hembed hOrient))
 
 end Etingof

--- a/progress/20260519T001317Z_5d759d28.md
+++ b/progress/20260519T001317Z_5d759d28.md
@@ -1,0 +1,108 @@
+# Progress — feature session 5d759d28
+
+## Accomplished
+
+Claimed and executed feature issue #2937: filled the body of
+`embed_etilde6_in_tree_per_kQ` in `Chapter6/FieldGenericETilde6.lean`,
+turning the stub from PR #2941 (`a7c940b`, partial #2932) into a
+sorry-free proof. The branch is rebased on top of PR #2941 since the
+stub is not yet on `main`; auto-merge will rebase cleanly once #2941
+lands.
+
+The body mirrors `embed_t125_in_tree_per_kQ`
+(`Chapter6/FieldGenericT125.lean:71-441`) but is shorter — Ẽ₆ = T(2, 2, 2)
+has uniform arm length 2, so only distance-2/3/4 non-edges are needed
+(vs. distance-2..7 for T(1, 2, 5)). Structure:
+
+1. **Adjacency framing** — `adj_comm` from `hsymm`; `ne_of_adj'` for
+   per-edge distinctness; `hv₀_ne_cᵢ` / `hcᵢ_ne_dᵢ` from the six edge
+   hypotheses; reversed-edge facts `hcᵢ_v₀` / `hdᵢ_cᵢ` for path use.
+
+2. **Six triangle non-edges** via `acyclic_no_triangle`:
+   * `hv₀dᵢ` for each arm (apex `cᵢ`)
+   * `hcᵢcⱼ` for the three c-pairs (apex `v₀`)
+
+3. **Cross-arm distinctness level 1** (six facts `hcᵢ_ne_dⱼ`, `i ≠ j`)
+   via rewriting `adj v₀ cᵢ = 1` to contradict the v₀-dⱼ triangle
+   non-edge.
+
+4. **Path helpers** — local `path_nodup4`, `path_nodup5`,
+   `path_edges4`, `path_edges5` copied verbatim from T125. Only the
+   length-4 and length-5 variants are needed.
+
+5. **Six distance-3 non-edges** via `acyclic_path_nonadj` on
+   `[dⱼ, cⱼ, v₀, cᵢ]` (yields `adj cᵢ dⱼ = 0` for all `i ≠ j`).
+
+6. **Cross-arm distinctness level 2** (three facts `dᵢ_ne_dⱼ`,
+   `i ≠ j`) via rewriting `adj cᵢ dᵢ = 1` to contradict the
+   `cᵢ-dⱼ` distance-3 non-edge.
+
+7. **Three distance-4 non-edges** via `acyclic_path_nonadj` on
+   `[dⱼ, cⱼ, v₀, cᵢ, dᵢ]` (yields `adj dᵢ dⱼ = 0`).
+
+8. **Embedding `φ : Fin 7 ↪ Fin n`** via `match` on `i.val`:
+   `0→v₀, 1→c₁, 2→d₁, 3→c₂, 4→d₂, 5→c₃, 6→d₃`. Injectivity by
+   double `fin_cases` + `first | rfl | absurd hij ‹_› | absurd hij.symm ‹_›`.
+
+9. **`hembed : ∀ i j, etilde6Adj i j = adj (φ i) (φ j)`** via 49-case
+   split with `simp only [etilde6Adj, φ, φ_fun] <;> norm_num <;>
+   linarith [...]` listing the seven diagonals, six edges, all 21
+   `adj_comm` pairs, and the fifteen non-edge facts.
+
+10. **Final dispatch** via `subgraph_infinite_type_transfer_per_kQ φ F Q`
+    applied to `etilde6_not_finite_type_per_kQ F (restrictOrientationViaEmb φ Q)
+    (restrictOrientationViaEmb_isOrientationOf φ hembed hOrient)` —
+    identical shape to the T125 closer.
+
+`lake build EtingofRepresentationTheory.Chapter6.FieldGenericETilde6`
+passes; sole remaining `sorry` in the file is the pre-existing
+`etilde6Rep_kQ_isIndecomposable` (wave-54 framework wall, unrelated).
+Build time for the file: 22s under the `set_option maxHeartbeats 3200000`
+budget already declared on the stub.
+
+## Current frontier
+
+- **This session:** PR pending, branch `agent/5d759d28` rebased on
+  `pr-2941` head (`c0e1786`) → adds one commit with the body fill.
+- **Sibling issue #2938** (`embed_etilde7_in_tree_per_kQ` body, 8
+  vertices / ~30 non-edges) still unclaimed — same dispatch pattern,
+  add a length-3 arm so distance-5 path helpers become necessary.
+- **Other unclaimed:** #2564 (Mathlib upstream tracker,
+  external-blocked).
+
+## Overall project progress
+
+Stage 3 (Lean formalisation). Wave-62 architectural milestone
+(Theorem 2.1.2 forward bridge sorry-free) was achieved in PR #2921 /
+recorded in #2930; residual work is per-(F, Q) leaf bodies. This
+session lands one of the two Ẽ-embedder bodies tracked as sub-issues
+of #2932 (non-adjacent-branches leaf case dispatcher).
+
+Sorry count on `main` was 19 / 11 files before this session; that
+count was unchanged by PR #2941 (the stub added a fresh `sorry` for
+the body) and is unchanged by this PR (this PR removes the freshly
+added `sorry`, net zero against `main` once both land). After both
+PR #2941 and this PR merge, the on-main count will drop by 1 net (just
+the original `embed_etilde6_in_tree_per_kQ` body sorry, since the
+strengthened `non_adjacent_branches_leaf_case_per_kQ` signature in
+#2941 is sorry-neutral).
+
+## Next step
+
+For the next worker / planner cycle:
+
+1. **Claim #2938** (`embed_etilde7_in_tree_per_kQ` body). The pattern
+   established here ports directly — same triangle / distance-3 /
+   distance-4 ladder, plus length-3-arm distance-5 non-edges needing
+   `path_nodup6` / `path_edges6` (already in T125 as a template).
+2. **Watch PR #2941** to merge before this PR; if #2941 fails, this PR
+   will need to be rebased once the stub lands via a different route.
+3. **#2923** (D2.nonAdj outer assembly) becomes the next downstream
+   client of both Ẽ-embedder bodies once they land.
+
+## Blockers
+
+PR for this issue depends on PR #2941 merging first (it adds the stub
+this body fills). Auto-merge handles the ordering: once #2941 squashes
+to `main`, the merge-base of this PR shifts and the diff against
+`main` reduces to just the body fill.


### PR DESCRIPTION
Closes #2937

Session: `5d759d28-8538-4412-a000-5b0353f5076f`

02b6db0 feat(Ch6 #2937): embed_etilde6_in_tree_per_kQ body — T(2, 2, 2) embedding
ebadc41 review(Ch6 #2935): audit single_branch_leaf_both_extend_t122_per_kQ — PASS on all five deliverables (#2942)
4c8cf56 progress: planner cycle aea69cd7 — wave-62 audit catch-up (#2934 + #2935) (#2936)
c0e1786 progress: 146fc377 — partial #2932 (signature + embedder stubs)
a7c940b feat(Ch6 #2932 partial): strengthen leaf_case signature + add Ẽ₆/Ẽ₇ embedder stubs

🤖 Prepared with Claude Code