### PR TITLE
progress(planner 14799d02): amend #2995 wave-63 chore-PR audit + handoff

### DIFF
--- a/plans/2995-amended.md
+++ b/plans/2995-amended.md
@@ -1,0 +1,173 @@
+## Current state
+
+Wave 63 closed **four** chore PRs that refreshed citations and
+docstrings affected by the non-adjacent-branches Phase 2 cascade.
+None have been audited:
+
+* **PR #2983** (closed #2982) — file docstring refresh for
+  `Chapter6/FieldGenericNonAdjacentBranches.lean`: replaced the
+  "API stub" framing with a "Status" section summarising the
+  landed Phase 1 + Phase 2 dispatch and citing the four sub-
+  issues for the residual.
+* **PR #2989** (closed #2986) — file docstring refresh for
+  `Chapter6/FieldGenericTpqr.lean`: rewrote the leaf-arm dispatch
+  bullet to describe the actual case-split (a₂/a₃ degree-2 split,
+  D-type collapse via `tree_two_leaf_posdef`); replaced the
+  `single_branch_leaf_case_per_kQ` "API stub" sentence with a
+  pointer at the remaining stub
+  `single_branch_leaf_case_both_extend_per_kQ` (line 1233, tracked
+  by #2905 sub-chain #2907/#2908/#2909/#2910); added
+  `non_adjacent_branches_infinite_type_per_kQ`
+  (`FieldGenericAssembly.lean:75`, PR #2943) to the sibling-
+  wrapper enumeration.
+* **PR #2993** (closed #2990) — cite sub-issues
+  #2974/#2976/#2977/#2978 in two residual-sorry comment blocks
+  in `FieldGenericNonAdjacentBranches.lean` (Block 1 upstream
+  enumeration at lines 994-1003 → 4 bullets; Block 2 residual
+  site at lines 1098-1102 → 4 bullets).
+* **PR #2994** (closed #2991) — cite sub-issues
+  #2907/#2908/#2909/#2910 (and parent #2905) in the TODO block
+  at lines 1267-1279 of `Chapter6/FieldGenericTpqr.lean`
+  (`single_branch_leaf_case_both_extend_per_kQ`).
+
+The two NonAdjacentBranches PRs (#2983 + #2993) address audit
+concerns raised by PR #2984's audit of PR #2979 (Case E.aa +
+E.s1c4 partial coverage of #2955):
+
+* PR #2984's **D3 concern** — residual comment-block enumeration
+  did not match the 4-way sub-issue decomposition. Resolved by
+  PR #2993.
+* PR #2984's **D5(a) concern** — same enumeration mismatch
+  cross-referenced. Resolved by PR #2993.
+* PR #2984's **D5(b)/(c) concerns** — file docstring stale
+  ("API stub" framing missing D̃₇ helper inventory). Resolved
+  by PR #2983.
+
+PRs #2989 + #2994 cover the parallel cleanup on
+`FieldGenericTpqr.lean`: #2989 refreshes the file-level docstring
+to reflect `single_branch_leaf_case_per_kQ` having a real body
+(post-#2903), and #2994 cites the #2905 sub-chain in the inner
+TODO block. The wave-63 planner cycle (`ffed68b7`) intentionally
+separated these: #2986 explicitly scoped out the TODO block, and
+#2991 picked it up as a follow-up chore.
+
+## Deliverables
+
+Consolidated six-dimension audit of the four chore PRs, with
+verdicts written to
+`progress/reviews/2026-05-20-wave-63-chore-citation-refresh.md`:
+
+* **D1 — Citation accuracy on `FieldGenericNonAdjacentBranches.lean`
+  Block 1** (post-#2993, lines 994-1003 era): verify the 4 bullets
+  cite #2974 (D̃₆ all-leaves), #2976 (Ẽ₇ mixed at chain.length=3),
+  #2977 (D̃₈ at chain.length=5), #2978 (parametric D̃_n at
+  chain.length≥6) with correct scope descriptions matching each
+  sub-issue's body. Confirm Block 2 (residual-sorry site, post-#2993
+  lines 1098-1102 era) mirrors Block 1's 4-bullet shape with the
+  same issue citations.
+
+* **D2 — Citation accuracy on `FieldGenericTpqr.lean` TODO block**
+  (post-#2994, lines 1267-1279 era): verify the bullets cite #2907
+  (Ẽ₇ embed q,r≥3), #2908 (T(1,q,2) b₃-leaf split), #2909
+  (T(1,2,r) b₂-leaf split), #2910 (T(1,2,2)=D₅ posdef
+  contradiction) plus parent #2905, with scope descriptions
+  matching each sub-issue's body. Confirm consistency with the
+  file-level docstring refreshed by PR #2989 (see D6).
+
+* **D3 — `FieldGenericNonAdjacentBranches.lean` file docstring
+  accuracy** (post-#2983, lines 27-90 era): verify the "Status"
+  section accurately summarises Phase 1 setup + Phase 2 dispatch
+  (Cases A/B/C-main/C.short/D + partial E.aa/E.s1c4) and lists the
+  four residual sub-issues. Verify
+  `d7tilde_not_finite_type_per_kQ` and `embed_d7tilde_in_tree_per_kQ`
+  are mentioned in the per-(F, Q) library inventory. Verify the
+  "Why a different strategy" paragraph mentions D̃₇ alongside
+  Ẽ₆/Ẽ₇/T(1,2,5).
+
+* **D4 — Audit-concern closure**: confirm the three concerns
+  raised by PR #2984 (D3, D5(a), D5(b)/(c)) are fully resolved
+  by the combined effect of PRs #2983 + #2993. No new concerns
+  introduced.
+
+* **D5 — Build sanity + cross-file consistency**: verify
+  `lake build EtingofRepresentationTheory.Chapter6.FieldGenericNonAdjacentBranches`
+  and
+  `lake build EtingofRepresentationTheory.Chapter6.FieldGenericTpqr`
+  both pass with exactly the expected `declaration uses sorry`
+  warning(s) at the documented residual sites (1 sorry in
+  `FieldGenericNonAdjacentBranches`, 1 sorry in `FieldGenericTpqr`
+  at `single_branch_leaf_case_both_extend_per_kQ:1240`). Confirm
+  no transitive build breakage in downstream files
+  (`FieldGenericAssembly`).
+
+* **D6 — `FieldGenericTpqr.lean` file docstring accuracy**
+  (post-#2989, lines 11-48 era): verify the leaf-arm dispatch
+  bullet describes the actual case-split (a₂/a₃ degree-2 split,
+  D-type collapse) and points at
+  `single_branch_leaf_case_both_extend_per_kQ` as the remaining
+  API stub with #2905 sub-chain citation
+  (#2907/#2908/#2909/#2910). Verify the sibling-wrapper
+  enumeration includes
+  `non_adjacent_branches_infinite_type_per_kQ`
+  (`FieldGenericAssembly.lean:75`, PR #2943). Verify consistency
+  with the inner TODO block from PR #2994 (see D2).
+
+For each verdict, cite the exact post-PR line numbers and quote
+the relevant comment text. Report PASS / CONCERN / FAIL per
+dimension and a one-paragraph summary verdict.
+
+## Context
+
+* Parent (decomposing-via-chore-PRs): #2955 (residual decomposition
+  into #2974/#2976/#2977/#2978) and #2905 (residual decomposition
+  into #2907/#2908/#2909/#2910).
+* Audit that originally raised the concerns: PR #2984 (audit of
+  PR #2979).
+* Audit precedent for file-level docstring refresh: PR #2984's D5
+  pattern. The D5 dimension is the natural place to confirm cross-
+  file consistency on this consolidated audit; D3 and D6 carry the
+  two file-docstring substance checks.
+* Previous reviews of the wave-63 cascade (already merged):
+  PR #2969 (#2933 + #2941 signature delta), PR #2975 (Phase 1 +
+  Cases A/B/C-main/D), PR #2981 (Case C.short + D̃₇ helper),
+  PR #2984 (Case E.aa + E.s1c4).
+* No code changes expected — this is a documentation/citation
+  consistency audit. Worker should verify against the merged
+  PRs by reading the affected files at HEAD and cross-referencing
+  the sub-issue bodies.
+
+## Verification
+
+* Audit report written to
+  `progress/reviews/2026-05-20-wave-63-chore-citation-refresh.md`
+  with six dimension verdicts + summary.
+* Build state recorded: `lake build` on the two affected modules
+  passes with documented sorry counts.
+* If any dimension verdicts CONCERN or FAIL, post follow-up
+  chore issues (do not include code changes in the review PR).
+
+## Sizing
+
+Small. Four chore PRs, all pure citation/docstring changes; no
+mathematical content. Estimate: 1 session, ~350-line audit
+report. The four cross-referenced sub-issues (#2974/#2976/#2977/
+#2978) and four sibling sub-issues (#2907/#2908/#2909/#2910)
+should each be opened in the GitHub UI and their scope
+descriptions compared against the in-file bullets.
+
+## Amendment note (planner cycle 14799d02)
+
+This issue body was amended by a follow-on planner cycle to:
+1. Correct the citation error in the original "Current state"
+   bullet 1, which attributed the `FieldGenericNonAdjacentBranches.lean`
+   file-docstring refresh to PR #2989. The actual PR for that
+   refresh is **#2983** (closing #2982). PR #2989 (closing #2986)
+   is the parallel `FieldGenericTpqr.lean` file-docstring refresh.
+2. Add **D6** to audit the previously-uncovered substance of
+   PR #2989 (the Tpqr file-docstring refresh). The original five-
+   dimension audit covered only #2993 (D1), #2994 (D2), and the
+   NonAdjacentBranches docstring refresh (D3, mis-cited as #2989
+   but described as the NonAdjacentBranches "Status" section
+   refresh — i.e. PR #2983's actual content).
+3. Update D3 / D4 / Verification / Sizing to reference the
+   corrected PR list (#2983 + #2989 + #2993 + #2994).

--- a/progress/20260520T032544Z_14799d02.md
+++ b/progress/20260520T032544Z_14799d02.md
@@ -1,0 +1,101 @@
+## Accomplished
+
+Planner cycle `14799d02`. Orient: deficit=1, queue-depth=2
+(unclaimed: #2564 externally blocked on Mathlib PR #38583, #2995
+review of wave-63 chore PRs).
+
+No mergeable-with-passing-CI PRs at orient time (the prior
+cycle's PR #2996 had already landed; PRs #2911, #2849, #2694,
+#2550 remain broken and are in the `/repair` queue).
+
+Amended issue **#2995** (the wave-63 chore-PR consolidated audit)
+to fix citation errors and plug an audit gap:
+
+* Original body attributed the `FieldGenericNonAdjacentBranches.lean`
+  file-docstring refresh ("API stub" → "Status" section) to
+  PR #2989. That refresh is actually **PR #2983** (closing #2982).
+  PR #2989 (closing #2986) is the parallel
+  `FieldGenericTpqr.lean` file-docstring refresh — a substantively
+  different chore on a different file. Fixed bullet 1 of "Current
+  state" and updated D3 / D4 / Verification / Sizing accordingly.
+* Added a new audit dimension **D6** specifically covering
+  PR #2989's `FieldGenericTpqr.lean` docstring substance: leaf-arm
+  dispatch bullet describing the a₂/a₃ degree-2 split + D-type
+  collapse, pointer at `single_branch_leaf_case_both_extend_per_kQ`
+  as the remaining API stub with #2905 sub-chain citation, sibling-
+  wrapper enumeration including
+  `non_adjacent_branches_infinite_type_per_kQ`. Without D6 the
+  Tpqr docstring refresh would have been entirely unaudited (the
+  original D3 explicitly references the NonAdjacentBranches file
+  while citing the wrong PR).
+* Posted a comment on #2995 explaining the amendment so the
+  claiming worker doesn't get confused by the git/issue history.
+
+No new issues filed this cycle. Rationale:
+
+* The deficit of 1 is small; the bulk of in-flight work is in the
+  `/replan` queue (≥12 `replan`-labelled issues including #2955
+  whose closure unblocks #2974/#2976/#2977/#2978, and #2967 whose
+  body would close the D̃₇ residual), owned by the `/replan`
+  agent.
+* The four broken PRs (#2911 conflict, #2849 CI-failed, #2694
+  conflict, #2550 conflict) are in the `/repair` queue.
+* Recent merged PRs (#2989/#2993/#2994 from this cycle's start,
+  and #2983 from the prior cycle) are now fully covered by the
+  amended #2995 audit.
+* No directives open. No unaudited substantive feature PRs. The
+  one remaining items.json gap (Theorem 2.1.2) is blocked on
+  Wall 1 (#2436, human-oversight + replan).
+* Scraping for marginal chores at deficit=1 would not justify
+  the worker session overhead, mirroring the previous planner's
+  judgement at deficit=2.
+
+No `/replan` triage performed (owned by `/replan`). No
+agent-pool resizing (project is mid-stream, not converging or
+tail).
+
+## Current frontier
+
+Wave-63 chore-PR audit (#2995) is the only planner-actionable
+queue item; expanded from 5 to 6 dimensions to fully cover the
+four wave-63 chore PRs. Wave-64 substantive work remains
+structurally blocked on the same items as wave-63 close
+(`/replan` triage of #2955, `/repair` of stale PRs, Kim's
+Wall 1 framework decision on #2436).
+
+## Overall project progress
+
+* 301 Lean source files, 289 sorry-free (96.0%).
+* 582/583 items sorry-free per `progress/items.json` (99.8%).
+* 20 sorries across 12 files per `progress/sorry-landscape.md`
+  (unchanged from wave 63 close).
+* Per-(F, Q) ↔ Theorem 2.1.2 bridge architecture closed.
+* Zero broken-main events in the third consecutive wave.
+
+## Next step
+
+* `/replan` should triage wave-63 `replan` issues; #2955 closure
+  unblocks #2974/#2976/#2977/#2978; #2967 unblocks the D̃₇
+  residual.
+* `/repair` should continue working PR #2550 (Wall 3, ~26d) and
+  the three other conflicting PRs (#2911, #2694, #2849).
+* The next worker can claim **#2995** for the wave-63 chore-PR
+  consolidated audit (now 6 dimensions covering PRs
+  #2983/#2989/#2993/#2994). Estimated 1 session, ~350-line audit
+  report.
+* If `/replan` unblocks any of the four #2955 sub-issues, the
+  next worker should claim #2974 first (smallest scope) per the
+  wave-63 progress recommendation.
+* If Kim provides a Wall 1 framework decision (#2436), the
+  unblocked work is two stub bodies in
+  `FieldGenericETilde6.lean` / `FieldGenericETilde7.lean`.
+
+## Blockers
+
+* `#2564` blocked on external Mathlib PR #38583 merge
+  (unchanged).
+* `#2841` blocked on external Mathlib PR #39523 merge
+  (unchanged).
+* Wave-63 sub-issues (#2974/#2976/#2977/#2978) blocked on
+  `/replan` triage of #2955.
+* Wall 1 framework decision pending (#2436, 9+ waves stale).


### PR DESCRIPTION
This PR carries planner cycle \`14799d02\` artefacts only (\`plans/\` + \`progress/\`). No code changes; no issue creation.

* Amended #2995's body (via \`gh issue edit\`) to fix a citation error and plug an audit gap:
  - Original body attributed the \`FieldGenericNonAdjacentBranches.lean\` file-docstring refresh (\`API stub\` → \`Status\` section) to PR #2989. That refresh is actually **PR #2983** (closing #2982); PR #2989 (closing #2986) is the parallel \`FieldGenericTpqr.lean\` docstring refresh.
  - Added a new audit dimension **D6** covering PR #2989's actual substance, so the Tpqr file-docstring refresh isn't unaudited.
  - Updated D3 / D4 / Verification / Sizing to reflect the corrected four-PR scope (#2983 + #2989 + #2993 + #2994).
* Posted an explanatory comment on #2995 so the claiming worker has context for the amendment.

No new issues were created this cycle. Rationale documented in \`progress/20260520T032544Z_14799d02.md\`: deficit=1, remaining actionable work is in \`/replan\`/\`/repair\` queues, marginal chore overhead not justified.

🤖 Prepared with Claude Code