### PR TITLE
chore(Ch6): correct FieldGenericTpqr docstring line number and PR #2912 attribution

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/FieldGenericTpqr.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericTpqr.lean
@@ -30,7 +30,7 @@ on whether all three arms have length ≥ 2:
   contradicting `h_not_posdef`.
 
 The remaining API stub in this file is
-`single_branch_leaf_case_both_extend_per_kQ` (line 1233) — the body is
+`single_branch_leaf_case_both_extend_per_kQ` (line 1240) — the body is
 `sorry`, tracked by the #2905 sub-chain.
 
 Audit-pattern recipe (per
@@ -1281,11 +1281,12 @@ theorem single_branch_leaf_case_both_extend_per_kQ {n : ℕ}
   --     `t125_not_finite_type_per_kQ` (sub-issue #2908).
   --   * `b₂` leaf, r ≥ 3 (T(1, 2, r)) — symmetric to the previous case;
   --     call `t125_not_finite_type_per_kQ` (sub-issue #2909).
-  --   * ADE shapes T(1, 2, 2/3/4) → contradict `h_not_posdef` via the
-  --     `e7_tree_posdef` / `e8_posdef`-style posdef facts in
-  --     `InfiniteTypeConstructions.lean` (sub-issue #2910; landed via
-  --     PR #2912, covering T(1, 2, 2), T(1, 2, 3), and T(1, 2, 4) in the
-  --     same posdef-contradiction branch).
+  --   * ADE shape T(1, 2, 2) = D₅ → contradict `h_not_posdef` via the
+  --     `d5_posdef`-style posdef facts in `InfiniteTypeConstructions.lean`
+  --     (sub-issue #2910; landed via PR #2912 — only T(1, 2, 2)). The
+  --     other ADE configurations T(1, 3, 2)/T(1, 4, 2)/T(1, 2, 3)/T(1, 2, 4)
+  --     are q,r ∈ {3, 4} sub-rows of #2908/#2909 above, not separately
+  --     tracked.
   -- The real body will need `set_option maxHeartbeats 6400000 in` (mirroring
   -- the `_kQ`-free original at `InfiniteTypeConstructions.lean:6896`); the
   -- stub elaborates fine without it.

--- a/progress/2026-05-21T08-32-39Z_2727a2a8.md
+++ b/progress/2026-05-21T08-32-39Z_2727a2a8.md
@@ -1,0 +1,62 @@
+# 2026-05-21T08:32:39Z — feature session 2727a2a8
+
+Issue: https://github.com/kim-em/Etingof-RepresentationTheory-draft1/issues/3002
+chore(Ch6): correct FieldGenericTpqr docstring line number and PR #2912
+attribution.
+
+## Accomplished
+
+Two textual edits in
+`EtingofRepresentationTheory/Chapter6/FieldGenericTpqr.lean`, per the
+issue's deliverables:
+
+1. File-level docstring at line 33: updated stale
+   `(line 1233)` → `(line 1240)` reference to
+   `single_branch_leaf_case_both_extend_per_kQ`. The shift came from PR
+   #2989 being authored against a pre-#2994 base (PR #2994 added a
+   5-line TODO block) and not being rebased; the theorem now begins at
+   line 1240, confirmed by the post-build sorry warning at that line.
+2. TODO block at lines 1284-1289: corrected the PR #2912 attribution.
+   The old text claimed PR #2912 covered "T(1, 2, 2), T(1, 2, 3), and
+   T(1, 2, 4) in the same posdef-contradiction branch", but
+   `gh pr diff 2912` shows it landed only
+   `single_branch_leaf_both_extend_t122_per_kQ` for T(1, 2, 2) = D₅.
+   New text uses `d5_posdef`-style instead of
+   `e7_tree_posdef`/`e8_posdef`-style, restricts the PR #2912 claim to
+   T(1, 2, 2), and notes that T(1, 3, 2)/T(1, 4, 2)/T(1, 2, 3)/T(1, 2, 4)
+   are q,r ∈ {3, 4} sub-rows of #2908/#2909 above, not separately
+   tracked.
+
+## Current frontier
+
+Both citation corrections from review issue #3002 are landed. Optional
+deferrable item from the issue (asymmetric inner per-theorem docstring
+at lines 1230-1235) was not addressed in this PR — left to a future
+cleanup as the issue itself flagged.
+
+## Overall project progress
+
+Comment-only PR. Sorry count unchanged: 1 in
+`FieldGenericTpqr.lean` (line 1240), matching the issue's expected
+verification.
+
+Verification:
+* `lake build EtingofRepresentationTheory.Chapter6.FieldGenericTpqr`
+  passes (8045 jobs); exactly one sorry warning at line 1240
+  (`single_branch_leaf_case_both_extend_per_kQ`).
+* `lake build EtingofRepresentationTheory.Chapter6.FieldGenericAssembly`
+  passes (8049 jobs); no transitive breakage.
+
+## Next step
+
+`/plan` triages the remaining unclaimed work. Issue #2564
+(MvPolynomial.eq_of_eval_eq_on_gl upstream tracker) is blocked on
+external Mathlib PR #38583 merging — re-open only after the project
+bumps to a Mathlib revision containing the new file. If the planner
+decides to extend the citation-refresh chore one further, the
+deferrable item from #3002 (asymmetric q-r split in the inner
+docstring at lines 1230-1235) is the natural next pickup.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #3002

Session: `2727a2a8-0a98-4f43-9a0c-40910b4dc9e7`

3ecf8e2 chore(Ch6): correct FieldGenericTpqr docstring line number and PR #2912 attribution

🤖 Prepared with Claude Code