### PR TITLE
chore(Ch6 #2995 D5(a)): drop redundant let _ := arm₂_ne_chain in residual-sorry block (FieldGenericNonAdjacentBranches.lean:1118)

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/FieldGenericNonAdjacentBranches.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericNonAdjacentBranches.lean
@@ -1115,7 +1115,7 @@ theorem non_adjacent_branches_leaf_case_per_kQ {n : ℕ}
               let _ := h_no_adj_branch_w
               let _ := hleaf_ne_arm₁; let _ := hleaf_ne_arm₂
               let _ := hside_ne_arm₁; let _ := hside_ne_arm₂
-              let _ := leaf_ne_chain; let _ := arm₂_ne_chain
+              let _ := leaf_ne_chain
               sorry
 
 end Etingof

--- a/progress/2026-05-21T08-46-06Z_cd5a0d8e.md
+++ b/progress/2026-05-21T08-46-06Z_cd5a0d8e.md
@@ -1,0 +1,48 @@
+## Accomplished
+
+Closed issue #3004 (wave-63 audit D5(a) sub-concern): dropped the
+redundant `let _ := arm₂_ne_chain` from the residual-`sorry` block in
+`EtingofRepresentationTheory/Chapter6/FieldGenericNonAdjacentBranches.lean`.
+
+The audit (`progress/reviews/2026-05-20-wave-63-chore-citation-refresh.md`)
+flagged that `arm₂_ne_chain` is already syntactically used at lines 459,
+877, 902, and 1088, so the `let _ := arm₂_ne_chain` at line 1118 was
+not needed to silence an unused-variable warning. Verified with
+`grep -n "arm₂_ne_chain"` before editing.
+
+Total diff: 1 line. Line 1118 now reads `              let _ := leaf_ne_chain`
+(the trailing `; let _ := arm₂_ne_chain` removed). The surrounding
+comment block (1100-1113), the other `let _` bindings (1114-1117), and
+the `sorry` (now line 1119) were left untouched per the issue.
+
+Verification: `lake build EtingofRepresentationTheory.Chapter6.FieldGenericNonAdjacentBranches`
+completes successfully. The only declaration-uses-`sorry` warning in
+this file remains at line 103 (`non_adjacent_branches_leaf_case_per_kQ`),
+unchanged. No new unused-variable warnings.
+
+## Current frontier
+
+Wave-63 chore-citation audit (#2995) sub-concerns from PR #2984's D3
+are now all resolved:
+* D5(a) (this issue): comment enumeration, citations, and the `let _`
+  asymmetry — all closed.
+
+The residual `sorry` at `FieldGenericNonAdjacentBranches.lean:1119` is
+decomposed into sub-issues #2974/#2976/#2977/#2978, all currently
+blocked on #2955.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. Chapter 6 residual sorries are tracked
+as separate sub-issues; this turn only cleaned up an audit-flagged
+cosmetic redundancy and did not touch the underlying proof.
+
+## Next step
+
+Pick up the next unclaimed feature/chore issue. The active blockers
+chain (#2955 → #2974/#2976/#2977/#2978) is not unlocked by this turn.
+
+## Blockers
+
+None for this turn's deliverables. Issue #2564 (MvPolynomial upstream
+tracker) remains blocked externally on Mathlib PR #38583.


### PR DESCRIPTION
Closes #3004

Session: `cd5a0d8e-92a5-4cf7-8eb1-e9d108a6eedf`

fa79b9b chore(Ch6 #3004): drop redundant let _ := arm₂_ne_chain in residual-sorry block

🤖 Prepared with Claude Code