### PR TITLE
progress: diagnose pod stdout pollution deadlocking dispatcher queue accounting

### DIFF
--- a/plans/pod-stdout-deadlock.md
+++ b/plans/pod-stdout-deadlock.md
@@ -1,0 +1,63 @@
+**This is a harness-infrastructure escalation, not formalization work. It cannot be fixed by an agent worker inside this repository — the fix is one line in the `pod` Python package — so it is filed for human / pod-maintainer attention and paired with a `return-to-human` signal.**
+
+## Symptom
+
+The dispatcher's work-accounting reports an empty queue while 32 `agent-plan` issues are open (11 of them ready/claimable). Every cycle the dispatcher therefore launches a *planner* (queue looks empty) but never a *worker* (no claimable issues visible), so the core formalization frontier never gets worked. This matches the long run of "Nth consecutive planner no-op cycle" commits.
+
+Observed, right now, on `main`:
+
+```
+coordination list-unclaimed   -> (empty)
+coordination list-replan      -> (empty)
+coordination queue-depth      -> 0
+```
+
+But direct `gh` shows 32 open `agent-plan` issues, of which 11 carry only `[agent-plan,feature]` (no `claimed`/`blocked`/`has-pr`/`replan`) and are genuinely ready: #2978 #2977 #2976 #2974 #2967 #2853 #2823 #2801 #2793 #2769 #2693.
+
+## Root cause
+
+`pod/cli.py` `_agent_config_sync_check()` prints template-divergence diagnostics to **stdout** (not stderr), at approximately lines 408-419:
+
+```python
+if updated:
+    print(f"pod: updated {len(updated)} file(s) from new pod version: ...")
+if custom:
+    print(f"pod: {len(custom)} project-customised file(s) differ from pod template: ...")
+if conflicts and not first_run:
+    print(f"pod: WARNING: {len(conflicts)} file(s) modified in both ...")
+elif conflicts and first_run:
+    print(f"pod: {len(conflicts)} file(s) differ from pod template ...")
+```
+
+`ensure_config()` calls this check on essentially every `pod` invocation. The coordination commands that need a trusted-author view of issues (`list-unclaimed`, `list-replan`, `queue-depth`, and the issue sections of `orient`) obtain it by spawning a **subprocess** `pod _filter-trusted-issues …` and capturing its stdout (`coordination.py:_filter_trusted_issues`). The warning line is therefore prepended to the captured JSON:
+
+```
+pod: 3 project-customised file(s) differ from pod template: commands/meditate.md, commands/plan.md, skills/agent-worker-flow/SKILL.md
+[ { ...real issue JSON... } ]
+```
+
+`coordination.py:_safe_json` does `json.loads(stripped)`, which fails on the leading non-JSON line and returns the `default=[]`. So the entire issue list is silently dropped. Verified: feeding the same `_filter-trusted-issues` output through a parser that skips the warning line yields 32 issues / 11 ready, exactly as expected.
+
+Commands that query `gh` directly in-process (`list-pr-repair`, the PR/directive sections of `orient`) are unaffected — which is why directives (#4516) and PR-repair still flow while ordinary feature/replan work is invisible.
+
+## Trigger (project side)
+
+The warning fires because this project intentionally customises three agent-config files, all of which differ from the pod template in the committed `main` state (so this affects every worktree, every session, persistently):
+
+- `.claude/commands/plan.md`
+- `.claude/commands/meditate.md`
+- `.claude/skills/agent-worker-flow/SKILL.md`
+
+These customisations are legitimate (the project's CLAUDE.md directs agents to "Update skills and commands instead"). Reverting them is **not** the right fix.
+
+## Fix
+
+In `pod/cli.py` `_agent_config_sync_check()`, route the four diagnostic `print(...)` calls to stderr: add `file=sys.stderr` (or use a logger). Diagnostics must never share stdout with machine-readable command output.
+
+Optional defense-in-depth in `coordination.py`: make `_safe_json` tolerant of leading non-JSON lines (skip to the first `[`/`{`), and/or have `_filter_trusted_issues` pass a quiet flag to the subprocess.
+
+## Impact
+
+Until fixed, the autonomous loop cannot dispatch workers to the formalization frontier; it can only spin planners (no-op) and service directives / PR-repair. Paired with a `return-to-human` signal so this is seen promptly rather than burning further planner cycles.
+
+🤖 Prepared with Claude Code

--- a/progress/2026-06-14T09-05-17Z.md
+++ b/progress/2026-06-14T09-05-17Z.md
@@ -1,0 +1,75 @@
+## Accomplished
+
+Planner cycle. Did **not** create new work items — the reported queue deficit
+(3) is a false reading caused by a harness bug, and the real queue is full.
+
+Diagnosed a project-wide deadlock of the dispatcher's work-accounting layer and
+filed it:
+
+- **#4518** `infra: pod template-diff warning on stdout corrupts coordination
+  queue JSON` — full root-cause analysis and one-line fix.
+- Signalled **`return-to-human`** (sentinel issue #2357) so the loop stops
+  spinning no-op planners and Kim/the pod-maintainer can apply the fix.
+- Annotated directive **#4516** explaining why its referenced frontier issues
+  are currently unworkable by the loop.
+
+### Root cause (verified)
+
+`pod/cli.py:_agent_config_sync_check()` prints template-divergence diagnostics
+to **stdout** (should be stderr), ~lines 408-419. `ensure_config()` runs this on
+every `pod` call. Coordination commands that need a trusted-author issue view
+(`list-unclaimed`, `list-replan`, `queue-depth`, and orient's issue sections)
+spawn a `pod _filter-trusted-issues` subprocess and capture its stdout; the
+warning line gets prepended to the JSON, `coordination.py:_safe_json` fails to
+parse it and returns `default=[]`. Result: the dispatcher sees an empty queue
+(depth 0) while 32 `agent-plan` issues are open (11 ready). It therefore
+launches planners (queue looks empty) but never workers (no claimable issues
+visible) — the "Nth consecutive planner no-op cycle" pattern.
+
+Trigger: three intentionally-customised, committed files differ from the pod
+template on `main` (so it affects every worktree/session): `.claude/commands/plan.md`,
+`.claude/commands/meditate.md`, `.claude/skills/agent-worker-flow/SKILL.md`.
+These customisations are legitimate; the fix is in pod (route the prints to
+stderr), NOT reverting them.
+
+Commands that hit `gh` directly in-process (`list-pr-repair`, orient's
+PR/directive sections) are unaffected — which is why directives (#4516) and
+PR-repair still flow while feature/replan work is invisible.
+
+Verification: feeding the same `pod _filter-trusted-issues` output through a
+parser that skips the leading non-JSON line yields 32 issues / 11 ready —
+exactly what `list-unclaimed` should have shown.
+
+## Current frontier
+
+Unchanged by this cycle. The genuine open frontier is the per-(F,Q) Chapter 6
+helpers and Chapter 5 Wall-3 / Schur-Weyl assembly issues. The 11 ready,
+currently-invisible issues: #2978 #2977 #2976 #2974 #2967 #2853 #2823 #2801
+#2793 #2769 #2693.
+
+## Overall project progress
+
+Stage 3 (formalization) in progress. Work is NOT converged — there is a healthy
+backlog (32 open `agent-plan` issues). The blocker is purely infrastructural:
+the dispatcher cannot see the queue, so the autonomous loop cannot make
+progress on the formalization frontier.
+
+Open PRs all need repair: #2911, #2694, #2550 (conflicts), #2849 (CI failed) —
+these are surfaced correctly by `list-pr-repair` and can be handled by repair
+agents once the loop resumes.
+
+## Next step
+
+1. **Human / pod-maintainer**: apply the one-line fix in #4518 (add
+   `file=sys.stderr` to the four diagnostic `print(...)` calls in
+   `pod/cli.py:_agent_config_sync_check`; optionally harden
+   `coordination.py:_safe_json` to skip leading non-JSON lines).
+2. Clear the signal: `coordination clear-return-to-human`.
+3. The loop will then see the real queue (11 ready issues) and dispatch
+   workers normally. No replanning needed — the backlog is already populated.
+
+## Blockers
+
+**#4518** (pod stdout pollution) blocks all dispatcher work-accounting. Cannot
+be fixed by an agent worker — the fix lives in the `pod` Python package outside
+this repo. `return-to-human` signalled.


### PR DESCRIPTION
This PR records a planner-cycle diagnosis: the `pod` template-diff warning is printed to stdout, so coordination's `pod _filter-trusted-issues` subprocess output is corrupted and `_safe_json` drops the whole issue list. The dispatcher reads queue depth 0 against 32 open `agent-plan` issues (11 ready) and keeps spinning no-op planners without ever dispatching workers to the formalization frontier. The fix is one line in `pod/cli.py` (route the diagnostic prints to stderr); it lives outside this repo, so it is filed as #4518 and paired with a `return-to-human` signal. No new work items were created this cycle because the real queue is already full.

Adds the mandated planner progress handoff and the issue body under `plans/`.

🤖 Prepared with Claude Code