### PR TITLE
feat(Ch6): reduce starRep_kQ to starRepGen at canonical orientation

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/FieldGenericStar.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericStar.lean
@@ -527,6 +527,59 @@ theorem starRep_kQ_dimVec
       (Fin (if v.val = 0 then 2 * (m + 1) else m + 1) → F)) :=
   ⟨LinearEquiv.refl F _⟩
 
+/-! ## Section: Reduction of `starRep_kQ` to `starRepGen` at the canonical orientation
+
+At the canonical all-sink orientation `starQuiver` the orientation-generic
+representation `starRep_kQ` coincides with the canonical F-generic representation
+`starRepGen`. The two have the same object family, instances, and dimension
+vector; their arrow maps agree on every arrow of `starQuiver` — all of the form
+leaf `i → 0`, where `starRepMap_kQ` and `starRepMapGen` select the same
+embedding. The reversed-edge arms of `starRepMap_kQ` (`0 → i`, using the
+projections `starProj_i_F`) are never reached because `starQuiver` has no such
+arrow. This lets the canonical-orientation indecomposability of `starRep_kQ`
+reuse `starRepGen_isIndecomposable` instead of reproving the ~210-line argument
+(review #2816 Q3, issue #2823). -/
+
+attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
+  CategoryTheory.ReflQuiver.toQuiver in
+/-- The orientation-generic K_{1,4} representation at the canonical orientation
+`starQuiver` equals the canonical F-generic representation `starRepGen`. -/
+theorem starRep_kQ_canonical_eq_starRepGen
+    (F : Type) [Field F] (m : ℕ)
+    (hOrient : @Etingof.IsOrientationOf 5 starQuiver starAdj) :
+    starRep_kQ F starQuiver hOrient m = starRepGen F m := by
+  letI : Quiver (Fin 5) := starQuiver
+  -- The two arrow maps agree on every arrow of `starQuiver`: such an arrow `a → b`
+  -- forces `a.val ≠ 0` and `b.val = 0`, i.e. a leaf `i → 0`, where both `starRepMap_kQ`
+  -- and `starRepMapGen` select the same embedding. On every other index pair an arrow
+  -- cannot exist (`b.val = 0` is contradicted), so the reversed-edge arms are unreached.
+  have hmap : ∀ (a b : Fin 5), @Quiver.Hom (Fin 5) starQuiver a b →
+      starRepMap_kQ F m a b = starRepMapGen F m a b := by
+    intro a b e
+    obtain ⟨ha, hb⟩ := e.down
+    fin_cases a <;> fin_cases b <;>
+      first
+        | rfl
+        | exact absurd hb (by decide)
+  unfold starRep_kQ starRepGen
+  congr 1
+  funext a b e
+  exact hmap a b e
+
+attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
+  CategoryTheory.ReflQuiver.toQuiver in
+/-- Canonical-orientation indecomposability of `starRep_kQ`, obtained from
+`starRepGen_isIndecomposable` via `starRep_kQ_canonical_eq_starRepGen`. This is
+the canonical-orientation half of the `star_not_finite_type_per_kQ` deliverable
+(issue #2801); the general orientation `Q` is handled separately. -/
+theorem starRep_kQ_canonical_isIndecomposable
+    (F : Type) [Field F] (m : ℕ)
+    (hOrient : @Etingof.IsOrientationOf 5 starQuiver starAdj) :
+    @Etingof.QuiverRepresentation.IsIndecomposable F _ (Fin 5) starQuiver
+      (starRep_kQ F starQuiver hOrient m) := by
+  rw [starRep_kQ_canonical_eq_starRepGen]
+  exact starRepGen_isIndecomposable F m
+
 attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
   CategoryTheory.ReflQuiver.toQuiver in
 /-- Per-(field, orientation) version of `star_not_finite_type`: for any

--- a/progress/2026-06-14T09-40-24Z_692f5e23.md
+++ b/progress/2026-06-14T09-40-24Z_692f5e23.md
@@ -1,0 +1,70 @@
+## Accomplished
+
+Worker session (`/work`), claimed and completed issue **#2823** —
+"bridge starRep_kQ ↔ starRepGen for the canonical orientation".
+
+Added two theorems to `EtingofRepresentationTheory/Chapter6/FieldGenericStar.lean`
+(after `starRep_kQ_dimVec`):
+
+- `starRep_kQ_canonical_eq_starRepGen` — the orientation-generic K_{1,4}
+  representation at the canonical all-sink orientation `starQuiver` *equals*
+  the canonical F-generic representation `starRepGen`. Proof: the two share
+  `obj`/instances; the arrow maps `starRepMap_kQ` and `starRepMapGen` agree on
+  every arrow of `starQuiver` (all of the form leaf `i → 0`, where both select
+  the same embedding), and the reversed-edge arms (`0 → i`, the `starProj_i_F`
+  projections) are never reached because `starQuiver` has no such arrow. The
+  per-arrow agreement is `fin_cases a <;> fin_cases b` discharged by `rfl` on
+  canonical arrows and by the `b.val = 0` contradiction elsewhere; the
+  structure equality is assembled via `unfold; congr 1; funext`.
+- `starRep_kQ_canonical_isIndecomposable` — canonical-orientation
+  indecomposability of `starRep_kQ`, obtained by rewriting along the equality
+  and applying `starRepGen_isIndecomposable` (eliminating the ~210-line reproof
+  that #2801 would otherwise need for the canonical case).
+
+Both are sorry-free. `lake build …FieldGenericStar` and the downstream
+`…FieldGenericInfiniteType` both pass.
+
+### Notes / decisions
+
+- Issue #2823 referenced `FieldGenericInfiniteType.lean`, but `starRep_kQ` /
+  `starRepGen` were moved to `FieldGenericStar.lean` by #2846. The new theorems
+  are placed there alongside their subjects; building `FieldGenericStar` is the
+  correct check.
+- Two `@`-explicit spellings were required because `starQuiver` is a `def`, not
+  an instance: the `IsIndecomposable` statement uses
+  `@Etingof.QuiverRepresentation.IsIndecomposable F _ (Fin 5) starQuiver …`
+  (matching `starRepGen_isIndecomposable`), and a `letI : Quiver (Fin 5) :=
+  starQuiver` is needed inside the equality proof so the `congr`-generated
+  `mapLinear` funext goal can resolve `a ⟶ b`.
+- Deliverable 2 (use the reduction to derive canonical indecomposability) is
+  delivered as the standalone reusable lemma `starRep_kQ_canonical_isIndecomposable`
+  rather than folded into #2801. The general-orientation `star_not_finite_type_per_kQ`
+  sorry (line ~610) is untouched — that is #2801/#2789 territory and needs the
+  arbitrary-`Q` indecomposability argument.
+
+## Current frontier
+
+`star_not_finite_type_per_kQ` (general orientation `Q` of `starAdj`) remains a
+`sorry` in `FieldGenericStar.lean` — issue #2801 (depends conceptually on the
+direction-aware subrep lemmas). The canonical case it must cover is now
+available as `starRep_kQ_canonical_isIndecomposable`.
+
+## Overall project progress
+
+Stage 3 (formalization) in progress. The per-(F, Q) Chapter 6 forbidden-subgraph
+program is the live frontier (directive #4516). This session removed one
+duplication-avoidance blocker (#2823) feeding the K_{1,4} case (#2801).
+
+## Next step
+
+Pick up #2801 (orientation-generic K_{1,4} indecomposability) — it can now
+dispatch the canonical orientation to `starRep_kQ_canonical_isIndecomposable`
+and only needs the reversed/mixed-arrow cases. Other ready frontier issues:
+#2967 (D̃₇ indec), #2853 (d5tilde leaf equalities), #2793 (T(1,2,5)).
+
+## Blockers
+
+None for this item. Project-wide: the pod dispatcher queue-accounting bug (#4518,
+`return-to-human` signalled) still blocks the autonomous loop from seeing the
+queue, per the prior planner handoff — but manual `/work` sessions can see and
+claim issues normally (as this session did).


### PR DESCRIPTION
This PR reduces the orientation-generic K_{1,4} representation to the canonical one at the all-sink orientation. It adds `starRep_kQ_canonical_eq_starRepGen`, proving that `starRep_kQ F starQuiver hOrient m` equals `starRepGen F m`: the two share object family and instances, their arrow maps agree on every arrow of `starQuiver` (each a leaf `i → 0`), and the reversed-edge arms of `starRepMap_kQ` are never reached because `starQuiver` has no arrow `0 → i`. It then derives `starRep_kQ_canonical_isIndecomposable` by rewriting along that equality and applying `starRepGen_isIndecomposable`, so the canonical case of the K_{1,4} indecomposability work (#2801) reuses the existing ~210-line argument instead of reproving it.

Both additions are sorry-free; `FieldGenericStar` and the downstream `FieldGenericInfiniteType` build. The theorems live in `FieldGenericStar.lean` alongside `starRep_kQ`/`starRepGen` (moved there by #2846), not in `FieldGenericInfiniteType.lean` as the issue predates that move.

Closes #2823

🤖 Prepared with Claude Code