### PR TITLE
feat(Ch6 #2801): land orientation-generic K_{1,4} per-leaf subspace reductions

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/FieldGenericStar.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericStar.lean
@@ -474,6 +474,50 @@ theorem starProj4_F_starEmbedNilp_F (F : Type) [Field F] (m : ℕ)
   simp [starProj4_F, starEmbedNilp_F, LinearMap.add_apply, LinearMap.comp_apply,
     starFirst_F_starEmbed1_F, starFirst_F_starEmbed2_F]
 
+/-! ### Directness transfer
+
+A pure submodule-lattice companion to `compl_le_forces_eq`. Where
+`compl_le_forces_eq` collapses `A ≤ B` between two complementary *pairs*
+via a finrank count, this one starts from the *lower* pair already
+spanning the whole space and needs no dimension argument. It is the key
+step that lets the orientation-generic K_{1,4} proof pin a leaf subspace
+from the center: a surjective reversed-leaf projection sends a center
+complement pair `(W₁ 0, W₂ 0)` to a pair that spans the leaf (`⊔ = ⊤`),
+and the leaf's own complement pair bounds it from above, so the two must
+coincide. -/
+
+/-- If `A₁ ⊔ A₂ = ⊤`, `A₁ ≤ B₁`, `A₂ ≤ B₂` and `B₁, B₂` are
+complementary, then `A₁ = B₁` and `A₂ = B₂`. The two lower spaces, already
+spanning the whole space, must fill their complementary upper bounds
+exactly. No finite-dimensionality required. -/
+theorem sup_top_le_isCompl_forces_eq
+    {F : Type*} [Field F] {V : Type*} [AddCommGroup V] [Module F V]
+    (A₁ A₂ B₁ B₂ : Submodule F V)
+    (htop : A₁ ⊔ A₂ = ⊤) (h1 : A₁ ≤ B₁) (h2 : A₂ ≤ B₂)
+    (hB : IsCompl B₁ B₂) :
+    A₁ = B₁ ∧ A₂ = B₂ := by
+  have hB1 : B₁ ≤ A₁ := by
+    intro b hb
+    have hb_top : b ∈ A₁ ⊔ A₂ := htop ▸ Submodule.mem_top
+    obtain ⟨a₁, ha₁, a₂, ha₂, rfl⟩ := Submodule.mem_sup.mp hb_top
+    have ha₂B1 : a₂ ∈ B₁ := by
+      have hsub : a₂ = (a₁ + a₂) - a₁ := by abel
+      rw [hsub]; exact B₁.sub_mem hb (h1 ha₁)
+    have : a₂ ∈ B₁ ⊓ B₂ := Submodule.mem_inf.mpr ⟨ha₂B1, h2 ha₂⟩
+    rw [hB.inf_eq_bot, Submodule.mem_bot] at this
+    rw [this, add_zero]; exact ha₁
+  have hB2 : B₂ ≤ A₂ := by
+    intro b hb
+    have hb_top : b ∈ A₁ ⊔ A₂ := htop ▸ Submodule.mem_top
+    obtain ⟨a₁, ha₁, a₂, ha₂, rfl⟩ := Submodule.mem_sup.mp hb_top
+    have ha₁B2 : a₁ ∈ B₂ := by
+      have hsub : a₁ = (a₁ + a₂) - a₂ := by abel
+      rw [hsub]; exact B₂.sub_mem hb (h2 ha₂)
+    have : a₁ ∈ B₁ ⊓ B₂ := Submodule.mem_inf.mpr ⟨h1 ha₁, ha₁B2⟩
+    rw [hB.inf_eq_bot, Submodule.mem_bot] at this
+    rw [this, zero_add]; exact ha₂
+  exact ⟨le_antisymm h1 hB1, le_antisymm h2 hB2⟩
+
 /-! ## Section: Orientation-generic K_{1,4} representation
 
 `starRep_kQ` matches `starRepGen` at the canonical orientation and uses the

--- a/EtingofRepresentationTheory/Chapter6/FieldGenericStar.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericStar.lean
@@ -518,6 +518,93 @@ theorem sup_top_le_isCompl_forces_eq
     rw [this, zero_add]; exact ha₂
   exact ⟨le_antisymm h1 hB1, le_antisymm h2 hB2⟩
 
+/-- **Reversed-leaf subspace reduction (abstract form).** When a leaf edge
+is oriented *into* the leaf (`0 → i`, the reversed direction), its map is a
+surjective projection `p : V₀ → Vᵢ`. Subrepresentation invariance then
+gives `map p (W 0) ≤ W i` for both halves of a complementary pair, and
+because `p` is surjective the two images already span `Vᵢ`. By
+`sup_top_le_isCompl_forces_eq` the leaf subspaces are therefore *exactly*
+the projected center subspaces: `W i = map p (W 0)`. This is the crux
+reduction for every reversed leaf in the orientation-generic D̃/star
+indecomposability proofs — the entire leaf datum is determined by the
+center. -/
+theorem reversed_leaf_subspace_eq
+    {F : Type*} [Field F] {V₀ Vᵢ : Type*}
+    [AddCommGroup V₀] [Module F V₀] [AddCommGroup Vᵢ] [Module F Vᵢ]
+    (p : V₀ →ₗ[F] Vᵢ) (hp : Function.Surjective p)
+    (U₁ U₂ : Submodule F V₀) (Wi₁ Wi₂ : Submodule F Vᵢ)
+    (hU : IsCompl U₁ U₂) (hWi : IsCompl Wi₁ Wi₂)
+    (h1 : U₁.map p ≤ Wi₁) (h2 : U₂.map p ≤ Wi₂) :
+    Wi₁ = U₁.map p ∧ Wi₂ = U₂.map p := by
+  have htop : U₁.map p ⊔ U₂.map p = ⊤ := by
+    rw [← Submodule.map_sup, hU.sup_eq_top, Submodule.map_top,
+      LinearMap.range_eq_top.mpr hp]
+  obtain ⟨e1, e2⟩ := sup_top_le_isCompl_forces_eq _ _ _ _ htop h1 h2 hWi
+  exact ⟨e1.symm, e2.symm⟩
+
+/-- General directness primitive: if the lower pair `(A₁, A₂)` already
+sups above the upper pair `(B₁, B₂)`, each `Aₖ ≤ Bₖ`, and the upper pair
+meets trivially, then the pairs coincide. Generalises
+`sup_top_le_isCompl_forces_eq` by replacing the ambient `⊤` with the
+common sup `A₁ ⊔ A₂`; used for the forward-leaf reduction, where the
+relevant ambient is `range e` rather than the whole space. -/
+theorem submodule_pair_eq_of_sup_le_of_inf_bot
+    {F : Type*} [Field F] {V : Type*} [AddCommGroup V] [Module F V]
+    (A₁ A₂ B₁ B₂ : Submodule F V)
+    (h1 : A₁ ≤ B₁) (h2 : A₂ ≤ B₂)
+    (hsup : B₁ ⊔ B₂ ≤ A₁ ⊔ A₂) (hinf : B₁ ⊓ B₂ = ⊥) :
+    A₁ = B₁ ∧ A₂ = B₂ := by
+  have hB1 : B₁ ≤ A₁ := by
+    intro b hb
+    have hb_top : b ∈ A₁ ⊔ A₂ := hsup (Submodule.mem_sup_left hb)
+    obtain ⟨a₁, ha₁, a₂, ha₂, rfl⟩ := Submodule.mem_sup.mp hb_top
+    have ha₂B1 : a₂ ∈ B₁ := by
+      have hsub : a₂ = (a₁ + a₂) - a₁ := by abel
+      rw [hsub]; exact B₁.sub_mem hb (h1 ha₁)
+    have : a₂ ∈ B₁ ⊓ B₂ := Submodule.mem_inf.mpr ⟨ha₂B1, h2 ha₂⟩
+    rw [hinf, Submodule.mem_bot] at this
+    rw [this, add_zero]; exact ha₁
+  have hB2 : B₂ ≤ A₂ := by
+    intro b hb
+    have hb_top : b ∈ A₁ ⊔ A₂ := hsup (Submodule.mem_sup_right hb)
+    obtain ⟨a₁, ha₁, a₂, ha₂, rfl⟩ := Submodule.mem_sup.mp hb_top
+    have ha₁B2 : a₁ ∈ B₂ := by
+      have hsub : a₁ = (a₁ + a₂) - a₂ := by abel
+      rw [hsub]; exact B₂.sub_mem hb (h2 ha₂)
+    have : a₁ ∈ B₁ ⊓ B₂ := Submodule.mem_inf.mpr ⟨h1 ha₁, ha₁B2⟩
+    rw [hinf, Submodule.mem_bot] at this
+    rw [this, zero_add]; exact ha₂
+  exact ⟨le_antisymm h1 hB1, le_antisymm h2 hB2⟩
+
+/-- **Forward-leaf subspace reduction (abstract form).** A leaf edge
+oriented *out of* the leaf (`i → 0`, the canonical direction) has an
+injective embedding `e : Vᵢ → V₀` as its map. Invariance gives
+`map e (W i) ≤ W 0` for both halves of a complementary pair, and since the
+two leaf images sup to `range e`, each is pinned to `W 0 ⊓ range e`. Dual
+to `reversed_leaf_subspace_eq`: together they reduce every leaf datum of
+the orientation-generic D̃/star representations to the center subspace. -/
+theorem forward_leaf_subspace_eq
+    {F : Type*} [Field F] {V₀ Vᵢ : Type*}
+    [AddCommGroup V₀] [Module F V₀] [AddCommGroup Vᵢ] [Module F Vᵢ]
+    (e : Vᵢ →ₗ[F] V₀)
+    (Wi₁ Wi₂ : Submodule F Vᵢ) (U₁ U₂ : Submodule F V₀)
+    (hWi : IsCompl Wi₁ Wi₂) (hU : IsCompl U₁ U₂)
+    (h1 : Wi₁.map e ≤ U₁) (h2 : Wi₂.map e ≤ U₂) :
+    Wi₁.map e = U₁ ⊓ LinearMap.range e ∧
+      Wi₂.map e = U₂ ⊓ LinearMap.range e := by
+  have hrange : Wi₁.map e ⊔ Wi₂.map e = LinearMap.range e := by
+    rw [← Submodule.map_sup, hWi.sup_eq_top, Submodule.map_top]
+  have hmr : ∀ W : Submodule F Vᵢ, W.map e ≤ LinearMap.range e :=
+    fun W => le_trans (Submodule.map_mono le_top) (Submodule.map_top e).le
+  have h1' : Wi₁.map e ≤ U₁ ⊓ LinearMap.range e := le_inf h1 (hmr _)
+  have h2' : Wi₂.map e ≤ U₂ ⊓ LinearMap.range e := le_inf h2 (hmr _)
+  refine submodule_pair_eq_of_sup_le_of_inf_bot _ _ _ _ h1' h2' ?_ ?_
+  · rw [hrange]; exact sup_le inf_le_right inf_le_right
+  · have hle : (U₁ ⊓ LinearMap.range e) ⊓ (U₂ ⊓ LinearMap.range e) ≤ U₁ ⊓ U₂ :=
+      le_inf (le_trans inf_le_left inf_le_left) (le_trans inf_le_right inf_le_left)
+    rw [hU.inf_eq_bot] at hle
+    exact le_bot_iff.mp hle
+
 /-! ## Section: Orientation-generic K_{1,4} representation
 
 `starRep_kQ` matches `starRepGen` at the canonical orientation and uses the

--- a/progress/2026-06-14T09-49-41Z_385df84b.md
+++ b/progress/2026-06-14T09-49-41Z_385df84b.md
@@ -1,0 +1,65 @@
+## Accomplished
+
+`/work` (meta) session, branch `agent/385df84b`.
+
+1. **Routed refuted issue #2793 to replan.** Its deliverable
+   (`t125Rep_kQ` single-nilpotent-twist + `t125Rep_kQ_isIndecomposable`)
+   was reverted as *unsound* in #4517 (commit 75dacf74) — the construction
+   is provably decomposable for every m ≥ 1, so the indecomposability
+   theorem would be **false**. Posted a detailed comment pointing at the
+   book's Tits-form/orbit-counting route (Etingof Problem 6.1.5/6.1.2) and
+   flagged siblings (#2976, Ẽ-family) for the same defect.
+
+2. **#2801 (K_{1,4} = D̃₄, the "hard half"): landed the per-leaf algebraic
+   foundation, verified, no sorry.** New lemmas in
+   `Chapter6/FieldGenericStar.lean`:
+   - `sup_top_le_isCompl_forces_eq` — directness from a top-spanning lower
+     pair (companion to `compl_le_forces_eq`, no finrank needed).
+   - `submodule_pair_eq_of_sup_le_of_inf_bot` — general directness primitive
+     (ambient = common sup).
+   - `reversed_leaf_subspace_eq` — reversed leaf (`0→i`, surjective
+     projection): `W i = map p (W 0)`.
+   - `forward_leaf_subspace_eq` — forward leaf (`i→0`, injective embedding):
+     `map e (W i) = W 0 ⊓ range e`.
+
+   Together these pin every leaf datum of an orientation-generic D̃/star
+   representation to the center subspace, regardless of edge direction —
+   the per-leaf content the indecomposability assembly consumes. They are
+   reusable across the whole D̃-family generic program (D̃₅/D̃₇/D̃₈ etc.).
+
+## Current frontier
+
+`star_not_finite_type_per_kQ` (`FieldGenericStar.lean`) remains the only
+sorry in that file. The remaining work — `starRep_kQ_isIndecomposable`
+(four-subspace/nilpotent center-crux assembly) + wiring the stub — is
+tracked by the new sub-issue **#4523**, which carries the full roadmap
+(orientation case-split per leaf via the landed reductions, then the
+nilpotent crux mirroring the canonical `starRepGen_isIndecomposable`
+endgame). #2801 marked `replan` via partial PR with a `Decomposed into
+#4523` breadcrumb.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. Chapter 6 forbidden-subgraph
+infinite-type program: the sound D̃-family per-(F,Q) generic refactor is
+progressing (cycle case complete and sorry-free; K_{1,4} per-leaf
+reductions now landed). The unsound single-nilpotent-twist constructions
+(t125, Ẽ₆v2, Ẽ₇) were reverted in #4517; their genuine theorems retain
+documented sorries awaiting the book's Tits-form existence proof. #2793
+(a t125 rebuild on the refuted approach) routed to replan this session.
+
+## Next step
+
+Claim **#4523** and execute the center-crux assembly using the four landed
+reductions. The all-forward case can invoke `starRepGen_isIndecomposable`
+directly; reversed leaves use `reversed_leaf_subspace_eq`. If the crux is
+large, decompose by number of reversed leaves. A planner should also
+re-scope **#2793** (and audit #2976 / Ẽ-family issues) onto the book's
+Tits-form/orbit-counting proof rather than the reverted explicit
+construction.
+
+## Blockers
+
+None for #4523 (all dependencies landed). #2793 and the Ẽ-family
+infinite-type theorems are blocked on the (much larger) Tits-form
+existence-proof approach, not on any single missing lemma.


### PR DESCRIPTION
This PR lands the verified per-leaf algebraic foundation for the orientation-generic K_{1,4} (D̃₄) indecomposability proof, partial progress on #2801. It adds four reusable lemmas to `Chapter6/FieldGenericStar.lean`: `sup_top_le_isCompl_forces_eq` and `submodule_pair_eq_of_sup_le_of_inf_bot` (submodule-lattice directness primitives), and the two leaf reductions `reversed_leaf_subspace_eq` (reversed leaf, surjective projection: `W i = map p (W 0)`) and `forward_leaf_subspace_eq` (forward leaf, injective embedding: `map e (W i) = W 0 ⊓ range e`). Together they pin every leaf datum of an orientation-generic D̃/star representation to the center subspace regardless of edge direction, and are reusable across the wider D̃-family generic program.

The remaining four-subspace/nilpotent center-crux assembly (`starRep_kQ_isIndecomposable` plus wiring the `star_not_finite_type_per_kQ` stub) is tracked by #4523 with a full roadmap; #2801 is marked `replan` accordingly.

🤖 Prepared with Claude Code