### PR TITLE
chore: commit standard pod harness commands (/replan, /repair, /once)

### DIFF
--- a/.claude/commands/once.md
+++ b/.claude/commands/once.md
@@ -1,0 +1,47 @@
+# One-Shot Priority Dispatch
+
+You are a **one-shot priority agent**. This session was launched via
+`pod once <N>` to work on **one specific issue**, then exit. You are
+**not** part of the regular dispatch pool — you bypass quota and the
+work-type priority order, and you do not pick from
+`coordination list-unclaimed`.
+
+The exact issue number is provided in the structured directive
+appended below this template (look for `ISSUE NUMBER: <N>`). Read it
+before doing anything else; if the directive is missing, exit
+immediately with `ABORT: no issue number provided`.
+
+## Workflow
+
+1. **Read the issue** with `gh issue view <N>`. Identify its type
+   from the labels (`feature`, `plan`, `repair`, `replan`, `review`,
+   etc.). The dispatch already inferred the worker type — it is in
+   the directive as `WORKER TYPE: <type>` — but read the labels too
+   so you can pick up any sub-workflow your worker type's skill
+   prescribes.
+2. **Read the matching worker skill** so you know the standard
+   lifecycle (`agent-worker-flow`, `pr-repair-flow`, etc.).
+3. **Claim the issue explicitly** with
+   `coordination claim <N> --label <type>`. Do **NOT** use
+   `coordination list-unclaimed` — you are not picking from the
+   queue.
+4. **If the claim fails** (issue already claimed by another agent,
+   issue closed, issue not labelled with the worker type, etc.),
+   exit immediately. Print `ABORT: claim failed for #<N>` and do
+   nothing else. No worktree commits, no branches, no PR.
+5. Once the claim succeeds, **execute the issue end-to-end**
+   following the standard worker flow for the matched type
+   (implementation, build, tests, commit, push, open PR).
+6. Run `/reflect` before finishing.
+
+## Hard constraints
+
+- **Single issue only.** Do not pick up other issues after this one,
+  even if you finish quickly. Your dispatch is one-shot.
+- **No queue listing.** Never call `coordination list-unclaimed`,
+  `gh issue list --label …`, or any other "pick the next thing"
+  helper. The issue number is fixed.
+- **Mismatch is fatal.** The launcher monitors `claimed_issue`;
+  claiming anything other than `<N>` terminates the session
+  immediately. Defend against this by being explicit in your
+  `coordination claim` argument.

--- a/.claude/commands/repair.md
+++ b/.claude/commands/repair.md
@@ -1,0 +1,50 @@
+# Repair a Pull Request
+
+You are a **repair** session. Your job is to salvage an unhealthy PR — merge
+conflicts, failed CI, or stuck CI — and get it back to a mergeable state, or
+decide it is unsalvageable and close it cleanly.
+
+**First, read the `pr-repair-flow` skill.** It covers the claim/diagnose/fix/
+verify/push lifecycle in detail, including when to abandon. This command
+only covers what is specific to starting a repair session.
+
+## Pick a PR
+
+```
+coordination list-pr-repair
+```
+
+Output is one PR per line in priority order (`conflict` > `failed` > `stuck`).
+Claim the top one:
+
+```
+coordination claim-pr-repair <pr-number>
+```
+
+If the claim output says the PR is already `repair-claimed` or you lost
+the race, skip it and try the next one. If every candidate is claimed,
+exit — a fresh dispatch will handle the work later.
+
+## Two Outcomes, No Escalation
+
+Repair has exactly two terminal states:
+
+1. **Salvaged** — you got the PR green and pushed:
+   ```
+   coordination mark-pr-salvaged <pr-number>
+   ```
+2. **Unsalvageable** — after bounded attempts, verification still fails, or
+   the branch is too stale to surgery:
+   ```
+   coordination close-pr-unsalvageable <pr-number> "<reason>"
+   ```
+   This closes the PR, removes `has-pr` from the linked issue, and adds
+   `replan` so the planner will produce a fresh approach.
+
+**Do not escalate by inventing a `directive`.** The `directive` label
+flows top-down from the project owner; agents do not author directives.
+The fix-or-abandon rule is non-negotiable: complex conflicts become
+re-implementations via `replan`, not human tickets.
+
+See the `pr-repair-flow` skill for retry budget, verification rules, and
+examples.

--- a/.claude/commands/replan.md
+++ b/.claude/commands/replan.md
@@ -1,0 +1,77 @@
+# Triage `replan` Issues
+
+You are a **replan** session. Your job is to triage issues labelled
+`replan` — those left behind by PRs closed unsalvageable
+(`coordination close-pr-unsalvageable`), worker skips
+(`coordination skip --replan`), or partial-completion publishes
+(`coordination create-pr --partial`). You do NOT execute any code
+changes and you do NOT create fresh planning work. That is `/plan`'s job.
+
+Replan sits between `repair` and `plan` in dispatch priority and shares
+the planner lock with `/plan`. The lock is managed by `pod` — do NOT
+call `coordination lock-planner` or `coordination unlock-planner`
+yourself.
+
+## Step 1: Orient
+
+1. `git fetch origin master`
+2. Read the last 5 files in `progress/` (sorted by filename) to
+   understand recent work.
+
+## Step 2: Pick up replan candidates
+
+```
+coordination list-replan
+```
+
+Output is one issue per line: `#<number> <title>`. The list goes
+through the same trusted-author gate as `list-unclaimed`. Issues with
+`claimed`, `blocked`, or `has-pr` are filtered out. `directive` issues
+never appear here: the skip / partial-PR / unsalvageable-close paths
+deliberately do not apply the `replan` label to a directive (that
+label would strand it — invisible to both this list and
+`list-unclaimed`). A stalled directive instead stays claimable via
+`list-unclaimed` so a fresh worker picks it up again; its satisfaction
+is judgment-laden and is decided by the worker who completes the
+deliverables, not by replan triage.
+
+If the list is empty, exit cleanly — pod will release the planner lock.
+
+## Step 3: Triage each candidate
+
+For each issue, read the body and any closing comment (from a closed
+PR) to understand why it was abandoned, then apply **exactly one** of
+the following:
+
+- **Work already done** (a subsequent PR merged it):
+  close with a forward link.
+- **Plan stale / approach changed**: create a corrected replacement
+  issue via `coordination plan`, close the original linking forward.
+- **Partial progress**: create an issue for the remaining deliverables,
+  close the original linking forward.
+- **Worker-decomposed**: the worker created sub-issues before releasing
+  the claim. Detect via a comment that starts with `Decomposed into #`
+  and lists the sub-issue numbers. Read the sub-issues and decide:
+  - sub-issues fully cover the parent → close the parent with a
+    forward link (do **not** re-create the sub-issues);
+  - residual scope remains → narrow the body to that residual and
+    remove the `replan` label so workers can claim it again.
+  In the partial-PR variant the parent will also have a merged or open
+  PR reference; treat it the same way and rely on the merged PR to
+  record the partial work.
+- **Still valid, body still accurate**: remove the `replan` label
+  (`gh issue edit N --remove-label replan`) to re-open for workers.
+- **Still valid, body stale**: update the issue body with current
+  state, then remove the `replan` label.
+
+Process **every** candidate from `list-replan` before exiting.
+
+## Step 4: Exit
+
+This session produces no PR — it edits issues directly. After every
+candidate has been disposed of, exit. The harness will release the
+planner lock.
+
+Do **not** create new `agent-plan` issues beyond residual sub-issues
+required to record narrowed scope. Fresh planning is the next
+planner's job, not yours.

--- a/.claude/skills/pr-repair-flow/SKILL.md
+++ b/.claude/skills/pr-repair-flow/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: pr-repair-flow
+description: Standard PR-repair workflow for pod `repair` agent sessions. Covers claim/diagnose/fix/verify/push lifecycle and the fix-or-abandon principle.
+allowed-tools: Bash, Read, Glob, Grep, Edit, Write
+---
+
+# PR Repair Flow for Pod Repair Agents
+
+This skill covers the workflow used by `/repair` sessions. Repair agents
+work on PRs, not on feature issues. Their job is to salvage unhealthy PRs
+(merge conflicts, failed CI, stuck CI) or close them cleanly when salvage
+is not worth doing.
+
+## Core Principle: Fix or Abandon
+
+Repair sessions have exactly two terminal outcomes:
+
+1. **Salvaged** — you pushed a green PR and called `coordination mark-pr-salvaged`.
+2. **Abandoned** — you called `coordination close-pr-unsalvageable` after a
+   bounded number of failed attempts. This removes `has-pr` from the linked
+   issue and adds `replan`, so a fresh plan can be produced.
+
+**Repair sessions do not author `directive` issues.** The `directive`
+label flows top-down from the project owner; it is not a place agents
+escalate to. Complex conflicts become re-implementations via `replan`,
+not human tickets. If verification keeps failing, abandon.
+
+## Coordination Commands
+
+| Command | Purpose |
+|---|---|
+| `coordination list-pr-repair` | Read-only list of PRs needing repair, priority-ordered (`conflict` > `failed` > `stuck`). No label writes. |
+| `coordination claim-pr-repair N` | Adds `repair-claimed` label + comment, races detected via a short re-read. Fails if already claimed or another session won the race. |
+| `coordination mark-pr-salvaged N` | Clears `repair-claimed`, comments salvage summary. Call after a successful push. |
+| `coordination close-pr-unsalvageable N "reason"` | Closes PR, adds `unsalvageable`, removes `has-pr` on linked issue, adds `replan`. |
+
+PR repair claims live in a namespace distinct from issue claims. Pod's
+housekeeping loop runs `check_dead_pr_claimed_prs` every 10 minutes to
+release claims whose owning session has died.
+
+## Step 1: Claim a PR
+
+```
+coordination list-pr-repair
+```
+
+Pick the top line (priority order is conflict > failed > stuck). Parse the
+PR number out of `#<num> [<reason>] <title>` and claim it:
+
+```
+coordination claim-pr-repair <pr-number>
+```
+
+If the claim output says the PR is already `repair-claimed` or you lost
+the race, move to the next candidate. If all candidates are claimed,
+exit — another dispatch will handle the work later.
+
+## Step 2: Check Out the PR Branch
+
+```bash
+gh pr checkout <pr-number>
+```
+
+Do **not** create a new branch. You are working on the existing PR's head
+branch. The PR will be updated by force-push when you're done.
+
+## Step 3: Diagnose
+
+Look at one thing at a time, in this order:
+
+1. `gh pr view <N> --json mergeable,statusCheckRollup,headRefName,baseRefName`
+2. If `mergeable == "CONFLICTING"`: `git fetch origin && git merge origin/<base>`
+   (or rebase) to surface the conflicting files.
+3. If any check conclusion is `FAILURE`: `gh pr checks <N>` then read the
+   failing job's log via `gh run view --log-failed`.
+4. If "stuck": the CI suite has been running past the configured threshold.
+   Usually this means a worker is hung or a runner was lost. Re-running
+   from a fresh commit (`git commit --allow-empty -m "kick CI"`) is a
+   reasonable first fix.
+
+## Step 4: Apply the Minimal Fix
+
+- **Merge conflicts**: resolve and commit. Prefer the cleaner of `merge` or
+  `rebase` — both produce the same end state but `merge` preserves the
+  original commits and is less fiddly if history is messy.
+- **Failing CI**: make the smallest change that makes the test pass. Do
+  **not** expand scope to refactoring or unrelated cleanup — that belongs
+  in separate issues.
+- **Stuck CI**: empty commit to trigger a re-run is usually enough. If it
+  sticks again, that's a signal to abandon.
+
+## Step 5: Verify
+
+Run the project's own verification — the same build/test flow a `/feature`
+session would run before opening a PR. See the project's top-level
+`CLAUDE.md` for the exact commands.
+
+**Verification is the arbiter.** Do not push until it passes locally.
+
+## Step 6: Push or Abandon
+
+**If verification passes:**
+```bash
+git push --force-with-lease
+coordination mark-pr-salvaged <pr-number>
+```
+Auto-merge (already set by `coordination create-pr`) will squash-merge the
+PR once the remote CI reports green. Exit the session.
+
+**If verification fails after at most 3 fix → verify cycles:**
+```
+coordination close-pr-unsalvageable <pr-number> "<reason>"
+```
+Valid reasons to abandon:
+- verification keeps failing despite targeted fixes
+- the branch is so stale that redoing the work is cheaper than conflict surgery
+- the implementation direction is wrong or has been superseded by other merged work
+- CI repair would require effectively reimplementing the feature from scratch
+
+Be specific in the reason — it goes on the closing comment and on the
+linked issue, and a future planner will read it when producing a replan.
+
+## Step 7: Exit
+
+Don't poll CI. Don't wait for auto-merge. The session ends once you've
+either marked salvaged or closed unsalvageable.
+
+## Labels You'll See
+
+- `repair-claimed` — set by `claim-pr-repair`, cleared by `mark-pr-salvaged`
+  / `close-pr-unsalvageable`, or by the housekeeping reconciler if the
+  claiming session dies.
+- `unsalvageable` — set by `close-pr-unsalvageable` on the PR for
+  observability. Not functional.
+
+There is intentionally no `needs-repair` label. Repair candidates are
+computed on demand by `list-pr-repair`; a label would drift out of sync.
+
+## What You Will Not Do
+
+- Open new issues (except as part of a `replan` comment if genuinely
+  helpful context).
+- Author a `directive` to escalate (directives are owner-issued only).
+- Keep trying the same fix with minor variations past the 3-cycle budget.
+- Fight healthy in-progress CI (the stuck threshold already filters for
+  checks past the configured age).
+- Modify the project's top-level `.claude/CLAUDE.md` or roadmap files.


### PR DESCRIPTION
This PR commits the standard pod `/replan`, `/repair`, and `/once` commands plus the `pr-repair-flow` skill, which existed locally but were never committed — so worker agents (running off `main`) could not find them and the dispatcher never ran `/replan` or `/repair`. The effect was a starving queue (20+ issues stuck in `replan` with no triage path to claimable work) and broken PRs that never got repaired. The files are byte-identical to the current pod template. Paired with registering the `replan` and `repair` worker types in the local `.pod/config.toml` and migrating the deprecated `[claude]` config section to `[agent.claude]`.

🤖 Prepared with Claude Code