### PR TITLE
doc(Ch6 #4523): refute starRep_kQ_isIndecomposable for reversed-leaf orientations

### DIFF
--- a/progress/2026-06-14T11-05-57Z_2b0a4f09.md
+++ b/progress/2026-06-14T11-05-57Z_2b0a4f09.md
@@ -1,0 +1,72 @@
+## Accomplished
+
+Session type: feature (claimed #4523 — `starRep_kQ_isIndecomposable`,
+orientation-generic D̃₄ center crux).
+
+**Found a definition/construction bug and escalated.** While scoping the
+proof I discovered `starRep_kQ_isIndecomposable` is **false as stated**: the
+orientation-generic K_{1,4} (D̃₄) representation decomposes whenever the
+diagonal leaf (leaf 3) is reversed, for every `m ≥ 1`.
+
+- Built an explicit complementary invariant pair (m = 1, orientation
+  `1→0, 2→0, 0→3, 4→0`), verified against the exact map definitions in
+  `FieldGenericStar.lean` (`starEmbed{1,2}_F`, `starEmbedNilp_F`,
+  `starProj3_F = starSecond_F`, `nilpotentShiftLinGen`). Both halves are
+  invariant at all four arrows, complementary at every vertex, nonzero and
+  proper. (Cross-checked that the canonical all-forward orientation does NOT
+  decompose by the same method — consistent with the proven sorry-free
+  `starRepGen_isIndecomposable`.)
+- Root cause (structural): each forward leaf forces `L_i = range(embed_i)` to
+  split under the center pair; each reversed leaf forces `ker(proj_i)` to
+  split, and each kernel is *another* `L_j`. The endgame needs all four
+  `L₁,L₂,L₃,L₄` to split, but reversing the diagonal leaf removes the only
+  constraint on `L₃ = Δ`, leaving an under-coupled center → decomposable.
+- This is the **same class of bug** the team already refuted and redesigned
+  for the sporadic cases (#4548, `sporadic-tube-redesign-design.md`,
+  `indecomposability-framework-investigation.md`) — single nilpotent twist
+  with insufficient coupling. The novelty: it also hits the **D̃ family**,
+  which is still being actively worked as if provable.
+
+Actions:
+- Created #4566 (detailed bug report with the explicit counterexample, root
+  cause, affected-issue list, and redesign recommendation).
+- Cross-referenced on the redesign parent #4548.
+- `coordination skip 4523` (marked replan) — cannot fill a sorry that has no
+  proof.
+
+No code changes; no PR. Baseline build of `FieldGenericStar` confirmed clean
+before/after (no edits).
+
+## Current frontier
+
+The orientation-generic D̃ indecomposability lemmas are refuted for reversed
+orientations and need the homogeneous-tube redesign (mirror #4548). Affected
+and likely-affected issues (for planner re-triage): #4523, #4527, #4529,
+#4531, #4535, #4546, #2851, #2853, #4543, #4551, #4533, #4534, #4528.
+
+## Overall project progress
+
+Stage 3 (formalization), Chapter 6 affine-Dynkin infinite-type strand. Only
+the cycle (Ã, all-identity-map) orientation-generic indecomposability is
+sorry-free; every D̃/Ẽ orientation-generic `_kQ_isIndecomposable` is stuck
+(6–13 sorries each) — now explained: the underlying explicit constructions
+are decomposable in (at least) reversed orientations. The sporadic redesign
+(#4548) is underway; the D̃ family now needs the same.
+
+## Next step
+
+A **planner** should triage #4566: decide whether to extend the #4548
+homogeneous-tube redesign to the D̃ family (preferred — gives correct
+constructions) or switch the per-(F,Q) infinite-type proofs to the book's
+Tits-form orbit-counting argument. Either way, the current D̃
+orientation-generic indecomposability issues should be closed/redesigned
+rather than worked further, and `d5/d6/d7/d8/dTilde Rep_kQ` audited for the
+same reversed-edge coupling loss. The `*_not_finite_type_per_kQ` theorems
+remain true (D̃ is affine = infinite type); only the explicit-rep
+indecomposability lemmas are false.
+
+## Blockers
+
+#4523 is mathematically false; no proof exists for the current definition.
+Resolution is a redesign decision for a planner/owner (tracked in #4566), not
+a worker task.


### PR DESCRIPTION
This PR records the finding that `starRep_kQ_isIndecomposable` (issue #4523) is false: the orientation-generic D̃₄ representation `starRep_kQ` decomposes whenever the diagonal leaf is reversed, for every `m ≥ 1`. It adds a progress note with the explicit `m = 1` complementary invariant pair and the root-cause analysis; the full bug report, affected-issue list, and redesign recommendation live in #4566. This is the same single-twist/under-coupling class the team already redesigned away for the sporadic cases (#4548); the D̃ family needs the same homogeneous-tube redesign. The canonical all-sink orientation of D̃₄ (`starRepGen_isIndecomposable`) is unaffected and remains sorry-free; the downstream `star_not_finite_type_per_kQ` remains true. No Lean changes — documentation only.

🤖 Prepared with Claude Code