### PR TITLE
feat(Ch6 #4551): γ-equiv packaging + two-sided (I-N)⁻¹ inverse (consumer half → #4578)

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/FieldGenericD5Tilde.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericD5Tilde.lean
@@ -347,6 +347,112 @@ theorem gammaInv_embed1_plus_embedNshift_F (F : Type) [Field F] (m : ℕ)
     LinearMap.sub_apply]
   rw [hP1, hP2, cumTailSumLin_oneSubNilp, sub_self, map_zero, zero_add]
 
+/-! ## Section 5d′: γ-equivalence packaging
+
+`d5tildeGamma_F` is a genuine linear isomorphism with closed-form inverse
+`d5tildeGammaInv_F`. The two compositions reduce, via the embed-decomposition
+(`center_decomp_F`) and the `γ` / `γ⁻¹` block identities, to the two-sided
+inversion facts `cumTailSumLin_oneSubNilp` (`M (I - N) = I`, for the
+left-inverse direction) and `oneSubNilp_cumTailSumLin` (`(I - N) M = I`, for
+the right-inverse direction).
+
+`d5tildeGammaEquiv_F` packages this as a `LinearEquiv` whose `.symm` *is*
+`d5tildeGammaInv_F` (definitionally, via `LinearEquiv.ofLinear`). This is the
+γ-equiv the shared untwisting lemma `linearEquiv_invariant_isCompl_symm_mem`
+(`FieldGenericStar.lean`) consumes to close the mixed-direction branch-vertex
+cases in the D̃-family leaf-equality proofs (d5 #2850, d6 #4551, d7 #4533,
+d8). It is shared by all four families, which reuse `d5tildeGamma_F` /
+`d5tildeGammaInv_F` for their `{2, 3}` γ edge. -/
+
+/-- General closed form of `d5tildeGammaInv_F` on an embed-decomposed input:
+`γ⁻¹(e₁ a + e₂ b) = e₁ (a - M (a - b)) + e₂ (M (a - b))`, `M = cumTailSumLin`.
+Subsumes `gammaInv_embed1_plus_embed2_F` (`b = a`) and
+`gammaInv_embed1_plus_embedNshift_F` (`b = N a`). -/
+theorem gammaInv_embed_general_F (F : Type) [Field F] (m : ℕ)
+    (a b : Fin (m + 1) → F) :
+    d5tildeGammaInv_F F m (starEmbed1_F F m a + starEmbed2_F F m b) =
+      starEmbed1_F F m (a - cumTailSumLin F m (a - b)) +
+        starEmbed2_F F m (cumTailSumLin F m (a - b)) := by
+  have hP1 : starFirst_F F m (starEmbed1_F F m a + starEmbed2_F F m b) = a := by
+    rw [map_add, starFirst_F_starEmbed1_F, starFirst_F_starEmbed2_F, add_zero]
+  have hP2 : starSecond_F F m (starEmbed1_F F m a + starEmbed2_F F m b) = b := by
+    rw [map_add, starSecond_F_starEmbed1_F, starSecond_F_starEmbed2_F, zero_add]
+  simp only [d5tildeGammaInv_F, LinearMap.add_apply, LinearMap.comp_apply,
+    LinearMap.sub_apply]
+  rw [hP1, hP2]
+
+/-- Right inverse: `γ (γ⁻¹ w) = w`. Needs `(I - N) M = I`
+(`oneSubNilp_cumTailSumLin`). -/
+theorem d5tildeGamma_gammaInv_F (F : Type) [Field F] (m : ℕ)
+    (w : Fin (2 * (m + 1)) → F) :
+    d5tildeGamma_F F m (d5tildeGammaInv_F F m w) = w := by
+  set a := starFirst_F F m w with ha
+  set b := starSecond_F F m w with hb
+  have hw : w = starEmbed1_F F m a + starEmbed2_F F m b := by
+    rw [ha, hb]; exact center_decomp_F F m w
+  rw [hw, gammaInv_embed_general_F, map_add, gamma_from_embed1_F,
+    gamma_from_embed2_F]
+  set q := cumTailSumLin F m (a - b) with hq
+  -- goal: (e₁ (a - q) + e₂ (a - q)) + (e₁ q + e₂ (N q)) = e₁ a + e₂ b
+  have hpq : (a - q) + q = a := by abel
+  have hpNq : (a - q) + nilpotentShiftLinGen F m q = b := by
+    have h : q - nilpotentShiftLinGen F m q = a - b := by
+      rw [hq]; exact oneSubNilp_cumTailSumLin F m (a - b)
+    have hrw : (a - q) + nilpotentShiftLinGen F m q
+        = a - (q - nilpotentShiftLinGen F m q) := by abel
+    rw [hrw, h]; abel
+  rw [show (starEmbed1_F F m (a - q) + starEmbed2_F F m (a - q)) +
+        (starEmbed1_F F m q + starEmbed2_F F m (nilpotentShiftLinGen F m q))
+        = starEmbed1_F F m ((a - q) + q) +
+            starEmbed2_F F m ((a - q) + nilpotentShiftLinGen F m q) from by
+      rw [map_add, map_add]; abel]
+  rw [hpq, hpNq]
+
+/-- Left inverse: `γ⁻¹ (γ w) = w`. Needs `M (I - N) = I`
+(`cumTailSumLin_oneSubNilp`). -/
+theorem d5tildeGammaInv_gamma_F (F : Type) [Field F] (m : ℕ)
+    (w : Fin (2 * (m + 1)) → F) :
+    d5tildeGammaInv_F F m (d5tildeGamma_F F m w) = w := by
+  set u := starFirst_F F m w with hu
+  set v := starSecond_F F m w with hv
+  have hw : w = starEmbed1_F F m u + starEmbed2_F F m v := by
+    rw [hu, hv]; exact center_decomp_F F m w
+  rw [hw, map_add, gamma_from_embed1_F, gamma_from_embed2_F]
+  -- now γ⁻¹ applied to (e₁ u + e₂ u) + (e₁ v + e₂ (N v))
+  rw [show (starEmbed1_F F m u + starEmbed2_F F m u) +
+        (starEmbed1_F F m v + starEmbed2_F F m (nilpotentShiftLinGen F m v))
+        = starEmbed1_F F m (u + v) +
+            starEmbed2_F F m (u + nilpotentShiftLinGen F m v) from by
+      rw [map_add, map_add]; abel]
+  rw [gammaInv_embed_general_F]
+  have hAB : (u + v) - (u + nilpotentShiftLinGen F m v)
+      = v - nilpotentShiftLinGen F m v := by abel
+  rw [hAB, cumTailSumLin_oneSubNilp, show (u + v) - v = u from by abel]
+
+attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
+  CategoryTheory.ReflQuiver.toQuiver in
+/-- `d5tildeGamma_F` packaged as a linear isomorphism, with `.symm` equal to
+the closed-form inverse `d5tildeGammaInv_F` (definitionally). Consumed by the
+shared untwisting lemma `linearEquiv_invariant_isCompl_symm_mem` in the
+mixed-direction D̃-family leaf-equality branches. -/
+noncomputable def d5tildeGammaEquiv_F (F : Type) [Field F] (m : ℕ) :
+    (Fin (2 * (m + 1)) → F) ≃ₗ[F] (Fin (2 * (m + 1)) → F) :=
+  LinearEquiv.ofLinear (d5tildeGamma_F F m) (d5tildeGammaInv_F F m)
+    (LinearMap.ext fun w => by
+      simp only [LinearMap.comp_apply, LinearMap.id_apply]
+      exact d5tildeGamma_gammaInv_F F m w)
+    (LinearMap.ext fun w => by
+      simp only [LinearMap.comp_apply, LinearMap.id_apply]
+      exact d5tildeGammaInv_gamma_F F m w)
+
+@[simp] theorem d5tildeGammaEquiv_F_apply (F : Type) [Field F] (m : ℕ)
+    (w : Fin (2 * (m + 1)) → F) :
+    d5tildeGammaEquiv_F F m w = d5tildeGamma_F F m w := rfl
+
+@[simp] theorem d5tildeGammaEquiv_F_symm_apply (F : Type) [Field F] (m : ℕ)
+    (w : Fin (2 * (m + 1)) → F) :
+    (d5tildeGammaEquiv_F F m).symm w = d5tildeGammaInv_F F m w := rfl
+
 /-! ## Section 5e: Leaf subspace equalities
 
 The leaf-equality theorem `d5tildeRep_kQ_leaf_equalities` derives the four

--- a/EtingofRepresentationTheory/Chapter6/FieldGenericStar.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericStar.lean
@@ -1087,6 +1087,49 @@ theorem cumTailSumLin_oneSubNilp (F : Type) [Field F] (m : ℕ)
     simp only [dif_pos hi1]
     ring
 
+/-- The other-sided inverse identity: `(I - N) ∘ M = I`, i.e.
+`cumTailSumLin v - N (cumTailSumLin v) = v`. Together with
+`cumTailSumLin_oneSubNilp` (`M ∘ (I - N) = I`) this exhibits
+`cumTailSumLin = M` as the genuine **two-sided** inverse of
+`I - nilpotentShiftLinGen`, which is what packaging `d5tildeGamma_F` as a
+`LinearEquiv` requires (the `γ ∘ γ⁻¹ = id` direction needs `(I - N) M = I`,
+not just `M (I - N) = I`).
+
+Unlike `cumTailSumLin_oneSubNilp` this needs no reverse induction: at index
+`i < m` the recursion `M v ⟨i⟩ = v ⟨i⟩ + M v ⟨i+1⟩` (`cumTailSumLin_apply_succ`)
+cancels the shifted term `N (M v) ⟨i⟩ = M v ⟨i+1⟩` directly, and at index `m`
+the shift vanishes while `M v ⟨m⟩ = v ⟨m⟩` (`cumTailSumLin_apply_last`). -/
+theorem oneSubNilp_cumTailSumLin (F : Type) [Field F] (m : ℕ)
+    (v : Fin (m + 1) → F) :
+    cumTailSumLin F m v - nilpotentShiftLinGen F m (cumTailSumLin F m v) = v := by
+  -- Closed form for `nilpotentShiftLinGen` applied to `cumTailSumLin F m v`.
+  have hN : ∀ j : Fin (m + 1),
+      nilpotentShiftLinGen F m (cumTailSumLin F m v) j =
+      if h : j.val + 1 < m + 1 then cumTailSumLin F m v ⟨j.val + 1, h⟩ else 0 := by
+    intro j
+    simp only [nilpotentShiftLinGen, Matrix.mulVecLin_apply, Matrix.mulVec, dotProduct,
+      nilpotentShiftMatrixGen]
+    split_ifs with h
+    · rw [Finset.sum_eq_single ⟨j.val + 1, h⟩]
+      · simp
+      · intro b _ hb; simp only [ite_mul, one_mul, zero_mul]; rw [if_neg]
+        intro hbi; exact hb (Fin.ext (by omega))
+      · intro habs; exact absurd (Finset.mem_univ _) habs
+    · apply Finset.sum_eq_zero; intro c _
+      simp only [ite_mul, one_mul, zero_mul]; rw [if_neg]
+      intro hji; exact h (by have := c.isLt; omega)
+  ext ⟨i, hi⟩
+  rw [Pi.sub_apply, hN]
+  by_cases h : i + 1 < m + 1
+  · simp only [dif_pos h]
+    rw [cumTailSumLin_apply_succ _ _ _ _ h]
+    ring
+  · have hi_eq_m : i = m := by omega
+    subst hi_eq_m
+    simp only [show ¬(i + 1 < i + 1) by omega, dite_false, sub_zero]
+    have hidx : (⟨i, hi⟩ : Fin (i + 1)) = ⟨i, lt_add_one i⟩ := rfl
+    rw [hidx, cumTailSumLin_apply_last]
+
 /-! ## Shared γ-preimage untwisting lemma
 
 The mixed-direction branch-vertex configuration in the D̃-family

--- a/progress/2026-06-14T11-20-19Z_1fec12c0.md
+++ b/progress/2026-06-14T11-20-19Z_1fec12c0.md
@@ -1,0 +1,64 @@
+## Accomplished
+
+Issue #4551 (D̃₆ mixed-direction leaf_equalities + N-invariance
+infrastructure), feature session — **partial**: delivered the foundational
+infrastructure (Deliverable 1, reframed), deferred the consumer branches
+(Deliverables 2-3) to successor #4578.
+
+The issue's Deliverable 1 asked for "N-invariance infrastructure", but #4554
+already established (and its progress note documented) that the literal
+per-leaf N-invariance spec is **circular**; the correct, non-circular tool is
+the abstract untwisting lemma `linearEquiv_invariant_isCompl_symm_mem` (landed
+in #4554) plus a **γ-equiv** to feed it. This session built that γ-equiv:
+
+- `oneSubNilp_cumTailSumLin` (`FieldGenericStar.lean`): the `(I - N) M = I`
+  direction, complementing the existing `cumTailSumLin_oneSubNilp`
+  (`M (I - N) = I`). Together these exhibit `cumTailSumLin` as the genuine
+  **two-sided** inverse of `I - nilpotentShiftLinGen` — required because the
+  `γ ∘ γ⁻¹ = id` direction needs `(I - N) M = I`, not just `M (I - N) = I`.
+  Proof is a direct termwise telescoping (no reverse induction needed).
+- `gammaInv_embed_general_F` (`FieldGenericD5Tilde.lean`): general closed form
+  `γ⁻¹(e₁ a + e₂ b) = e₁(a - M(a-b)) + e₂(M(a-b))`, subsuming the two prior
+  pattern-specific gammaInv identities.
+- `d5tildeGamma_gammaInv_F` / `d5tildeGammaInv_gamma_F`: both composition
+  identities, via embed-decomposition + the two inversion facts.
+- `d5tildeGammaEquiv_F`: `d5tildeGamma_F` as a `LinearEquiv` whose `.symm` is
+  **definitionally** `d5tildeGammaInv_F` (built with `LinearEquiv.ofLinear`),
+  plus `@[simp]` apply/symm_apply lemmas. Shared by d5/d6/d7/d8 (all reuse the
+  same γ for their `{2,3}` edge).
+
+Builds verified: `FieldGenericStar`, `FieldGenericD5Tilde`, `FieldGenericD6Tilde`
+all compile. No new sorries; the 5 pre-existing `d6tildeRep_kQ_leaf_equalities`
+sorries are unchanged (they are the consumer work in #4578).
+
+## Current frontier
+
+The γ-equiv and the abstract untwisting lemma are both in place. The
+mixed-direction D̃₆ branches (combo C/C′ + the three outer reversed branches)
+can now be closed by instantiating `linearEquiv_invariant_isCompl_symm_mem`
+with `g = d5tildeGammaEquiv_F`, `A_i = W_i⟨2⟩`, `B_i = W_i⟨3⟩`, using the
+`hMain_23`/`hOther_23` pushes as the carry hypotheses. No worked precedent
+exists yet (the analogous d5 combo C is also unsolved), so this is a fresh
+construction — scoped into #4578.
+
+## Overall project progress
+
+Chapter 6 D̃-family orientation-generic indecomposability program ongoing.
+This session removes the last shared infrastructure blocker for the
+mixed-direction leaf-equality branches across the whole D̃ family: the γ-equiv
+packaging that #4554's untwisting lemma needs as input now exists and is
+reusable by d5/d6/d7/d8.
+
+## Next step
+
+Pick up #4578: close D̃₆ combo C with the new infrastructure as the
+proof-of-concept (consider proving it in d5 first as a smaller proving
+ground), then C′ and the three outer reversed branches. Once
+`d6tildeRep_kQ_leaf_equalities` is sorry-free, #4543 (D̃₆ final assembly) is
+unblocked.
+
+## Blockers
+
+None for the delivered infrastructure. #4578 (the consumer half) is genuinely
+multi-session but no longer gated on missing math infrastructure — only on the
+assembly work.


### PR DESCRIPTION
Partial progress on #4551

Session: `1fec12c0-72b4-4997-9dea-631414d3d0a5`

359d7d20 doc(Ch6 #4551): progress — γ-equiv infrastructure landed, consumer → #4578
63801d8d feat(Ch6 #4551): γ-equiv packaging + two-sided (I-N)⁻¹ inverse

🤖 Prepared with Claude Code