### PR TITLE
doc(Ch5 R2.b): refute R2.b.i (#2769) with a (2,2) counterexample

### DIFF
--- a/progress/20260614T113454Z_646f769f.md
+++ b/progress/20260614T113454Z_646f769f.md
@@ -1,0 +1,48 @@
+## Accomplished
+
+Feature session `646f769f`, claimed issue #2769 (Ch5 Wall 3 R2.b.i,
+`twistedPolytabloid_residual_no_colStd_zero`). Applied counterexample-first
+verification **before** investing in the proof and **refuted the statement**.
+
+- Derived a clean closed form for the residual coefficient:
+  `Δ(α) = Σ_{q∈Q} sign(q)·[w q⁻¹ σ ≡ α] − Σ_{q∈R} Σ_{s∈Q} sign(q)sign(s)·[s w q⁻¹ σ ≡ α]`
+  where `R = perQ_low ∪ perQ_eq` (using `twistedIHPart_eq_signed_polytabloid_sum`).
+- Brute-forced the meditate's own canonical example (λ=(2,2), σ=swap(0,1),
+  w=(0 2 1)) in `progress/r2bi-counterexample-check.py`. The script replicates
+  the exact Lean conventions and **reproduces the meditate ground truth exactly**
+  (regions match §2.4: `Q_low={1,q₃}`, `Q_eq={q₁}`, `Q_eqHi={q₂}`, `Q_high=∅`;
+  `Δ = −ψ_{(0 1 3 2)}`).
+- Result: `Δ = −ψ_{(0 1 3 2)}` with `(0 1 3 2)` **column-standard**. Such a
+  polytabloid carries `±1` at every column-class of its tableau (the map
+  `q ↦ [q⁻¹τ]` is injective on `Q_λ`), including non-column-standardizable ones.
+  `Δ` is **nonzero** at three no-col-std tabloids strictly below `[σ]`:
+  `(0,1,1,0)→+1`, `(1,0,0,1)→+1`, `(1,0,1,0)→−1`. The claimed lemma is false.
+- Filed meditate issue #4584 with the full refutation and three candidate
+  redesign directions for proving `Δ ∈ V` (R2.b) without pointwise vanishing.
+- Skipped #2769 (→ replan) referencing #4584.
+
+## Current frontier
+
+Wall 3 R2.b decomposition is unsound: the R2.b.i (#2769) / R2.b.ii (#2770)
+split rests on a false pointwise-cancellation premise (`q-high-involution.md`
+§4.2 step 4). The end goal `Δ ∈ V` (hence `garnir_twisted_in_lower_span`) is
+still TRUE — verified `Δ = −ψ_τ ∈ V` on the example — but needs a different
+proof route. Meditate #4584 owns the redesign.
+
+## Overall project progress
+
+Etingof draft 1, Stage 3. Ch5 Wall 3 Garnir straightening: R1 (#2669), R2.a
+(#2700) merged; R2.b now reopened for redesign via #4584; R2.c (#2703) still
+blocked downstream. No Lean changes this turn (statement refuted, not proven).
+
+## Next step
+
+A meditate session claims #4584, produces the corrected `Δ ∈ V` design note
+(candidate 1 "direct polytabloid identification" looks most promising: on the
+example `Δ` is literally `−ψ_τ` for a single col-std `τ` at smaller srRank), and
+re-scopes #2770. A planner then closes/narrows #2769 and #2770 accordingly.
+
+## Blockers
+
+#2769 and its consumer #2770 are blocked on the R2.b redesign (meditate #4584).
+The underlying mathematics (`Δ ∈ V`) is sound; only the decomposition was wrong.

--- a/progress/r2bi-counterexample-check.py
+++ b/progress/r2bi-counterexample-check.py
@@ -1,0 +1,100 @@
+from itertools import permutations
+
+rowOf=[0,0,1,1]; colOf=[0,1,0,1]; n=4
+def mul(a,b): return tuple(a[b[k]] for k in range(n))   # (a*b)(k)=a(b(k))
+def inv(a):
+    r=[0]*n
+    for k in range(n): r[a[k]]=k
+    return tuple(r)
+def sign(a):
+    s=1
+    for i in range(n):
+        for j in range(i+1,n):
+            if a[i]>a[j]: s=-s
+    return s
+def tab(a): return tuple(rowOf[a[k]] for k in range(n))   # entry k -> row
+def isColStd(a):
+    ai=inv(a)
+    for p1 in range(n):
+        for p2 in range(n):
+            if colOf[p1]==colOf[p2] and rowOf[p1]<rowOf[p2]:
+                if not ai[p1]<ai[p2]: return False
+    return True
+allp=list(permutations(range(n)))
+Q=[p for p in allp if all(colOf[p[k]]==colOf[k] for k in range(n))]
+Rsub=[p for p in allp if all(rowOf[p[k]]==rowOf[k] for k in range(n))]
+def cumul(a,k,i): return sum(1 for e in range(n) if e<=k and rowOf[a[e]]<i)
+def dominates(a,b): return all(cumul(b,k,i)<=cumul(a,k,i) for k in range(n) for i in range(n+1))
+def strictDom(a,b): return dominates(a,b) and tab(a)!=tab(b)
+def rowInv(a):
+    ai=inv(a); c=0
+    for p1 in range(n):
+        for p2 in range(n):
+            if rowOf[p1]==rowOf[p2] and colOf[p1]<colOf[p2] and ai[p2]<ai[p1]: c+=1
+    return c
+# tabloid with no col-std rep:
+tabs_with_colstd=set(tab(a) for a in allp if isColStd(a))
+all_tabs=set(tab(a) for a in allp)
+no_colstd=all_tabs-tabs_with_colstd
+
+sigma=(1,0,2,3)  # swap(0,1)
+w=(2,0,1,3)      # (0 2 1): w(0)=2,w(1)=0,w(2)=1,w(3)=3
+assert isColStd(sigma)
+
+def gamma(q):
+    base=mul(w,mul(inv(q),sigma))     # w q^{-1} sigma
+    cands=[g for g in Q if isColStd(mul(g,base))]
+    assert len(cands)==1, (q,len(cands))
+    return cands[0]
+def tau(q): return mul(gamma(q),mul(w,mul(inv(q),sigma)))
+
+# regions
+def inR(q):
+    t=tau(q)
+    if strictDom(sigma,t): return True
+    if tab(t)==tab(sigma) and rowInv(t)<rowInv(sigma): return True
+    return False
+R=[q for q in Q if inR(q)]
+
+def fw(alpha_tab):
+    return sum(sign(q)*(1 if tab(mul(w,mul(inv(q),sigma)))==alpha_tab else 0) for q in Q)
+def psi(tauperm, alpha_tab):
+    return sum(sign(p)*(1 if tab(mul(inv(p),tauperm))==alpha_tab else 0) for p in Q)
+def IHpart(alpha_tab):
+    return sum(sign(q)*psi(mul(w,mul(inv(q),sigma)), alpha_tab) for q in R)
+def Delta(alpha_tab):
+    return fw(alpha_tab)-IHpart(alpha_tab)
+
+print("rowInv(sigma)=",rowInv(sigma))
+print("no-col-std tabloids:",sorted(no_colstd))
+print("all tabloids:",sorted(all_tabs))
+bad=[]
+for t in sorted(all_tabs):
+    d=Delta(t)
+    flag=""
+    if t in no_colstd: flag="NO-COLSTD"
+    # strictly below sigma?
+    below = strictDom(sigma, next(a for a in allp if tab(a)==t)) if t!=tab(sigma) else False
+    print(f"tab={t} Delta={d:2d} fw={fw(t):2d} IH={IHpart(t):2d} {flag} below={below}")
+    if t in no_colstd and d!=0:
+        bad.append((t,d))
+print("VIOLATIONS (no-colstd & Delta!=0):", bad)
+
+print("\n=== region debug ===")
+print("|Q|=",len(Q),"|R|=",len(R))
+for q in Q:
+    base=mul(w,mul(inv(q),sigma))
+    g=gamma(q); t=tau(q)
+    reg="low" if strictDom(sigma,t) else ("eq" if (tab(t)==tab(sigma) and rowInv(t)<rowInv(sigma)) else ("eqHi" if tab(t)==tab(sigma) else "high"))
+    print(f"q={q} sgn={sign(q):2d} base_tab={tab(base)} gamma={g} tau={t} tau_tab={tab(t)} rowInv_tau={rowInv(t)} region={reg} inR={q in R}")
+
+# validate against meditate: Delta should equal -psi_{(1,3,0,2)} ((0 1 3 2) cycle)
+t0=(1,3,0,2)
+print("\n(0132) isColStd:",isColStd(t0),"tab=",tab(t0))
+print("compare Delta vs -psi_(0132):")
+ok=True
+for t in sorted(all_tabs):
+    d=Delta(t); e=-psi(t0,t)
+    if d!=e: ok=False
+    print(f"tab={t} Delta={d:2d} -psi={e:2d} {'OK' if d==e else 'MISMATCH'}")
+print("Delta == -psi_(0132) everywhere:", ok)


### PR DESCRIPTION
This PR adds a reproducible counterexample script and a progress note refuting
the Wall 3 R2.b.i lemma `twistedPolytabloid_residual_no_colStd_zero` (#2769).
A brute-force check on the meditate's own canonical example (λ=(2,2),
σ=swap(0,1), w=(0 2 1)) reproduces the §2.4 region table and `Δ = −ψ_{(0 1 3 2)}`
exactly, then shows `Δ` is nonzero (±1) at three non-column-standardizable
tabloids strictly below `[σ]`. The residual lies in `V` for a global reason
(`Δ = −ψ_τ` for a column-standard `τ` at smaller srRank), not by pointwise
cancellation at no-col-std tabloids, so the R2.b.i/R2.b.ii decomposition premise
(`q-high-involution.md` §4.2 step 4) is unsound. The redesign is tracked by the
meditate issue #4584; #2769 is skipped to replan.

🤖 Prepared with Claude Code
