### PR TITLE
doc: session 0ccdb7d5 progress — #2708 ℂ-vs-generic-k mis-scope finding

### DIFF
--- a/progress/20260614T121120Z_0ccdb7d5.md
+++ b/progress/20260614T121120Z_0ccdb7d5.md
@@ -1,0 +1,82 @@
+## Accomplished
+
+Work session `0ccdb7d5` (`/work` meta-dispatch). Claimed #2708
+(Schur-Weyl C-4a aggregation — close `schurModuleSubmodule_isSimple_centralizer`),
+diagnosed it as **mis-scoped**, and skipped it to `replan` with an
+actionable finding (no Lean changes).
+
+- **#2543 race**: first tried to claim #2543 (a clean self-contained Ch5
+  pigeonhole proof) but it was claimed by another agent mid-selection.
+- **#2708 dependency readiness verified**: #2682/#2683/#2684 (β.1/β.2/β.3),
+  #2693/#2694 (γ.B/γ.A) are all CLOSED/merged, and the aggregation helper
+  `image_of_primitive_idempotent_isSimple_centralizer`
+  (`PrimitiveIdempotentSimplicity.lean:220`) exists. So the issue's stated
+  preconditions hold.
+- **Found the real blocker — a field-genericity mismatch the planner
+  overlooked.** The goal `schurModuleSubmodule_isSimple_centralizer`
+  (`SchurModuleSimple.lean:143`) is over a *generic* alg-closed CharZero
+  field `k` (namespace `variable (k …)` at `:22`). The generic helper and
+  sub-α `Theorem5_18_4_bimodule_decomposition_explicit`
+  (`Theorem5_18_4.lean:464`) are fine, but the **three per-block analysis
+  inputs the glue must supply are all hardcoded to `ℂ`**:
+  - `trace_symGroupAction_eq_spechtModuleCharacter` (`Theorem5_22_1.lean:1029`)
+    — per-block Specht label / `h_label`.
+  - `youngSym_action_vanishes_off_block` (`Theorem5_22_1.lean:2158`, β.3)
+    — `f i = 0` for `i ≠ iLam`.
+  - `youngSym_action_on_special_block_rank_one_scaled_proj`
+    (`Theorem5_22_1.lean:2279`, γ) — `α, π, hπ_idem, hπ_rank, hπ_special`.
+  `grep` confirms no generic-`k` variants exist. Generic `k` does not
+  base-change from `ℂ`, so the ℂ lemmas can't be transported to close the
+  generic goal. The "≤50 lines of mechanical glue" framing is therefore
+  wrong as stated.
+- **Also confirmed nothing outside `SchurModuleSimple.lean` consumes
+  `schurModuleSubmodule_isSimple_centralizer` or `schurModule_isSimple`**
+  (grep clean) — no live downstream forces generic `k` today.
+- Posted a detailed finding comment on #2708 with two resolution paths and
+  skipped the issue.
+
+## Current frontier
+
+#2708 is back in the `replan` queue with a precise diagnosis. The Ch5
+Schur-Weyl C-4c critical-path entry (`schurModule_isSimple`) remains open,
+gated on the genericity decision below.
+
+## Overall project progress
+
+Etingof draft 1, Stage 3. Ch5 Schur-Weyl: the character-theoretic
+backbone of `Theorem 5.22.1` (labeling, off-block vanishing, rank-one
+projection) is fully proven **over ℂ**; the C-4a aggregation and C-4c
+final theorem are stated over generic `k` and cannot yet be discharged
+because of the ℂ-vs-`k` mismatch. Ch5 Wall 3 Garnir straightening
+(#4593 R2.b) active elsewhere. Ch6 affine-Dynkin indecomposability
+(D̃/Ẽ/T tubes) is the other active frontier — a genuine research wall:
+the universal `dTildeRep_isIndecomposable` (`InfiniteTypeConstructions.lean:3114`)
+is complete only because it transports from the ℂ-canonical
+`dTildeRep'_isIndecomposable`; the F-generic / arbitrary-orientation
+ports (d6/d7/d8/parametric) have no completed precedent and their
+leaf-equality infrastructure is still in-flight (claimed #4533/#4569/#4576/#4578).
+
+## Next step
+
+Planner re-scopes #2708. **Recommended: path 1 — specialize the C-4a/C-4c
+statements (`schurModuleSubmodule_isSimple_centralizer`,
+`schurModule_isSimple`) from generic `k` to `ℂ`** (drop the `variable k`
+in `SchurModuleSimple.lean`). This matches the actual proven generality of
+the rest of the Schur-Weyl backbone, is faithful to Etingof, and unblocks
+the aggregation against the existing ℂ lemmas. Then a feature session
+writes the aggregation — still a real proof (a few hundred lines, not
+trivial glue): obtain the bimodule decomposition, label each block via
+`trace_symGroupAction_eq_spechtModuleCharacter`, establish existence of
+the `iLam = weightToPartition N lam` block, supply the per-block
+`hf_block` factorization (see `youngSym_block_factorization`
+`Theorem5_22_1.lean:699` and `block_factorization_extended` in
+`PrimitiveIdempotentSimplicity.lean`), and manage the `restrictScalars`
+coercions between `Submodule (symGroupImage)`, `↥(S.restrictScalars ℂ)`,
+and `↥(S i) →ₗ[A] E`. Alternative path 2: first generalize lemmas
+1029/2158/2279 to generic alg-closed CharZero `k` (larger, character-theory
+heavy), keeping the generic statements.
+
+## Blockers
+
+#2708 blocked on the planner's genericity re-scope decision (documented in
+the issue comment). No code blockers introduced this session.


### PR DESCRIPTION
This PR records the progress note for work session `0ccdb7d5`, which diagnosed that issue #2708 (Schur-Weyl C-4a aggregation) cannot be discharged as the planned "mechanical glue": the per-block analysis inputs it must feed `image_of_primitive_idempotent_isSimple_centralizer` — `trace_symGroupAction_eq_spechtModuleCharacter` (`Theorem5_22_1.lean:1029`), `youngSym_action_vanishes_off_block` (`:2158`, β.3), and `youngSym_action_on_special_block_rank_one_scaled_proj` (`:2279`, γ) — are all hardcoded to `ℂ`, while the goal `schurModuleSubmodule_isSimple_centralizer` is over a generic alg-closed CharZero field `k`. #2708 was skipped to `replan` with two re-scope paths (recommended: specialize C-4a/C-4c to `ℂ`). No code changes; documentation only.

🤖 Prepared with Claude Code