### PR TITLE
doc(Ch5 #2482): decompose Schur-Weyl #5 + flag highest-weight/circularity finding

### DIFF
--- a/progress/20260614T121144Z_7617b9d0.md
+++ b/progress/20260614T121144Z_7617b9d0.md
@@ -1,0 +1,72 @@
+## Accomplished
+
+Feature session `7617b9d0`. Originally targeted #4593 (recommended by the
+previous handoff) but it was already claimed; claimed the next oldest feature
+issue **#2482** (Schur-Weyl #5: "polynomial GL_N-rep decomposes as a direct
+sum of Schur modules").
+
+After a thorough cross-file investigation I found #2482 as literally stated is
+**larger than its "1-2 session, medium risk" estimate and has an
+architecture/circularity problem**, so I decomposed it (no Lean code this
+turn) and documented the finding for a planner:
+
+- **The stated dependencies do not deliver concrete `SchurModule` summands.**
+  What actually exists is `glTensorRep_equivariant_schurWeyl_decomposition`
+  (`FormalCharacterIso.lean:775`, `V^{⊗n} ≅ ⨁ S_i ⊗ L_i` with **abstract**
+  simple `L_i`), `Theorem5_18_4_GL_rep_decomposition_simple`
+  (`SchurWeylGLTransfer.lean:659`, the `L_i` are simple), and the
+  **character-level** `formalCharacter_glTensorRep_eq_sum_specht_smul_schurPoly`
+  (`:1090`). There is **no** module-level `L_i ≅ SchurModule k N λ`; the
+  `schurWeyl_gl_decomposition` named in the issue does not exist.
+- **The file's own comment (lines 1053-1075) flags #2482 as needing the
+  highest-weight classification** `char(L_i) = schurPoly N λ`, and warns the
+  naive "via Schur's lemma" assembly is **circular** (also in the
+  lean-formalization skill via PR #4581).
+- **Circularity with consumer #6** (`iso_of_formalCharacter_eq_schurPoly`,
+  `:388`): the concrete-naming step here is essentially what #6 proves.
+- **Filed two self-contained, non-circular sub-issues** that any version of
+  the final theorem needs:
+  - **#4598** — FDRep-level GL-equivariant embedding `M ↪ (V^{⊗n})^m`
+    (the polynomial+weight-homogeneous ⟹ `hpoly'` det⁻¹-elimination over the
+    existing `polynomialRep_embeds_in_tensorPower'`).
+  - **#4600** — generic isotypic extraction (a subrep of a finite ⊕ of
+    simples is a ⊕ of those simples), with Mathlib API pointers
+    (`Mathlib/RingTheory/SimpleModule/Isotypic.lean`:
+    `Submodule.linearEquiv_of_le_sSup`,
+    `IsSemisimpleModule.exists_linearEquiv_fin_dfinsupp`, isotypic
+    components) posted as a comment.
+- **Skipped #2482 → `replan`** with a `Decomposed into #4598, #4600`
+  breadcrumb and a full architecture comment recommending the planner author
+  the assembly in **abstract-summand** form and decide where the concrete
+  `SchurModule` naming / highest-weight classification belongs.
+
+## Current frontier
+
+#2482 is correctly re-scoped (replan). #4598 and #4600 are ready to claim
+(independent of each other). The concrete-`SchurModule` assembly and the
+`Theorem5_23_2_i` amendment await a planner architecture decision.
+
+## Overall project progress
+
+Etingof draft 1, Stage 3. Ch5 Schur-Weyl chain: the character-level
+decomposition of `V^{⊗n}` is in place (#2493); the module-level decomposition
+of a general polynomial rep into Schur modules (#2482 / #6) is blocked on the
+highest-weight classification, now decomposed into #4598 + #4600 + a
+to-be-authored abstract-form assembly. Ch6 affine-Dynkin frontier active
+elsewhere.
+
+## Next step
+
+A worker claims **#4598** (concrete path: derive `hpoly'` from
+`IsAlgebraicRepresentation` + weight-homogeneity, then call
+`polynomialRep_embeds_in_tensorPower'`) or **#4600** (generic; use the
+`Isotypic.lean` lemmas noted in its comment). A **planner** should triage the
+#2482 `replan`: close it (subs cover the achievable scope) and file the
+abstract-form assembly issue, deciding the concrete-naming/highest-weight
+architecture per the comment.
+
+## Blockers
+
+None new. #2482's concrete form is blocked on the highest-weight
+classification (does not yet exist) and needs an acyclic re-architecture vs.
+consumer #6 — flagged for the planner.


### PR DESCRIPTION
This PR records the investigation handoff for Schur-Weyl #5 (#2482). It
decomposes #2482 into two self-contained, non-circular sub-issues (#4598
GL-equivariant embedding `M ↪ (V^⊗n)^m`, #4600 generic isotypic extraction)
after finding the concrete-`SchurModule` form of the theorem requires the
highest-weight classification `char(L_i) = schurPoly N λ` — infrastructure
that does not yet exist and risks circularity with consumer #6
(`iso_of_formalCharacter_eq_schurPoly`). The existing decompositions only
yield abstract simple summands `L_i` plus a character-level identity; the
file's own comment (FormalCharacterIso.lean:1053-1075) confirms the gap.
#2482 has been routed to `replan` with a full architecture comment so a
planner can author the assembly in abstract-summand form and place the
concrete naming correctly. No Lean changes.

🤖 Prepared with Claude Code
