### PR TITLE
feat(Ch5 #4595): verified assembly of dim V_λ = n!/∏hooks from Part A (#4608) + Part B (#4609)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/CharValueHookFormula.lean
+++ b/EtingofRepresentationTheory/Chapter5/CharValueHookFormula.lean
@@ -26,25 +26,102 @@ namespace Etingof
 noncomputable section
 open scoped BigOperators
 
+/-- **Part A — Frobenius → Vandermonde determinant**
+(book `Discussion_hook_length_derivation`, lines 1–18).
+
+The Frobenius character value at the identity equals `n!` times the Vandermonde
+product of the beta-numbers `l_j = λ_j + (N-1-j)` (here `shiftedExps N lam.parts`),
+divided by `∏_j l_j!`.
+
+`charValue N λ 1` is the coefficient of `x^{λ+ρ}` in `Δ(x)·(∑ᵢ Xᵢ)^n`
+(`psumPart_trivialCycleType`). Expanding `Δ` as a signed monomial sum
+(`vandermondePoly_eq_sum_sign_monomial`) and extracting the coefficient
+(`coeff_vandermonde_mul`, multinomial coefficients of `(∑X)^n`) yields the
+determinant `det(l_j^{N-i})`, which by `Matrix.det_vandermonde` equals
+`∏_{i<j}(l_i − l_j)`. This is self-contained `MvPolynomial`/`Matrix.det`
+algebra — no representation theory, no straightening.
+
+For `i < j` the beta-numbers are strictly decreasing (`shiftedExps` is strictly
+antitone, see `charValue_trivialCycleType_eq_hookFormula` below), so the ℕ
+subtraction `l_i − l_j` is the genuine positive difference. -/
+theorem charValue_trivialCycleType_eq_frobeniusDetForm
+    (N : ℕ) {n : ℕ} (lam : BoundedPartition N n) :
+    charValue N lam (trivialCycleType n) =
+      (n.factorial : ℚ) *
+        ((∏ i, ∏ j ∈ Finset.Ioi i,
+            (shiftedExps N lam.parts i - shiftedExps N lam.parts j) : ℕ) : ℚ) /
+        ((∏ j, (shiftedExps N lam.parts j).factorial : ℕ) : ℚ) := by
+  sorry
+
+/-- **Part B — the hook-length identity**
+(book `Discussion_hook_length_derivation`, lines 18–end).
+
+The Vandermonde product of the beta-numbers `l_j = λ_j + (N-1-j)` times the
+hook-length product of `λ` equals `∏_j l_j!`. This is the cancellation that turns
+the determinant formula `n!·∏(l_i−l_j)/∏l_j!` into the hook-length formula
+`n!/∏h(i,j)`. Pure combinatorics — independent of all representation theory and of
+Part A. -/
+theorem hookLengthProduct_mul_vandermonde_eq_prod_factorial
+    (N : ℕ) {n : ℕ} (lam : BoundedPartition N n) :
+    (∏ i, ∏ j ∈ Finset.Ioi i,
+        (shiftedExps N lam.parts i - shiftedExps N lam.parts j) : ℕ) *
+      (lam.sum_eq ▸ weightToPartition N lam.parts).toYoungDiagram.hookLengthProduct =
+      (∏ j, (shiftedExps N lam.parts j).factorial : ℕ) := by
+  sorry
+
+/-- The arithmetic that combines Part A (`n!·V/L`) and Part B (`V·H = L`) into the
+hook-length quotient `n!/H`, with the ℕ-division on the right cast to ℚ via
+`H ∣ n!`. -/
+private lemma frobeniusDetForm_eq_hookFormula_aux {nf V H L : ℕ}
+    (hB : V * H = L) (hVpos : 0 < V) (hHpos : 0 < H) (hdvd : H ∣ nf) :
+    (nf : ℚ) * (V : ℚ) / (L : ℚ) = ((nf / H : ℕ) : ℚ) := by
+  have hV' : (V : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr hVpos.ne'
+  have hH' : (H : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr hHpos.ne'
+  subst hB
+  rw [Nat.cast_div hdvd hH']
+  push_cast
+  field_simp
+
 /-- **(THE ONE HARD STEP — book's `Discussion_hook_length_derivation`.)**
 The Frobenius character value at the identity equals the hook-length quotient.
 
-`charValue N λ (1)` is by definition the coefficient of `x^{λ+ρ}` in
-`Δ(x) · (∑ᵢ Xᵢ)^n` (Vandermonde determinant times the trivial power-sum).
-Expanding `Δ` as a signed monomial sum and extracting the coefficient
-(`coeff_vandermonde_mul`, multinomial coefficients of `(∑X)^n`) yields the
-determinant `det(l_j^{N-i})`, which by the Vandermonde formula equals
-`n!/∏ l_j! · ∏_{i<j}(l_i - l_j) = n!/∏ h(i,j)`.
-
-This is self-contained `MvPolynomial`/`Matrix.det` algebra — no representation
-theory, no straightening. -/
+Combines the two book steps: Part A
+(`charValue_trivialCycleType_eq_frobeniusDetForm`, the Vandermonde determinant
+computation `charValue = n!·∏(l_i−l_j)/∏l_j!`) and Part B
+(`hookLengthProduct_mul_vandermonde_eq_prod_factorial`, the cancellation
+`∏(l_i−l_j)·∏h = ∏l_j!`). The beta-numbers `l_j = λ_j + (N-1-j)` are strictly
+decreasing, so the Vandermonde product is positive; with `H ∣ n!`
+(`hookLengthProduct_dvd_factorial`) the ℕ-division casts cleanly to ℚ. -/
 theorem charValue_trivialCycleType_eq_hookFormula
     (N : ℕ) {n : ℕ} (lam : BoundedPartition N n) :
     charValue N lam (trivialCycleType n) =
       ((n.factorial /
         (lam.sum_eq ▸ weightToPartition N lam.parts).toYoungDiagram.hookLengthProduct
           : ℕ) : ℚ) := by
-  sorry
+  rw [charValue_trivialCycleType_eq_frobeniusDetForm N lam]
+  have hVpos : 0 < (∏ i, ∏ j ∈ Finset.Ioi i,
+      (shiftedExps N lam.parts i - shiftedExps N lam.parts j) : ℕ) := by
+    apply Finset.prod_pos
+    intro i _
+    apply Finset.prod_pos
+    intro j hj
+    have hij : i < j := Finset.mem_Ioi.mp hj
+    have hlt : shiftedExps N lam.parts j < shiftedExps N lam.parts i := by
+      simp only [shiftedExps]
+      have h1 : lam.parts j ≤ lam.parts i := lam.decreasing hij.le
+      have h2 : N - 1 - (j : ℕ) < N - 1 - (i : ℕ) := by
+        have hjlt : (j : ℕ) < N := j.isLt
+        have hij' : (i : ℕ) < (j : ℕ) := hij
+        omega
+      omega
+    omega
+  have hHpos : 0 < (lam.sum_eq ▸ weightToPartition N lam.parts).toYoungDiagram.hookLengthProduct :=
+    YoungDiagram.hookLengthProduct_pos _
+  have hdvd : (lam.sum_eq ▸ weightToPartition N lam.parts).toYoungDiagram.hookLengthProduct ∣
+      n.factorial :=
+    hookLengthProduct_dvd_factorial n (lam.sum_eq ▸ weightToPartition N lam.parts)
+  exact frobeniusDetForm_eq_hookFormula_aux
+    (hookLengthProduct_mul_vandermonde_eq_prod_factorial N lam) hVpos hHpos hdvd
 
 /-- **Book route, payoff 1:** the Frobenius character value at the identity
 equals the number of standard Young tableaux — via the hook-length quotient on

--- a/progress/2026-06-14T12-25-57Z_f04a9be1.md
+++ b/progress/2026-06-14T12-25-57Z_f04a9be1.md
@@ -1,0 +1,62 @@
+## Accomplished
+
+Worked issue #4595 (Frobenius route to `dim V_λ = #SYT`, retiring Wall 3).
+The scaffold `CharValueHookFormula.lean` already had the target lemma
+`charValue_trivialCycleType_eq_hookFormula` as a single hard `sorry`.
+
+Found that the proof needs **two genuinely-missing, independent pieces** —
+neither exists, and the existing `charValue_trivialCycleType_eq_spechtFinrank`
+reaches `charValue` via representation theory, not this determinant route:
+
+* **Part A** (`charValue_trivialCycleType_eq_frobeniusDetForm`): the
+  Frobenius/Vandermonde determinant computation
+  `charValue = n!·∏_{i<j}(l_i−l_j)/∏_j l_j!` (book derivation lines 1–18).
+  Deep `MvPolynomial`/`Matrix.det` work, crosses a ℚ/ℂ boundary.
+* **Part B** (`hookLengthProduct_mul_vandermonde_eq_prod_factorial`): the
+  hook-length identity `∏_{i<j}(l_i−l_j)·∏h(i,j) = ∏_j l_j!` (book lines
+  18–end). Pure combinatorics.
+
+Per worker-flow Step 4b, decomposed top-down with a **verified assembly**:
+stated A and B as precise sub-lemmas (`sorry`) and **proved**
+`charValue_trivialCycleType_eq_hookFormula` from them — strict decrease of the
+beta-numbers `l_j = λ_j+(N-1-j)` (= `shiftedExps`) gives a positive Vandermonde
+product, and `H ∣ n!` (`hookLengthProduct_dvd_factorial`) casts the ℕ-division
+cleanly to ℚ. The assembly is real, verified content: it certifies that A ∧ B
+suffice, so the two sub-issues are guaranteed-correct specs.
+
+`lake build EtingofRepresentationTheory.Chapter5.CharValueHookFormula` succeeds
+with only the two expected sub-lemma `sorry`s (lines 47, 64).
+
+Numerically sanity-checked both A and B (λ=(2)/N=2: n!·V/L = 2·3/6 = 1, V·H =
+3·2 = 6 = L; λ=(1,1): 2·1/2 = 1, 1·2 = 2 = L).
+
+## Current frontier
+
+`CharValueHookFormula.lean` has two precisely-stated `sorry`s:
+Part A (`charValue_trivialCycleType_eq_frobeniusDetForm`) and Part B
+(`hookLengthProduct_mul_vandermonde_eq_prod_factorial`). The downstream lemmas
+(`charValue_trivialCycleType_eq_card_syt`,
+`finrank_spechtModule_eq_card_syt_via_frobenius`) chain off the now-proven
+assembly with no further work.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. This turn converts the single vague
+"hard step" of the book-faithful dim-formula route into two independent,
+parallel-attackable sub-lemmas plus a verified assembly. Completing #4608 and
+#4609 fully retires Wall 3 (Garnir straightening: #2703, #2543).
+
+## Next step
+
+Two new feature sub-issues created:
+* **#4608** (Part A) — Frobenius/Vandermonde determinant form. Self-contained
+  body with the full book route + the ℚ/ℂ bridge note.
+* **#4609** (Part B) — hook-length identity. Pure combinatorics; check
+  FRTHelpers.lean for reusable per-cell hook machinery before reproving.
+
+They are independent and can be worked in parallel. Parent #4595 marked
+`replan` (decomposed) for the next planner to close or narrow.
+
+## Blockers
+
+None. Both sub-issues are unblocked and fully specified.


### PR DESCRIPTION
Partial progress on #4595

Session: `f04a9be1-370b-44e8-8cd3-b546a896cda1`

e878eaa8 doc: progress for #4595 — decompose hookFormula into #4608 (Part A) + #4609 (Part B) with verified assembly
beccd535 feat(Ch5 #4595): reduce hookFormula to Part A (Frobenius det) + Part B (hook identity) with verified assembly

🤖 Prepared with Claude Code