### PR TITLE
doc(Ch5 #4604): refute R2.b sub-A crux strategy + corrected analysis

### DIFF
--- a/.claude/skills/validation-first/SKILL.md
+++ b/.claude/skills/validation-first/SKILL.md
@@ -49,6 +49,33 @@ After individual content work is complete, run a **cross-validation** pass that 
 
 Cross-validation should be a separate issue, not an afterthought. Plan for it explicitly.
 
+## Validating Proof Strategies (not just output format)
+
+Crux issues often *prescribe a proof strategy* and mandate a numerical
+pre-formalization check ("validate before formalizing"). That check validates
+the **strategy**, not just an output format — and it can refute the strategy
+while the deliverable (the lemma statement) is still true.
+
+When validation refutes the prescribed strategy:
+
+- **Trust the computation over the issue prose.** A small exact-arithmetic
+  enumeration over the actual model (permutations, tabloids, signs) is ground
+  truth; the issue's strategy paragraph is a hypothesis. If they disagree, the
+  strategy is wrong. Distinguish "the lemma is false" (rare — re-scope hard)
+  from "the lemma is true but the stated mechanism is wrong" (common).
+- **Find the corrected mechanism before bouncing.** A refutation plus a
+  *validated corrected mechanism* makes the replan actionable; a bare "this
+  doesn't work" does not. Probe variants (e.g. is the property true one level
+  up? is it a maximal-only phenomenon? does it reduce to a known sub-fact?).
+- **Preserve the analysis via a `--partial` PR, not a bare `skip`.** A
+  `--partial` PR ("Partial progress on #N") merges your validation scripts and
+  analysis doc into the repo *and* marks the issue `replan`; a bare `skip`
+  strands all of it on an unmerged branch where the next planner can't see it.
+  Keep the issue's Lean signature, flag only the refuted strategy section.
+- **Repeated mis-scoping of the same crux is a signal.** If a crux has now been
+  mis-scoped more than once, say so in the replan — the planner may need to
+  reconsider the surrounding decomposition, not just patch the strategy.
+
 ## Phase 3: Formalization Verification Patterns
 
 Formalization adds a new dimension to validation — the Lean compiler itself is the ultimate validator.

--- a/progress/2026-06-14T13-07-08Z_c8db6773.md
+++ b/progress/2026-06-14T13-07-08Z_c8db6773.md
@@ -1,0 +1,51 @@
+## Accomplished
+
+Feature session on #4604 (Wall 3 R2.b sub-A: `twistedResidual_maximal_support_colStd`).
+Performed the issue-mandated pre-formalization validation and **refuted the
+issue's prescribed proof strategy** (column-antisymmetry on `f_w` via the
+`Q ∩ w⁻¹Pw` stabiliser). The deliverable lemma is true, but the stated
+mechanism is computationally false:
+
+- The fiber stabiliser `H = Q ∩ w⁻¹Pw` is a single *global* subgroup; the
+  fibers `{q : [wq⁻¹σ]=[β]}` are its cosets. "H has an odd element" is therefore
+  global/all-or-nothing — it cannot single out individual non-col-std tabloids.
+- Validated: `supp(f_w)` contains 56 non-column-standardizable tabloids on
+  shape (3,3) (`FW-VIOLATION` in `r2b-crux-ext-validation.py`), directly
+  refuting "`[β]∈supp(f_w) ⟹ [β] col-std-izable`".
+- Validated TRUE facts: max tabloid of `f_w` is always col-std-izable (0
+  violations); max tabloid of `Δ` is always col-std-izable (167 non-col-std in
+  supp Δ, 0 maximal). But `max(Δ) ≠ max(f_w)` ~60% of the time and `max(Δ)` is
+  not always a `[τ_q]` — so no cheap bridge; the deliverable is the genuine
+  James column-straightening theorem, not a one-shot coset cancellation.
+
+Artifacts added (no Lean changed): `progress/r2b-crux-strategy-refuted.md`
+(full analysis + corrected mechanism + planner options),
+`progress/r2b-crux-ext-validation.py`, `progress/r2b-crux-mechanism-probe.py`.
+
+## Current frontier
+
+#4604 routed to `replan` via a partial PR. The corrected strategy (column-
+straightening induction on the running maximal tabloid; the invariant is
+"`max(f_w − M)` col-std-izable for `M ∈ V`, `supp ≼ [σ]`") is documented for the
+next planner in `r2b-crux-strategy-refuted.md`.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. Wall 3 R2.b remains open: its sub-A crux is
+harder than scoped (full James straightening). R2.b → R2.c → `garnir_twisted_in_lower_span`
+chain still blocked. Other tracks (Ch5 dim formula #4595 family, Ch6 tube
+indecomposability) unaffected.
+
+## Next step
+
+Planner: re-scope #4604 per `progress/r2b-crux-strategy-refuted.md` §Recommendation.
+Option (a): split into (a1) "max tabloid of `f_w` is col-std-izable" (reusable,
+hard) + (a2) the `M`-subtraction dominance bridge. Option (b): reconsider the
+R2.b decomposition to peel `f_w`'s own leading term first. Keep the issue's Lean
+signature; replace only the "Strategy — column-antisymmetry / `Q∩w⁻¹Pw`" section.
+
+## Blockers
+
+The prescribed crux strategy is refuted; #4604 cannot be formalized as written.
+Needs a planner re-scope (the true proof is a column-straightening induction,
+materially larger than the single conjugate-coset lemma the issue describes).

--- a/progress/r2b-crux-ext-validation.py
+++ b/progress/r2b-crux-ext-validation.py
@@ -1,0 +1,142 @@
+# Extension of /tmp/r2b_crux.py per issue #4604:
+# For every NON-column-standardizable tabloid [beta] in supp(Delta), confirm
+#   (a) [beta] is NON-maximal in supp(Delta)  (so the maximal one is always col-std-izable)
+#   (b) the coset {q in Q : [w q^-1 sigma] = [beta]} has stabiliser
+#         H = Q cap w^-1 (Row) w  containing an odd element
+#       => the f_w coefficient at [beta] is 0 (the col-antisymmetry cancellation).
+# Also confirm the clean lemma: f_w([beta]) != 0  =>  [beta] is col-std-izable.
+from itertools import permutations
+import random
+
+def test_shape(rowOf, colOf, trials):
+    n = len(rowOf)
+    def mul(a, b): return tuple(a[b[k]] for k in range(n))
+    def inv(a):
+        r = [0]*n
+        for k in range(n): r[a[k]] = k
+        return tuple(r)
+    def sign(a):
+        s = 1
+        for i in range(n):
+            for j in range(i+1, n):
+                if a[i] > a[j]: s = -s
+        return s
+    def tab(a): return tuple(rowOf[a[k]] for k in range(n))
+    def isColStd(a):
+        ai = inv(a)
+        for p1 in range(n):
+            for p2 in range(n):
+                if colOf[p1] == colOf[p2] and rowOf[p1] < rowOf[p2] and not ai[p1] < ai[p2]:
+                    return False
+        return True
+    allp = list(permutations(range(n)))
+    Q = [p for p in allp if all(colOf[p[k]] == colOf[k] for k in range(n))]
+    P = [p for p in allp if all(rowOf[p[k]] == rowOf[k] for k in range(n))]
+    Pset = set(P)
+    def cumul(a, k, i): return sum(1 for e in range(n) if e <= k and rowOf[a[e]] < i)
+    def dom(a, b): return all(cumul(b, k, i) <= cumul(a, k, i) for k in range(n) for i in range(n+1))
+    def strictDom(a, b): return dom(a, b) and tab(a) != tab(b)
+    def rowInv(a):
+        ai = inv(a); c = 0
+        for p1 in range(n):
+            for p2 in range(n):
+                if rowOf[p1] == rowOf[p2] and colOf[p1] < colOf[p2] and ai[p2] < ai[p1]: c += 1
+        return c
+    tabs = sorted(set(tab(a) for a in allp))
+    rep = {t: next(a for a in allp if tab(a) == t) for t in tabs}
+    colstd_tabs = {t for t in tabs if any(tab(a) == t and isColStd(a) for a in allp)}
+    def psi(tauperm):
+        v = {}
+        for p in Q:
+            t = tab(mul(inv(p), tauperm)); v[t] = v.get(t, 0) + sign(p)
+        return {t: c for t, c in v.items() if c}
+    def gamma_unique(sigma, w):
+        for q in Q:
+            base = mul(w, mul(inv(q), sigma))
+            if len([g for g in Q if isColStd(mul(g, base))]) != 1: return False
+        return True
+    def tau(sigma, w, q):
+        base = mul(w, mul(inv(q), sigma))
+        g = [g for g in Q if isColStd(mul(g, base))][0]
+        return mul(g, base)
+    # H = Q cap w^-1 P w  (stabiliser of the fiber [w q^-1 sigma])
+    def stabiliser(w):
+        wi = inv(w)
+        H = [h for h in Q if mul(w, mul(h, wi)) in Pset]
+        return H
+
+    sigmas = [s for s in allp if isColStd(s) and rowInv(s) > 0]
+    n_fw_nonzero_check = 0   # f_w coeff != 0 => col-std-izable
+    n_fw_violation = 0
+    n_noncs_in_delta = 0     # non-col-std tabloids appearing in supp(Delta)
+    n_noncs_maximal = 0      # ... that are MAXIMAL (should be 0)
+    n_coset_cancel_ok = 0    # fiber stabiliser has odd elt => f_w coeff 0 (verify)
+    n_coset_cancel_bad = 0
+    tested = 0
+    for _ in range(trials):
+        sigma = random.choice(sigmas)
+        ws = [w for w in allp if w not in Q and w not in Pset and w != tuple(range(n))]
+        random.shuffle(ws)
+        w = None
+        for cand in ws:
+            if gamma_unique(sigma, cand): w = cand; break
+        if w is None: continue
+        tested += 1
+        def inR(q):
+            t = tau(sigma, w, q)
+            return strictDom(sigma, t) or (tab(t) == tab(sigma) and rowInv(t) < rowInv(sigma))
+        R = [q for q in Q if inR(q)]
+        fw = {}
+        for q in Q:
+            t = tab(mul(w, mul(inv(q), sigma))); fw[t] = fw.get(t, 0) + sign(q)
+        fw = {t: c for t, c in fw.items() if c}
+        tIH = {}
+        for q in R:
+            for t, c in psi(mul(w, mul(inv(q), sigma))).items():
+                tIH[t] = tIH.get(t, 0) + sign(q)*c
+        delta = {t: fw.get(t, 0) - tIH.get(t, 0) for t in set(fw) | set(tIH)}
+        delta = {t: c for t, c in delta.items() if c}
+
+        # --- clean lemma: f_w coeff != 0 => col-std-izable ---
+        for t, c in fw.items():
+            n_fw_nonzero_check += 1
+            if t not in colstd_tabs:
+                n_fw_violation += 1
+                print(f"  FW-VIOLATION sigma={sigma} w={w} beta={t} coeff={c}")
+
+        # --- coset cancellation mechanism: stabiliser odd-elt => fw coeff 0 ---
+        H = stabiliser(w)
+        H_has_odd = any(sign(h) == -1 for h in H)
+        if H_has_odd:
+            # every fiber sum must vanish => fw identically 0 on all tabloids
+            if all(c == 0 for c in fw.values()) and len(fw) == 0:
+                n_coset_cancel_ok += 1
+            else:
+                # fw nonempty: check each present coeff really used a fiber w/o odd stab.
+                # Recompute per-fiber: group q by tab(w q^-1 sigma); the present ones
+                # must have coset-sum != 0 which forces (for that coset) all-even -- but
+                # H is global. If H has an odd elt, EVERY fiber sum is 0 => fw empty.
+                n_coset_cancel_bad += 1
+                print(f"  COSET-BAD sigma={sigma} w={w}: H has odd but fw nonempty {fw}")
+        else:
+            n_coset_cancel_ok += 1
+
+        # --- non-col-std tabloids in Delta must be non-maximal ---
+        supp = list(delta)
+        maximals = [t for t in supp if not any(s != t and dom(rep[s], rep[t]) for s in supp)]
+        for t in supp:
+            if t not in colstd_tabs:
+                n_noncs_in_delta += 1
+                if t in maximals:
+                    n_noncs_maximal += 1
+                    print(f"  MAXIMAL-NONCS sigma={sigma} w={w} beta={t}")
+    print(f"shape rowOf={rowOf}: tested={tested}")
+    print(f"   f_w nonzero coeffs checked={n_fw_nonzero_check} violations(non-colstd)={n_fw_violation}")
+    print(f"   coset-cancel: ok={n_coset_cancel_ok} bad={n_coset_cancel_bad}")
+    print(f"   non-colstd-in-Delta={n_noncs_in_delta}  of which MAXIMAL={n_noncs_maximal}")
+
+random.seed(1)
+test_shape([0,0,1,1], [0,1,0,1], 80)
+test_shape([0,0,0,1,1], [0,1,2,0,1], 60)
+test_shape([0,0,1,1,2], [0,1,0,1,0], 60)   # (2,2,1)
+test_shape([0,0,0,1,1,1], [0,1,2,0,1,2], 30) # (3,3)

--- a/progress/r2b-crux-mechanism-probe.py
+++ b/progress/r2b-crux-mechanism-probe.py
@@ -1,0 +1,113 @@
+# Find the REAL reason the dominance-maximal tabloid of Delta is col-std-izable.
+# Investigate: what IS beta_max?  Is it [sigma]?  Is it some [tau_q]?  Is the
+# maximal tabloid of Delta always EQUAL to the maximal tabloid of f_w, and is
+# that maximal-of-f_w col-std-izable (even though lower f_w terms are not)?
+from itertools import permutations
+import random
+
+def test_shape(rowOf, colOf, trials):
+    n = len(rowOf)
+    def mul(a, b): return tuple(a[b[k]] for k in range(n))
+    def inv(a):
+        r = [0]*n
+        for k in range(n): r[a[k]] = k
+        return tuple(r)
+    def sign(a):
+        s = 1
+        for i in range(n):
+            for j in range(i+1, n):
+                if a[i] > a[j]: s = -s
+        return s
+    def tab(a): return tuple(rowOf[a[k]] for k in range(n))
+    def isColStd(a):
+        ai = inv(a)
+        for p1 in range(n):
+            for p2 in range(n):
+                if colOf[p1] == colOf[p2] and rowOf[p1] < rowOf[p2] and not ai[p1] < ai[p2]:
+                    return False
+        return True
+    allp = list(permutations(range(n)))
+    Q = [p for p in allp if all(colOf[p[k]] == colOf[k] for k in range(n))]
+    Pset = set(p for p in allp if all(rowOf[p[k]] == rowOf[k] for k in range(n)))
+    def cumul(a, k, i): return sum(1 for e in range(n) if e <= k and rowOf[a[e]] < i)
+    def dom(a, b): return all(cumul(b, k, i) <= cumul(a, k, i) for k in range(n) for i in range(n+1))
+    def strictDom(a, b): return dom(a, b) and tab(a) != tab(b)
+    def rowInv(a):
+        ai = inv(a); c = 0
+        for p1 in range(n):
+            for p2 in range(n):
+                if rowOf[p1] == rowOf[p2] and colOf[p1] < colOf[p2] and ai[p2] < ai[p1]: c += 1
+        return c
+    tabs = sorted(set(tab(a) for a in allp))
+    rep = {t: next(a for a in allp if tab(a) == t) for t in tabs}
+    colstd_tabs = {t for t in tabs if any(tab(a) == t and isColStd(a) for a in allp)}
+    def psi(tauperm):
+        v = {}
+        for p in Q:
+            t = tab(mul(inv(p), tauperm)); v[t] = v.get(t, 0) + sign(p)
+        return {t: c for t, c in v.items() if c}
+    def gamma_unique(sigma, w):
+        for q in Q:
+            base = mul(w, mul(inv(q), sigma))
+            if len([g for g in Q if isColStd(mul(g, base))]) != 1: return False
+        return True
+    def tau(sigma, w, q):
+        base = mul(w, mul(inv(q), sigma))
+        g = [g for g in Q if isColStd(mul(g, base))][0]
+        return mul(g, base)
+
+    sigmas = [s for s in allp if isColStd(s) and rowInv(s) > 0]
+    tested = 0
+    fwmax_colstd_viol = 0      # is the MAXIMAL tabloid of f_w col-std-izable?
+    deltamax_eq_fwmax = 0      # does max(Delta) == max(f_w) ?
+    deltamax_eq_sigma = 0
+    n_deltamax = 0
+    for _ in range(trials):
+        sigma = random.choice(sigmas)
+        ws = [w for w in allp if w not in Q and w not in Pset and w != tuple(range(n))]
+        random.shuffle(ws)
+        w = None
+        for cand in ws:
+            if gamma_unique(sigma, cand): w = cand; break
+        if w is None: continue
+        tested += 1
+        sig_t = tab(sigma)
+        def inR(q):
+            t = tau(sigma, w, q)
+            return strictDom(sigma, t) or (tab(t) == tab(sigma) and rowInv(t) < rowInv(sigma))
+        R = [q for q in Q if inR(q)]
+        fw = {}
+        for q in Q:
+            t = tab(mul(w, mul(inv(q), sigma))); fw[t] = fw.get(t, 0) + sign(q)
+        fw = {t: c for t, c in fw.items() if c}
+        tIH = {}
+        for q in R:
+            for t, c in psi(mul(w, mul(inv(q), sigma))).items():
+                tIH[t] = tIH.get(t, 0) + sign(q)*c
+        delta = {t: fw.get(t, 0) - tIH.get(t, 0) for t in set(fw) | set(tIH)}
+        delta = {t: c for t, c in delta.items() if c}
+        if not delta: continue
+
+        def maxima(d):
+            supp = list(d)
+            return [t for t in supp if not any(s != t and dom(rep[s], rep[t]) for s in supp)]
+        dmax = maxima(delta)
+        fmax = maxima(fw) if fw else []
+        for bt in dmax:
+            n_deltamax += 1
+            if bt == sig_t: deltamax_eq_sigma += 1
+            if bt in fmax: deltamax_eq_fwmax += 1
+        # is each maximal tabloid of f_w col-std-izable?
+        for bt in fmax:
+            if bt not in colstd_tabs:
+                fwmax_colstd_viol += 1
+    print(f"shape {rowOf}: tested={tested} deltamax_count={n_deltamax}")
+    print(f"   max(Delta)==[sigma]: {deltamax_eq_sigma}/{n_deltamax}")
+    print(f"   max(Delta) in max(f_w): {deltamax_eq_fwmax}/{n_deltamax}")
+    print(f"   max(f_w) NOT col-std-izable (violations): {fwmax_colstd_viol}")
+
+random.seed(2)
+test_shape([0,0,1,1], [0,1,0,1], 120)
+test_shape([0,0,0,1,1], [0,1,2,0,1], 80)
+test_shape([0,0,1,1,2], [0,1,0,1,0], 80)
+test_shape([0,0,0,1,1,1], [0,1,2,0,1,2], 50)

--- a/progress/r2b-crux-strategy-refuted.md
+++ b/progress/r2b-crux-strategy-refuted.md
@@ -1,0 +1,109 @@
+# Wall 3 R2.b sub-A (#4604): stated crux strategy is computationally REFUTED
+
+Feature session (UUID c8db6773). Outcome: **the deliverable lemma is true, but
+the proof strategy the issue prescribes (column-antisymmetry on `f_w` via the
+`Q ∩ w⁻¹Pw` stabiliser) is refuted by computation.** No Lean landed; issue
+routed back to replan with a corrected analysis. The mandated pre-formalization
+validation (issue: "extend `r2b_crux.py` ... confirm the coset-sum-cancellation
+mechanism") is what exposed the flaw.
+
+Scripts (saved this session):
+* `progress/r2b-crux-ext-validation.py` — the f_w/coset/non-col-std checks.
+* `progress/r2b-crux-mechanism-probe.py` — max(f_w) vs max(Δ) vs [σ].
+* (probe `max ∈ {[τ_q]}` reproduced inline below.)
+
+## The flaw in the prescribed strategy
+
+The issue says:
+
+> `f_w(σ)([β]) = Σ_{q : [w q⁻¹ σ] = [β]} sign(q)`. The `q` giving a fixed `[β]`
+> form a coset of `Q ∩ w⁻¹ P w`. If that stabiliser contains an odd-sign
+> element the coset sum cancels to 0, so any `[β] ∈ supp(f_w(σ))` has a
+> column-standard representative.
+
+`H := Q ∩ w⁻¹ P w` is a **single global subgroup**, and the fibers
+`{q : [w q⁻¹ σ] = [β]}` are its cosets `q₀·H` (all the same size, same `H`).
+So "H contains an odd-sign element" is **not a per-`β` condition** — it is
+global and all-or-nothing:
+
+* `H ⊆ Aₙ` (all even)  ⟹  no fiber cancels  ⟹  `supp(f_w) = { [w q⁻¹ σ] : q∈Q }`
+  in full, **including non-column-standardizable tabloids**;
+* `H ⊄ Aₙ`            ⟹  *every* fiber sum vanishes  ⟹  `f_w ≡ 0`.
+
+Either way the mechanism cannot single out individual non-col-std tabloids, so
+it does **not** prove "`[β] ∈ supp(f_w) ⟹ [β] col-std-izable". And that
+implication is **false**: `r2b-crux-ext-validation.py` exhibits 56
+non-column-standardizable tabloids in `supp(f_w)` on shape (3,3) (search
+`FW-VIOLATION`). The earlier S_n-invariance and explicit-`q∉R`-formula dead ends
+(see `r2b-crux-is-column-antisymmetry.md`) were correctly ruled out; this third,
+*prescribed* route is a fourth dead end.
+
+## What IS true (validated)
+
+1. **The deliverable holds.** Over 4 shapes the dominance-maximal tabloid of `Δ`
+   is always column-standardizable: `non-colstd-in-Delta=167  of which MAXIMAL=0`
+   (`r2b-crux-ext-validation.py`). Consistent with the original `stuck=0` over
+   160 examples.
+
+2. **The genuine clean fact is one level up:** the dominance-**maximal** tabloid
+   of `f_w` is column-standardizable (0 violations across all shapes;
+   `r2b-crux-mechanism-probe.py`, `max(f_w) NOT col-std-izable: 0`). The
+   non-col-std tabloids of `f_w` are all strictly below its maximal tabloid(s).
+   This is the standard James "leading tabloid is column-standard" phenomenon,
+   but for the *twisted* polytabloid.
+
+3. **No cheap bridge from f_w-max to Δ-max.** `max(Δ) = max(f_w)` only
+   ~30–40% of the time, and `max(Δ) = [σ]` only ~65–75% of the time
+   (`r2b-crux-mechanism-probe.py`). Even "`max(Δ)` is some `[τ_q]`" fails
+   (124/133, 75/82, 83/87, 45/52 — NOT 100%). So the maximal-support
+   col-std-izability of `Δ` is **not** reducible to membership in the
+   col-std set `{[τ_q]}` nor to any single coset-cancellation.
+
+## Corrected mechanism (for the planner)
+
+The real reason is the **classical James column-straightening / dominance
+induction**, not a one-shot coset cancellation. Concretely, the property
+"the dominance-maximal support tabloid is column-standardizable" is preserved
+by the whole elimination because:
+
+* it is a structural invariant of `f_w − (any V-element with support ≼ [σ])`,
+  i.e. of `Δ_k = f_w − M_k` where `M_k ∈ V` is the accumulated peeled part
+  (`M_0 = twistedIHPart`; each peel adds `c·ψ_{β'}` with `β'` col-std,
+  `[β'] ≼ [σ]`), and
+* each polytabloid `ψ_τ` (τ col-std) has *column-standard leading tabloid* `[τ]`
+  with everything else strictly below it (`generalizedPolytabloidTab_coeff_dominance`
+  + `..._coeff_self` already give this).
+
+The honest statement that sub-B actually consumes (iterated, not just `Δ_0`) is:
+
+> For col-std σ, arbitrary w, and **any** `M ∈ V` (SYT-polytabloid span) with
+> `supp(f_w σ − M) ≼ [σ]`, every dominance-maximal tabloid of `X := f_w σ − M`
+> is column-standardizable, with a representative `β'` that is IH-available
+> (`[β'] ≼ [σ]`).
+
+This subsumes the issue's `Δ_0`-only statement and is what the leading-term
+elimination in sub-B needs at every step. Proving it is a genuine
+column-straightening theorem on the twisted polytabloid — **substantially
+larger than the single conjugate-coset lemma the issue scoped**, and the
+`Q ∩ w⁻¹Pw` machinery the issue suggested building is *not* the right tool.
+
+## Recommendation
+
+Re-scope #4604 (and re-examine #4605/#4593). Options for the planner:
+
+* **(a)** Split the corrected lemma into: (a1) "max tabloid of `f_w` is
+  col-std-izable" (the reusable James leading-term fact for the twisted
+  polytabloid), and (a2) the `M`-subtraction stability bridge to `X = f_w − M`.
+  (a1) is the hard, reusable nut; (a2) is a dominance-bookkeeping induction.
+* **(b)** Reconsider whether R2.b needs maximal-support col-std-izability at
+  all, or whether `Δ ∈ V` can be reached by a different decomposition that
+  keeps `f_w`'s leading structure explicit (e.g. peel `f_w`'s own maximal term
+  first, where col-std-izability *is* clean, then induct on a smaller twisted
+  object). The validated invariant in §"Corrected mechanism" suggests an
+  induction on `(srRank, rowInv)` of the *running maximal tabloid* rather than
+  on `σ`.
+
+The deliverable's Lean signature in the issue is fine to keep; only the
+"Strategy — column-antisymmetry (James) ... `Q ∩ w⁻¹Pw` sign-cancellation"
+section is wrong and must be replaced by the column-straightening induction
+above.


### PR DESCRIPTION
Partial progress on #4604

Session: `c8db6773-e84f-408d-913f-4e7b6677d507`

3646a5e0 doc(skill): validation-first — refuting a prescribed proof strategy → corrected mechanism + --partial replan
f77b5357 doc(Ch5 #4604): refute R2.b sub-A crux strategy; validation + corrected analysis

🤖 Prepared with Claude Code