### PR TITLE
doc(Ch6 #4578): decompose mixed-direction D̃₆ leaf-equalities into #4631/#4632

### DIFF
--- a/progress/2026-06-14T13-26-21Z_0748f779.md
+++ b/progress/2026-06-14T13-26-21Z_0748f779.md
@@ -1,0 +1,65 @@
+## Accomplished
+
+Feature session on #4578 (consume `d5tildeGammaEquiv_F` to close D̃₆
+mixed-direction leaf-equality branches). After deep orientation on
+`FieldGenericD6Tilde.lean` / `FieldGenericD5Tilde.lean` /
+`FieldGenericStar.lean`, **decomposed** #4578 into two focused sub-issues
+and recorded a correction to the planner's instantiation hint:
+
+- **#4631** (sub-A): mixed-direction v=4 forcing lemma + close d6tilde
+  combo C (`:710`) / C′ (`:719`).
+- **#4632** (sub-B): close the three outer reversed branches e02/e12/e23
+  (`:825/:823/:821`); depends on #4631.
+- Parent #4578 marked `replan` with a `Decomposed into #4631, #4632`
+  breadcrumb.
+
+**Key finding (corrects #4578's hint).** The hint claimed `g.symm`
+(γ-equiv inverse) makes the canonical leaf-5 push and reversed leaf-6 pull
+"line up without the residual (I-N) twist." Verified by hand this is
+incomplete: with M := `cumTailSumLin` = (I-N)⁻¹, N := `nilpotentShiftLinGen`,
+
+`d5tildeGammaInv_F (starEmbed1_F s) = starEmbed1_F (s - M s) + starEmbed2_F (M s)`
+(I - M = -N M).
+
+Center-4 is exactly `{ e1(p+q) + e2(p+Nq) : p∈W₁⟨0⟩, q∈W₁⟨1⟩ }` (via the
+center-2 product decomposition pushed through γ). Matching `e1 s ∈ W₁⟨4⟩`
+forces `s = (I-N)q`, `p = -Nq`, giving the **twisted** relations
+`M·W₁⟨5⟩ = W₁⟨1⟩` (i.e. `W₁⟨5⟩ = (I-N)·W₁⟨1⟩`), `W₁⟨0⟩ ⊆ W₁⟨6⟩`,
+`N·W₁⟨1⟩ ⊆ W₁⟨6⟩`. The genuine missing ingredient is a general-pair
+N-invariance / (I-N)-transversality **forcing lemma** that collapses these
+to `W₁⟨0⟩=W₁⟨1⟩=W₁⟨5⟩=W₁⟨6⟩`. `nilpotent_invariant_compl_trivial_gen`
+is the wrong tool (it forces U∈{⊥,⊤}; leaf-equality holds for any
+invariant complementary pair).
+
+Confirmed this mixed case is unsolved across the **whole D̃ family**
+(d5 combo C at `FieldGenericD5Tilde.lean:925` is the identical sorry; no
+proven precedent in d5/d6/d7/d8).
+
+## Current frontier
+
+#4631 is the crux: a reusable mixed-direction forcing lemma. #4632
+(outer branches) nests it and is `blocked` on #4631.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. Ch6 affine-ADE indecomposability wall:
+the D̃₆ leaf-equalities have all-canonical + combo D proven inline; the two
+mixed v=4 cases and three outer reversed branches remain (now #4631/#4632).
+No change to global sorry counts this session (decomposition + analysis,
+no Lean edits).
+
+## Next step
+
+Claim #4631. Establish the forcing lemma first in d5
+(`d5tildeRep_kQ_leaf_equalities` combo C, `:925`) as the smaller proving
+ground, then port to d6 (`3↦4,4↦5,5↦6`). Use the center-4 product
+characterization above plus complementarity at vertices 0/1/5/6 to drive a
+dimension/transversality forcing argument (each leaf space is finite-dim
+`Fin (m+1) → F`).
+
+## Blockers
+
+None for #4631 (all infra in place: `d5tildeGammaEquiv_F`,
+`gammaInv_embed_general_F`, `cumTailSumLin(_oneSubNilp)` /
+`oneSubNilp_cumTailSumLin`, `linearEquiv_invariant_isCompl_symm_mem`,
+`d6tilde_core_F` / `d6tilde_core4_F`). #4632 blocked on #4631.


### PR DESCRIPTION
This PR adds a progress note decomposing #4578 (D̃₆ mixed-direction leaf-equality branches) into two focused sub-issues, #4631 (mixed v=4 forcing lemma + combo C / C′) and #4632 (the three outer reversed branches, depends on #4631), and records the correction to the planner's instantiation hint.

Pre-implementation analysis showed the `g.symm` (γ-equiv inverse) does not untwist the leaf-5 canonical push as #4578 assumed: it carries a residual `M = (I-N)⁻¹` twist, yielding `M·W₁⟨5⟩ = W₁⟨1⟩` (i.e. `W₁⟨5⟩ = (I-N)·W₁⟨1⟩`) rather than a clean line-up. The genuine missing ingredient is a general-pair N-invariance / transversality forcing lemma, now tracked in #4631. This mixed case is unsolved across the whole D̃ family (d5 combo C at `FieldGenericD5Tilde.lean:925` is the identical sorry), so it is genuinely multi-session. No Lean changes; documentation only.

🤖 Prepared with Claude Code