### PR TITLE
doc(Ch6 #4631): refute mixed-direction d6tilde leaf-equalities (combo C/C′)

### DIFF
--- a/progress/2026-06-14T13-50-28Z_c9d70dd8.md
+++ b/progress/2026-06-14T13-50-28Z_c9d70dd8.md
@@ -1,0 +1,58 @@
+## Accomplished
+
+Claimed #4631 (feat(Ch6 #4578 sub-A): mixed-direction v=4 forcing lemma + close
+d6tilde combo C / C′). After a counterexample-first feasibility check, **refuted
+the statement** the issue asks to prove and skipped it to `replan`.
+
+`d6tildeRep_kQ_leaf_equalities` (`FieldGenericD6Tilde.lean:606`) is FALSE in the
+two mixed-direction branches it targets:
+
+- **combo C** (`:710`, 5→4 canonical / 4→6 reversed): over ℚ at m=1 there is a
+  rep-endomorphism idempotent `P` giving a complementary invariant pair with
+  `W₁⟨0⟩ = span{(7/6,1)}` but `W₁⟨1⟩ = 0` — the claimed `⟨0⟩=⟨1⟩` fails.
+- **combo C′** (`:719`, 4→5 reversed / 6→4 canonical): `W₁⟨0⟩=W₁⟨1⟩=W₁⟨5⟩` but
+  `W₁⟨6⟩` is the `(I−N)`-twisted line — the claimed `⟨0⟩=⟨6⟩` fails.
+
+Root cause: the current single-twist `d6tildeRep_kQ` is **under-coupled**. At
+m=1 its dimension vector is `2·δ` (δ = D̃₆ null root), and for this tame quiver
+that representation is decomposable (`End` dim 4–5; explicit idempotents found).
+A reversed leaf edge removes the coupling its forward edge supplied, so the
+"forcing step" the issue postulates (N-invariance of the leaf subspaces) simply
+does not hold. This is exactly the failure mode documented in the
+`lean-formalization` skill ("Indecomposability of explicit affine-Dynkin reps …
+too weakly coupled" / "This also refutes the `*_kQ_leaf_equalities` sub-lemmas …
+only the all-canonical and all-leaves-reversed branches are provable").
+
+The same refutation applies to the d5 combo C sorry
+(`FieldGenericD5Tilde.lean:930`) and, structurally, to the d7/d8 analogs.
+
+Verification script committed at
+`progress/d6tilde-mixed-leafeq-counterexample.py` (exact arithmetic, sympy).
+
+## Current frontier
+
+#4631 skipped → `replan`. No `.lean` changes (filling the sorries would require
+proving a false statement). Counterexample script + this note added under
+`progress/`.
+
+## Overall project progress
+
+Deep depth-phase. The orientation-generic D̃ family (`dNtildeRep_kQ`) leaf-equality
+chains are partially blocked: the mixed-direction branches are unprovable on the
+current construction. The accepted fix is the homogeneous-tube redesign tracked
+in #4597 ("replaces refuted under-coupled starRep_kQ / dNtildeRep_kQ").
+
+## Next step
+
+Replan #4631 (and the parallel d5/d7/d8 `combo C` sorries) under the
+homogeneous-tube redesign #4597 rather than as forcing-lemma fills. The current
+`d6tildeRep_kQ_leaf_equalities` should either (a) be restricted to the
+all-canonical / all-leaves-reversed orientations it can actually prove, with the
+mixed branches removed, or (b) be re-stated against the redesigned tube rep from
+#4597. Do not attempt to fill `FieldGenericD6Tilde.lean:710` / `:719` against the
+current rep — they are false.
+
+## Blockers
+
+`d6tildeRep_kQ_leaf_equalities` is false in the mixed branches (design-level
+blocker, not proof difficulty). Resolution depends on the #4597 redesign.

--- a/progress/d6tilde-mixed-leafeq-counterexample.py
+++ b/progress/d6tilde-mixed-leafeq-counterexample.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Exact-arithmetic refutation of `d6tildeRep_kQ_leaf_equalities` (and the d5
+analog) in the MIXED-direction branches (combo C / combo C').
+
+Context: issue #4631 asked for a "mixed-direction forcing lemma" to close
+combo C (`FieldGenericD6Tilde.lean:710`) and combo C' (`:719`). No such lemma
+can exist: the leaf-equality statement is FALSE in those branches because the
+current under-coupled `d6tildeRep_kQ` is decomposable at m=1 (dimension vector
+2*delta, delta = D~6 null root), and some direct-sum decompositions break the
+claimed leaf equality.
+
+We exhibit, over exact arithmetic, a complementary invariant pair
+(W1 = im P, W2 = im (I-P)) for a rep-endomorphism idempotent P, with unequal
+leaf subspaces. m = 1 throughout (leaf dim = 2, center dim = 4).
+
+Run: python3 d6tilde-mixed-leafeq-counterexample.py   (needs sympy)
+
+Verified results:
+  combo C  (over Q): W1(leaf 0) = span{(7/6,1)} but W1(leaf 1) = 0  -> <0>=<1> FALSE
+  combo C' :         W1(0)=W1(1)=W1(5) but W1(6) is the (I-N)-twisted line -> <0>=<6> FALSE
+
+The fix is the homogeneous-tube redesign of the D~ family (#4597), not a
+forcing lemma on the current construction.
+"""
+import sympy as sp
+
+# m = 1. Vertices: leaves 0,1 -> center 2; path 2-3-4; leaves 5,6 -> center 4.
+dim = {0: 2, 1: 2, 2: 4, 3: 4, 4: 4, 5: 2, 6: 2}
+
+# Block maps (mirror FieldGenericStar.lean / FieldGenericD5Tilde.lean at m=1).
+e1 = sp.Matrix([[1, 0], [0, 1], [0, 0], [0, 0]])          # starEmbed1_F : x -> (x,0)
+e2 = sp.Matrix([[0, 0], [0, 0], [1, 0], [0, 1]])          # starEmbed2_F : x -> (0,x)
+sFirst = sp.Matrix([[1, 0, 0, 0], [0, 1, 0, 0]])          # starFirst_F  : (a,b)->a
+sSecond = sp.Matrix([[0, 0, 1, 0], [0, 0, 0, 1]])         # starSecond_F : (a,b)->b
+gamma = sp.Matrix([[1, 0, 1, 0], [0, 1, 0, 1],            # d5tildeGamma_F = [[I,I],[I,N]]
+                   [1, 0, 0, 1], [0, 1, 0, 0]])
+I4 = sp.eye(4)
+
+
+def endo_algebra(edges):
+    verts = list(dim)
+    sl = {}
+    o = 0
+    for v in verts:
+        sl[v] = (o, o + dim[v] ** 2)
+        o += dim[v] ** 2
+    X = sp.symbols(f'x0:{o}')
+    phi = {v: sp.Matrix(dim[v], dim[v],
+                        lambda i, j: X[sl[v][0] + i * dim[v] + j]) for v in verts}
+    eqs = [c for (a, b, M) in edges for c in list(M * phi[a] - phi[b] * M)]
+    sols = list(sp.linsolve(eqs, X))[0]
+    return X, phi, sols
+
+
+def spectral_idem(edges, pt):
+    """A rep-endomorphism idempotent P from a spectral projection of a generic
+    point `pt` of the endomorphism algebra."""
+    X, phi, sols = endo_algebra(edges)
+    free = sorted(set().union(*[s.free_symbols for s in sols]), key=lambda t: t.name)
+    sub = dict(zip(free, [sp.Rational(v) for v in pt]))
+    phic = {v: phi[v].subs(dict(zip(X, sols))).subs(sub) for v in dim}
+    lams = list(phic[2].eigenvals().keys())
+    lam, others = lams[0], [mu for mu in lams if mu != lams[0]]
+    P = {}
+    for v in dim:
+        Pv = sp.eye(dim[v])
+        for mu in others:
+            Pv = Pv * (phic[v] - mu * sp.eye(dim[v])) / (lam - mu)
+        P[v] = sp.simplify(Pv)
+    okE = all(sp.simplify(M * P[a] - P[b] * M) == sp.zeros(dim[b], dim[a])
+              for (a, b, M) in edges)
+    okI = all(sp.simplify(P[v] * P[v] - P[v]) == sp.zeros(dim[v], dim[v]) for v in dim)
+    return P, okE, okI
+
+
+def report(name, edges, pt):
+    P, okE, okI = spectral_idem(edges, pt)
+    print(f"=== {name} ===")
+    print(f"  P is rep-endomorphism: {okE}; P idempotent: {okI}")
+    for v in [0, 1, 5, 6]:
+        cs = P[v].columnspace()
+        print(f"  W1(leaf {v}) = " +
+              ("0  (zero subspace)" if not cs else f"span{list(cs[0].T)}"))
+    print()
+
+
+if __name__ == "__main__":
+    report("combo C  (5->4 canonical e1, 4->6 reversed starSecond)",
+           [(0, 2, e1), (1, 2, e2), (2, 3, gamma), (3, 4, I4),
+            (5, 4, e1), (4, 6, sSecond)], [2, 3, 5, 7, 11])
+    report("combo C' (4->5 reversed starFirst, 6->4 canonical e2)",
+           [(0, 2, e1), (1, 2, e2), (2, 3, gamma), (3, 4, I4),
+            (4, 5, sFirst), (6, 4, e2)], [2, 3, 5, 7])


### PR DESCRIPTION
This PR records the refutation of the mixed-direction branches of `d6tildeRep_kQ_leaf_equalities` (`FieldGenericD6Tilde.lean` combo C `:710` / combo C′ `:719`, issue #4631) and adds an exact-arithmetic verification script under `progress/`.

The current single-twist `d6tildeRep_kQ` is under-coupled: at m=1 its dimension vector is `2·δ` (δ = D̃₆ null root) and the representation is decomposable. Explicit complementary invariant pairs break the claimed leaf equality — combo C: `W₁⟨0⟩ = span{(7/6,1)}` but `W₁⟨1⟩ = 0` over ℚ; combo C′: `W₁⟨6⟩` is the `(I−N)`-twisted line. No mixed-direction "forcing lemma" can exist, so #4631 is routed to `replan` under the homogeneous-tube redesign #4597. The same refutation covers the d5 combo C sorry and the d7/d8 analogs.

No `.lean` changes. This does not close #4631.

🤖 Prepared with Claude Code
