### PR TITLE
feat(Ch5 #4643): decompose hpoly' det⁻¹ elimination into scalar-action + assembly pieces

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/PolynomialRepEmbedding.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialRepEmbedding.lean
@@ -763,6 +763,79 @@ theorem polynomialRep_embeds_in_tensorPower' (n : ℕ)
   exact polynomialRep_embeds_in_tensorPower k N n ρ halg
     ⟨d, b, P, hhom, hP, fun g a c' => hP_mul_of_hP k N b P ρ hP g a c'⟩
 
+/-- The scalar matrix `t • 1 ∈ GL_N(k)`.  Diagonal with the unit `t` in every
+slot; equivalently `Matrix.diagonal (fun _ => (t : k)) = (t : k) • 1`.  This is
+the element `∏ᵢ diagUnit i t` referenced in the `det⁻¹`-elimination strategy. -/
+noncomputable def scalarGL (t : kˣ) :
+    Matrix.GeneralLinearGroup (Fin N) k where
+  val := Matrix.diagonal fun _ => (t : k)
+  inv := Matrix.diagonal fun _ => ((t⁻¹ : kˣ) : k)
+  val_inv := by
+    rw [Matrix.diagonal_mul_diagonal]
+    simp only [Units.mul_inv]
+    exact Matrix.diagonal_one
+  inv_val := by
+    rw [Matrix.diagonal_mul_diagonal]
+    simp only [Units.inv_mul]
+    exact Matrix.diagonal_one
+
+/-- **Piece 1 of `det⁻¹` elimination — the scalar matrix acts by `t^n`.**
+On a weight-homogeneous-of-degree-`n` algebraic `GL_N`-representation, the scalar
+matrix `scalarGL t = t • 1` acts as the scalar `t ^ n`.
+
+Strategy (issue #4598 decomposition, Piece 1; see sub-issue for the genuine
+content): over an algebraically closed field of characteristic zero an algebraic
+representation has diagonalisable torus action, so the weight spaces span `M`
+(the missing *general* lemma `⨆ μ, glWeightSpace k N M μ = ⊤` for an arbitrary
+`IsAlgebraicRepresentation` — currently proven only for Schur modules at
+`Proposition5_22_2.glWeightSpace_schurModule_iSup_eq_top`).  On a weight space
+`M_μ` the generator `diagUnit i t` acts by `t ^ (μ i)`
+(`glWeightSpace_le_maxGenEigenspace`), so `scalarGL t = ∏ᵢ diagUnit i t` acts by
+`t ^ (∑ᵢ μ i) = t ^ n` (`h_homog`).  Hence `M.ρ (scalarGL t) = t^n • id`. -/
+private theorem scalarGL_acts_as_pow (n : ℕ)
+    [CharZero k] [IsAlgClosed k]
+    (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
+    (halg : Etingof.IsAlgebraicRepresentation N M.ρ)
+    (h_homog : ∀ μ : Fin N → ℕ, glWeightSpace k N M μ ≠ ⊥ → ∑ i, μ i = n)
+    (t : kˣ) :
+    M.ρ (scalarGL k N t) = ((t : k) ^ n) • LinearMap.id := by
+  -- TODO (issue #4653): diagonalisability of the torus action on an arbitrary
+  -- algebraic representation, i.e. `⨆ μ, glWeightSpace k N M μ = ⊤`; the
+  -- Schur-module case is `glWeightSpace_schurModule_iSup_eq_top`.
+  sorry
+
+/-- **Piece 2 of `det⁻¹` elimination — assembly given the scalar action.**
+Given that the scalar matrix acts by `t ^ n` (Piece 1, `scalarGL_acts_as_pow`),
+the algebraic-representation matrix coefficients are bare-entry polynomials in
+`Fin N × Fin N`, homogeneous of degree `n`.
+
+Strategy (issue #4598 decomposition, Piece 2; see sub-issue): each matrix
+coefficient `f_{a,c}(g) = b.repr (M.ρ g (b c)) a` satisfies `f (t • g) = t^n f(g)`
+by `h_scalar` and `M.ρ.map_mul` (since `scalarGL t * g = t • g`).  The
+algebraic-rep polynomial `P a c ∈ k[Xᵢⱼ, D]` (`evalAtGL` substitutes `D ↦
+det⁻¹`, scaling by `t^{-N}` under `g ↦ t • g`).  Writing `P a c = Q / det^r` and
+matching the `t`-degree forces `Q` homogeneous of degree `n + N r`; nonnegativity
+of the weights forces the minimal `r = 0`, so `f` is a genuine bare-entry
+polynomial homogeneous of degree `n`.  Identity over all of `GL` upgrades to a
+polynomial identity by `MvPolynomial.eq_of_eval_eq_on_gl` (cf. `hP_mul_of_hP`). -/
+private theorem hpoly'_of_scalarGL_action (n : ℕ)
+    [CharZero k] [IsAlgClosed k]
+    (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
+    (halg : Etingof.IsAlgebraicRepresentation N M.ρ)
+    (h_scalar : ∀ t : kˣ, M.ρ (scalarGL k N t) = ((t : k) ^ n) • LinearMap.id) :
+    ∃ (d : ℕ) (b : Module.Basis (Fin d) k M)
+       (P : Fin d → Fin d → MvPolynomial (Fin N × Fin N) k),
+         (∀ a c, (P a c).IsHomogeneous n) ∧
+         (∀ (g : Matrix.GeneralLinearGroup (Fin N) k) a c,
+           b.repr (M.ρ g (b c)) a =
+             MvPolynomial.eval
+               (fun ij : Fin N × Fin N =>
+                 (g : Matrix (Fin N) (Fin N) k) ij.1 ij.2)
+               (P a c)) := by
+  -- TODO (issue #4654): clear the `det⁻¹` denominator and use the scaling
+  -- behaviour to force the homogeneous degree, then `eq_of_eval_eq_on_gl`.
+  sorry
+
 /-- **Weight-homogeneity kills the `det⁻¹` variable (issue #4598 core).**
 A weight-homogeneous-of-degree-`n` algebraic `GL_N`-representation `M` has its
 matrix coefficients given, in a suitable basis, by **homogeneous degree-`n`
@@ -797,8 +870,10 @@ theorem polynomialRep_homogeneous_hpoly'
              MvPolynomial.eval
                (fun ij : Fin N × Fin N =>
                  (g : Matrix (Fin N) (Fin N) k) ij.1 ij.2)
-               (P a c)) := by
-  sorry
+               (P a c)) :=
+  -- Assemble Piece 2 (det⁻¹ elimination) over Piece 1 (scalar action).
+  hpoly'_of_scalarGL_action k N n M halg
+    (fun t => scalarGL_acts_as_pow k N n M halg h_homog t)
 
 /-- **A weight-homogeneous-of-degree-`n` algebraic `GL_N`-rep embeds
 `GL_N`-equivariantly into `(V^{⊗n})^m`** (issue #4598, FDRep-facing corollary

--- a/progress/2026-06-14T14-13-35Z_4e9aca81.md
+++ b/progress/2026-06-14T14-13-35Z_4e9aca81.md
@@ -1,0 +1,52 @@
+## Accomplished
+
+Session type: feature (/work → /feature on #4643).
+
+- Triaged the unclaimed queue. **Flagged #4528 as unworkable**: it asks to fill
+  the body of `starRep_kQ_isIndecomposable`, but #4597 documents a
+  machine-checked refutation (`starRep_kQ_reversedLeaf3_decomposable`, PR #4589)
+  proving that lemma false. Added a triage comment + `replan` label.
+- Enabled auto-merge on PR #4646 (CI was in progress); it has since merged.
+- Confirmed Mathlib PR #38583 (`eq_of_eval_eq_on_gl`) **merged via Bors** — so
+  tracker #2564 is now actionable (but is a low-priority, risky revision bump).
+- Claimed and **decomposed #4643** (Ch5 #4598 core, `det⁻¹` elimination):
+  - Added a sorry-free `def scalarGL k N t = Matrix.diagonal (fun _ => (t:k))`
+    (the `t • 1` of the strategy).
+  - Rewrote `polynomialRep_homogeneous_hpoly'` as a **sorry-free assembly** over
+    two private helpers, matching the issue's own "two separable pieces":
+    - `scalarGL_acts_as_pow` (Piece 1): `M.ρ (scalarGL t) = t^n • id`. Sorry'd;
+      its genuine content is the general weight-span lemma
+      `⨆ μ, glWeightSpace k N M μ = ⊤` for arbitrary `IsAlgebraicRepresentation`
+      (only known for Schur modules). → sub-issue **#4653**.
+    - `hpoly'_of_scalarGL_action` (Piece 2): `det⁻¹` elimination given the scalar
+      action (independent of Piece 1 — takes it as a hypothesis). Sorry'd.
+      → sub-issue **#4654**.
+- `lake build EtingofRepresentationTheory.Chapter5.PolynomialRepEmbedding` passes.
+
+## Current frontier
+
+`polynomialRep_homogeneous_hpoly'` is a clean assembly; the two mathematical
+pieces are isolated, documented, and independently claimable (#4653, #4654).
+
+## Overall project progress
+
+Stage 3 (formalization). Schur-Weyl chain: #4598 interface landed; #4643's core
+now decomposed into Piece 1 (#4653) + Piece 2 (#4654). #2482 (Schur-Weyl #5
+assembly) consumes the equivariant embedding downstream.
+
+## Next step
+
+Claim **#4653** (general torus diagonalisability / weight-span — the reusable
+GL_N rep-theory lemma; the harder, higher-leverage piece) or **#4654** (the
+det⁻¹-elimination assembly, self-contained given the scalar-action hypothesis).
+
+## Blockers
+
+None new. #4653 is genuine GL_N representation-theory infrastructure
+(diagonalisability of algebraic torus actions); budget accordingly.
+
+## Quality metric delta
+
+PolynomialRepEmbedding.lean: 1 sorry → 2 sorries (decomposition: +1 sorry, but
+the monolithic core split into two scoped, documented, independently-claimable
+sorries plus one new sorry-free `def`).


### PR DESCRIPTION
Partial progress on #4643

Session: `4e9aca81-6d9f-46da-b3f6-15bb929d1440`

e8d42d67 feat(Ch5 #4643): decompose polynomialRep_homogeneous_hpoly' det⁻¹ elimination into scalar-action + assembly pieces

🤖 Prepared with Claude Code