### PR TITLE
doc(skill): note _kQ rep obj-projection opacity + explicit-carrier workaround

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -217,6 +217,15 @@ Mathlib.GroupTheory.GroupAction.Basic
 
 **When Mathlib doesn't have it:** This is the most important work in the project — prove it here. Check the `.refs.md` file for the item. If coverage is "gap", build the definition and proof from scratch. These are the highest-priority items, not items to defer. If the book proves the result (or assigns it as an exercise with hints), follow the book's approach. If it's genuinely external mathematics, prove it anyway — that's what this project is for.
 
+### `_kQ` rep `obj` projection does not reduce in signatures (sporadic tube family)
+
+The per-(field, orientation) reps `<X>Rep_kQ` (`FieldGeneric{Star,D5/6/7Tilde,ETilde6/7,T125,Tube}.lean`) are built tactically: `noncomputable def … := by letI := Q; exact { obj := fun v => Fin (<X>Dim m v) → F, … }`. The structure projection `(<X>Rep_kQ …).obj ⟨v, _⟩` does **not** reduce to `Fin (k·(m+1)) → F` under the transparency that `Membership`-instance synthesis uses. Consequences when stating lemmas over the rep family `W : ∀ v, Submodule F ((<X>Rep_kQ …).obj v)`:
+
+- A **top-level signature** with a concrete-element membership — `∀ (x : Fin (k·(m+1)) → F), x ∈ W ⟨v, _⟩ → …` — fails to elaborate (`failed to synthesize Membership (Fin … → F) (Submodule F ((…).obj ⟨v, ?⟩))`). Equalities/`≤` between two `W ⟨v⟩` only typecheck when the two vertices share a dim (e.g. the four dim-`(m+1)` leaves of the D̃ family); for distinct-dim vertices (e.g. T(1,2,5)) they don't.
+- `(…).obj ⟨v,_⟩ = (Fin (<X>Dim m ⟨v,_⟩) → F) := rfl` ✓ (projection reduces with `<X>Dim` symbolic), but `… = (Fin (k·(m+1)) → F) := rfl` ✗ (the `<X>Dim` match won't reduce in the same step).
+
+**Workarounds.** (1) State reusable arm/flag helpers over **explicit `Fin (k·(m+1)) → F` carriers** plus per-edge hypotheses (as `t125_prefix_sub` / `t125_canonical_collapse` do) — these elaborate cleanly. (2) Do the `W ⟨v⟩` → explicit-carrier bridge **inside a proof body**, where `simp only [<X>Rep_kQ, <X>RepMap_kQ]` unfolds the rep and concrete memberships elaborate at default transparency (this is why the local `core`/`leaf*_sub` haves inside `starTubeRepGen_isIndecomposable` work). Do not try to expose a rep-level `…_leaf_equalities` theorem whose *conclusion* carries concrete memberships; assemble that content in the consuming indecomposability proof instead.
+
 ## Scaffolding Anti-Patterns
 
 These patterns were discovered during Chapter 2 and 7-8 reviews. Avoid them in all scaffolding work.

--- a/EtingofRepresentationTheory/Chapter6/FieldGenericT125.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericT125.lean
@@ -470,6 +470,91 @@ theorem t125_suffix_sub
     rwa [suffixBlockEmbed_comp_F F 2 3 6 m (by omega) (by omega)] at h
   exact ⟨h5, h6, h7, fun x hx => h7 _ (hW_87 x hx)⟩
 
+/-! ## Section 3c: All-canonical arm→center collapse spine (sub-B2 of #4612, #4620)
+
+The all-canonical orientation branch of the leaf-collapse: every arm flag
+points toward the center (`1→0`, `3→2→0`, `8→7→6→5→4→0`). Given the eight
+raw per-edge invariance facts for a single invariant family, every
+non-center vertex's subspace lands in the center along its composite arm
+embedding. This folds the sub-B1 flag helpers (`t125_prefix_sub`,
+`t125_suffix_sub`) over the arm-2 prefix and arm-3 suffix flags, and passes
+the arm-1 eigenvalue-tube push through unchanged.
+
+**Why this is stated over explicit `Fin (k·(m+1)) → F` carriers** (not the
+rep family `W : ∀ v, Submodule F ((t125Rep_kQ …).obj v)`): the structure
+projection `(t125Rep_kQ …).obj ⟨v, …⟩` does not reduce under the
+type-class-instance transparency used by `Membership` synthesis, so a
+hypothesis or goal of the form `(x : Fin (k·(m+1)) → F) ∈ W ⟨v⟩` fails to
+elaborate in a top-level signature (the `obj` carrier and the concrete
+`Fin` type never unify, even though they are propositionally — and, with
+`t125Dim` kept symbolic, definitionally — equal). The same wall blocks a
+rep-level `t125Rep_kQ_leaf_equalities`; the bridge from `W ⟨v⟩` to these
+explicit carriers must therefore be performed *inside* the indecomposability
+proof (sub-C, #4613), where `simp only [t125Rep_kQ, t125RepMap_kQ]` unfolds
+the rep and the per-edge facts elaborate (exactly as the local `core` /
+`leaf*_sub` haves do inside `starTubeRepGen_isIndecomposable`,
+`FieldGenericTube.lean`). This matches the explicit-carrier style of the
+landed sub-B1 helpers. -/
+
+/-- **All-canonical arm→center collapse spine** (explicit-carrier form).
+From the eight canonical per-edge containments (arm-1 eigenvalue tube push
+`1→0`; arm-2 prefix pushes `3→2`, `2→0`; arm-3 suffix pushes `8→7`, `7→6`,
+`6→5`, `5→4`, `4→0`), derive that every non-center vertex embeds into the
+center `W0` along its full arm flag. The arm-2 leaf (`W3`) and arm-3 vertices
+(`W5`–`W8`) are folded through the flags by `t125_prefix_sub` /
+`t125_suffix_sub`; the arm-1 (`W1`), arm-2 inner (`W2`) and arm-3 deepest
+(`W4`) containments are the corresponding hypotheses verbatim. -/
+theorem t125_canonical_collapse
+    (F : Type) [Field F] (lam : F) (m : ℕ)
+    (W0 : Submodule F (Fin (6 * (m + 1)) → F))
+    (W1 : Submodule F (Fin (3 * (m + 1)) → F))
+    (W2 : Submodule F (Fin (4 * (m + 1)) → F))
+    (W3 : Submodule F (Fin (2 * (m + 1)) → F))
+    (W4 : Submodule F (Fin (5 * (m + 1)) → F))
+    (W5 : Submodule F (Fin (4 * (m + 1)) → F))
+    (W6 : Submodule F (Fin (3 * (m + 1)) → F))
+    (W7 : Submodule F (Fin (2 * (m + 1)) → F))
+    (W8 : Submodule F (Fin (m + 1) → F))
+    (h10 : ∀ (x : Fin (3 * (m + 1)) → F), x ∈ W1 →
+        t125Arm1Tube_F F lam m x ∈ W0)
+    (h32 : ∀ (x : Fin (2 * (m + 1)) → F), x ∈ W3 →
+        prefixBlockEmbed_F F 2 4 m x ∈ W2)
+    (h20 : ∀ (x : Fin (4 * (m + 1)) → F), x ∈ W2 →
+        prefixBlockEmbed_F F 4 6 m x ∈ W0)
+    (h87 : ∀ (x : Fin (m + 1) → F), x ∈ W8 →
+        starEmbed2_F F m x ∈ W7)
+    (h76 : ∀ (x : Fin (2 * (m + 1)) → F), x ∈ W7 →
+        suffixBlockEmbed_F F 2 3 m x ∈ W6)
+    (h65 : ∀ (x : Fin (3 * (m + 1)) → F), x ∈ W6 →
+        suffixBlockEmbed_F F 3 4 m x ∈ W5)
+    (h54 : ∀ (x : Fin (4 * (m + 1)) → F), x ∈ W5 →
+        suffixBlockEmbed_F F 4 5 m x ∈ W4)
+    (h40 : ∀ (x : Fin (5 * (m + 1)) → F), x ∈ W4 →
+        suffixBlockEmbed_F F 5 6 m x ∈ W0) :
+    -- arm 1 (eigenvalue tube): v1 → center
+    (∀ (x : Fin (3 * (m + 1)) → F), x ∈ W1 →
+        t125Arm1Tube_F F lam m x ∈ W0) ∧
+    -- arm 2 (prefix flag): v2, v3 → center
+    (∀ (x : Fin (4 * (m + 1)) → F), x ∈ W2 →
+        prefixBlockEmbed_F F 4 6 m x ∈ W0) ∧
+    (∀ (x : Fin (2 * (m + 1)) → F), x ∈ W3 →
+        prefixBlockEmbed_F F 2 6 m x ∈ W0) ∧
+    -- arm 3 (suffix flag): v4, v5, v6, v7, v8 → center
+    (∀ (x : Fin (5 * (m + 1)) → F), x ∈ W4 →
+        suffixBlockEmbed_F F 5 6 m x ∈ W0) ∧
+    (∀ (x : Fin (4 * (m + 1)) → F), x ∈ W5 →
+        suffixBlockEmbed_F F 4 6 m x ∈ W0) ∧
+    (∀ (x : Fin (3 * (m + 1)) → F), x ∈ W6 →
+        suffixBlockEmbed_F F 3 6 m x ∈ W0) ∧
+    (∀ (x : Fin (2 * (m + 1)) → F), x ∈ W7 →
+        suffixBlockEmbed_F F 2 6 m x ∈ W0) ∧
+    (∀ (x : Fin (m + 1) → F), x ∈ W8 →
+        suffixBlockEmbed_F F 2 6 m (starEmbed2_F F m x) ∈ W0) := by
+  have hpre := t125_prefix_sub F m W0 W2 W3 h32 h20
+  obtain ⟨hsuf5, hsuf6, hsuf7, hsuf8⟩ :=
+    t125_suffix_sub F m W0 W4 W5 W6 W7 W8 h87 h76 h65 h54 h40
+  exact ⟨h10, h20, hpre, h40, hsuf5, hsuf6, hsuf7, hsuf8⟩
+
 /-! ## Section 4: Indecomposability (corrected homogeneous tube)
 
 `t125Rep_kQ` is now the genuine homogeneous tube `R_λ^{(m+1)}` at the

--- a/progress/2026-06-14T14-15-11Z_f8c4ae8a.md
+++ b/progress/2026-06-14T14-15-11Z_f8c4ae8a.md
@@ -1,0 +1,67 @@
+## Accomplished
+
+Worker session on **#4620** (sub-B2 of #4612): the all-canonical
+`t125Rep_kQ_leaf_equalities` assembly for T(1,2,5) = Ẽ₈.
+
+Landed the sorry-free **`t125_canonical_collapse`** in
+`Chapter6/FieldGenericT125.lean` (Section 3c): from the eight canonical
+per-edge invariance facts (arm-1 eigenvalue tube push `1→0`; arm-2 prefix
+pushes `3→2`, `2→0`; arm-3 suffix pushes `8→7`, `7→6`, `6→5`, `5→4`,
+`4→0`) it derives that every non-center vertex embeds into the center along
+its full arm flag, folding the sub-B1 helpers `t125_prefix_sub` /
+`t125_suffix_sub`. `lake build FieldGenericT125` passes; sorry count
+unchanged (the one pre-existing sorry is `t125Rep_kQ_isIndecomposable`).
+
+## Current frontier
+
+Key finding (the reason this is a **partial**): the rep-level interface
+`t125Rep_kQ_leaf_equalities` envisioned by the issue (concluding
+concrete-element memberships `(x : Fin (k·(m+1)) → F) ∈ W₁ ⟨v⟩`) **cannot
+be stated as a top-level signature**. The structure projection
+`(t125Rep_kQ …).obj ⟨v, …⟩` of the `by letI := Q; exact {…}` representation
+does not reduce under the type-class-instance transparency used by
+`Membership` synthesis, so the concrete `Fin` element type never unifies
+with the `obj` carrier. Empirically:
+
+- `(t125Rep_kQ …).obj ⟨0,_⟩ = (Fin (t125Dim m ⟨0,_⟩) → F) := rfl` ✓
+  (projection reduces with `t125Dim` symbolic)
+- `… = (Fin (6*(m+1)) → F) := rfl` ✗ (full match-reduction fails)
+- a signature hypothesis `∀ (x : Fin (2*(m+1))→F), x ∈ W ⟨3,_⟩ → …` ✗
+- the sub-B1 docstring's claimed `t125_prefix_sub … (W ⟨0⟩) (W ⟨2⟩) …`
+  call pattern ✗ (same wall)
+
+The membership *does* work **inside a proof body** (as the local
+`core`/`leaf*_sub` haves of `starTubeRepGen_isIndecomposable` show), because
+`simp only [t125Rep_kQ, t125RepMap_kQ]` unfolds the rep there. Hence the
+explicit-`Fin`-carrier form is the only one that elaborates at top level —
+matching the landed sub-B1 helpers — and the rep→carrier bridge belongs
+inside the sub-C (#4613) indecomposability proof.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing; sporadic affine tube family (D̃/Ẽ) is the
+active frontier. T(1,2,5) sub-B1 (#4619, flag helpers) + sub-B2 collapse
+core (this) landed; sub-B3 (#4621, non-canonical case tree), sub-C (#4613,
+indecomposability), and the rep-level wiring remain.
+
+## Next step
+
+For a planner: re-scope #4620. The all-canonical *collapse assembly* is
+done (`t125_canonical_collapse`). What remains of "rep-level
+`t125Rep_kQ_leaf_equalities`" should be folded into sub-C (#4613), since the
+W⟨v⟩→carrier bridge only elaborates inside the indecomposability proof.
+sub-B3 (#4621, non-canonical orientations) likewise should target the
+explicit-carrier collapse, not a rep-level signature.
+
+For sub-C (#4613): inside the proof, extract per-edge facts via
+`simp only [t125Rep_kQ, t125RepMap_kQ]`, then feed them to
+`t125_canonical_collapse` (passing `W₁ ⟨v⟩` works at default transparency
+inside the proof). Run it on both complementary summands, then do the
+cross-arm disentangling at the center (the arm-1 moment-curve core, #4633)
+and the `eigenvalue_jordan_invariant_compl_trivial_gen` reduction.
+
+## Blockers
+
+None hard. The obj-projection-opacity finding reshapes the interface
+(explicit carriers, bridge inside proofs) but does not block forward
+progress; it is documented in the code and the #4620 PR/issue comment.


### PR DESCRIPTION
This PR records, in the `lean-formalization` skill, the elaboration gotcha discovered while landing the T(1,2,5) collapse spine (#4620, PR #4657): the tactically-built `<X>Rep_kQ` reps have an `obj` projection that does not reduce under `Membership`-instance transparency, so concrete-element memberships `x ∈ W ⟨v⟩` fail in top-level signatures but work inside proof bodies after `simp [<X>Rep_kQ, <X>RepMap_kQ]`. The note gives the two workarounds (explicit-`Fin`-carrier helpers; bridge inside the proof) so future sporadic-tube workers don't rediscover it.

🤖 Prepared with Claude Code