### PR TITLE
feat(Ch5 #2708 sub-A): special-block existence/uniqueness — the unique Schur-Weyl block labeled weightToPartition (character crux)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5.lean
+++ b/EtingofRepresentationTheory/Chapter5.lean
@@ -104,6 +104,7 @@ import EtingofRepresentationTheory.Chapter5.SchurWeylPolynomialIdentity
 -- Section 5.23: Algebraic Representations of GL(V)
 import EtingofRepresentationTheory.Chapter5.Definition5_23_1
 import EtingofRepresentationTheory.Chapter5.Theorem5_23_2
+import EtingofRepresentationTheory.Chapter5.SchurModuleSpecialBlock
 import EtingofRepresentationTheory.Chapter5.PolynomialGLDecomposition
 
 -- Section 5.25: Representations of GL₂(𝔽_q)

--- a/EtingofRepresentationTheory/Chapter5/SchurModuleSpecialBlock.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurModuleSpecialBlock.lean
@@ -48,7 +48,7 @@ theorem youngSymEndomorphism_ne_zero (N : ℕ) (lam : Fin N → ℕ) (hlam : Ant
 /-! ## The character-determines-module gap (cited dependency)
 
 This is the only genuinely character-theoretic ingredient of the special-block
-lemma still open. See issue tracker for the dedicated follow-up. -/
+lemma still open. Tracked as the dedicated follow-up issue #4679. -/
 
 set_option maxHeartbeats 800000 in
 set_option synthInstance.maxHeartbeats 400000 in
@@ -81,6 +81,9 @@ theorem simpleSymGroupImageSubmodule_iso_of_spechtCharacter_eq
             (fun _ hv => symGroupAction_mem_of_symGroupImage_submodule S' σ hv)) =
           spechtModuleCharacter n la σ) :
     Nonempty (↥S ≃ₗ[↥(symGroupImage ℂ (Fin N → ℂ) n)] ↥S') := by
+  -- Cited dependency, tracked as issue #4679: classify each restrictScalars
+  -- module as a Specht module, use Specht character injectivity to pin both
+  -- labels to `la`, then transfer the SymGroupAlgebra-iso to a symGroupImage-iso.
   sorry
 
 /-! ## Existence and uniqueness of the special block -/

--- a/EtingofRepresentationTheory/Chapter5/SchurModuleSpecialBlock.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurModuleSpecialBlock.lean
@@ -1,0 +1,229 @@
+import Mathlib
+import EtingofRepresentationTheory.Chapter5.Theorem5_22_1
+import EtingofRepresentationTheory.Chapter5.Theorem5_23_2
+
+/-!
+# Theorem 5.22.1 (Schur-Weyl L_i, part C-4a sub-A): the special Schur-Weyl block
+
+This file isolates the one genuinely character-theoretic fact required to assemble
+`schurModuleSubmodule_isSimple_centralizer` (the C-4a aggregation) from
+`image_of_primitive_idempotent_isSimple_centralizer`: among the simple blocks of
+the Schur-Weyl bimodule decomposition of `V^⊗n`, there is a **unique** block whose
+Specht-module label is `weightToPartition N lam`.
+
+The two halves of the statement reduce to:
+
+* **Existence** of a `weightToPartition`-labelled block. By contraposition: if *every*
+  block carried a label `≠ weightToPartition`, off-block vanishing
+  (`youngSym_action_vanishes_off_block`) plus block factorization
+  (`youngSym_block_factorization`) would force `youngSymEndomorphism ℂ N lam = 0`,
+  contradicting `youngSymEndomorphism_ne_zero` (proved here from
+  `schurModuleSubmodule_ne_bot`, i.e. the Weyl character formula `ch(L_λ) = s_λ ≠ 0`).
+
+* **Uniqueness** (at most one `weightToPartition`-labelled block). Two simple
+  `symGroupImage`-submodules with the same Specht character are isomorphic as
+  `symGroupImage`-modules, hence equal by the decomposition's distinctness clause.
+  This "character determines the module over ℂ" step is the single remaining gap,
+  isolated as `simpleSymGroupImageSubmodule_iso_of_spechtCharacter_eq` below.
+-/
+
+noncomputable section
+
+namespace Etingof
+
+open scoped TensorProduct
+
+/-! ## Nonvanishing of the Young symmetrizer endomorphism -/
+
+/-- The Young symmetrizer endomorphism on `(ℂ^N)^{⊗n}` is nonzero whenever `lam` is
+antitone. Its range is `SchurModuleSubmodule ℂ N lam`, which is nonzero by the Weyl
+character formula `ch(L_λ) = s_λ ≠ 0` (`schurModuleSubmodule_ne_bot`). -/
+theorem youngSymEndomorphism_ne_zero (N : ℕ) (lam : Fin N → ℕ) (hlam : Antitone lam) :
+    youngSymEndomorphism ℂ N lam ≠ 0 := by
+  intro h
+  apply schurModuleSubmodule_ne_bot (k := ℂ) N lam hlam
+  change LinearMap.range (youngSymEndomorphism ℂ N lam) = ⊥
+  rw [h, LinearMap.range_zero]
+
+/-! ## The character-determines-module gap (cited dependency)
+
+This is the only genuinely character-theoretic ingredient of the special-block
+lemma still open. See issue tracker for the dedicated follow-up. -/
+
+set_option maxHeartbeats 800000 in
+set_option synthInstance.maxHeartbeats 400000 in
+/-- **Character determines the module over ℂ.** Two simple `symGroupImage`-submodules
+`S, S' ≤ V^⊗n` whose `σ`-trace functions both equal `spechtModuleCharacter n la`
+are isomorphic as `symGroupImage`-modules.
+
+Route (deferred): transport `S.restrictScalars ℂ`, `S'.restrictScalars ℂ` to simple
+`SymGroupAlgebra n`-modules (`submoduleAsSymGroupAlgebra_isSimpleModule`), classify
+each as `spechtModule` of its label (Theorem 5.12.2), use linear independence of
+irreducible characters to pin both labels to `la` (so the Specht modules coincide),
+then transfer the resulting `SymGroupAlgebra`-iso back through the surjection
+`symGroupAlgHomToImage` to a `symGroupImage`-iso. -/
+theorem simpleSymGroupImageSubmodule_iso_of_spechtCharacter_eq
+    {N n : ℕ}
+    (S S' : Submodule (symGroupImage ℂ (Fin N → ℂ) n) (TensorPower ℂ (Fin N → ℂ) n))
+    [IsSimpleModule (↥(symGroupImage ℂ (Fin N → ℂ) n)) ↥S]
+    [IsSimpleModule (↥(symGroupImage ℂ (Fin N → ℂ) n)) ↥S']
+    (la : Nat.Partition n)
+    (hS : ∀ σ : Equiv.Perm (Fin n),
+        LinearMap.trace ℂ ↥(S.restrictScalars ℂ)
+          ((symGroupAction ℂ (Fin N → ℂ) n σ).toLinearMap.restrict
+            (p := S.restrictScalars ℂ) (q := S.restrictScalars ℂ)
+            (fun _ hv => symGroupAction_mem_of_symGroupImage_submodule S σ hv)) =
+          spechtModuleCharacter n la σ)
+    (hS' : ∀ σ : Equiv.Perm (Fin n),
+        LinearMap.trace ℂ ↥(S'.restrictScalars ℂ)
+          ((symGroupAction ℂ (Fin N → ℂ) n σ).toLinearMap.restrict
+            (p := S'.restrictScalars ℂ) (q := S'.restrictScalars ℂ)
+            (fun _ hv => symGroupAction_mem_of_symGroupImage_submodule S' σ hv)) =
+          spechtModuleCharacter n la σ) :
+    Nonempty (↥S ≃ₗ[↥(symGroupImage ℂ (Fin N → ℂ) n)] ↥S') := by
+  sorry
+
+/-! ## Existence and uniqueness of the special block -/
+
+set_option maxHeartbeats 3200000 in
+set_option synthInstance.maxHeartbeats 1200000 in
+/-- If `youngSymEndomorphism ℂ N lam` vanishes on every block `S i` of a bimodule
+decomposition `e`, then it is the zero endomorphism. The block factorization
+`youngSym_block_factorization` shows that, through `e`, `youngSymEndomorphism` acts on
+block `i` by `(youngSymElement • -) ⊗ id`; vanishing on each `S i` kills the first
+factor, hence the whole map on the spanning pure tensors `e.symm (of i (v ⊗ₜ l))`. -/
+private theorem youngSymEndomorphism_eq_zero_of_blocks_vanish
+    (N : ℕ) (lam : Fin N → ℕ)
+    {ι : Type} [DecidableEq ι]
+    (S : ι → Submodule (symGroupImage ℂ (Fin N → ℂ) (∑ i, lam i))
+      (TensorPower ℂ (Fin N → ℂ) (∑ i, lam i)))
+    (e : TensorPower ℂ (Fin N → ℂ) (∑ i, lam i) ≃ₗ[ℂ]
+      DirectSum ι (fun i => ↥(S i) ⊗[ℂ]
+        (↥(S i) →ₗ[↥(symGroupImage ℂ (Fin N → ℂ) (∑ i, lam i))]
+          TensorPower ℂ (Fin N → ℂ) (∑ i, lam i))))
+    (he : ∀ (i : ι) (v : ↥(S i))
+        (l : ↥(S i) →ₗ[↥(symGroupImage ℂ (Fin N → ℂ) (∑ i, lam i))]
+          TensorPower ℂ (Fin N → ℂ) (∑ i, lam i)),
+      e.symm (DirectSum.of _ i (v ⊗ₜ[ℂ] l)) = l v)
+    (hvanish : ∀ (i : ι) (v : ↥(S i)), youngSymEndomorphism ℂ N lam v.val = 0) :
+    youngSymEndomorphism ℂ N lam = 0 := by
+  have hcomp : (youngSymEndomorphism ℂ N lam) ∘ₗ e.symm.toLinearMap = 0 := by
+    apply DirectSum.linearMap_ext
+    intro i
+    apply TensorProduct.ext'
+    intro v l
+    simp only [LinearMap.comp_apply, LinearMap.zero_comp, LinearMap.zero_apply,
+      DirectSum.lof_eq_of]
+    have hbf := youngSym_block_factorization ℂ N lam S e he i v l
+    have hzero : youngSymElement ℂ N lam • v = 0 := by
+      apply Subtype.ext
+      rw [Submodule.coe_smul, ZeroMemClass.coe_zero, Subalgebra.smul_def,
+        Module.End.smul_def, youngSymElement_val]
+      exact hvanish i v
+    rw [hzero, TensorProduct.zero_tmul, map_zero] at hbf
+    have := congrArg e.symm hbf
+    rwa [e.symm_apply_apply, map_zero] at this
+  refine LinearMap.ext fun x => ?_
+  have hx := LinearMap.congr_fun hcomp (e x)
+  rw [LinearMap.zero_apply, LinearMap.comp_apply] at hx
+  rwa [LinearEquiv.coe_coe, e.symm_apply_apply] at hx
+
+set_option maxHeartbeats 1600000 in
+set_option synthInstance.maxHeartbeats 400000 in
+/-- **The unique special Schur-Weyl block.**
+
+Given the explicit bimodule decomposition `(S, hSimp, hDist, hSfin, e, he)` of
+`V^⊗n` (from `Theorem5_18_4_bimodule_decomposition_explicit` over `ℂ`,
+`V = Fin N → ℂ`), there is a unique block index `iLam` whose Specht-module label is
+`weightToPartition N lam`: the trace on `S iLam` realises
+`spechtModuleCharacter (∑ i, lam i) (weightToPartition N lam)`, while every other
+block carries a label `≠ weightToPartition N lam`.
+
+This is sub-A of the C-4a aggregation `schurModuleSubmodule_isSimple_centralizer`;
+sub-B feeds the two conjuncts to the off-block (β.3) and rank-1 (γ) analyses. -/
+theorem exists_unique_special_block
+    (N : ℕ) (lam : Fin N → ℕ) (hlam : Antitone lam)
+    {ι : Type} [Fintype ι] [DecidableEq ι]
+    (S : ι → Submodule (symGroupImage ℂ (Fin N → ℂ) (∑ i, lam i))
+      (TensorPower ℂ (Fin N → ℂ) (∑ i, lam i)))
+    (hSimp : ∀ i, IsSimpleModule (↥(symGroupImage ℂ (Fin N → ℂ) (∑ i, lam i))) ↥(S i))
+    (hDist : ∀ i j,
+      Nonempty (↥(S i) ≃ₗ[↥(symGroupImage ℂ (Fin N → ℂ) (∑ i, lam i))] ↥(S j)) → i = j)
+    (hSfin : ∀ i, Module.Finite ℂ ↥(S i))
+    (e : TensorPower ℂ (Fin N → ℂ) (∑ i, lam i) ≃ₗ[ℂ]
+      DirectSum ι (fun i => ↥(S i) ⊗[ℂ]
+        (↥(S i) →ₗ[↥(symGroupImage ℂ (Fin N → ℂ) (∑ i, lam i))]
+          TensorPower ℂ (Fin N → ℂ) (∑ i, lam i))))
+    (he : ∀ (i : ι) (v : ↥(S i))
+        (l : ↥(S i) →ₗ[↥(symGroupImage ℂ (Fin N → ℂ) (∑ i, lam i))]
+          TensorPower ℂ (Fin N → ℂ) (∑ i, lam i)),
+      e.symm (DirectSum.of _ i (v ⊗ₜ[ℂ] l)) = l v) :
+    ∃ iLam : ι,
+      (∀ σ : Equiv.Perm (Fin (∑ i, lam i)),
+        LinearMap.trace ℂ ↥((S iLam).restrictScalars ℂ)
+          ((symGroupAction ℂ (Fin N → ℂ) (∑ i, lam i) σ).toLinearMap.restrict
+            (p := (S iLam).restrictScalars ℂ) (q := (S iLam).restrictScalars ℂ)
+            (fun _ hv => symGroupAction_mem_of_symGroupImage_submodule (S iLam) σ hv)) =
+          spechtModuleCharacter (∑ i, lam i) (weightToPartition N lam) σ) ∧
+      (∀ i, i ≠ iLam → ∃ la' : Nat.Partition (∑ i, lam i),
+        la' ≠ weightToPartition N lam ∧
+        ∀ σ : Equiv.Perm (Fin (∑ i, lam i)),
+          LinearMap.trace ℂ ↥((S i).restrictScalars ℂ)
+            ((symGroupAction ℂ (Fin N → ℂ) (∑ i, lam i) σ).toLinearMap.restrict
+              (p := (S i).restrictScalars ℂ) (q := (S i).restrictScalars ℂ)
+              (fun _ hv => symGroupAction_mem_of_symGroupImage_submodule (S i) σ hv)) =
+            spechtModuleCharacter (∑ i, lam i) la' σ) := by
+  -- Per-block Specht labels with the trace property (β.2).
+  have hlabexists : ∀ i, ∃ la' : Nat.Partition (∑ i, lam i),
+      ∀ σ : Equiv.Perm (Fin (∑ i, lam i)),
+        LinearMap.trace ℂ ↥((S i).restrictScalars ℂ)
+          ((symGroupAction ℂ (Fin N → ℂ) (∑ i, lam i) σ).toLinearMap.restrict
+            (p := (S i).restrictScalars ℂ) (q := (S i).restrictScalars ℂ)
+            (fun _ hv => symGroupAction_mem_of_symGroupImage_submodule (S i) σ hv)) =
+          spechtModuleCharacter (∑ i, lam i) la' σ := by
+    intro i
+    haveI := hSimp i
+    exact trace_symGroupAction_eq_spechtModuleCharacter (S i)
+  choose lab hlab using hlabexists
+  -- Uniqueness: distinct blocks carry distinct labels.
+  have hUniq : ∀ i j, lab i = lab j → i = j := by
+    intro i j hij
+    haveI := hSimp i
+    haveI := hSimp j
+    apply hDist i j
+    apply simpleSymGroupImageSubmodule_iso_of_spechtCharacter_eq (S i) (S j) (lab i)
+      (hlab i)
+    intro σ
+    rw [hij]
+    exact hlab j σ
+  -- Existence: some block carries the label `weightToPartition N lam`.
+  have hExists : ∃ iLam, lab iLam = weightToPartition N lam := by
+    by_contra hcon
+    push_neg at hcon
+    -- Every block: `youngSymEndomorphism` vanishes on `S i` (β.3).
+    have hvanish : ∀ (i : ι) (v : ↥(S i)),
+        youngSymEndomorphism ℂ N lam v.val = 0 := by
+      intro i v
+      haveI := hSimp i
+      haveI : Module.Finite ℂ ↥((S i).restrictScalars ℂ) := hSfin i
+      have hr := youngSym_action_vanishes_off_block N lam (S i) (lab i) (hlab i) (hcon i)
+      have hv0 := LinearMap.congr_fun hr v
+      rw [LinearMap.zero_apply] at hv0
+      have := congrArg Subtype.val hv0
+      rwa [LinearMap.restrict_coe_apply, ZeroMemClass.coe_zero] at this
+    -- Block factorization forces `youngSymEndomorphism ℂ N lam = 0`.
+    exact youngSymEndomorphism_ne_zero N lam hlam
+      (youngSymEndomorphism_eq_zero_of_blocks_vanish N lam S e he hvanish)
+  obtain ⟨iLam, hLamEq⟩ := hExists
+  refine ⟨iLam, ?_, ?_⟩
+  · intro σ
+    have := hlab iLam σ
+    rwa [hLamEq] at this
+  · intro i hi
+    refine ⟨lab i, ?_, hlab i⟩
+    intro hcontra
+    exact hi (hUniq i iLam (hcontra.trans hLamEq.symm))
+
+end Etingof
+
+end

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
@@ -736,7 +736,7 @@ theorem youngSym_block_factorization
 
 /-- A `symGroupImage`-stable submodule of `V^⊗n` is preserved by every
 permutation operator (viewed as the linear endomorphism `symGroupAction σ`). -/
-private lemma symGroupAction_mem_of_symGroupImage_submodule
+lemma symGroupAction_mem_of_symGroupImage_submodule
     {k : Type*} [Field k] {N n : ℕ}
     (S : Submodule (symGroupImage k (Fin N → k) n)
       (TensorPower k (Fin N → k) n))

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_23_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_23_2.lean
@@ -229,7 +229,7 @@ private theorem schurPoly_ne_zero (N : ℕ) (lam : Fin N → ℕ) (hlam : Antito
 
 -- The SchurModuleSubmodule is nonzero for any antitone weight.
 -- Uses the Weyl character formula: ch(L_λ) = s_λ ≠ 0.
-private theorem schurModuleSubmodule_ne_bot (N : ℕ) (lam : Fin N → ℕ) (hlam : Antitone lam) :
+theorem schurModuleSubmodule_ne_bot (N : ℕ) (lam : Fin N → ℕ) (hlam : Antitone lam) :
     SchurModuleSubmodule k N lam ≠ ⊥ := by
   intro h
   -- If SchurModuleSubmodule = ⊥, the Schur module is zero

--- a/progress/2026-06-14T16-20-28Z_5e626950.md
+++ b/progress/2026-06-14T16-20-28Z_5e626950.md
@@ -1,0 +1,53 @@
+## Accomplished
+
+Session type: `/work` (feature). Claimed and delivered issue #4634
+(Ch5 #2708 sub-A): the special-block existence/uniqueness fact for the
+Schur-Weyl C-4a aggregation.
+
+- New file `Chapter5/SchurModuleSpecialBlock.lean` delivering
+  `exists_unique_special_block` with the issue's exact signature (added an
+  explicit `(hlam : Antitone lam)`, which the consumer
+  `schurModuleSubmodule_isSimple_centralizer` already carries and the
+  existence half needs). The lemma is fully assembled and `sorry`-free
+  modulo a single cited dependency.
+- **Existence half fully proved**:
+  - `youngSymEndomorphism_ne_zero` — from the Weyl character formula via
+    `schurModuleSubmodule_ne_bot` (`SchurModuleSubmodule = range(c_λ) ≠ ⊥`).
+  - `youngSymEndomorphism_eq_zero_of_blocks_vanish` — block-vanishing core:
+    if `c_λ` vanishes on every block `S i`, then `youngSym_block_factorization`
+    + a `DirectSum`/`TensorProduct` ext on the spanning pure tensors
+    `e.symm (of i (v ⊗ₜ l))` forces `c_λ = 0`. Contraposition with β.3
+    (`youngSym_action_vanishes_off_block`) gives the special block.
+  - Uniqueness assembled from the cited helper + `hDist`.
+- **Single cited gap**: `simpleSymGroupImageSubmodule_iso_of_spechtCharacter_eq`
+  (character determines the simple module over ℂ) left `sorry`, tracked as
+  the well-scoped follow-up issue #4679.
+- Un-privated `schurModuleSubmodule_ne_bot` (`Theorem5_23_2.lean`) and
+  `symGroupAction_mem_of_symGroupImage_submodule` (`Theorem5_22_1.lean`) for
+  reuse; registered the new file in `Chapter5.lean`.
+
+## Current frontier
+
+`exists_unique_special_block` builds. `lake build
+EtingofRepresentationTheory.Chapter5.SchurModuleSpecialBlock` passes with
+exactly one `sorry` (the cited `simpleSymGroupImageSubmodule_iso_of_spechtCharacter_eq`).
+
+## Overall project progress
+
+Stage 3 formalization ongoing. This closes the genuinely
+character-theoretic existence gap of Schur-Weyl C-4a (parent #2708); the
+final assembly is sub-B (#4636, blocked on #4634 → now unblockable once this
+PR merges). Remaining sub-A residue is the iso/character-injectivity gap
+#4679.
+
+## Next step
+
+- A planner should let `check-blocked` unblock #4636 once this PR merges.
+- A worker should pick up #4679 (character-determines-module) to make
+  `SchurModuleSpecialBlock.lean` fully `sorry`-free.
+
+## Blockers
+
+None. #4679 is a follow-up, not a blocker for #4634's scoped deliverable
+(the issue explicitly permits leaving the special-block lemma sorry-free
+modulo one cited dependency).


### PR DESCRIPTION
Closes #4634

Session: `5e626950-8fe6-44a4-a35f-520483704d49`

50f0c991 doc(Ch5 #4634): cite follow-up #4679 for uniqueness gap; progress file
1ed97b87 feat(Ch5 #2708 sub-A): exists_unique_special_block assembled; nonvanishing + existence closed

🤖 Prepared with Claude Code