### PR TITLE
doc(Ch6 #4642): investigation brief + obj↔concrete skill note

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -2126,3 +2126,35 @@ through the Fin wrapper.
 **Finset.erase parsing:** `S.erase a |>.erase b` in a type annotation
 parses as `(S.erase a).erase b` in term position but `(x ∈ S.erase a).erase b`
 in proposition position. Always use explicit parentheses: `(S.erase a).erase b`.
+
+## obj↔concrete type bridge in `leaf_equalities` (quiver-rep collapse proofs)
+
+When writing an orientation-generic `leaf_equalities`/collapse lemma over a
+quiver representation, the invariant subspaces are typed
+`W : ∀ v, Submodule F ((someRep_kQ …).obj v)`. The per-vertex object
+`(someRep_kQ …).obj ⟨v, _⟩` is **definitionally** `Fin (k·(m+1)) → F`, but the
+unifier will **not** reduce it to the concrete form — not even under an explicit
+ascription `(W ⟨v,_⟩ : Submodule F (Fin (k·(m+1)) → F))`, which errors with a
+"type mismatch … `(someRep_kQ …).obj ⟨v, ?m⟩` vs `Fin (k·(m+1)) → F`". This bites
+hardest when the per-vertex dimension `…Dim` is defined by `match v.val with …`
+(does not reduce through the `Fin 8` proof metavar); an `if … then … else …`
+dimension reduces and avoids the wall (this is why some `_kQ_leaf_equalities`
+families compile in obj-form and others do not).
+
+**Consequence:** you cannot directly pass obj-typed `W ⟨v⟩` into a foundation
+lemma stated over concrete `Fin (k·(m+1)) → F` spaces. Two fixes:
+1. **Stay obj-form (preferred, mirrors the working D̃₇ family).** Build the
+   leaf→center map `e` as a composite of the rep's **own** `mapLinear` along the
+   relevant arrows (e.g.
+   `(rep).mapLinear a20 ∘ (rep).mapLinear a32 ∘ (rep).mapLinear a43`), which is
+   obj-typed by construction, and apply a space-generic criterion like
+   `leaf_center_mem_iff_of_forward` (`FieldGenericETilde6.lean`). Then
+   `simp only [someRep_kQ, someRepMap_kQ]` rewrites that composite to the concrete
+   map (`blockEmbedAt_F …`, etc.) only where you actually need the concrete form.
+2. Add obj-form wrappers of the concrete foundation lemmas.
+
+A membership *statement* `concreteMap x ∈ W ⟨0,_⟩` (deposit into an obj-typed
+submodule) elaborates if you ascribe the element to the obj type:
+`(concreteMap x : (rep).obj ⟨0, by omega⟩) ∈ W ⟨0, by omega⟩` — the ascription
+forces a default-transparency defeq that *does* reduce. The proof body still
+needs fix (1) or (2).

--- a/progress/2026-06-14T16-26-57Z_9b8467cd.md
+++ b/progress/2026-06-14T16-26-57Z_9b8467cd.md
@@ -1,0 +1,53 @@
+## Accomplished
+
+- Triage: corrected a mis-recorded dependency. Claimed #4570 (Ẽ₇ sub-C
+  indecomposability assembly), then found its real blocker is **#4642**
+  (the `etilde7tildeRep_kQ_leaf_equalities` case tree), not the closed #4569.
+  #4569 had been closed after decomposition into sub-B1 (#4677, merged) +
+  sub-B2 (#4642, still open). Added `depends-on #4642` to #4570 (now `blocked`)
+  and released #4570 back to replan with a breadcrumb.
+- Claimed #4642 and investigated deeply. Did not land code; instead posted a
+  precise technical brief on #4642 (see issue comment) capturing two genuine
+  obstacles so the next worker starts ahead, and released it for replan.
+
+## Current frontier
+
+Ẽ₇ = T(1,3,3) homogeneous-tube indecomposability program. sub-A (#4568, tube
+`def`) and sub-B1 (#4677, orientation-independent flag-collapse foundation) are
+on `main`. sub-B2 (#4642, the orientation-generic leaf-equality case tree) is
+the live frontier; sub-C (#4570, the assembly) is blocked behind it.
+
+## Overall project progress
+
+Stage 3 formalization, Chapter 6 infinite-type / sporadic-tube work. Many
+parallel tube programs (D̃₅–D̃₈, T(1,2,5), T(1,3,3), T(2,2,2)) at the
+leaf-equality / indecomposability-assembly stage.
+
+## Next step (for the replanner / next worker on #4642)
+
+Two obstacles documented on #4642:
+
+1. **obj↔concrete type bridge.** `etilde7tildeRep_kQ_leaf_equalities` must take
+   `W : ∀ v, Submodule F ((etilde7Rep_kQ …).obj v)`, but the sub-B1 foundation
+   lemmas are stated over concrete `Fin (k·(m+1)) → F`. `(rep).obj ⟨v⟩` is
+   defeq to the concrete form but the unifier will NOT reduce it (even under
+   explicit ascription) because `etilde7Dim` is a `match` (vs `d7tildeDim`'s
+   `if`, which is why D̃₇ helpers stay obj-form and compile). **Fix:** build the
+   leaf→center map `e` from the rep's own `mapLinear` composites along the
+   canonical arrows (obj-typed by construction) and apply the space-generic
+   `leaf_center_mem_iff_of_forward` (`FieldGenericETilde6.lean:329`) in obj-form;
+   or add obj-form wrappers of the sub-B1 lemmas.
+
+2. **Eigenvalue-coupled core + conclusion coupled to sub-C.** Arm 1 is the
+   eigenvalue tube (only coupling between center blocks 0 and 3); the canonical
+   collapse must force a common `F^{m+1}` and feed
+   `eigenvalue_jordan_invariant_compl_trivial_gen`. This is a
+   `starTubeRepGen_isIndecomposable`-scale proof, and the exact `leaf_equalities`
+   conclusion is what the still-unwritten sub-C (#4570) consumes. **Recommend**
+   writing #4642 + #4570 as one unit, or narrowing #4642 to the standalone
+   obj-form flag-collapse criteria and deferring the eigenvalue core.
+
+## Blockers
+
+- #4642 canonical branch is `starTubeRepGen`-scale and its interface is unpinned
+  until sub-C (#4570) is written. Recommend co-designing the two.


### PR DESCRIPTION
This PR records the session 9b8467cd investigation of the Ẽ₇ (#4642) leaf-equality case tree: a progress handoff documenting the two obstacles (the obj↔concrete type bridge when consuming concrete-typed sub-B1 foundation lemmas from the obj-typed `leaf_equalities`, and the eigenvalue-coupled canonical core whose conclusion is coupled to the still-unwritten sub-C #4570), and a `lean-formalization` skill note capturing the obj↔concrete bridge gotcha so future workers do not rediscover it. No Lean source changes; #4642 and #4570 were handed back for replan with precise breadcrumbs.

🤖 Prepared with Claude Code