### PR TITLE
feat(Ch5 #4608 sub-A2): descPochhammer alternant determinant = ∏(β_i−β_j) via Vandermonde column reduction (step 7)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/CharValueHookFormula.lean
+++ b/EtingofRepresentationTheory/Chapter5/CharValueHookFormula.lean
@@ -240,6 +240,81 @@ theorem hookLengthProduct_eq_prod_rows (N : ℕ) {n : ℕ} (lam : BoundedPartiti
   · intro p hp; rfl
   · intro c hc; rfl
 
+/-- **Part A, step 7 (algebraic / Vandermonde half, #4670).**
+
+The falling-factorial alternant determinant with the *reflected* column exponents
+`vandermondeExps N j = N-1-j` equals the genuine descending product
+`∏_{i<j}(βᵢ − βⱼ)` of a strictly antitone node sequence `β`.
+
+Proof: `descPochhammer ℤ k` is monic of degree `k`, so
+`Matrix.det_eval_matrixOfPolynomials_eq_det_vandermonde` identifies the *ascending*
+falling-factorial matrix (columns `j ↦ (descPochhammer ℤ j).eval ·`) with a true
+Vandermonde determinant. The reflected matrix is obtained from the ascending one of
+the *reversed* node sequence `γ := β ∘ Fin.rev` by the `rev`-on-both-indices
+submatrix, whose determinant is unchanged (`det_submatrix_equiv_self`) — so no
+column-reflection sign survives. `Matrix.det_vandermonde` then gives
+`∏_{i<j}(γⱼ − γᵢ)`, and the pair-involution `(i,j) ↦ (rev j, rev i)` rewrites this
+as `∏_{i<j}(βᵢ − βⱼ)` (each difference a genuine positive `ℕ` subtraction since
+`β` is strictly decreasing). -/
+private theorem descPochhammer_alternant_det_eq_prod_sub
+    (N : ℕ) (β : Fin N → ℕ) (hβ : StrictAnti β) :
+    (Matrix.of fun i j : Fin N =>
+        (descPochhammer ℤ (vandermondeExps N j)).eval (β i : ℤ)).det =
+      ((∏ i, ∏ j ∈ Finset.Ioi i, (β i - β j) : ℕ) : ℤ) := by
+  classical
+  set γ : Fin N → ℤ := fun i => (β (Fin.rev i) : ℤ) with hγ
+  -- The Vandermonde determinant of the reversed nodes `γ` equals the determinant of
+  -- the *ascending* falling-factorial matrix of `γ` (monic degree-`k` polynomials).
+  have hBγ : (Matrix.vandermonde γ).det
+      = (Matrix.of fun i j : Fin N => (descPochhammer ℤ (j : ℕ)).eval (γ i)).det :=
+    Matrix.det_eval_matrixOfPolynomials_eq_det_vandermonde γ
+      (fun i : Fin N => descPochhammer ℤ (i : ℕ))
+      (fun i => descPochhammer_natDegree ℤ i)
+      (fun i => monic_descPochhammer ℤ i)
+  -- The `rev`-on-both-indices submatrix of our reflected matrix is exactly that
+  -- ascending falling-factorial matrix of `γ`.
+  have hsub : (Matrix.of fun i j : Fin N =>
+        (descPochhammer ℤ (vandermondeExps N j)).eval (β i : ℤ)).submatrix
+          Fin.revPerm Fin.revPerm
+      = (Matrix.of fun i j : Fin N => (descPochhammer ℤ (j : ℕ)).eval (γ i)) := by
+    ext i j
+    have hvj : vandermondeExps N (Fin.rev j) = (j : ℕ) := by
+      have hj := j.isLt
+      simp only [vandermondeExps, Fin.val_rev]
+      omega
+    simp only [Matrix.submatrix_apply, Matrix.of_apply, Fin.revPerm_apply, hγ, hvj]
+  -- Chain: det(reflected) = det(submatrix) = det(vandermonde γ) = ∏ (γ j − γ i).
+  have hdet : (Matrix.of fun i j : Fin N =>
+        (descPochhammer ℤ (vandermondeExps N j)).eval (β i : ℤ)).det
+      = ∏ i : Fin N, ∏ j ∈ Finset.Ioi i, (γ j - γ i) := by
+    rw [← Matrix.det_submatrix_equiv_self Fin.revPerm
+          (Matrix.of fun i j : Fin N =>
+            (descPochhammer ℤ (vandermondeExps N j)).eval (β i : ℤ)),
+        hsub, ← hBγ, Matrix.det_vandermonde]
+  rw [hdet]
+  -- Cast the `ℕ` target into a product of genuine `ℤ` differences.
+  have hcast : ((∏ i, ∏ j ∈ Finset.Ioi i, (β i - β j) : ℕ) : ℤ)
+      = ∏ i : Fin N, ∏ j ∈ Finset.Ioi i, ((β i : ℤ) - (β j : ℤ)) := by
+    rw [Nat.cast_prod]
+    refine Finset.prod_congr rfl (fun i _ => ?_)
+    rw [Nat.cast_prod]
+    refine Finset.prod_congr rfl (fun j hj => ?_)
+    exact Nat.cast_sub (hβ (Finset.mem_Ioi.mp hj)).le
+  rw [hcast, Finset.prod_sigma', Finset.prod_sigma']
+  -- The pair involution `(i,j) ↦ (rev j, rev i)` matches `γ j − γ i` with `βᵢ − βⱼ`.
+  apply Finset.prod_nbij'
+    (fun x : Σ _ : Fin N, Fin N => (⟨Fin.rev x.2, Fin.rev x.1⟩ : Σ _ : Fin N, Fin N))
+    (fun x : Σ _ : Fin N, Fin N => (⟨Fin.rev x.2, Fin.rev x.1⟩ : Σ _ : Fin N, Fin N))
+  · intro x hx
+    simp only [Finset.mem_sigma, Finset.mem_univ, Finset.mem_Ioi, true_and] at hx ⊢
+    exact Fin.rev_lt_rev.mpr hx
+  · intro x hx
+    simp only [Finset.mem_sigma, Finset.mem_univ, Finset.mem_Ioi, true_and] at hx ⊢
+    exact Fin.rev_lt_rev.mpr hx
+  · intro x _; simp only [Fin.rev_rev]
+  · intro x _; simp only [Fin.rev_rev]
+  · intro x _; simp only [hγ]
+
 /-- **Part A — Frobenius → Vandermonde determinant**
 (book `Discussion_hook_length_derivation`, lines 1–18).
 

--- a/progress/2026-06-14T16-34-31Z_9deda9cc.md
+++ b/progress/2026-06-14T16-34-31Z_9deda9cc.md
@@ -1,0 +1,69 @@
+## Accomplished
+
+Work session `9deda9cc` (`/work` → `/feature`). Closed **#4670** (Ch5 #4608
+sub-A2): proved the **algebraic / Vandermonde half** of the Frobenius
+determinant route, `descPochhammer_alternant_det_eq_prod_sub` in
+`Chapter5/CharValueHookFormula.lean`, **sorry-free**
+(`#print axioms` = `[propext, Classical.choice, Quot.sound]`, no `sorryAx`).
+
+Statement (matches the issue body verbatim, the shape the #4608 capstone consumes):
+
+```lean
+private theorem descPochhammer_alternant_det_eq_prod_sub
+    (N : ℕ) (β : Fin N → ℕ) (hβ : StrictAnti β) :
+    (Matrix.of fun i j : Fin N =>
+        (descPochhammer ℤ (vandermondeExps N j)).eval (β i : ℤ)).det =
+      ((∏ i, ∏ j ∈ Finset.Ioi i, (β i - β j) : ℕ) : ℤ)
+```
+
+### Proof route (the sign-free variant)
+
+The design note (`progress/frobeniusDetForm-route-design.md`, step 7) suggested
+computing the column-reflection sign `(-1)^{C(N,2)}` and cancelling it against the
+sign of `∏(βⱼ−βᵢ) = (-1)^{C(N,2)}∏(βᵢ−βⱼ)`. I avoided **both** sign computations:
+
+- Let `γ := β ∘ Fin.rev` (strictly **increasing**).
+  `Matrix.det_eval_matrixOfPolynomials_eq_det_vandermonde` (descPochhammer is monic
+  of degree `k`) gives `det(vandermonde γ) = det(of fun i j => (descPochhammer ℤ j).eval (γ i))`.
+- The reflected matrix's `rev`-on-**both**-indices submatrix is *exactly* that
+  ascending falling-factorial matrix of `γ` (key fact:
+  `vandermondeExps N (rev j) = N-1-(N-1-j) = j`). `Matrix.det_submatrix_equiv_self`
+  then says `det(reflected) = det(submatrix)` with **no sign** — the two reflections
+  fuse into one same-equiv-both-sides submatrix.
+- `Matrix.det_vandermonde` gives `∏_{i<j}(γⱼ−γᵢ)`, and the pair involution
+  `(i,j) ↦ (rev j, rev i)` (via `Finset.prod_sigma'` + `Finset.prod_nbij'`) rewrites
+  it as `∏_{i<j}(βᵢ−βⱼ)`. `Nat.cast_sub` discharges the genuine-positive-ℕ-subtraction
+  cast since `β` is strictly decreasing.
+
+Key Mathlib lemmas: `det_eval_matrixOfPolynomials_eq_det_vandermonde`,
+`det_submatrix_equiv_self`, `det_vandermonde`, `monic_descPochhammer`,
+`descPochhammer_natDegree`, `Fin.revPerm`/`val_rev`/`rev_lt_rev`/`rev_rev`,
+`Finset.prod_sigma'`, `Finset.prod_nbij'`, `Nat.cast_sub`.
+
+## Current frontier
+
+`CharValueHookFormula.lean` now has its sub-A2 piece landed. Remaining open work
+on the Frobenius route:
+- **#4669** (sub-A1, analytic / coefficient-extraction half, steps 1–6): reduce
+  `charValue` to `(n!/∏β!)·det(descPochhammer matrix)`. Unclaimed, unblocked.
+- **#4671** (capstone, step 8): combine #4669 + #4670, cast ℤ→ℚ. Blocked on both.
+  Once #4669 lands, the capstone closes `charValue_trivialCycleType_eq_frobeniusDetForm`
+  (the lone remaining `sorry` in the file, line 336), and the whole Frobenius route
+  to `dim V_λ = #SYT` (#4595) follows.
+
+## Overall project progress
+
+Etingof draft 1, Stage 3. Ch5 Frobenius route (#4595): Part B done (#4617);
+Part A now has sub-A2 (#4670, this turn) done; sub-A1 (#4669) is the last
+genuinely-new piece, then the small capstone (#4671). Ch6 sporadic-tube redesign
+active elsewhere.
+
+## Next step
+
+A worker claims **#4669** (sub-A1) — the analytic half. With #4670 already in,
+the #4671 capstone (#4608 step 8) unblocks as soon as #4669 lands.
+
+## Blockers
+
+None for #4670 (done, PR up). #4671 blocked on #4669; #4595 transitively blocked
+on #4669 + #4671.


### PR DESCRIPTION
Closes #4670

Session: `9deda9cc-5209-43b4-8549-34d11dce590b`

f61ef5aa feat(Ch5 #4670): descPochhammer alternant det = ∏(βᵢ−βⱼ) (Vandermonde column reflection, step 7)

🤖 Prepared with Claude Code