### PR TITLE
feat(Ch5 #2708 sub-A follow-up): close simpleSymGroupImageSubmodule_iso_of_spechtCharacter_eq (character determines simple module over ℂ)

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -382,6 +382,28 @@ Two traps recur when using Mathlib's `IsSemisimpleModule` / `IsSimpleModule` API
   comes from `DirectSum.component.lof_self` (a left inverse) and the coordinate
   lines span via `DFinsupp.iSup_range_lsingle`.
 
+- **Opaque-parameter isolation defeats `whnf`/`isDefEq` heartbeat timeouts in
+  `compHom`/`restrictScalars` transfer constructions.** When building a
+  `LinearEquiv` over the deep `Subalgebra → Subsemiring → Module` chain (e.g.
+  transferring a `SymGroupAlgebra`-iso to a `symGroupImage`-iso through
+  `symGroupAlgHomToImage`), a complex equiv held in a local `let`
+  (`set g := e₁.trans e₂.symm`) makes the structure-field proofs time out —
+  `whnf` unfolds the large source isos (here `Theorem5_12_2_classification`).
+  `clear_value g` does **not** help. Fix: move the construction into a standalone
+  `def` that takes the big equiv as an explicit **parameter** (`letI`-typed if it
+  needs the `compHom` module instance); the body elaborates once with the equiv
+  genuinely opaque. Then the caller is a one-line `exact ⟨transferDef S S' g⟩`.
+
+- **Pin `f (N := N) (n := n)` on a hom application feeding a `•`** whose scalar
+  type is being inferred (e.g. `(symGroupAlgHomToImage (N := N) (n := n) a) • x`).
+  Otherwise `N` is a stuck metavariable ("typeclass instance problem is stuck").
+
+- **`congrArg Subtype.val (g.<lemma> ⟨x.val, x.property⟩)`** discharges the
+  `left_inv`/`right_inv`/`map_add'` fields of a carrier-identity submodule
+  `LinearEquiv` by defeq. Prefer it over `rw [show ⟨…⟩ = g … from rfl, …]`, which
+  fails on "pattern not found" because the post-`Subtype.ext` goal is not
+  syntactically normalised.
+
 ### Norm-Based Contradiction (Analysis Proofs)
 
 For proofs requiring algebraic integer arguments (e.g., Lemma 5.4.5):

--- a/EtingofRepresentationTheory/Chapter5/SchurModuleSpecialBlock.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurModuleSpecialBlock.lean
@@ -80,11 +80,12 @@ theorem simpleSymGroupImageSubmodule_iso_of_spechtCharacter_eq
             (p := S'.restrictScalars ℂ) (q := S'.restrictScalars ℂ)
             (fun _ hv => symGroupAction_mem_of_symGroupImage_submodule S' σ hv)) =
           spechtModuleCharacter n la σ) :
-    Nonempty (↥S ≃ₗ[↥(symGroupImage ℂ (Fin N → ℂ) n)] ↥S') := by
-  -- Cited dependency, tracked as issue #4679: classify each restrictScalars
-  -- module as a Specht module, use Specht character injectivity to pin both
-  -- labels to `la`, then transfer the SymGroupAlgebra-iso to a symGroupImage-iso.
-  sorry
+    Nonempty (↥S ≃ₗ[↥(symGroupImage ℂ (Fin N → ℂ) n)] ↥S') :=
+  -- Proved in `Theorem5_22_1.lean` where the Specht-bridge infrastructure lives:
+  -- classify each `restrictScalars` module as a Specht module, pin both labels
+  -- to `la` by Specht character injectivity, then transfer the resulting
+  -- `SymGroupAlgebra`-iso to a `symGroupImage`-iso through `symGroupAlgHomToImage`.
+  simpleSubmodule_iso_of_spechtCharacter_eq S S' la hS hS'
 
 /-! ## Existence and uniqueness of the special block -/
 

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_15_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_15_1.lean
@@ -2320,6 +2320,26 @@ private theorem specht_char_inner (n : ℕ) (ν μ : Nat.Partition n) :
   rw [mul_comm, hcard] at horth
   by_cases h : ν = μ <;> simp [h] at horth ⊢ <;> exact horth
 
+/-- **Specht character injectivity over ℂ.** Two Specht modules whose
+`σ`-characters agree pointwise carry the same partition label. This is the
+character-theoretic uniqueness underlying the special Schur-Weyl block: the
+inner product `∑_σ χ_μ(σ)·χ_ν(σ⁻¹) = n!·δ_{μ,ν}` (`specht_char_inner`) is
+nonzero exactly when `μ = ν`, so equal characters force `μ = ν`. -/
+theorem spechtModuleCharacter_injective (n : ℕ) {μ ν : Nat.Partition n}
+    (h : ∀ σ, spechtModuleCharacter n μ σ = spechtModuleCharacter n ν σ) : μ = ν := by
+  by_contra hne
+  have h1 := specht_char_inner n μ ν
+  have h2 := specht_char_inner n μ μ
+  rw [if_neg hne, mul_zero] at h1
+  rw [if_pos rfl, mul_one] at h2
+  have key : (∑ σ : Equiv.Perm (Fin n),
+        spechtModuleCharacter n μ σ * spechtModuleCharacter n ν σ⁻¹) =
+      ∑ σ : Equiv.Perm (Fin n),
+        spechtModuleCharacter n μ σ * spechtModuleCharacter n μ σ⁻¹ :=
+    Finset.sum_congr rfl fun σ _ => by rw [h σ⁻¹]
+  rw [key, h2] at h1
+  exact Nat.factorial_ne_zero n (by exact_mod_cast h1)
+
 /-- **Norm-squared identity**: ∑_ν L²_{νλ} = 1.
 Proof: n! · ∑L² = ∑_σ θ(σ)θ(σ⁻¹) = ∑_σ θ² = n!, cancel n!.
 Uses character orthonormality, cycle type invariance, and Cauchy bilinear identity. -/

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
@@ -912,6 +912,19 @@ private theorem symGroupAlgHomToImage_of (σ : Equiv.Perm (Fin n)) :
   rfl
 
 set_option synthInstance.maxHeartbeats 200000 in
+/-- Value-level description of the `↥(symGroupImage)`-action on a submodule
+`S ≤ V^⊗n` via `symGroupAlgHomToImage`: `(symGroupAlgHomToImage a • x).val`
+applies the endomorphism `symGroupAlgHom a` to `x.val`. -/
+private theorem symGroupAlgHomToImage_smul_val
+    (S : Submodule (symGroupImage ℂ (Fin N → ℂ) n)
+      (TensorPower ℂ (Fin N → ℂ) n))
+    (a : SymGroupAlgebra n) (x : ↥S) :
+    ((symGroupAlgHomToImage (N := N) (n := n) a) • x).val =
+      (symGroupAlgHom ℂ (Fin N → ℂ) n a) x.val := by
+  rw [Submodule.coe_smul, Subalgebra.smul_def, Module.End.smul_def,
+      symGroupAlgHomToImage_val]
+
+set_option synthInstance.maxHeartbeats 200000 in
 -- `Module.compHom` synthesises a `Module (symGroupImage) ↥(S.restrictScalars ℂ)`
 -- instance, traversing a deep `Subalgebra → Subsemiring → Module` chain that
 -- exceeds the default 20000 heartbeats.
@@ -1015,45 +1028,38 @@ private theorem spechtModule_smul_of
   rfl
 
 set_option maxHeartbeats 400000 in
--- Bumped: the Specht-bridge construction unfolds Module.compHom, traverses a
--- `Subalgebra → Subsemiring → Module` chain, and applies trace conjugation.
 set_option synthInstance.maxHeartbeats 200000 in
-/-- **Specht bridge** (β.2). Every simple `symGroupImage`-submodule `S ≤ V^⊗n`
-admits a partition `la'` such that the trace of every `σ`-permutation operator
-restricted to `S` equals `spechtModuleCharacter n la' σ`.
-
-The bridge: identify `↥(S.restrictScalars ℂ)` (with the SymGroupAlgebra-action
-via `symGroupAlgHomToImage`) as a simple `SymGroupAlgebra n`-module, apply the
-Specht classification (Theorem 5.12.2), then transport the trace through the
-ℂ-linear part of the resulting iso. -/
-theorem trace_symGroupAction_eq_spechtModuleCharacter
+/-- The conjugation step of the Specht bridge, factored out so it can be reused
+when the classification iso `e` is obtained separately (when both the iso and
+the trace identity are needed downstream). Given a `SymGroupAlgebra n`-iso
+`e : ↥(S.restrictScalars ℂ) ≃ₗ SpechtModule n la'`, the trace of the restricted
+`σ`-action on `↥(S.restrictScalars ℂ)` equals `spechtModuleCharacter n la' σ`,
+by trace-conjugation through the ℂ-linear part of `e`. -/
+private theorem trace_restrictedSymGroupAction_eq_of_spechtIso
     (S : Submodule (symGroupImage ℂ (Fin N → ℂ) n)
       (TensorPower ℂ (Fin N → ℂ) n))
-    [IsSimpleModule (↥(symGroupImage ℂ (Fin N → ℂ) n)) ↥S] :
-    ∃ la' : Nat.Partition n, ∀ σ : Equiv.Perm (Fin n),
-      LinearMap.trace ℂ ↥(S.restrictScalars ℂ)
-          ((symGroupAction ℂ (Fin N → ℂ) n σ).toLinearMap.restrict
-            (p := S.restrictScalars ℂ) (q := S.restrictScalars ℂ)
-            (fun _ hv =>
-              symGroupAction_mem_of_symGroupImage_submodule S σ hv)) =
-        spechtModuleCharacter n la' σ := by
+    (la' : Nat.Partition n)
+    (e : letI := submoduleAsSymGroupAlgebraModule S
+         ↥(S.restrictScalars ℂ) ≃ₗ[SymGroupAlgebra n] ↥(SpechtModule n la'))
+    (σ : Equiv.Perm (Fin n)) :
+    LinearMap.trace ℂ ↥(S.restrictScalars ℂ)
+        ((symGroupAction ℂ (Fin N → ℂ) n σ).toLinearMap.restrict
+          (p := S.restrictScalars ℂ) (q := S.restrictScalars ℂ)
+          (fun _ hv =>
+            symGroupAction_mem_of_symGroupImage_submodule S σ hv)) =
+      spechtModuleCharacter n la' σ := by
   letI := submoduleAsSymGroupAlgebraModule S
   haveI := submoduleAsSymGroupAlgebra_isScalarTower S
-  haveI := submoduleAsSymGroupAlgebra_isSimpleModule S
-  obtain ⟨la', ⟨e⟩⟩ :=
-    Theorem5_12_2_classification n ↥(S.restrictScalars ℂ)
-  refine ⟨la', fun σ => ?_⟩
   -- Convert `e` to a ℂ-linear equiv.
   let eℂ : ↥(S.restrictScalars ℂ) ≃ₗ[ℂ] ↥(SpechtModule n la') :=
     LinearEquiv.restrictScalars ℂ e
-  -- Goal: trace of restricted symGroupAction σ = spechtModuleCharacter n la' σ.
   set restrictedAction :
       ↥(S.restrictScalars ℂ) →ₗ[ℂ] ↥(S.restrictScalars ℂ) :=
     (symGroupAction ℂ (Fin N → ℂ) n σ).toLinearMap.restrict
       (p := S.restrictScalars ℂ) (q := S.restrictScalars ℂ)
       (fun _ hv =>
         symGroupAction_mem_of_symGroupImage_submodule S σ hv)
-  -- Show eℂ intertwines restrictedAction with spechtModuleAction n la' σ.
+  -- `eℂ` intertwines `restrictedAction` with `spechtModuleAction n la' σ`.
   have h_intertwine : ∀ v : ↥(S.restrictScalars ℂ),
       eℂ (restrictedAction v) = spechtModuleAction n la' σ (eℂ v) := by
     intro v
@@ -1084,6 +1090,134 @@ theorem trace_symGroupAction_eq_spechtModuleCharacter
     rfl
   rw [h_conj, LinearMap.trace_conj']
   rfl
+
+set_option maxHeartbeats 400000 in
+-- Bumped: the Specht-bridge construction unfolds Module.compHom, traverses a
+-- `Subalgebra → Subsemiring → Module` chain, and applies trace conjugation.
+set_option synthInstance.maxHeartbeats 200000 in
+/-- **Specht bridge** (β.2). Every simple `symGroupImage`-submodule `S ≤ V^⊗n`
+admits a partition `la'` such that the trace of every `σ`-permutation operator
+restricted to `S` equals `spechtModuleCharacter n la' σ`.
+
+The bridge: identify `↥(S.restrictScalars ℂ)` (with the SymGroupAlgebra-action
+via `symGroupAlgHomToImage`) as a simple `SymGroupAlgebra n`-module, apply the
+Specht classification (Theorem 5.12.2), then transport the trace through the
+ℂ-linear part of the resulting iso. -/
+theorem trace_symGroupAction_eq_spechtModuleCharacter
+    (S : Submodule (symGroupImage ℂ (Fin N → ℂ) n)
+      (TensorPower ℂ (Fin N → ℂ) n))
+    [IsSimpleModule (↥(symGroupImage ℂ (Fin N → ℂ) n)) ↥S] :
+    ∃ la' : Nat.Partition n, ∀ σ : Equiv.Perm (Fin n),
+      LinearMap.trace ℂ ↥(S.restrictScalars ℂ)
+          ((symGroupAction ℂ (Fin N → ℂ) n σ).toLinearMap.restrict
+            (p := S.restrictScalars ℂ) (q := S.restrictScalars ℂ)
+            (fun _ hv =>
+              symGroupAction_mem_of_symGroupImage_submodule S σ hv)) =
+        spechtModuleCharacter n la' σ := by
+  letI := submoduleAsSymGroupAlgebraModule S
+  haveI := submoduleAsSymGroupAlgebra_isScalarTower S
+  haveI := submoduleAsSymGroupAlgebra_isSimpleModule S
+  obtain ⟨la', ⟨e⟩⟩ :=
+    Theorem5_12_2_classification n ↥(S.restrictScalars ℂ)
+  exact ⟨la', fun σ => trace_restrictedSymGroupAction_eq_of_spechtIso S la' e σ⟩
+
+set_option maxHeartbeats 1600000 in
+set_option synthInstance.maxHeartbeats 400000 in
+/-- Transfer a `SymGroupAlgebra n`-linear equivalence between the restricted-scalar
+modules `↥(S.restrictScalars ℂ)` and `↥(S'.restrictScalars ℂ)` to a
+`symGroupImage`-linear equivalence `↥S ≃ₗ ↥S'`. Valid because both module
+structures factor through the surjective algebra hom `symGroupAlgHomToImage`:
+the carriers are shared, and `symGroupImage`-linearity follows from
+`SymGroupAlgebra`-linearity by surjectivity. `g` is taken as an opaque parameter
+so this construction elaborates without unfolding the (large) classification isos. -/
+private noncomputable def transferToSymGroupImageEquiv
+    (S S' : Submodule (symGroupImage ℂ (Fin N → ℂ) n)
+      (TensorPower ℂ (Fin N → ℂ) n))
+    (g : letI := submoduleAsSymGroupAlgebraModule S
+         letI := submoduleAsSymGroupAlgebraModule S'
+         ↥(S.restrictScalars ℂ) ≃ₗ[SymGroupAlgebra n] ↥(S'.restrictScalars ℂ)) :
+    ↥S ≃ₗ[↥(symGroupImage ℂ (Fin N → ℂ) n)] ↥S' :=
+  letI := submoduleAsSymGroupAlgebraModule S
+  letI := submoduleAsSymGroupAlgebraModule S'
+  { toFun := fun x => ⟨(g ⟨x.val, x.property⟩).val, (g ⟨x.val, x.property⟩).property⟩
+    invFun := fun y =>
+      ⟨(g.symm ⟨y.val, y.property⟩).val, (g.symm ⟨y.val, y.property⟩).property⟩
+    left_inv := fun x => by
+      apply Subtype.ext
+      exact congrArg Subtype.val (g.symm_apply_apply ⟨x.val, x.property⟩)
+    right_inv := fun y => by
+      apply Subtype.ext
+      exact congrArg Subtype.val (g.apply_symm_apply ⟨y.val, y.property⟩)
+    map_add' := fun x y => by
+      apply Subtype.ext
+      exact congrArg Subtype.val (g.map_add ⟨x.val, x.property⟩ ⟨y.val, y.property⟩)
+    map_smul' := fun b x => by
+      obtain ⟨a, rfl⟩ := symGroupAlgHomToImage_surjective b
+      apply Subtype.ext
+      have hxeq : (⟨((symGroupAlgHomToImage (N := N) (n := n) a) • x).val,
+            ((symGroupAlgHomToImage (N := N) (n := n) a) • x).property⟩ :
+            ↥(S.restrictScalars ℂ))
+            = a • (⟨x.val, x.property⟩ : ↥(S.restrictScalars ℂ)) := by
+        apply Subtype.ext
+        rw [submoduleAsSymGroupAlgebraModule_smul_def, symGroupAlgHomToImage_smul_val]
+      show (g ⟨((symGroupAlgHomToImage (N := N) (n := n) a) • x).val,
+            ((symGroupAlgHomToImage (N := N) (n := n) a) • x).property⟩).val = _
+      rw [hxeq, map_smul, submoduleAsSymGroupAlgebraModule_smul_def,
+          RingHom.id_apply, symGroupAlgHomToImage_smul_val] }
+
+set_option maxHeartbeats 800000 in
+set_option synthInstance.maxHeartbeats 400000 in
+/-- **Character determines the module over ℂ** (the uniqueness ingredient of the
+special Schur-Weyl block). Two simple `symGroupImage`-submodules `S, S' ≤ V^⊗n`
+whose `σ`-trace functions both equal `spechtModuleCharacter n la` are isomorphic
+as `symGroupImage`-modules.
+
+Route: classify each `↥(S.restrictScalars ℂ)` as a Specht module
+(`Theorem5_12_2_classification`); the trace through that iso equals
+`spechtModuleCharacter` of its label (`trace_restrictedSymGroupAction_eq_of_spechtIso`),
+so character injectivity (`spechtModuleCharacter_injective`) pins both labels to
+`la`; the two Specht modules then coincide, yielding a `SymGroupAlgebra n`-iso
+`g : ↥(S.restrictScalars ℂ) ≃ₗ ↥(S'.restrictScalars ℂ)`. Finally transfer `g` to a
+`symGroupImage`-iso: the `SymGroupAlgebra n`-action factors through the surjection
+`symGroupAlgHomToImage`, so a `SymGroupAlgebra`-linear bijection on the shared
+carriers is automatically `symGroupImage`-linear. -/
+theorem simpleSubmodule_iso_of_spechtCharacter_eq
+    (S S' : Submodule (symGroupImage ℂ (Fin N → ℂ) n)
+      (TensorPower ℂ (Fin N → ℂ) n))
+    [IsSimpleModule (↥(symGroupImage ℂ (Fin N → ℂ) n)) ↥S]
+    [IsSimpleModule (↥(symGroupImage ℂ (Fin N → ℂ) n)) ↥S']
+    (la : Nat.Partition n)
+    (hS : ∀ σ : Equiv.Perm (Fin n),
+        LinearMap.trace ℂ ↥(S.restrictScalars ℂ)
+          ((symGroupAction ℂ (Fin N → ℂ) n σ).toLinearMap.restrict
+            (p := S.restrictScalars ℂ) (q := S.restrictScalars ℂ)
+            (fun _ hv => symGroupAction_mem_of_symGroupImage_submodule S σ hv)) =
+          spechtModuleCharacter n la σ)
+    (hS' : ∀ σ : Equiv.Perm (Fin n),
+        LinearMap.trace ℂ ↥(S'.restrictScalars ℂ)
+          ((symGroupAction ℂ (Fin N → ℂ) n σ).toLinearMap.restrict
+            (p := S'.restrictScalars ℂ) (q := S'.restrictScalars ℂ)
+            (fun _ hv => symGroupAction_mem_of_symGroupImage_submodule S' σ hv)) =
+          spechtModuleCharacter n la σ) :
+    Nonempty (↥S ≃ₗ[↥(symGroupImage ℂ (Fin N → ℂ) n)] ↥S') := by
+  letI := submoduleAsSymGroupAlgebraModule S
+  letI := submoduleAsSymGroupAlgebraModule S'
+  haveI := submoduleAsSymGroupAlgebra_isScalarTower S
+  haveI := submoduleAsSymGroupAlgebra_isScalarTower S'
+  haveI := submoduleAsSymGroupAlgebra_isSimpleModule S
+  haveI := submoduleAsSymGroupAlgebra_isSimpleModule S'
+  -- Classify each restrictScalars module as a Specht module.
+  obtain ⟨μ, ⟨eS⟩⟩ := Theorem5_12_2_classification n ↥(S.restrictScalars ℂ)
+  obtain ⟨μ', ⟨eS'⟩⟩ := Theorem5_12_2_classification n ↥(S'.restrictScalars ℂ)
+  -- Both labels equal `la` by Specht character injectivity.
+  have hμ : μ = la := spechtModuleCharacter_injective n fun σ =>
+    (trace_restrictedSymGroupAction_eq_of_spechtIso S μ eS σ).symm.trans (hS σ)
+  have hμ' : μ' = la := spechtModuleCharacter_injective n fun σ =>
+    (trace_restrictedSymGroupAction_eq_of_spechtIso S' μ' eS' σ).symm.trans (hS' σ)
+  have hμμ' : μ = μ' := hμ.trans hμ'.symm
+  subst hμμ'
+  -- The resulting `SymGroupAlgebra n`-iso between the two restrictScalars modules.
+  exact ⟨transferToSymGroupImageEquiv S S' (eS.trans eS'.symm)⟩
 
 end SpechtBridge
 

--- a/progress/20260614T173144Z_453ce29c.md
+++ b/progress/20260614T173144Z_453ce29c.md
@@ -1,0 +1,80 @@
+## Accomplished
+
+Work session `453ce29c` (`/work` → `/feature`). Closed **#4679** (Ch5 #2708
+sub-A follow-up): proved `simpleSymGroupImageSubmodule_iso_of_spechtCharacter_eq`
+in `Chapter5/SchurModuleSpecialBlock.lean`, **sorry-free** (the last cited
+character-theoretic gap of `exists_unique_special_block`). `#print axioms` =
+`[propext, Classical.choice, Quot.sound]` for all new declarations (no `sorryAx`).
+
+The proof "character determines the module over ℂ" splits into two new
+ingredients plus a refactor:
+
+1. **`spechtModuleCharacter_injective`** (`Theorem5_15_1.lean`, public): pointwise
+   equal Specht characters ⟹ equal partition labels. One-liner from the existing
+   private inner-product identity `specht_char_inner`
+   (`∑_σ χ_μ(σ)·χ_ν(σ⁻¹) = n!·δ_{μν}`): if `χ_μ = χ_ν` then the `μ,ν` inner
+   product equals the `μ,μ` one `= n! ≠ 0`, forcing `μ = ν`.
+
+2. **`simpleSubmodule_iso_of_spechtCharacter_eq`** (`Theorem5_22_1.lean`, in the
+   `SpechtBridge` section where the private transfer machinery lives): classify
+   each `↥(S.restrictScalars ℂ)` as a Specht module
+   (`Theorem5_12_2_classification`), use injectivity to pin both labels to `la`,
+   then transfer the resulting `SymGroupAlgebra n`-iso to a `symGroupImage`-iso.
+
+Supporting changes in `Theorem5_22_1.lean`:
+- Factored the trace-conjugation step out of `trace_symGroupAction_eq_spechtModuleCharacter`
+  into a reusable private `trace_restrictedSymGroupAction_eq_of_spechtIso` (takes
+  the classification iso `e` explicitly). The old bridge now just classifies and
+  applies it — no logic duplicated.
+- `symGroupAlgHomToImage_smul_val`: value-level description of the
+  `↥(symGroupImage)`-action via `symGroupAlgHomToImage`
+  (`Submodule.coe_smul` → `Subalgebra.smul_def` → `Module.End.smul_def`).
+- `transferToSymGroupImageEquiv`: the actual transfer. A `SymGroupAlgebra`-linear
+  bijection between the shared carriers is `symGroupImage`-linear because the
+  action factors through the surjection `symGroupAlgHomToImage`
+  (`symGroupAlgHomToImage_surjective` + `submoduleSemilinearId`-style identity).
+
+`SchurModuleSpecialBlock.lean`: target lemma is now a thin wrapper calling
+`simpleSubmodule_iso_of_spechtCharacter_eq`.
+
+## Key patterns discovered
+
+- **Opaque-parameter isolation kills elaboration blowup.** The hand-built
+  `LinearEquiv` transfer timed out at `whnf`/`isDefEq` (800000 heartbeats) when
+  `g := eS.trans eS'.symm` was a local `let` (or even after `clear_value`),
+  because `whnf` unfolded the large `Theorem5_12_2_classification` isos. Moving
+  the construction into a standalone `def` that takes `g` as an explicit
+  *parameter* makes `g` genuinely opaque: the def body elaborates once, cheaply.
+- **Pin `symGroupAlgHomToImage (N := N) (n := n)`** when its result feeds a `•`
+  whose scalar type is being inferred — otherwise `N` is a stuck metavariable
+  ("typeclass instance problem is stuck").
+- **`congrArg Subtype.val (g.<lemma> ⟨x.val, x.property⟩)`** closes the
+  `left_inv`/`right_inv`/`map_add'` obligations of a carrier-identity submodule
+  `LinearEquiv` by defeq, avoiding `rw`-pattern-matching failures from
+  unnormalised goals.
+
+## Current frontier
+
+#4679 complete; PR up. `exists_unique_special_block` (#2708 sub-A) is now fully
+sorry-free, so the Schur-Weyl special-block uniqueness is closed. Downstream
+consumer is the C-4a aggregation `schurModuleSubmodule_isSimple_centralizer`
+(#4636, open/unclaimed) which also needs sub-A's special-block lemma (landed via
+#4682) — now unblocked on the character side.
+
+## Overall project progress
+
+Etingof draft 1, Stage 3. Ch5 Schur-Weyl L_i: special-block existence (#4682) +
+uniqueness (this issue) both landed. Frobenius route (#4595) advancing in
+parallel (Part B #4617 done; Part A replanned). Ch6 sporadic-tube redesign
+(#4548/#4597) active elsewhere.
+
+## Next step
+
+A worker claims **#4636** (ℂ-specialized assembly of
+`schurModuleSubmodule_isSimple_centralizer`): all its cited dependencies
+(special block #4682, and now the character-uniqueness gap) are satisfied.
+
+## Blockers
+
+None for #4679 (done). Full `lake build EtingofRepresentationTheory.Chapter5`
+passes (8116 jobs).


### PR DESCRIPTION
Closes #4679

Session: `453ce29c-a58e-40b3-bbb2-7cb1a1f28fd6`

8b9c5398 doc(skill): opaque-parameter isolation for compHom/restrictScalars equiv transfers
db8549f9 doc(#4679): progress handoff for character-uniqueness special-block gap
82377096 feat(Ch5 #4679): close simpleSymGroupImageSubmodule_iso_of_spechtCharacter_eq
427e84f6 feat(Ch5 #4679): add spechtModuleCharacter_injective (character pins partition label)

🤖 Prepared with Claude Code