### PR TITLE
feat(Ch5 #2482 bridge-1): glTensorRep_schurWeyl_decomposition_equivariant_simple — unify equivariance + L_i simplicity

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/PolynomialGLDecomposition.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialGLDecomposition.lean
@@ -68,6 +68,8 @@ variable (k : Type u) [Field k] (N : ℕ)
 `GL_N`-equivariant decompositions are stated. -/
 abbrev GLAlg := MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k)
 
+set_option maxHeartbeats 3200000 in
+set_option synthInstance.maxHeartbeats 1600000 in
 /-- **Unified equivariant + simple Schur-Weyl decomposition of `V^{⊗n}`.**
 
 This is `glTensorRep_equivariant_schurWeyl_decomposition`
@@ -82,7 +84,13 @@ The proof therefore re-runs the equivariance computation of the former while
 keeping the centralizer-side simplicity clause that
 `isSimpleModule_monoidAlgebra_GL_of_centralizer_simple` transports to `GL_N`.
 
-TODO (sub-issue of #2482): merge the two existing proofs. -/
+Built by destructuring `Theorem5_18_4_bimodule_decomposition_explicit` once
+(keeping both its centralizer-side simplicity clause `homA_simp` and its
+evaluation formula `he`), reconstructing the `GL_N`-action `ρ_i` exactly as
+`Theorem5_18_4_GL_rep_decomposition_explicit`, then assembling the equivariance
+(à la `glTensorRep_equivariant_schurWeyl_decomposition`) and the per-`L i`
+simplicity (à la `Theorem5_18_4_GL_rep_decomposition_simple`'s `hL_simple`) over
+that one shared `ρ_i`. -/
 theorem glTensorRep_schurWeyl_decomposition_equivariant_simple
     [IsAlgClosed k] [CharZero k] (n : ℕ) (hN : n ≤ N) :
     ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
@@ -99,8 +107,54 @@ theorem glTensorRep_schurWeyl_decomposition_equivariant_simple
           e (glTensorRep k N n g v) =
             Representation.directSum (fun i =>
               (Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
-                (S i)).tprod (L i).ρ) g (e v) :=
-  sorry
+                (S i)).tprod (L i).ρ) g (e v) := by
+  classical
+  -- The combined explicit + simple decomposition supplies, over one shared
+  -- `ρ_i`, the simplicity clause AND the explicit equivariance ingredients
+  -- (the iso `e` already typed in the `(L i : Type u)` family, the evaluation
+  -- formula `he`, and the action formula `h_act`).
+  obtain ⟨ι, hιFin, hιDec, S', hS'_simp, hS'_dist, hSi_fin, L, hL_simple,
+      L_carrier, e, he, h_act⟩ :=
+    Theorem5_18_4_GL_rep_decomposition_explicit_simple k N n hN
+  refine ⟨ι, hιFin, hιDec, fun i => ↥(S' i),
+    fun _ => inferInstance, fun _ => inferInstance,
+    fun i => hSi_fin i, L, hL_simple, ?_, ?_⟩
+  · exact e
+  intro g v
+  -- Reduce equivariance to: (glTensorRep g) ∘ e.symm = e.symm ∘ directSum_action g.
+  have h_lin :
+      (glTensorRep k N n g) ∘ₗ (e.symm : _ →ₗ[k] _) =
+        (e.symm : _ →ₗ[k] _) ∘ₗ
+          (Representation.directSum (fun i =>
+            (Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
+              (↥(S' i))).tprod (L i).ρ) g) := by
+    refine DirectSum.linearMap_ext k fun i => ?_
+    apply TensorProduct.ext'
+    intro s l
+    change (glTensorRep k N n g) (e.symm
+        (DirectSum.lof k ι (fun i => ↥(S' i) ⊗[k] (L i : Type u)) i
+          (s ⊗ₜ[k] l))) =
+      e.symm ((Representation.directSum (fun i =>
+        (Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
+          (↥(S' i))).tprod (L i).ρ) g)
+        (DirectSum.lof k ι _ i (s ⊗ₜ[k] l)))
+    rw [DirectSum.lof_eq_of, he i s l]
+    change _ = e.symm (DirectSum.lmap
+      (fun i => ((Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
+        (↥(S' i))).tprod (L i).ρ) g) (DirectSum.of _ i (s ⊗ₜ[k] l)))
+    rw [DirectSum.lmap_of, Representation.tprod_apply, TensorProduct.map_tmul,
+      Representation.trivial_apply, he i s ((L i).ρ g l)]
+    exact (h_act i g l s).symm
+  have h := LinearMap.congr_fun h_lin (e v)
+  rw [LinearMap.comp_apply, LinearMap.comp_apply] at h
+  rw [show (e.symm : _ →ₗ[k] _) (e v) = v from e.symm_apply_apply v] at h
+  rw [show (e.symm : _ →ₗ[k] _) ((Representation.directSum (fun i =>
+      (Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
+        (↥(S' i))).tprod (L i).ρ) g) (e v)) =
+    e.symm ((Representation.directSum (fun i =>
+      (Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
+        (↥(S' i))).tprod (L i).ρ) g) (e v)) from rfl] at h
+  exact (LinearEquiv.eq_symm_apply e).mp h
 
 /-- **`M` embeds `R`-linearly as a submodule of a finite direct sum of the
 abstract simple summands `L i`.**

--- a/EtingofRepresentationTheory/Chapter5/SchurWeylGLTransfer.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurWeylGLTransfer.lean
@@ -799,4 +799,173 @@ theorem Theorem5_18_4_GL_rep_decomposition_simple
     hS'_simp, hS'_dist, hS'_fin,
     fun i => FDRep.of (ρ_i i), hL_simple, ⟨e⟩⟩
 
+-- Heartbeats bumped above `_GL_rep_decomposition_explicit`'s and
+-- `_GL_rep_decomposition_simple`'s budgets: this theorem combines BOTH the
+-- explicit construction (its `L_carrier` / evaluation / action existential
+-- output with 12+ ∀-binders) AND the per-`i` simplicity transfer, in a single
+-- declaration.
+set_option maxHeartbeats 6400000 in
+set_option synthInstance.maxHeartbeats 3200000 in
+/-- Schur-Weyl duality, part (iii), GL_N-representation form, **explicit +
+simple**.
+
+Combines `Theorem5_18_4_GL_rep_decomposition_explicit` (the explicit
+`Submodule` realisations, the `L_carrier` identification, the explicit iso `e`,
+and the evaluation / action formulas) with the per-`L i` simplicity clause of
+`Theorem5_18_4_GL_rep_decomposition_simple`
+(`∀ i, IsSimpleModule (MonoidAlgebra k GL_N) (asModule (L i).ρ)`), over a single
+shared `ρ i = (postCompCentralizerMonoidHom …).comp glHom`.
+
+This is the form consumed by
+`glTensorRep_schurWeyl_decomposition_equivariant_simple` (#4666): the explicit
+`e` is already typed in the `(L i : Type u)` family (the `FGModuleCat.of_carrier`
+coercion is paid here, once, at the `refine`), so the downstream equivariance
+computation can use it opaquely without re-triggering that coercion. -/
+theorem Theorem5_18_4_GL_rep_decomposition_explicit_simple
+    (k : Type u) [Field k] [IsAlgClosed k] [CharZero k]
+    (N n : ℕ) (hN : n ≤ N) :
+    ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
+      (S : ι → Submodule (symGroupImage k (Fin N → k) n)
+        (TensorPower k (Fin N → k) n))
+      (_ : ∀ i, IsSimpleModule (symGroupImage k (Fin N → k) n) (S i))
+      (_ : ∀ i j,
+        Nonempty (↥(S i) ≃ₗ[symGroupImage k (Fin N → k) n] ↥(S j)) → i = j)
+      (_ : ∀ i, Module.Finite k ↥(S i))
+      (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
+      (_ : ∀ i, IsSimpleModule
+        (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
+        (Representation.asModule (L i).ρ))
+      (L_carrier : ∀ i, (L i : Type u) ≃ₗ[k]
+        (↥(S i) →ₗ[symGroupImage k (Fin N → k) n]
+          TensorPower k (Fin N → k) n)),
+      ∃ (e : TensorPower k (Fin N → k) n ≃ₗ[k]
+          DirectSum ι (fun i => ↥(S i) ⊗[k] (L i : Type u))),
+        (∀ (i : ι) (v : ↥(S i)) (l : (L i : Type u)),
+          e.symm (DirectSum.of (fun i => ↥(S i) ⊗[k] (L i : Type u)) i
+              (v ⊗ₜ[k] l)) = (L_carrier i l) v) ∧
+        (∀ (i : ι) (g : Matrix.GeneralLinearGroup (Fin N) k)
+            (l : (L i : Type u)) (v : ↥(S i)),
+          (L_carrier i ((L i).ρ g l)) v =
+            PiTensorProduct.map
+              (fun _ : Fin n => Matrix.mulVecLin (R := k) g.val)
+              ((L_carrier i l) v)) := by
+  set V : Type u := Fin N → k with hV
+  haveI : Module.Finite k V := inferInstance
+  have hfinrank : Module.finrank k V = N :=
+    (Module.finrank_pi k).trans (Fintype.card_fin N)
+  have hN' : n ≤ Module.finrank k V := hfinrank.symm ▸ hN
+  haveI := symGroupImage_isSemisimpleRing k V n
+  haveI := symGroupImage_faithfulSMul k V n hN'
+  -- Keep `homA_simp` this time (the `_explicit` wrapper discards it).
+  obtain ⟨ι, hι, hι_dec, S', hS'_simp, hS'_dist, hS'_fin, homA_simp, e, he⟩ :=
+    Theorem5_18_4_bimodule_decomposition_explicit k V n hN'
+  let glHom : Matrix.GeneralLinearGroup (Fin N) k →*
+      ↥(Subalgebra.centralizer k
+        (symGroupImage k V n : Set (Module.End k (TensorPower k V n)))) :=
+    glHom_to_centralizer_symGroupImage k N n
+  haveI hLi_fin : ∀ i, Module.Finite k
+      ((↥(S' i) : Type u) →ₗ[symGroupImage k V n] TensorPower k V n) :=
+    fun i => by
+      haveI : Module.Finite k (↥(S' i) : Type u) := hS'_fin i
+      haveI : Module.Free k (↥(S' i) : Type u) :=
+        Module.Free.of_divisionRing k (↥(S' i))
+      haveI : Module.Finite k
+          ((↥(S' i) : Type u) →ₗ[k] TensorPower k V n) :=
+        Module.Finite.linearMap k k (↥(S' i)) (TensorPower k V n)
+      exact Module.Finite.of_injective
+        (LinearMap.restrictScalarsₗ k (symGroupImage k V n) (↥(S' i))
+          (TensorPower k V n) k)
+        (LinearMap.restrictScalars_injective _)
+  let ρ : ∀ i, Matrix.GeneralLinearGroup (Fin N) k →*
+      Module.End k (↥(S' i) →ₗ[symGroupImage k V n] TensorPower k V n) := fun i =>
+    (postCompCentralizerMonoidHom k (TensorPower k V n) (symGroupImage k V n)
+      (↥(S' i))).comp glHom
+  let L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k) := fun i =>
+    FDRep.of (ρ i)
+  let L_carrier : ∀ i, (L i : Type u) ≃ₗ[k]
+      (↥(S' i) →ₗ[symGroupImage k V n] TensorPower k V n) :=
+    fun i => LinearEquiv.refl k _
+  -- Centralizer = diagonalActionImage equality.
+  have h_eq : Subalgebra.centralizer k
+      (symGroupImage k V n : Set (Module.End k (TensorPower k V n))) =
+      diagonalActionImage k V n :=
+    ((Theorem5_18_4_centralizers k V n hN').2).symm
+  -- Per-`L i` simplicity over `MonoidAlgebra k GL_N` (à la `_simple`'s `hL_simple`).
+  have hL_simple : ∀ i, IsSimpleModule
+      (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
+      (Representation.asModule (L i).ρ) := by
+    intro i
+    letI hC_mod :
+        Module (↥(Subalgebra.centralizer k
+          (symGroupImage k V n : Set (Module.End k (TensorPower k V n)))))
+          (↥(S' i) →ₗ[symGroupImage k V n] TensorPower k V n) :=
+      centralizerModuleHom (A := symGroupImage k V n)
+        (V := (↥(S' i) : Type u))
+    haveI hC_st :
+        IsScalarTower k
+          (↥(Subalgebra.centralizer k
+            (symGroupImage k V n : Set (Module.End k (TensorPower k V n)))))
+          (↥(S' i) →ₗ[symGroupImage k V n] TensorPower k V n) := by
+      refine ⟨fun a c f => ?_⟩
+      refine LinearMap.ext fun v => ?_
+      change (a • c).val (f v) = a • c.val (f v)
+      rw [SetLike.val_smul]
+      exact LinearMap.smul_apply a c.val (f v)
+    haveI hC_simp :
+        IsSimpleModule
+          (↥(Subalgebra.centralizer k
+            (symGroupImage k V n : Set (Module.End k (TensorPower k V n)))))
+          (↥(S' i) →ₗ[symGroupImage k V n] TensorPower k V n) :=
+      homA_simp i
+    let φ : ↥(diagonalActionImage k V n) ≃ₐ[k]
+        ↥(Subalgebra.centralizer k
+          (symGroupImage k V n : Set (Module.End k (TensorPower k V n)))) :=
+      Subalgebra.equivOfEq _ _ h_eq.symm
+    letI hD_mod :
+        Module (↥(diagonalActionImage k V n))
+          (↥(S' i) →ₗ[symGroupImage k V n] TensorPower k V n) :=
+      Module.compHom (↥(S' i) →ₗ[symGroupImage k V n] TensorPower k V n)
+        (φ : ↥(diagonalActionImage k V n) →+*
+          ↥(Subalgebra.centralizer k
+            (symGroupImage k V n : Set (Module.End k (TensorPower k V n)))))
+    haveI hD_st :
+        IsScalarTower k (↥(diagonalActionImage k V n))
+          (↥(S' i) →ₗ[symGroupImage k V n] TensorPower k V n) := by
+      refine ⟨fun a d m => ?_⟩
+      change φ (a • d) • m = a • φ d • m
+      rw [map_smul]
+      exact (smul_assoc a (φ d) m).symm
+    haveI hφ_surj :
+        RingHomSurjective
+          (φ : ↥(diagonalActionImage k V n) →+*
+            ↥(Subalgebra.centralizer k
+              (symGroupImage k V n : Set (Module.End k (TensorPower k V n))))) :=
+      ⟨φ.surjective⟩
+    haveI hD_simp :
+        IsSimpleModule (↥(diagonalActionImage k V n))
+          (↥(S' i) →ₗ[symGroupImage k V n] TensorPower k V n) := by
+      let l : (↥(S' i) →ₗ[symGroupImage k V n] TensorPower k V n)
+          →ₛₗ[(φ : ↥(diagonalActionImage k V n) →+*
+              ↥(Subalgebra.centralizer k
+                (symGroupImage k V n : Set (Module.End k (TensorPower k V n)))))]
+            (↥(S' i) →ₗ[symGroupImage k V n] TensorPower k V n) :=
+        { toFun := id
+          map_add' := fun _ _ => rfl
+          map_smul' := fun _ _ => rfl }
+      exact (LinearMap.isSimpleModule_iff_of_bijective l
+        Function.bijective_id).mpr hC_simp
+    haveI : Module.Finite k
+        (↥(S' i) →ₗ[symGroupImage k V n] TensorPower k V n) :=
+      hLi_fin i
+    refine isSimpleModule_monoidAlgebra_GL_of_centralizer_simple k
+      (N := N) (n := n)
+      (M := ↥(S' i) →ₗ[symGroupImage k V n] TensorPower k V n)
+      (FDRep.of (ρ i)).ρ ?_
+    intro g x
+    exact LinearMap.ext fun _ => rfl
+  refine ⟨ι, hι, hι_dec, S', hS'_simp, hS'_dist, hS'_fin, L, hL_simple,
+    L_carrier, e, he, ?_⟩
+  intro i g l v
+  rfl
+
 end Etingof

--- a/progress/2026-06-14T23-36-09Z_dbb8081f.md
+++ b/progress/2026-06-14T23-36-09Z_dbb8081f.md
@@ -1,0 +1,57 @@
+## Accomplished
+
+Work session `dbb8081f` (`/work` → `/feature`), issue **#4666**
+(`glTensorRep_schurWeyl_decomposition_equivariant_simple`, Ch5 Schur-Weyl #5
+Step E bridge-1, parent #2482).
+
+Closed the single `sorry` in
+`glTensorRep_schurWeyl_decomposition_equivariant_simple`
+(`Chapter5/PolynomialGLDecomposition.lean`) — the unified equivariant + simple
+Schur-Weyl decomposition of `V^{⊗n}`.
+
+Route taken (a refinement of the issue's strategy B):
+
+- The two source theorems (`glTensorRep_equivariant_schurWeyl_decomposition`
+  for equivariance, `Theorem5_18_4_GL_rep_decomposition_simple` for the per-`L i`
+  simplicity) both destructure `Theorem5_18_4_bimodule_decomposition_explicit`
+  but keep disjoint clauses, so their existential outputs cannot be merged
+  post-hoc (different `e`).
+- A pure single-file merge in `PolynomialGLDecomposition` hit a heartbeat/`whnf`
+  blowup: the bimodule `e` is typed in the hom-space family
+  `↥(S' i) →ₗ[A] V^⊗n`, and re-typing it to the `(L i).V` family inside the
+  proof (via `let e'`) forces repeated `whnf` through the non-reducible
+  `FGModuleCat.of_carrier` coercion during the equivariance rewrites.
+- **Fix:** added `Theorem5_18_4_GL_rep_decomposition_explicit_simple` to
+  `SchurWeylGLTransfer.lean` (where the simplicity helper
+  `isSimpleModule_monoidAlgebra_GL_of_centralizer_simple` lives). It merges the
+  `_explicit` construction (keeping `homA_simp`) with the `_simple` `hL_simple`
+  block over one shared `ρ i`, paying the family coercion **once** at its
+  `refine` so `e` is output already typed in the `(L i : Type u)` family.
+  The bridge in `PolynomialGLDecomposition` is now a thin equivariance wrapper
+  (verbatim `glTensorRep_equivariant_…` proof) consuming the opaque `e`,
+  threading `hL_simple`. No `whnf` blowup; fits inside the 3.2M heartbeat budget.
+
+## Current frontier
+
+`PolynomialGLDecomposition.lean` has one remaining `sorry`: bridge-2,
+`polynomial_homog_rep_asModule_embeds_directSum_simple` (issue #4667, currently
+`Blocked on #4666`). With #4666 now landing, #4667 is unblocked.
+
+## Overall project progress
+
+Etingof draft 1, Stage 3. Ch5 Schur-Weyl #5 Step E (#2482): bridge-1 closed.
+Once bridge-2 (#4667) lands, `decompose_polynomial_gl_rep` is a clean
+application of the isotypic engine (#4600). New reusable lemma
+`Theorem5_18_4_GL_rep_decomposition_explicit_simple` available for any consumer
+needing the explicit decomposition data together with per-`L i` simplicity.
+
+## Next step
+
+A worker claims **#4667** (bridge-2): `polynomial_homog_rep_asModule_embeds_directSum_simple`
+— package #4598 + the now-closed #4666 + the `asModule` transfer + the
+`Fin m`-fold product / `S ⊗ L` splitting into the single `R`-linear embedding
+form consumed by the isotypic engine.
+
+## Blockers
+
+None for this item. #4667 was blocked on #4666; it is now unblocked.


### PR DESCRIPTION
Closes #4666

Session: `dbb8081f-b3ef-46a9-8da1-81dae905f18f`

384a84c9 feat(Ch5 #4666): close glTensorRep_schurWeyl_decomposition_equivariant_simple

🤖 Prepared with Claude Code