### PR TITLE
feat(Ch5 #2708 sub-B): ℂ-specialized assembly of schurModuleSubmodule_isSimple_centralizer (interface + centralizer/imageSubmoduleB transfer)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/SchurModuleSimple.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurModuleSimple.lean
@@ -1,6 +1,9 @@
 import Mathlib
 import EtingofRepresentationTheory.Chapter5.Theorem5_22_1
 import EtingofRepresentationTheory.Chapter5.SchurWeylGLTransfer
+import EtingofRepresentationTheory.Chapter5.Theorem5_18_4
+import EtingofRepresentationTheory.Chapter5.SchurModuleSpecialBlock
+import EtingofRepresentationTheory.Chapter5.PrimitiveIdempotentSimplicity
 
 /-!
 # Theorem 5.22.1 (Schur-Weyl L_i, part C-4c): the Schur module is a simple GL_N-rep.
@@ -116,35 +119,143 @@ instance schurModuleSubmodule_diagonalActionImage_isScalarTower
     change (c • b.val) v.val = c • b.val v.val
     rfl
 
-/-! ## C-4a aggregation (sorry pending parallel work)
+/-! ## C-4a aggregation
 
-`schurModuleSubmodule_isSimple_centralizer` aggregates the C-4a sub-pieces:
+`schurModuleSubmodule_isSimple_centralizer` aggregates the C-4a sub-pieces over `ℂ`:
 * sub-α: bimodule decomposition `Theorem5_18_4_bimodule_decomposition_explicit`;
-* sub-β: off-block vanishing (β.2 = #2683 merged via PR #2697; β.3 = #2684
-  unclaimed);
-* sub-γ: rank-1 scaled-projection structure (γ.A in flight as PR #2694;
-  γ.B = #2693 blocked on β.3);
-* C-4a-ii: `image_of_primitive_idempotent_isSimple_centralizer` in
-  `PrimitiveIdempotentSimplicity.lean`, merged via PR #2698.
+* sub-A (#4634): `exists_unique_special_block` — the unique block labelled
+  `weightToPartition N lam`;
+* sub-β: off-block vanishing (`youngSym_action_vanishes_off_block`);
+* sub-γ: rank-1 scaled projection (`youngSym_action_on_special_block_rank_one_scaled_proj`);
+* C-4a-ii: `image_of_primitive_idempotent_isSimple_centralizer`.
 
-The sorry will be discharged by a follow-up planner issue (the "C-4a
-aggregation" step) once γ.A, γ.B, and β.3 land. -/
+The two substantial steps are factored as `schurBlock_imageSubmoduleB_isSimple`
+(the interface application, simplicity of `imageSubmoduleB c` over the centralizer)
+and the transfer to `diagonalActionImage`/`SchurModuleSubmodule`. -/
 
-/-- **Schur-Weyl L_i, part C-4a (aggregated).**
+section CAggregation
 
-The Schur module submodule `SchurModuleSubmodule k N λ`, viewed as a
-`diagonalActionImage k V n`-module via the canonical action above, is simple.
+variable (N : ℕ) (lam : Fin N → ℕ)
+
+/-- `n ≤ Module.finrank ℂ (Fin N → ℂ)`, the dimension bound needed by the
+bimodule decomposition and the centralizer equality. -/
+private lemma finrank_bound (hN : (∑ i, lam i) ≤ N) :
+    (∑ i, lam i) ≤ Module.finrank ℂ (Fin N → ℂ) := by
+  rw [Module.finrank_pi, Fintype.card_fin]; exact hN
+
+/-- The Young-symmetrizer endomorphism preserves each `symGroupImage`-stable
+submodule (as a `ℂ`-submodule via `restrictScalars`). The membership proof used
+to build `LinearMap.restrict`; proof-irrelevant, so it matches the (private)
+proof inside the off-block / rank-one lemmas. -/
+private lemma youngSymEndo_mem_restrictScalars
+    (S : Submodule (symGroupImage ℂ (Fin N → ℂ) (∑ i, lam i))
+      (TensorPower ℂ (Fin N → ℂ) (∑ i, lam i)))
+    (x : TensorPower ℂ (Fin N → ℂ) (∑ i, lam i))
+    (hx : x ∈ S.restrictScalars ℂ) :
+    youngSymEndomorphism ℂ N lam x ∈ S.restrictScalars ℂ := by
+  rw [Submodule.restrictScalars_mem] at hx ⊢
+  have h := S.smul_mem (youngSymElement ℂ N lam) hx
+  rwa [Subalgebra.smul_def, Module.End.smul_def, youngSymElement_val] at h
+
+set_option maxHeartbeats 6400000 in
+set_option synthInstance.maxHeartbeats 3200000 in
+/-- **Schur-Weyl L_i, C-4a interface step.** The image of the Young symmetrizer
+`c = youngSymElement ℂ N lam`, packaged as `imageSubmoduleB c`, is simple as a
+module over `centralizer(symGroupImage)`. This is the application of
+`image_of_primitive_idempotent_isSimple_centralizer` to the explicit Schur-Weyl
+bimodule decomposition, feeding it off-block vanishing (sub-β) and the rank-1
+scaled projection on the special block (sub-γ). -/
+private theorem schurBlock_imageSubmoduleB_isSimple
+    (hlam : Antitone lam) (hN : (∑ i, lam i) ≤ N) :
+    IsSimpleModule
+      (↥(Subalgebra.centralizer ℂ
+        (symGroupImage ℂ (Fin N → ℂ) (∑ i, lam i) :
+          Set (Module.End ℂ (TensorPower ℂ (Fin N → ℂ) (∑ i, lam i))))))
+      ↥(imageSubmoduleB (youngSymElement ℂ N lam)) := by
+  classical
+  have hN' : (∑ i, lam i) ≤ Module.finrank ℂ (Fin N → ℂ) := finrank_bound N lam hN
+  -- sub-α: explicit bimodule decomposition.
+  obtain ⟨ι, _, _, S, hSimp, hDist, hSfin, _hLsimp, e, he⟩ :=
+    Theorem5_18_4_bimodule_decomposition_explicit
+      (k := ℂ) (V := Fin N → ℂ) (n := ∑ i, lam i) hN'
+  haveI : IsSemisimpleModule (symGroupImage ℂ (Fin N → ℂ) (∑ i, lam i))
+      (TensorPower ℂ (Fin N → ℂ) (∑ i, lam i)) := IsSemisimpleRing.isSemisimpleModule
+  -- sub-A (#4634): the unique special block.
+  obtain ⟨iLam, hLabel_iLam, hLabel_other⟩ :=
+    exists_unique_special_block N lam hlam S hSimp hDist hSfin e he
+  -- The scalar `α` with `c² = α • c` (directly over ℂ); nonvanishing is deferred
+  -- to the reconciliation `α = α'` below (`α'` is the rank-1 lemma's nonzero scalar).
+  obtain ⟨α, hα_sq⟩ := YoungSymmetrizerK_sq_scalar ℂ (∑ i, lam i) (weightToPartition N lam)
+  -- `c = youngSymElement`, with `c² = α • c`.
+  have hc_sq : youngSymElement ℂ N lam * youngSymElement ℂ N lam =
+      α • youngSymElement ℂ N lam := by
+    apply Subtype.ext
+    rw [Subalgebra.coe_mul, Subalgebra.coe_smul, youngSymElement_val]
+    exact youngSymEndomorphism_sq_scalar ℂ N lam α hα_sq
+  -- The per-block `ℂ`-linear maps `f i = c|_{S i}`.
+  let f : ∀ i, ↥(S i) →ₗ[ℂ] ↥(S i) := fun i =>
+    (youngSymEndomorphism ℂ N lam).restrict
+      (p := (S i).restrictScalars ℂ) (q := (S i).restrictScalars ℂ)
+      (youngSymEndo_mem_restrictScalars N lam (S i))
+  -- Block factorization (sub-(1)).
+  have hf_block : ∀ (i : ι) (v : ↥(S i))
+      (l : ↥(S i) →ₗ[symGroupImage ℂ (Fin N → ℂ) (∑ i, lam i)]
+        TensorPower ℂ (Fin N → ℂ) (∑ i, lam i)),
+      e ((youngSymElement ℂ N lam).val (e.symm (DirectSum.of _ i (v ⊗ₜ[ℂ] l)))) =
+        DirectSum.of _ i (f i v ⊗ₜ[ℂ] l) := by
+    intro i v l
+    exact youngSym_block_factorization ℂ N lam S e he i v l
+  -- sub-β: off blocks vanish.
+  have hf_zero : ∀ i, i ≠ iLam → f i = 0 := by
+    intro i hi
+    obtain ⟨la', hla'_ne, hla'_trace⟩ := hLabel_other i hi
+    haveI : Module.Finite ℂ ↥((S i).restrictScalars ℂ) := hSfin i
+    exact youngSym_action_vanishes_off_block N lam (S i) la' hla'_trace hla'_ne
+  -- sub-γ: rank-1 scaled projection on the special block.
+  haveI : Module.Finite ℂ ↥((S iLam).restrictScalars ℂ) := hSfin iLam
+  obtain ⟨α', π', hα'_ne, hπ'_idem, hπ'_rank, hf_eq_raw⟩ :=
+    youngSym_action_on_special_block_rank_one_scaled_proj N lam (S iLam) hLabel_iLam
+  have hf_eq : f iLam = α' • π' := hf_eq_raw
+  -- Reconcile `α' = α` using `f iLam² = α • f iLam` and `f iLam = α' • π'`.
+  have hf_sq : f iLam * f iLam = α • f iLam :=
+    youngSymEndomorphism_restrict_sq_scalar (k := ℂ) N lam (S iLam) α hα_sq
+  have hπ'_ne : π' ≠ 0 := by
+    intro h0
+    rw [h0, LinearMap.range_zero, finrank_bot] at hπ'_rank
+    exact one_ne_zero hπ'_rank.symm
+  have hαeq : α' = α := by
+    have h1 : f iLam * f iLam = (α' * α') • π' := by
+      rw [hf_eq, smul_mul_smul_comm, hπ'_idem]
+    have h2 : α • f iLam = (α * α') • π' := by rw [hf_eq, smul_smul]
+    have key : (α' * α') • π' = (α * α') • π' := by rw [← h1, hf_sq, h2]
+    have hscal : α' * α' = α * α' := smul_left_injective ℂ hπ'_ne key
+    exact mul_right_cancel₀ hα'_ne hscal
+  have hα_ne : α ≠ 0 := hαeq ▸ hα'_ne
+  have hf_special : f iLam = α • π' := by rw [hf_eq, hαeq]
+  -- Apply the interface.
+  exact image_of_primitive_idempotent_isSimple_centralizer
+    (youngSymElement ℂ N lam) α hα_ne hc_sq S e he iLam (hSimp iLam)
+    f hf_block hf_zero π' hπ'_idem hπ'_rank hf_special
+
+end CAggregation
+
+/-- **Schur-Weyl L_i, part C-4a (aggregated, over ℂ).**
+
+The Schur module submodule `SchurModuleSubmodule ℂ N λ`, viewed as a
+`diagonalActionImage ℂ V n`-module via the canonical action above, is simple.
 
 Equivalently, by `Theorem5_18_4_centralizers` (which requires `n ≤ N`),
 it is simple as a `centralizer(symGroupImage)`-module. The proof aggregates
-the pieces `sub-α`, `sub-β`, `sub-γ`, `C-4a-ii` of the C-4a programme via
+the pieces `sub-α`, `sub-A`, `sub-β`, `sub-γ`, `C-4a-ii` of the C-4a programme via
 `image_of_primitive_idempotent_isSimple_centralizer`
-(`PrimitiveIdempotentSimplicity.lean`). -/
+(`PrimitiveIdempotentSimplicity.lean`) in `schurBlock_imageSubmoduleB_isSimple`,
+then transfers along the centralizer equality `diagonalActionImage = centralizer`
+and the carrier identity `imageSubmoduleB c = SchurModuleSubmodule`. -/
 theorem schurModuleSubmodule_isSimple_centralizer
-    (N : ℕ) (lam : Fin N → ℕ) (_hlam : Antitone lam) (_hN : (∑ i, lam i) ≤ N) :
+    (N : ℕ) (lam : Fin N → ℕ) (hlam : Antitone lam) (hN : (∑ i, lam i) ≤ N) :
     IsSimpleModule
-      (↥(diagonalActionImage k (Fin N → k) (∑ i, lam i)))
-      (SchurModuleSubmodule k N lam) := by
+      (↥(diagonalActionImage ℂ (Fin N → ℂ) (∑ i, lam i)))
+      (SchurModuleSubmodule ℂ N lam) := by
   sorry
 
 /-! ## Final assembly: `schurModule_isSimple` -/
@@ -160,13 +271,13 @@ GL-action factor as `g • v ↦ ⟨g^⊗n, _⟩ • v`, so `diagonalActionImage
 transfers to `MonoidAlgebra k GL_N`-simplicity. -/
 theorem schurModule_isSimple
     (N : ℕ) (lam : Fin N → ℕ) (hlam : Antitone lam) (hN : (∑ i, lam i) ≤ N) :
-    IsSimpleModule (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
-      (Representation.asModule (SchurModule k N lam).ρ) := by
-  haveI := schurModuleSubmodule_isSimple_centralizer k N lam hlam hN
-  refine isSimpleModule_monoidAlgebra_GL_of_centralizer_simple k
+    IsSimpleModule (MonoidAlgebra ℂ (Matrix.GeneralLinearGroup (Fin N) ℂ))
+      (Representation.asModule (SchurModule ℂ N lam).ρ) := by
+  haveI := schurModuleSubmodule_isSimple_centralizer N lam hlam hN
+  refine isSimpleModule_monoidAlgebra_GL_of_centralizer_simple ℂ
     (N := N) (n := ∑ i, lam i)
-    (M := ↥(SchurModuleSubmodule k N lam))
-    (schurModuleRep k N lam) ?_
+    (M := ↥(SchurModuleSubmodule ℂ N lam))
+    (schurModuleRep ℂ N lam) ?_
   intro g x
   -- Both sides apply `g^⊗n` to `x.val` and re-bundle into `SchurModuleSubmodule`.
   -- LHS: `(schurModuleRep g) x = (glTensorRep g).restrict ... x`.

--- a/EtingofRepresentationTheory/Chapter5/SchurModuleSimple.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurModuleSimple.lean
@@ -9,9 +9,8 @@ import EtingofRepresentationTheory.Chapter5.PrimitiveIdempotentSimplicity
 # Theorem 5.22.1 (Schur-Weyl L_i, part C-4c): the Schur module is a simple GL_N-rep.
 
 Final assembly step combining the algebraic core
-`schurModuleSubmodule_isSimple_centralizer` (the C-4a aggregation, sorry pending the
-parallel Schur-Weyl C-4a-i and C-4a-ii sub-issues) with the GL_N transfer
-`isSimpleModule_monoidAlgebra_GL_of_centralizer_simple`
+`schurModuleSubmodule_isSimple_centralizer` (the C-4a aggregation, proved over `ℂ`)
+with the GL_N transfer `isSimpleModule_monoidAlgebra_GL_of_centralizer_simple`
 (C-4b, in `SchurWeylGLTransfer.lean`).
 
 The deliverable is `schurModule_isSimple`: simplicity of `SchurModule k N λ` as a
@@ -239,6 +238,8 @@ private theorem schurBlock_imageSubmoduleB_isSimple
 
 end CAggregation
 
+set_option maxHeartbeats 1600000 in
+set_option synthInstance.maxHeartbeats 800000 in
 /-- **Schur-Weyl L_i, part C-4a (aggregated, over ℂ).**
 
 The Schur module submodule `SchurModuleSubmodule ℂ N λ`, viewed as a
@@ -256,7 +257,50 @@ theorem schurModuleSubmodule_isSimple_centralizer
     IsSimpleModule
       (↥(diagonalActionImage ℂ (Fin N → ℂ) (∑ i, lam i)))
       (SchurModuleSubmodule ℂ N lam) := by
-  sorry
+  classical
+  have hN' : (∑ i, lam i) ≤ Module.finrank ℂ (Fin N → ℂ) := finrank_bound N lam hN
+  -- `diagonalActionImage = centralizer(symGroupImage)`.
+  have hBD : diagonalActionImage ℂ (Fin N → ℂ) (∑ i, lam i) =
+      Subalgebra.centralizer ℂ
+        (symGroupImage ℂ (Fin N → ℂ) (∑ i, lam i) :
+          Set (Module.End ℂ (TensorPower ℂ (Fin N → ℂ) (∑ i, lam i)))) :=
+    (Theorem5_18_4_centralizers ℂ (Fin N → ℂ) (∑ i, lam i) hN').2
+  -- The interface result: `imageSubmoduleB c` is simple over the centralizer.
+  have h1 := schurBlock_imageSubmoduleB_isSimple N lam hlam hN
+  -- Ring iso induced by the subalgebra equality.
+  let φ : ↥(diagonalActionImage ℂ (Fin N → ℂ) (∑ i, lam i)) ≃+*
+      ↥(Subalgebra.centralizer ℂ
+        (symGroupImage ℂ (Fin N → ℂ) (∑ i, lam i) :
+          Set (Module.End ℂ (TensorPower ℂ (Fin N → ℂ) (∑ i, lam i))))) :=
+    (Subalgebra.equivOfEq _ _ hBD).toRingEquiv
+  haveI : RingHomInvPair φ.toRingHom φ.symm.toRingHom :=
+    ⟨by ext x; simpa using φ.symm_apply_apply x,
+      by ext x; simpa using φ.apply_symm_apply x⟩
+  haveI : RingHomInvPair φ.symm.toRingHom φ.toRingHom :=
+    ⟨by ext x; simpa using φ.apply_symm_apply x,
+      by ext x; simpa using φ.symm_apply_apply x⟩
+  -- The carrier identity `SchurModuleSubmodule = range c.val = imageSubmoduleB c`,
+  -- packaged as a `φ`-semilinear equiv.
+  let e : ↥(SchurModuleSubmodule ℂ N lam) ≃ₛₗ[φ.toRingHom]
+      ↥(imageSubmoduleB (youngSymElement ℂ N lam)) :=
+    { toFun := fun x => ⟨x.val, by rw [mem_imageSubmoduleB]; exact x.property⟩
+      map_add' := fun _ _ => rfl
+      map_smul' := fun a x => by
+        apply Subtype.ext
+        rw [schurModuleSubmodule_diagonalActionImage_smul_coe, SetLike.val_smul]
+        rfl
+      invFun := fun y => ⟨y.val, by
+        have hy := y.property; rw [mem_imageSubmoduleB] at hy; exact hy⟩
+      left_inv := fun _ => rfl
+      right_inv := fun _ => rfl }
+  -- Transfer simplicity along the induced order isomorphism of submodule lattices.
+  have hso1 : IsSimpleOrder
+      (Submodule (↥(Subalgebra.centralizer ℂ
+        (symGroupImage ℂ (Fin N → ℂ) (∑ i, lam i) :
+          Set (Module.End ℂ (TensorPower ℂ (Fin N → ℂ) (∑ i, lam i))))))
+        ↥(imageSubmoduleB (youngSymElement ℂ N lam))) := h1.toIsSimpleOrder
+  have hso2 := (Submodule.orderIsoMapComap e).isSimpleOrder_iff.mpr hso1
+  exact { toIsSimpleOrder := hso2 }
 
 /-! ## Final assembly: `schurModule_isSimple` -/
 

--- a/progress/2026-06-14T23-59-47Z_8202e746.md
+++ b/progress/2026-06-14T23-59-47Z_8202e746.md
@@ -1,0 +1,52 @@
+## Accomplished
+
+Work session `8202e746` (`/work` → `/feature`), issue **#4636**
+(`schurModuleSubmodule_isSimple_centralizer`, the ℂ-specialized C-4a aggregation
+of Schur-Weyl L_i, parent #2708).
+
+Closed both sorries in `Chapter5/SchurModuleSimple.lean` — the file is now
+**sorry-free** and `Chapter5` builds.
+
+- **Interface step** `schurBlock_imageSubmoduleB_isSimple` (private): applied
+  `image_of_primitive_idempotent_isSimple_centralizer` to the explicit Schur-Weyl
+  bimodule decomposition (`Theorem5_18_4_bimodule_decomposition_explicit`) +
+  `exists_unique_special_block` (#4634). The per-block maps `f i = c|_{S i}` are
+  built as `youngSymEndomorphism.restrict` (proof-irrelevant membership, so they
+  match the off-block / rank-one lemmas' restrict maps by defeq); off-block
+  vanishing (`youngSym_action_vanishes_off_block`) gives `hf_zero`, the rank-1
+  scaled projection (`youngSym_action_on_special_block_rank_one_scaled_proj`)
+  gives `π'`. The scalar `α` (from `YoungSymmetrizerK_sq_scalar ℂ`, directly over
+  ℂ — no ℚ cast / private lemmas needed) is reconciled with the rank-1 lemma's
+  `α'` via `f² = α·f`, `f = α'·π'`, `π' ≠ 0`, `smul_left_injective`.
+- **Transfer**: built a `φ`-semilinear carrier-identity equiv `e` between
+  `SchurModuleSubmodule` (`diagonalActionImage`-module) and `imageSubmoduleB`
+  (`centralizer`-module), where `φ` is the ring iso from `Theorem5_18_4_centralizers`
+  (`diagonalActionImage = centralizer(symGroupImage)`). `RingHomInvPair` for the
+  `RingEquiv` is **not** a Mathlib instance — provided locally. Transferred
+  `IsSimpleModule` along `Submodule.orderIsoMapComap e` + `OrderIso.isSimpleOrder_iff`.
+- Specialized both `schurModuleSubmodule_isSimple_centralizer` and
+  `schurModule_isSimple` to ℂ (a grep confirmed no external consumers — only doc
+  comments in `SchurModuleSpecialBlock.lean`).
+
+## Current frontier
+
+`SchurModuleSimple.lean` sorry-free. Downstream: `schurModule_isSimple` (Schur
+module is a simple GL_N(ℂ)-rep) is now unconditionally available over ℂ.
+
+## Overall project progress
+
+Etingof draft 1, Stage 3. Ch5 Schur-Weyl L_i (parent #2708): the C-4c endpoint
+`schurModule_isSimple` is closed over ℂ. Remaining Ch5 Schur-Weyl sorries live in
+`PolynomialGLDecomposition.lean` (2, the #4666/#4667 bridge lemmas) and the
+det⁻¹-elimination chain (#4694/#4695).
+
+## Next step
+
+A worker picks up another open item (e.g. #4666 bridge-1 if unclaimed, or a Ch6
+tube assembly). No follow-up needed for #4636.
+
+## Blockers
+
+None. Both deliverables landed sorry-free; the "Stalls / pivots" escape (leaving
+a sorry + follow-up) was not needed — the restrictScalars carrier defeq and the
+semilinear-equiv transfer both went through.


### PR DESCRIPTION
Closes #4636

Session: `8202e746-94eb-429c-aaa2-aa682389b64a`

caabaf87 Merge remote-tracking branch 'origin/main' into agent/8202e746
c24a4e00 doc(Ch5 #4636): progress file for SchurModuleSimple sorry-free
21c32da7 feat(Ch5 #4636): close schurModuleSubmodule_isSimple_centralizer + schurModule_isSimple (ℂ)
ddaa6000 feat(Ch5 #4636): close C-4a interface step schurBlock_imageSubmoduleB_isSimple (ℂ)

🤖 Prepared with Claude Code