### PR TITLE
fix(Ch5): add essential h_span hypothesis to the polynomial GL-rep decomposition bridge

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/PolynomialGLDecomposition.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialGLDecomposition.lean
@@ -174,12 +174,17 @@ ambient summand is, an `R`-linear identification `e` of the ambient
 `(V^{⊗n})^m`-module with `⨁_{c : κ} asModule (L (g c))`, and a submodule `M'`
 of that ambient module together with an `R`-linear iso `asModule M.ρ ≃ M'`.
 
-TODO (sub-issue of #2482): supply the `asModule` transfer glue and the
-`Fin m`-fold product / `S ⊗ L` splitting. -/
+The hypothesis `h_span` — that the `ℕ`-indexed weight spaces span `M` — is
+**essential** (it says `M` is genuinely *polynomial*, not merely algebraic). It
+feeds `polynomial_homog_rep_equivariant_embedding` (#4598); without it the
+statement is false, since `IsAlgebraicRepresentation` + `h_homog` admits the
+counterexample `M = Sym²(V) ⊗ det⁻¹` (`N = 2`, `n = 0`), which has no embedding
+into `V^{⊗0}`. -/
 theorem polynomial_homog_rep_asModule_embeds_directSum_simple
     [IsAlgClosed k] [CharZero k] (n : ℕ) (hN : n ≤ N)
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
     (halg : Etingof.IsAlgebraicRepresentation N M.ρ)
+    (h_span : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M (fun i => μ i) = ⊤)
     (h_homog : ∀ μ : Fin N → ℕ, glWeightSpace k N M μ ≠ ⊥ → ∑ i, μ i = n) :
     ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
       (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
@@ -209,6 +214,7 @@ theorem decompose_polynomial_gl_rep
     [IsAlgClosed k] [CharZero k] (n : ℕ) (hN : n ≤ N)
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
     (halg : Etingof.IsAlgebraicRepresentation N M.ρ)
+    (h_span : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M (fun i => μ i) = ⊤)
     (h_homog : ∀ μ : Fin N → ℕ, glWeightSpace k N M μ ≠ ⊥ → ∑ i, μ i = n) :
     ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
       (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
@@ -220,7 +226,7 @@ theorem decompose_polynomial_gl_rep
   -- Embed `M.asModule` as a submodule `M'` of an ambient module `W` that is
   -- `R`-linearly a finite direct sum of the simple `L (gκ c)`.
   obtain ⟨ι, hιFin, hιDec, L, hLsimp, κ, hκFin, gκ, W, hWacg, hWmod, e, M', ⟨eM⟩⟩ :=
-    polynomial_homog_rep_asModule_embeds_directSum_simple k N n hN M halg h_homog
+    polynomial_homog_rep_asModule_embeds_directSum_simple k N n hN M halg h_span h_homog
   -- The ambient summand family, indexed by `κ`.
   set Lsum : κ → Type u := fun c => Representation.asModule (L (gκ c)).ρ with hLsum
   haveI : ∀ c, IsSimpleModule (GLAlg k N) (Lsum c) := fun c => hLsimp (gκ c)

--- a/progress/2026-06-15T00-31-05Z_f4590c78.md
+++ b/progress/2026-06-15T00-31-05Z_f4590c78.md
@@ -1,0 +1,54 @@
+## Accomplished
+
+Feature session on **#4667** (Ch5 #2482 bridge-2,
+`polynomial_homog_rep_asModule_embeds_directSum_simple` in
+`Chapter5/PolynomialGLDecomposition.lean`).
+
+- **Statement-correctness fix (landed).** The target theorem and its consumer
+  `decompose_polynomial_gl_rep` were **false as stated**: both relied (via #4598,
+  `polynomial_homog_rep_equivariant_embedding`) on the weight spaces spanning
+  `M`, but neither carried that hypothesis. The same file documents the
+  counterexample explicitly (`PolynomialRepEmbedding.lean:1139-1148`):
+  `M = Sym²(V) ⊗ det⁻¹` (`N=2`, `n=0`) is algebraic and satisfies `h_homog`
+  vacuously, yet does not embed into `V^{⊗0}`. Added
+  `h_span : ⨆ μ : Fin N →₀ ℕ, glWeightSpace k N M (fun i => μ i) = ⊤` to both
+  theorems, threaded it through the call site, and documented it in the
+  docstring. Neither theorem is consumed outside the file, so no downstream
+  breakage. `lake build EtingofRepresentationTheory.Chapter5.PolynomialGLDecomposition`
+  passes (only the pre-existing `sorry` warning at the main theorem remains).
+
+- **Decomposition of the remaining proof.** Audited the assembly: the conversion
+  primitive `Representation.IntertwiningMap.equivLinearMapAsModule`
+  (`Mathlib/RepresentationTheory/Intertwining.lean`) handles equivariant-map →
+  `MonoidAlgebra`-linear-map, but the decomposition target is a `DirectSum` of
+  `asModule`s, requiring three reusable glue equivs plus intricate
+  `κ = Fin m × Σᵢ basis(Sᵢ)` indexing. Filed:
+  - **#4714** glue-A: `asModule (Representation.directSum ρs) ≃ₗ[k[G]] ⨁ asModule (ρs i)`
+    (keystone; carriers defeq, only `map_smul'` via `MonoidAlgebra.induction_linear`).
+  - **#4715** glue-B: `asModule ((trivial S).tprod σ) ≃ₗ[k[G]] ⨁_basis asModule σ`
+    (dep #4714).
+  - **#4716** assembly: compose #4598 + `glTensorRep_schurWeyl_decomposition_equivariant_simple`
+    + glue-A/B + `LinearEquiv.ofInjective` (dep #4714, #4715).
+
+## Current frontier
+
+#4667 decomposed; statement fix ready to merge as a partial PR. The mathematical
+content of the bridge now lives in #4714/#4715/#4716.
+
+## Overall project progress
+
+Stage 3 (formalization), Schur-Weyl #5 chain. #4666 (unified equivariant+simple
+decomposition) merged earlier today; #4667 is the next bridge for #2482, whose
+downstream consumer is #2483 (`iso_of_formalCharacter_eq_schurPoly`).
+
+## Next step
+
+Work #4714 (glue-A) — it is unblocked and is the keystone the other two depend
+on. The proof is a single `LinearEquiv` whose underlying map is the identity on
+`⨁ i, V i` (carriers are defeq); only `map_smul'` over `MonoidAlgebra k G` needs
+the `single_smul` + `DirectSum.lmap`-componentwise computation.
+
+## Blockers
+
+None. #4715 and #4716 are correctly marked `blocked` on their dependencies and
+will unblock automatically as #4714/#4715 close.


### PR DESCRIPTION
Partial progress on #4667

Session: `f4590c78-45a5-4075-8d0e-c2572ecd6ab4`

e337e61d fix(Ch5 #4667): add essential h_span hypothesis to polynomial_homog_rep_asModule_embeds_directSum_simple + decompose

🤖 Prepared with Claude Code