### PR TITLE
feat(Ch5 #4721): well-pose Schur-Weyl simples classification crux/headline + surface GL-simplicity

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/FormalCharacterIso.lean
+++ b/EtingofRepresentationTheory/Chapter5/FormalCharacterIso.lean
@@ -1,6 +1,7 @@
 import Mathlib
 import EtingofRepresentationTheory.Chapter5.Theorem5_22_1
 import EtingofRepresentationTheory.Chapter5.SchurWeylPolynomialIdentity
+import EtingofRepresentationTheory.Chapter5.SchurWeylGLTransfer
 
 /-!
 # Formal character determines isomorphism class
@@ -779,7 +780,10 @@ theorem glTensorRep_equivariant_schurWeyl_decomposition
       (_ : ∀ i, AddCommGroup (S i))
       (_ : ∀ i, Module k (S i))
       (_ : ∀ i, Module.Finite k (S i))
-      (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k)),
+      (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
+      (_ : ∀ i, IsSimpleModule
+        (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
+        (Representation.asModule (L i).ρ)),
       ∃ (e : TensorPower k (Fin N → k) n ≃ₗ[k]
           (DirectSum ι (fun i => S i ⊗[k] (L i : Type u)))),
         ∀ (g : Matrix.GeneralLinearGroup (Fin N) k)
@@ -789,13 +793,15 @@ theorem glTensorRep_equivariant_schurWeyl_decomposition
               (Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
                 (S i)).tprod (L i).ρ) g (e v) := by
   classical
-  -- Get the explicit GL_N decomposition (issue #2572).
-  obtain ⟨ι, hιFin, hιDec, S', hS'_simp, hS'_dist, hSi_fin, L, L_carrier, e, he,
-      h_act⟩ :=
-    Theorem5_18_4_GL_rep_decomposition_explicit k N n hN
+  -- Get the explicit GL_N decomposition **with per-`L i` simplicity** (issue
+  -- #2572 / #4721): `_explicit_simple` carries the same explicit `(L, e, he,
+  -- h_act)` data as `_explicit`, plus `hL_simp : ∀ i, IsSimpleModule … (L i)`.
+  obtain ⟨ι, hιFin, hιDec, S', hS'_simp, hS'_dist, hSi_fin, L, hL_simp, L_carrier,
+      e, he, h_act⟩ :=
+    Theorem5_18_4_GL_rep_decomposition_explicit_simple k N n hN
   refine ⟨ι, hιFin, hιDec, fun i => ↥(S' i),
     fun _ => inferInstance, fun _ => inferInstance,
-    fun i => hSi_fin i, L, ?_, ?_⟩
+    fun i => hSi_fin i, L, hL_simp, ?_, ?_⟩
   · exact e
   intro g v
   -- Reduce equivariance to: (glTensorRep g) ∘ e.symm = e.symm ∘ directSum_action g.
@@ -871,7 +877,7 @@ theorem formalCharacter_tensorPower_eq_sum_character_L
       formalCharacter k N (FDRep.of (glTensorRep k N n)) =
         ∑ i : ι, (Module.finrank k (S i) : ℚ) • formalCharacter k N (L i) := by
   -- Invoke the GL_N-equivariant Schur-Weyl decomposition (Theorem 5.18.4 iii).
-  obtain ⟨ι, hιFin, hιDec, S, hS_acg, hS_mod, hS_fin, L, e, he⟩ :=
+  obtain ⟨ι, hιFin, hιDec, S, hS_acg, hS_mod, hS_fin, L, _hL_simp, e, he⟩ :=
     glTensorRep_equivariant_schurWeyl_decomposition k N n hN
   refine ⟨ι, hιFin, hιDec, S, hS_acg, hS_mod, hS_fin, L, ?_⟩
   -- Step 1: push char(glTensorRep) across the equivariant iso to the

--- a/EtingofRepresentationTheory/Chapter5/SchurWeylSimplesClassification.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurWeylSimplesClassification.lean
@@ -80,17 +80,29 @@ This is the deferred highest-weight classification: "a simple polynomial
 `GL_N`-rep is determined by its character, and the simples of `V^{⊗n}` are
 exactly the `SchurModule k N λ` for antitone `λ`, `|λ| = n`, `length ≤ N`."
 
+Well-posedness (issue #4721, replacing #4704): the conclusion needs two
+hypotheses on the abstract simples `L` that the bare equivariance data `(e, he)`
+does not pin down, so they are taken explicitly:
+* `hLsimp` — each `L i` is a simple polynomial `GL_N`-rep. Without it `char(L i)`
+  need not be a single `schurPoly` (a reducible `A ⊕ B` summand absorbs into the
+  equivariance), so `char(L i) = schurPoly N λᵢ` would be false.
+* `hLdist` — the `L i` are pairwise non-isomorphic. Without it an isotypic
+  component `S ⊗ L` with `dim S ≥ 2` re-presents as two indices sharing one `L`,
+  forcing `L i ≅ L j` and making `Function.Injective lam` impossible.
+Both are surfaced by `glTensorRep_equivariant_schurWeyl_decomposition` (simplicity
+now, distinctness pending the Schur-Weyl GL-side injectivity sub-issue).
+
 Proof strategy (per #4698 / #2483): each `SchurModule k N λ` is simple
 (`schurModule_isSimple`), algebraic, and homogeneous of degree `n = ∑ λ`, so under
 the abstract decomposition it lands as a single summand `L i₀` with
 `char(L i₀) = formalCharacter k N (SchurModule k N λ) = schurPoly N λ`
-(`formalCharacter_schurModule_eq_schurPoly`). Injectivity of `lam` follows because
-the `L i` are pairwise non-isomorphic simples and `schurPoly` is injective on
-antitone partitions (`schurPoly_injective`).
+(`formalCharacter_schurModule_eq_schurPoly`). Injectivity of `lam` follows from
+`hLdist` and `schurPoly_injective`.
 
-The proof is deferred (the conceptual crux); the single `sorry` is isolated here
-so the reduction and the headline corollary below are otherwise sorry-free. The
-proof is tracked by issue #4704. -/
+The deep step — "a simple polynomial `GL_N`-rep is character-determined ⇒
+`char = schurPoly`" — is the deferred Tier-4 highest-weight content; the single
+residual `sorry` is isolated here so the reduction and headline corollary remain
+otherwise sorry-free. Tracked by issue #4721. -/
 theorem schurWeyl_simples_formalCharacter_classification_core
     (N n : ℕ) (hN : n ≤ N)
     {ι : Type} [Fintype ι] [DecidableEq ι]
@@ -104,10 +116,19 @@ theorem schurWeyl_simples_formalCharacter_classification_core
           e (glTensorRep k N n g v) =
             Representation.directSum (fun i =>
               (Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
-                (S i)).tprod (L i).ρ) g (e v)) :
+                (S i)).tprod (L i).ρ) g (e v))
+    (hLsimp : ∀ i, IsSimpleModule
+        (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
+        (Representation.asModule (L i).ρ))
+    (hLdist : Pairwise (fun i j => ¬ Nonempty ((L i) ≅ (L j)))) :
     ∃ lam : ι → {l : Fin N → ℕ // Antitone l},
       Function.Injective lam ∧
       ∀ i, formalCharacter k N (L i) = schurPoly N (lam i).val := by
+  -- Well-posed (issue #4721) once the highest-weight classification is supplied:
+  -- `hLsimp` (each `L i` simple) pins `char(L i)` to a single `schurPoly N λᵢ`;
+  -- `hLdist` (the `L i` pairwise non-isomorphic) gives `Function.Injective lam`
+  -- via `schurPoly_injective`. The deep step "a simple polynomial `GL_N`-rep is
+  -- character-determined ⇒ `char = schurPoly`" is the deferred Tier-4 content.
   sorry
 
 /-- **Headline (sorry-free given the crux).** The formal characters of the
@@ -131,10 +152,14 @@ theorem glTensorRep_schurWeyl_simples_formalCharacter_linearIndependent
           e (glTensorRep k N n g v) =
             Representation.directSum (fun i =>
               (Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
-                (S i)).tprod (L i).ρ) g (e v)) :
+                (S i)).tprod (L i).ρ) g (e v))
+    (hLsimp : ∀ i, IsSimpleModule
+        (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
+        (Representation.asModule (L i).ρ))
+    (hLdist : Pairwise (fun i j => ¬ Nonempty ((L i) ≅ (L j)))) :
     LinearIndependent ℚ (fun i => formalCharacter k N (L i)) := by
   obtain ⟨lam, hlam_inj, hlam_char⟩ :=
-    schurWeyl_simples_formalCharacter_classification_core k N n hN L e he
+    schurWeyl_simples_formalCharacter_classification_core k N n hN L e he hLsimp hLdist
   exact formalCharacter_linearIndependent_of_eq_schurPoly k N L lam hlam_inj hlam_char
 
 end Etingof

--- a/progress/2026-06-15T00-50-50Z_acbc3e1b.md
+++ b/progress/2026-06-15T00-50-50Z_acbc3e1b.md
@@ -1,0 +1,50 @@
+## Accomplished
+
+Worked issue #4721 (re-scope + close the Schur-Weyl simples character
+classification crux). Partial completion landing the **correctness fix** and one
+provable strengthening; the two genuine Tier-4 pieces are carved into sub-issues.
+
+- **Strengthened `glTensorRep_equivariant_schurWeyl_decomposition`**
+  (`Chapter5/FormalCharacterIso.lean:775`): rebuilt it on
+  `Theorem5_18_4_GL_rep_decomposition_explicit_simple` so it now also outputs
+  per-`Lᵢ` GL-simplicity
+  `∀ i, IsSimpleModule (MonoidAlgebra k GL_N) (asModule (Lᵢ).ρ)`. Added the
+  `SchurWeylGLTransfer` import (verified no import cycle: that file's closure is
+  `Theorem5_18_4 → 5_18_{1,2,3}`, none reaching `FormalCharacterIso`). Updated
+  the sole consumer `formalCharacter_tensorPower_eq_sum_character_L`.
+
+- **Made the crux + headline well-posed**
+  (`Chapter5/SchurWeylSimplesClassification.lean`): added the two hypotheses the
+  #4704 audit found missing — `hLsimp` (each `L i` simple) and `hLdist` (the
+  `L i` pairwise non-isomorphic) — to
+  `schurWeyl_simples_formalCharacter_classification_core` and the headline
+  `glTensorRep_schurWeyl_simples_formalCharacter_linearIndependent`. The headline
+  threads them into the crux and is sorry-free given it. Previously the headline's
+  conclusion was provably false (the audit's `S ⊗ L` counterexample); it is now
+  well-posed.
+
+Both currently-clean downstream importers (`Proposition5_22_2`,
+`PolynomialGLDecomposition`) still build.
+
+## Current frontier
+
+The crux `schurWeyl_simples_formalCharacter_classification_core` retains a single,
+clearly-scoped residual `sorry` (line ~106) for the Tier-4 highest-weight step
+"a simple polynomial `GL_N`-rep is character-determined ⇒ `char = schurPoly`".
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. This advances Schur-Weyl #6 (#2483): the
+linear-independence headline route is now well-posed end-to-end; only the two
+Tier-4 cores remain (GL-side injectivity, highest-weight char classification).
+
+## Next step
+
+- #4731: surface GL-side distinctness `Pairwise ¬Nonempty (L i ≅ L j)` from the
+  decomposition (double-centralizer injectivity) so `hLdist` is dischargeable.
+- #4732: prove the crux (`char(L i) = schurPoly N λ_i`) via highest-weight
+  theory — the remaining residual sorry.
+
+## Blockers
+
+None. The two residual pieces are filed as #4731 and #4732.


### PR DESCRIPTION
Partial progress on #4721

Session: `acbc3e1b-dc0c-4d7b-a9bd-ecd88d6a6402`

51deb2d4 doc(Ch5 #4721): progress entry — well-posed crux/headline + GL-simplicity; residual Tier-4 in #4731/#4732
2753491e feat(Ch5 #4721): make classification crux + headline well-posed
aee7d7dc feat(Ch5 #4721): surface per-L_i GL-simplicity in glTensorRep_equivariant_schurWeyl_decomposition

🤖 Prepared with Claude Code