### PR TITLE
feat(Ch6 #4692): γ_λ LinearEquiv + central-canonical untwist-core decomposition

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/FieldGenericD5Tilde.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericD5Tilde.lean
@@ -270,6 +270,35 @@ theorem d5tildeGammaTubeInv_gammaTube_F (F : Type) [Field F] (lam : F) (m : ℕ)
       eigTailSumLin_eigSub F lam m hlam]
   rw [hKey, show (u + v) + -v = u from by abel, neg_neg]
 
+/-- The corrected eigenvalue-site central iso `γ_λ = d5tildeGammaTube_F` packaged
+as a `LinearEquiv`, with `.symm` equal to the closed-form inverse
+`d5tildeGammaTubeInv_F` (definitionally). This is the `Λ = λ·id + J` analogue of
+`d5tildeGammaEquiv_F` (which packages the refuted rank-deficient `γ`). Both
+two-sided inverse witnesses are `d5tildeGammaTube_gammaTubeInv_F` and
+`d5tildeGammaTubeInv_gammaTube_F` (`λ ≠ 1`, supplied by `d5tildeTubeLam_ne_one`).
+Consumed by the shared untwisting lemma
+`linearEquiv_invariant_isCompl_symm_mem` in the mixed-direction /
+central-reversed leaf-equality branches of `d5tildeRep_kQ_leaf_equalities`. -/
+noncomputable def d5tildeGammaTubeEquiv_F (F : Type) [Field F] (lam : F) (m : ℕ)
+    (hlam : lam ≠ 1) :
+    (Fin (2 * (m + 1)) → F) ≃ₗ[F] (Fin (2 * (m + 1)) → F) :=
+  LinearEquiv.ofLinear (d5tildeGammaTube_F F lam m) (d5tildeGammaTubeInv_F F lam m)
+    (LinearMap.ext fun w => by
+      simp only [LinearMap.comp_apply, LinearMap.id_apply]
+      exact d5tildeGammaTube_gammaTubeInv_F F lam m hlam w)
+    (LinearMap.ext fun w => by
+      simp only [LinearMap.comp_apply, LinearMap.id_apply]
+      exact d5tildeGammaTubeInv_gammaTube_F F lam m hlam w)
+
+@[simp] theorem d5tildeGammaTubeEquiv_F_apply (F : Type) [Field F] (lam : F) (m : ℕ)
+    (hlam : lam ≠ 1) (w : Fin (2 * (m + 1)) → F) :
+    d5tildeGammaTubeEquiv_F F lam m hlam w = d5tildeGammaTube_F F lam m w := rfl
+
+@[simp] theorem d5tildeGammaTubeEquiv_F_symm_apply (F : Type) [Field F] (lam : F)
+    (m : ℕ) (hlam : lam ≠ 1) (w : Fin (2 * (m + 1)) → F) :
+    (d5tildeGammaTubeEquiv_F F lam m hlam).symm w = d5tildeGammaTubeInv_F F lam m w :=
+  rfl
+
 /-! ## Section 4: Orientation-generic D̃₅ representation
 
 The map function is a match on `(a.val, b.val)` mirroring `d5tildeRepMap`
@@ -1010,6 +1039,66 @@ theorem d5tilde_gammaTube_containment_F
     rw [gammaTube_from_embed2_F] at hgamma
     exact (d5tilde_core3_F F Q hOrient m Wmain Wother hMain_43 hMain_53
       hOther_43 hOther_53 hc y (jordanShiftLinGen F lam m y) hgamma).2
+
+attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
+  CategoryTheory.ReflQuiver.toQuiver in
+/-- Central-canonical untwist decomposition at center 2. For a complementary
+invariant pair `(Wmain, Wother)` with the central edge **canonical** (`2→3`
+carrying `γ_λ`) and both `v=2` leaf edges canonical (`0→2`, `1→2`), any
+center-3 element `starEmbed1_F p + starEmbed2_F q ∈ Wmain ⟨3⟩` pulls back through
+`γ_λ⁻¹` to center 2 and decomposes there:
+
+  `p + K(p − q) ∈ Wmain ⟨0⟩`  and  `K(p − q) ∈ Wmain ⟨1⟩`,   `K = eigTailSumLin`.
+
+This is the substitute for the missing `v=3` leaf push in the mixed-direction
+branches of `d5tildeRep_kQ_leaf_equalities` (combo C / C′): there one `v=3` leaf
+edge is canonical and the other reversed, so `d5tilde_core3_F` (which needs both
+`v=3` pushes) does not apply. Routing through the central γ-isomorphism and the
+`v=2` core decomposition recovers leaf information at center 2 instead. Uses the
+shared untwisting lemma `linearEquiv_invariant_isCompl_symm_mem` with
+`d5tildeGammaTubeEquiv_F`, then `gammaTubeInv_embed_general_F` and
+`d5tilde_core_F`. -/
+theorem d5tilde_centralCanon_untwist_core_F
+    (F : Type) [Field F] [IsAlgClosed F]
+    (Q : @Quiver.{0, 0} (Fin 6))
+    [∀ a b, Subsingleton (@Quiver.Hom (Fin 6) Q a b)]
+    (hOrient : @Etingof.IsOrientationOf 6 Q d5tildeAdj)
+    (lam : F) (m : ℕ) (hlam : lam ≠ 1)
+    (Wmain Wother : ∀ v, Submodule F ((d5tildeRep_kQ F Q hOrient m).obj v))
+    (hMain_02 : ∀ (x : Fin (m + 1) → F), x ∈ Wmain ⟨0, by omega⟩ →
+        starEmbed1_F F m x ∈ Wmain ⟨2, by omega⟩)
+    (hMain_12 : ∀ (x : Fin (m + 1) → F), x ∈ Wmain ⟨1, by omega⟩ →
+        starEmbed2_F F m x ∈ Wmain ⟨2, by omega⟩)
+    (hOther_02 : ∀ (x : Fin (m + 1) → F), x ∈ Wother ⟨0, by omega⟩ →
+        starEmbed1_F F m x ∈ Wother ⟨2, by omega⟩)
+    (hOther_12 : ∀ (x : Fin (m + 1) → F), x ∈ Wother ⟨1, by omega⟩ →
+        starEmbed2_F F m x ∈ Wother ⟨2, by omega⟩)
+    (hMain_23 : ∀ (x : Fin (2 * (m + 1)) → F), x ∈ Wmain ⟨2, by omega⟩ →
+        d5tildeGammaTube_F F lam m x ∈ Wmain ⟨3, by omega⟩)
+    (hOther_23 : ∀ (x : Fin (2 * (m + 1)) → F), x ∈ Wother ⟨2, by omega⟩ →
+        d5tildeGammaTube_F F lam m x ∈ Wother ⟨3, by omega⟩)
+    (hc : ∀ v, IsCompl (Wmain v) (Wother v))
+    (p q : Fin (m + 1) → F)
+    (hmem : starEmbed1_F F m p + starEmbed2_F F m q ∈ Wmain ⟨3, by omega⟩) :
+    p + eigTailSumLin F lam m (p - q) ∈ Wmain ⟨0, by omega⟩ ∧
+      eigTailSumLin F lam m (p - q) ∈ Wmain ⟨1, by omega⟩ := by
+  -- Untwist the center-3 element back to center 2 through the `γ_λ` equiv.
+  have huntwist : d5tildeGammaTubeInv_F F lam m
+      (starEmbed1_F F m p + starEmbed2_F F m q) ∈ Wmain ⟨2, by omega⟩ := by
+    have hpre := linearEquiv_invariant_isCompl_symm_mem
+      (d5tildeGammaTubeEquiv_F F lam m hlam)
+      (Wmain ⟨2, by omega⟩) (Wother ⟨2, by omega⟩)
+      (Wmain ⟨3, by omega⟩) (Wother ⟨3, by omega⟩)
+      (hc ⟨2, by omega⟩) (hc ⟨3, by omega⟩)
+      (fun x hx => hMain_23 x hx) (fun x hx => hOther_23 x hx)
+      _ hmem
+    simpa using hpre
+  rw [gammaTubeInv_embed_general_F] at huntwist
+  obtain ⟨h0, h1⟩ := d5tilde_core_F F Q hOrient m Wmain Wother
+    hMain_02 hMain_12 hOther_02 hOther_12 hc
+    (p + eigTailSumLin F lam m (p - q)) (-(eigTailSumLin F lam m (p - q))) huntwist
+  refine ⟨h0, ?_⟩
+  simpa only [LinearMap.neg_apply, neg_neg] using Submodule.neg_mem _ h1
 
 attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
   CategoryTheory.ReflQuiver.toQuiver in

--- a/progress/2026-06-15T00-50-37Z_5a85d530.md
+++ b/progress/2026-06-15T00-50-37Z_5a85d530.md
@@ -1,0 +1,96 @@
+## Accomplished
+
+Worked on #4692 (close the 5 residual orientation branches of
+`d5tildeRep_kQ_leaf_equalities` in `Chapter6/FieldGenericD5Tilde.lean`). Landed
+**infrastructure** the residual branches need and produced a **complete
+mathematical reduction** of the hardest branch.
+
+Added (file builds; only the two pre-existing `sorry` warnings remain —
+`d5tildeRep_kQ_leaf_equalities` and `d5tildeRep_kQ_isIndecomposable`):
+
+1. `d5tildeGammaTubeEquiv_F` — the corrected eigenvalue-site central iso
+   `γ_λ = d5tildeGammaTube_F` packaged as a `LinearEquiv` (with
+   `.symm = d5tildeGammaTubeInv_F`), the `Λ = λ·id + J` analogue of the existing
+   `d5tildeGammaEquiv_F`, plus `apply` / `symm_apply` simp lemmas. The issue
+   explicitly asked for this.
+
+2. `d5tilde_centralCanon_untwist_core_F` — the central-canonical untwist
+   decomposition. For a complementary invariant pair with the central edge
+   canonical (`2→3` carrying `γ_λ`) and both `v=2` leaves canonical, a center-3
+   element `starEmbed1 p + starEmbed2 q ∈ Wmain⟨3⟩` pulls back through `γ_λ⁻¹` to
+   center 2 and decomposes there:
+   `p + K(p−q) ∈ Wmain⟨0⟩` and `K(p−q) ∈ Wmain⟨1⟩` (`K = eigTailSumLin`). Routes
+   through `linearEquiv_invariant_isCompl_symm_mem` + `gammaTubeInv_embed_general_F`
+   + `d5tilde_core_F`. This is the substitute for the missing `v=3` leaf push in
+   the mixed-direction branches.
+
+## Current frontier
+
+The 5 `sorry`s in `d5tildeRep_kQ_leaf_equalities` remain (combo C′, combo C, and
+the three central-reversed subtrees `e23`/`e12`/`e02`). They are **not** simple
+leaf collapses — they are the indecomposability crux.
+
+### Complete reduction of combo C′ (the worked example)
+
+Combo C′ = `0→2, 1→2, 2→3` canonical, leaf `4→3` canonical (push), leaf `3→5`
+reversed (pull). Write `U := W₁⟨4⟩`, `U' := W₂⟨4⟩`, `Λ = λ·id + J`,
+`K = (Λ−I)⁻¹ = eigTailSumLin` (both invertible, `λ ∉ {0,1}`). Using only the
+edge maps + the new untwist-core tool + `compl_le_forces_eq` (each applied with
+an **invertible** operator, so containment upgrades to equality):
+
+- leaf 5 (pull) on `γ_λ(starEmbed1 x)=(x,x)` ⟹ `W₁⟨0⟩ ⊆ W₁⟨5⟩`, and on
+  `γ_λ(starEmbed2 c)=(c,Λc)` ⟹ `Λ·W₁⟨1⟩ ⊆ W₁⟨5⟩`. With the `W₂` versions and
+  `compl_le_forces_eq`: **`W₁⟨5⟩ = W₁⟨0⟩`** and **`W₁⟨5⟩ = Λ·W₁⟨1⟩`**.
+- leaf 4 (push) `(a,0)∈W₁⟨3⟩` + untwist-core ⟹ `K·U ⊆ W₁⟨1⟩` and
+  `(I+K)U ⊆ W₁⟨0⟩`. With `W₂` versions + `compl_le_forces_eq` (both `K` and
+  `I+K = KΛ` invertible): **`W₁⟨1⟩ = K·U`** and **`W₁⟨0⟩ = KΛ·U`**.
+
+Therefore `W₁⟨0⟩ = W₁⟨1⟩  ⟺  KΛ·U = K·U  ⟺  Λ·U = U`, i.e. the whole combo-C′
+leaf equality is **equivalent to `W₁⟨4⟩` (and `W₂⟨4⟩`) being `Λ`-invariant**
+(equivalently `J`-invariant, since `λ·id` preserves every subspace).
+
+### Why this is hard
+
+`Λ`-invariance of `W₁⟨4⟩` is **not** supplied by any edge (leaf 4 has no
+self-loop). For the tube (indecomposable) the only complementary invariant pairs
+are trivial, so it holds — but proving it without assuming indecomposability is
+the eigenvalue/nilpotent-kernel argument itself. The workhorse
+`eigenvalue_jordan_invariant_compl_trivial_gen` (`FieldGenericStar.lean:104`)
+goes the *other* way (Λ-invariance ⟹ one summand `⊥`), so it cannot supply the
+invariance. The proven branches (all-canonical, combo-D) avoid this entirely
+because there **both** `v=3` leaves have extraction (`core3_F` / its `proj`
+siblings), reading `U` off directly without needing `Λ`-invariance.
+
+Note: D̃₆ (`FieldGenericD6Tilde.lean`) has the **same** five branches still
+`sorry` — it is not a worked model for them. No tube member in the codebase has
+closed a mixed combo-C branch; `#4702` shows even the D̃₄ orientation-generic
+collapse is still open.
+
+## Overall project progress
+
+Chapter 6 D̃-family indecomposability is the active frontier. Many sub-issues in
+flight (#4649, #4652, #4663, #4689, #4702, …). Chapter 5 Frobenius/Schur-Weyl
+(#4669, #4595) is the other marquee thread.
+
+## Next step
+
+Two viable routes for the residual #4692 branches:
+
+1. Prove the leaf `Λ`-invariance lemma directly: for the corrected tube, every
+   complementary invariant pair has `Λ`-invariant leaf subspaces. This is a real
+   sub-lemma (probably a rank-1-kernel argument on `J`) and likely shared by all
+   D̃-family mixed branches — worth its own issue. Once it exists, combo C/C′
+   close immediately from the reduction above (the relations `W₁⟨1⟩=K·U`,
+   `W₁⟨0⟩=KΛ·U`, `W₁⟨5⟩=W₁⟨0⟩` are already mechanizable with
+   `d5tilde_centralCanon_untwist_core_F`). The three central-reversed subtrees
+   need a `γ_λ⁻¹` analogue of the untwist-core tool (mirror with the equiv's
+   `.symm`).
+
+2. Re-scope #4692: the mixed branches are genuinely the indecomposability crux,
+   so a planner may prefer to fold them into the `d5tildeRep_kQ_isIndecomposable`
+   work rather than keep them as a standalone leaf-equality residual.
+
+## Blockers
+
+None hard. The residual is frontier-difficulty (indecomposability crux), not
+blocked on a missing dependency. Infrastructure to attack it is now in place.


### PR DESCRIPTION
This PR adds infrastructure toward the five residual orientation branches of `d5tildeRep_kQ_leaf_equalities` (#4692) and records a complete mathematical reduction of the hardest branch. It lands `d5tildeGammaTubeEquiv_F` (the corrected eigenvalue-site central iso γ_λ packaged as a `LinearEquiv` with `.symm = d5tildeGammaTubeInv_F`, the Λ=λ·id+J analogue of `d5tildeGammaEquiv_F`, with apply/symm_apply simp lemmas) and `d5tilde_centralCanon_untwist_core_F` (the central-canonical untwist decomposition: a center-3 element `starEmbed1 p + starEmbed2 q ∈ Wmain⟨3⟩` pulls back through γ_λ⁻¹ and decomposes at center 2 as `p + K(p−q) ∈ Wmain⟨0⟩`, `K(p−q) ∈ Wmain⟨1⟩`, the substitute for the missing v=3 leaf push in the mixed branches).

Partial: no `sorry` is closed. The five mixed/central-reversed branches are the indecomposability crux — combo C′ reduces exactly to `W₁⟨4⟩`/`W₂⟨4⟩` being Λ-invariant (full reduction in the issue comment and progress note). The file builds with only the two pre-existing sorries (`d5tildeRep_kQ_leaf_equalities`, `d5tildeRep_kQ_isIndecomposable`).

Closes nothing; #4692 is marked `replan` for re-scoping.

🤖 Prepared with Claude Code