### PR TITLE
feat(Ch5): prove dim V_λ = #SYT via Frobenius character formula (Theorem 5.17.1, book route) — retires Wall 3 Garnir straightening

### DIFF
--- a/EtingofRepresentationTheory/Chapter5.lean
+++ b/EtingofRepresentationTheory/Chapter5.lean
@@ -71,7 +71,10 @@ import EtingofRepresentationTheory.Chapter5.PowerSumCauchyIdentity
 import EtingofRepresentationTheory.Chapter5.SYTFintype
 import EtingofRepresentationTheory.Chapter5.PolytabloidBasis
 import EtingofRepresentationTheory.Chapter5.TabloidModule
-import EtingofRepresentationTheory.Chapter5.SpechtModuleBasis
+-- `SpechtModuleBasis` (the Garnir-straightening route to dim V_λ = #SYT, issues
+-- #2703/#2543) is retired off the critical path: Theorem 5.17.1 now goes through
+-- the Frobenius character formula (`Theorem5_17_1` → `CharValueHookFormula`). The
+-- file is kept as a non-book bonus but no longer built by this aggregator.
 import EtingofRepresentationTheory.Chapter5.Theorem5_17_1
 
 -- Section 5.18: Schur-Weyl Duality

--- a/EtingofRepresentationTheory/Chapter5/CharValueHookFormula.lean
+++ b/EtingofRepresentationTheory/Chapter5/CharValueHookFormula.lean
@@ -1,6 +1,6 @@
 import Mathlib
 import EtingofRepresentationTheory.Chapter5.SchurWeylPolynomialIdentity
-import EtingofRepresentationTheory.Chapter5.Theorem5_17_1
+import EtingofRepresentationTheory.Chapter5.FRTHelpers
 
 /-!
 # Frobenius route to `dim V_λ = #SYT` (Etingof Theorem 5.17.1) — bypasses Wall 3
@@ -752,6 +752,127 @@ theorem finrank_spechtModule_eq_card_syt_via_frobenius
   rw [← charValue_trivialCycleType_eq_spechtFinrank_rat]
   exact charValue_trivialCycleType_eq_card_syt N lam
 
+/-! ## Surjectivity: every partition is a `BoundedPartition n n` weight (issue #4595)
+
+`finrank_spechtModule_eq_card_syt_via_frobenius` is stated for partitions of the
+shape `weightToPartition n bp.parts`. To reach an *arbitrary* `Nat.Partition n`
+we show every partition of `n` arises this way: pad its sorted parts with zeros
+to length `n`. The helper lemmas reproduce the `private` `canonicalBP` machinery
+of `Theorem5_22_1.lean`, specialised so the construction starts from the
+partition itself rather than from another bounded partition. -/
+
+/-- A list of positive naturals has length at most its sum. -/
+private lemma list_length_le_sum_of_pos (m : List ℕ) (hm : ∀ x ∈ m, 0 < x) :
+    m.length ≤ m.sum := by
+  induction m with
+  | nil => exact Nat.zero_le _
+  | cons a t ih =>
+    simp only [List.length_cons, List.sum_cons]
+    have ha := hm a (by simp)
+    have ht := ih (fun x hx => hm x (by simp [hx]))
+    omega
+
+/-- Summing `l.getD · 0` over `Fin n` recovers the list sum once `l.length ≤ n`. -/
+private lemma sum_getD_eq_sum (l : List ℕ) (n : ℕ) (hlen : l.length ≤ n) :
+    ∑ i : Fin n, l.getD i.val 0 = l.sum := by
+  induction n generalizing l with
+  | zero =>
+    have := List.eq_nil_of_length_eq_zero (by omega : l.length = 0)
+    subst this; rfl
+  | succ n ih =>
+    rw [Fin.sum_univ_succ]
+    cases l with
+    | nil => simp [ih [] (Nat.zero_le _)]
+    | cons a t =>
+      simp only [List.getD_cons_zero, List.sum_cons, Fin.val_zero]
+      congr 1
+      have hstep : ∀ i : Fin n, (a :: t).getD i.succ.val 0 = t.getD i.val 0 := by
+        intro ⟨i, _⟩; simp [List.getD_cons_succ]
+      simp_rw [hstep]
+      exact ih t (by simpa using hlen)
+
+/-- `l.getD · 0` is antitone on `Fin n` when `l` is sorted in weakly decreasing order. -/
+private lemma getD_antitone_of_pairwise {n : ℕ} (l : List ℕ) (h : l.Pairwise (· ≥ ·)) :
+    Antitone (fun i : Fin n => l.getD i.val 0) := by
+  intro i j hij
+  show l.getD j.val 0 ≤ l.getD i.val 0
+  rcases eq_or_lt_of_le hij with rfl | hlt
+  · exact le_refl _
+  · by_cases hj : j.val < l.length
+    · have hi : i.val < l.length := by omega
+      rw [List.getD_eq_getElem (hn := hj), List.getD_eq_getElem (hn := hi)]
+      exact List.pairwise_iff_get.mp h ⟨i.val, hi⟩ ⟨j.val, hj⟩ hlt
+    · rw [List.getD_eq_default (hn := by omega)]
+      exact Nat.zero_le _
+
+/-- Filtering the positive entries out of `ofFn (l.getD · 0)` on `Fin m` recovers `l`,
+provided `l` has only positive entries and `l.length ≤ m`. -/
+private lemma ofFn_getD_filter_pos :
+    ∀ (m : ℕ) (ll : List ℕ), (∀ x ∈ ll, 0 < x) → ll.length ≤ m →
+      (List.ofFn (fun i : Fin m => ll.getD i.val 0)).filter (fun x => decide (0 < x)) = ll := by
+  intro m
+  induction m with
+  | zero => intro ll _ hlen; simp [List.eq_nil_of_length_eq_zero (by omega : ll.length = 0)]
+  | succ m ih =>
+    intro ll hll hlen
+    simp only [List.ofFn_succ, Fin.val_zero, List.filter_cons]
+    cases ll with
+    | nil =>
+      simp only [List.getD_nil, List.ofFn_const, List.filter_replicate,
+        show ¬ decide (0 < 0) = true from by simp]
+      simp
+    | cons a t =>
+      simp only [List.getD_cons_zero]
+      have ha : 0 < a := hll a (by simp)
+      rw [show decide (0 < a) = true from decide_eq_true ha]
+      simp only [ite_true]
+      congr 1
+      show (List.ofFn (fun i : Fin m => t.getD i.val 0)).filter (fun x => decide (0 < x)) = t
+      exact ih t (fun x hx => hll x (by simp [hx]))
+        (by simp only [List.length_cons] at hlen; omega)
+
+/-- **Surjectivity of the Schur-Weyl weight map.** Every `Nat.Partition n` is the
+underlying partition of some `BoundedPartition n n` (its sorted parts, padded with
+zeros to length `n`). This lets the Frobenius dimension result, stated for
+`weightToPartition`-shaped partitions, descend to an arbitrary partition. -/
+theorem exists_boundedPartition_weightToPartition_eq (n : ℕ) (la : Nat.Partition n) :
+    ∃ bp : BoundedPartition n n,
+      (bp.sum_eq ▸ weightToPartition n bp.parts : Nat.Partition n) = la := by
+  have hpos : ∀ x ∈ la.sortedParts, 0 < x := by
+    intro x hx
+    refine la.parts_pos ?_
+    have h := Multiset.sort_eq la.parts (· ≥ ·)
+    rw [show la.parts.sort (· ≥ ·) = la.sortedParts from rfl] at h
+    exact h ▸ Multiset.mem_coe.mpr hx
+  have hlen : la.sortedParts.length ≤ n := by
+    have hsum : la.sortedParts.sum = n := sortedParts_sum_eq n la
+    have := list_length_le_sum_of_pos la.sortedParts hpos
+    omega
+  refine ⟨{ parts := fun i : Fin n => la.sortedParts.getD i.val 0
+            decreasing := getD_antitone_of_pairwise la.sortedParts
+              (by rw [show la.sortedParts = la.parts.sort (· ≥ ·) from rfl]
+                  exact Multiset.pairwise_sort _ _)
+            sum_eq := by
+              rw [sum_getD_eq_sum la.sortedParts n hlen]; exact sortedParts_sum_eq n la }, ?_⟩
+  have hrec : ∀ (p q : ℕ) (h : p = q) (P : Nat.Partition p), (h ▸ P).parts = P.parts := by
+    intro p q h P; subst h; rfl
+  apply Nat.Partition.ext
+  rw [hrec _ _ _ (weightToPartition n (fun i : Fin n => la.sortedParts.getD i.val 0))]
+  show (Finset.univ.val.map (fun i : Fin n => la.sortedParts.getD i.val 0)).filter (0 < ·) =
+      la.parts
+  rw [Fin.univ_val_map, Multiset.filter_coe, ofFn_getD_filter_pos n la.sortedParts hpos hlen]
+  exact Multiset.sort_eq _ _
+
+/-- **Book route, payoff 2 (general `λ`):** `dim_ℂ V_λ = #SYT` for an *arbitrary*
+partition `λ`, from `finrank_spechtModule_eq_card_syt_via_frobenius` plus
+surjectivity of `weightToPartition`. This is the Wall-3-free (no Garnir
+straightening) replacement for the polytabloid-basis route. -/
+theorem finrank_spechtModule_eq_card_syt_general (n : ℕ) (la : Nat.Partition n) :
+    Module.finrank ℂ (SpechtModule n la) = Nat.card (StandardYoungTableau n la) := by
+  obtain ⟨bp, hbp⟩ := exists_boundedPartition_weightToPartition_eq n la
+  have h := finrank_spechtModule_eq_card_syt_via_frobenius n bp
+  rw [hbp] at h
+  exact_mod_cast h
 
 end
 end Etingof

--- a/EtingofRepresentationTheory/Chapter5/FRTHelpers.lean
+++ b/EtingofRepresentationTheory/Chapter5/FRTHelpers.lean
@@ -1982,6 +1982,21 @@ theorem card_standardYoungTableau_mul (n : ℕ) (la : Nat.Partition n) :
   | zero => exact card_standardYoungTableau_mul_zero la
   | succ n ih => exact card_standardYoungTableau_mul_succ n ih la
 
+/-- The hook length product divides n!. Follows from the multiplicative form
+of the Frame–Robinson–Thrall theorem. -/
+theorem hookLengthProduct_dvd_factorial (n : ℕ) (la : Nat.Partition n) :
+    la.toYoungDiagram.hookLengthProduct ∣ n.factorial :=
+  ⟨Nat.card (StandardYoungTableau n la), by linarith [card_standardYoungTableau_mul n la]⟩
+
+/-- Frame–Robinson–Thrall theorem (1954): the number of standard Young tableaux
+of shape λ equals n! / ∏ h(i,j). Derived from the multiplicative form. -/
+theorem card_standardYoungTableau_eq (n : ℕ) (la : Nat.Partition n) :
+    Nat.card (StandardYoungTableau n la) =
+      n.factorial / la.toYoungDiagram.hookLengthProduct := by
+  have h := card_standardYoungTableau_mul n la
+  have hpos := YoungDiagram.hookLengthProduct_pos la.toYoungDiagram
+  rw [← h, Nat.mul_div_cancel _ hpos]
+
 end
 
 end Etingof

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_17_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_17_1.lean
@@ -1,7 +1,5 @@
 import Mathlib
-import EtingofRepresentationTheory.Chapter5.Definition5_14_2
-import EtingofRepresentationTheory.Chapter5.SpechtModuleBasis
-import EtingofRepresentationTheory.Chapter5.FRTHelpers
+import EtingofRepresentationTheory.Chapter5.CharValueHookFormula
 
 /-!
 # Theorem 5.17.1: Hook Length Formula
@@ -28,33 +26,17 @@ namespace Etingof
 
 noncomputable section
 
-/-- The hook length product divides n!. Follows from the multiplicative form
-of the Frame–Robinson–Thrall theorem. -/
-theorem hookLengthProduct_dvd_factorial (n : ℕ) (la : Nat.Partition n) :
-    la.toYoungDiagram.hookLengthProduct ∣ n.factorial :=
-  ⟨Nat.card (StandardYoungTableau n la), by linarith [card_standardYoungTableau_mul n la]⟩
-
 /-- The dimension of V_λ equals the number of standard Young tableaux of shape λ.
-This is the core representation-theoretic content: the polytabloid basis of the
-Specht module is naturally indexed by SYT(λ).
+This is the core representation-theoretic content.
 
-The proof delegates to `finrank_spechtModule_eq_card_syt` (which uses
-`Fintype.card`) and converts to `Nat.card`. The underlying proof constructs
-the polytabloid basis: linear independence + spanning of polytabloids. -/
+Proved via the **Frobenius character formula** (`finrank_spechtModule_eq_card_syt_general`,
+`CharValueHookFormula.lean`), NOT via the polytabloid/Garnir-straightening basis —
+that route (`finrank_spechtModule_eq_card_syt'`, `SpechtModuleBasis.lean`) is no
+longer on the critical path for the hook length formula. -/
 theorem finrank_spechtModule_eq_card_standardYoungTableau (n : ℕ) (la : Nat.Partition n) :
     Module.finrank ℂ (SpechtModule n la) =
-      Nat.card (StandardYoungTableau n la) := by
-  rw [Nat.card_eq_fintype_card]
-  exact finrank_spechtModule_eq_card_syt' n la
-
-/-- Frame–Robinson–Thrall theorem (1954): the number of standard Young tableaux
-of shape λ equals n! / ∏ h(i,j). Derived from the multiplicative form. -/
-theorem card_standardYoungTableau_eq (n : ℕ) (la : Nat.Partition n) :
-    Nat.card (StandardYoungTableau n la) =
-      n.factorial / la.toYoungDiagram.hookLengthProduct := by
-  have h := card_standardYoungTableau_mul n la
-  have hpos := YoungDiagram.hookLengthProduct_pos la.toYoungDiagram
-  rw [← h, Nat.mul_div_cancel _ hpos]
+      Nat.card (StandardYoungTableau n la) :=
+  finrank_spechtModule_eq_card_syt_general n la
 
 /-- Hook length formula: dim V_λ = n! / ∏ h(i,j).
 (Etingof Theorem 5.17.1)

--- a/progress/2026-06-15T01-13-38Z_3b6d4e9a.md
+++ b/progress/2026-06-15T01-13-38Z_3b6d4e9a.md
@@ -1,0 +1,70 @@
+## Accomplished
+
+Issue #4595 (feat(Ch5): retire Wall 3 Garnir straightening — route dim V_λ = #SYT
+through the Frobenius character formula). The Frobenius route was already
+sorry-free on `main`; this turn did the downstream rewiring + cleanup:
+
+1. **Broke the import cycle.** Moved `card_standardYoungTableau_eq` and
+   `hookLengthProduct_dvd_factorial` from `Theorem5_17_1.lean` into
+   `FRTHelpers.lean` (their only deps — `card_standardYoungTableau_mul`,
+   `YoungDiagram.hookLengthProduct_pos` — already live there). Re-pointed
+   `CharValueHookFormula.lean` at `FRTHelpers` instead of `Theorem5_17_1`, so
+   `CharValueHookFormula` is now a leaf (imported by nothing) and `Theorem5_17_1`
+   can import it.
+
+2. **Surjectivity of the weight map + general-λ corollary** (new, in
+   `CharValueHookFormula.lean`): `exists_boundedPartition_weightToPartition_eq`
+   (every `Nat.Partition n` is `bp.sum_eq ▸ weightToPartition n bp.parts` for some
+   `bp : BoundedPartition n n` — pad sorted parts with zeros to length n) and
+   `finrank_spechtModule_eq_card_syt_general` (extends the Frobenius
+   `dim V_λ = #SYT` result from `weightToPartition`-shaped partitions to an
+   arbitrary partition). Reproduced the four small private helpers from the
+   `canonicalBP` machinery in `Theorem5_22_1.lean`, specialised to start from the
+   partition itself. No `sorry`.
+
+3. **Re-routed `Theorem5_17_1`.** `finrank_spechtModule_eq_card_standardYoungTableau`
+   now delegates to `finrank_spechtModule_eq_card_syt_general` (Frobenius) instead
+   of `finrank_spechtModule_eq_card_syt'` (Garnir straightening). Dropped the
+   `SpechtModuleBasis` + `Definition5_14_2` imports; now imports only
+   `CharValueHookFormula`.
+
+4. **Retired the straightening apparatus.** `Theorem5_17_1`'s transitive import
+   closure no longer contains `SpechtModuleBasis` (verified). Removed the
+   `SpechtModuleBasis` import from the `Chapter5.lean` aggregator so the file (and
+   its two Garnir sorries, #2703/#2543) is no longer built; kept on disk as a
+   non-book bonus. Issues #2703 and #2543 were already CLOSED.
+
+## Verification
+
+- `lake build EtingofRepresentationTheory.Chapter5.CharValueHookFormula` — green,
+  no sorry.
+- `lake build EtingofRepresentationTheory.Chapter5.Theorem5_17_1` — green.
+- `#print axioms Theorem5_17_1` and
+  `#print axioms finrank_spechtModule_eq_card_standardYoungTableau` →
+  `[propext, Classical.choice, Quot.sound]` — **no `sorryAx`**. The hook length
+  formula is genuinely sorry-free end-to-end via Frobenius.
+- `lake build EtingofRepresentationTheory.Chapter5` — green (8117 jobs), no errors;
+  pre-existing unrelated sorry remains in `PolynomialGLDecomposition.lean:183`.
+- Verified `generalizedPolytabloidTab_mem_span_polytabloidTab` (the straightening
+  lemma) is off the critical path: only `Chapter5.lean` referenced
+  `SpechtModuleBasis`, and only via doc-comment mentions elsewhere.
+
+## Current frontier
+
+Issue #4595 deliverables complete. PR pending.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. Wall 3 (Garnir straightening) is retired: the
+Specht-dimension hook length formula no longer depends on the open
+straightening sorries. Ch5 Schur-Weyl classification work (#4731, #4732) and Ch6
+tube-indecomposability work remain the active frontiers.
+
+## Next step
+
+Pick up the next unclaimed feature issue (e.g. #4731 GL-side distinctness or
+#4732 the classification crux, both deep Tier-4; or a Ch6 tube assembly).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4595

Session: `3b6d4e9a-512f-4e48-b968-ba2da3d7c67f`

a310cdb3 feat(Ch5 #4595): route Theorem 5.17.1 through Frobenius; retire Garnir straightening
538bd538 feat(Ch5 #4595): surjectivity + general-λ Frobenius dim corollary; relocate FRT lemmas to FRTHelpers

🤖 Prepared with Claude Code