### PR TITLE
feat(Ch6 #4647): restrict d5tildeRep_kQ_leaf_equalities to eigenvalue-free orientations; fold mixed-v3 branches into d5tildeRep_kQ_isIndecomposable (#4663)

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/FieldGenericD5Tilde.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericD5Tilde.lean
@@ -1102,24 +1102,34 @@ theorem d5tilde_centralCanon_untwist_core_F
 
 attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
   CategoryTheory.ReflQuiver.toQuiver in
-/-- For any orientation `Q` of `d5tildeAdj` and any complementary invariant
-submodule pair `(W₁, W₂)` of `d5tildeRep_kQ F Q hOrient m`, the leaf
-vertices `0, 1, 4, 5` carry equal `W₁`-subspaces. (The analogous statement
-for `W₂` follows by applying the theorem with the arguments `(W₂, W₁)`
-flipped — `IsCompl` is symmetric.)
+/-- For an **eigenvalue-free** orientation `Q` of `d5tildeAdj` and any
+complementary invariant submodule pair `(W₁, W₂)` of
+`d5tildeRep_kQ F Q hOrient m`, the leaf vertices `0, 1, 4, 5` carry equal
+`W₁`-subspaces. (The analogous statement for `W₂` follows by applying the
+theorem with the arguments `(W₂, W₁)` flipped — `IsCompl` is symmetric.)
+
+"Eigenvalue-free" is the restriction carried by the explicit orientation
+hypotheses (#4743): the two `v=3` leaf edges point the **same** direction
+(`hv3`), and the two `v=2` leaf edges plus the central edge are canonical
+(`hc02`, `hc12`, `hc23`). This is exactly the all-canonical ⊕ combo-D scope.
+The architectural finding (#4692/#4743) is that the *mixed-`v3`* orientations
+(`hv3` false) reduce to needing `Λ`-invariance of the leaf-4 subspace, which
+no edge of the acyclic D̃₅ tree supplies — so they are not separately
+derivable and are proven **jointly** with the eigenvalue collapse inside
+`d5tildeRep_kQ_isIndecomposable` (#4663). The reversed `v=2`/central
+orientations (`hc*` false) are likewise out of scope here; the projection
+infrastructure (`d5tilde_core_F_proj1/2`, `d5tilde_centralCanon_untwist_core_F`)
+needed to broaden to them is a follow-up.
 
 This is the analog of the leaf-equality block in the ℂ-specific proof
 (`InfiniteTypeConstructions.lean:1820-1834`).
 
-**Proof body partially deferred** — see #2850 for the decomposition. The
-all-canonical orientation branch (0→2, 1→2, 2→3, 4→3, 5→3) is proven
-inline by mirroring the ℂ-source proof: the helper invariance facts are
-specialized via `simp only [d5tildeRep_kQ, d5tildeRepMap_kQ]`, then the
-`core_F` (v=2 decomposition), `core3_F` (v=3 decomposition), and
-`gamma_containment_F` (γ-coupled leaf containments) lemmas are
-established. Final `compl_le_forces_eq` applications chain the
-containments into the three equalities. The remaining 31 orientation
-branches are tracked as follow-up sub-issues. -/
+The two in-scope branches are proven inline by mirroring the ℂ-source proof:
+the helper invariance facts are specialized via
+`simp only [d5tildeRep_kQ, d5tildeRepMap_kQ]`, then the `core_F` /
+`core3_F` / `gamma_containment_F` lemmas chain through `compl_le_forces_eq`.
+The off-restriction branches are discharged by orientation antisymmetry
+(`IsOrientationOf.2.2`) against `hc*` / `hv3`. -/
 theorem d5tildeRep_kQ_leaf_equalities
     (F : Type) [Field F] [IsAlgClosed F]
     (Q : @Quiver.{0, 0} (Fin 6))
@@ -1131,7 +1141,21 @@ theorem d5tildeRep_kQ_leaf_equalities
       ∀ x ∈ W₁ a, (d5tildeRep_kQ F Q hOrient m).mapLinear e x ∈ W₁ b)
     (hW₂_inv : ∀ {a b : Fin 6} (e : @Quiver.Hom _ Q a b),
       ∀ x ∈ W₂ a, (d5tildeRep_kQ F Q hOrient m).mapLinear e x ∈ W₂ b)
-    (hcompl : ∀ v, IsCompl (W₁ v) (W₂ v)) :
+    (hcompl : ∀ v, IsCompl (W₁ v) (W₂ v))
+    -- Eigenvalue-free orientation restriction (#4743): the two `v=3` leaf edges
+    -- (4–3 and 5–3) point the same direction (`hv3`), and the two `v=2` leaf
+    -- edges plus the central edge are canonical (`hc02`, `hc12`, `hc23`). This is
+    -- exactly the all-canonical ⊕ combo-D scope, where no eigenvalue-site
+    -- self-map is needed and the collapse is `sorry`-free. The mixed-`v3`
+    -- orientations (`hv3` false) and reversed `v=2`/central orientations are
+    -- logically entangled with the eigenvalue deposit and are handled jointly
+    -- inside `d5tildeRep_kQ_isIndecomposable` (#4663) — see the #4692/#4743
+    -- architectural finding.
+    (hc02 : Nonempty (@Quiver.Hom (Fin 6) Q ⟨0, by omega⟩ ⟨2, by omega⟩))
+    (hc12 : Nonempty (@Quiver.Hom (Fin 6) Q ⟨1, by omega⟩ ⟨2, by omega⟩))
+    (hc23 : Nonempty (@Quiver.Hom (Fin 6) Q ⟨2, by omega⟩ ⟨3, by omega⟩))
+    (hv3 : Nonempty (@Quiver.Hom (Fin 6) Q ⟨4, by omega⟩ ⟨3, by omega⟩) ↔
+           Nonempty (@Quiver.Hom (Fin 6) Q ⟨5, by omega⟩ ⟨3, by omega⟩)) :
     W₁ ⟨0, by omega⟩ = W₁ ⟨1, by omega⟩ ∧
     W₁ ⟨0, by omega⟩ = W₁ ⟨4, by omega⟩ ∧
     W₁ ⟨0, by omega⟩ = W₁ ⟨5, by omega⟩ := by
@@ -1228,16 +1252,17 @@ theorem d5tildeRep_kQ_leaf_equalities
                 (W₁ ⟨4, by omega⟩) (W₂ ⟨4, by omega⟩)
                 (hcompl ⟨1, by omega⟩) (hcompl ⟨4, by omega⟩) h14 h14').1
             exact ⟨heq04.trans heq14.symm, heq04, heq05⟩
-          · -- e53 reversed (3→5), e43 canonical (4→3): combo C′ — central-canonical,
-            -- mixed v=3 leaves. Follow-up sub-issue (#4662 residual).
-            sorry
+          · -- e53 reversed (3→5), e43 canonical (4→3): combo C′ — mixed v=3 leaves.
+            -- Excluded by `hv3` (eigenvalue-free restriction): `hv3.mp ⟨a43⟩` gives
+            -- `5→3`, contradicting the reversed `3→5` arrow `hQ53`.
+            exact (hOrient.2.2 ⟨5, by omega⟩ ⟨3, by omega⟩ (hv3.mp ⟨a43⟩) hQ53).elim
         · -- e43 reversed (3→4)
           obtain ⟨a34⟩ := hQ43
           rcases hOrient_edge ⟨5, by omega⟩ ⟨3, by omega⟩ h53 with hQ53 | hQ53
-          · -- e53 canonical (5→3): combo C — central-canonical, mixed v=3 leaves.
-            -- Follow-up sub-issue (#4662 residual).
+          · -- e53 canonical (5→3): combo C — mixed v=3 leaves. Excluded by `hv3`:
+            -- `hv3.mpr ⟨a53⟩` gives `4→3`, contradicting the reversed `3→4` arrow.
             obtain ⟨a53⟩ := hQ53
-            sorry
+            exact (hOrient.2.2 ⟨4, by omega⟩ ⟨3, by omega⟩ (hv3.mpr ⟨a53⟩) ⟨a34⟩).elim
           · -- e53 reversed (3→5): COMBO D — both v=3 leaf edges reversed.
             obtain ⟨a35⟩ := hQ53
             have hW₁_34 (w : Fin (2 * (m + 1)) → F) (hw : w ∈ W₁ ⟨3, by omega⟩) :
@@ -1304,12 +1329,12 @@ theorem d5tildeRep_kQ_leaf_equalities
                 (W₁ ⟨4, by omega⟩) (W₂ ⟨4, by omega⟩)
                 (hcompl ⟨1, by omega⟩) (hcompl ⟨4, by omega⟩) h14 h14').1
             exact ⟨heq04.trans heq14.symm, heq04, heq05⟩
-      · -- e23 reversed (3→2): central edge carries `γ_λ⁻¹`. Follow-up sub-issue.
-        sorry
-    · -- e12 reversed (2→1): uses `starSecond_F` projection. Follow-up sub-issue.
-      sorry
-  · -- e02 reversed (2→0): uses `starFirst_F` projection. Follow-up sub-issue.
-    sorry
+      · -- e23 reversed (3→2): excluded by the canonical-central restriction `hc23`.
+        exact (hOrient.2.2 ⟨2, by omega⟩ ⟨3, by omega⟩ hc23 hQ23).elim
+    · -- e12 reversed (2→1): excluded by the canonical-`v=2` restriction `hc12`.
+      exact (hOrient.2.2 ⟨1, by omega⟩ ⟨2, by omega⟩ hc12 hQ12).elim
+  · -- e02 reversed (2→0): excluded by the canonical-`v=2` restriction `hc02`.
+    exact (hOrient.2.2 ⟨0, by omega⟩ ⟨2, by omega⟩ hc02 hQ02).elim
 
 /-! ## Section 6: Orientation-generic indecomposability (path b: deferred)
 
@@ -1365,12 +1390,10 @@ theorem d5tildeRep_kQ_isIndecomposable
     change Nontrivial (Fin (m + 1) → F)
     infer_instance
   · intro W₁ W₂ hW₁_inv hW₂_inv hcompl
-    -- Orientation-generic leaf collapse (sub-B): the four leaves are equal.
-    obtain ⟨heq01, heq04, heq05⟩ :=
-      d5tildeRep_kQ_leaf_equalities F Q hOrient m W₁ W₂ hW₁_inv hW₂_inv hcompl
-    obtain ⟨heq01', heq04', heq05'⟩ :=
-      d5tildeRep_kQ_leaf_equalities F Q hOrient m W₂ W₁ hW₂_inv hW₁_inv
-        (fun v => (hcompl v).symm)
+    -- Leaf collapse (sub-B) is now invoked per-branch: the restricted
+    -- `d5tildeRep_kQ_leaf_equalities` (#4743) carries explicit eigenvalue-free
+    -- orientation hypotheses, which are discharged from the canonical arrows
+    -- inside the all-canonical branch below.
     -- Adjacency facts (canonical edge directions).
     have h02 : d5tildeAdj ⟨0, by omega⟩ ⟨2, by omega⟩ = 1 := by simp [d5tildeAdj]
     have h12 : d5tildeAdj ⟨1, by omega⟩ ⟨2, by omega⟩ = 1 := by simp [d5tildeAdj]
@@ -1388,6 +1411,15 @@ theorem d5tildeRep_kQ_isIndecomposable
             rcases hEdge ⟨5, by omega⟩ ⟨3, by omega⟩ h53 with hQ53 | hQ53
             · obtain ⟨a53⟩ := hQ53
               -- ALL CANONICAL: full reduction.
+              -- Leaf collapse (restricted #4743): supply the eigenvalue-free
+              -- orientation hypotheses from the canonical arrows (`hv3` holds as
+              -- both `v=3` leaves are canonical).
+              obtain ⟨heq01, heq04, heq05⟩ :=
+                d5tildeRep_kQ_leaf_equalities F Q hOrient m W₁ W₂ hW₁_inv hW₂_inv
+                  hcompl ⟨a02⟩ ⟨a12⟩ ⟨a23⟩ (iff_of_true ⟨a43⟩ ⟨a53⟩)
+              obtain ⟨heq01', heq04', heq05'⟩ :=
+                d5tildeRep_kQ_leaf_equalities F Q hOrient m W₂ W₁ hW₂_inv hW₁_inv
+                  (fun v => (hcompl v).symm) ⟨a02⟩ ⟨a12⟩ ⟨a23⟩ (iff_of_true ⟨a43⟩ ⟨a53⟩)
               -- Per-vertex invariance pushes (canonical maps).
               have hW₁_02 (x : Fin (m + 1) → F) (hx : x ∈ W₁ ⟨0, by omega⟩) :
                   starEmbed1_F F m x ∈ W₁ ⟨2, by omega⟩ := by

--- a/progress/2026-06-15T01-52-02Z_a50ff3bb.md
+++ b/progress/2026-06-15T01-52-02Z_a50ff3bb.md
@@ -1,0 +1,74 @@
+## Accomplished
+
+Work session `a50ff3bb` (`/work` → `/feature` on **#4743**): restricted
+`d5tildeRep_kQ_leaf_equalities` (`Chapter6/FieldGenericD5Tilde.lean`) to the
+eigenvalue-free orientation scope and made it **sorry-free**.
+
+Changes:
+1. **Added explicit orientation hypotheses** to the lemma signature encoding
+   the eigenvalue-free restriction:
+   - `hc02`, `hc12`, `hc23`: the two `v=2` leaf edges and the central edge are
+     canonical (`0→2`, `1→2`, `2→3`).
+   - `hv3 : Nonempty (Hom 4 3) ↔ Nonempty (Hom 5 3)`: the two `v=3` leaf edges
+     point the **same** direction.
+   This is exactly the all-canonical ⊕ combo-D scope (both branches already
+   proven inline on `main`).
+2. **Discharged all five previously-deferred `sorry` branches** by orientation
+   antisymmetry (`IsOrientationOf.2.2`, the "no arrows both ways" conjunct)
+   against the restriction hypotheses:
+   - combo C′ / combo C (mixed-`v3`) contradict `hv3`;
+   - e02/e12/e23-reversed contradict `hc02`/`hc12`/`hc23`.
+3. **Moved the call site** in `d5tildeRep_kQ_isIndecomposable` from the
+   orientation-generic top of the proof into the all-canonical branch, where
+   `⟨a02⟩ ⟨a12⟩ ⟨a23⟩ (iff_of_true ⟨a43⟩ ⟨a53⟩)` supply the new hypotheses.
+4. Rewrote the lemma docstring to state the restricted scope and the
+   architectural reason the mixed-`v3` cases live in #4663.
+
+`lake build EtingofRepresentationTheory.Chapter6.FieldGenericD5Tilde` passes
+(8043 jobs, exit 0). The only remaining `sorry` in the file is the #4740
+residual in `d5tildeRep_kQ_isIndecomposable` (separate claimed issue) — the
+`leaf_equalities` lemma no longer emits a `declaration uses 'sorry'` warning.
+
+## Key patterns discovered
+
+- **`IsOrientationOf.2.2` is the antisymmetry tool.** `IsOrientationOf` is a
+  3-tuple; its third conjunct `∀ i j, Nonempty (Hom i j) → Nonempty (Hom j i)
+  → False` discharges any off-restriction orientation branch as a
+  `(... ).elim` against a canonicity/same-direction hypothesis. This is the
+  clean way to "restrict the statement instead of leaving bare sorries".
+- **Restrict via Hom-direction hypotheses, not a re-stated `IsOrientationOf`.**
+  Passing `Nonempty (Hom a b)` arguments (plus a same-direction `Iff`) keeps the
+  existing `rcases hOrient_edge` case tree intact — only the previously-sorry
+  leaves change to contradiction terms, a minimal diff.
+- **When restricting a lemma consumed generically, move the call into the
+  branch that can supply the restriction.** `isIndecomposable` only uses the
+  leaf equalities in its all-canonical branch (the rest sorry), so relocating
+  the two calls there (and feeding `iff_of_true ⟨a43⟩ ⟨a53⟩`) needs no new math.
+
+## Current frontier
+
+`d5tildeRep_kQ_leaf_equalities` sorry-free at the eigenvalue-free scope.
+Downstream `isIndecomposable` all-canonical branch still consumes it (sorry-free
+there); its five reversed-orientation branches remain `sorry` (#4740).
+
+## Overall project progress
+
+Etingof draft 1, Stage 3. Ch6 D̃-family tube redesign (#4548/#4597) active.
+D̃₅ leaf-equalities now sorry-free (restricted); first member of the family with
+a clean restricted-scope leaf collapse. The same restrict-by-Hom-hypothesis +
+antisymmetry-discharge pattern should port to D̃₆/₇ leaf_equalities (#4722/#4689).
+
+## Next step
+
+A worker may broaden `d5tildeRep_kQ_leaf_equalities` to the reversed
+`v=2`/central orientations (still same-`v3`) using the existing projection
+infrastructure (`d5tilde_core_F_proj1/2`, `d5tilde_centralCanon_untwist_core_F`)
+— optional, since the downstream consumer only needs all-canonical. Otherwise
+continue the D̃-family indecomposability assemblies (#4740 residual, #4724/#4690
+blocked chains) applying the restrict-and-discharge pattern to their
+leaf_equalities.
+
+## Blockers
+
+None for the landed restriction. The mixed-`v3` leaf equalities are
+(by design) out of scope here and belong to #4663's joint eigenvalue collapse.


### PR DESCRIPTION
Closes #4743

Session: `a50ff3bb-15b4-424a-8adb-3967d86ccdd7`

9896bc9f doc(progress): #4743 eigenvalue-free leaf_equalities restriction (a50ff3bb)
f90bbee8 feat(Ch6 #4743): restrict d5tildeRep_kQ_leaf_equalities to eigenvalue-free orientations (sorry-free)

🤖 Prepared with Claude Code