### PR TITLE
feat(Ch6 #4746): arm-1 tube block-projection readout + Ẽ₇ eigenvalue-core entanglement diagnosis

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/FieldGenericETilde7.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericETilde7.lean
@@ -302,6 +302,72 @@ theorem etilde7_center_sum_zero_F (F : Type) [Field F] (m : ℕ)
       blockProjAt_embedAt_disjoint_F F (3 * (m + 1)) (2 * (m + 1)) m (by omega) (by omega),
       add_zero, zero_add] using hp
 
+/-- Expanded block form of the arm-1 eigenvalue tube: with `p = starFirst_F w`
+(the `P` plane coordinate) and `q = starSecond_F w` (the `Q` coordinate),
+`etilde7Arm1Tube_F w` is the sum of the four block deposits
+`(p+q, p+Λq, p+Λ²q, p+Λ³q)` at offsets `0, m+1, 2(m+1), 3(m+1)`. -/
+theorem etilde7Arm1Tube_expand_F (F : Type) [Field F] (lam : F) (m : ℕ)
+    (w : Fin (2 * (m + 1)) → F) :
+    etilde7Arm1Tube_F F lam m w =
+      blockEmbedAt_F F 0 m (starFirst_F F m w + starSecond_F F m w)
+      + blockEmbedAt_F F (m + 1) m
+          (starFirst_F F m w + jordanShiftLinGen F lam m (starSecond_F F m w))
+      + blockEmbedAt_F F (2 * (m + 1)) m
+          (starFirst_F F m w
+            + jordanShiftLinGen F lam m (jordanShiftLinGen F lam m (starSecond_F F m w)))
+      + blockEmbedAt_F F (3 * (m + 1)) m
+          (starFirst_F F m w
+            + jordanShiftLinGen F lam m
+                (jordanShiftLinGen F lam m
+                  (jordanShiftLinGen F lam m (starSecond_F F m w)))) := by
+  simp only [etilde7Arm1Tube_F, LinearMap.add_apply, LinearMap.comp_apply]
+
+/-- The four single-block projections read the arm-1 tube's four eigenvalue-site
+deposits: block `0` is `p+q`, block `1` is `p+Λq`, block `2` is `p+Λ²q`, block
+`3` is `p+Λ³q` (`Λ = jordanShiftLinGen`, `p = starFirst_F w`, `q = starSecond_F w`).
+This is the eigenvalue-coupling readout consumed by the canonical leaf-equality
+core: blocks `0` and `3` are exactly where the two long-arm flags deposit, and
+the four readouts pin them together through the single `Λ` site. -/
+theorem etilde7_arm1Tube_blockProj_F (F : Type) [Field F] (lam : F) (m : ℕ)
+    (w : Fin (2 * (m + 1)) → F) :
+    blockProjAt_F F 0 m (by omega) (etilde7Arm1Tube_F F lam m w)
+        = starFirst_F F m w + starSecond_F F m w
+    ∧ blockProjAt_F F (m + 1) m (by omega) (etilde7Arm1Tube_F F lam m w)
+        = starFirst_F F m w + jordanShiftLinGen F lam m (starSecond_F F m w)
+    ∧ blockProjAt_F F (2 * (m + 1)) m (by omega) (etilde7Arm1Tube_F F lam m w)
+        = starFirst_F F m w
+            + jordanShiftLinGen F lam m (jordanShiftLinGen F lam m (starSecond_F F m w))
+    ∧ blockProjAt_F F (3 * (m + 1)) m (by omega) (etilde7Arm1Tube_F F lam m w)
+        = starFirst_F F m w
+            + jordanShiftLinGen F lam m
+                (jordanShiftLinGen F lam m
+                  (jordanShiftLinGen F lam m (starSecond_F F m w))) := by
+  refine ⟨?_, ?_, ?_, ?_⟩ <;> rw [etilde7Arm1Tube_expand_F]
+  · rw [map_add, map_add, map_add,
+      blockProjAt_comp_embedAt_F F 0 m (by omega),
+      blockProjAt_embedAt_disjoint_F F 0 (m + 1) m (by omega) (by omega),
+      blockProjAt_embedAt_disjoint_F F 0 (2 * (m + 1)) m (by omega) (by omega),
+      blockProjAt_embedAt_disjoint_F F 0 (3 * (m + 1)) m (by omega) (by omega),
+      add_zero, add_zero, add_zero]
+  · rw [map_add, map_add, map_add,
+      blockProjAt_embedAt_disjoint_F F (m + 1) 0 m (by omega) (by omega),
+      blockProjAt_comp_embedAt_F F (m + 1) m (by omega),
+      blockProjAt_embedAt_disjoint_F F (m + 1) (2 * (m + 1)) m (by omega) (by omega),
+      blockProjAt_embedAt_disjoint_F F (m + 1) (3 * (m + 1)) m (by omega) (by omega),
+      add_zero, add_zero, zero_add]
+  · rw [map_add, map_add, map_add,
+      blockProjAt_embedAt_disjoint_F F (2 * (m + 1)) 0 m (by omega) (by omega),
+      blockProjAt_embedAt_disjoint_F F (2 * (m + 1)) (m + 1) m (by omega) (by omega),
+      blockProjAt_comp_embedAt_F F (2 * (m + 1)) m (by omega),
+      blockProjAt_embedAt_disjoint_F F (2 * (m + 1)) (3 * (m + 1)) m (by omega) (by omega),
+      add_zero, zero_add, zero_add]
+  · rw [map_add, map_add, map_add,
+      blockProjAt_embedAt_disjoint_F F (3 * (m + 1)) 0 m (by omega) (by omega),
+      blockProjAt_embedAt_disjoint_F F (3 * (m + 1)) (m + 1) m (by omega) (by omega),
+      blockProjAt_embedAt_disjoint_F F (3 * (m + 1)) (2 * (m + 1)) m (by omega) (by omega),
+      blockProjAt_comp_embedAt_F F (3 * (m + 1)) m (by omega),
+      zero_add, zero_add, zero_add]
+
 /-- Arm-2 (prefix flag) leaf-4 → center composite for the canonical
 orientation `4→3→2→0`:
 `x ↦ (x, 0, 0, 0)`, i.e. the chain

--- a/progress/2026-06-15T01-51-40Z_05bc153e.md
+++ b/progress/2026-06-15T01-51-40Z_05bc153e.md
@@ -1,0 +1,94 @@
+## Accomplished
+
+Worked #4746 (Ẽ₇ `etilde7Rep_kQ_leaf_equalities` eigenvalue core + non-canonical
+case tree). Landed the sorry-free **arm-1 tube block-projection readout**
+infrastructure that deliverable 1 ("extract the four center blocks") requires,
+in `Chapter6/FieldGenericETilde7.lean` (Section 2):
+
+- `etilde7Arm1Tube_expand_F`: the arm-1 eigenvalue tube in explicit four-block
+  form, `etilde7Arm1Tube_F w = Σ_o blockEmbedAt_F o (p + Λ^k q)` with
+  `p = starFirst_F w`, `q = starSecond_F w`, `Λ = jordanShiftLinGen F lam m`.
+- `etilde7_arm1Tube_blockProj_F`: the four single-block projections read off
+  `(p+q, p+Λq, p+Λ²q, p+Λ³q)`. This is the eigenvalue-coupling readout: blocks
+  `0` and `3` are exactly where the two long-arm flags deposit (leaf-4 → block 0
+  via `etilde7_prefixArm_comp_F`, leaf-7 → block 3 via `etilde7_suffixArm_comp_F`),
+  and the readout pins them together through the single `Λ` site.
+
+`lake build EtingofRepresentationTheory.Chapter6.FieldGenericETilde7` passes,
+0 errors; the only `FieldGenericETilde7` sorry remains the pre-existing
+`etilde7Rep_kQ_isIndecomposable` (now line 763).
+
+## Current frontier
+
+The genuine **eigenvalue core (deliverable 1)** and the final
+`etilde7Rep_kQ_leaf_equalities` theorem (deliverable 2) are NOT landed. After
+full study of the proven `starRep_kQ_isIndecomposable` template (#4752) and the
+Ẽ₇ geometry, the canonical branch does **not** reduce to a single mechanical
+crux the way the issue body anticipated. See the diagnosis below.
+
+### Diagnosis: the Ẽ₇ canonical core is entangled (mirrors the d5tilde #4743 wall)
+
+The star (D̃₄) template works because its center is **2 blocks**, each reached by
+exactly one single-block leaf (`embed1`→block1, `embed2`→block2), and the
+eigenvalue site (`starEmbedTube_F`, leaf 4) is itself a leaf depositing
+`x ↦ (x, (λI+N)x)`. The `core` lemma then decomposes any
+`embed1 x + embed2 z ∈ W⟨0⟩` into `x ∈ W⟨1⟩ ∧ z ∈ W⟨2⟩` using only
+complementarity of the two leaves, and N-invariance falls out of leaf 4 directly.
+
+Ẽ₇ breaks every one of those assumptions:
+
+- The center is **4 blocks** (`F^{4(m+1)}`).
+- The eigenvalue site is a **separate 2-plane vertex** (vertex 1), not a leaf.
+  Via `etilde7Arm1Tube_F` it maps to **all four** center blocks
+  `(p+q, p+Λq, p+Λ²q, p+Λ³q)`.
+- The two deep flag leaves (4, 7) reach only blocks **0 and 3**. The **interior
+  blocks 1 and 2** are reached only by the flag *intermediate* vertices (2, 5):
+  vertex 2 (`prefixBlockEmbed_F 3 4`) covers blocks 0,1,2; vertex 5
+  (`suffixBlockEmbed_F 3 4`) covers blocks 1,2,3.
+
+Consequently a center-core decomposition for Ẽ₇ needs the W-spans of vertices
+2 and 5 (hence leaf-equality structure for the *whole* prefix/suffix arms,
+vertices 2,3,5,6), not just the two deep leaves. And N-invariance on the common
+`F^{m+1}` site cannot be read off one leaf: it must be derived **jointly** with
+the flag collapse, exactly the finding that re-scoped the directly-analogous
+`d5tildeRep_kQ_leaf_equalities` (#4743): *"these leaf equalities are logically
+entangled with `…_isIndecomposable` and must be proven jointly with the
+eigenvalue collapse."* `d7tildeRep_kQ_leaf_equalities` (#4689) is still `sorry`
+for the same reason.
+
+Stating `etilde7Rep_kQ_leaf_equalities` with a guessed conclusion shape now would
+risk re-introducing an **un-derivable** statement (the d5tilde mistake). The
+statement shape should be fixed *together with* the center-collapse design, not
+ahead of it.
+
+## Overall project progress
+
+Ch6 affine-tube indecomposability program. The proven sorry-free templates are
+`starTubeRepGen_isIndecomposable` (all-forward) and now (#4752)
+`starRep_kQ_isIndecomposable` (orientation-generic D̃₄, canonical branch). The
+D̃₅/D̃₆/D̃₇/Ẽ₆/Ẽ₇/T(1,2,5) tubes all still have `sorry` `…_isIndecomposable`
+and most have `sorry`/un-landed `…_leaf_equalities`, blocked on the same
+joint-collapse content.
+
+## Next step
+
+Re-scope #4746 (or a planner replan) along the lines #4743 took for d5tilde:
+
+1. Build the Ẽ₇ **4-block center-core decomposition** as a concrete primitive
+   first (analogue of star's `core`), consuming the prefix/suffix intermediate
+   vertices (2, 5) so the interior blocks 1, 2 are covered. This is the genuine
+   open content and is reusable.
+2. Only after the center-core exists, fix the `etilde7Rep_kQ_leaf_equalities`
+   conclusion shape and prove the canonical branch + N-invariance jointly,
+   consuming `etilde7_arm1Tube_blockProj_F` (landed this turn) to read off the
+   eigenvalue coupling, and finish with
+   `eigenvalue_jordan_invariant_compl_trivial_gen` + `compl_le_forces_eq`.
+3. Consider proving leaf-equalities and `_isIndecomposable` **jointly** (one
+   theorem) rather than separately, per the d5tilde conclusion.
+
+## Blockers
+
+None hard. The eigenvalue-core content is research-level and entangled (see
+diagnosis); it needs the center-core primitive built first. Landed infrastructure
+(`etilde7_arm1Tube_blockProj_F`) is the eigenvalue-coupling readout that step
+will consume.


### PR DESCRIPTION
This PR lands the sorry-free arm-1 tube block-projection readout for the Ẽ₇ homogeneous-tube eigenvalue core (#4746 deliverable 1 prerequisite) and records a structural diagnosis that re-scopes the remaining work. `etilde7Arm1Tube_expand_F` rewrites the arm-1 eigenvalue tube into explicit four-block form, and `etilde7_arm1Tube_blockProj_F` reads its four single-block projections off as `(p+q, p+Λq, p+Λ²q, p+Λ³q)` (`Λ = jordanShiftLinGen`), the eigenvalue-coupling readout that pins center blocks 0 and 3 — the two long-arm flag deposits — together through the single Λ site.

The eigenvalue core itself and the `etilde7Rep_kQ_leaf_equalities` theorem are deferred: the canonical branch does not reduce to a single mechanical crux as the issue anticipated. Ẽ₇'s 4-block center has its eigenvalue site on a separate 2-plane vertex mapping to all four blocks, while the deep flag leaves reach only blocks 0 and 3 and the interior blocks 1, 2 come only from the flag intermediate vertices (2, 5). N-invariance must therefore be derived jointly with the flag collapse — the same entanglement that re-scoped `d5tildeRep_kQ_leaf_equalities` (#4743) and left `d7tildeRep_kQ_leaf_equalities` (#4689) open. The diagnosis and recommended replan (build the 4-block center-core primitive first, then fix the leaf-equality shape and prove it jointly) are in `progress/2026-06-15T01-51-40Z_05bc153e.md` and on #4746.

`lake build EtingofRepresentationTheory.Chapter6.FieldGenericETilde7` passes; the new lemmas are sorry-free and the only remaining sorry in the file is the pre-existing `etilde7Rep_kQ_isIndecomposable`.

🤖 Prepared with Claude Code