### PR TITLE
feat(Ch6 #4779): adopt book iso-class finite-type definition + backward direction

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/FieldGenericAssembly.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericAssembly.lean
@@ -16,7 +16,7 @@ Per-(F, Q) means the conclusion is
                           V.IsIndecomposable ∧ dim V = d }`
 
 for an algebraically closed `F` and an arbitrary orientation `Q`. This
-is strictly stronger than the universal `¬ IsFiniteTypeQuiver n adj`,
+is strictly stronger than the universal `¬ IsFiniteTypeQuiverDimVec n adj`,
 which only asserts that *some* (F, Q) witnesses infinitely many
 indecomposables — the per-(F, Q) form is the one Chapter 2 needs to
 close `not_posdef_not_HasFiniteRepresentationType`.

--- a/EtingofRepresentationTheory/Chapter6/FieldGenericInfiniteType.lean
+++ b/EtingofRepresentationTheory/Chapter6/FieldGenericInfiniteType.lean
@@ -314,7 +314,7 @@ theorem compl_le_forces_eq
 /-! ## Per-(field, orientation) subgraph transfer
 
 The existing `subgraph_infinite_type_transfer` works at the
-`IsFiniteTypeQuiver` level (universal over `k` and orientations). The
+`IsFiniteTypeQuiverDimVec` level (universal over `k` and orientations). The
 per-(field, orientation) refactor needs a version that fixes `F` and `Q`
 externally and transfers infinite-type from the restricted subgraph
 orientation, `restrictOrientationViaEmb φ Q`, to `Q` itself.

--- a/EtingofRepresentationTheory/Chapter6/FiniteTypeDefs.lean
+++ b/EtingofRepresentationTheory/Chapter6/FiniteTypeDefs.lean
@@ -9,6 +9,22 @@ This file defines `AreIsomorphic` (isomorphism of quiver representations) and
 `IsFiniteTypeQuiver` (finite representation type). These are extracted from
 `Problem6_1_5_theorem.lean` to break a circular import dependency with
 `InfiniteTypeConstructions.lean`.
+
+## The two finiteness notions
+
+`IsFiniteTypeQuiver` is the book's literal definition (Etingof Problem 6.1.5):
+*finitely many isomorphism classes of (finite-dimensional) indecomposable
+representations.* This is the notion the orbit-counting argument (directive
+#4777) consumes, so it is the canonical one.
+
+`IsFiniteTypeQuiverDimVec` is the older, strictly weaker auxiliary notion: *the
+set of dimension vectors supporting an indecomposable is finite.* The two are
+**not** interchangeable — the orbit argument at a single dimension vector
+produces infinitely many iso classes whose indecomposable summands share
+finitely many dimension vectors, refuting the iso-class notion but not the
+dimension-vector notion. `IsFiniteTypeQuiverDimVec` is retained only because the
+(to-be-retired) explicit-construction track in `InfiniteTypeConstructions.lean`
+and the `FieldGeneric*` files are stated against it.
 -/
 
 section QuiverRepresentationIso
@@ -25,16 +41,19 @@ def Etingof.QuiverRepresentation.AreIsomorphic
 
 end QuiverRepresentationIso
 
-/-- A quiver on n vertices (with underlying graph given by adjacency matrix adj) is of
-**finite type** if for every algebraically closed field k and every orientation Q of
-the graph, the set of dimension vectors supporting an indecomposable representation
-is finite.
+/-- **Auxiliary (weaker) finiteness notion.** A quiver on `n` vertices (with
+underlying graph given by adjacency matrix `adj`) is of *dimension-vector finite
+type* if for every algebraically closed field `k` and every orientation `Q` of
+the graph, the set of dimension vectors supporting an indecomposable
+representation is finite.
 
-This is equivalent to there being only finitely many isomorphism classes of
-indecomposable representations, since for finite type quivers each dimension vector
-supports at most one indecomposable (up to isomorphism).
-Uses `QuiverRepresentation.IsIndecomposable` from Proposition 6.6.5. -/
-def Etingof.IsFiniteTypeQuiver (n : ℕ) (adj : Matrix (Fin n) (Fin n) ℤ) : Prop :=
+This is implied by, but **not** equivalent to, the iso-class notion
+`IsFiniteTypeQuiver`: infinitely many iso classes can share finitely many
+dimension vectors. It is retained only for the explicit-construction track in
+`InfiniteTypeConstructions.lean` and the `FieldGeneric*` files, which are slated
+for retirement (directive #4777). Uses `QuiverRepresentation.IsIndecomposable`
+from Proposition 6.6.5. -/
+def Etingof.IsFiniteTypeQuiverDimVec (n : ℕ) (adj : Matrix (Fin n) (Fin n) ℤ) : Prop :=
   ∀ (k : Type) [Field k] [IsAlgClosed k]
     (Q : @Quiver.{0, 0} (Fin n))
     [∀ (a b : Fin n), Subsingleton (@Quiver.Hom (Fin n) Q a b)],
@@ -43,3 +62,26 @@ def Etingof.IsFiniteTypeQuiver (n : ℕ) (adj : Matrix (Fin n) (Fin n) ℤ) : Pr
         {d : Fin n → ℕ |
           ∃ (V : Etingof.QuiverRepresentation.{0, 0, 0, 0} k (Fin n)),
             V.IsIndecomposable ∧ ∀ v, Nonempty (V.obj v ≃ₗ[k] (Fin (d v) → k))}
+
+/-- A quiver on `n` vertices (with underlying graph given by adjacency matrix
+`adj`) is of **finite type** if for every algebraically closed field `k` and
+every orientation `Q` of the graph, there are only **finitely many isomorphism
+classes of finite-dimensional indecomposable representations**.
+
+We encode "finitely many iso classes" as the existence of a finite set `reps` of
+indecomposable representatives such that every finite-dimensional indecomposable
+is isomorphic (via `AreIsomorphic`) to one of them. This is the book's literal
+definition (Etingof Problem 6.1.5) and the notion the orbit-counting argument
+consumes. Uses `QuiverRepresentation.AreIsomorphic` and
+`QuiverRepresentation.IsIndecomposable` (Proposition 6.6.5). -/
+def Etingof.IsFiniteTypeQuiver (n : ℕ) (adj : Matrix (Fin n) (Fin n) ℤ) : Prop :=
+  ∀ (k : Type) [Field k] [IsAlgClosed k]
+    (Q : @Quiver.{0, 0} (Fin n))
+    [∀ (a b : Fin n), Subsingleton (@Quiver.Hom (Fin n) Q a b)],
+    @Etingof.IsOrientationOf n Q adj →
+      ∃ reps : Set (Etingof.QuiverRepresentation.{0, 0, 0, 0} k (Fin n)),
+        reps.Finite ∧
+        (∀ V ∈ reps, V.IsIndecomposable) ∧
+        ∀ (W : Etingof.QuiverRepresentation.{0, 0, 0, 0} k (Fin n)),
+          (∀ v, Module.Free k (W.obj v)) → (∀ v, Module.Finite k (W.obj v)) →
+            W.IsIndecomposable → ∃ V ∈ reps, W.AreIsomorphic V

--- a/EtingofRepresentationTheory/Chapter6/InfiniteTypeConstructions.lean
+++ b/EtingofRepresentationTheory/Chapter6/InfiniteTypeConstructions.lean
@@ -384,7 +384,7 @@ attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
   CategoryTheory.ReflQuiver.toQuiver in
 /-- The cycle graph on k ≥ 3 vertices has infinite representation type. -/
 theorem cycle_not_finite_type (k : ℕ) (hk : 3 ≤ k) :
-    ¬ Etingof.IsFiniteTypeQuiver k (cycleAdj k hk) := by
+    ¬ Etingof.IsFiniteTypeQuiverDimVec k (cycleAdj k hk) := by
   intro hft
   letI := cycleQuiver k hk
   have hfin := @hft ℂ _ inferInstance (cycleQuiver k hk)
@@ -784,7 +784,7 @@ attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
 /-- The star graph K_{1,4} has infinite representation type:
     for each m, there is an indecomposable rep with distinct dim vector. -/
 theorem star_not_finite_type :
-    ¬ Etingof.IsFiniteTypeQuiver 5 starAdj := by
+    ¬ Etingof.IsFiniteTypeQuiverDimVec 5 starAdj := by
   intro hft
   letI := starQuiver
   have hfin := @hft ℂ _ inferInstance starQuiver
@@ -815,7 +815,7 @@ restriction to the image of φ equals adj_sub, we show that infinite representat
 type transfers from the subgraph to the full graph.
 
 The proof strategy:
-1. Given ¬ IsFiniteTypeQuiver m adj_sub, assume IsFiniteTypeQuiver n adj for contradiction.
+1. Given ¬ IsFiniteTypeQuiverDimVec m adj_sub, assume IsFiniteTypeQuiverDimVec n adj for contradiction.
 2. For any orientation Q_sub of adj_sub, extend it to an orientation Q of adj.
 3. Map each Q_sub-indecomposable to a Q-indecomposable via extension by zero.
 4. The dim vector injection gives a contradiction with finiteness. -/
@@ -912,11 +912,11 @@ theorem subgraph_infinite_type_transfer (φ : Fin m ↪ Fin n)
     (hadj_symm : adj.IsSymm)
     (hadj_noloop : ∀ v, adj v v ≠ 1)
     (hembed : ∀ i j, adj_sub i j = adj (φ i) (φ j))
-    (h_inf : ¬ Etingof.IsFiniteTypeQuiver m adj_sub) :
-    ¬ Etingof.IsFiniteTypeQuiver n adj := by
+    (h_inf : ¬ Etingof.IsFiniteTypeQuiverDimVec m adj_sub) :
+    ¬ Etingof.IsFiniteTypeQuiverDimVec n adj := by
   intro hft
   apply h_inf
-  -- Show IsFiniteTypeQuiver m adj_sub by mapping dim vectors into the finite n-graph set
+  -- Show IsFiniteTypeQuiverDimVec m adj_sub by mapping dim vectors into the finite n-graph set
   intro k _ _ Q_sub hss hori_sub
   -- Extend orientation to full graph
   letI Q_ext := extendOrientation φ adj Q_sub
@@ -1137,7 +1137,7 @@ theorem star_subgraph_not_finite_type {n : ℕ} (adj : Matrix (Fin n) (Fin n) �
     (hleaves_ne : ∀ i, leaves i ≠ center)
     (hadj_edge : ∀ i, adj center (leaves i) = 1)
     (hadj_indep : ∀ i j, adj (leaves i) (leaves j) = 0) :
-    ¬ Etingof.IsFiniteTypeQuiver n adj := by
+    ¬ Etingof.IsFiniteTypeQuiverDimVec n adj := by
   -- Construct embedding φ : Fin 5 ↪ Fin n mapping star K_{1,4} into the graph
   -- φ maps: 0 ↦ center, k+1 ↦ leaves k
   have h_leaf (i : Fin 5) (h : i.val ≠ 0) : i.val - 1 < 4 := by omega
@@ -1195,7 +1195,7 @@ theorem tree_degree_ge_4_not_finite_type {n : ℕ} (adj : Matrix (Fin n) (Fin n)
     -- Triangle-free: no two neighbors of the same vertex are adjacent
     (htri_free : ∀ v w₁ w₂, adj v w₁ = 1 → adj v w₂ = 1 → w₁ ≠ w₂ → adj w₁ w₂ = 0)
     (v : Fin n) (hv : 4 ≤ vertexDegree adj v) :
-    ¬ Etingof.IsFiniteTypeQuiver n adj := by
+    ¬ Etingof.IsFiniteTypeQuiverDimVec n adj := by
   -- Extract 4 distinct neighbors from the neighbor set of v
   set S := Finset.univ.filter (fun w => adj v w = 1) with hS_def
   -- Get a subset of size 4
@@ -1945,7 +1945,7 @@ attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
 /-- The extended Dynkin diagram D̃₅ has infinite representation type:
     for each m, there is an indecomposable rep with distinct dim vector. -/
 theorem d5tilde_not_finite_type :
-    ¬ Etingof.IsFiniteTypeQuiver 6 d5tildeAdj := by
+    ¬ Etingof.IsFiniteTypeQuiverDimVec 6 d5tildeAdj := by
   intro hft
   letI := d5tildeQuiver
   have hfin := @hft ℂ _ inferInstance d5tildeQuiver
@@ -3174,7 +3174,7 @@ theorem dTildeRep_isIndecomposable (k m : ℕ) :
 attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
   CategoryTheory.ReflQuiver.toQuiver in
 theorem dTilde_not_finite_type (k : ℕ) :
-    ¬ Etingof.IsFiniteTypeQuiver (k + 6) (dTildeAdj k) := by
+    ¬ Etingof.IsFiniteTypeQuiverDimVec (k + 6) (dTildeAdj k) := by
   intro hft
   letI := dTildeQuiver k
   have hfin := @hft ℂ _ inferInstance (dTildeQuiver k)
@@ -3247,7 +3247,7 @@ theorem etilde6v2Orientation_isOrientationOf :
 
 
 theorem etilde6_not_finite_type :
-    ¬ Etingof.IsFiniteTypeQuiver 7 etilde6Adj := by
+    ¬ Etingof.IsFiniteTypeQuiverDimVec 7 etilde6Adj := by
   -- TRUE statement: Ẽ₆ is an affine (extended) Dynkin diagram and therefore
   -- has infinite representation type. The previous proof routed through an
   -- explicit single-nilpotent-twist construction that was shown UNSOUND
@@ -3296,7 +3296,7 @@ attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
 This follows because it contains Ẽ_6 = T_{2,2,2} as a subgraph, which itself has
 infinite representation type. -/
 theorem etilde8_not_finite_type :
-    ¬ Etingof.IsFiniteTypeQuiver 11 etilde8Adj :=
+    ¬ Etingof.IsFiniteTypeQuiverDimVec 11 etilde8Adj :=
   subgraph_infinite_type_transfer etilde6_to_etilde8 etilde8Adj etilde6Adj
     etilde8Adj_symm
     (fun v h => by linarith [etilde8Adj_diag v])
@@ -3390,7 +3390,7 @@ def etilde7Dim (m : ℕ) (v : Fin 8) : ℕ :=
 attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
   CategoryTheory.ReflQuiver.toQuiver in
 theorem etilde7_not_finite_type :
-    ¬ Etingof.IsFiniteTypeQuiver 8 etilde7Adj := by
+    ¬ Etingof.IsFiniteTypeQuiverDimVec 8 etilde7Adj := by
   -- TRUE statement: Ẽ₇ is an affine (extended) Dynkin diagram and therefore
   -- has infinite representation type. The previous proof routed through an
   -- explicit single-nilpotent-twist construction that was shown UNSOUND
@@ -3494,7 +3494,7 @@ def t125Dim (m : ℕ) (v : Fin 9) : ℕ :=
 attribute [-instance] CategoryTheory.CategoryStruct.toQuiver
   CategoryTheory.ReflQuiver.toQuiver in
 theorem t125_not_finite_type :
-    ¬ Etingof.IsFiniteTypeQuiver 9 t125Adj := by
+    ¬ Etingof.IsFiniteTypeQuiverDimVec 9 t125Adj := by
   -- TRUE statement: T(1,2,5) is an affine (extended) Dynkin diagram and therefore
   -- has infinite representation type. The previous proof routed through an
   -- explicit single-nilpotent-twist construction that was shown UNSOUND
@@ -3532,7 +3532,7 @@ theorem triangle_infinite_type {n : ℕ} (adj : Matrix (Fin n) (Fin n) ℤ)
     (_h01 : ∀ i j, adj i j = 0 ∨ adj i j = 1)
     (a b c : Fin n) (hab : a ≠ b) (hbc : b ≠ c) (hac : a ≠ c)
     (h_ab : adj a b = 1) (h_bc : adj b c = 1) (h_ac : adj a c = 1) :
-    ¬ IsFiniteTypeQuiver n adj := by
+    ¬ IsFiniteTypeQuiverDimVec n adj := by
   -- Construct embedding φ : Fin 3 ↪ Fin n mapping 0 ↦ a, 1 ↦ b, 2 ↦ c
   let φ_fun : Fin 3 → Fin n := ![a, b, c]
   have hφ_inj : Function.Injective φ_fun := by
@@ -3567,14 +3567,14 @@ theorem graph_with_list_cycle_infinite_type {n : ℕ} (adj : Matrix (Fin n) (Fin
       adj (cycle.get ⟨k, by omega⟩) (cycle.get ⟨k + 1, hk⟩) = 1)
     (hclose : adj (cycle.get ⟨cycle.length - 1, by omega⟩)
                    (cycle.get ⟨0, by omega⟩) = 1) :
-    ¬ IsFiniteTypeQuiver n adj := by
+    ¬ IsFiniteTypeQuiverDimVec n adj := by
   -- Strong induction on cycle length, quantified over all cycles of that length
   revert cycle hlen hnodup hedge hclose
   have key : ∀ m, (hm : 3 ≤ m) → ∀ (cyc : List (Fin n)), (hlen : cyc.length = m) → cyc.Nodup →
       (∀ k, (hk : k + 1 < cyc.length) →
         adj (cyc.get ⟨k, by omega⟩) (cyc.get ⟨k + 1, hk⟩) = 1) →
       (adj (cyc.get ⟨cyc.length - 1, by omega⟩) (cyc.get ⟨0, by omega⟩) = 1) →
-      ¬ IsFiniteTypeQuiver n adj := by
+      ¬ IsFiniteTypeQuiverDimVec n adj := by
     intro m
     induction m using Nat.strongRecOn with
     | _ m ih =>
@@ -3715,7 +3715,7 @@ theorem degree_ge_4_infinite_type {n : ℕ} (adj : Matrix (Fin n) (Fin n) ℤ)
     (hdiag : ∀ i, adj i i = 0)
     (h01 : ∀ i j, adj i j = 0 ∨ adj i j = 1)
     (v : Fin n) (hv : 4 ≤ vertexDegree adj v) :
-    ¬ IsFiniteTypeQuiver n adj := by
+    ¬ IsFiniteTypeQuiverDimVec n adj := by
   -- Get 4 distinct neighbors of v
   set S := Finset.univ.filter (fun w => adj v w = 1) with hS_def
   have hS_card : 4 ≤ S.card := hv
@@ -3764,7 +3764,7 @@ theorem chordless_cycle_infinite_type {n k : ℕ} (adj : Matrix (Fin n) (Fin n) 
     (hk : 3 ≤ k)
     (φ : Fin k ↪ Fin n)
     (hembed : ∀ i j, cycleAdj k hk i j = adj (φ i) (φ j)) :
-    ¬ IsFiniteTypeQuiver n adj :=
+    ¬ IsFiniteTypeQuiverDimVec n adj :=
   subgraph_infinite_type_transfer φ adj (cycleAdj k hk) hsymm
     (fun v h => by linarith [hdiag v]) hembed (cycle_not_finite_type k hk)
 
@@ -4421,7 +4421,7 @@ private theorem adjacent_branches_infinite_type {n : ℕ} (adj : Matrix (Fin n) 
         (cycle.get ⟨0, by omega⟩) ≠ 1)
     (v₀ w : Fin n) (hv₀_deg : vertexDegree adj v₀ = 3)
     (hw_deg : vertexDegree adj w = 3) (hvw_adj : adj v₀ w = 1) :
-    ¬ IsFiniteTypeQuiver n adj := by
+    ¬ IsFiniteTypeQuiverDimVec n adj := by
   -- adj_comm: adj i j = adj j i (from symmetry)
   have adj_comm : ∀ i j, adj i j = adj j i := fun i j => hsymm.apply j i
   -- ne_of_adj: adjacent vertices are distinct
@@ -4582,7 +4582,7 @@ private theorem embed_t125_in_tree {n : ℕ}
     (hu₁_ne_p₁ : u₁ ≠ p₁) (hu₁_ne_q₁ : u₁ ≠ q₁) (hp₁_ne_q₁ : p₁ ≠ q₁)
     (hp₂_ne_v₀ : p₂ ≠ v₀) (hq₂_ne_v₀ : q₂ ≠ v₀)
     (hq₃_ne_q₁ : q₃ ≠ q₁) (hq₄_ne_q₂ : q₄ ≠ q₂) (hq₅_ne_q₃ : q₅ ≠ q₃) :
-    ¬ Etingof.IsFiniteTypeQuiver n adj := by
+    ¬ Etingof.IsFiniteTypeQuiverDimVec n adj := by
   have adj_comm : ∀ i j, adj i j = adj j i := fun i j => hsymm.apply j i
   have ne_of_adj' : ∀ a b, adj a b = 1 → a ≠ b := fun a b h hab => by
     rw [hab, hdiag] at h; exact one_ne_zero h.symm
@@ -6568,7 +6568,7 @@ private theorem single_branch_leaf_case {n : ℕ}
       0 < dotProduct x ((2 • (1 : Matrix (Fin n) (Fin n) ℤ) - adj).mulVec x))
     (leaf : Fin n) (h_leaf_adj : adj v₀ leaf = 1)
     (h_leaf_deg : vertexDegree adj leaf = 1) :
-    ¬ IsFiniteTypeQuiver n adj := by
+    ¬ IsFiniteTypeQuiverDimVec n adj := by
   have adj_comm : ∀ i j, adj i j = adj j i := fun i j => hsymm.apply j i
   have ne_of_adj' : ∀ a b, adj a b = 1 → a ≠ b := fun a b h hab => by
     rw [hab, hdiag] at h; exact one_ne_zero h.symm
@@ -8066,7 +8066,7 @@ private theorem single_branch_not_posdef_infinite_type {n : ℕ}
     (h_unique : ∀ w, vertexDegree adj w = 3 → w = v₀)
     (h_not_posdef : ¬ ∀ x : Fin n → ℤ, x ≠ 0 →
       0 < dotProduct x ((2 • (1 : Matrix (Fin n) (Fin n) ℤ) - adj).mulVec x)) :
-    ¬ IsFiniteTypeQuiver n adj := by
+    ¬ IsFiniteTypeQuiverDimVec n adj := by
   have adj_comm : ∀ i j, adj i j = adj j i := fun i j => hsymm.apply j i
   have ne_of_adj : ∀ a b, adj a b = 1 → a ≠ b := fun a b h hab => by
     rw [hab, hdiag] at h; exact one_ne_zero h.symm
@@ -9345,7 +9345,7 @@ private theorem non_adjacent_branches_infinite_type {n : ℕ}
     (h_deg : ∀ v, vertexDegree adj v < 4)
     (v₀ w : Fin n) (hv₀ : vertexDegree adj v₀ = 3) (hw : vertexDegree adj w = 3)
     (hne : w ≠ v₀) (h_no_adj_branch : ∀ u, adj v₀ u = 1 → vertexDegree adj u < 3) :
-    ¬ IsFiniteTypeQuiver n adj := by
+    ¬ IsFiniteTypeQuiverDimVec n adj := by
   -- Case 1: If some pair of branch points is adjacent somewhere, use that directly
   by_cases h_adj_exists : ∃ x y, adj x y = 1 ∧ vertexDegree adj x = 3 ∧ vertexDegree adj y = 3
   · obtain ⟨x, y, hxy, hx, hy⟩ := h_adj_exists
@@ -9417,7 +9417,7 @@ private theorem non_adjacent_branches_infinite_type {n : ℕ}
     --   - T(1,2,5)       (when long arm at w beyond chain length)
     -- Subgraph transfer via `subgraph_infinite_type_transfer`.
     have leaf_case : ∀ leaf : Fin n, adj v₀ leaf = 1 → vertexDegree adj leaf = 1 →
-        ¬ IsFiniteTypeQuiver n adj := fun leaf h_leaf_adj h_leaf_deg => by
+        ¬ IsFiniteTypeQuiverDimVec n adj := fun leaf h_leaf_adj h_leaf_deg => by
       -- v₀ and w are not adjacent (no adjacent degree-3 pair exists)
       have h_v₀w_nonadj : adj v₀ w ≠ 1 := by
         intro hadj
@@ -10273,7 +10273,7 @@ theorem acyclic_branch_not_posdef_infinite_type {n : ℕ} (adj : Matrix (Fin n) 
     (h_has_branch : ∃ v, vertexDegree adj v = 3)
     (h_not_posdef : ¬ ∀ x : Fin n → ℤ, x ≠ 0 →
       0 < dotProduct x ((2 • (1 : Matrix (Fin n) (Fin n) ℤ) - adj).mulVec x)) :
-    ¬ IsFiniteTypeQuiver n adj := by
+    ¬ IsFiniteTypeQuiverDimVec n adj := by
   obtain ⟨v₀, hv₀⟩ := h_has_branch
   -- Does v₀ have an adjacent branch point?
   by_cases h_adj_branch : ∃ u, adj v₀ u = 1 ∧ vertexDegree adj u = 3
@@ -10318,7 +10318,7 @@ theorem not_posdef_infinite_type {n : ℕ} (adj : Matrix (Fin n) (Fin n) ℤ)
         adj (path.get ⟨k, by omega⟩) (path.get ⟨k + 1, h⟩) = 1)
     (h_not_posdef : ¬ ∀ x : Fin n → ℤ, x ≠ 0 →
       0 < dotProduct x ((2 • (1 : Matrix (Fin n) (Fin n) ℤ) - adj).mulVec x)) :
-    ¬ IsFiniteTypeQuiver n adj := by
+    ¬ IsFiniteTypeQuiverDimVec n adj := by
   -- Case 1: ∃ vertex with degree ≥ 4
   by_cases h_deg4 : ∃ v, 4 ≤ vertexDegree adj v
   · obtain ⟨v, hv⟩ := h_deg4
@@ -10379,7 +10379,7 @@ theorem non_ade_graph_not_finite_type {n : ℕ} (adj : Matrix (Fin n) (Fin n) �
         adj (path.get ⟨k, by omega⟩) (path.get ⟨k + 1, h⟩) = 1)
     (h_not_ade : ¬ ∃ t : DynkinType, ∃ σ : Fin t.rank ≃ Fin n,
       ∀ i j, adj (σ i) (σ j) = t.adj i j) :
-    ¬ IsFiniteTypeQuiver n adj := by
+    ¬ IsFiniteTypeQuiverDimVec n adj := by
   -- Step 1: ¬ADE → ¬IsDynkinDiagram (by Dynkin classification theorem)
   have h_not_dynkin : ¬ IsDynkinDiagram n adj := by
     intro hD

--- a/EtingofRepresentationTheory/Chapter6/Problem6_1_5_theorem.lean
+++ b/EtingofRepresentationTheory/Chapter6/Problem6_1_5_theorem.lean
@@ -3,7 +3,8 @@ import EtingofRepresentationTheory.Chapter6.Definition6_1_4
 import EtingofRepresentationTheory.Chapter6.Corollary6_8_4
 import EtingofRepresentationTheory.Chapter6.Proposition6_6_5
 import EtingofRepresentationTheory.Chapter6.Theorem6_5_2
-import EtingofRepresentationTheory.Chapter6.InfiniteTypeConstructions
+import EtingofRepresentationTheory.Chapter6.Theorem_Dynkin_classification
+import EtingofRepresentationTheory.Chapter6.FiniteTypeDefs
 
 /-!
 # Theorem (Problem 6.1.5): Finite Type iff Dynkin
@@ -20,36 +21,26 @@ Gabriel's theorem is NOT in Mathlib. Quiver representations have basic support
 ## Formalization note
 
 The statement uses `IsDynkinDiagram` (Definition 6.1.4) for the combinatorial
-condition. `IsFiniteTypeQuiver` is defined in `FiniteTypeDefs.lean` using quiver
-representation isomorphism and indecomposability, quantified over all orientations
-and algebraically closed fields.
+condition. `IsFiniteTypeQuiver` is defined in `FiniteTypeDefs.lean` as "finitely
+many isomorphism classes of finite-dimensional indecomposable representations"
+(the book's literal definition), quantified over all orientations and
+algebraically closed fields.
+
+## Status of the two directions
+
+* **Backward** (Dynkin ⟹ finite type): proved here, sorry-free. Each
+  finite-dimensional indecomposable has a dimension vector that is a positive
+  root (Theorem 6.5.2b), positive roots are finite (Theorem 6.5.2a), each
+  positive root is realized by a unique indecomposable up to isomorphism
+  (Theorem 6.5.2c). The finite set of those realizers covers every
+  indecomposable up to `AreIsomorphic`.
+* **Forward** (finite type ⟹ Dynkin): the Tits-form positive-definiteness is the
+  output of the orbit-counting chain of directive #4777
+  (#4780 → #4782 → #4783 → #4784), to be wired into the positivity component by
+  #4786. It is the single remaining `sorry` below.
 -/
 
 open Etingof in
-/-- A connected simple graph on n ≥ 1 vertices that is not graph-isomorphic to any
-standard Dynkin type (A_n, D_n, E₆, E₇, E₈) has infinite representation type.
-
-This is proved by case analysis on the graph structure:
-- Graphs containing cycles → `cycle_not_finite_type` + subgraph transfer
-- Trees with degree ≥ 4 → `tree_degree_ge_4_not_finite_type`
-- Trees with ≥ 2 branch points of degree 3 → D̃₅ subgraph + `d5tilde_not_finite_type`
-- T_{p,q,r} with p ≥ 2 → Ẽ₆ = T_{2,2,2} subgraph + `etilde6_not_finite_type`
-- T_{1,q,r} with q ≥ 3 → Ẽ₇ type: extended Dynkin infinite type
-- T_{1,2,r} with r ≥ 5 → Ẽ₈ type: extended Dynkin infinite type -/
-private theorem not_ade_not_finite_type {n : ℕ} (adj : Matrix (Fin n) (Fin n) ℤ)
-    (hn : 1 ≤ n)
-    (hsymm : adj.IsSymm)
-    (hdiag : ∀ i, adj i i = 0)
-    (h01 : ∀ i j, adj i j = 0 ∨ adj i j = 1)
-    (hconn : ∀ i j : Fin n, ∃ path : List (Fin n),
-      path.head? = some i ∧ path.getLast? = some j ∧
-      ∀ k, (h : k + 1 < path.length) →
-        adj (path.get ⟨k, by omega⟩) (path.get ⟨k + 1, h⟩) = 1)
-    (h_not_ade : ¬ ∃ t : DynkinType, ∃ σ : Fin t.rank ≃ Fin n,
-      ∀ i j, adj (σ i) (σ j) = t.adj i j) :
-    ¬ IsFiniteTypeQuiver n adj :=
-  Etingof.non_ade_graph_not_finite_type adj hn hsymm hdiag h01 hconn h_not_ade
-
 /-- Gabriel's theorem: a connected quiver (given by its symmetric adjacency matrix)
 is of finite type (finitely many indecomposable representations up to isomorphism)
 if and only if its underlying unoriented graph is a Dynkin diagram.
@@ -64,70 +55,68 @@ theorem Etingof.Theorem_6_1_5 (n : ℕ) (adj : Matrix (Fin n) (Fin n) ℤ)
         adj (path.get ⟨k, by omega⟩) (path.get ⟨k + 1, h⟩) = 1) :
     Etingof.IsFiniteTypeQuiver n adj ↔ Etingof.IsDynkinDiagram n adj := by
   constructor
-  · -- Forward: finite type → Dynkin diagram
-    intro hft
+  · -- Forward: finite type → Dynkin diagram.
+    -- The four combinatorial conditions hold by hypothesis; positive-definiteness
+    -- of the Tits form is the orbit-counting output of directive #4777
+    -- (#4780 → #4782 → #4783 → #4784), to be wired in by #4786.
+    intro _hft
     refine ⟨hsymm, hdiag, h01, hconn, fun x hx => ?_⟩
-    -- By contradiction: if B(x,x) ≤ 0, then the graph is not Dynkin, hence not ADE,
-    -- hence has infinite representation type, contradicting finite type.
-    by_contra h_not_pos
-    push_neg at h_not_pos
-    -- The other 4 conditions + ¬pos_def → ¬IsDynkinDiagram
-    have h_not_dynkin : ¬ Etingof.IsDynkinDiagram n adj := by
-      intro ⟨_, _, _, _, hpos⟩
-      exact not_lt.mpr h_not_pos (hpos x hx)
-    -- For n = 0: impossible (no nonzero x : Fin 0 → ℤ)
-    by_cases hn : n = 0
-    · subst hn; exact hx (funext (fun i => i.elim0))
-    · -- For n ≥ 1: by Dynkin classification, not ADE
-      have hn1 : 1 ≤ n := Nat.one_le_iff_ne_zero.mpr hn
-      have h_not_ade : ¬ ∃ t : Etingof.DynkinType, ∃ σ : Fin t.rank ≃ Fin n,
-          ∀ i j, adj (σ i) (σ j) = t.adj i j := by
-        intro hade
-        exact h_not_dynkin ((Etingof.Theorem_Dynkin_classification n adj hn1).mpr hade)
-      exact not_ade_not_finite_type adj hn1 hsymm hdiag h01 hconn h_not_ade hft
-  · -- Backward: Dynkin diagram → finite type
-    -- Every indecomposable has dim vector that is a positive root (Theorem 6.5.2b),
-    -- and positive roots are finite (Theorem 6.5.2a).
+    -- TODO(#4786): 0 < B(x, x) from finite type via the orbit-counting argument.
+    sorry
+  · -- Backward: Dynkin diagram → finite type.
     intro hDynkin k _inst_field _inst_algclosed Q _inst_ss hOrient
-    -- Cast map from ℕ dim vectors to ℤ vectors
-    set f : (Fin n → ℕ) → (Fin n → ℤ) := fun d i => ↑(d i)
-    -- f is injective
-    have hf_inj : Function.Injective f := by
-      intro d₁ d₂ heq; ext i
-      have := congr_fun heq i; simp only [f] at this; exact_mod_cast this
-    -- The set of dim vectors of indecomposables maps into positive roots
-    apply Set.Finite.subset
-      ((Etingof.Theorem_6_5_2a_finiteness hDynkin).preimage (hf_inj.injOn))
-    intro d ⟨V, hV_indec, hV_equiv⟩
-    simp only [Set.mem_preimage, Set.mem_setOf_eq]
-    -- Show f d is a positive root: nonneg, nonzero, B(f d, f d) = 2
-    refine ⟨⟨?_, ?_⟩, fun i => Int.natCast_nonneg (d i)⟩
-    · -- f d ≠ 0 (V is indecomposable → nontrivial at some vertex → d v ≥ 1)
-      obtain ⟨⟨v, hv⟩, _⟩ := hV_indec
-      intro heq
-      have hv_zero : d v = 0 := by
-        have h := congr_fun heq v
-        change (d v : ℤ) = 0 at h
-        exact_mod_cast h
-      -- V.obj v ≃ₗ[k] (Fin 0 → k), so V.obj v is trivial, contradicting Nontrivial
-      obtain ⟨e⟩ := hV_equiv v
-      rw [hv_zero] at e
-      haveI : Subsingleton (V.obj v) := e.toEquiv.injective.subsingleton
-      exact not_nontrivial (V.obj v) hv
-    · -- B(f d, f d) = 2: indecomposable dim vectors satisfy the Tits form condition.
-      -- Derive Module.Free and Module.Finite from the linear equivs
-      haveI : ∀ v, Module.Free k (V.obj v) := fun v =>
-        Module.Free.of_equiv ((hV_equiv v).some.symm)
-      haveI : ∀ v, Module.Finite k (V.obj v) := fun v =>
-        Module.Finite.equiv ((hV_equiv v).some.symm)
-      -- Bridge: show finrank equals d v via LinearEquiv
-      have hdim : ∀ v, Module.finrank k (V.obj v) = d v := fun v => by
-        rw [(hV_equiv v).some.finrank_eq, Module.finrank_fin_fun]
-      -- Rewrite the goal to use finrank
-      have : f d = fun v => (Module.finrank k (V.obj v) : ℤ) := by
-        ext v; simp only [f]; rw [hdim v]
-      rw [this]
-      exact Etingof.indecomposable_bilinearForm_eq_two hDynkin hOrient V hV_indec
+    classical
+    -- The set of positive roots is finite (Theorem 6.5.2a).
+    have hPR_fin : Set.Finite {α : Fin n → ℤ | Etingof.IsPositiveRoot n adj α} :=
+      Etingof.Theorem_6_5_2a_finiteness hDynkin
+    -- For each positive root, Theorem 6.5.2c gives an indecomposable representative.
+    have hex : ∀ α : Fin n → ℤ, Etingof.IsPositiveRoot n adj α →
+        ∃ ρ : @Etingof.QuiverRepresentation.{0, 0, 0, 0} k (Fin n) _ Q,
+          (∀ v, Module.Free k (ρ.obj v)) ∧ (∀ v, Module.Finite k (ρ.obj v)) ∧
+            ρ.IsIndecomposable ∧ ∀ v, α v = (Module.finrank k (ρ.obj v) : ℤ) := by
+      intro α hα
+      obtain ⟨ρ, hfree, hfin, hindec, hdim⟩ :=
+        (Etingof.Theorem_6_5_2c_bijection hDynkin k hOrient α hα).1
+      exact ⟨ρ, hfree, hfin, hindec, hdim⟩
+    choose! g hg_free hg_fin hg_indec hg_dim using hex
+    -- The chosen representatives, indexed by the (finite) set of positive roots; the
+    -- representative set is the dependent image of the finite root set under `g`.
+    refine ⟨_, hPR_fin.dependent_image (fun α hα => g α hα), ?_, ?_⟩
+    · -- Each representative is indecomposable.
+      rintro V ⟨α, hα, rfl⟩
+      exact hg_indec α hα
+    · -- Every finite-dimensional indecomposable is isomorphic to a representative.
+      intro W hWfree hWfin hWindec
+      haveI : ∀ v, Module.Free k (W.obj v) := hWfree
+      haveI : ∀ v, Module.Finite k (W.obj v) := hWfin
+      -- Dimension vector of W.
+      set dW : Fin n → ℤ := fun v => (Module.finrank k (W.obj v) : ℤ) with hdW
+      -- dW is a positive root (Theorem 6.5.2b).
+      have hdW_root : Etingof.IsPositiveRoot n adj dW := by
+        refine Etingof.Theorem_6_5_2b_dimvec_is_positive_root hDynkin dW
+          (fun i => Int.natCast_nonneg _) ?_ ?_
+        · -- dW ≠ 0: W is indecomposable, hence nontrivial at some vertex.
+          obtain ⟨v, hv⟩ := hWindec.1
+          intro heq
+          have hv0 : Module.finrank k (W.obj v) = 0 := by
+            have h := congr_fun heq v
+            simpa [hdW] using h
+          letI : AddCommGroup (W.obj v) := Etingof.addCommGroupOfRing (k := k)
+          haveI : Subsingleton (W.obj v) := Module.finrank_zero_iff.mp hv0
+          exact not_nontrivial (W.obj v) hv
+        · -- B(dW, dW) = 2 (Tits form on an indecomposable dimension vector).
+          exact Etingof.indecomposable_bilinearForm_eq_two hDynkin hOrient W hWindec
+      -- The representative attached to dW.
+      refine ⟨g dW hdW_root, ⟨dW, hdW_root, rfl⟩, ?_⟩
+      -- W ≅ g dW by uniqueness (Theorem 6.5.2c), both indecomposable with dim vector dW.
+      haveI : ∀ v, Module.Free k ((g dW hdW_root).obj v) := hg_free dW hdW_root
+      haveI : ∀ v, Module.Finite k ((g dW hdW_root).obj v) := hg_fin dW hdW_root
+      have huniq :=
+        (Etingof.Theorem_6_5_2c_bijection hDynkin k hOrient dW hdW_root).2
+          W (g dW hdW_root) hWindec (hg_indec dW hdW_root) (fun _ => rfl)
+          (hg_dim dW hdW_root)
+      obtain ⟨iso⟩ := huniq
+      exact ⟨iso.equivAt, fun {a b} f => by ext x; simpa using iso.naturality f x⟩
 
 /-- Corollary: A connected simple graph that is not a Dynkin diagram has infinite
 representation type. (Non-circular version, proved as corollary of Theorem_6_1_5.) -/

--- a/progress/2026-06-21T04-43-17Z_d5c888aa.md
+++ b/progress/2026-06-21T04-43-17Z_d5c888aa.md
@@ -1,0 +1,81 @@
+## Accomplished
+
+Closed issue #4779 (directive #4777, step S-def): switched the canonical
+finite-type predicate to the book's literal iso-class definition and re-proved
+the backward direction of Gabriel's theorem against it.
+
+**`FiniteTypeDefs.lean`:**
+- Renamed the old "set of supporting dimension vectors is finite" predicate to
+  `Etingof.IsFiniteTypeQuiverDimVec` (kept as a deprecated/auxiliary def for the
+  to-be-retired explicit-construction and `FieldGeneric*` track).
+- Added the new canonical `Etingof.IsFiniteTypeQuiver`: *finitely many
+  isomorphism classes of finite-dimensional indecomposable representations*,
+  encoded as the existence of a finite set `reps` of indecomposable
+  representatives covering every finite-dim indecomposable up to
+  `AreIsomorphic`. This is the notion the orbit-counting argument (#4777)
+  consumes. Documented why the two notions are not interchangeable.
+
+**`Problem6_1_5_theorem.lean`:**
+- Restated `Etingof.Theorem_6_1_5` against the new definition.
+- **Backward (Dynkin ⟹ finite type): fully sorry-free.** Built the covering set
+  as the dependent image (`Set.Finite.dependent_image`) of the finite set of
+  positive roots (Theorem 6.5.2a) under a representative-choosing function
+  (`choose!` over Theorem 6.5.2c existence). Every finite-dim indecomposable `W`
+  has dimension vector a positive root (`indecomposable_bilinearForm_eq_two` +
+  `Theorem_6_5_2b_dimvec_is_positive_root`), so its representative is in the set,
+  and uniqueness (Theorem 6.5.2c.2) gives `W ≅ rep`, converted from `Iso` to
+  `AreIsomorphic`. Note: 6.5.2c provides **both** existence and uniqueness, so no
+  6.5.2b-uniqueness sorry was needed (the issue allowed one).
+- **Forward (finite type ⟹ Dynkin): single explicit `sorry`** on the Tits-form
+  positive-definiteness component, with a `TODO(#4786)` pointer. The four
+  combinatorial conditions are discharged from hypotheses; positivity is the
+  output of the orbit-counting chain (#4780 → #4782 → #4783 → #4784), to be wired
+  in by #4786. Dropped the `InfiniteTypeConstructions` import (forward no longer
+  routes through the explicit-construction track) and added the
+  `Theorem_Dynkin_classification` import for the bottom corollaries.
+
+**Mechanical rename** of `IsFiniteTypeQuiver → IsFiniteTypeQuiverDimVec` in the
+three files that referenced the old predicate: `InfiniteTypeConstructions.lean`
+(28 code sites), `FieldGenericInfiniteType.lean`, `FieldGenericAssembly.lean`
+(prose only).
+
+## Verification
+
+`lake exe cache get` then per-module builds (cache warm):
+- `EtingofRepresentationTheory.Chapter6.FiniteTypeDefs` — green.
+- `EtingofRepresentationTheory.Chapter6.Problem6_1_5_theorem` — green; the only
+  `sorry` warning is the documented forward-direction one (line 65).
+- `EtingofRepresentationTheory.Chapter6.InfiniteTypeConstructions` — green
+  (rename correct; its 4 pre-existing sorries are unchanged).
+- `EtingofRepresentationTheory.Chapter6.FieldGenericInfiniteType` — green.
+
+This matches the issue's verification criterion (Problem6_1_5 + FiniteTypeDefs
+build, backward green).
+
+## Current frontier
+
+Issue #4779 complete. The forward direction of Theorem 6.1.5 is the sole `sorry`
+in the touched files, explicitly delegated to the #4777 orbit-counting chain.
+
+## Overall project progress
+
+Stage 3 (formalization), endgame. Directive #4777 (orbit-counting redirect):
+S-def done. Remaining: S0 #4780, S2a #4782, S2b #4783, S4 #4786 (forward
+direction + deletion of `InfiniteTypeConstructions` and `FieldGeneric*`).
+
+## Next step
+
+Pick up the next link in the #4777 chain (S0 #4780: representation space `W(m)`,
+∏GL action, orbit↔isomorphism). When #4786 wires in `finite ⟹ q-pos-def`, fill
+the forward `sorry` in `Problem6_1_5_theorem.lean` and delete the now-dead
+`IsFiniteTypeQuiverDimVec` track.
+
+## Blockers
+
+None for #4779. **Note (pre-existing, not introduced here):** `main` CI is
+currently red — `FieldGenericD5Tilde.lean` fails to build (unbound `heq01`/`heq04`
+/`heq05` in sibling branches of `d5tildeRep_kQ_isIndecomposable`, from commit
+`d920bb52` "restrict d5tildeRep_kQ_leaf_equalities to eigenvalue-free
+orientations"). This blocks the full-library build (and thus `FieldGenericAssembly`,
+which imports D5Tilde) independently of this PR. It is a separate issue for the
+repair/replan track, not part of #4779.


### PR DESCRIPTION
This PR adopts the book's literal finite-type definition (Etingof Problem 6.1.5) as the canonical `Etingof.IsFiniteTypeQuiver`: finitely many isomorphism classes of finite-dimensional indecomposable representations, encoded as a finite set of indecomposable representatives covering every finite-dimensional indecomposable up to `AreIsomorphic`. This is the notion the orbit-counting argument of directive #4777 consumes; the old supporting-dimension-vectors predicate is retained as the auxiliary `IsFiniteTypeQuiverDimVec` for the to-be-retired explicit-construction and `FieldGeneric*` track.

It restates `Theorem_6_1_5` against the new definition and re-proves the backward direction (Dynkin diagram implies finite type) sorry-free, via Theorem 6.5.2a (positive roots are finite) together with Theorem 6.5.2c (existence and uniqueness of the indecomposable realizing each positive root). Since 6.5.2c supplies both existence and uniqueness, no 6.5.2b-uniqueness sorry was required. The forward direction is a single documented `sorry` on the Tits-form positive-definiteness component, delegated to the #4777 orbit-counting chain (#4780, #4782, #4783, #4784) and to be wired in by #4786.

Builds verified per module: `FiniteTypeDefs`, `Problem6_1_5_theorem` (only the documented forward sorry), `InfiniteTypeConstructions`, and `FieldGenericInfiniteType` are all green. Note that `main` CI is already red from a pre-existing breakage in `FieldGenericD5Tilde.lean` (commit d920bb52), which blocks the full-library build independently of this change.

Closes #4779

🤖 Prepared with Claude Code