### PR TITLE
feat(Ch5 #4715): glue-B — trivial-tensor representation splits into copies

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -1568,6 +1568,18 @@ haveI : Nontrivial m := IsSimpleModule.nontrivial (MonoidAlgebra ℂ A) ↥m
 
 **When to use:** Any proof that extracts characters from representations of commutative groups (e.g., `exists_character_in_rep` in the Mackey machine, #2036).
 
+## Building `≃ₗ[k[G]]` equivalences between `asModule`s (glue-A/B, #4714/#4715)
+
+When promoting a `k`-linear intertwiner to a `MonoidAlgebra k G`-linear equivalence (the Schur-Weyl Step E "glue" cluster, `Chapter5/PolynomialGLDecomposition.lean`), three instance/unification stalls recur:
+
+1. **Keep both sides genuine `asModule`s; never map straight to a raw `DirectSum` of carriers.** A `k`-linear equiv `e : V ≃ₗ[k] ⨁_β W` has codomain `DirectSum β (fun _ => W)`, and bare `W` carries *no* `k[G]`-module, so the `r • _` on the target in `map_smul'` is a **stuck instance** ("typeclass instance problem is stuck", `(i : ?m) → AddCommMonoid …`). Land in `asModule (Representation.directSum (fun _ => σ))` first (both sides are `asModule`s of representations, so `single_smul` and the `k[G]`-action resolve), then `.trans asModule_directSum_equiv` (glue-A) to reach `DirectSum β (fun _ => asModule σ)`.
+
+2. **Pin `Representation.directSum`'s family `V` explicitly.** `Representation.directSum (fun _ : β => σ)` leaves `V : β → Type` as a higher-order-unification metavar → the same stuck-instance error. Write `Representation.directSum (V := fun _ => W) (fun _ : β => σ)`, and call glue-A as `asModule_directSum_equiv (ι := β) (V := fun _ => W) (fun _ : β => σ)`. Use the *same* `(V := …)` everywhere so the `.trans` typechecks.
+
+3. **`DirectSum.ext`'s family implicit is named `β`.** If your index type is also `β`, supply it: `refine DirectSum.ext (β := fun _ : β => W) fun i => ?_`. Then close componentwise with `tprodSplitEquiv_tmul_apply`, `Representation.directSum_apply`, `DirectSum.lmap_apply`, `DirectSum.smul_apply`, `map_smul`.
+
+The `map_smul'` of the `asModule`-to-`asModule` aux reduces to the carrier-level intertwiner via `rw [single_smul, single_smul, map_smul]; simp only [Representation.asModuleEquiv]; congr 1; exact <intertwiner>` (`asModuleEquiv` is `LinearEquiv.refl`, so it normalizes away with the def-unfold alone — `LinearEquiv.refl_apply` is then an unused simp arg).
+
 ## FDRep Morphism Extensionality Patterns
 
 FDRep morphisms are `Action.Hom` wrapping `FGModuleCat.Hom` wrapping `ModuleCat.Hom` wrapping `LinearMap`. Proving `f = g` for FDRep morphisms requires decomposing through all layers.

--- a/EtingofRepresentationTheory/Chapter5/PolynomialGLDecomposition.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialGLDecomposition.lean
@@ -110,6 +110,105 @@ noncomputable def asModule_directSum_equiv (ρs : (i : ι) → Representation k 
 
 end DirectSumAsModule
 
+section TrivialTprodSplit
+
+open scoped TensorProduct
+open TensorProduct
+
+variable {k G S W : Type*} [CommRing k] [Monoid G]
+variable [AddCommGroup S] [Module k S] [AddCommGroup W] [Module k W]
+variable {β : Type*} [Fintype β] [DecidableEq β]
+
+/-- The underlying `k`-linear splitting `S ⊗[k] W ≃ ⨁_β W` determined by a basis
+`b` of `S`: a pure tensor `s ⊗ w` is sent to the family `j ↦ b.repr s j • w`.
+
+Composition of `b.repr` (turning `S` into `β →₀ k`), `finsuppScalarLeft`
+(absorbing the `Finsupp` into the right factor), the finite `Finsupp ≃ Pi`, and
+`DirectSum ≃ Pi` for the `Fintype` index. -/
+noncomputable def tprodSplitEquiv (b : Module.Basis β k S) :
+    S ⊗[k] W ≃ₗ[k] DirectSum β (fun _ => W) :=
+  TensorProduct.congr b.repr (LinearEquiv.refl k W) ≪≫ₗ
+    TensorProduct.finsuppScalarLeft k W β ≪≫ₗ
+      Finsupp.linearEquivFunOnFinite k W β ≪≫ₗ
+        (DirectSum.linearEquivFunOnFintype k β (fun _ => W)).symm
+
+/-- The `Pi`-coordinate form of `tprodSplitEquiv` on a pure tensor. -/
+theorem linearEquivFunOnFintype_tprodSplitEquiv_tmul (b : Module.Basis β k S)
+    (s : S) (w : W) :
+    (DirectSum.linearEquivFunOnFintype k β (fun _ => W)) (tprodSplitEquiv (W := W) b (s ⊗ₜ[k] w))
+      = fun i => b.repr s i • w := by
+  simp only [tprodSplitEquiv, LinearEquiv.trans_apply, LinearEquiv.apply_symm_apply,
+    TensorProduct.congr_tmul, LinearEquiv.refl_apply]
+  funext i
+  simp [Finsupp.linearEquivFunOnFinite_apply, finsuppScalarLeft_apply_tmul_apply]
+
+/-- The `i`-th component of `tprodSplitEquiv` on a pure tensor. -/
+@[simp]
+theorem tprodSplitEquiv_tmul_apply (b : Module.Basis β k S) (s : S) (w : W) (i : β) :
+    tprodSplitEquiv (W := W) b (s ⊗ₜ[k] w) i = b.repr s i • w := by
+  have := congrFun (linearEquivFunOnFintype_tprodSplitEquiv_tmul b s w) i
+  simpa using this
+
+/-- `tprodSplitEquiv` intertwines the trivial-tensor action `(trivial S).tprod σ`
+with the componentwise action `directSum (fun _ : β => σ)`: on the `S`-factor the
+action is the identity, so under the basis splitting each coordinate carries an
+independent copy of `σ`. -/
+theorem tprodSplitEquiv_intertwines (b : Module.Basis β k S) (σ : Representation k G W)
+    (g : G) (x : S ⊗[k] W) :
+    tprodSplitEquiv b (((Representation.trivial k G S).tprod σ) g x)
+      = (Representation.directSum (V := fun _ => W) (fun _ : β => σ)) g (tprodSplitEquiv b x) := by
+  induction x using TensorProduct.induction_on with
+  | zero => simp
+  | tmul s w =>
+    rw [Representation.tprod_apply, TensorProduct.map_tmul, Representation.trivial_apply]
+    refine DirectSum.ext (β := fun _ : β => W) fun i => ?_
+    rw [tprodSplitEquiv_tmul_apply, Representation.directSum_apply, DirectSum.lmap_apply,
+      tprodSplitEquiv_tmul_apply, map_smul]
+  | add x y hx hy => simp only [map_add, hx, hy]
+
+/-- The `MonoidAlgebra k G`-linear carrier identification underlying glue-B, before
+the final `asModule`-splitting: `asModule ((trivial S).tprod σ) ≃ asModule` of the
+direct-sum representation `directSum (fun _ : β => σ)`. The carrier map is
+`tprodSplitEquiv`; equivariance reduces to `tprodSplitEquiv_intertwines` via
+`single_smul`. -/
+noncomputable def asModule_trivial_tprod_equiv_aux (b : Module.Basis β k S)
+    (σ : Representation k G W) :
+    Representation.asModule ((Representation.trivial k G S).tprod σ) ≃ₗ[MonoidAlgebra k G]
+      Representation.asModule (Representation.directSum (V := fun _ => W) (fun _ : β => σ)) where
+  toFun := tprodSplitEquiv b
+  invFun := (tprodSplitEquiv b).symm
+  map_add' := map_add _
+  left_inv := (tprodSplitEquiv b).left_inv
+  right_inv := (tprodSplitEquiv b).right_inv
+  map_smul' r x := by
+    simp only [RingHom.id_apply]
+    induction r using MonoidAlgebra.induction_linear with
+    | zero => simp
+    | add a c ha hc => simp only [add_smul, map_add, ha, hc]
+    | single g t =>
+      rw [Representation.single_smul, Representation.single_smul, map_smul]
+      simp only [Representation.asModuleEquiv]
+      congr 1
+      exact tprodSplitEquiv_intertwines b σ g _
+
+/-- **glue-B (#4715).** Splitting a trivial-tensor representation into copies: as a
+`MonoidAlgebra k G`-module, `asModule ((trivial k G S).tprod σ)` is the direct sum,
+indexed by a basis `b` of `S`, of `dim S` copies of `asModule σ`.
+
+The `GL_N`-action is trivial on the `S`-factor (`trivial S`), so under the basis
+splitting `S ⊗ W ≃ ⨁_β W` (`tprodSplitEquiv`) the action becomes the componentwise
+copy of `σ` (`asModule_trivial_tprod_equiv_aux`); glue-A
+(`asModule_directSum_equiv`, #4714) then splits that `asModule` of a
+`Representation.directSum` into the `DirectSum` of the component `asModule`s. -/
+noncomputable def asModule_trivial_tprod_equiv (b : Module.Basis β k S)
+    (σ : Representation k G W) :
+    Representation.asModule ((Representation.trivial k G S).tprod σ) ≃ₗ[MonoidAlgebra k G]
+      DirectSum β (fun _ => Representation.asModule σ) :=
+  asModule_trivial_tprod_equiv_aux b σ ≪≫ₗ
+    asModule_directSum_equiv (ι := β) (V := fun _ => W) (fun _ : β => σ)
+
+end TrivialTprodSplit
+
 end Representation
 
 namespace Etingof.PolynomialGLDecomposition

--- a/progress/2026-06-21T05-51-46Z_d7673c98.md
+++ b/progress/2026-06-21T05-51-46Z_d7673c98.md
@@ -1,0 +1,65 @@
+## Accomplished
+
+Closed issue #4715 (Schur-Weyl Step E #4667, glue-B): **splitting a
+trivial-tensor representation into copies**. Added a sorry-free
+`MonoidAlgebra k G`-linear equivalence in
+`Chapter5/PolynomialGLDecomposition.lean` (new section `TrivialTprodSplit`,
+inside `namespace Representation`, after glue-A):
+
+- `tprodSplitEquiv b : S ⊗[k] W ≃ₗ[k] DirectSum β (fun _ => W)` — the underlying
+  `k`-linear basis splitting `s ⊗ w ↦ (j ↦ b.repr s j • w)`, built from
+  `TensorProduct.congr b.repr`, `TensorProduct.finsuppScalarLeft`,
+  `Finsupp.linearEquivFunOnFinite`, and `DirectSum.linearEquivFunOnFintype`.
+- `tprodSplitEquiv_tmul_apply` — the `i`-th component on a pure tensor
+  (`= b.repr s i • w`), via a `Pi`-coordinate helper lemma.
+- `tprodSplitEquiv_intertwines` — `tprodSplitEquiv` carries `(trivial S).tprod σ`
+  to `directSum (fun _ : β => σ)` (the `S`-factor acts trivially, so each
+  coordinate is an independent copy of `σ`).
+- `asModule_trivial_tprod_equiv_aux` — the equivariant carrier identification
+  `asModule ((trivial S).tprod σ) ≃ₗ[k[G]] asModule (directSum (fun _ => σ))`.
+- `asModule_trivial_tprod_equiv` — **the deliverable**:
+  `asModule ((trivial k G S).tprod σ) ≃ₗ[k[G]] DirectSum β (fun _ => asModule σ)`,
+  obtained by composing the aux with glue-A (`asModule_directSum_equiv`, #4714).
+
+Signature matches the issue exactly.
+
+## Decisions / patterns
+
+- The action only lives on the `W`-factor, so the cleanest route is the issue's
+  suggested one: prove the carrier `tprodSplitEquiv` is an intertwiner
+  `(trivial S).tprod σ → directSum (fun _ => σ)` (a `k`-linear / representation
+  statement), promote to an `asModule` equiv via `single_smul`, then `.trans`
+  glue-A. A one-step variant (mapping straight to `DirectSum β (fun _ => asModule σ)`)
+  fails: `tprodSplitEquiv`'s codomain is `DirectSum β (fun _ => W)`, and bare `W`
+  carries no `k[G]`-module, so the `r • _` on the target is a stuck instance. Keep
+  both sides genuine `asModule`s until glue-A.
+- `Representation.directSum (fun _ : β => σ)` triggers higher-order-unification
+  stalls on its `V` family. Pin it: `directSum (V := fun _ => W) (...)`, and call
+  glue-A as `asModule_directSum_equiv (ι := β) (V := fun _ => W) (...)`.
+- `DirectSum.ext`'s family implicit is named `β`, colliding with the index `β`;
+  supply it explicitly: `DirectSum.ext (β := fun _ : β => W) fun i => ?_`.
+
+## Current frontier
+
+glue-B is done and sorry-free. The #4667 assembly
+`polynomial_homog_rep_asModule_embeds_directSum_simple`
+(`PolynomialGLDecomposition.lean`, still one pre-existing `sorry`) is #4716, and
+can now consume glue-A + glue-B.
+
+## Overall project progress
+
+Chapter 5 Schur-Weyl Step E (#4667): glue-A (#4714, merged) and glue-B (#4715,
+this PR) are both in. Remaining sub-task before the assembly: glue-A/B are wired
+by #4716. Chapter 6 orbit-counting redirect (directive #4777) continues
+separately (S2b #4783 claimed, S4 #4786 unclaimed but gated on S2b).
+
+## Next step
+
+Pick up #4716 (assembly): close
+`polynomial_homog_rep_asModule_embeds_directSum_simple` using #4598 + glue-A
+(`asModule_directSum_equiv`) + glue-B (`asModule_trivial_tprod_equiv`).
+
+## Blockers
+
+None for glue-B. The file retains the pre-existing #4716 assembly `sorry`
+(line ~336), untouched by this work.


### PR DESCRIPTION
Closes #4715

Session: `d7673c98-12d6-43cd-bae4-3e405abddae3`

6958dff1 doc(skill): glue-A/B idiom — keep asModule both sides, pin directSum V, name DirectSum.ext β (#4715)
5b63ea08 feat(Ch5 #4715): glue-B — trivial-tensor representation splits into copies

🤖 Prepared with Claude Code