### PR TITLE
feat(Ch5 #4712 sub-2): det-power normal form f = Q/detʳ on A[det⁻¹]

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -1476,6 +1476,23 @@ define both conversion directions in the SAME file as the type definition, or us
 **Stop after 3 failed approaches** — if `match`-based proof doesn't work, the issue is structural
 (needs upstream definition changes), not tactical.
 
+### Pattern 6: freeze a derived term before `rw [h]` substitutes its variable
+
+When a hypothesis `h : f = <expr>` is rewritten into a goal that *also* mentions
+`f` **inside** a derived term like `detExp f`, `Nat.find _`, `degree f`, etc.,
+`rw [h]` replaces **every** `f` — including the one inside `detExp f` — corrupting
+the exponent/index (symptom: the goal sprouts `detExp (<expr>)` where you wanted a
+plain `detExp f`). Freeze the derived term as an opaque local first:
+```lean
+obtain ⟨s, hsdef⟩ : ∃ s, detExp f = s := ⟨_, rfl⟩
+rw [hsdef] at h ⊢   -- now the goal/h talk about `s`, not `detExp f`
+rw [h]              -- safe: `s` contains no `f`
+-- recover at the end:  rw [hsdef] at <the ≤ fact>; omega
+```
+Cleaner than `nth_rewrite`/`conv` targeting because it removes the `f`-dependence
+everywhere at once. Use it whenever the minimal-exponent / `Nat.find` value of the
+very element you are rewriting appears in the goal.
+
 ## Issue Description Feasibility Check
 
 **Issue descriptions sometimes contain mathematically incorrect proof strategies.** Before committing to a proof approach described in an issue:

--- a/EtingofRepresentationTheory/Chapter5/DetLocalization.lean
+++ b/EtingofRepresentationTheory/Chapter5/DetLocalization.lean
@@ -31,10 +31,18 @@ with `D ↦ det⁻¹`) **factors through** `A[det⁻¹]` via the coordinate hom 
 These are exactly the moves the kernel-lemma assembly needs to pass between
 honest localization elements and functions on `GL`.
 
-The two remaining pieces of issue #4712 — `detPoly` irreducibility/primeness and
-the det-power normal form `f = Q / detʳ` — are split off into successor issues
-(they require a substantial inductive determinant-irreducibility formalization
-that Mathlib lacks); see the progress entry.
+## The det-power normal form
+
+Every element of `A[det⁻¹]` is `Q · det⁻ʳ` for a polynomial `Q` and an exponent
+`r` (`exists_invSelf_normalForm`). Defining `detExp f` as the **least** such `r`
+(`Nat.find`) gives the reduced normal form: at the minimal exponent the numerator
+`Q` is coprime to `det` (`not_dvd_num_of_detExp_pos`), the pair `(detExp f, Q)`
+is unique (`reduced_normalForm_unique`), and `detExp f = 0 ↔ f` is an honest
+polynomial (`detExp_eq_zero_iff`, the predicate the det-power filtration
+`A_r := det⁻ʳ · A` keys on). The whole development rests only on injectivity of
+`A → A[det⁻¹]` (`detPoly` a nonzerodivisor) and `det · det⁻¹ = 1`; the
+`detPoly`-cancellation is done by the minimal-exponent definition, so primeness
+of `detPoly` is not needed here.
 -/
 
 namespace Etingof.DetLocalization
@@ -220,5 +228,225 @@ theorem evalAtGL_eq_evalGLAway_coordToAway
           Pi.evalRingHom_apply, coordToAway_X_inr, evalGLAway_invSelf_apply]
   have := RingHom.congr_fun hΦΨ p
   simpa [Etingof.evalAtGL] using this
+
+/-! ### The det-power normal form `f = Q · det⁻ʳ` -/
+
+/-- The polynomial ring `A = k[Xᵢⱼ]` injects into its localization `A[det⁻¹]`:
+`detPoly` is a nonzerodivisor (domain, `detPoly ≠ 0`). -/
+theorem algebraMap_away_injective :
+    Function.Injective
+      (algebraMap (MvPolynomial (Fin N × Fin N) k) (Localization.Away (detPoly k N))) :=
+  IsLocalization.injective _ powers_detPoly_le_nonZeroDivisors
+
+/-- `detⁿ · det⁻ⁿ = 1` in `A[det⁻¹]`. -/
+theorem algebraMap_detPoly_pow_mul_invSelf_pow (n : ℕ) :
+    (algebraMap (MvPolynomial (Fin N × Fin N) k) (Localization.Away (detPoly k N))
+          (detPoly k N)) ^ n
+        * IsLocalization.Away.invSelf (detPoly k N) ^ n = 1 := by
+  rw [← mul_pow, IsLocalization.Away.mul_invSelf, one_pow]
+
+/-- **Det-power normal form (existence).** Every element of `A[det⁻¹]` can be
+written `Q · det⁻ʳ` for a polynomial `Q` and an exponent `r`. -/
+theorem exists_invSelf_normalForm (f : Localization.Away (detPoly k N)) :
+    ∃ (r : ℕ) (Q : MvPolynomial (Fin N × Fin N) k),
+      f = algebraMap _ (Localization.Away (detPoly k N)) Q
+            * IsLocalization.Away.invSelf (detPoly k N) ^ r := by
+  obtain ⟨n, a, h⟩ := IsLocalization.Away.surj (detPoly k N) f
+  refine ⟨n, a, ?_⟩
+  have key := algebraMap_detPoly_pow_mul_invSelf_pow (k := k) (N := N) n
+  calc
+    f = f * ((algebraMap _ (Localization.Away (detPoly k N)) (detPoly k N)) ^ n
+            * IsLocalization.Away.invSelf (detPoly k N) ^ n) := by rw [key, mul_one]
+    _ = (f * (algebraMap _ (Localization.Away (detPoly k N)) (detPoly k N)) ^ n)
+            * IsLocalization.Away.invSelf (detPoly k N) ^ n := by ring
+    _ = algebraMap _ (Localization.Away (detPoly k N)) a
+            * IsLocalization.Away.invSelf (detPoly k N) ^ n := by rw [h]
+
+open Classical in
+/-- The minimal `det`-power exponent in the normal form of `f`: the least `r`
+with `f = Q · det⁻ʳ` for some polynomial `Q`. The reduced normal form keys on it
+(`A_r := det⁻ʳ · A`). -/
+noncomputable def detExp (f : Localization.Away (detPoly k N)) : ℕ :=
+  Nat.find (exists_invSelf_normalForm f)
+
+open Classical in
+/-- A numerator realising the minimal exponent `detExp f`. -/
+theorem detExp_spec (f : Localization.Away (detPoly k N)) :
+    ∃ Q : MvPolynomial (Fin N × Fin N) k,
+      f = algebraMap _ (Localization.Away (detPoly k N)) Q
+            * IsLocalization.Away.invSelf (detPoly k N) ^ detExp f :=
+  Nat.find_spec (exists_invSelf_normalForm f)
+
+open Classical in
+/-- `detExp f` is the least exponent: any normal form `f = Q · det⁻ʳ` has
+`detExp f ≤ r`. -/
+theorem detExp_le {f : Localization.Away (detPoly k N)} {r : ℕ}
+    (h : ∃ Q : MvPolynomial (Fin N × Fin N) k,
+          f = algebraMap _ (Localization.Away (detPoly k N)) Q
+            * IsLocalization.Away.invSelf (detPoly k N) ^ r) :
+    detExp f ≤ r :=
+  Nat.find_min' (exists_invSelf_normalForm f) h
+
+/-- Clearing denominators: `Q = f · detʳ` for any normal form `f = Q · det⁻ʳ`. -/
+theorem algebraMap_num_eq {f : Localization.Away (detPoly k N)} {r : ℕ}
+    {Q : MvPolynomial (Fin N × Fin N) k}
+    (hQ : f = algebraMap _ (Localization.Away (detPoly k N)) Q
+            * IsLocalization.Away.invSelf (detPoly k N) ^ r) :
+    algebraMap _ (Localization.Away (detPoly k N)) Q
+      = f * algebraMap _ (Localization.Away (detPoly k N)) (detPoly k N) ^ r := by
+  rw [hQ, mul_assoc,
+    show IsLocalization.Away.invSelf (detPoly k N) ^ r
+        * algebraMap _ (Localization.Away (detPoly k N)) (detPoly k N) ^ r = 1
+      from by rw [mul_comm]; exact algebraMap_detPoly_pow_mul_invSelf_pow r,
+    mul_one]
+
+/-- **Uniqueness of the numerator** at a fixed exponent: the localization is a
+domain, so `det⁻ʳ` cancels and `algebraMap` is injective. -/
+theorem normalForm_num_unique {f : Localization.Away (detPoly k N)} {r : ℕ}
+    {Q₁ Q₂ : MvPolynomial (Fin N × Fin N) k}
+    (h₁ : f = algebraMap _ (Localization.Away (detPoly k N)) Q₁
+            * IsLocalization.Away.invSelf (detPoly k N) ^ r)
+    (h₂ : f = algebraMap _ (Localization.Away (detPoly k N)) Q₂
+            * IsLocalization.Away.invSelf (detPoly k N) ^ r) :
+    Q₁ = Q₂ :=
+  algebraMap_away_injective (by rw [algebraMap_num_eq h₁, algebraMap_num_eq h₂])
+
+/-- If a normal form has exponent strictly above the minimal one, its numerator
+carries a `detPoly` factor (it is `Qₛ · detʳ⁻ˢ` for the minimal numerator `Qₛ`). -/
+theorem dvd_num_of_detExp_lt {f : Localization.Away (detPoly k N)} {r : ℕ}
+    {Q : MvPolynomial (Fin N × Fin N) k}
+    (hQ : f = algebraMap _ (Localization.Away (detPoly k N)) Q
+            * IsLocalization.Away.invSelf (detPoly k N) ^ r)
+    (hlt : detExp f < r) : detPoly k N ∣ Q := by
+  obtain ⟨Qs, hs⟩ := detExp_spec f
+  -- freeze `detExp f` as an opaque `s`, else `rw [hs]` corrupts the exponent
+  obtain ⟨s, hsdef⟩ : ∃ s, detExp f = s := ⟨_, rfl⟩
+  rw [hsdef] at hs hlt
+  have hQeq : algebraMap _ (Localization.Away (detPoly k N)) Q
+      = algebraMap _ (Localization.Away (detPoly k N)) (Qs * detPoly k N ^ (r - s)) := by
+    rw [algebraMap_num_eq hQ, hs, map_mul, map_pow,
+      show algebraMap _ (Localization.Away (detPoly k N)) (detPoly k N) ^ r
+          = algebraMap _ (Localization.Away (detPoly k N)) (detPoly k N) ^ s
+            * algebraMap _ (Localization.Away (detPoly k N)) (detPoly k N) ^ (r - s)
+        from by rw [← pow_add]; congr 1; omega]
+    calc
+      (algebraMap _ (Localization.Away (detPoly k N)) Qs
+            * IsLocalization.Away.invSelf (detPoly k N) ^ s)
+          * (algebraMap _ (Localization.Away (detPoly k N)) (detPoly k N) ^ s
+            * algebraMap _ (Localization.Away (detPoly k N)) (detPoly k N) ^ (r - s))
+        = (IsLocalization.Away.invSelf (detPoly k N) ^ s
+            * algebraMap _ (Localization.Away (detPoly k N)) (detPoly k N) ^ s)
+          * (algebraMap _ (Localization.Away (detPoly k N)) Qs
+            * algebraMap _ (Localization.Away (detPoly k N)) (detPoly k N) ^ (r - s)) := by
+          ring
+      _ = algebraMap _ (Localization.Away (detPoly k N)) Qs
+            * algebraMap _ (Localization.Away (detPoly k N)) (detPoly k N) ^ (r - s) := by
+          rw [show IsLocalization.Away.invSelf (detPoly k N) ^ s
+                * algebraMap _ (Localization.Away (detPoly k N)) (detPoly k N) ^ s = 1
+              from by rw [mul_comm]; exact algebraMap_detPoly_pow_mul_invSelf_pow _, one_mul]
+  have hQ2 : Q = Qs * detPoly k N ^ (r - s) := algebraMap_away_injective hQeq
+  rw [hQ2]
+  exact (dvd_pow_self (detPoly k N) (by omega : r - s ≠ 0)).mul_left Qs
+
+/-- **Reduced numerator is coprime to `det`.** At the minimal exponent (when it
+is positive) the numerator is not divisible by `detPoly` — otherwise the factor
+would cancel and lower the exponent. -/
+theorem not_dvd_num_of_detExp_pos {f : Localization.Away (detPoly k N)}
+    {Q : MvPolynomial (Fin N × Fin N) k}
+    (hQ : f = algebraMap _ (Localization.Away (detPoly k N)) Q
+            * IsLocalization.Away.invSelf (detPoly k N) ^ detExp f)
+    (hpos : 1 ≤ detExp f) : ¬ detPoly k N ∣ Q := by
+  intro hd
+  obtain ⟨Q', rfl⟩ := hd
+  -- freeze `detExp f` as an opaque `s`, else `rw [hQ]` corrupts the exponent
+  obtain ⟨s, hsdef⟩ : ∃ s, detExp f = s := ⟨_, rfl⟩
+  rw [hsdef] at hQ hpos
+  have hlow : ∃ Q'' : MvPolynomial (Fin N × Fin N) k,
+      f = algebraMap _ (Localization.Away (detPoly k N)) Q''
+            * IsLocalization.Away.invSelf (detPoly k N) ^ (s - 1) := by
+    refine ⟨Q', ?_⟩
+    rw [hQ, map_mul,
+      show IsLocalization.Away.invSelf (detPoly k N) ^ s
+          = IsLocalization.Away.invSelf (detPoly k N) ^ (s - 1)
+            * IsLocalization.Away.invSelf (detPoly k N)
+        from by conv_lhs => rw [← Nat.sub_add_cancel hpos, pow_succ]]
+    calc
+      algebraMap _ (Localization.Away (detPoly k N)) (detPoly k N)
+            * algebraMap _ (Localization.Away (detPoly k N)) Q'
+          * (IsLocalization.Away.invSelf (detPoly k N) ^ (s - 1)
+            * IsLocalization.Away.invSelf (detPoly k N))
+        = (algebraMap _ (Localization.Away (detPoly k N)) (detPoly k N)
+            * IsLocalization.Away.invSelf (detPoly k N))
+          * (algebraMap _ (Localization.Away (detPoly k N)) Q'
+            * IsLocalization.Away.invSelf (detPoly k N) ^ (s - 1)) := by ring
+      _ = algebraMap _ (Localization.Away (detPoly k N)) Q'
+            * IsLocalization.Away.invSelf (detPoly k N) ^ (s - 1) := by
+          rw [IsLocalization.Away.mul_invSelf, one_mul]
+  have hle := detExp_le hlow
+  rw [hsdef] at hle
+  omega
+
+/-- The minimal exponent is exactly the reduced one: any normal form whose
+numerator is coprime to `det` (or whose exponent is `0`) already has the minimal
+exponent. -/
+theorem detExp_eq_of_reduced {f : Localization.Away (detPoly k N)} {r : ℕ}
+    {Q : MvPolynomial (Fin N × Fin N) k}
+    (hQ : f = algebraMap _ (Localization.Away (detPoly k N)) Q
+            * IsLocalization.Away.invSelf (detPoly k N) ^ r)
+    (hred : r = 0 ∨ ¬ detPoly k N ∣ Q) : r = detExp f := by
+  refine le_antisymm ?_ (detExp_le ⟨Q, hQ⟩)
+  by_contra hlt
+  push_neg at hlt
+  rcases hred with h0 | hnd
+  · omega
+  · exact hnd (dvd_num_of_detExp_lt hQ hlt)
+
+/-- **Reduced det-power normal form.** Every `f` has a normal form
+`f = Q · det⁻ʳ` with `r = detExp f` minimal and, when `r ≥ 1`, numerator `Q`
+coprime to `det`. -/
+theorem exists_reduced_normalForm (f : Localization.Away (detPoly k N)) :
+    ∃ (r : ℕ) (Q : MvPolynomial (Fin N × Fin N) k),
+      f = algebraMap _ (Localization.Away (detPoly k N)) Q
+            * IsLocalization.Away.invSelf (detPoly k N) ^ r
+        ∧ (1 ≤ r → ¬ detPoly k N ∣ Q)
+        ∧ ∀ (r' : ℕ) (Q' : MvPolynomial (Fin N × Fin N) k),
+            f = algebraMap _ (Localization.Away (detPoly k N)) Q'
+                  * IsLocalization.Away.invSelf (detPoly k N) ^ r' → r ≤ r' := by
+  obtain ⟨Q, hQ⟩ := detExp_spec f
+  exact ⟨detExp f, Q, hQ, fun hpos => not_dvd_num_of_detExp_pos hQ hpos,
+    fun _ Q' h' => detExp_le ⟨Q', h'⟩⟩
+
+/-- **Uniqueness of the reduced normal form.** Two reduced representations of `f`
+(each with exponent `0` or numerator coprime to `det`) agree in both exponent and
+numerator. -/
+theorem reduced_normalForm_unique {f : Localization.Away (detPoly k N)} {r₁ r₂ : ℕ}
+    {Q₁ Q₂ : MvPolynomial (Fin N × Fin N) k}
+    (h₁ : f = algebraMap _ (Localization.Away (detPoly k N)) Q₁
+            * IsLocalization.Away.invSelf (detPoly k N) ^ r₁)
+    (hred₁ : r₁ = 0 ∨ ¬ detPoly k N ∣ Q₁)
+    (h₂ : f = algebraMap _ (Localization.Away (detPoly k N)) Q₂
+            * IsLocalization.Away.invSelf (detPoly k N) ^ r₂)
+    (hred₂ : r₂ = 0 ∨ ¬ detPoly k N ∣ Q₂) :
+    r₁ = r₂ ∧ Q₁ = Q₂ := by
+  have e₁ := detExp_eq_of_reduced h₁ hred₁
+  have e₂ := detExp_eq_of_reduced h₂ hred₂
+  refine ⟨e₁.trans e₂.symm, ?_⟩
+  rw [e₁] at h₁
+  rw [e₂] at h₂
+  exact normalForm_num_unique h₁ h₂
+
+/-- **`r = 0 ↔ f` is an honest polynomial.** The reduced exponent vanishes
+exactly when `f` lies in the image of the polynomial subring `A` — the predicate
+the det-power filtration `A_r := det⁻ʳ · A` (with `A = A_0`) keys on. -/
+theorem detExp_eq_zero_iff (f : Localization.Away (detPoly k N)) :
+    detExp f = 0 ↔ f ∈ Set.range
+      (algebraMap (MvPolynomial (Fin N × Fin N) k) (Localization.Away (detPoly k N))) := by
+  constructor
+  · intro h0
+    obtain ⟨Q, hQ⟩ := detExp_spec f
+    rw [h0, pow_zero, mul_one] at hQ
+    exact ⟨Q, hQ.symm⟩
+  · rintro ⟨Q, rfl⟩
+    exact Nat.le_zero.mp (detExp_le (r := 0) ⟨Q, by rw [pow_zero, mul_one]⟩)
 
 end Etingof.DetLocalization

--- a/progress/2026-06-21T08-16-24Z_5104fa79.md
+++ b/progress/2026-06-21T08-16-24Z_5104fa79.md
@@ -1,0 +1,55 @@
+## Accomplished
+
+- **Closed #4737** (Ch5 #4712 sub-2): det-power normal form `f = Q · det⁻ʳ` on
+  `A[det⁻¹] = Localization.Away (detPoly k N)`, added to
+  `Chapter5/DetLocalization.lean` (all new lemmas sorry-free, axioms
+  `[propext, Classical.choice, Quot.sound]` only).
+  - `exists_invSelf_normalForm` (deliverable 1): every `f` is
+    `Q · det⁻ʳ` for some polynomial `Q` and exponent `r` — directly from
+    `IsLocalization.Away.surj` plus `detⁿ · det⁻ⁿ = 1`
+    (`algebraMap_detPoly_pow_mul_invSelf_pow`).
+  - `detExp f := Nat.find (exists_invSelf_normalForm f)` — the **minimal**
+    exponent — with `detExp_spec` (a realising numerator) and `detExp_le`
+    (minimality). This single definition does the `detPoly`-cancellation.
+  - Reduced form (deliverable 2): `not_dvd_num_of_detExp_pos` (at the minimal
+    exponent, `r ≥ 1 ⟹ ¬ detPoly ∣ Q` — else the factor cancels and lowers `r`),
+    `normalForm_num_unique` (numerator unique at fixed exponent, via
+    `algebraMap` injectivity + `det⁻ʳ` cancellation), `detExp_eq_of_reduced`
+    (any coprime/zero-exponent normal form already has the minimal exponent),
+    `exists_reduced_normalForm` and `reduced_normalForm_unique` packaging the
+    reduced pair `(detExp f, Q)` and its uniqueness.
+  - `detExp_eq_zero_iff` (deliverable 3): `detExp f = 0 ↔ f ∈ range (algebraMap)`
+    — the predicate the det-power filtration `A_r := det⁻ʳ · A` (with `A = A_0`)
+    keys on.
+
+## Current frontier
+
+`DetLocalization.lean` builds clean and sorry-free. Notable simplification: the
+deliverable framed everything via `Prime (detPoly)` (#4736), but defining the
+reduced exponent as the *minimal* one makes the cancellation automatic, so the
+whole normal-form API rests only on injectivity of `A → A[det⁻¹]` (`detPoly` a
+nonzerodivisor) and `det · det⁻¹ = 1`. It therefore does **not** transitively
+depend on the open `sorry` in `detPoly_irreducible`/`detPoly_prime`
+(`DetIrreducible.lean`).
+
+## Overall project progress
+
+- Ch5 det⁻¹-elimination kernel-lemma chain (#4694, route doc
+  `progress/kernel-lemma-K-route.md`): deliverable 3 of #4712 (faithful
+  functions-on-GL model) was already landed; this turn lands deliverable 2 (the
+  det-power normal form). The det-power filtration reduction of #4712 now has its
+  normal-form API in place.
+- Remaining on #4712/#4694: assembly of the det-power filtration argument that
+  consumes `detExp_eq_zero_iff` / `exists_reduced_normalForm`, and the genuine
+  representation-theoretic core (K′) #4713.
+
+## Next step
+
+- A worker can pick up the #4694 det-power filtration assembly, now that the
+  normal-form API (`exists_reduced_normalForm`, `detExp_eq_zero_iff`) is
+  available, or tackle the deep core #4713.
+
+## Blockers
+
+- None for this PR. (#4713 and the #2483 classification crux #4732 remain the
+  hard open cores, unaffected by this work.)


### PR DESCRIPTION
Closes #4737

Session: `5104fa79-7618-4b20-acc5-344b6075b8ba`

74da9a03 doc(skill): record freeze-derived-term-before-rw pattern (#4737)
f4d6ec61 feat(Ch5 #4737): det-power normal form f = Q·det⁻ʳ on A[det⁻¹]

🤖 Prepared with Claude Code