### PR TITLE
feat(Ch5 #4736 successor): close detPoly_irreducible induction (cofactor + minor-rename + coprimality + isolation)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/DetIrreducible.lean
+++ b/EtingofRepresentationTheory/Chapter5/DetIrreducible.lean
@@ -166,7 +166,8 @@ private lemma mem_vars_detPoly {m : ℕ} :
   have hmat₂ : (Matrix.mvPolynomialX (Fin (m + 1)) (Fin (m + 1)) k).map (eval g₂)
       = Matrix.diagonal (fun i => if i = (0 : Fin (m + 1)) then (0 : k) else 1) := by
     ext i j
-    rw [Matrix.map_apply, Matrix.mvPolynomialX_apply, MvPolynomial.eval_X, Matrix.diagonal_apply, hg₂]
+    rw [Matrix.map_apply, Matrix.mvPolynomialX_apply, MvPolynomial.eval_X, Matrix.diagonal_apply,
+      hg₂]
     by_cases hij : i = j
     · subst hij; simp [Prod.ext_iff]
     · simp [hij, Prod.ext_iff]
@@ -178,9 +179,182 @@ private lemma mem_vars_detPoly {m : ℕ} :
   rw [hL, hR] at hcongr
   exact one_ne_zero hcongr
 
-/-- **Primeness of the generic determinant polynomial** (for `N ≥ 1`). -/
+/-- **Primeness of the generic determinant polynomial** (for `N ≥ 1`).
+
+Proved by induction on `N`, cofactor-expanding along column `0`. -/
 theorem detPoly_prime (hN : 0 < N) : Prime (detPoly k N) := by
-  sorry
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hN.ne'
+  clear hN
+  induction m with
+  | zero =>
+    have hbase : detPoly k 1 = X ((0 : Fin 1), (0 : Fin 1)) := by
+      rw [detPoly, Matrix.det_fin_one, Matrix.mvPolynomialX_apply]
+    rw [hbase]; exact MvPolynomial.X_prime
+  | succ n ih =>
+    classical
+    set A := Matrix.mvPolynomialX (Fin (n + 2)) (Fin (n + 2)) k with hA
+    set v₀ : Fin (n + 2) × Fin (n + 2) := (0, 0) with hv₀
+    set M₀ : MvPolynomial (Fin (n + 2) × Fin (n + 2)) k :=
+      (A.submatrix (0 : Fin (n + 2)).succAbove Fin.succ).det with hM₀
+    set M₁ : MvPolynomial (Fin (n + 2) × Fin (n + 2)) k :=
+      (A.submatrix (1 : Fin (n + 2)).succAbove Fin.succ).det with hM₁
+    set R : MvPolynomial (Fin (n + 2) × Fin (n + 2)) k :=
+      ∑ i : Fin (n + 1),
+        (-1 : MvPolynomial (Fin (n + 2) × Fin (n + 2)) k) ^ ((i.succ : Fin (n + 2)) : ℕ)
+          * X ((i.succ : Fin (n + 2)), (0 : Fin (n + 2)))
+          * (A.submatrix (i.succ).succAbove Fin.succ).det with hR
+    have hf0inj := minor_index_injective (n := n + 1) (0 : Fin (n + 2))
+    have hf1inj := minor_index_injective (n := n + 1) (1 : Fin (n + 2))
+    have hM₀rw : M₀
+        = rename (Prod.map (0 : Fin (n + 2)).succAbove Fin.succ) (detPoly k (n + 1)) := by
+      rw [hM₀, hA]; exact minor_det_eq_rename (0 : Fin (n + 2))
+    have hM₁rw : M₁
+        = rename (Prod.map (1 : Fin (n + 2)).succAbove Fin.succ) (detPoly k (n + 1)) := by
+      rw [hM₁, hA]; exact minor_det_eq_rename (1 : Fin (n + 2))
+    have hPrimeM₀ : Prime M₀ := by rw [hM₀rw]; exact (prime_rename_of_injective hf0inj).mpr ih
+    have hPrimeM₁ : Prime M₁ := by rw [hM₁rw]; exact (prime_rename_of_injective hf1inj).mpr ih
+    -- Step: degreeOf facts (M₀ and R are free of the variable `X(0,0)`).
+    have hdegM₀ : degreeOf v₀ M₀ = 0 := by
+      rw [degreeOf_eq_zero_iff_notMem_vars, hM₀rw]
+      intro hmem
+      obtain ⟨w, _, hw⟩ := mem_vars_rename _ _ hmem
+      apply Fin.succ_ne_zero w.2
+      simpa [hv₀, Prod.map_snd] using congrArg Prod.snd hw
+    have hdegR : degreeOf v₀ R = 0 := by
+      rw [hR]
+      apply Nat.le_zero.mp
+      apply le_trans (degreeOf_sum_le v₀ Finset.univ
+        (fun i : Fin (n + 1) => (-1 : MvPolynomial (Fin (n + 2) × Fin (n + 2)) k)
+          ^ ((i.succ : Fin (n + 2)) : ℕ) * X ((i.succ : Fin (n + 2)), (0 : Fin (n + 2)))
+          * (A.submatrix (i.succ).succAbove Fin.succ).det))
+      apply Finset.sup_le
+      intro i _
+      have hMi0 : degreeOf v₀ ((A.submatrix (i.succ).succAbove Fin.succ).det) = 0 := by
+        rw [degreeOf_eq_zero_iff_notMem_vars, hA, minor_det_eq_rename (i.succ)]
+        intro hmem
+        obtain ⟨w, _, hw⟩ := mem_vars_rename _ _ hmem
+        apply Fin.succ_ne_zero w.2
+        simpa [hv₀, Prod.map_snd] using congrArg Prod.snd hw
+      have hXne : v₀ ≠ ((i.succ : Fin (n + 2)), (0 : Fin (n + 2))) := by
+        intro h
+        apply Fin.succ_ne_zero i
+        simpa [hv₀] using (congrArg Prod.fst h).symm
+      have hXdeg : degreeOf v₀ (X ((i.succ : Fin (n + 2)), (0 : Fin (n + 2)))
+          : MvPolynomial (Fin (n + 2) × Fin (n + 2)) k) = 0 := by
+        rw [degreeOf_X, if_neg hXne]
+      have hsign : ((-1 : MvPolynomial (Fin (n + 2) × Fin (n + 2)) k)
+          ^ ((i.succ : Fin (n + 2)) : ℕ))
+          = MvPolynomial.C ((-1 : k) ^ ((i.succ : Fin (n + 2)) : ℕ)) := by
+        rw [map_pow, map_neg, map_one]
+      have hXterm : degreeOf v₀ ((-1 : MvPolynomial (Fin (n + 2) × Fin (n + 2)) k)
+          ^ ((i.succ : Fin (n + 2)) : ℕ) * X ((i.succ : Fin (n + 2)), (0 : Fin (n + 2)))) = 0 := by
+        rw [hsign]
+        exact Nat.le_zero.mp ((degreeOf_C_mul_le _ _ _).trans hXdeg.le)
+      calc degreeOf v₀ ((-1 : MvPolynomial (Fin (n + 2) × Fin (n + 2)) k)
+              ^ ((i.succ : Fin (n + 2)) : ℕ) * X ((i.succ : Fin (n + 2)), (0 : Fin (n + 2)))
+              * (A.submatrix (i.succ).succAbove Fin.succ).det)
+          ≤ degreeOf v₀ ((-1 : MvPolynomial (Fin (n + 2) × Fin (n + 2)) k)
+              ^ ((i.succ : Fin (n + 2)) : ℕ) * X ((i.succ : Fin (n + 2)), (0 : Fin (n + 2))))
+            + degreeOf v₀ ((A.submatrix (i.succ).succAbove Fin.succ).det) := degreeOf_mul_le _ _ _
+        _ = 0 := by rw [hXterm, hMi0]
+    -- Step 3: coprimality `M₀ ∤ R`.
+    have hcop : ¬ (M₀ ∣ R) := by
+      intro hdvd
+      set g : Fin (n + 2) × Fin (n + 2) → MvPolynomial (Fin (n + 2) × Fin (n + 2)) k :=
+        fun v => if v.2 = 0 then (if v.1 = 1 then 1 else 0) else X v with hg
+      have hev_minor : ∀ j : Fin (n + 2),
+          aeval g (rename (Prod.map j.succAbove (Fin.succ : Fin (n + 1) → Fin (n + 2)))
+              (detPoly k (n + 1)))
+            = rename (Prod.map j.succAbove Fin.succ) (detPoly k (n + 1)) := by
+        intro j
+        rw [aeval_rename]
+        have hcomp : (g ∘ Prod.map j.succAbove (Fin.succ : Fin (n + 1) → Fin (n + 2)))
+            = ((X : (Fin (n + 2) × Fin (n + 2)) → _) ∘ Prod.map j.succAbove Fin.succ) := by
+          funext pq
+          simp only [Function.comp_apply, hg, Prod.map_snd]
+          rw [if_neg (Fin.succ_ne_zero pq.2)]
+        rw [hcomp, ← aeval_rename, MvPolynomial.aeval_X_left_apply]
+      have hevM₀ : aeval g M₀ = M₀ := by rw [hM₀rw]; exact hev_minor 0
+      have hg10 : g ((1 : Fin (n + 2)), (0 : Fin (n + 2))) = 1 := by simp [hg]
+      have hmin : aeval g ((A.submatrix (1 : Fin (n + 2)).succAbove Fin.succ).det) = M₁ := by
+        conv_rhs => rw [hM₁rw]
+        rw [hA, minor_det_eq_rename (1 : Fin (n + 2))]
+        exact hev_minor (1 : Fin (n + 2))
+      have hevR : aeval g R = -M₁ := by
+        rw [hR, map_sum, Finset.sum_eq_single (0 : Fin (n + 1))]
+        · rw [Fin.succ_zero_eq_one', map_mul, map_mul, map_pow, map_neg, map_one,
+            MvPolynomial.aeval_X, hg10, hmin]
+          simp
+        · intro i _ hi0
+          rw [map_mul, map_mul, MvPolynomial.aeval_X]
+          have hne1 : (i.succ : Fin (n + 2)) ≠ 1 := by
+            intro h
+            apply hi0
+            apply Fin.succ_injective
+            rw [h, Fin.succ_zero_eq_one']
+          rw [show g ((i.succ : Fin (n + 2)), (0 : Fin (n + 2))) = 0 by simp [hg, hne1]]
+          ring
+        · intro h; exact absurd (Finset.mem_univ _) h
+      have hdvd2 : M₀ ∣ M₁ := by
+        have hh := map_dvd (MvPolynomial.aeval g) hdvd
+        rw [hevM₀, hevR] at hh
+        exact dvd_neg.mp hh
+      obtain ⟨u, hu⟩ := hPrimeM₀.associated_of_dvd hPrimeM₁ hdvd2
+      obtain ⟨c₀, hc₀unit, hc₀eq⟩ := (MvPolynomial.isUnit_iff_eq_C_of_isReduced).mp u.isUnit
+      have hM₁eq : M₁ = MvPolynomial.C c₀ * M₀ := by rw [← hu, hc₀eq, mul_comm]
+      set w₁ : Fin (n + 2) × Fin (n + 2) := (0, 1) with hw₁
+      have hdegM₁pos : degreeOf w₁ M₁ ≠ 0 := by
+        rw [hM₁rw]
+        have hf1 : Prod.map (1 : Fin (n + 2)).succAbove
+            (Fin.succ : Fin (n + 1) → Fin (n + 2)) (0, 0) = w₁ := by
+          simp [Prod.map, hw₁]
+        rw [← hf1, degreeOf_rename_of_injective hf1inj, Ne, degreeOf_eq_zero_iff_notMem_vars,
+          not_not]
+        exact mem_vars_detPoly (m := n)
+      have hdegM₁zero : degreeOf w₁ M₁ = 0 := by
+        rw [hM₁eq, degreeOf_C_mul w₁ c₀ (mem_nonZeroDivisors_of_ne_zero hc₀unit.ne_zero),
+          degreeOf_eq_zero_iff_notMem_vars, hM₀rw]
+        intro hmem
+        obtain ⟨z, _, hz⟩ := mem_vars_rename _ _ hmem
+        apply Fin.succ_ne_zero z.1
+        simpa [hw₁, Prod.map_fst, Fin.succAbove_zero] using congrArg Prod.fst hz
+      exact hdegM₁pos hdegM₁zero
+    -- Step 4: isolate the variable `X(0,0)` and apply the linear criterion.
+    set Φ : MvPolynomial (Fin (n + 2) × Fin (n + 2)) k
+        ≃ₐ[k] Polynomial (MvPolynomial {v : Fin (n + 2) × Fin (n + 2) // v ≠ v₀} k) :=
+      (renameEquiv k (Equiv.optionSubtypeNe v₀).symm).trans (optionEquivLeft k _) with hΦ
+    have hΦeq : ∀ p : MvPolynomial (Fin (n + 2) × Fin (n + 2)) k,
+        Φ p = optionEquivLeft k _ (rename (Equiv.optionSubtypeNe v₀).symm p) := by
+      intro p; simp only [hΦ, AlgEquiv.trans_apply, renameEquiv_apply]
+    have hΦX : Φ (X v₀) = Polynomial.X := by
+      rw [hΦeq, rename_X, Equiv.optionSubtypeNe_symm_self, optionEquivLeft_X_none]
+    have hnatM₀ : (Φ M₀).natDegree = 0 := by
+      rw [hΦeq, ← degreeOf_eq_natDegree]; exact hdegM₀
+    have hnatR : (Φ R).natDegree = 0 := by
+      rw [hΦeq, ← degreeOf_eq_natDegree]; exact hdegR
+    set a₀ := (Φ M₀).coeff 0 with ha₀
+    set b₀ := (Φ R).coeff 0 with hb₀
+    have hΦM₀ : Φ M₀ = Polynomial.C a₀ := Polynomial.eq_C_of_natDegree_eq_zero hnatM₀
+    have hΦR : Φ R = Polynomial.C b₀ := Polynomial.eq_C_of_natDegree_eq_zero hnatR
+    have hdecomp : detPoly k (n + 2) = X v₀ * M₀ + R := by
+      rw [detPoly, Matrix.det_succ_column_zero, Fin.sum_univ_succ, hM₀, hR, hA, hv₀]
+      simp only [Matrix.mvPolynomialX_apply, Fin.val_zero, pow_zero, one_mul]
+    have hΦdet : Φ (detPoly k (n + 2)) = Polynomial.C a₀ * Polynomial.X + Polynomial.C b₀ := by
+      rw [hdecomp, map_add, map_mul, hΦX, hΦM₀, hΦR]; ring
+    have ha₀prime : Prime a₀ := by
+      rw [← Polynomial.prime_C_iff, ← hΦM₀]
+      exact (MulEquiv.prime_iff Φ.toMulEquiv).mpr hPrimeM₀
+    have hndvd : ¬ a₀ ∣ b₀ := by
+      intro h
+      apply hcop
+      have hdC : Φ M₀ ∣ Φ R := by rw [hΦM₀, hΦR]; exact map_dvd Polynomial.C h
+      have hback := map_dvd Φ.symm hdC
+      simpa using hback
+    have hirr : Irreducible (detPoly k (n + 2)) := by
+      have hlin := irreducible_C_mul_X_add_C ha₀prime hndvd
+      rw [← hΦdet] at hlin
+      exact (MulEquiv.irreducible_iff Φ.toMulEquiv).mp hlin
+    exact (UniqueFactorizationMonoid.irreducible_iff_prime).mp hirr
 
 /-- **Irreducibility of the generic determinant polynomial** (for `N ≥ 1`):
 immediate from `detPoly_prime`. -/

--- a/EtingofRepresentationTheory/Chapter5/DetIrreducible.lean
+++ b/EtingofRepresentationTheory/Chapter5/DetIrreducible.lean
@@ -119,26 +119,72 @@ theorem prime_rename_of_injective {σ τ : Type*} {e : σ → τ}
   rw [hcomp, prime_rename_iff (Set.range e), hrw]
   exact MulEquiv.prime_iff (renameEquiv k (Equiv.ofInjective e he))
 
-/-- **Irreducibility of the generic determinant polynomial** (for `N ≥ 1`).
+/-- A variable does not occur in a polynomial exactly when its `degreeOf` is `0`. -/
+private lemma degreeOf_eq_zero_iff_notMem_vars {σ R : Type*} [CommSemiring R]
+    (j : σ) (p : MvPolynomial σ R) : degreeOf j p = 0 ↔ j ∉ p.vars := by
+  classical
+  rw [degreeOf_def, vars_def, Multiset.mem_toFinset]
+  exact Multiset.count_eq_zero
 
-Route (successor issue): induction on `N`. Cofactor-expand along column `0`
-(`Matrix.det_succ_column_zero`) to write `detPoly k (N+1) = X(0,0)·M₀₀ + R`,
-where `M₀₀` is the `(0,0)`-minor and `R` collects the other column-`0` terms;
-both are free of the variable `X(0,0)`. The minor `M₀₀` equals
-`rename ψ (detPoly k N)` for the injective `ψ : (i,j) ↦ (i.succ, j.succ)`, so it
-is prime by the induction hypothesis (`prime_rename_of_injective`). The
-coprimality `M₀₀ ∤ R` holds because substituting the column-`0` variables shows
-`M₀₀ ∣ R → M₀₀ ∣ M₁₀` for a second minor `M₁₀`, forcing the two distinct prime
-minors to be associate — impossible, as `M₁₀` involves a row-`0` variable absent
-from `M₀₀`. Finally `irreducible_C_mul_X_add_C` (with `a = M₀₀`, `b = R`) gives
-irreducibility through the single-variable isolation equivalence. -/
-theorem detPoly_irreducible (hN : 0 < N) : Irreducible (detPoly k N) := by
+/-- The index map carving out the `(i,·)`-minor of the generic `(n+1)×(n+1)`
+matrix: `(p,q) ↦ (i.succAbove p, q.succ)`. It is injective. -/
+private lemma minor_index_injective {n : ℕ} (i : Fin (n + 1)) :
+    Function.Injective (Prod.map i.succAbove (Fin.succ : Fin n → Fin (n + 1))) :=
+  (Fin.succAbove_right_injective).prodMap (Fin.succ_injective n)
+
+/-- The `(i,0)`-cofactor minor of the generic determinant is a `rename` of the
+generic determinant one size down. -/
+private lemma minor_det_eq_rename {n : ℕ} (i : Fin (n + 1)) :
+    ((Matrix.mvPolynomialX (Fin (n + 1)) (Fin (n + 1)) k).submatrix i.succAbove Fin.succ).det
+      = rename (Prod.map i.succAbove (Fin.succ : Fin n → Fin (n + 1))) (detPoly k n) := by
+  rw [detPoly, AlgHom.map_det]
+  congr 1
+  ext p q
+  simp [Matrix.submatrix_apply, Matrix.map_apply, Matrix.mvPolynomialX_apply]
+
+/-- The variable `X(0,0)` occurs in the generic determinant polynomial (for
+`m ≥ 1`): the determinant genuinely depends on the top-left entry, witnessed by
+evaluating at the identity matrix versus the identity with the `(0,0)` entry
+zeroed (det `1` versus `0`). -/
+private lemma mem_vars_detPoly {m : ℕ} :
+    ((0 : Fin (m + 1)), (0 : Fin (m + 1))) ∈ (detPoly k (m + 1)).vars := by
+  classical
+  by_contra hv
+  set g₁ : Fin (m + 1) × Fin (m + 1) → k := fun p => if p.1 = p.2 then (1 : k) else 0 with hg₁
+  set g₂ : Fin (m + 1) × Fin (m + 1) → k :=
+    fun p => if p = ((0 : Fin (m + 1)), (0 : Fin (m + 1))) then (0 : k)
+      else (if p.1 = p.2 then 1 else 0) with hg₂
+  have hcongr : eval g₁ (detPoly k (m + 1)) = eval g₂ (detPoly k (m + 1)) := by
+    apply eval₂Hom_congr' rfl _ rfl
+    intro i hi _
+    have hne : i ≠ ((0 : Fin (m + 1)), (0 : Fin (m + 1))) := by rintro rfl; exact hv hi
+    simp only [hg₁, hg₂, if_neg hne]
+  have hmat₁ : (Matrix.mvPolynomialX (Fin (m + 1)) (Fin (m + 1)) k).map (eval g₁)
+      = (1 : Matrix (Fin (m + 1)) (Fin (m + 1)) k) := by
+    ext i j
+    simp [Matrix.map_apply, Matrix.mvPolynomialX_apply, MvPolynomial.eval_X, Matrix.one_apply, hg₁]
+  have hmat₂ : (Matrix.mvPolynomialX (Fin (m + 1)) (Fin (m + 1)) k).map (eval g₂)
+      = Matrix.diagonal (fun i => if i = (0 : Fin (m + 1)) then (0 : k) else 1) := by
+    ext i j
+    rw [Matrix.map_apply, Matrix.mvPolynomialX_apply, MvPolynomial.eval_X, Matrix.diagonal_apply, hg₂]
+    by_cases hij : i = j
+    · subst hij; simp [Prod.ext_iff]
+    · simp [hij, Prod.ext_iff]
+  have hL : eval g₁ (detPoly k (m + 1)) = 1 := by
+    rw [detPoly, RingHom.map_det, RingHom.mapMatrix_apply, hmat₁, Matrix.det_one]
+  have hR : eval g₂ (detPoly k (m + 1)) = 0 := by
+    rw [detPoly, RingHom.map_det, RingHom.mapMatrix_apply, hmat₂, Matrix.det_diagonal]
+    exact Finset.prod_eq_zero (Finset.mem_univ (0 : Fin (m + 1))) (by simp)
+  rw [hL, hR] at hcongr
+  exact one_ne_zero hcongr
+
+/-- **Primeness of the generic determinant polynomial** (for `N ≥ 1`). -/
+theorem detPoly_prime (hN : 0 < N) : Prime (detPoly k N) := by
   sorry
 
-/-- **Primeness of the generic determinant polynomial** (for `N ≥ 1`): immediate
-from `detPoly_irreducible` since `MvPolynomial (Fin N × Fin N) k` is a unique
-factorisation monoid. -/
-theorem detPoly_prime (hN : 0 < N) : Prime (detPoly k N) :=
-  (UniqueFactorizationMonoid.irreducible_iff_prime).mp (detPoly_irreducible hN)
+/-- **Irreducibility of the generic determinant polynomial** (for `N ≥ 1`):
+immediate from `detPoly_prime`. -/
+theorem detPoly_irreducible (hN : 0 < N) : Irreducible (detPoly k N) :=
+  (detPoly_prime hN).irreducible
 
 end Etingof.DetLocalization

--- a/progress/2026-06-21T08-27-51Z_d3d5f04f.md
+++ b/progress/2026-06-21T08-27-51Z_d3d5f04f.md
@@ -1,0 +1,53 @@
+## Accomplished
+
+- **Closed #4775** (Ch5 #4736 successor): proved
+  `Etingof.DetLocalization.detPoly_irreducible` / `detPoly_prime` sorry-free in
+  `Chapter5/DetIrreducible.lean`. Both `#print axioms` to the standard
+  `[propext, Classical.choice, Quot.sound]`; the module builds clean with no
+  errors, warnings, or sorries.
+  - Rewired so `detPoly_prime (hN : 0 < N) : Prime (detPoly k N)` is the
+    inductively-proven result and `detPoly_irreducible := (detPoly_prime hN).irreducible`.
+  - Proof is by induction on `N`. Base `N = 1`: `detPoly k 1 = X (0,0)`
+    (`Matrix.det_fin_one`), prime by `MvPolynomial.X_prime`. Step `N = n+2`,
+    cofactor-expanding column 0 (`Matrix.det_succ_column_zero` + `Fin.sum_univ_succ`):
+    `detPoly = X(0,0)·M₀ + R`.
+  - New private helper lemmas: `degreeOf_eq_zero_iff_notMem_vars`,
+    `minor_index_injective` (the index map `(p,q) ↦ (i.succAbove p, q.succ)` is
+    injective), `minor_det_eq_rename` (each column-0 minor is a `rename` of the
+    next-smaller generic determinant via `AlgHom.map_det`), and `mem_vars_detPoly`
+    (the variable `X(0,0)` occurs in `detPoly`, shown by evaluating at the identity
+    matrix vs. the identity with `(0,0)` zeroed: det `1` vs `0`).
+  - `M₀` is prime by `prime_rename_of_injective` + IH; `M₀ ∤ R` by substituting
+    the column-0 variables (`aeval` sending `X(i,0) ↦ [i = 1]`) to force
+    `M₀ ∣ M₁` for a second minor, then ruling that out because two distinct prime
+    minors associated would force `degreeOf (0,1) M₁ = degreeOf (0,1) M₀`, but the
+    first is `degreeOf (0,0) (detPoly k (n+1)) ≠ 0` and the second is `0`.
+  - Final assembly isolates `X(0,0)` through
+    `Φ = renameEquiv (optionSubtypeNe v₀).symm ≫ optionEquivLeft`, rewrites
+    `Φ detPoly = C a₀ · X + C b₀` (using `degreeOf v₀ M₀ = degreeOf v₀ R = 0` ⟹
+    the images are constants via `degreeOf_eq_natDegree`), applies the existing
+    `irreducible_C_mul_X_add_C` (with `a₀` prime via `Polynomial.prime_C_iff`,
+    `a₀ ∤ b₀` transported back through `Φ`), and transfers irreducibility back with
+    `MulEquiv.irreducible_iff`.
+
+## Current frontier
+
+`Chapter5/DetIrreducible.lean` is complete and sorry-free. `detPoly_prime`
+unblocks #4737 (det-power normal form `f = Q/detʳ`, which needs `Prime (detPoly)`).
+
+## Overall project progress
+
+- Chapter 5 det⁻¹-elimination kernel track (#4712 / #4694 / #4683): the
+  `detPoly` primeness/irreducibility prerequisite is now fully proved. #4737
+  (normal-form, `depends-on #4736`, now satisfied) is the next consumer.
+- No downstream module currently imports `detPoly_prime`/`detPoly_irreducible`, so
+  this PR introduces no regression risk to existing modules.
+
+## Next step
+
+- A worker can pick up #4737 (det-power normal form on `A[det⁻¹]`), which now has
+  its `Prime (detPoly k N)` dependency available on `main` once this PR merges.
+
+## Blockers
+
+- None.


### PR DESCRIPTION
Closes #4775

Session: `d3d5f04f-9cda-4d7c-bf8a-4c17fe0ac34c`

1d041492 doc(progress): record #4775 detPoly_prime/irreducible closure
a5a3a0f6 feat(Ch5 #4775): close detPoly_irreducible/detPoly_prime sorry-free
ecdb753f feat(Ch5 #4775): WIP detPoly irreducibility — helper lemmas (minor-rename, var membership)

🤖 Prepared with Claude Code