### PR TITLE
doc(Ch5 #4732): decompose Schur-Weyl simples character-classification crux

### DIFF
--- a/progress/2026-06-21T08-36-33Z_060df28b.md
+++ b/progress/2026-06-21T08-36-33Z_060df28b.md
@@ -1,0 +1,54 @@
+## Accomplished
+
+`/work` → `/feature` session `060df28b`, claimed **#4732** (the Tier-4 Schur-Weyl
+simples character-classification crux, `SchurWeylSimplesClassification.lean:106`).
+
+Investigated the crux in depth, found it is genuinely multi-session, and
+**decomposed** it (Step 4b) into two well-scoped, accurately-analysed sub-issues:
+
+- **#4820 (sub-α)** — generalize SchurModule simplicity off ℂ to general
+  alg-closed char-0 `k`. Mapped the full ℂ→k cascade: the framework lemmas
+  (trace-sum, restrict-sq-scalar, trace-zero-idempotent, GL transfer) are
+  *already general-`k`*, but the cascade bottoms out at **Specht-module character
+  orthogonality**, which is genuinely ℂ-rooted (`spechtModuleCharacter` is
+  `LinearMap.trace ℂ` via Mathlib `FDRep.char_orthonormal`; `SymGroupAlgebra` is
+  `MonoidAlgebra ℂ`). So sub-α is a **major sub-project**, not a find-replace.
+- **#4821 (sub-β)** — close the crux. Wrote three routes; identified a
+  **base-change-from-ℂ** route (route 3) that closes the crux *without* sub-α:
+  `formalCharacter` is field-independent ℚ-polynomial data, so prove over ℂ and
+  descend. This is the recommended, substantially-cheaper path.
+
+Both parent (#4732) and sub-α (#4820) skipped to `replan` with the analysis;
+sub-β (#4821) left unblocked (route 3 needs no α). Captured everything in
+`progress/schur-weyl-crux-4732-decomposition.md` (incl. post-investigation
+obstruction map). Verified #4758 (#4745 sub-B) is a downstream *consumer* of the
+crux, not a duplicate.
+
+## Current frontier
+
+The #2483 linear-independence route's last `sorryAx` is the #4732 crux, now
+decomposed. The genuine open content is sub-β #4821 (recommended: base-change
+descent from ℂ). No code landed (the crux factors below any single-session
+boundary); the deliverable is a precise decomposition + obstruction map.
+
+## Overall project progress
+
+Etingof draft 1, Stage 3. Ch6 infinite-type now on the orbit-counting directive
+(#4777, sub-issues #4798 has-pr / #4786 blocked). Ch5 Schur-Weyl #6 (#2483):
+reduction + headline sorry-free; crux #4732 decomposed this session into
+#4820/#4821.
+
+## Next step
+
+A worker claims **#4821** and attempts **route 3 (base change)**: prove a
+base-change-invariance lemma for `formalCharacter` (weight-space dimensions of
+the ℚ-defined `V^{⊗n}`/`glTensorRep` are field-independent), prove the crux over
+ℂ, and descend to general `k`. If route 3 holds, the planner closes #4820.
+Otherwise route 1 needs sub-α #4820 (the Specht-character-over-`k` sub-project).
+
+## Blockers
+
+None hard. #4820 (sub-α) is a major sub-project (Specht-character orthogonality
+over general `k`, replacing Mathlib's ℂ-specific `FDRep.char_orthonormal`) and is
+likely avoidable via the #4821 base-change route — a planner route-1-vs-route-3
+decision.

--- a/progress/schur-weyl-crux-4732-decomposition.md
+++ b/progress/schur-weyl-crux-4732-decomposition.md
@@ -1,0 +1,139 @@
+# Scoping: `schurWeyl_simples_formalCharacter_classification_core` (#4732)
+
+Session decomposing the Tier-4 crux at
+`Chapter5/SchurWeylSimplesClassification.lean:106`. The single residual `sorry`
+(line 132) is the highest-weight classification: given the equivariant
+decomposition `e : V^{⊗n} ≃ ⨁ᵢ Sᵢ ⊗ Lᵢ` with each `Lᵢ` a simple polynomial
+`GL_N`-rep, pairwise non-isomorphic, produce an injective antitone-partition
+assignment `lam` with `char(Lᵢ) = schurPoly N (lam i)`.
+
+## Why it doesn't fit one session
+
+The crux factors into two genuinely independent pieces, one of which is the same
+deep gap that blocks `iso_of_formalCharacter_eq_schurPoly` (#4699):
+
+### Piece α — SchurModule simplicity/character over general `k` (foundation)
+
+`schurModule_isSimple` (`Chapter5/SchurModuleSimple.lean:316`) and its whole
+helper chain (`schurModuleSubmodule_isSimple_centralizer` :255,
+`schurBlock_imageSubmoduleB_isSimple` :167, `finrank_bound` :141,
+`youngSymEndo_mem_restrictScalars` :149, and
+`isSimpleModule_monoidAlgebra_GL_of_centralizer_simple` in
+`SchurWeylGLTransfer.lean:553`) are stated and proved **only over `ℂ`**.
+
+But the crux is over a general `k : Field, IsAlgClosed, CharZero`, and the
+*hypotheses* it consumes (from `glTensorRep_equivariant_schurWeyl_decomposition`,
+`FormalCharacterIso.lean:753`) are over general `k`. To match an abstract `Lᵢ`
+(simple over `k`) against a concrete `SchurModule k N λ`, the concrete side must
+be known simple **over `k`**.
+
+Good news: the underlying double-centralizer infrastructure is already
+general-`k`:
+- `Theorem5_18_4_centralizers` (`Theorem5_18_4.lean:268`) — `[Field k] [CharZero k]`.
+- `Theorem5_18_4_semisimple` (:292) — same.
+- `SchurModuleSubmodule k N lam`, `schurModuleRep k N lam` (`Theorem5_22_1.lean:282,289`) — general `[Field k]`.
+- `SchurModuleSimple.lean` already opens `variable (k) [Field k] [IsAlgClosed k] [CharZero k]` (line 24); the first helper `schurModuleSubmodule_smul_mem_aux` is over `k`. The ℂ-pinning is an *unforced* specialization in the later theorems.
+
+So α is a mostly-mechanical `ℂ → k` generalization, but it cascades through
+several helpers (`YoungSymmetrizerK_sq_scalar`, `youngSymEndomorphism_sq_scalar`,
+the rank-one block lemmas) — verify each is general-`k` or generalize it too.
+
+### Piece β — completeness: every `Lᵢ ≅ SchurModule(λᵢ)` (the deep Tier-4 content)
+
+This is the genuine highest-weight content, shared with #4699. Two viable routes:
+
+1. **Isotypic matching + counting (avoids full highest-weight machinery).**
+   - Each `SchurModule k N λ` (λ antitone, |λ|=n, ℓ(λ)≤N) is a simple GL-submodule
+     of `V^{⊗n}` (it *is* `SchurModuleSubmodule k N lam ⊆ TensorPower k (Fin N→k) (∑λ)`,
+     GL-stable because the Young symmetrizer lives in the `Sₙ`-group-algebra and
+     commutes with the diagonal GL action). [needs α for simplicity]
+   - By uniqueness of isotypic decomposition of the semisimple `V^{⊗n}` against
+     the abstract `e`-decomposition, `SchurModule k N λ ≅ L_{φλ}` for a unique
+     index `φλ`; `φ : P ↪ ι` is injective because distinct λ give distinct
+     characters (`schurPoly_injective`) hence non-isomorphic SchurModules.
+   - **Completeness** = `φ` surjective = `|ι| = |P|`, where `P = {λ antitone :
+     |λ|=n, ℓ(λ)≤N}`. By the double-centralizer pairing (`Theorem5_18_4`), the
+     number of distinct simple GL-types in `V^{⊗n}` equals the number of distinct
+     simple `Sₙ`-types occurring, and the Specht modules occurring in
+     `V^{⊗n} = (kᴺ)^{⊗n}` are exactly those with `ℓ(λ) ≤ N`, i.e. `|P|` of them.
+     `φ` injective between finite sets of equal size ⟹ bijective ⟹ done.
+   - Then `lam := φ⁻¹` (each `i = φλ` ↦ `λ`), giving `char(Lᵢ) = char(SchurModule λ)
+     = schurPoly N λ` (`formalCharacter_schurModule_eq_schurPoly`,
+     `formalCharacter_eq_of_rep_iso`).
+
+2. **Highest-weight leading-monomial.** Each simple `Lᵢ` has a 1-dimensional
+   highest weight space at a dominant `λᵢ`, and a symmetric character with leading
+   term `m^{λᵢ}` (coeff 1) equals `schurPoly N λᵢ`. More infrastructure to build;
+   route 1 reuses existing double-centralizer work and is preferred.
+
+The hardest, most uncertain step is the **counting equality `|ι| = |P|`** (the
+`Sₙ`-side: which Specht modules occur in `(kᴺ)^{⊗n}`). The β worker should expect
+to decompose further around that step.
+
+## Assembly (thin, lives in β)
+
+Given α + the completeness bijection `φ : P ≃ ι`, define `lam i := (φ⁻¹ i)` and
+discharge `Function.Injective lam` (φ⁻¹ injective) and the character equality.
+Available glue: `formalCharacter_schurModule_eq_schurPoly`,
+`formalCharacter_eq_of_rep_iso`, `schurPoly_injective`,
+`SemisimpleIsotypic.submodule_of_directSum_simple_iso_directSum`
+(`Chapter5/SemisimpleIsotypic.lean`).
+
+## Decomposition
+
+- **sub-α** (no in-set deps): generalize SchurModule simplicity off ℂ to general
+  `k`, and expose `SchurModule k N λ` as a simple GL-submodule of `V^{⊗(∑λ)}`.
+- **sub-β** (depends on α): close the crux via route 1 (isotypic matching +
+  counting). May decompose further around the `|ι| = |P|` step.
+
+Parent #4732 is skipped (→ `replan`) with a `Decomposed into #α, #β` breadcrumb.
+
+---
+
+## Update — post-investigation obstruction map (sub-α is a major sub-project)
+
+A deeper read of the ℂ→k cascade for sub-α (#4820) revised the difficulty
+sharply. The **top** layers' proof text uses no ℂ-specific API, but the cascade
+bottoms out at **Specht-module character orthogonality**, which is genuinely
+ℂ-rooted:
+
+- `spechtModuleCharacter` (`Theorem5_15_1.lean:79`) `:= LinearMap.trace ℂ _ (spechtModuleAction …)` — **ℂ-valued by definition**, via an `FDRep ℂ (Perm (Fin n))` bridge that uses Mathlib's `FDRep.char_orthonormal` (complex character inner-product orthonormality — ℂ-specific).
+- `SymGroupAlgebra n := MonoidAlgebra ℂ (Perm (Fin n))` (`Theorem5_12_2_Irreducible.lean:22`) — **ℂ-based**.
+- The orthogonality heart: `trace_mulLeft_youngSym_eq'` (`Theorem5_22_1.lean:2176`), `mulLeft_youngSym_zero_of_ne'` (:2120), `sum_coeff_char_eq_trace'` (:2093), `youngSym_trace_kronecker'` (:2205), and the casts `youngSymmetrizerK_complex_eq` (:2263), `youngSym_coeff_cast'` (:2040), `youngSym_sq_ℂ'` (:2047) — all `private`, all over ℂ.
+
+By contrast, the **framework** lemmas are *already general-`k`* and need no work:
+`trace_youngSymEndomorphism_restrict_eq_sum` (:793, `{k}[Field k]`),
+`youngSymEndomorphism_restrict_sq_scalar` (:836, `{k}[Field k]`),
+`isIdempotentElem_eq_zero_of_trace_eq_zero` (:2244, `{K}[Field K][CharZero K]`),
+`YoungSymmetrizerK_sq_scalar(_ne_zero)` (over ℚ), and the GL transfer
+`isSimpleModule_monoidAlgebra_GL_of_centralizer_simple`
+(`SchurWeylGLTransfer.lean:553`, general `k`).
+
+So sub-α's real content = **generalize Specht-module character theory and its
+orthogonality off ℂ to a general algebraically-closed char-0 field**, replacing
+the Mathlib `FDRep.char_orthonormal` (complex inner-product) route with a
+field-agnostic one. That is a major sub-project, not a one-session feature.
+
+### Strategic consequence — prefer base change for sub-β, drop sub-α
+
+A **descent from ℂ** likely closes the #4732 crux without generalizing Specht
+character theory at all:
+
+- `formalCharacter k N M : MvPolynomial (Fin N) ℚ` is **field-independent data** —
+  it records `finrank` of `ℕ`-weight spaces, and for `V^{⊗n}` / `glTensorRep`
+  (constructions defined over ℚ) those dimensions are combinatorial, the same for
+  every alg-closed char-0 `k`.
+- The crux's conclusion (`∃ lam, injective ∧ char(L i) = schurPoly N (lam i)`)
+  is a statement about these ℚ-polynomials. Prove it over ℂ (where the Specht /
+  SchurModule machinery already exists), then transfer to general `k` via
+  base-change invariance of the weight-space dimensions / the decomposition's
+  numerical content.
+- This needs a base-change-invariance lemma for `formalCharacter` (and possibly
+  for the multiplicities in `glTensorRep_equivariant_schurWeyl_decomposition`),
+  but **not** SchurModule simplicity over `k`.
+
+**Recommendation:** the planner should decide between (1) the major sub-project of
+Specht-character-over-`k` (sub-α #4820 → #4821 route 1), or (2) the base-change
+route in sub-β that drops sub-α. Route (2) looks substantially cheaper. Sub-α
+(#4820) is skipped back to `replan` pending that decision.
+


### PR DESCRIPTION
This PR records the decomposition and full obstruction analysis of the Tier-4 crux `schurWeyl_simples_formalCharacter_classification_core` (#4732), the last `sorryAx` of the #2483 Schur-Weyl linear-independence route. The crux is split into sub-α (#4820, generalize SchurModule simplicity off ℂ to general alg-closed char-0 `k`) and sub-β (#4821, close the crux). Investigation found the ℂ→k cascade bottoms out at Specht-module character orthogonality, which is genuinely ℂ-rooted (`spechtModuleCharacter` is `LinearMap.trace ℂ` via Mathlib `FDRep.char_orthonormal`; `SymGroupAlgebra` is `MonoidAlgebra ℂ`), making sub-α a major sub-project — while the trace framework lemmas are already general-`k`. It also identifies a base-change-from-ℂ route for sub-β that closes the crux without sub-α, since `formalCharacter` is field-independent ℚ-polynomial data. Adds `progress/schur-weyl-crux-4732-decomposition.md` (scoping + post-investigation obstruction map) and the session progress entry. No code or `sorry` changes.

🤖 Prepared with Claude Code