### PR TITLE
doc(Ch6 #4786): scope strict −1 dim-bound gap as #4824

### DIFF
--- a/progress/2026-06-21T08-40-55Z_8749d691.md
+++ b/progress/2026-06-21T08-40-55Z_8749d691.md
@@ -1,0 +1,67 @@
+## Accomplished
+
+Claimed **#4786** (Ch6 #4777 S4: wire finite⟹q-pos-def into `Theorem_6_1_5`;
+delete the explicit-construction track). Investigated the full orbit-counting
+chain and discovered that the issue is **blocked on a previously-unscoped
+mathematical gap**. Scoped that gap precisely and filed it.
+
+- Mapped the orbit chain end-to-end (S0 `OrbitSpace` → S1b `OrbitFiniteness` →
+  S2a `DenseOrbit`/`OrbitInjective` → S2b `OrbitComorphism` → S2c
+  `FieldEmbedding`/`DimBound` → S3 `PosDef`/`TitsBridge`). All files are
+  sorry-free, and there IS a path `IsFiniteTypeQuiver ⟹ Finite orbits ⟹`
+  non-strict bound `card (WIdx m) ≤ card (GIdx m)`
+  (`Problem6_1_5_DimBound.repSpace_finrank_le_repGroup_ambient_finrank`).
+- **The gap:** the S3 hook the forward direction must consume,
+  `Etingof.isDynkinDiagram_of_strict_finrank` (`Problem6_1_5_TitsBridge.lean`),
+  needs the **strict** bound `dim W(m) < dim G(m)`. The merged deps #4798 (S1b)
+  and #4803 (S2 injectivity) deliver only the **non-strict** bound. The strict
+  `−1` refinement (global scalars `k*` acting trivially) exists nowhere in the
+  codebase and was never scoped — the directive step list #4780→#4784 skipped it.
+  Non-strict only gives `q(m) ≥ 0` (positive semidefinite = affine Dynkin =
+  infinite type), so the strict bound is mathematically essential.
+- Filed **#4824** (`feat(Ch6 #4777 S2c-strict): strict dim bound …`) with the
+  full route: under the simultaneous scaling `X⟨i,(a,b)⟩ ↦ λ·X⟨i,(a,b)⟩` of all
+  `GIdx m` generators, the image of `orbitComorphism m v₀` is invariant (the `λ`
+  and `λ⁻¹` from `G_j · v₀ · G_i⁻¹` cancel), so it lies in the degree-0 part `B₀`;
+  over `K = k(GIdx m)` the degree-0 subfield `K₀` has `trdeg = card(GIdx m) − 1`
+  (since `K = K₀(g*)` purely transcendental degree 1), forcing
+  `card (WIdx m) ≤ card (GIdx m) − 1`.
+- Added `depends-on: #4824` to #4786 (now `blocked`), left an explanatory
+  comment, and released the claim (`coordination skip 4786` → `replan`).
+
+No code changes (no PR). The deliverable of this turn is the precise scoping of
+the missing crux.
+
+## Current frontier
+
+`Problem6_1_5_TitsBridge.isDynkinDiagram_of_strict_finrank` is ready and waiting
+for its `hstrict` input. The non-strict bound is proven. The strict `−1`
+refinement (#4824) is the single remaining mathematical obstacle to the entire
+Gabriel forward direction.
+
+## Overall project progress
+
+- Ch6 orbit-counting redirect (#4777): S0/S1b/S2a/S2b/S2c/S3 all merged and
+  sorry-free. The chain produces the **non-strict** dimension bound. The strict
+  refinement (#4824) is newly identified and unproven.
+- #4786 (S4 final assembly + construction-track deletion) is wired and ready but
+  blocked on #4824. Deletion also requires migrating
+  `Chapter2/Theorem2_1_2.lean`'s forward direction off the `FieldGeneric*` track,
+  which likewise needs the strict bound sorry-free.
+
+## Next step
+
+A worker should claim **#4824** and prove the strict dimension bound. Suggested
+internal split (the worker may file sub-issues): (A) construction-specific —
+image of `orbitComorphism m v₀` is invariant under the global-scalar scaling
+endomorphism of `B` / lies in `B₀`; (B) reusable algebra —
+`trdeg_k (degree-0 subfield of k(τ)) = card τ − 1` for nonempty finite `τ`, hence
+injective `k[σ] ↪ B₀` gives `card σ < card τ`. Check Mathlib transcendence-degree
+API (`IsTranscendenceBasis`) for (B); the ratios `g_j/g*` are the transcendence
+basis of `K₀`. Once #4824 lands, #4786 unblocks (`check-blocked`) and is a short
+assembly.
+
+## Blockers
+
+- #4786 is blocked on #4824 (strict `−1` dimension bound), now filed. No human
+  action required — this is normal forward decomposition of an unscoped gap.


### PR DESCRIPTION
This PR records the investigation of #4786 (Ch6 #4777 S4 final assembly), which is blocked on a previously-unscoped mathematical gap. The orbit-counting chain delivers only the non-strict dimension bound `dim W(m) ≤ dim G(m)`, but the forward direction of Gabriel's theorem needs the strict `−1` refinement (global scalars k* acting trivially) consumed by `isDynkinDiagram_of_strict_finrank`. Non-strict yields only positive-semidefinite (affine Dynkin = infinite type), so the strict bound is essential. Filed #4824 with the full route, blocked #4786 on it, and added the progress handoff. No code changes.

🤖 Prepared with Claude Code