### PR TITLE
feat(Ch5 #4713 partial): right-translation GL rep on k[Xᵢⱼ] — the foundation (K′) is stated over

### DIFF
--- a/EtingofRepresentationTheory/Chapter5.lean
+++ b/EtingofRepresentationTheory/Chapter5.lean
@@ -87,6 +87,7 @@ import EtingofRepresentationTheory.Chapter5.PolynomialTensorBridge
 import EtingofRepresentationTheory.Chapter5.PolynomialRepEmbedding
 import EtingofRepresentationTheory.Chapter5.DetLocalization
 import EtingofRepresentationTheory.Chapter5.DetIrreducible
+import EtingofRepresentationTheory.Chapter5.PolynomialGLRightAction
 
 -- Section 5.19: Schur-Weyl Duality and Schur Functors
 import EtingofRepresentationTheory.Chapter5.Proposition5_19_1

--- a/EtingofRepresentationTheory/Chapter5/PolynomialGLRightAction.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialGLRightAction.lean
@@ -1,0 +1,123 @@
+import Mathlib
+import EtingofRepresentationTheory.Chapter5.DetLocalization
+
+/-!
+# The right-translation `GL_N`-action on the coordinate ring `k[Xᵢⱼ]`
+
+This file constructs the **right-translation representation** of `GL_N(k)` on the
+polynomial coordinate ring `A = k[Xᵢⱼ] = MvPolynomial (Fin N × Fin N) k`, the
+representation-theoretic object the det⁻¹-elimination kernel lemma (K′) (issue
+#4713, route doc `progress/kernel-lemma-K-route.md`) is stated over.
+
+On the coordinate functions `X_{ij}(g) = g_{ij}` the right translation
+`(R_h f)(g) = f(g · h)` acts by
+`R_h X_{ij} = ∑_l h_{lj} X_{il}` — it mixes the **column** index `j` (right
+multiplication acts on columns) and fixes the **row** index `i`. We package this
+as an algebra endomorphism `rTransAlgHom M` for an arbitrary matrix `M`, show it
+is multiplicative in `M` (`rTransAlgHom_one`, `rTransAlgHom_mul`), and restrict to
+`GL_N` to obtain a genuine `Representation k GL_N A` (`polyRightRep`).
+
+## The determinant is a semi-invariant
+
+The generic determinant `det(Xᵢⱼ)` transforms by the determinant character:
+`R_h det(X) = det(h) · det(X)` (`rTransAlgHom_det`). Consequently the principal
+ideal `(det)` is `GL_N`-stable (`detIdeal_stable`), so the quotient `A/det`
+inherits a right-`GL_N`-action — this is exactly the rep `A/det` that (K′)
+analyses (twisted by the determinant character `χ^{-r}`).
+
+These are the structural prerequisites for the genuine representation-theoretic
+core (K′): every irreducible constituent of `k[Xᵢⱼ]/(det)` has last
+highest-weight coordinate `ν_N = 0`, proved via the `GL×GL`-equivariant Cauchy
+decomposition. That core is tracked in the follow-up sub-issue; this file
+supplies the action it is phrased over.
+-/
+
+namespace Etingof.PolynomialGLAction
+
+open MvPolynomial
+
+variable {k : Type*} [CommRing k] {N : ℕ}
+
+/-- The right-translation endomorphism of `A = k[Xᵢⱼ]` attached to a matrix `M`:
+the algebra hom sending the coordinate `X_{ij}` to `∑_l M_{lj} X_{il}`. For
+`M = h ∈ GL_N` this is the right translation `(R_h f)(g) = f(g · h)` (right
+multiplication acts on the column index, fixes the row index). -/
+noncomputable def rTransAlgHom (M : Matrix (Fin N) (Fin N) k) :
+    MvPolynomial (Fin N × Fin N) k →ₐ[k] MvPolynomial (Fin N × Fin N) k :=
+  MvPolynomial.aeval (fun ij : Fin N × Fin N => ∑ l : Fin N, M l ij.2 • MvPolynomial.X (ij.1, l))
+
+@[simp] theorem rTransAlgHom_X (M : Matrix (Fin N) (Fin N) k) (i j : Fin N) :
+    rTransAlgHom M (MvPolynomial.X (i, j)) = ∑ l, M l j • MvPolynomial.X (i, l) := by
+  simp [rTransAlgHom]
+
+/-- The identity matrix acts trivially: `R_1 = id`. -/
+theorem rTransAlgHom_one :
+    rTransAlgHom (1 : Matrix (Fin N) (Fin N) k) = AlgHom.id k _ := by
+  apply MvPolynomial.algHom_ext
+  rintro ⟨i, j⟩
+  rw [rTransAlgHom_X]
+  simp only [Matrix.one_apply, ite_smul, one_smul, zero_smul, AlgHom.id_apply]
+  rw [Finset.sum_ite_eq' Finset.univ j (fun l => MvPolynomial.X (i, l))]
+  simp
+
+/-- Multiplicativity in the matrix argument: `R_{M₁ M₂} = R_{M₁} ∘ R_{M₂}`.
+This is the homomorphism property making the right translation a representation. -/
+theorem rTransAlgHom_mul (M₁ M₂ : Matrix (Fin N) (Fin N) k) :
+    rTransAlgHom (M₁ * M₂) = (rTransAlgHom M₁).comp (rTransAlgHom M₂) := by
+  apply MvPolynomial.algHom_ext
+  rintro ⟨i, j⟩
+  rw [AlgHom.comp_apply, rTransAlgHom_X, rTransAlgHom_X, map_sum]
+  simp_rw [map_smul, rTransAlgHom_X, Matrix.mul_apply, Finset.sum_smul,
+    Finset.smul_sum, smul_smul]
+  rw [Finset.sum_comm]
+  refine Finset.sum_congr rfl fun l _ => Finset.sum_congr rfl fun m _ => ?_
+  rw [mul_comm]
+
+/-- The **right-translation representation** of `GL_N(k)` on `A = k[Xᵢⱼ]`:
+`g ↦ (R_g : f ↦ f(· g))`. The right translation `(R_h f)(g) = f(g h)` acts on
+generators by `R_h X_{ij} = ∑_l h_{lj} X_{il}`. -/
+noncomputable def polyRightRep (k : Type*) [CommRing k] (N : ℕ) :
+    Representation k (Matrix.GeneralLinearGroup (Fin N) k)
+      (MvPolynomial (Fin N × Fin N) k) where
+  toFun g := (rTransAlgHom (g : Matrix (Fin N) (Fin N) k)).toLinearMap
+  map_one' := by
+    change (rTransAlgHom ((1 : Matrix.GeneralLinearGroup (Fin N) k) :
+      Matrix (Fin N) (Fin N) k)).toLinearMap = _
+    rw [Units.val_one, rTransAlgHom_one]
+    rfl
+  map_mul' g₁ g₂ := by
+    change (rTransAlgHom ((g₁ * g₂ : Matrix.GeneralLinearGroup (Fin N) k) :
+      Matrix (Fin N) (Fin N) k)).toLinearMap = _
+    rw [Units.val_mul, rTransAlgHom_mul]
+    rfl
+
+@[simp] theorem polyRightRep_apply_X (g : Matrix.GeneralLinearGroup (Fin N) k)
+    (i j : Fin N) :
+    polyRightRep k N g (MvPolynomial.X (i, j))
+      = ∑ l, (g : Matrix (Fin N) (Fin N) k) l j • MvPolynomial.X (i, l) :=
+  rTransAlgHom_X _ i j
+
+/-- The generic determinant matrix `(rTransAlgHom M).mapMatrix mvPolynomialX`
+equals `mvPolynomialX * M.map C`: applying the column-mixing substitution to the
+generic matrix of variables is right multiplication by the constant matrix `M`. -/
+theorem mapMatrix_mvPolynomialX (M : Matrix (Fin N) (Fin N) k) :
+    (rTransAlgHom M).mapMatrix (Matrix.mvPolynomialX (Fin N) (Fin N) k)
+      = Matrix.mvPolynomialX (Fin N) (Fin N) k
+        * M.map (MvPolynomial.C : k →+* MvPolynomial (Fin N × Fin N) k) := by
+  ext i j
+  simp only [AlgHom.mapMatrix_apply, Matrix.map_apply, Matrix.mvPolynomialX,
+    Matrix.of_apply, rTransAlgHom_X, Matrix.mul_apply, MvPolynomial.smul_eq_C_mul]
+  simp only [mul_comm]
+
+/-- **Determinant semi-invariance.** The generic determinant `det(Xᵢⱼ)`
+transforms under right translation by the determinant character:
+`R_M det(X) = det(M) · det(X)`. For `M = h ∈ GL_N` this is `R_h det = det(h)·det`,
+the statement that `det` spans a copy of the determinant character `χ`. -/
+theorem rTransAlgHom_det (M : Matrix (Fin N) (Fin N) k) :
+    rTransAlgHom M (Matrix.det (Matrix.mvPolynomialX (Fin N) (Fin N) k))
+      = MvPolynomial.C M.det * Matrix.det (Matrix.mvPolynomialX (Fin N) (Fin N) k) := by
+  have hmap : (M.map (MvPolynomial.C : k →+* MvPolynomial (Fin N × Fin N) k)).det
+      = MvPolynomial.C M.det := (RingHom.map_det _ _).symm
+  rw [AlgHom.map_det, mapMatrix_mvPolynomialX, Matrix.det_mul, hmap, mul_comm]
+
+end Etingof.PolynomialGLAction

--- a/EtingofRepresentationTheory/Chapter5/PolynomialGLRightAction.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialGLRightAction.lean
@@ -21,8 +21,8 @@ is multiplicative in `M` (`rTransAlgHom_one`, `rTransAlgHom_mul`), and restrict 
 
 The generic determinant `det(Xᵢⱼ)` transforms by the determinant character:
 `R_h det(X) = det(h) · det(X)` (`rTransAlgHom_det`). Consequently the principal
-ideal `(det)` is `GL_N`-stable (`detIdeal_stable`), so the quotient `A/det`
-inherits a right-`GL_N`-action — this is exactly the rep `A/det` that (K′)
+ideal `(det)` is `GL_N`-stable (`rTransAlgHom_mem_detIdeal`), so the quotient
+`A/det` inherits a right-`GL_N`-action — this is exactly the rep `A/det` that (K′)
 analyses (twisted by the determinant character `χ^{-r}`).
 
 These are the structural prerequisites for the genuine representation-theoretic
@@ -119,5 +119,20 @@ theorem rTransAlgHom_det (M : Matrix (Fin N) (Fin N) k) :
   have hmap : (M.map (MvPolynomial.C : k →+* MvPolynomial (Fin N × Fin N) k)).det
       = MvPolynomial.C M.det := (RingHom.map_det _ _).symm
   rw [AlgHom.map_det, mapMatrix_mvPolynomialX, Matrix.det_mul, hmap, mul_comm]
+
+/-- **The determinant ideal `(det)` is right-`GL_N`-stable.** A multiple of the
+generic determinant maps under right translation to a multiple of it (the
+semi-invariance `rTransAlgHom_det` keeps the factor `det`). Consequently the
+quotient ring `A/det = k[Xᵢⱼ]/(det)` inherits the right-`GL_N`-action: it is the
+representation (twisted by `χ^{-r}`) that the kernel lemma (K′) analyses. -/
+theorem rTransAlgHom_mem_detIdeal (M : Matrix (Fin N) (Fin N) k)
+    {f : MvPolynomial (Fin N × Fin N) k}
+    (hf : f ∈ Ideal.span {Matrix.det (Matrix.mvPolynomialX (Fin N) (Fin N) k)}) :
+    rTransAlgHom M f ∈
+      Ideal.span {Matrix.det (Matrix.mvPolynomialX (Fin N) (Fin N) k)} := by
+  rw [Ideal.mem_span_singleton] at hf ⊢
+  obtain ⟨q, rfl⟩ := hf
+  rw [map_mul, rTransAlgHom_det]
+  exact ⟨MvPolynomial.C M.det * rTransAlgHom M q, by ring⟩
 
 end Etingof.PolynomialGLAction

--- a/progress/2026-06-21T08-45-30Z_97a58acf.md
+++ b/progress/2026-06-21T08-45-30Z_97a58acf.md
@@ -1,0 +1,56 @@
+## Accomplished
+
+Partial progress on #4713 (Ch5 #4694 sub-K-cauchy, the kernel-lemma deep core).
+Landed the **foundational representation-theoretic objects** that the kernel
+lemma (K′) is stated over, sorry-free, in a new file
+`EtingofRepresentationTheory/Chapter5/PolynomialGLRightAction.lean`
+(namespace `Etingof.PolynomialGLAction`):
+
+- `rTransAlgHom M` — the column-mixing algebra endomorphism of `A = k[Xᵢⱼ]`
+  sending `X_{ij} ↦ ∑_l M_{lj} X_{il}` (right translation on generators).
+- `rTransAlgHom_one`, `rTransAlgHom_mul` — multiplicativity in `M`, the
+  homomorphism property making it a representation.
+- `polyRightRep : Representation k GL_N k[Xᵢⱼ]` — the right-translation
+  representation `R_h X_{ij} = ∑_l h_{lj} X_{il}`, with `polyRightRep_apply_X`.
+- `mapMatrix_mvPolynomialX` — `(rTransAlgHom M).mapMatrix mvPolynomialX
+  = mvPolynomialX * M.map C` (the generic-matrix transform is right-mult by `M`).
+- `rTransAlgHom_det` — **determinant semi-invariance**
+  `R_M det(X) = det(M) · det(X)`, i.e. `det` spans a copy of the determinant
+  character `χ`.
+- `rTransAlgHom_mem_detIdeal` — the principal ideal `(det)` is right-`GL_N`-stable,
+  so the quotient `A/det = k[Xᵢⱼ]/(det)` inherits the right-`GL_N`-action. This
+  is exactly the rep `(A/det) ⊗ χ^{-r}` that (K′) analyses.
+
+Wired into `EtingofRepresentationTheory/Chapter5.lean`. Axioms
+`[propext, Classical.choice, Quot.sound]` only; zero `sorry`, zero warnings.
+
+## Current frontier
+
+`PolynomialGLRightAction.lean` builds clean. The genuine core (K′) — stating and
+proving that `(A/det) ⊗ χ^{-r}` (`r ≥ 1`) has no nonzero nonneg-weight right-GL
+submodule, equivalently constituents of `k[Xᵢⱼ]/(det)` have `ν_N = 0` — is NOT
+done. It is the original #4713 scope minus the foundation now in place.
+
+## Overall project progress
+
+Ch5 det⁻¹-elimination kernel-lemma chain (#4694, route doc
+`progress/kernel-lemma-K-route.md`): deliverable 3 (faithful functions-on-GL
+model) and deliverable 2 (det-power normal form, #4712) already landed. This turn
+adds the right-translation GL-rep on the coordinate ring — the rep-theoretic
+object the deep core (K′) is phrased over. The remaining work is the
+GL×GL-equivariant Cauchy decomposition + highest-weight theory.
+
+## Next step
+
+Pick up **#4826** (created this turn): state and prove (K′) over the new
+`polyRightRep` / `A/det` objects, via the equivariant Cauchy decomposition. It
+`depends-on #4699` (the highest-weight classification entry point, an open sorry).
+The #4713 deep-core scope is superseded by #4826; the planner should re-narrow or
+close #4713 (partial PR marks it `replan`).
+
+## Blockers
+
+- The deep core (K′) transitively depends on `iso_of_formalCharacter_eq_schurPoly`
+  (#4699, open sorry) and the GL×GL-equivariant Cauchy/Peter–Weyl decomposition
+  (`Theorem5_23_2_ii` is currently only a rank iso, no weight data). These are the
+  research-level gaps recorded in the route doc's "Missing infrastructure" §.


### PR DESCRIPTION
Partial progress on #4713

Session: `97a58acf-de50-4c81-b904-11715c9afa48`

8fadfbc9 doc(progress): #4713 partial — right-translation GL rep foundation; deep core → #4826
a1c7e683 feat(Ch5 #4713 sub-action): det ideal is GL-stable, so A/det is a GL-rep
ec449667 feat(Ch5 #4713 sub-action): right-translation GL rep on k[Xᵢⱼ] + det semi-invariance

🤖 Prepared with Claude Code