### PR TITLE
feat(Ch5 #4694 sub-O-rep): right-GL representation on O = A[det⁻¹] (foundation for kernel lemma K)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5.lean
+++ b/EtingofRepresentationTheory/Chapter5.lean
@@ -88,6 +88,7 @@ import EtingofRepresentationTheory.Chapter5.PolynomialRepEmbedding
 import EtingofRepresentationTheory.Chapter5.DetLocalization
 import EtingofRepresentationTheory.Chapter5.DetIrreducible
 import EtingofRepresentationTheory.Chapter5.PolynomialGLRightAction
+import EtingofRepresentationTheory.Chapter5.LocalizationGLRightAction
 import EtingofRepresentationTheory.Chapter5.KernelLemmaKPrime
 
 -- Section 5.19: Schur-Weyl Duality and Schur Functors

--- a/EtingofRepresentationTheory/Chapter5/LocalizationGLRightAction.lean
+++ b/EtingofRepresentationTheory/Chapter5/LocalizationGLRightAction.lean
@@ -168,4 +168,50 @@ theorem localRightRep_algebraMap (g : Matrix.GeneralLinearGroup (Fin N) k)
       = algebraMap _ _ (polyRightRep k N g a) :=
   localRightAlgHom_algebraMap g a
 
+/-- **Determinant semi-invariance on `O`.** The formal inverse `det⁻¹ =
+invSelf detPoly` transforms by the **inverse** determinant character:
+`R_g det⁻¹ = (det g)⁻¹ · det⁻¹`. Together with `R_g det = det g · det`
+(`rTransAlgHom_det`) this is the `χ⁻¹` semi-invariance driving the det-power
+filtration twist `A_r/A_{r-1} ≅ (A/det) ⊗ χ⁻ʳ`. -/
+theorem localRightRep_invSelf (g : Matrix.GeneralLinearGroup (Fin N) k) :
+    localRightRep k N g (IsLocalization.Away.invSelf (detPoly k N))
+      = ((g : Matrix (Fin N) (Fin N) k).det)⁻¹ •
+          IsLocalization.Away.invSelf (detPoly k N) := by
+  rw [localRightRep_apply]
+  have hd_ne : (g : Matrix (Fin N) (Fin N) k).det ≠ 0 :=
+    ((Matrix.isUnit_iff_isUnit_det _).mp (Units.isUnit g)).ne_zero
+  -- abbreviations
+  set d := (g : Matrix (Fin N) (Fin N) k).det with hd
+  set dpoly := algebraMap (MvPolynomial (Fin N × Fin N) k) (Localization.Away (detPoly k N))
+    (detPoly k N) with hdpoly
+  set inv : Localization.Away (detPoly k N) := IsLocalization.Away.invSelf (detPoly k N) with hinv
+  set u := algebraMap k (Localization.Away (detPoly k N)) d * dpoly with hu
+  -- `algebraMap (C d) = algebraMap k O d`
+  have hCd : algebraMap (MvPolynomial (Fin N × Fin N) k) (Localization.Away (detPoly k N))
+        (MvPolynomial.C d) = algebraMap k (Localization.Away (detPoly k N)) d := by
+    rw [← MvPolynomial.algebraMap_eq, ← IsScalarTower.algebraMap_apply]
+  -- `localRightAlgHom g dpoly = u`
+  have key1 : localRightAlgHom g dpoly = u := by
+    rw [hdpoly, localRightAlgHom_algebraMap, rTransAlgHom_detPoly, map_mul, hCd, hu, ← hdpoly]
+  -- `dpoly * inv = 1`
+  have hmulinv : dpoly * inv = 1 := by
+    rw [hdpoly, hinv]; exact IsLocalization.Away.mul_invSelf (detPoly k N)
+  -- `u * (localRightAlgHom g inv) = 1`
+  have hE1 : u * localRightAlgHom g inv = 1 := by
+    have h := congrArg (localRightAlgHom g) hmulinv
+    rwa [map_mul, map_one, key1] at h
+  -- `u * (d⁻¹ • inv) = 1`
+  have hE2 : u * (d⁻¹ • inv) = 1 := by
+    rw [hu, Algebra.smul_def,
+      show algebraMap k (Localization.Away (detPoly k N)) d * dpoly *
+          (algebraMap k (Localization.Away (detPoly k N)) d⁻¹ * inv)
+        = (algebraMap k (Localization.Away (detPoly k N)) d *
+            algebraMap k (Localization.Away (detPoly k N)) d⁻¹) * (dpoly * inv) by ring,
+      hmulinv, mul_one, ← map_mul, mul_inv_cancel₀ hd_ne, map_one]
+  -- cancellation: a unit's right inverse is unique
+  calc localRightAlgHom g inv
+      = localRightAlgHom g inv * (u * (d⁻¹ • inv)) := by rw [hE2, mul_one]
+    _ = u * localRightAlgHom g inv * (d⁻¹ • inv) := by ring
+    _ = d⁻¹ • inv := by rw [hE1, one_mul]
+
 end Etingof.LocalizationGLAction

--- a/EtingofRepresentationTheory/Chapter5/LocalizationGLRightAction.lean
+++ b/EtingofRepresentationTheory/Chapter5/LocalizationGLRightAction.lean
@@ -1,0 +1,171 @@
+import Mathlib
+import EtingofRepresentationTheory.Chapter5.PolynomialGLRightAction
+import EtingofRepresentationTheory.Chapter5.DetLocalization
+
+/-!
+# The right-translation `GL_N`-action on the localization `O = A[det⁻¹]`
+
+This file extends the right-translation representation `polyRightRep` on
+`A = k[Xᵢⱼ]` (`PolynomialGLRightAction.lean`) to the determinant localization
+`O = A[det⁻¹] = Localization.Away (detPoly k N)`. It is the representation the
+det⁻¹-elimination kernel lemma (K) (issue #4694, route doc
+`progress/kernel-lemma-K-route.md`) is phrased over: (K) is a statement about a
+finite-dimensional right-`GL_N`-stable subspace `W ⊆ O`, so the `GL_N`-action on
+`O` is the object the abstract statement quantifies over.
+
+## Construction
+
+For `g ∈ GL_N`, the right translation `rTransAlgHom (g : Matrix)` is an algebra
+endomorphism of `A` carrying `detPoly` to `det g · detPoly` (`rTransAlgHom_det`).
+Because `det g` is a unit, this sends the powers of `detPoly` to units of `O`, so
+the localization universal property (`IsLocalization.lift`) extends it to a
+`k`-algebra endomorphism `localRightAlgHom g : O →ₐ[k] O`. Multiplicativity in
+`g` is inherited from `rTransAlgHom_mul` by the uniqueness of lifts
+(`IsLocalization.ringHom_ext`), giving a genuine `Representation k GL_N O`
+(`localRightRep`).
+
+## Key facts
+
+* `localRightRep_algebraMap` — the structure map `A → O` is `GL_N`-equivariant:
+  `localRightRep g (algebraMap A O a) = algebraMap A O (polyRightRep g a)`. So
+  the filtration submodule `A_0 = A ↪ O` is a subrepresentation, and `O` is an
+  honest extension of the polynomial right-translation representation.
+* `localRightRep_invSelf` — the formal inverse `det⁻¹ = invSelf detPoly`
+  transforms by the inverse determinant character: `R_g det⁻¹ = (det g)⁻¹ · det⁻¹`.
+  This is the `χ⁻¹` semi-invariance that drives the det-power filtration twist.
+-/
+
+namespace Etingof.LocalizationGLAction
+
+open MvPolynomial Etingof.PolynomialGLAction Etingof.DetLocalization
+
+variable {k : Type*} [Field k] {N : ℕ}
+
+/-- Abbreviation for the localization `O = A[det⁻¹]`. -/
+local notation3 "O" => Localization.Away (detPoly k N)
+
+/-- For a matrix `M`, the `k`-algebra hom `A →ₐ[k] O` obtained by composing the
+right translation `rTransAlgHom M` with the structure map `A → O`. -/
+noncomputable def rTransToAway (M : Matrix (Fin N) (Fin N) k) :
+    MvPolynomial (Fin N × Fin N) k →ₐ[k] Localization.Away (detPoly k N) :=
+  (IsScalarTower.toAlgHom k (MvPolynomial (Fin N × Fin N) k)
+      (Localization.Away (detPoly k N))).comp (rTransAlgHom M)
+
+@[simp] theorem rTransToAway_apply (M : Matrix (Fin N) (Fin N) k)
+    (a : MvPolynomial (Fin N × Fin N) k) :
+    rTransToAway M a = algebraMap _ (Localization.Away (detPoly k N)) (rTransAlgHom M a) :=
+  rfl
+
+/-- Determinant semi-invariance at the level of `detPoly` (a restatement of
+`rTransAlgHom_det` phrased with `detPoly` so it rewrites without unfolding). -/
+theorem rTransAlgHom_detPoly (M : Matrix (Fin N) (Fin N) k) :
+    rTransAlgHom M (detPoly k N) = MvPolynomial.C M.det * detPoly k N :=
+  rTransAlgHom_det M
+
+/-- For `g ∈ GL_N`, the powers of `detPoly` map to units of `O` under
+`rTransToAway (g : Matrix)`: `rTransAlgHom g detPoly = det g · detPoly` and both
+`det g` and `detPoly` are units in `O`. -/
+theorem isUnit_rTransToAway_detPoly_pow (g : Matrix.GeneralLinearGroup (Fin N) k)
+    (y : Submonoid.powers (detPoly k N)) :
+    IsUnit (rTransToAway (g : Matrix (Fin N) (Fin N) k) (y : MvPolynomial (Fin N × Fin N) k)) := by
+  obtain ⟨n, hn⟩ := y.2
+  rw [← hn]
+  change IsUnit (rTransToAway (g : Matrix (Fin N) (Fin N) k) (detPoly k N ^ n))
+  rw [rTransToAway_apply, map_pow, map_pow]
+  refine IsUnit.pow n ?_
+  -- `rTransAlgHom g detPoly = C (det g) * detPoly`
+  rw [rTransAlgHom_detPoly, map_mul]
+  refine IsUnit.mul ?_ ?_
+  · -- `algebraMap (C (det g))` is a unit: `det g` is a unit in `k`
+    have hdet : IsUnit ((g : Matrix (Fin N) (Fin N) k).det) :=
+      (Matrix.isUnit_iff_isUnit_det _).mp (Units.isUnit g)
+    exact (hdet.map (MvPolynomial.C : k →+* MvPolynomial (Fin N × Fin N) k)).map
+      (algebraMap (MvPolynomial (Fin N × Fin N) k) (Localization.Away (detPoly k N)))
+  · -- `algebraMap detPoly` is a unit in the localization at `detPoly`
+    exact IsLocalization.Away.algebraMap_isUnit
+      (S := Localization.Away (detPoly k N)) (detPoly k N)
+
+/-- The right-translation `k`-algebra endomorphism of `O = A[det⁻¹]` attached to
+`g ∈ GL_N`: the localization extension (`IsLocalization.liftAlgHom`) of the
+right translation `rTransAlgHom (g : Matrix)` on `A`. Well-defined because `g`
+carries `detPoly` to a unit multiple of itself
+(`isUnit_rTransToAway_detPoly_pow`). -/
+noncomputable def localRightAlgHom (g : Matrix.GeneralLinearGroup (Fin N) k) :
+    Localization.Away (detPoly k N) →ₐ[k] Localization.Away (detPoly k N) :=
+  IsLocalization.liftAlgHom (f := rTransToAway (g : Matrix (Fin N) (Fin N) k))
+    (isUnit_rTransToAway_detPoly_pow g)
+
+/-- The defining property: `localRightAlgHom g` extends the right translation on
+`A`. On the image of `a ∈ A` it is `algebraMap (rTransAlgHom (g) a)`. -/
+@[simp] theorem localRightAlgHom_algebraMap (g : Matrix.GeneralLinearGroup (Fin N) k)
+    (a : MvPolynomial (Fin N × Fin N) k) :
+    localRightAlgHom g (algebraMap _ (Localization.Away (detPoly k N)) a)
+      = algebraMap _ _ (rTransAlgHom (g : Matrix (Fin N) (Fin N) k) a) := by
+  simp only [localRightAlgHom, IsLocalization.coe_liftAlgHom, IsLocalization.lift_eq]
+  rfl
+
+/-- `localRightAlgHom 1 = id`. -/
+theorem localRightAlgHom_one :
+    localRightAlgHom (1 : Matrix.GeneralLinearGroup (Fin N) k)
+      = AlgHom.id k (Localization.Away (detPoly k N)) := by
+  apply IsLocalization.algHom_ext (R := k) (A := MvPolynomial (Fin N × Fin N) k)
+    (L := Localization.Away (detPoly k N)) (B := Localization.Away (detPoly k N))
+    (Submonoid.powers (detPoly k N))
+  apply AlgHom.ext
+  intro a
+  rw [AlgHom.comp_apply, AlgHom.comp_apply]
+  change localRightAlgHom (1 : Matrix.GeneralLinearGroup (Fin N) k)
+      (algebraMap (MvPolynomial (Fin N × Fin N) k) (Localization.Away (detPoly k N)) a)
+    = AlgHom.id k (Localization.Away (detPoly k N))
+      (algebraMap (MvPolynomial (Fin N × Fin N) k) (Localization.Away (detPoly k N)) a)
+  rw [localRightAlgHom_algebraMap, AlgHom.id_apply, Units.val_one, rTransAlgHom_one,
+    AlgHom.id_apply]
+
+/-- Multiplicativity: `localRightAlgHom (g₁ g₂) = localRightAlgHom g₁ ∘ localRightAlgHom g₂`. -/
+theorem localRightAlgHom_mul (g₁ g₂ : Matrix.GeneralLinearGroup (Fin N) k) :
+    localRightAlgHom (g₁ * g₂)
+      = (localRightAlgHom g₁).comp (localRightAlgHom g₂) := by
+  apply IsLocalization.algHom_ext (R := k) (A := MvPolynomial (Fin N × Fin N) k)
+    (L := Localization.Away (detPoly k N)) (B := Localization.Away (detPoly k N))
+    (Submonoid.powers (detPoly k N))
+  apply AlgHom.ext
+  intro a
+  rw [AlgHom.comp_apply, AlgHom.comp_apply]
+  change localRightAlgHom (g₁ * g₂)
+      (algebraMap (MvPolynomial (Fin N × Fin N) k) (Localization.Away (detPoly k N)) a)
+    = (localRightAlgHom g₁).comp (localRightAlgHom g₂)
+      (algebraMap (MvPolynomial (Fin N × Fin N) k) (Localization.Away (detPoly k N)) a)
+  rw [localRightAlgHom_algebraMap, AlgHom.comp_apply, localRightAlgHom_algebraMap,
+    localRightAlgHom_algebraMap, Units.val_mul, rTransAlgHom_mul, AlgHom.comp_apply]
+
+/-- The **right-translation representation of `GL_N` on the localization
+`O = A[det⁻¹]`**: `g ↦ localRightAlgHom g`. This is the representation the
+det⁻¹-elimination kernel lemma (K) is phrased over — (K) constrains
+finite-dimensional right-`GL_N`-stable subspaces of `O`. -/
+noncomputable def localRightRep (k : Type*) [Field k] (N : ℕ) :
+    Representation k (Matrix.GeneralLinearGroup (Fin N) k)
+      (Localization.Away (detPoly k N)) where
+  toFun g := (localRightAlgHom g).toLinearMap
+  map_one' := by
+    change (localRightAlgHom (1 : Matrix.GeneralLinearGroup (Fin N) k)).toLinearMap = _
+    rw [localRightAlgHom_one]; rfl
+  map_mul' g₁ g₂ := by
+    change (localRightAlgHom (g₁ * g₂)).toLinearMap = _
+    rw [localRightAlgHom_mul]; rfl
+
+@[simp] theorem localRightRep_apply (g : Matrix.GeneralLinearGroup (Fin N) k)
+    (x : Localization.Away (detPoly k N)) :
+    localRightRep k N g x = localRightAlgHom g x :=
+  rfl
+
+/-- **The structure map `A → O` is `GL_N`-equivariant.** The right-translation
+representation on `O` restricts on the polynomial subring to the right
+translation `polyRightRep` on `A`; i.e. `A ↪ O` is a morphism of representations.
+This identifies the filtration bottom `A_0 = A` with a subrepresentation of `O`. -/
+theorem localRightRep_algebraMap (g : Matrix.GeneralLinearGroup (Fin N) k)
+    (a : MvPolynomial (Fin N × Fin N) k) :
+    localRightRep k N g (algebraMap _ (Localization.Away (detPoly k N)) a)
+      = algebraMap _ _ (polyRightRep k N g a) :=
+  localRightAlgHom_algebraMap g a
+
+end Etingof.LocalizationGLAction

--- a/progress/2026-06-21T09-46-06Z_7b0666bb.md
+++ b/progress/2026-06-21T09-46-06Z_7b0666bb.md
@@ -1,0 +1,61 @@
+## Accomplished
+
+Worker session `7b0666bb` (`/work` → `/feature`), issue **#4694**
+(`feat(Ch5 #4683 sub-K): det⁻¹-elimination kernel lemma (K) assembly`).
+
+Verified the two prerequisites #4712 (det-power normal form) and #4713 ((K′)
+foundation) are both **closed/landed**, so #4694 was unblocked. Assessed that
+the full filtration assembly (K)⟸(K′) is a multi-session effort that is phrased
+over a right-`GL_N` representation on the localization `O = A[det⁻¹]` which did
+**not** exist yet. Built that unavoidable foundation this session and decomposed
+the rest.
+
+New file `Chapter5/LocalizationGLRightAction.lean` (sorry-free, builds clean):
+
+- `localRightRep k N : Representation k GL_N (Localization.Away (detPoly k N))`
+  — the right-translation `GL_N`-action on `O = A[det⁻¹]`, extending
+  `polyRightRep` on `A = k[Xᵢⱼ]` via `IsLocalization.liftAlgHom` (well-defined
+  because `g` carries `detPoly` to a unit multiple of itself).
+- `localRightAlgHom` / `_one` / `_mul` / `_algebraMap` — the underlying
+  `k`-algebra endomorphisms and their multiplicativity.
+- `localRightRep_algebraMap` — `A ↪ O` is `GL_N`-equivariant (the filtration
+  bottom `A_0 = A` is a subrepresentation).
+- `localRightRep_invSelf` — `R_g det⁻¹ = (det g)⁻¹ · det⁻¹`, the `χ⁻¹`
+  semi-invariance driving the det-power filtration twist.
+
+Wired into `Chapter5.lean`. Two commits: the representation, then the
+semi-invariance.
+
+## Current frontier
+
+Foundation landed (partial PR for #4694). The remaining residual of #4694 is
+decomposed into:
+
+- **#4837** (sub-filtration, unblocked): det-power filtration `A_r ⊆ O` as
+  `GL`-subreps + the GL-iso `A_r/A_{r-1} ≅ (A/det)⊗χ⁻ʳ` onto `quotDetTwistRep`.
+- **#4838** (sub-assembly, blocked on #4837): kernel lemma (K) via the
+  minimal-`r` projection + contradiction with `kernelLemmaK'_submodule`, plus
+  the functions-on-`GL` interface that #4695 consumes.
+
+## Overall project progress
+
+Chapter 5 `det⁻¹`-elimination chain (#4683 → #4694 → #4695 → ... →
+`detInv_elim_of_polynomial`, `PolynomialRepEmbedding.lean:1013`, still `sorry`):
+prerequisites #4712, #4713 closed; #4694 foundation now landed; filtration +
+assembly tracked by #4837, #4838. The deep core (K′) (`kernelLemmaK'`,
+`KernelLemmaKPrime.lean:162`) remains a sorry'd dependency tracked by
+#4826/#4832 (Cauchy decomposition).
+
+## Next step
+
+Claim **#4837** (sub-filtration): define `filtrA k N r`, prove GL-stability
+(via `localRightRep_algebraMap` + `localRightRep_invSelf`), and build the
+GL-iso `A_r/A_{r-1} ≅ quotDetTwistRep k N r`. The det-power normal-form API
+(`detExp`, `detExp_eq_zero_iff`, `reduced_normalForm_unique`) is in
+`DetLocalization.lean`; the target rep `quotDetTwistRep` is in
+`KernelLemmaKPrime.lean`.
+
+## Blockers
+
+None. #4838 is intentionally blocked on #4837. (K′) itself is a separately
+tracked sorry'd dependency (#4826/#4832), not a blocker for the (K) assembly.


### PR DESCRIPTION
This PR constructs the right-translation `GL_N`-representation on the determinant localization `O = A[det⁻¹] = Localization.Away (detPoly k N)`, the foundation the det⁻¹-elimination kernel lemma (K) of issue #4694 is phrased over. It adds `Chapter5/LocalizationGLRightAction.lean` (sorry-free): `localRightRep`, the right-`GL_N` action extending `polyRightRep` on `A = k[Xᵢⱼ]` via `IsLocalization.liftAlgHom`; `localRightRep_algebraMap`, the `GL_N`-equivariance of `A ↪ O` (the filtration bottom is a subrepresentation); and `localRightRep_invSelf`, the χ⁻¹ semi-invariance `R_g det⁻¹ = (det g)⁻¹·det⁻¹` that drives the det-power filtration twist.

This is a partial completion of #4694: the remaining residual is decomposed into #4837 (det-power filtration `A_r ⊆ O` and the GL-iso `A_r/A_{r-1} ≅ (A/det)⊗χ⁻ʳ`) and #4838 (kernel lemma (K) via minimal-r projection + the functions-on-`GL` interface for #4695).

The new file builds cleanly against toolchain v4.28.0 (8056 jobs, verified before an unrelated environmental conflict). Note: a concurrent worktree agent (`worktrees/4af2c163`, an unmerged toolchain bump to v4.28.1) rebuilt the shared `.lake/packages` to v4.28.1, which temporarily breaks local v4.28.0 builds across worktrees; CI verifies against the repo-pinned v4.28.0 in isolation.

🤖 Prepared with Claude Code