### PR TITLE
fix(Ch5 #4832): correct kernelLemmaK' — was false, restate over GL-invariant subreps

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/KernelLemmaKPrime.lean
+++ b/EtingofRepresentationTheory/Chapter5/KernelLemmaKPrime.lean
@@ -30,13 +30,21 @@ det⁻¹-elimination kernel lemma (K) (issue #4694, route doc
 
 ## The statement
 
-`kernelLemmaK'` : for `r ≥ 1` the supremum of all **nonnegative**-weight spaces
-of `(A/det) ⊗ χ⁻ʳ` is `⊥`. Equivalently (`kernelLemmaK'_submodule`), every
-right-`GL_N`-submodule all of whose torus weights lie in `ℕ^N` is `⊥`.
+`kernelLemmaK'` : for `r ≥ 1`, every right-`GL_N`-**subrepresentation** `W` of
+`(A/det) ⊗ χ⁻ʳ` all of whose torus weights lie in `ℕ^N` is `⊥`. The consumable
+corollary `kernelLemmaK'_submodule` rephrases this for an explicitly
+`GL_N`-invariant submodule.
 
 This is the form the #4694 det-power-filtration assembly consumes: the assembly
-produces a *nonzero* nonneg-weight submodule `W̄ ⊆ (A/det) ⊗ χ⁻ʳ`, and (K′)
-contradicts it.
+produces a *nonzero* nonneg-weight invariant submodule `W̄ ⊆ (A/det) ⊗ χ⁻ʳ`, and
+(K′) contradicts it.
+
+**Statement correction (issue #4847).** An earlier phrasing — "the supremum of
+all nonneg-weight *spaces* of `(A/det) ⊗ χ⁻ʳ` is `⊥`" — is **false**: a single
+nonneg-weight vector (e.g. the class of `X₁₁X₂₂`, weight `(0,0)` after the `χ⁻¹`
+twist) exists inside an irreducible whose `GL_N`-orbit also realizes negative
+weights. `GL_N`-invariance of `W` is essential and cannot be dropped; see the
+`kernelLemmaK'` docstring.
 
 ## Status
 
@@ -149,32 +157,60 @@ noncomputable def glWeightSpaceℤ (k : Type*) [Field k] (N : ℕ) {V : Type*}
 
 /-! ### The kernel lemma (K′) -/
 
-/-- **Kernel lemma (K′).** For `r ≥ 1`, the supremum of all *nonnegative*-weight
-spaces of the twisted quotient representation `(A/det) ⊗ χ⁻ʳ` is `⊥`: it has no
-nonzero vector whose right-torus weight lies in `ℕ^N`.
+/-- **Kernel lemma (K′).** For `r ≥ 1`, every right-`GL_N`-**subrepresentation**
+`W` of the twisted quotient `(A/det) ⊗ χ⁻ʳ` all of whose right-torus weights are
+nonnegative (`W.toSubmodule` is contained in the span of the `ℕ^N`-weight spaces)
+is `⊥`.
 
-The mathematics: by the `GL×GL`-equivariant Cauchy decomposition every
-irreducible constituent of `A/det = k[Xᵢⱼ]/(det)` has last highest-weight
-coordinate `ν_N = 0`; twisting by `χ⁻ʳ` (weight `(−r,…,−r)`) makes the last
-coordinate `ν_N − r = −r < 0`, so no weight is `≥ 0`. This Cauchy-decomposition
-core is tracked as a research-level residual `sorry` (follow-up sub-issue of
-#4826); the statement and all the objects it quantifies over are in place. -/
+The mathematics: by complete reducibility (`Theorem5_23_2_i`) `W` decomposes into
+irreducibles, each — having all weights `≥ 0` — a *polynomial* irrep with highest
+weight `ν ∈ ℕ^N` (lowest-weight theory). But by the `GL×GL`-equivariant Cauchy
+decomposition every irreducible constituent of `A/det = k[Xᵢⱼ]/(det)` has last
+highest-weight coordinate `ν_N = 0`; twisting by `χ⁻ʳ` (weight `(−r,…,−r)`) makes
+the last coordinate `ν_N − r = −r < 0`, contradicting `ν ≥ 0`. So `W = ⊥`. This
+Cauchy-decomposition core is tracked as a research-level residual `sorry`
+(follow-up sub-issue of #4826); the statement and all the objects it quantifies
+over are in place.
+
+**Statement correction (issue #4847).** The earlier phrasing of (K′) — "the
+supremum of all nonneg-weight *spaces* of `(A/det) ⊗ χ⁻ʳ` is `⊥`" — is **false**.
+For `N = 2, r = 1` the class of `X₁₁X₂₂` in `A/det` is nonzero (`X₁₁X₂₂ ∉ (det)`)
+with right-torus weight the column-sum `(1,1)`, which the `χ⁻¹` twist shifts to
+`(0,0) ≥ 0`; so it is a nonzero vector of `glWeightSpaceℤ … (0,0)` and the
+supremum of nonneg-weight spaces is **not** `⊥`. A single nonneg-weight *vector*
+may sit inside an irreducible whose full `GL_N`-orbit also realizes negative
+weights — `GL_N`-invariance of `W` is exactly what makes the highest-weight bound
+apply, and it cannot be dropped. The genuine (K′) is therefore about invariant
+subrepresentations, as stated here. -/
 theorem kernelLemmaK' (k : Type*) [Field k] [IsAlgClosed k] [CharZero k] (N : ℕ)
-    (r : ℕ) (hr : 1 ≤ r) :
-    (⨆ (μ : Fin N → ℕ), glWeightSpaceℤ k N (quotDetTwistRep k N r)
-      (fun i => (μ i : ℤ))) = ⊥ := by
+    (r : ℕ) (hr : 1 ≤ r) (W : Subrepresentation (quotDetTwistRep k N r))
+    (hW : W.toSubmodule ≤ ⨆ (μ : Fin N → ℕ),
+      glWeightSpaceℤ k N (quotDetTwistRep k N r) (fun i => (μ i : ℤ))) :
+    W = ⊥ := by
   sorry
 
-/-- Consumable form of (K′): every submodule of `(A/det) ⊗ χ⁻ʳ` all of whose
-torus weights lie in `ℕ^N` (i.e. contained in the supremum of nonneg-weight
-spaces) is `⊥`. This is what the #4694 det-power-filtration assembly contradicts:
-it produces a *nonzero* such submodule. -/
+/-- Consumable form of (K′): every `GL_N`-**invariant** submodule of
+`(A/det) ⊗ χ⁻ʳ` all of whose torus weights lie in `ℕ^N` (i.e. contained in the
+supremum of nonneg-weight spaces) is `⊥`. This is what the #4694 det-power-
+filtration assembly contradicts: it produces a *nonzero* such invariant submodule
+(the image of a nonneg-weight subrep under the equivariant subquotient iso).
+
+The `GL_N`-invariance hypothesis `hW_inv` is essential — without it the statement
+is false (see the note on `kernelLemmaK'`). -/
 theorem kernelLemmaK'_submodule (k : Type*) [Field k] [IsAlgClosed k] [CharZero k]
     (N : ℕ) (r : ℕ) (hr : 1 ≤ r)
     {W : Submodule k (MvPolynomial (Fin N × Fin N) k ⧸ detSubmodule k N)}
+    (hW_inv : ∀ (g : Matrix.GeneralLinearGroup (Fin N) k),
+      ∀ w ∈ W, quotDetTwistRep k N r g w ∈ W)
     (hW : W ≤ ⨆ (μ : Fin N → ℕ),
       glWeightSpaceℤ k N (quotDetTwistRep k N r) (fun i => (μ i : ℤ))) :
-    W = ⊥ :=
-  le_bot_iff.mp (le_of_le_of_eq hW (kernelLemmaK' k N r hr))
+    W = ⊥ := by
+  -- Package `W` as a subrepresentation and apply `kernelLemmaK'`.
+  let W' : Subrepresentation (quotDetTwistRep k N r) :=
+    ⟨W, fun g _ hw => hW_inv g _ hw⟩
+  have hW'bot : W' = ⊥ := kernelLemmaK' k N r hr W' hW
+  have : W'.toSubmodule = (⊥ : Subrepresentation (quotDetTwistRep k N r)).toSubmodule :=
+    congrArg Subrepresentation.toSubmodule hW'bot
+  simpa [W'] using this
 
 end Etingof.KernelLemmaKPrime

--- a/progress/2026-06-21T11-03-58Z_08b86ddc.md
+++ b/progress/2026-06-21T11-03-58Z_08b86ddc.md
@@ -1,0 +1,72 @@
+## Accomplished
+
+Worked #4832 (Ch5: prove `kernelLemmaK'`). **The deliverable statement was found
+to be mathematically false** and has been corrected in place (new issue #4847
+records the bug).
+
+The false statement (landed by #4826, `Chapter5/KernelLemmaKPrime.lean`):
+
+```lean
+theorem kernelLemmaK' … (r : ℕ) (hr : 1 ≤ r) :
+    (⨆ (μ : Fin N → ℕ), glWeightSpaceℤ k N (quotDetTwistRep k N r) (fun i => (μ i : ℤ))) = ⊥
+```
+
+"the span of all nonneg-weight *spaces* of `(A/det) ⊗ χ⁻ʳ` is `⊥`."
+
+**Counterexample (N=2, r=1):** `[X₁₁X₂₂] ∈ A/det` is nonzero (`X₁₁X₂₂ ∉ (det)`),
+right-torus weight = column-sum `(1,1)`, which the `χ⁻¹` twist shifts to
+`(0,0) ≥ 0`. So `glWeightSpaceℤ … (0,0) ≠ ⊥` and the supremum is not `⊥`. The
+old corollary `kernelLemmaK'_submodule` quantified over an arbitrary `k`-submodule
+(no `GL`-invariance), so it was equally false. Both confirmed by OpenAI Codex.
+
+**Root cause:** genuine (K′) is about `GL_N`-**invariant** subspaces. A single
+nonneg-weight vector can live in an irreducible whose `GL_N`-orbit realizes
+negative weights; invariance is what makes complete reducibility + the
+highest-weight bound `ν_N = 0` apply. The route doc
+`progress/kernel-lemma-K-route.md` always stated (K′) correctly (with
+"submodule" = invariant); only the Lean formalization dropped invariance.
+
+**The fix (this PR):**
+- `kernelLemmaK'` now takes a `Subrepresentation (quotDetTwistRep k N r)` whose
+  `toSubmodule ≤ ⨆ (nonneg weight spaces)`, concluding `W = ⊥`. The deep
+  Cauchy-decomposition core remains the single residual `sorry` — now sitting on
+  a **true** statement.
+- `kernelLemmaK'_submodule` now takes an explicit `GL_N`-invariance hypothesis
+  `hW_inv` and is **sorry-free** (packaged as a `Subrepresentation` and fed to
+  the headline).
+- Docstrings + module header + route doc note the correction and reference #4847.
+
+`lake build EtingofRepresentationTheory.Chapter5.KernelLemmaKPrime` passes (8056
+jobs); the only sorry is `kernelLemmaK'` (line 185, the deep core).
+
+## Current frontier
+
+`KernelLemmaKPrime.lean` now correctly states (K′). The genuine
+Cauchy-decomposition core is unchanged and still open. No in-repo consumer
+referenced the old statement (the #4694 det-power-filtration assembly is not yet
+built), so the correction is non-breaking.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. The det⁻¹-elimination kernel-lemma sub-project
+(#4683 → #4694 → #4826 → #4832) now has a correctly-stated (K′). The deep core
+(equivariant Cauchy decomposition + `det·A ≅ A⊗χ` highest-weight shift) remains
+the research-level gap, plus the #4694 det-power-filtration assembly that will
+consume `kernelLemmaK'_submodule` (supplying `hW_inv` from
+`localRightRep_mem_filtrA` / `filtrQuotEquiv_equivariant`).
+
+## Next step
+
+Prove the deep core of `kernelLemmaK'`: every irreducible constituent of
+`k[Xᵢⱼ]/(det)` has highest weight with `ν_N = 0`, via the `GL×GL`-equivariant
+Cauchy decomposition + the `det·A ≅ A⊗χ` shift, then apply complete reducibility
+(`Theorem5_23_2_i`) + lowest-weight theory (all weights `≥ 0` ⟺ polynomial irrep,
+`ν ∈ ℕ^N`). This needs the equivariant-Cauchy / highest-weight infrastructure
+flagged in `progress/kernel-lemma-K-route.md` (§"Missing infrastructure") — a
+multi-issue effort; expect to decompose further before attempting.
+
+## Blockers
+
+The deep core of `kernelLemmaK'` needs the `GL×GL`-equivariant Cauchy
+decomposition and `GL_N` highest-weight theory, neither in the repo nor Mathlib
+(see route doc). Not a blocker for the statement fix delivered here.

--- a/progress/kernel-lemma-K-route.md
+++ b/progress/kernel-lemma-K-route.md
@@ -58,6 +58,14 @@ The reduction is finished by:
 
 `(K′)` contradicts `W̄ ≠ 0`; hence `W ⊆ A`. ∎ (reduction)
 
+> **NB (issue #4847).** The word **submodule** here means *`GL_N`-invariant*
+> submodule — this is essential. The first Lean formalization of (K′)
+> (`KernelLemmaKPrime.lean`, landed by #4826) mistakenly phrased it as "the span
+> of all nonneg-weight *spaces* is `⊥`" (and a corollary over an arbitrary
+> `k`-submodule), dropping invariance; that is **false** (e.g. `[X₁₁X₂₂]` is a
+> nonzero weight-`(0,0)` vector of `(A/det) ⊗ χ⁻¹`). The Lean statement was
+> corrected to the `Subrepresentation` form to match this route doc.
+
 ## Why the torus alone is insufficient (explicit, confirms the route doc)
 
 Right-multiplying by the full diagonal torus `diag(z₁,…,z_N)` and using


### PR DESCRIPTION
Closes #4832

Session: `08b86ddc-9b6d-40c9-9da6-1bdc18b0e976`

a747bd79 fix(Ch5 #4832): correct kernelLemmaK' — was false, restate over GL-invariant subreps (#4847)

🤖 Prepared with Claude Code