### PR TITLE
doc(skill): verify cited 'already-landed' deps exist before building on them

### DIFF
--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -149,6 +149,17 @@ Check that the plan's assumptions still hold:
 - Quality metrics match what the issue says
 - Files mentioned in the issue still exist and haven't been restructured
 - No recently merged PR invalidates the plan
+- **Cited "already-landed" dependencies actually exist.** Planner issue bodies
+  drift from reality — an issue can claim a prerequisite "Part 1 landed
+  (file `X.lean`, lemmas `foo`/`bar`)" when no such file or declaration was
+  ever merged. Before building on any such claim, `find`/`grep` for the named
+  files and declarations. If they are absent, the issue is mis-scoped: check
+  whether its real deliverable duplicates a *still-open* sibling/parent issue
+  (the "Part 1/Part 2" split may be a planner artifact). If so, `skip` →
+  replan with a comment naming the duplicate and recommending consolidation,
+  rather than re-deriving the phantom prerequisite. (Observed on #4849, whose
+  cited Part 1 `SchurWeylLDistinct.lean` never existed and whose real core
+  duplicated the open #4731.)
 
 If stale:
 ```

--- a/progress/20260621T111754Z_ae4f1ddb.md
+++ b/progress/20260621T111754Z_ae4f1ddb.md
@@ -1,0 +1,76 @@
+## Accomplished
+
+`/work` → `/feature` session `ae4f1ddb`. Claimed **#4849** (Ch5 "#4731 Part 2":
+B-side/C-side distinctness wired into `glTensorRep_equivariant_schurWeyl_decomposition`),
+then **skipped it (→ replan)** after a verification pass showed the issue is
+mis-scoped.
+
+Findings (posted to #4849 as a reconciliation comment + skip reason):
+
+- **The cited "Part 1" does not exist.** #4849's body claims Part 1 "landed" as
+  `Chapter5/SchurWeylLDistinct.lean` with `homACentralizerLinearEquivOfUnitTensorPowIntertwine`,
+  `homA_centralizer_smul_comm_of_unitTensorPow_intertwine`, `unitTensorPowCentralizer`.
+  None of these files/declarations exist (`find`/`grep` both empty). So
+  deliverables (2) "apply Part 1" and (3) "wire it in" are impossible as written.
+- **#4849 duplicates the still-open #4731.** #4731's *current* body targets the
+  identical core — "C-side distinctness of the hom-spaces, which
+  `Theorem5_18_4_bimodule_decomposition_explicit` does not surface" — i.e. exactly
+  #4849's deliverable (1). The "Part 1 / Part 2" split was a planner artifact.
+- **#4731's claim is dead:** no remote branch for any of its claiming sessions
+  (`acbdc777/acbc3e1b/7a7f4f1f/94b8e9de`), no open PR, and its comment log records
+  those worker sessions dying. `release-stale-claims` did not free it (under the
+  age threshold), so it still shows "claimed" in `orient`.
+
+No Lean changed (working tree clean; no PR).
+
+## Current frontier
+
+The real, independent deliverable behind both #4731 and #4849 is **C-side
+distinctness** of the multiplicity spaces `M_i := ↥(S i) →ₗ[A] E`
+(`A = symGroupImage k V n`, `C = centralizer(A) = diagonalActionImage`,
+`E = V^{⊗n}`): `Nonempty (M_i ≃ₗ[C] M_j) → i = j`, over the objects of
+`Theorem5_18_4_bimodule_decomposition_explicit` (`Theorem5_18_4.lean:464`, which
+already gives A-side `hS'_dist` and C-side `homA_simp`).
+
+Concrete route (in the #4849 comment): an abstract **symmetric** lemma
+`multiplicitySpace_distinct_of_symmetric` mirroring the A-side mechanism at
+`Theorem5_18_1.lean:971-978`, whose genuine Tier-4 core is the isolatable
+**biduality reflexivity** A-iso `V_i ≃ₗ[A] Hom_C(Hom_A(V_i,E), E)` (natural
+evaluation `v ↦ (f ↦ f v)`, iso by the double centralizer). Verified-present
+infrastructure: `Theorem5_18_1_double_centralizer` (`:226`),
+`Theorem5_18_4_centralizers` (`:268`), `Theorem5_18_4_semisimple` (`:296`),
+`isSimpleModule_homA_centralizer` (`:619`), `schurEvaluationEquiv`,
+`homIsotypicBridge`. This is a multi-session crux (~100+ lines for the
+reflexivity alone); decompose the reflexivity sub-lemma out first.
+
+## Overall project progress
+
+Etingof draft 1, Stage 3, Ch5 Schur-Weyl backbone. The #2483 route's last
+`sorryAx` is `schurWeyl_simples_formalCharacter_classification_core`
+(`SchurWeylSimplesClassification.lean:132`), which consumes `hLdist`
+(GL-side distinctness) as a hypothesis. Supplying `hLdist` reduces to the C-side
+distinctness above. Unclaimed feature queue after this turn: #4821 (Ch5 #4732
+sub-β, route-3 base-change crux — planner already flagged for decomposition),
+#2564 / #2841 (Mathlib-upstream trackers, both **externally blocked** on open
+Mathlib PRs awaiting merge). Ch6 directive #4777's only remaining sub-issue (S4
+#4786) is claimed.
+
+## Next step
+
+Planner action: **consolidate #4849 into #4731** (close #4849 as duplicate or
+fold it in), **release #4731's stale/dead claim**, and have one issue carry the
+C-side-distinctness work, decomposed as: (a) the biduality reflexivity A-iso
+sub-lemma, (b) the abstract `multiplicitySpace_distinct_of_symmetric` assembly,
+(c) the `glTensorRep_equivariant_schurWeyl_decomposition` `..._classified` sibling
+threading `Pairwise (¬ Nonempty (L i ≅ L j))` into the #4821/#4699 consumer.
+
+A worker wanting concrete Lean now should take **#4821** but follow the planner
+triage there and DECOMPOSE (route-3 base-change + the ℂ-side `|ι|=|P|` count),
+not attempt it whole.
+
+## Blockers
+
+- #4849: skipped/replan (false premise + duplicate of #4731). No code blocker.
+- #4731: stale "claimed" with a dead session; needs a manual claim release before
+  a live worker can take it.
+- #2564 / #2841: externally blocked on Mathlib PR merges.


### PR DESCRIPTION
This PR adds a worker-flow Step-4 assumption check: before building on an issue's claim that a prerequisite has already landed, find/grep for the cited files and declarations, and skip→replan with a consolidation note when they are phantom.

Surfaced while executing #4849, whose body claimed a Part 1 had landed (`SchurWeylLDistinct.lean` plus named lemmas `homACentralizerLinearEquivOfUnitTensorPowIntertwine` etc.) that never existed; the real deliverable (C-side distinctness of the Schur-Weyl multiplicity spaces) duplicated the still-open #4731. #4849 was skipped → replan with a reconciliation comment and concrete proof route. No project Lean changed.

🤖 Prepared with Claude Code