### PR TITLE
feat(Ch5 #4695 sub-K): glWeightSpaceℤ functoriality + det-power filtration step toward kernel lemma (K)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5.lean
+++ b/EtingofRepresentationTheory/Chapter5.lean
@@ -91,6 +91,7 @@ import EtingofRepresentationTheory.Chapter5.PolynomialGLRightAction
 import EtingofRepresentationTheory.Chapter5.LocalizationGLRightAction
 import EtingofRepresentationTheory.Chapter5.KernelLemmaKPrime
 import EtingofRepresentationTheory.Chapter5.DetPowerFiltration
+import EtingofRepresentationTheory.Chapter5.KernelLemmaK
 
 -- Section 5.19: Schur-Weyl Duality and Schur Functors
 import EtingofRepresentationTheory.Chapter5.Proposition5_19_1

--- a/EtingofRepresentationTheory/Chapter5/KernelLemmaK.lean
+++ b/EtingofRepresentationTheory/Chapter5/KernelLemmaK.lean
@@ -81,4 +81,44 @@ theorem glWeightSpaceℤ_iSup_map_le {V W : Type*}
   rw [Submodule.map_iSup]
   exact iSup_mono fun i => glWeightSpaceℤ_map_le ρV ρW φ hφ (μs i)
 
+/-! ### One filtration step against (K′) -/
+
+open Etingof.DetPowerFiltration Etingof.DetLocalization
+
+variable [IsAlgClosed k] [CharZero k]
+
+/-- **One descent step of the det-power filtration.** Let `W ⊆ A_r` be a submodule
+of `O` (`r ≥ 1`) whose image under the subquotient map `filtrToQuot k N r` is a
+*nonnegative-weight* submodule of `(A/det) ⊗ χ⁻ʳ`. Then (K′)
+(`kernelLemmaK'_submodule`) forces that image to be `⊥`, i.e. `filtrToQuot` kills
+`W`; equivalently `W ⊆ A_{r-1}`.
+
+This is the sorry-free contradiction half of the filtration descent. Supplying
+the image-nonnegativity hypothesis from nonnegativity of `W` itself is the
+remaining ingredient (torus-semisimplicity of `O`), tracked separately. -/
+theorem kernelLemmaK_step (r : ℕ) (hr : 1 ≤ r)
+    {W : Submodule k (Localization.Away (detPoly k N))}
+    (hWr : W ≤ filtrA k N r)
+    (hWnn : Submodule.map (filtrToQuot k N r) (W.comap (filtrA k N r).subtype) ≤
+      ⨆ (μ : Fin N → ℕ), glWeightSpaceℤ k N (quotDetTwistRep k N r) (fun i => (μ i : ℤ))) :
+    W ≤ filtrA k N (r - 1) := by
+  -- (K′) collapses the image to `⊥`.
+  have hbot : Submodule.map (filtrToQuot k N r) (W.comap (filtrA k N r).subtype) = ⊥ :=
+    kernelLemmaK'_submodule k N r hr hWnn
+  -- Read off `W ⊆ A_{r-1}` element-wise: `filtrToQuot` kills `W ∩ A_r`, and its
+  -- kernel is `A_{r-1} ∩ A_r` (`ker_filtrToQuot`).
+  intro w hw
+  have hwr : w ∈ filtrA k N r := hWr hw
+  have hx : (⟨w, hwr⟩ : ↥(filtrA k N r)) ∈ W.comap (filtrA k N r).subtype := hw
+  have hker : filtrToQuot k N r ⟨w, hwr⟩ = 0 := by
+    have hmem : filtrToQuot k N r ⟨w, hwr⟩ ∈
+        Submodule.map (filtrToQuot k N r) (W.comap (filtrA k N r).subtype) :=
+      Submodule.mem_map_of_mem hx
+    rw [hbot, Submodule.mem_bot] at hmem
+    exact hmem
+  have hmem' : (⟨w, hwr⟩ : ↥(filtrA k N r)) ∈
+      (filtrA k N (r - 1)).comap (filtrA k N r).subtype := by
+    rw [← ker_filtrToQuot r hr, LinearMap.mem_ker]; exact hker
+  rwa [Submodule.mem_comap, Submodule.coe_subtype] at hmem'
+
 end Etingof.KernelLemmaKPrime

--- a/EtingofRepresentationTheory/Chapter5/KernelLemmaK.lean
+++ b/EtingofRepresentationTheory/Chapter5/KernelLemmaK.lean
@@ -1,0 +1,84 @@
+import Mathlib
+import EtingofRepresentationTheory.Chapter5.KernelLemmaKPrime
+import EtingofRepresentationTheory.Chapter5.DetPowerFiltration
+
+/-!
+# The kernel lemma (K): assembling the det⁻¹-elimination from (K′)
+
+This file builds the **det-power-filtration assembly** that derives the full
+kernel lemma (K) — *a nonnegative-weight, right-`GL_N`-stable submodule of
+`O = A[det⁻¹]` lies in the polynomial subring `A`* — from the deep core (K′)
+(`Etingof.KernelLemmaKPrime.kernelLemmaK'_submodule`) via the increasing
+filtration `A_r = det⁻ʳ · A` (`Etingof.DetPowerFiltration`).
+
+The geometry: `O = ⋃_r A_r` (`iSup_filtrA`), the steps are `GL_N`-stable
+(`localRightRep_mem_filtrA`), and the subquotient is the twisted quotient
+`A_r / A_{r-1} ≅ (A/det) ⊗ χ⁻ʳ` (`filtrToQuot`, `filtrToQuot_equivariant`).
+A nonneg-weight submodule meeting `A_r` (`r ≥ 1`) maps to a nonneg-weight
+submodule of `(A/det) ⊗ χ⁻ʳ`, which (K′) forces to be `⊥`; so it already lay in
+`A_{r-1}`. Descending the filtration lands it in `A_0 = A`.
+
+## Contents
+
+* `glWeightSpaceℤ_map_le` / `glWeightSpaceℤ_iSup_map_le` — **functoriality** of the
+  integer weight spaces: a `GL_N`-equivariant `k`-linear map sends the `μ`-weight
+  space into the `μ`-weight space (and the supremum of nonneg-weight spaces into
+  the supremum of nonneg-weight spaces). Reusable keystone for transporting the
+  nonnegativity hypothesis across the subquotient map.
+* `kernelLemmaK_step` — **one filtration step** (sorry-free): if the image of a
+  submodule `W ⊆ A_r` (`r ≥ 1`) under `filtrToQuot` is nonneg-weight, then
+  `W ⊆ A_{r-1}`. This is the direct contradiction against (K′).
+
+The remaining ingredient for the full descent — that the *image* nonnegativity
+hypothesis of `kernelLemmaK_step` follows from nonnegativity of `W` itself —
+requires torus-semisimplicity of `O` over `ℤ`-weights (every torus-stable
+submodule is the sum of its weight pieces), which is **not** yet available in the
+repo for the infinite-dimensional `O`. That gap, and the final `det⁻¹`-elimination
+wiring (`detInv_elim_of_polynomial`, #4695), are tracked separately.
+-/
+
+open MvPolynomial
+
+namespace Etingof.KernelLemmaKPrime
+
+variable {k : Type*} [Field k] {N : ℕ}
+
+/-! ### Functoriality of integer weight spaces -/
+
+/-- **Functoriality of `glWeightSpaceℤ`.** A `GL_N`-equivariant `k`-linear map
+`φ : V → W` (intertwining `ρV` and `ρW`) sends the `μ`-weight space into the
+`μ`-weight space: `(M_μ).map φ ≤ N_μ`. Only the intertwining property is needed,
+so `φ` may be any linear map (not necessarily an equivalence). -/
+theorem glWeightSpaceℤ_map_le {V W : Type*}
+    [AddCommGroup V] [Module k V] [AddCommGroup W] [Module k W]
+    (ρV : Representation k (Matrix.GeneralLinearGroup (Fin N) k) V)
+    (ρW : Representation k (Matrix.GeneralLinearGroup (Fin N) k) W)
+    (φ : V →ₗ[k] W)
+    (hφ : ∀ (g : Matrix.GeneralLinearGroup (Fin N) k) (v : V), φ (ρV g v) = ρW g (φ v))
+    (μ : Fin N → ℤ) :
+    (glWeightSpaceℤ k N ρV μ).map φ ≤ glWeightSpaceℤ k N ρW μ := by
+  rw [Submodule.map_le_iff_le_comap]
+  intro v hv
+  simp only [glWeightSpaceℤ, Submodule.mem_iInf, LinearMap.mem_ker, LinearMap.sub_apply,
+    LinearMap.smul_apply, LinearMap.id_coe, id_eq, Submodule.mem_comap] at hv ⊢
+  intro i t
+  have h : ρV (diagUnit k N i t) v = (((t ^ μ i : kˣ) : k)) • v := sub_eq_zero.mp (hv i t)
+  have hW : ρW (diagUnit k N i t) (φ v) = (((t ^ μ i : kˣ) : k)) • φ v := by
+    rw [← hφ, h, map_smul]
+  exact sub_eq_zero.mpr hW
+
+/-- **Functoriality on the supremum of weight spaces.** An equivariant `φ` sends a
+supremum of weight spaces into the corresponding supremum; in particular it sends
+the supremum of nonneg-weight spaces into the supremum of nonneg-weight spaces. -/
+theorem glWeightSpaceℤ_iSup_map_le {V W : Type*}
+    [AddCommGroup V] [Module k V] [AddCommGroup W] [Module k W]
+    (ρV : Representation k (Matrix.GeneralLinearGroup (Fin N) k) V)
+    (ρW : Representation k (Matrix.GeneralLinearGroup (Fin N) k) W)
+    (φ : V →ₗ[k] W)
+    (hφ : ∀ (g : Matrix.GeneralLinearGroup (Fin N) k) (v : V), φ (ρV g v) = ρW g (φ v))
+    {ι : Type*} (μs : ι → (Fin N → ℤ)) :
+    (⨆ i, glWeightSpaceℤ k N ρV (μs i)).map φ ≤ ⨆ i, glWeightSpaceℤ k N ρW (μs i) := by
+  rw [Submodule.map_iSup]
+  exact iSup_mono fun i => glWeightSpaceℤ_map_le ρV ρW φ hφ (μs i)
+
+end Etingof.KernelLemmaKPrime

--- a/progress/2026-06-21T11-21-49Z_4e8cef62.md
+++ b/progress/2026-06-21T11-21-49Z_4e8cef62.md
@@ -1,0 +1,64 @@
+## Accomplished
+
+Worker (meta `/work`) session. Surveyed the unclaimed queue; the two headline
+items (#4821 schurWeyl simples character-classification, #4832 `kernelLemmaK'`
+Cauchy core) are both confirmed **Tier-4 research cruxes** that reduce to the
+same highest-weight/Cauchy gap and are not one-session closeable. Claimed #4821,
+verified intractability (route-3 base-change infra is itself a major project and
+still leaves the ℂ-side `|ι| = |P|` counting gap open), and `coordination skip`ped
+it back to `replan` with an honest reason rather than a failed heroic attempt.
+
+Pivoted to the **tractable kernel-lemma (K) filtration assembly** that uses only
+landed sorry-free infrastructure and unblocks #4695. Landed
+`Chapter5/KernelLemmaK.lean` (sorry-free, wired into the Chapter5 aggregator):
+
+* `glWeightSpaceℤ_map_le` / `glWeightSpaceℤ_iSup_map_le` — **functoriality** of the
+  integer weight spaces: a `GL_N`-equivariant `k`-linear map sends the `μ`-weight
+  space (and the supremum of nonneg-weight spaces) into the same. Mirrors the
+  forward direction of `glWeightSpace_map_eq_of_rep_iso` but for a bare linear map
+  and `ℤ`-weights. Reusable keystone for transporting nonnegativity across the
+  subquotient map.
+* `kernelLemmaK_step` — **one det-power filtration descent**: for `r ≥ 1`, a
+  submodule `W ⊆ A_r` whose `filtrToQuot k N r`-image is nonneg-weight in
+  `(A/det) ⊗ χ⁻ʳ` satisfies `W ⊆ A_{r-1}`. Direct contradiction against
+  `kernelLemmaK'_submodule` via `ker_filtrToQuot`. Sorry-free.
+
+## Key discovery
+
+The full (K) descent needs a **torus-semisimplicity of `O = A[det⁻¹]`** fact
+(SS-O): every `diagUnit`-stable submodule is the direct sum of its `ℤ^N`-weight
+pieces, so a nonneg-weight `w ∈ W ∩ A_r` decomposes into weight components that
+*still lie in `A_r`*. Without it, deriving image-nonnegativity (the hypothesis of
+`kernelLemmaK_step`) from nonnegativity of `W` fails at the
+`(⨆ G_μ).comap subtype ≤ ⨆ (G_μ.comap subtype)` step. The repo only has
+`glWeightSpace_iSupIndep` for finite-dimensional reps with `ℕ`-weights — there is
+no `ℤ`-graded weight decomposition for the infinite-dimensional `O`. This hidden
+dependency in #4695's "apply kernel lemma" step is now documented and tracked as
+the new issue #4854.
+
+## Current frontier
+
+`lake build EtingofRepresentationTheory.Chapter5` passes (0 errors). New file
+sorry-free. Branch `agent/4e8cef62`. The (K) descent is reduced to (SS-O) + the
+final downward induction (#4854); #4695's `detInv_elim_of_polynomial` then
+consumes the assembled (K).
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. The Chapter-5 polynomial-rep / Schur-Weyl
+program continues to converge on two Tier-4 research cruxes (highest-weight
+classification #4699/#4821 and Cauchy decomposition #4832). The det⁻¹-elimination
+chain (#4683 → #4695) is now one well-scoped infrastructure step (#4854,
+torus-semisimplicity of `O`) away from its kernel lemma (K).
+
+## Next step
+
+Pick up #4854: build the `ℤ^N`-graded weight decomposition of `O` (or each `A_r`)
+from the monomial eigenbasis, then chain `kernelLemmaK_step` by downward induction
+to land the full (K), and wire it into #4695's `detInv_elim_of_polynomial`.
+
+## Blockers
+
+None for #4854 (uses only landed infra). The two Tier-4 cruxes (#4821, #4832)
+remain genuinely multi-session research and should not be claimed for a
+one-shot close.


### PR DESCRIPTION
This PR lands the sorry-free keystone for the kernel-lemma (K) det-power-filtration assembly that unblocks the det⁻¹-elimination step #4695, in a new file `Chapter5/KernelLemmaK.lean`. It adds `glWeightSpaceℤ_map_le` / `glWeightSpaceℤ_iSup_map_le` (a `GL_N`-equivariant linear map sends integer weight spaces, and the supremum of nonneg-weight spaces, into the same), and `kernelLemmaK_step` (for `r ≥ 1`, a submodule `W ⊆ A_r` whose `filtrToQuot`-image is nonneg-weight in `(A/det) ⊗ χ⁻ʳ` lies in `A_{r-1}` — the direct contradiction against `kernelLemmaK'_submodule`). It wires the file into the `Chapter5` aggregator.

The assembly also surfaced a previously-undocumented dependency: chaining the step into the full descent needs torus-semisimplicity of the infinite-dimensional `O = A[det⁻¹]` over `ℤ`-weights (every torus-stable submodule is the direct sum of its weight pieces), which is not yet in the repo or Mathlib. That gap and the final (K) induction are tracked as #4854.

🤖 Prepared with Claude Code
