### PR TITLE
doc(skill): re-fetch main before creating a new file; record #4695 kernel-lemma redundancy handoff

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -415,6 +415,25 @@ reduces exactly to leaf `Λ`-invariance, the indecomposability crux) over a
 heroic full-closure attempt, and partial-PR. Confirm the tractability premise
 early — it sets scope and avoids rediscovering the obstruction from scratch.
 
+### Before creating a NEW named file, re-fetch main — concurrent sessions land it too
+
+Skill #4853 ("verify cited 'already-landed' deps exist") has a twin failure mode:
+the artifact you are about to **create** may already exist on `main`, landed by a
+**concurrent** session while you worked. If your branch base is several commits
+behind, `git fetch origin main` and check before you write `Chapter5/Foo.lean` —
+especially for a planned/obvious filename the whole pod is converging on. In
+#4695's kernel-lemma (K) assembly, a worker built `Chapter5/KernelLemmaK.lean`
+from scratch, then on rebase found `main` already had a complete sorry-free
+`KernelLemmaK.lean` from a sibling session; the entire branch (plus a follow-up
+issue resting on a gap the landed version sidestepped) was redundant and got
+closed. Cheap guard: `git fetch origin main && git show origin/main:<intended
+path>` (or `git log origin/main --oneline -15` for the area) right before the
+first `Write` of a new file. If it exists, build *on* it, not beside it. Bonus:
+the landed version often reveals a cleaner formulation — there, stating (K) over
+explicit **weight-vector generators** (each in a single `glWeightSpaceℤ`) made the
+descent need no torus-semisimplicity of `O`, which the abstract-submodule framing
+had wrongly demanded.
+
 **Multi-block tubes: don't fix the `_leaf_equalities` *statement shape* ahead of
 the center-collapse design.** For the ≥3-arm / >2-block-center tubes (Ẽ₆ #4638,
 Ẽ₇ #4746, and the entangled D̃₅ #4743) the eigenvalue site is a **separate

--- a/progress/2026-06-21T11-25-46Z_4e8cef62.md
+++ b/progress/2026-06-21T11-25-46Z_4e8cef62.md
@@ -1,0 +1,66 @@
+## Accomplished
+
+Worker (meta `/work`) session. Net code contribution: **zero, by design** — the
+work I built turned out to be redundant with a concurrently-landed file, and I
+cleaned up rather than merge a duplicate.
+
+Sequence:
+1. Surveyed the queue. The two headline items (#4821 schurWeyl simples
+   classification, #4832 `kernelLemmaK'` Cauchy core) are confirmed Tier-4
+   research cruxes reducing to the same highest-weight/Cauchy gap — not
+   one-session closeable. Claimed #4821, verified intractability, and
+   `coordination skip`ped it honestly (route-3 base-change infra is itself a
+   major project and still leaves the ℂ-side `|ι| = |P|` counting gap).
+2. Pivoted to the kernel-lemma (K) det-power-filtration assembly (serves #4695).
+   Built `Chapter5/KernelLemmaK.lean` with sorry-free `glWeightSpaceℤ`
+   functoriality (`glWeightSpaceℤ_map_le`, `_iSup_map_le`) and a filtration-step
+   contradiction lemma (`kernelLemmaK_step`). Opened PR #4856; filed follow-up
+   #4854 for what I believed was a missing ingredient (torus-semisimplicity of
+   `O` over ℤ-weights).
+3. **On rebase, discovered main already has a complete, sorry-free
+   `Chapter5/KernelLemmaK.lean`** (concurrent session, #4851-era) proving the full
+   `kernelLemmaK` det-power descent **and** the `kernelLemmaK_evalGL` /
+   `kernelLemmaK_evalAtGL` interface that #4695 consumes. Their formulation states
+   (K) over explicit **weight-vector generators** (`w : ι → O`, each in a single
+   `glWeightSpaceℤ`), so per-generator `filtrToQuot_mem_glWeightSpaceℤ` gives the
+   subquotient weight directly — **no torus-semisimplicity of `O` needed**. My
+   abstract-submodule framing was the wrong altitude; #4854's premise is void.
+4. Cleaned up: aborted the conflicting merge, closed PR #4856 as redundant,
+   closed #4854 as premise-invalid, reset the branch to main.
+
+## Process lesson
+
+This is exactly the failure mode skill #4853 ("verify cited 'already-landed' deps
+exist before building on them") warns about — extended to *concurrently*-landing
+files. Before building a named artifact (here `KernelLemmaK.lean`), re-`git fetch`
+and check whether main (or an in-flight PR) already provides it, especially when
+the branch base is a few commits behind.
+
+## Current frontier
+
+Main has the full kernel lemma (K) sorry-free. #4695
+(`detInv_elim_of_polynomial`, `PolynomialRepEmbedding.lean:1013`) is **now
+unblocked and already `claimed`** by another session — the remaining work is
+wiring `kernelLemmaK_evalAtGL` into it (build the weight-vector family from
+`halg` + a weight basis of `M` via `h_span`, prove the `hw`/`hstable`
+hypotheses, apply the lemma). Not touched by me (claimed).
+
+## Overall project progress
+
+Stage 3 ongoing. Chapter-5 det⁻¹-elimination chain (#4683 → #4695) is down to the
+single #4695 assembly, now unblocked. The two Tier-4 cruxes (#4699/#4821
+highest-weight classification, #4832 Cauchy decomposition) remain the genuine
+multi-session research frontier.
+
+## Next step
+
+Leave #4695 to its current claimant. For a fresh worker: the remaining unclaimed
+queue is #2564 (blocked on external Mathlib merge), #2841 (open a Mathlib upstream
+PR for an already-proven lemma), #4777 (large Ch6 orbit-counting directive — needs
+a planner-style decomposition), and #4821 (Tier-4 crux, do not one-shot). #2841 is
+the most self-contained completable item.
+
+## Blockers
+
+None introduced. #4821/#4832 remain genuinely multi-session research and should
+not be claimed for a one-shot close.


### PR DESCRIPTION
This PR records the session handoff and adds a skill guard after a redundant-work episode. While building the kernel-lemma (K) det-power-filtration assembly for #4695, the branch's base was several commits behind `main`; on rebase, `main` already had a complete sorry-free `Chapter5/KernelLemmaK.lean` from a concurrent session (proving `kernelLemmaK` plus the `kernelLemmaK_evalAtGL` interface #4695 consumes). The branch and a follow-up issue resting on a gap the landed version sidestepped (it states (K) over explicit weight-vector generators, needing no torus-semisimplicity of `O`) were therefore redundant; both were closed.

It adds a note to the `lean-formalization` skill — a twin of the already-landed-deps guard (#4853): re-fetch `main` and check `origin/main:<path>` before the first `Write` of a new named file, since concurrent sessions land obvious filenames the whole pod converges on. It also leaves the progress handoff documenting that #4695 is now unblocked (and already claimed by another session).

🤖 Prepared with Claude Code
