### PR TITLE
doc(Ch5 #4821): de-risk the Schur-Weyl classification crux; base-change route is a red herring

### DIFF
--- a/progress/20260621T120000Z_ba73b7ed.md
+++ b/progress/20260621T120000Z_ba73b7ed.md
@@ -1,0 +1,63 @@
+## Accomplished
+
+`/work` → `/feature` session `ba73b7ed`. Claimed **#4821** (Ch5 #4732 sub-β, the
+last `sorryAx` of the #2483 route: highest-weight classification of the
+Schur-Weyl abstract simples), confirmed it is a genuine multi-session Tier-4 crux
+with no clean one-session partial, and **decomposed** it per the standing triage:
+
+- Created **#4861** (sub-a: field-independence of `formalCharacter` for
+  `glTensorRep`) and **#4862** (sub-b: ℂ-side highest-weight classification +
+  `|ι|=|P|` counting); left the `Decomposed into #4861, #4862` breadcrumb on
+  #4821 and skipped it (→ replan).
+- **Then found #4861 vacuous** and skipped it as already-covered. The literal
+  field-independence ask is an immediate corollary of existing, already-`k`-general
+  theorems:
+  - `formalCharacter_glTensorRep_eq_pow` (`FormalCharacterIso.lean:1028`):
+    `char(V^{⊗n}) = (∑ᵢ Xᵢ)^n` (fixed `MvPolynomial (Fin N) ℚ`).
+  - `sum_X_pow_eq_sum_finrank_smul_schurPoly` (`SchurWeylPolynomialIdentity.lean:134`).
+  - `formalCharacter_tensorPower_eq_sum_character_L` (`FormalCharacterIso.lean:846`):
+    `char(V^{⊗n}) = ∑ᵢ dim(Sᵢ)·char(Lᵢ)`.
+- **Key correction recorded on all three issues + the route doc:** the route-3
+  "descent from ℂ / base-change" framing is a **red herring** — the polynomial
+  identities it would transport are already field-independent and stated over a
+  general alg-closed char-0 `k`. There is no base-change gap. Refocused #4862 to
+  work directly over `k`.
+
+No Lean changed (the relevant character identities already exist). This commit
+carries only the route-doc update + this progress file.
+
+## Current frontier
+
+The entire genuine #4732/#4821 crux is now isolated on **#4862**: upgrade the
+already-available **numerical** identity
+`∑ᵢ dim(Sᵢ)·char(Lᵢ) = ∑_λ dim(Specht_λ)·schurPoly(λ)` to the **individual**
+matching `char(Lᵢ) = schurPoly(lam i)` with `lam` injective. Two halves:
+1. injective isotypic matching `SchurModule k N λ ≅ L_{φλ}` — open: does it need
+   SchurModule-simplicity-over-`k` (ℂ-rooted, ex-sub-α #4820) or can it read
+   simplicity off `hLsimp` + character-distinctness?
+2. surjectivity / counting `|ι| = |P|` (double-centralizer pairing; deep,
+   decompose further).
+
+## Overall project progress
+
+Etingof draft 1, Stage 3, Ch5 Schur-Weyl backbone. `#2483` route's last `sorry`
+is `schurWeyl_simples_formalCharacter_classification_core`
+(`SchurWeylSimplesClassification.lean:132`). It now has a crisp, de-risked
+decomposition: the base-change half is a non-issue (already in the codebase); the
+real work is the abstract-simple matching/counting on #4862. Other unclaimed
+features (#2564/#2841) remain externally blocked on Mathlib PRs; directive #4777's
+sub-issue #4786 is claimed. Open PR #4857 (toolchain v4.31.0) was building.
+
+## Next step
+
+A worker taking **#4862**: work directly over the given `k` (do NOT specialize to
+ℂ or re-prove SchurModule-simplicity unless half-1 demonstrably requires it).
+Land half-1 (injective `φ`, character equality on its image) as a partial,
+leaving `|ι|=|P|` as the tracked residual; decompose the counting step further.
+Planner: close #4861 (covered) and #4821 (fully superseded by #4862 + the
+existing field-independent identities + assembly glue).
+
+## Blockers
+
+- #4862: deep Tier-4 (counting `|ι|=|P|`); needs further decomposition.
+- #2564 / #2841: externally blocked on Mathlib PR merges.

--- a/progress/schur-weyl-crux-4732-decomposition.md
+++ b/progress/schur-weyl-crux-4732-decomposition.md
@@ -137,3 +137,36 @@ Specht-character-over-`k` (sub-α #4820 → #4821 route 1), or (2) the base-chan
 route in sub-β that drops sub-α. Route (2) looks substantially cheaper. Sub-α
 (#4820) is skipped back to `replan` pending that decision.
 
+
+---
+
+## Update (2026-06-21, session ba73b7ed) — the base-change route is a red herring; sub-α/sub-(a) is vacuous
+
+Re-decomposed #4821 into #4861 (sub-a: field-independence of `formalCharacter`)
+and #4862 (sub-b: ℂ-side classification), then **found #4861 already covered**:
+
+- `formalCharacter_glTensorRep_eq_pow` (`FormalCharacterIso.lean:1028`):
+  `formalCharacter k N (FDRep.of (glTensorRep k N n)) = (∑ᵢ Xᵢ)^n` — fixed
+  `MvPolynomial (Fin N) ℚ`, identical for every field. Field-independence of the
+  V^{⊗n} character is therefore *already a theorem*.
+- `sum_X_pow_eq_sum_finrank_smul_schurPoly` (`SchurWeylPolynomialIdentity.lean:134`):
+  `(∑ᵢ Xᵢ)^n = ∑_λ dim(Specht_λ)·schurPoly(λ)`.
+- `formalCharacter_tensorPower_eq_sum_character_L` (`FormalCharacterIso.lean:846`):
+  `char(V^{⊗n}) = ∑ᵢ dim(Sᵢ)·char(Lᵢ)`.
+
+Chaining these gives, **over a general alg-closed char-0 `k` with no base change**,
+the numerical identity `∑ᵢ dim(Sᵢ)·char(Lᵢ) = ∑_λ dim(Specht_λ)·schurPoly(λ)`.
+
+**Consequence:** there is no field-independence gap to close, so the "descent from
+ℂ" framing (this doc's earlier "Strategic consequence" section) does not buy
+anything — the polynomial identities it would transport are *already* `k`-free and
+`k`-general. #4861 was skipped (→ replan, planner to close as covered).
+
+The entire genuine crux is piece (b) #4862: upgrade the **numerical** identity to
+the **individual** matching `char(Lᵢ) = schurPoly(lam i)`, `lam` injective. Two
+halves, both directly over the given `k`:
+1. injective isotypic matching `SchurModule k N λ ≅ L_{φλ}` — open question whether
+   it needs SchurModule-simplicity-over-`k` (former sub-α, ℂ-rooted) or can read
+   simplicity off `hLsimp` + character-distinctness;
+2. surjectivity / counting `|ι| = |P|` via the double-centralizer pairing (deep;
+   decompose further).


### PR DESCRIPTION
This PR records the decomposition and a key correction for the #4732/#4821 highest-weight classification crux (the last `sorry` of the #2483 route). It splits the crux into #4861 (field-independence of `formalCharacter`) and #4862 (ℂ-side classification + counting), then documents that #4861 is already covered by existing, already-`k`-general theorems (`formalCharacter_glTensorRep_eq_pow`, `sum_X_pow_eq_sum_finrank_smul_schurPoly`, `formalCharacter_tensorPower_eq_sum_character_L`). The consequence, appended to the route doc `progress/schur-weyl-crux-4732-decomposition.md`, is that the "descent from ℂ / base-change" framing buys nothing — the polynomial identities it would transport are already field-independent — so the genuine crux is entirely the abstract-simple matching and `|ι|=|P|` counting now isolated on #4862. Documentation only; no Lean changes.

🤖 Prepared with Claude Code