### PR TITLE
feat(Ch5 #4745 sub-B): expose schurPoly-classification of abstract simples through decompose_polynomial_gl_rep

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/PolynomialGLDecomposition.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialGLDecomposition.lean
@@ -2,6 +2,7 @@ import EtingofRepresentationTheory.Chapter5.FormalCharacterIso
 import EtingofRepresentationTheory.Chapter5.SchurWeylGLTransfer
 import EtingofRepresentationTheory.Chapter5.PolynomialRepEmbedding
 import EtingofRepresentationTheory.Chapter5.SemisimpleIsotypic
+import EtingofRepresentationTheory.Chapter5.SchurWeylSimplesClassification
 
 /-!
 # Schur-Weyl #5, Step E: a polynomial `GL_N`-rep is a direct sum of abstract simples
@@ -401,6 +402,8 @@ theorem polynomial_homog_rep_asModule_embeds_directSum_simple
     ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
       (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
       (_ : ∀ i, IsSimpleModule (GLAlg k N) (Representation.asModule (L i).ρ))
+      (_ : ∃ lam : ι → {l : Fin N → ℕ // Antitone l}, Function.Injective lam ∧
+        ∀ i, formalCharacter k N (L i) = schurPoly N (lam i).val)
       (κ : Type) (_ : Finite κ) (gκ : κ → ι)
       (W : Type u) (_ : AddCommGroup W) (_ : Module (GLAlg k N) W)
       (_ : W ≃ₗ[GLAlg k N]
@@ -415,6 +418,12 @@ theorem polynomial_homog_rep_asModule_embeds_directSum_simple
   -- (2) unified equivariant + simple Schur–Weyl decomposition of `V^{⊗n}`.
   obtain ⟨ι, hιFin, hιDec, S, hSacg, hSmod, hSfin, L, hLsimp, e, he⟩ :=
     glTensorRep_schurWeyl_decomposition_equivariant_simple (k := k) (N := N) n hN
+  -- schurPoly-classification of the abstract simples (#4758), read off the bare
+  -- decomposition data `(e, he, hLsimp)` via the classification crux (#4732) and
+  -- the deferred distinctness (#4731 / #4849-chain).
+  have hclass : ∃ lam : ι → {l : Fin N → ℕ // Antitone l}, Function.Injective lam ∧
+      ∀ i, formalCharacter k N (L i) = schurPoly N (lam i).val :=
+    Etingof.glTensorRep_schurWeyl_simples_schurPoly_classified k N n hN L e he hLsimp
   haveI iSfree : ∀ i, Module.Free k (S i) := fun i => Module.Free.of_divisionRing k (S i)
   -- basis index of each multiplicity space, in `Type 0` so `κ` stays small.
   set β : ι → Type := fun i => Fin (Module.finrank k (S i)) with hβ
@@ -462,7 +471,7 @@ theorem polynomial_homog_rep_asModule_embeds_directSum_simple
   let ψ := (Eouter.toLinearMap ∘ₗ E2.toLinearMap ∘ₗ E1.toLinearMap) ∘ₗ φR
   have hψinj : Function.Injective ψ :=
     ((Eouter.injective.comp E2.injective).comp E1.injective).comp hφRinj
-  refine ⟨ι, hιFin, hιDec, L, hLsimp,
+  refine ⟨ι, hιFin, hιDec, L, hLsimp, hclass,
     (Σ _ : Fin m, Σ i : ι, β i), inferInstance, (fun c => c.2.1),
     DirectSum (Σ _ : Fin m, Σ i : ι, β i) (fun c => Representation.asModule (L c.2.1).ρ),
     inferInstance, inferInstance, LinearEquiv.refl (GLAlg k N) _,
@@ -480,7 +489,16 @@ sum of the abstract simple summands `L i` of `V^{⊗n}`:
 Reading off `mult i := Nat.card {j // f j = i}` recovers the
 multiplicity-indexed form `M ≅ ⨁_i (Fin (mult i) → L i)`. The decomposition is
 stated for the *abstract* `L i` (not concrete Schur modules) to keep the
-dependency graph with the consumer #6 acyclic. -/
+dependency graph with the consumer #6 acyclic.
+
+In addition (issue #4758) the output exposes that the abstract simples are
+*schurPoly-classified*: an injective assignment `lam : ι → {antitone partitions}`
+with `formalCharacter k N (L i) = schurPoly N (lam i)`. This is what the
+Schur-Weyl #6 assembly (`iso_of_formalCharacter_eq_schurPoly`, #4745) consumes to
+force `p = 1`: the characters `char (L i)` are distinct Schur polynomials, hence
+linearly independent, so a single-`schurPoly` left side has a single summand. The
+classification is read off the bare decomposition data via
+`glTensorRep_schurWeyl_simples_schurPoly_classified`. -/
 theorem decompose_polynomial_gl_rep
     [IsAlgClosed k] [CharZero k] (n : ℕ) (hN : n ≤ N)
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
@@ -490,13 +508,15 @@ theorem decompose_polynomial_gl_rep
     ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
       (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
       (_ : ∀ i, IsSimpleModule (GLAlg k N) (Representation.asModule (L i).ρ))
+      (_ : ∃ lam : ι → {l : Fin N → ℕ // Antitone l}, Function.Injective lam ∧
+        ∀ i, formalCharacter k N (L i) = schurPoly N (lam i).val)
       (p : ℕ) (f : Fin p → ι),
       Nonempty (Representation.asModule M.ρ ≃ₗ[GLAlg k N]
         DirectSum (Fin p) (fun j => Representation.asModule (L (f j)).ρ)) := by
   classical
   -- Embed `M.asModule` as a submodule `M'` of an ambient module `W` that is
   -- `R`-linearly a finite direct sum of the simple `L (gκ c)`.
-  obtain ⟨ι, hιFin, hιDec, L, hLsimp, κ, hκFin, gκ, W, hWacg, hWmod, e, M', ⟨eM⟩⟩ :=
+  obtain ⟨ι, hιFin, hιDec, L, hLsimp, hclass, κ, hκFin, gκ, W, hWacg, hWmod, e, M', ⟨eM⟩⟩ :=
     polynomial_homog_rep_asModule_embeds_directSum_simple k N n hN M halg h_span h_homog
   -- The ambient summand family, indexed by `κ`.
   set Lsum : κ → Type u := fun c => Representation.asModule (L (gκ c)).ρ with hLsum
@@ -506,7 +526,7 @@ theorem decompose_polynomial_gl_rep
     SemisimpleIsotypic.submodule_of_directSum_simple_iso_directSum
       (R := GLAlg k N) Lsum (fun c => hLsimp (gκ c)) e M'
   -- Compose: `M.asModule ≃ M' ≃ ⨁_{j} Lsum (h j) = ⨁_{j} asModule (L (gκ (h j)))`.
-  refine ⟨ι, hιFin, hιDec, L, hLsimp, p, fun j => gκ (h j), ⟨?_⟩⟩
+  refine ⟨ι, hιFin, hιDec, L, hLsimp, hclass, p, fun j => gκ (h j), ⟨?_⟩⟩
   exact eM.trans eM'
 
 end Etingof.PolynomialGLDecomposition

--- a/EtingofRepresentationTheory/Chapter5/SchurWeylSimplesClassification.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurWeylSimplesClassification.lean
@@ -131,6 +131,77 @@ theorem schurWeyl_simples_formalCharacter_classification_core
   -- character-determined ⇒ `char = schurPoly`" is the deferred Tier-4 content.
   sorry
 
+/-- **Pairwise distinctness of the Schur-Weyl simples (deferred, isolated
+`sorry`).** The abstract simple summands `L i` of `V^{⊗n}` produced by the
+equivariant decomposition `glTensorRep_equivariant_schurWeyl_decomposition` are
+pairwise non-isomorphic.
+
+This is the GL-side distinctness output targeted by issue #4731. Part 1
+(`SchurWeylLDistinct.lean`, the GL-equivariant ⟹ centralizer-linear reduction)
+has landed; the remaining B-side step `M_i ≅_C M_j ⟹ i = j` (the symmetric
+double-centralizer argument) is in flight as #4849/#4859/#4862. Until that chain
+lands, the `Pairwise` conclusion is isolated here as a single `sorry`, mirroring
+`schurWeyl_simples_formalCharacter_classification_core`, so the downstream
+schurPoly-classification API (`decompose_polynomial_gl_rep`, issue #4758) stays
+otherwise sorry-free. -/
+theorem glTensorRep_schurWeyl_simples_pairwise_distinct
+    (N n : ℕ) (hN : n ≤ N)
+    {ι : Type} [Fintype ι] [DecidableEq ι]
+    {S : ι → Type u} [∀ i, AddCommGroup (S i)] [∀ i, Module k (S i)]
+    [∀ i, Module.Finite k (S i)]
+    (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
+    (e : TensorPower k (Fin N → k) n ≃ₗ[k]
+        (DirectSum ι (fun i => S i ⊗[k] (L i : Type u))))
+    (he : ∀ (g : Matrix.GeneralLinearGroup (Fin N) k)
+          (v : TensorPower k (Fin N → k) n),
+          e (glTensorRep k N n g v) =
+            Representation.directSum (fun i =>
+              (Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
+                (S i)).tprod (L i).ρ) g (e v))
+    (hLsimp : ∀ i, IsSimpleModule
+        (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
+        (Representation.asModule (L i).ρ)) :
+    Pairwise (fun i j => ¬ Nonempty ((L i) ≅ (L j))) := by
+  -- Deferred: the B-side distinctness `M_i ≅_C M_j ⟹ i = j` (#4849/#4859/#4862)
+  -- transported to the GL-side `L i ≇ L j` via the Part-1 centralizer-linear
+  -- reduction (`SchurWeylLDistinct.lean`, #4731). Isolated here as one `sorry`.
+  sorry
+
+/-- **schurPoly-classification of the Schur-Weyl simples (from the bare
+equivariance data).** Combines the deferred distinctness
+(`glTensorRep_schurWeyl_simples_pairwise_distinct`) with the classification crux
+(`schurWeyl_simples_formalCharacter_classification_core`) to produce, from only
+the decomposition data `(e, he)` and per-summand simplicity `hLsimp`, an
+injective antitone-partition assignment `lam` with
+`char(L i) = schurPoly N (lam i)`.
+
+This is the form consumed by `decompose_polynomial_gl_rep` (issue #4758): it lets
+the Schur-Weyl #6 assembly read the partition classification of the abstract
+simples without re-deriving the tensor-power decomposition data `(e, he, hLsimp,
+hLdist)` itself. -/
+theorem glTensorRep_schurWeyl_simples_schurPoly_classified
+    (N n : ℕ) (hN : n ≤ N)
+    {ι : Type} [Fintype ι] [DecidableEq ι]
+    {S : ι → Type u} [∀ i, AddCommGroup (S i)] [∀ i, Module k (S i)]
+    [∀ i, Module.Finite k (S i)]
+    (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
+    (e : TensorPower k (Fin N → k) n ≃ₗ[k]
+        (DirectSum ι (fun i => S i ⊗[k] (L i : Type u))))
+    (he : ∀ (g : Matrix.GeneralLinearGroup (Fin N) k)
+          (v : TensorPower k (Fin N → k) n),
+          e (glTensorRep k N n g v) =
+            Representation.directSum (fun i =>
+              (Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
+                (S i)).tprod (L i).ρ) g (e v))
+    (hLsimp : ∀ i, IsSimpleModule
+        (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
+        (Representation.asModule (L i).ρ)) :
+    ∃ lam : ι → {l : Fin N → ℕ // Antitone l},
+      Function.Injective lam ∧
+      ∀ i, formalCharacter k N (L i) = schurPoly N (lam i).val :=
+  schurWeyl_simples_formalCharacter_classification_core k N n hN L e he hLsimp
+    (glTensorRep_schurWeyl_simples_pairwise_distinct k N n hN L e he hLsimp)
+
 /-- **Headline (sorry-free given the crux).** The formal characters of the
 abstract simple summands `L i` of `V^{⊗n}` (from
 `glTensorRep_equivariant_schurWeyl_decomposition`) are linearly independent over

--- a/progress/2026-06-21T12-12-05Z_8d0921df.md
+++ b/progress/2026-06-21T12-12-05Z_8d0921df.md
@@ -1,0 +1,47 @@
+## Accomplished
+
+Feature session for **#4758** (Ch5 #4745 sub-B): expose the schurPoly-classification
+of the abstract simples through `decompose_polynomial_gl_rep`.
+
+- Added two lemmas to `SchurWeylSimplesClassification.lean`:
+  - `glTensorRep_schurWeyl_simples_pairwise_distinct` — the GL-side pairwise
+    distinctness `Pairwise (¬ Nonempty (L i ≅ L j))` of the V^{⊗n} simples, taking
+    the bare decomposition data `(e, he, hLsimp)`. This is the **single new sorry**,
+    isolated and documented (mirrors `classification_core`): #4731 Part 1 landed,
+    B-side distinctness is in flight as #4849/#4859/#4862.
+  - `glTensorRep_schurWeyl_simples_schurPoly_classified` — sorry-free convenience
+    lemma combining the distinctness with the classification crux
+    (`schurWeyl_simples_formalCharacter_classification_core`, #4732) to produce
+    `∃ lam, Function.Injective lam ∧ ∀ i, formalCharacter k N (L i) = schurPoly N (lam i)`
+    from `(e, he, hLsimp)` alone.
+- Strengthened `polynomial_homog_rep_asModule_embeds_directSum_simple` and
+  `decompose_polynomial_gl_rep` (`PolynomialGLDecomposition.lean`) to additionally
+  expose that `∃ lam` classification clause; threaded it through both proofs.
+- Added `import …SchurWeylSimplesClassification` to `PolynomialGLDecomposition`
+  (no import cycle: that file imports only `FormalCharacterIso`).
+
+## Current frontier
+
+`decompose_polynomial_gl_rep` now returns the schurPoly-classification of its
+abstract simples. The #4745 assembly `iso_of_formalCharacter_eq_schurPoly`
+(`SchurWeylFormalCharacterIso.lean`, still `sorry`) can now read the `lam`/`char =
+schurPoly` data without re-deriving `(e, he, hLsimp, hLdist)`.
+
+## Overall project progress
+
+Stage 3 (formalization), Chapter 5 Schur-Weyl chain. Builds green:
+`SchurWeylSimplesClassification`, `PolynomialGLDecomposition`,
+`SchurWeylFormalCharacterIso` all compile (8059–8060 jobs).
+
+## Next step
+
+#4745 residual: prove `iso_of_formalCharacter_eq_schurPoly` sorry-free using the
+newly exposed classification (Step 4: distinct Schur polys ⟹ linear independence
+⟹ p = 1). Still also needs the det-twist algebraicity / `h_span` plumbing (#4756).
+Separately, discharge the distinctness sorry via the #4849/#4859/#4862 B-side chain.
+
+## Blockers
+
+None for this item. One new sorry introduced
+(`glTensorRep_schurWeyl_simples_pairwise_distinct`), tracked by the open
+distinctness chain #4849/#4859/#4862 (parent #4731).

--- a/progress/2026-06-21T12-12-05Z_8d0921df.md
+++ b/progress/2026-06-21T12-12-05Z_8d0921df.md
@@ -45,3 +45,13 @@ Separately, discharge the distinctness sorry via the #4849/#4859/#4862 B-side ch
 None for this item. One new sorry introduced
 (`glTensorRep_schurWeyl_simples_pairwise_distinct`), tracked by the open
 distinctness chain #4849/#4859/#4862 (parent #4731).
+
+## PR status (update 12:35Z)
+
+Branch `agent/8d0921df` is pushed (commits 18c06ce1, 1e03ca9e). PR creation is
+blocked by GitHub's **account-wide secondary rate limit** ("was submitted too
+quickly", createPullRequest) — no PR has been created project-wide since #4863
+at 11:37Z (~1h). Primary GraphQL quota is healthy (4784 remaining), so this is
+content-creation throttling on the shared token across all pod agents, not a
+per-session quota. Work is committed and pushed; a successor (or a later retry)
+should run `coordination create-pr 4758` once the limit clears.


### PR DESCRIPTION
Closes #4758

Session: `8d0921df-d993-424f-a9a9-c3be17e42ce5`

0642e637 doc(Ch5 #4758): note PR blocked by account-wide secondary rate limit
1e03ca9e doc(Ch5 #4758): document schurPoly-classification output; progress file
18c06ce1 feat(Ch5 #4758): expose schurPoly-classification of abstract simples through decompose_polynomial_gl_rep

🤖 Prepared with Claude Code