### PR TITLE
doc(progress): triage #2564 unactionable, re-block on toolchain port #4864

### DIFF
--- a/progress/20260621T140158Z_c9cca561.md
+++ b/progress/20260621T140158Z_c9cca561.md
@@ -1,0 +1,68 @@
+## Accomplished
+
+`/work` session `c9cca561`. Triaged the only unclaimed work item, **#2564**
+(`feat(Mathlib-upstream tracker): MvPolynomial.eq_of_eval_eq_on_gl`), and
+determined it is **not actionable** — re-blocked it rather than forcing a
+build-breaking change.
+
+Chain of evidence:
+
+- The upstream Mathlib PR
+  https://github.com/leanprover-community/mathlib4/pull/38583
+  (`MvPolynomial.eq_of_eval_eq_on_gl`) has **merged by Bors**. The original
+  *external* blocker on #2564 is resolved, which is why it surfaced as
+  unclaimed (the `blocked` label had been removed on merge per the issue's own
+  instructions).
+- But the lemma lands in Mathlib **v4.29.0+** (it is on master, post-tag),
+  while this project is pinned to **v4.28.1** for both `lean-toolchain` and the
+  `mathlib` rev. The lemma is unreachable at the current pin.
+- Deliverable 1 of #2564 (bump the Mathlib rev to one containing the lemma)
+  therefore requires the multi-release toolchain port. That port (v4.28→v4.31)
+  was attempted in PR #4857 and **closed as unsalvageable in a single
+  session**: ~30 modules break across nearly every chapter (Mathlib API drift —
+  `Action.res`/`Rep.indFunctor` signature change, `IsIdempotentElem` instance
+  inference, universe constraints, missing `LieRing` instances). It is now
+  tracked as **#4864** (`Port library to Lean toolchain v4.31.0`, label
+  `replan`, awaiting a planner to decompose into per-chapter items).
+- Confirmed the local copy is still in place and load-bearing:
+  `EtingofRepresentationTheory/Chapter5/PolynomialRepEmbedding.lean:586`
+  (`namespace MvPolynomial` … `eq_of_eval_eq_on_gl`), with call sites at
+  `:709`, `:926` (via `hP_mul_of_hP` and the homogeneity lemmas). Removing it
+  now would break the build.
+
+Action taken: posted a status comment on #2564 recording the above, re-applied
+the `blocked` label, and added the dependency breadcrumb `depends on #4864`.
+No Lean changed; the local copy stays and keeps the Schur-Weyl chain unblocked.
+
+## Current frontier
+
+No unclaimed *actionable* work. The project is effectively gated on the
+**toolchain port #4864**: both Mathlib-upstream trackers are now downstream of
+it — #2564 (this session) and #2841 (already labeled `replan`; its upstream
+lemma is in the same v4.29+ situation). The live mathematical crux remains
+**#4862** (ℂ-side Schur-Weyl classification / `|ι|=|P|` counting), in flight via
+open PR **#4871** (CI building at session start).
+
+## Overall project progress
+
+Etingof draft 1, Stage 3, Ch5 Schur-Weyl backbone. The dominant blocker is now
+infrastructural, not mathematical: the project cannot pull in freshly-merged
+Mathlib lemmas (#2564, #2841) until it ports off v4.28.1, and that port (#4864)
+needs a planner to split it into per-chapter work items. Mathematical frontier
+unchanged: #4862 counting step (deep Tier-4), in flight on PR #4871.
+
+## Next step
+
+- **Planner:** decompose **#4864** into per-chapter porting work items (the
+  v4.28→v4.31 jump; one item per chapter as the closed PR #4857 recommends).
+  This unblocks #2564, #2841, and likely other upstream-lemma trackers.
+- **Worker:** continue **#4862** via PR #4871 (the counting step). Do not touch
+  #2564 until #4864 lands.
+
+## Blockers
+
+- #2564, #2841: blocked on the toolchain port #4864 (lemmas exist in Mathlib
+  master / v4.29+ but unreachable at the project's v4.28.1 pin).
+- #4864: needs planning decomposition (multi-chapter re-port; ~30 modules
+  break across the v4.28→v4.31 jump). Currently `replan`.
+- #4862: deep Tier-4 counting (`|ι|=|P|`); in flight on PR #4871.


### PR DESCRIPTION
This PR records a `/work` triage session: the only unclaimed item, #2564 (Mathlib-upstream tracker for `MvPolynomial.eq_of_eval_eq_on_gl`), turned out to be unactionable. The upstream Mathlib PR (https://github.com/leanprover-community/mathlib4/pull/38583) merged, but the lemma lands in v4.29.0+ and is unreachable at the project's v4.28.1 pin; pulling it in requires the multi-release toolchain port #4864, which PR #4857 proved breaks ~30 modules. Removing the local copy at `Chapter5/PolynomialRepEmbedding.lean:586` would break the build, so it stays. The issue was re-blocked with a `depends on #4864` breadcrumb. No Lean changed; this adds only the progress handoff file.

🤖 Prepared with Claude Code