### PR TITLE
doc: mark Gabriel's theorem (2.1.2) sorry_free in items.json

### DIFF
--- a/progress/items.json
+++ b/progress/items.json
@@ -130,8 +130,8 @@
     "end_page": "8",
     "start_line": 5,
     "end_line": 7,
-    "status": "statement_formalized",
-    "needs_statement": true
+    "status": "sorry_free",
+    "needs_statement": false
   },
   {
     "id": "Chapter2/Discussion_after_Theorem2.1.2",


### PR DESCRIPTION
This PR updates `progress/items.json` to record that Gabriel's theorem (Chapter 2, Theorem 2.1.2) is now fully proven. It had been held at `statement_formalized` because the forward direction routed through bridge sorries; those were eliminated on 2026-06-21 when Chapter 6 was rerouted onto the book's orbit-counting proof and the off-book `FieldGeneric*` construction track was deleted. The full project build is green and the `Theorem_2_1_2` / `Theorem_6_1_5` dependency cone contains no `sorry`, so the item is marked `sorry_free` (and `needs_statement: false`, matching the convention for other proven theorems such as Theorem 2.1.1).

This brings items.json into line with the codebase under its existing item-level convention, where helper-lemma sorries are tracked separately (in `progress/sorry-landscape.md` and GitHub issues) rather than in items.json. Six such helper sorries remain, all in Chapter 5 (Schur-Weyl character theory and Garnir straightening); the book items that delegate to them (Proposition 5.22.2, the hook-length formula) are left at their existing `sorry_free` marking per that convention.

🤖 Prepared with Claude Code