### PR TITLE
doc: downgrade Proposition 5.22.2 to statement_formalized (transitive honesty)

### DIFF
--- a/progress/items.json
+++ b/progress/items.json
@@ -3869,9 +3869,9 @@
     "end_page": "133",
     "start_line": 3,
     "end_line": 6,
-    "status": "sorry_free",
-    "attention_note": "detRep defined sorry-free. Theorem blocked: SchurModule is opaque sorry placeholder.",
-    "notes": "Triage 2026-03-18: Blocked on SchurModule (Theorem 5.22.1) which is entirely sorry'd (definition + character + theorem). detRep definition exists but uses a workaround. Issue #1016 was closed with replan. Cannot make progress until SchurModule is defined. Keep attention_needed \u2014 needs SchurModule infrastructure first."
+    "status": "statement_formalized",
+    "attention_note": "Statement and proof structure complete, but the proof delegates to the Schur-Weyl character-classification chain, which still has sorries.",
+    "notes": "Triage 2026-06-22: Theorem5_22_1 (SchurModule) is now sorry_free, so the 2026-03-18 blocker is resolved. Proposition5_22_2 itself compiles, but its proof routes through iso_of_formalCharacter_eq_schurPoly (SchurWeylFormalCharacterIso.lean), whose cone carries the Cluster A sorries: schurWeyl_simples_formalCharacter_classification_core and glTensorRep_schurWeyl_simples_pairwise_distinct (SchurWeylSimplesClassification.lean), detInv_elim_of_polynomial (PolynomialRepEmbedding.lean), and kernelLemmaK' (KernelLemmaKPrime.lean). Tracked transitively-honest as statement_formalized until those land."
   },
   {
     "id": "Chapter5/Introduction_5.23",


### PR DESCRIPTION
This PR makes `progress/items.json` transitively honest for the Schur-Weyl chain. Following up on the Theorem 2.1.2 correction (#4873), it downgrades `Chapter5/Proposition5.22.2` from `sorry_free` to `statement_formalized`: the proposition compiles, but its proof routes through `iso_of_formalCharacter_eq_schurPoly`, whose dependency cone still carries the four Cluster A Schur-Weyl sorries (`schurWeyl_simples_formalCharacter_classification_core`, `glTensorRep_schurWeyl_simples_pairwise_distinct`, `detInv_elim_of_polynomial`, `kernelLemmaK'`).

A transitive-taint analysis over all six remaining `sorry`s (comment-stripped reference closure across the whole library) confirms Proposition 5.22.2 is the only book item affected. The Garnir-straightening sorry (`garnir_twisted_in_lower_span`) sits in a superseded tabloid-straightening route inside `SpechtModuleBasis.lean` with zero external consumers; the book's Specht-module dimension and hook-length formula (Theorem 5.17.1) are proven sorry-free via the independent Frobenius character route, as that file's own docstring states.

This PR also refreshes the badly stale 2026-03-18 note on the item, which claimed the proof was blocked on `SchurModule` (Theorem 5.22.1) being sorry'd — that blocker is long resolved (Theorem 5.22.1 is now sorry_free).

🤖 Prepared with Claude Code