### PR TITLE
refactor(Ch5): degree-unrestrict Schur-Weyl decomposition chain (n ≤ N was vestigial)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/FormalCharacterIso.lean
+++ b/EtingofRepresentationTheory/Chapter5/FormalCharacterIso.lean
@@ -751,7 +751,7 @@ with the action formula
 ((L_carrier i l) v)` collapse equivariance to a per-pure-tensor
 computation. -/
 theorem glTensorRep_equivariant_schurWeyl_decomposition
-    (N n : ℕ) (hN : n ≤ N) :
+    (N n : ℕ) (_hN : n ≤ N) :
     ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
       (S : ι → Type u)
       (_ : ∀ i, AddCommGroup (S i))
@@ -775,7 +775,7 @@ theorem glTensorRep_equivariant_schurWeyl_decomposition
   -- h_act)` data as `_explicit`, plus `hL_simp : ∀ i, IsSimpleModule … (L i)`.
   obtain ⟨ι, hιFin, hιDec, S', hS'_simp, hS'_dist, hSi_fin, L, hL_simp, L_carrier,
       e, he, h_act⟩ :=
-    Theorem5_18_4_GL_rep_decomposition_explicit_simple k N n hN
+    Theorem5_18_4_GL_rep_decomposition_explicit_simple k N n
   refine ⟨ι, hιFin, hιDec, fun i => ↥(S' i),
     fun _ => inferInstance, fun _ => inferInstance,
     fun i => hSi_fin i, L, hL_simp, ?_, ?_⟩

--- a/EtingofRepresentationTheory/Chapter5/PolynomialGLDecomposition.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialGLDecomposition.lean
@@ -305,7 +305,7 @@ evaluation formula `he`), reconstructing the `GL_N`-action `ρ_i` exactly as
 simplicity (à la `Theorem5_18_4_GL_rep_decomposition_simple`'s `hL_simple`) over
 that one shared `ρ_i`. -/
 theorem glTensorRep_schurWeyl_decomposition_equivariant_simple
-    [IsAlgClosed k] [CharZero k] (n : ℕ) (hN : n ≤ N) :
+    [IsAlgClosed k] [CharZero k] (n : ℕ) :
     ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
       (S : ι → Type u)
       (_ : ∀ i, AddCommGroup (S i))
@@ -328,7 +328,7 @@ theorem glTensorRep_schurWeyl_decomposition_equivariant_simple
   -- formula `he`, and the action formula `h_act`).
   obtain ⟨ι, hιFin, hιDec, S', hS'_simp, hS'_dist, hSi_fin, L, hL_simple,
       L_carrier, e, he, h_act⟩ :=
-    Theorem5_18_4_GL_rep_decomposition_explicit_simple k N n hN
+    Theorem5_18_4_GL_rep_decomposition_explicit_simple k N n
   refine ⟨ι, hιFin, hιDec, fun i => ↥(S' i),
     fun _ => inferInstance, fun _ => inferInstance,
     fun i => hSi_fin i, L, hL_simple, ?_, ?_⟩
@@ -394,7 +394,7 @@ statement is false, since `IsAlgebraicRepresentation` + `h_homog` admits the
 counterexample `M = Sym²(V) ⊗ det⁻¹` (`N = 2`, `n = 0`), which has no embedding
 into `V^{⊗0}`. -/
 theorem polynomial_homog_rep_asModule_embeds_directSum_simple
-    [IsAlgClosed k] [CharZero k] (n : ℕ) (hN : n ≤ N)
+    [IsAlgClosed k] [CharZero k] (n : ℕ)
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
     (halg : Etingof.IsAlgebraicRepresentation N M.ρ)
     (h_span : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M (fun i => μ i) = ⊤)
@@ -417,13 +417,13 @@ theorem polynomial_homog_rep_asModule_embeds_directSum_simple
       (M := M) (halg := halg) (h_span := h_span) (h_homog := h_homog)
   -- (2) unified equivariant + simple Schur–Weyl decomposition of `V^{⊗n}`.
   obtain ⟨ι, hιFin, hιDec, S, hSacg, hSmod, hSfin, L, hLsimp, e, he⟩ :=
-    glTensorRep_schurWeyl_decomposition_equivariant_simple (k := k) (N := N) n hN
+    glTensorRep_schurWeyl_decomposition_equivariant_simple (k := k) (N := N) n
   -- schurPoly-classification of the abstract simples (#4758), read off the bare
   -- decomposition data `(e, he, hLsimp)` via the classification crux (#4732) and
   -- the deferred distinctness (#4731 / #4849-chain).
   have hclass : ∃ lam : ι → {l : Fin N → ℕ // Antitone l}, Function.Injective lam ∧
       ∀ i, formalCharacter k N (L i) = schurPoly N (lam i).val :=
-    Etingof.glTensorRep_schurWeyl_simples_schurPoly_classified k N n hN L e he hLsimp
+    Etingof.glTensorRep_schurWeyl_simples_schurPoly_classified k N n L e he hLsimp
   haveI iSfree : ∀ i, Module.Free k (S i) := fun i => Module.Free.of_divisionRing k (S i)
   -- basis index of each multiplicity space, in `Type 0` so `κ` stays small.
   set β : ι → Type := fun i => Fin (Module.finrank k (S i)) with hβ
@@ -500,7 +500,7 @@ linearly independent, so a single-`schurPoly` left side has a single summand. Th
 classification is read off the bare decomposition data via
 `glTensorRep_schurWeyl_simples_schurPoly_classified`. -/
 theorem decompose_polynomial_gl_rep
-    [IsAlgClosed k] [CharZero k] (n : ℕ) (hN : n ≤ N)
+    [IsAlgClosed k] [CharZero k] (n : ℕ)
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
     (halg : Etingof.IsAlgebraicRepresentation N M.ρ)
     (h_span : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M (fun i => μ i) = ⊤)
@@ -517,7 +517,7 @@ theorem decompose_polynomial_gl_rep
   -- Embed `M.asModule` as a submodule `M'` of an ambient module `W` that is
   -- `R`-linearly a finite direct sum of the simple `L (gκ c)`.
   obtain ⟨ι, hιFin, hιDec, L, hLsimp, hclass, κ, hκFin, gκ, W, hWacg, hWmod, e, M', ⟨eM⟩⟩ :=
-    polynomial_homog_rep_asModule_embeds_directSum_simple k N n hN M halg h_span h_homog
+    polynomial_homog_rep_asModule_embeds_directSum_simple k N n M halg h_span h_homog
   -- The ambient summand family, indexed by `κ`.
   set Lsum : κ → Type u := fun c => Representation.asModule (L (gκ c)).ρ with hLsum
   haveI : ∀ c, IsSimpleModule (GLAlg k N) (Lsum c) := fun c => hLsimp (gκ c)

--- a/EtingofRepresentationTheory/Chapter5/SchurModuleSimple.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurModuleSimple.lean
@@ -165,18 +165,17 @@ module over `centralizer(symGroupImage)`. This is the application of
 bimodule decomposition, feeding it off-block vanishing (sub-β) and the rank-1
 scaled projection on the special block (sub-γ). -/
 private theorem schurBlock_imageSubmoduleB_isSimple
-    (hlam : Antitone lam) (hN : (∑ i, lam i) ≤ N) :
+    (hlam : Antitone lam) (_hN : (∑ i, lam i) ≤ N) :
     IsSimpleModule
       (↥(Subalgebra.centralizer ℂ
         (symGroupImage ℂ (Fin N → ℂ) (∑ i, lam i) :
           Set (Module.End ℂ (TensorPower ℂ (Fin N → ℂ) (∑ i, lam i))))))
       ↥(imageSubmoduleB (youngSymElement ℂ N lam)) := by
   classical
-  have hN' : (∑ i, lam i) ≤ Module.finrank ℂ (Fin N → ℂ) := finrank_bound N lam hN
   -- sub-α: explicit bimodule decomposition.
   obtain ⟨ι, _, _, S, hSimp, hDist, hSfin, _hLsimp, e, he⟩ :=
     Theorem5_18_4_bimodule_decomposition_explicit
-      (k := ℂ) (V := Fin N → ℂ) (n := ∑ i, lam i) hN'
+      (k := ℂ) (V := Fin N → ℂ) (n := ∑ i, lam i)
   haveI : IsSemisimpleModule (symGroupImage ℂ (Fin N → ℂ) (∑ i, lam i))
       (TensorPower ℂ (Fin N → ℂ) (∑ i, lam i)) := IsSemisimpleRing.isSemisimpleModule
   -- sub-A (#4634): the unique special block.
@@ -258,13 +257,12 @@ theorem schurModuleSubmodule_isSimple_centralizer
       (↥(diagonalActionImage ℂ (Fin N → ℂ) (∑ i, lam i)))
       (SchurModuleSubmodule ℂ N lam) := by
   classical
-  have hN' : (∑ i, lam i) ≤ Module.finrank ℂ (Fin N → ℂ) := finrank_bound N lam hN
   -- `diagonalActionImage = centralizer(symGroupImage)`.
   have hBD : diagonalActionImage ℂ (Fin N → ℂ) (∑ i, lam i) =
       Subalgebra.centralizer ℂ
         (symGroupImage ℂ (Fin N → ℂ) (∑ i, lam i) :
           Set (Module.End ℂ (TensorPower ℂ (Fin N → ℂ) (∑ i, lam i)))) :=
-    (Theorem5_18_4_centralizers ℂ (Fin N → ℂ) (∑ i, lam i) hN').2
+    (Theorem5_18_4_centralizers ℂ (Fin N → ℂ) (∑ i, lam i)).2
   -- The interface result: `imageSubmoduleB c` is simple over the centralizer.
   have h1 := schurBlock_imageSubmoduleB_isSimple N lam hlam hN
   -- Ring iso induced by the subalgebra equality.

--- a/EtingofRepresentationTheory/Chapter5/SchurWeylGLTransfer.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurWeylGLTransfer.lean
@@ -658,7 +658,7 @@ Combines:
 -/
 theorem Theorem5_18_4_GL_rep_decomposition_simple
     (k : Type u) [Field k] [IsAlgClosed k] [CharZero k]
-    (N n : ℕ) (hN : n ≤ N) :
+    (N n : ℕ) (_hN : n ≤ N) :
     ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
       (S : ι → Type u)
       (_ : ∀ i, AddCommGroup (S i))
@@ -676,16 +676,13 @@ theorem Theorem5_18_4_GL_rep_decomposition_simple
         DirectSum ι (fun i => S i ⊗[k] (L i : Type u))) := by
   set V : Type u := Fin N → k with hV
   haveI : Module.Finite k V := inferInstance
-  have hfinrank : Module.finrank k V = N :=
-    (Module.finrank_pi k).trans (Fintype.card_fin N)
-  have hN' : n ≤ Module.finrank k V := hfinrank.symm ▸ hN
   haveI := symGroupImage_isSemisimpleRing k V n
-  haveI := symGroupImage_faithfulSMul k V n hN'
+  haveI := symGroupImage_faithfulSMul k V n
   -- Re-destructure the bimodule decomposition; this time we keep `homA_simp`
   -- (the centralizer-side simplicity clause) which the inner
   -- `_GL_rep_decomposition_explicit` discards.
   obtain ⟨ι, hι, hι_dec, S', hS'_simp, hS'_dist, hS'_fin, homA_simp, e, _he⟩ :=
-    Theorem5_18_4_bimodule_decomposition_explicit k V n hN'
+    Theorem5_18_4_bimodule_decomposition_explicit k V n
   -- Build the GL_N action data exactly as in `_explicit`.
   let glHom : Matrix.GeneralLinearGroup (Fin N) k →*
       ↥(Subalgebra.centralizer k
@@ -712,7 +709,7 @@ theorem Theorem5_18_4_GL_rep_decomposition_simple
   have h_eq : Subalgebra.centralizer k
       (symGroupImage k V n : Set (Module.End k (TensorPower k V n))) =
       diagonalActionImage k V n :=
-    ((Theorem5_18_4_centralizers k V n hN').2).symm
+    ((Theorem5_18_4_centralizers k V n).2).symm
   -- For each i, prove simplicity of the GL_N-representation `FDRep.of (ρ_i i)`
   -- as a `MonoidAlgebra k GL_N`-module.
   have hL_simple : ∀ i, IsSimpleModule
@@ -823,7 +820,7 @@ coercion is paid here, once, at the `refine`), so the downstream equivariance
 computation can use it opaquely without re-triggering that coercion. -/
 theorem Theorem5_18_4_GL_rep_decomposition_explicit_simple
     (k : Type u) [Field k] [IsAlgClosed k] [CharZero k]
-    (N n : ℕ) (hN : n ≤ N) :
+    (N n : ℕ) :
     ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
       (S : ι → Submodule (symGroupImage k (Fin N → k) n)
         (TensorPower k (Fin N → k) n))
@@ -851,14 +848,11 @@ theorem Theorem5_18_4_GL_rep_decomposition_explicit_simple
               ((L_carrier i l) v)) := by
   set V : Type u := Fin N → k with hV
   haveI : Module.Finite k V := inferInstance
-  have hfinrank : Module.finrank k V = N :=
-    (Module.finrank_pi k).trans (Fintype.card_fin N)
-  have hN' : n ≤ Module.finrank k V := hfinrank.symm ▸ hN
   haveI := symGroupImage_isSemisimpleRing k V n
-  haveI := symGroupImage_faithfulSMul k V n hN'
+  haveI := symGroupImage_faithfulSMul k V n
   -- Keep `homA_simp` this time (the `_explicit` wrapper discards it).
   obtain ⟨ι, hι, hι_dec, S', hS'_simp, hS'_dist, hS'_fin, homA_simp, e, he⟩ :=
-    Theorem5_18_4_bimodule_decomposition_explicit k V n hN'
+    Theorem5_18_4_bimodule_decomposition_explicit k V n
   let glHom : Matrix.GeneralLinearGroup (Fin N) k →*
       ↥(Subalgebra.centralizer k
         (symGroupImage k V n : Set (Module.End k (TensorPower k V n)))) :=
@@ -889,7 +883,7 @@ theorem Theorem5_18_4_GL_rep_decomposition_explicit_simple
   have h_eq : Subalgebra.centralizer k
       (symGroupImage k V n : Set (Module.End k (TensorPower k V n))) =
       diagonalActionImage k V n :=
-    ((Theorem5_18_4_centralizers k V n hN').2).symm
+    ((Theorem5_18_4_centralizers k V n).2).symm
   -- Per-`L i` simplicity over `MonoidAlgebra k GL_N` (à la `_simple`'s `hL_simple`).
   have hL_simple : ∀ i, IsSimpleModule
       (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))

--- a/EtingofRepresentationTheory/Chapter5/SchurWeylLDistinct.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurWeylLDistinct.lean
@@ -69,7 +69,7 @@ drives an `Algebra.adjoin_induction`: the intertwining property is closed under
 generators by hypothesis. -/
 theorem homA_centralizer_smul_comm_of_unitTensorPow_intertwine
     [Module.Finite k V] [Infinite k] [CharZero k] {n : ℕ}
-    (hN : n ≤ Module.finrank k V)
+    (_hN : n ≤ Module.finrank k V)
     {S W : Submodule (symGroupImage k V n) (TensorPower k V n)}
     (ψ : (↥S →ₗ[symGroupImage k V n] TensorPower k V n) ≃ₗ[k]
         (↥W →ₗ[symGroupImage k V n] TensorPower k V n))
@@ -109,7 +109,7 @@ theorem homA_centralizer_smul_comm_of_unitTensorPow_intertwine
   -- `C = Algebra.adjoin k {g^{⊗n} : g unit}`.
   have hCeq : C = Algebra.adjoin k (Set.range fun (g : (Module.End k V)ˣ) =>
       PiTensorProduct.map (R := k) (fun _ : Fin n => (g : Module.End k V))) := by
-    rw [hC, centralizer_symGroupImage_eq_diagonalActionImage k V n hN,
+    rw [hC, centralizer_symGroupImage_eq_diagonalActionImage k V n,
       ← adjoin_unitsTensorPow_eq_diagonalActionImage k (V := V) (n := n)]
   -- Reduce to an adjoin induction over `cval ∈ adjoin k {g^{⊗n}}`.
   have hgen : cval ∈ Algebra.adjoin k
@@ -161,7 +161,7 @@ that intertwines post-composition by every `g^{⊗n}` to a `C`-linear equiv over
 the centralizer `C = centralizer(symGroupImage k V n)`. -/
 noncomputable def homACentralizerLinearEquivOfUnitTensorPowIntertwine
     [Module.Finite k V] [Infinite k] [CharZero k] {n : ℕ}
-    (hN : n ≤ Module.finrank k V)
+    (_hN : n ≤ Module.finrank k V)
     {S W : Submodule (symGroupImage k V n) (TensorPower k V n)}
     (ψ : (↥S →ₗ[symGroupImage k V n] TensorPower k V n) ≃ₗ[k]
         (↥W →ₗ[symGroupImage k V n] TensorPower k V n))
@@ -175,7 +175,7 @@ noncomputable def homACentralizerLinearEquivOfUnitTensorPowIntertwine
   invFun := ψ.symm
   map_add' := ψ.map_add
   map_smul' c l :=
-    homA_centralizer_smul_comm_of_unitTensorPow_intertwine hN ψ h_int c l
+    homA_centralizer_smul_comm_of_unitTensorPow_intertwine _hN ψ h_int c l
   left_inv := ψ.left_inv
   right_inv := ψ.right_inv
 

--- a/EtingofRepresentationTheory/Chapter5/SchurWeylSimplesClassification.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurWeylSimplesClassification.lean
@@ -104,7 +104,7 @@ The deep step — "a simple polynomial `GL_N`-rep is character-determined ⇒
 residual `sorry` is isolated here so the reduction and headline corollary remain
 otherwise sorry-free. Tracked by issue #4721. -/
 theorem schurWeyl_simples_formalCharacter_classification_core
-    (N n : ℕ) (hN : n ≤ N)
+    (N n : ℕ)
     {ι : Type} [Fintype ι] [DecidableEq ι]
     {S : ι → Type u} [∀ i, AddCommGroup (S i)] [∀ i, Module k (S i)]
     [∀ i, Module.Finite k (S i)]
@@ -145,7 +145,7 @@ lands, the `Pairwise` conclusion is isolated here as a single `sorry`, mirroring
 schurPoly-classification API (`decompose_polynomial_gl_rep`, issue #4758) stays
 otherwise sorry-free. -/
 theorem glTensorRep_schurWeyl_simples_pairwise_distinct
-    (N n : ℕ) (hN : n ≤ N)
+    (N n : ℕ)
     {ι : Type} [Fintype ι] [DecidableEq ι]
     {S : ι → Type u} [∀ i, AddCommGroup (S i)] [∀ i, Module k (S i)]
     [∀ i, Module.Finite k (S i)]
@@ -180,7 +180,7 @@ the Schur-Weyl #6 assembly read the partition classification of the abstract
 simples without re-deriving the tensor-power decomposition data `(e, he, hLsimp,
 hLdist)` itself. -/
 theorem glTensorRep_schurWeyl_simples_schurPoly_classified
-    (N n : ℕ) (hN : n ≤ N)
+    (N n : ℕ)
     {ι : Type} [Fintype ι] [DecidableEq ι]
     {S : ι → Type u} [∀ i, AddCommGroup (S i)] [∀ i, Module k (S i)]
     [∀ i, Module.Finite k (S i)]
@@ -199,8 +199,8 @@ theorem glTensorRep_schurWeyl_simples_schurPoly_classified
     ∃ lam : ι → {l : Fin N → ℕ // Antitone l},
       Function.Injective lam ∧
       ∀ i, formalCharacter k N (L i) = schurPoly N (lam i).val :=
-  schurWeyl_simples_formalCharacter_classification_core k N n hN L e he hLsimp
-    (glTensorRep_schurWeyl_simples_pairwise_distinct k N n hN L e he hLsimp)
+  schurWeyl_simples_formalCharacter_classification_core k N n L e he hLsimp
+    (glTensorRep_schurWeyl_simples_pairwise_distinct k N n L e he hLsimp)
 
 /-- **Headline (sorry-free given the crux).** The formal characters of the
 abstract simple summands `L i` of `V^{⊗n}` (from
@@ -211,7 +211,7 @@ The proof obtains the partition classification from
 `schurWeyl_simples_formalCharacter_classification_core` and feeds it to the
 reduction `formalCharacter_linearIndependent_of_eq_schurPoly`. -/
 theorem glTensorRep_schurWeyl_simples_formalCharacter_linearIndependent
-    (N n : ℕ) (hN : n ≤ N)
+    (N n : ℕ) (_hN : n ≤ N)
     {ι : Type} [Fintype ι] [DecidableEq ι]
     {S : ι → Type u} [∀ i, AddCommGroup (S i)] [∀ i, Module k (S i)]
     [∀ i, Module.Finite k (S i)]
@@ -230,7 +230,7 @@ theorem glTensorRep_schurWeyl_simples_formalCharacter_linearIndependent
     (hLdist : Pairwise (fun i j => ¬ Nonempty ((L i) ≅ (L j)))) :
     LinearIndependent ℚ (fun i => formalCharacter k N (L i)) := by
   obtain ⟨lam, hlam_inj, hlam_char⟩ :=
-    schurWeyl_simples_formalCharacter_classification_core k N n hN L e he hLsimp hLdist
+    schurWeyl_simples_formalCharacter_classification_core k N n L e he hLsimp hLdist
   exact formalCharacter_linearIndependent_of_eq_schurPoly k N L lam hlam_inj hlam_char
 
 end Etingof

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_18_4.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_18_4.lean
@@ -176,8 +176,7 @@ instance symGroupImage_isSemisimpleRing
 /-- V⊗ⁿ is a faithful module over symGroupImage when n ≤ dim V.
 Distinct permutations produce distinct operators on V⊗ⁿ when
 there are enough linearly independent vectors. -/
-theorem symGroupImage_faithfulSMul
-    (hN : n ≤ Module.finrank k V) :
+theorem symGroupImage_faithfulSMul :
     FaithfulSMul (symGroupImage k V n) (TensorPower k V n) := by
   constructor
   intro a b hab
@@ -210,8 +209,7 @@ for all σ, so n!·φ = Σ_σ conj_σ(φ). By multilinear polarization
 Dividing by n! (char 0) gives φ ∈ diagonalActionImage.
 -/
 theorem centralizer_symGroupImage_eq_diagonalActionImage
-    [CharZero k]
-    (_hN : n ≤ Module.finrank k V) :
+    [CharZero k] :
     Subalgebra.centralizer k
       (symGroupImage k V n :
         Set (Module.End k (TensorPower k V n))) =
@@ -266,21 +264,20 @@ Specifically, symGroupImage = centralizer(diagonalActionImage) and
 diagonalActionImage = centralizer(symGroupImage).
 (Etingof Theorem 5.18.4, part i) -/
 theorem Theorem5_18_4_centralizers
-    [CharZero k]
-    (hN : n ≤ Module.finrank k V) :
+    [CharZero k] :
     symGroupImage k V n = Subalgebra.centralizer k
       (diagonalActionImage k V n :
         Set (Module.End k (TensorPower k V n)))
     ∧ diagonalActionImage k V n = Subalgebra.centralizer k
       (symGroupImage k V n :
         Set (Module.End k (TensorPower k V n))) := by
-  have h_cent := centralizer_symGroupImage_eq_diagonalActionImage k V n hN
+  have h_cent := centralizer_symGroupImage_eq_diagonalActionImage k V n
   constructor
   · -- symGroupImage = centralizer(diagonalActionImage)
     -- By double centralizer theorem: centralizer(centralizer(symGroupImage)) = symGroupImage
     -- Since centralizer(symGroupImage) = diagonalActionImage, this gives the result
     haveI := symGroupImage_isSemisimpleRing k V n
-    haveI := symGroupImage_faithfulSMul k V n hN
+    haveI := symGroupImage_faithfulSMul k V n
     rw [← h_cent]
     exact (Theorem5_18_1_double_centralizer k (TensorPower k V n) (symGroupImage k V n)).symm
   · -- diagonalActionImage = centralizer(symGroupImage)
@@ -291,7 +288,7 @@ action subalgebras of End(V^⊗n) are both semisimple.
 (Etingof Theorem 5.18.4, part ii) -/
 theorem Theorem5_18_4_semisimple
     [CharZero k]
-    (hN : n ≤ Module.finrank k V) :
+    (_hN : n ≤ Module.finrank k V) :
     IsSemisimpleRing (symGroupImage k V n)
     ∧ IsSemisimpleRing (diagonalActionImage k V n) := by
   constructor
@@ -299,9 +296,9 @@ theorem Theorem5_18_4_semisimple
   · -- diagonalActionImage = centralizer(symGroupImage)
     -- centralizer of semisimple subalgebra is semisimple
     rw [← centralizer_symGroupImage_eq_diagonalActionImage
-      k V n hN]
+      k V n]
     haveI := symGroupImage_isSemisimpleRing k V n
-    haveI := symGroupImage_faithfulSMul k V n hN
+    haveI := symGroupImage_faithfulSMul k V n
     exact Theorem5_18_1_commutant_semisimple k (TensorPower k V n) (symGroupImage k V n)
 
 /-- Schur-Weyl duality, part (iii): Decomposition of V^⊗n.
@@ -314,7 +311,7 @@ polynomial GL(V)-representations.
 (Etingof Theorem 5.18.4, part iii) -/
 theorem Theorem5_18_4_decomposition
     [CharZero k]
-    (hN : n ≤ Module.finrank k V) :
+    (_hN : n ≤ Module.finrank k V) :
     ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
       (S : ι → Type (max u v)) (L : ι → Type u)
       (_ : ∀ i, AddCommGroup (S i))
@@ -324,7 +321,7 @@ theorem Theorem5_18_4_decomposition
       Nonempty (TensorPower k V n ≃ₗ[k]
         DirectSum ι (fun i => S i ⊗[k] L i)) := by
   haveI := symGroupImage_isSemisimpleRing k V n
-  haveI := symGroupImage_faithfulSMul k V n hN
+  haveI := symGroupImage_faithfulSMul k V n
   obtain ⟨ι, hι, hι_dec, V', W', hV'_acg, hV'_mod,
     hV'_Amod, hV'_simp, hW'_acg, hW'_mod, ⟨e⟩⟩ :=
     Theorem5_18_1_decomposition k
@@ -413,7 +410,7 @@ from `Theorem5_18_4_centralizers`.
 (Etingof Theorem 5.18.4, part iii, bimodule form.) -/
 theorem Theorem5_18_4_bimodule_decomposition
     [IsAlgClosed k] [CharZero k]
-    (hN : n ≤ Module.finrank k V) :
+    (_hN : n ≤ Module.finrank k V) :
     ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
       (S : ι → Type (max u v))
       (_ : ∀ i, AddCommGroup (S i))
@@ -428,7 +425,7 @@ theorem Theorem5_18_4_bimodule_decomposition
       Nonempty (TensorPower k V n ≃ₗ[k]
         DirectSum ι (fun i => S i ⊗[k] L i)) := by
   haveI := symGroupImage_isSemisimpleRing k V n
-  haveI := symGroupImage_faithfulSMul k V n hN
+  haveI := symGroupImage_faithfulSMul k V n
   obtain ⟨ι, hι, hι_dec, S', hS'_acg, hS'_mod, hS'_Amod, hS'_simp,
     hS'_dist, hS'_fin, L', hL'_acg, hL'_mod, hL'_Bmod, _hL'_smul, _hL'_fin, ⟨e⟩⟩ :=
     Theorem5_18_1_bimodule_decomposition k (TensorPower k V n)
@@ -439,7 +436,7 @@ theorem Theorem5_18_4_bimodule_decomposition
   have h_eq : Subalgebra.centralizer k
       (symGroupImage k V n : Set (Module.End k (TensorPower k V n))) =
         diagonalActionImage k V n :=
-    (Theorem5_18_4_centralizers k V n hN).2.symm
+    (Theorem5_18_4_centralizers k V n).2.symm
   refine ⟨ι, hι, hι_dec, S', hS'_acg, hS'_mod, hS'_Amod, hS'_simp, hS'_dist,
     hS'_fin, L', hL'_acg, hL'_mod, fun i => h_eq ▸ hL'_Bmod i, ⟨e⟩⟩
 
@@ -462,8 +459,7 @@ of the iso with respect to the centralizer-post-composition action).
 
 (Etingof Theorem 5.18.4, part iii, bimodule form, explicit version.) -/
 theorem Theorem5_18_4_bimodule_decomposition_explicit
-    [IsAlgClosed k] [CharZero k]
-    (hN : n ≤ Module.finrank k V) :
+    [IsAlgClosed k] [CharZero k] :
     ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
       (S : ι → Submodule (symGroupImage k V n) (TensorPower k V n))
       (_ : ∀ i, IsSimpleModule (symGroupImage k V n) (S i))
@@ -480,7 +476,7 @@ theorem Theorem5_18_4_bimodule_decomposition_explicit
           (l : ↥(S i) →ₗ[symGroupImage k V n] TensorPower k V n),
           e.symm (DirectSum.of _ i (v ⊗ₜ[k] l)) = l v := by
   haveI := symGroupImage_isSemisimpleRing k V n
-  haveI := symGroupImage_faithfulSMul k V n hN
+  haveI := symGroupImage_faithfulSMul k V n
   exact Theorem5_18_1_bimodule_decomposition_explicit k (TensorPower k V n)
     (symGroupImage k V n)
 
@@ -579,7 +575,7 @@ issue #2540): the evaluation formula together with the post-composition
 `GL_N`-action formula make equivariance computable on pure tensors. -/
 theorem Theorem5_18_4_GL_rep_decomposition_explicit
     (k : Type u) [Field k] [IsAlgClosed k] [CharZero k]
-    (N n : ℕ) (hN : n ≤ N) :
+    (N n : ℕ) (_hN : n ≤ N) :
     ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
       (S : ι → Submodule (symGroupImage k (Fin N → k) n)
         (TensorPower k (Fin N → k) n))
@@ -604,15 +600,12 @@ theorem Theorem5_18_4_GL_rep_decomposition_explicit
               ((L_carrier i l) v)) := by
   set V : Type u := Fin N → k with hV
   haveI : Module.Finite k V := inferInstance
-  have hfinrank : Module.finrank k V = N :=
-    (Module.finrank_pi k).trans (Fintype.card_fin N)
-  have hN' : n ≤ Module.finrank k V := hfinrank.symm ▸ hN
   haveI := symGroupImage_isSemisimpleRing k V n
-  haveI := symGroupImage_faithfulSMul k V n hN'
+  haveI := symGroupImage_faithfulSMul k V n
   -- Get the explicit bimodule decomposition with concrete summand types
   -- and the evaluation formula.
   obtain ⟨ι, hι, hι_dec, S', hS'_simp, hS'_dist, hS'_fin, _, e, he⟩ :=
-    Theorem5_18_4_bimodule_decomposition_explicit k V n hN'
+    Theorem5_18_4_bimodule_decomposition_explicit k V n
   -- Monoid hom GL_N → centralizer(symGroupImage):
   --   g ↦ PiTensorProduct.map (fun _ => mulVecLin g.val).
   -- The explicit type ascription forces unification of `V` with `Fin N → k`

--- a/progress/2026-06-21T14-44-52Z_197e354a.md
+++ b/progress/2026-06-21T14-44-52Z_197e354a.md
@@ -1,0 +1,58 @@
+## Accomplished
+
+Worked issue **#4745** (prove relocated `iso_of_formalCharacter_eq_schurPoly`
+sorry-free). The issue was scoped as "final assembly only — all ingredients
+landed," but diagnosis revealed a real blocker the plan missed, which I removed.
+
+- **Diagnosis.** `iso_of_formalCharacter_eq_schurPoly`'s only route is
+  `decompose_polynomial_gl_rep`, which carried a hypothesis `n ≤ N` (homogeneity
+  degree ≤ ambient dimension). The sole consumer (`schurModule_shift_iso_detTwist`,
+  Proposition 5.22.2) decomposes the det-twisted Schur module, whose homogeneity
+  degree is `∑λ + N > N` — so the consumer can **never** satisfy `n ≤ N`. The
+  assembly as specified was therefore unprovable against the existing API. No
+  degree-unrestricted decomposition existed in the project.
+- **Root cause.** The `n ≤ N` hypothesis is **vestigial** throughout the entire
+  Schur-Weyl decomposition chain: it is only ever forwarded to
+  `symGroupImage_faithfulSMul` (image faithfulness is automatic — the proof
+  ignores it) and `centralizer_symGroupImage_eq_diagonalActionImage` (whose proof
+  is the char-0 averaging/polarization `map_span_eq_top` argument, dimension-
+  independent; its binder was even named `_hN`).
+- **Fix (committed, `refactor(Ch5 #4745)`).** Stripped the `n ≤ N` binder from the
+  11 chain lemmas across `Theorem5_18_4.lean`, `SchurWeylGLTransfer.lean`,
+  `PolynomialGLDecomposition.lean`, `SchurWeylSimplesClassification.lean`; dropped
+  the forwarded args at all call sites; consumer lemmas keep their (now-unused)
+  hypothesis renamed `_hN`. `decompose_polynomial_gl_rep` is now degree-
+  unrestricted. **Build verified**: `PolynomialGLDecomposition` and its entire
+  import closure (all 7 changed files) compile; no new sorries; no new style
+  warnings.
+
+## Current frontier
+
+The degree-unrestriction prerequisite is landed. The assembly itself
+(`iso_of_formalCharacter_eq_schurPoly` proof + `Proposition5_22_2` consumer
+update) is **not** done — filed as **#4882** with the full route and ingredients.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing in Chapter 5. This turn removed an infrastructure
+constraint blocking the Schur-Weyl #6 capstone (#2483/#4745) and several adjacent
+items that decompose reps of degree > N.
+
+## Next step
+
+Claim **#4882**: prove `iso_of_formalCharacter_eq_schurPoly` sorry-free against the
+now-degree-unrestricted `decompose_polynomial_gl_rep`, and update
+`Proposition5_22_2` (supply `halg = detTwistedSchurModuleRep_isAlgebraic` and hoist
+`h₁_top` as `h_span`). The main remaining piece of new infrastructure is the
+`asModule` (`GLAlg`-linear) → `FDRep` (`k`-linear GL-equivariant) character bridge
+for step 3.
+
+## Blockers
+
+- **Merge-order interaction with PR #4871** (open, `#4862` Complex classification).
+  That PR adds `SchurWeylSimplesClassificationComplex.lean`, which references the
+  classification lemmas whose signatures I changed
+  (`schurWeyl_simples_formalCharacter_classification_core` etc. lost `hN`). If #4871
+  merges after this refactor, its call sites may need the `hN` args dropped (CI will
+  flag them). The Complex file is not on `main`, so this refactor PR is self-
+  consistent; the second PR to merge resolves the overlap.


### PR DESCRIPTION
This PR degree-unrestricts the Schur-Weyl decomposition chain by removing the
vestigial `n ≤ N` (`n ≤ Module.finrank k V`) hypothesis from
`decompose_polynomial_gl_rep` and the 11 lemmas it transitively depends on.
The hypothesis was never used essentially: it was only forwarded to
`symGroupImage_faithfulSMul` (image faithfulness is automatic) and
`centralizer_symGroupImage_eq_diagonalActionImage` (proved by the char-0
averaging/polarization `map_span_eq_top` argument, which is dimension-
independent — its binder was even named `_hN`). Stripping it lets
`decompose_polynomial_gl_rep` decompose homogeneous polynomial `GL_N`
representations of any degree, which is exactly what its consumer
`iso_of_formalCharacter_eq_schurPoly` (#4745) needs: the det-twist case
(Proposition 5.22.2) decomposes a representation of homogeneity degree
`∑λ + N > N`, forbidden under the old constraint.

The change strips the binder from the chain lemmas and drops the forwarded
argument at every call site; consumer lemmas that are not on the decomposition
path keep their own now-unused hypothesis, renamed `_hN`, so their signatures
and callers are untouched. No proof logic changed and no new `sorry` was
introduced; the full build passes (`PolynomialGLDecomposition` and its entire
import closure compile).

This is partial progress on #4745: it removes the blocker the issue's plan did
not anticipate. The remaining assembly — proving
`iso_of_formalCharacter_eq_schurPoly` sorry-free and updating its consumer
`Proposition5_22_2` — is filed as #4882, now unblocked.

Note on merge order: the open PR #4871 (#4862 ℂ-side classification) adds
`SchurWeylSimplesClassificationComplex.lean`, which references the classification
lemmas whose signatures change here. That file is not on `main`, so this PR is
self-consistent; whichever of the two merges second will need its call sites to
drop the `hN` arguments (CI will flag them).

🤖 Prepared with Claude Code
