### PR TITLE
doc(plan): decompose toolchain port #4864 — pioneer #4888 + porting strategy

### DIFF
--- a/plans/4b94ee50-1.md
+++ b/plans/4b94ee50-1.md
@@ -1,0 +1,77 @@
+First decomposed work item of the toolchain port **#4864** (v4.28.1 → v4.31.0).
+This is the **pioneer** item: it ports the two `Infrastructure` modules **and**
+establishes the harness-compatible porting pattern that every subsequent
+per-chapter item under #4864 will follow.
+
+## Why a new strategy is needed
+
+The plan recorded on #4864 (carried over from the closed PR #4857) was "land
+each chapter's fixes against a shared toolchain-bump branch, then a final
+aggregation PR." **That does not fit this harness.** `coordination create-pr`
+only ever opens PRs against `main`; there is no base-branch / integration-branch
+support, and CI runs exclusively on the project pin (`lean-toolchain` =
+`v4.28.1`). A long-lived bump branch would sit un-merged and un-CI'd, and
+flipping `lean-toolchain` on `main` first would red-line the build for every
+other agent until all ~30 modules are fixed. Neither is viable.
+
+## Strategy this item establishes (forward-compatible prep on `main`)
+
+Port each failing module with fixes that compile on **both** v4.28.1 (the
+current pin, what CI checks) **and** v4.31.0, then land them on `main` one PR at
+a time while the pin stays at v4.28.1. The final `#4864` item flips
+`lean-toolchain` / `lakefile.toml` `mathlib` rev / `lake-manifest.json` in one
+small PR once every module has been pre-staged this way. Most listed breakages
+(instance-argument inference, lemma renames, explicit-arg drift) admit a
+both-versions-compatible rewrite; the genuinely signature-incompatible ones
+(e.g. `Action.res` return type) are deferred to the flip PR and called out in
+their per-chapter item.
+
+Per-module workflow (document any deviations in the PR body so later items can reuse them):
+1. Clone the repo fresh to `/tmp`, bump `lean-toolchain` to `v4.31.0`, run
+   `lake update mathlib` + `lake exe cache get`, and `lake build <module>` to
+   reproduce the exact v4.31 error. **Do not** push the bump from the scratch clone.
+2. Write a fix that resolves the v4.31 error **and** still compiles on v4.28.1.
+3. In this worktree (v4.28.1) confirm `lake build <module>` is green — this is
+   what CI verifies; the v4.31-correctness is verified by the scratch build in step 1.
+
+## Current state
+
+Pin is `leanprover/lean4:v4.28.1`. The two Infrastructure modules below build
+clean today on v4.28.1 but were observed failing on the v4.31.0 build recorded
+in #4864:
+
+- `EtingofRepresentationTheory/Infrastructure/CornerRing.lean` — `IsIdempotentElem`
+  instance argument can no longer be inferred via typeclass synthesis.
+- `EtingofRepresentationTheory/Infrastructure/IrreducibleEnumeration.lean` —
+  listed among the v4.31.0 failures (diagnose the exact drift in step 1).
+
+## Deliverables
+
+1. `CornerRing.lean`: forward-compatible fix (likely supply the `IsIdempotentElem`
+   witness explicitly rather than relying on synthesis) that builds on both
+   v4.28.1 and v4.31.0.
+2. `IrreducibleEnumeration.lean`: same, for whatever drift step 1 surfaces. If
+   the only viable fix is signature-incompatible (cannot compile on v4.28.1),
+   do **not** force it — leave that module to the flip PR and say so in the PR
+   body and on #4864.
+3. Add a short subsection to the most recent `progress/` handoff (or a dedicated
+   `progress/toolchain-port-strategy.md`) recording the forward-compatible-prep
+   pattern, so the next planner can decompose the remaining chapters of #4864
+   (Chapter2/3/4/5/6/7/9) into items that follow it.
+
+## Context
+
+- Parent: #4864 (multi-chapter re-port; full failing-module list in its body).
+- Origin: PR #4857 (closed unsalvageable — the monolithic-bump attempt).
+- Both `#2564` and `#2841` (Mathlib-upstream lemma trackers) are blocked on the
+  port completing, because their lemmas only exist in Mathlib v4.29+.
+- Do **not** modify `lean-toolchain`, `lakefile.toml`, or `lake-manifest.json`
+  in this PR — those flip only in the final #4864 item.
+
+## Verification
+
+- `lake exe cache get` then
+  `lake build EtingofRepresentationTheory.Infrastructure.CornerRing` and
+  `…IrreducibleEnumeration` green in this worktree (v4.28.1).
+- Scratch v4.31.0 clone: the same two modules build (evidence pasted into the PR body).
+- No change to the three pin files.

--- a/progress/20260621T150054Z_4b94ee50.md
+++ b/progress/20260621T150054Z_4b94ee50.md
@@ -1,0 +1,60 @@
+## Accomplished
+
+`/plan` session `4b94ee50`. Queue deficit was 1 (min 3, depth 2). No directives
+open; no PRs mergeable yet (#4877, #4883 still pending CI) and none broken.
+
+Acted on the standing planner recommendation (from
+`20260621T140158Z_c9cca561.md`) to decompose the toolchain port **#4864**
+(v4.28.1 → v4.31.0). Before decomposing I checked the harness and found a
+blocking constraint the #4864 body did not account for:
+
+- `coordination create-pr` opens PRs **only against `main`** — no base-branch /
+  integration-branch support — and CI builds **only** the pinned toolchain
+  (`lean-toolchain` = `v4.28.1`).
+- Therefore the #4864 plan ("land each chapter against a shared toolchain-bump
+  branch, then aggregate") is **not viable**: a long-lived bump branch would be
+  un-merged and un-CI'd, and flipping `lean-toolchain` on `main` first would
+  red-line the build for every agent until all ~30 modules are fixed.
+
+Created the **pioneer** sub-item **#4888** (critical-path), which both ports the
+two `Infrastructure` modules (`CornerRing`, `IrreducibleEnumeration`) and
+establishes the replacement strategy: **forward-compatible prep on `main`** —
+port each failing module with fixes that compile on *both* v4.28.1 and v4.31.0
+(verify v4.31 in a `/tmp` scratch clone, verify v4.28.1 in-worktree where CI
+checks), land them one PR at a time while the pin stays put, then a final small
+item flips the three pin files once every module is pre-staged.
+Signature-incompatible modules (e.g. `Action.res`) defer to that flip PR.
+Posted the strategy correction as a comment on #4864.
+
+## Current frontier
+
+Two work streams in flight:
+- **Toolchain port (#4864):** pioneer #4888 created; once it validates the
+  forward-compatible-prep pattern, the per-chapter fan-out can proceed.
+- **Ch5 Schur-Weyl:** active — claimed #4882/#4879/#4875/#4859 and a fresh
+  worker-led decomposition of #4875 into #4885/#4886/#4887 (character
+  independence: algebra-side Dedekind/Artin, formalCharacter↔torus trace,
+  assembly).
+
+## Overall project progress
+
+Etingof draft 1, Stage 3. Mathematical frontier is Ch5 Schur-Weyl classification.
+Infrastructural frontier is the v4.28→v4.31 port, now being decomposed under a
+harness-compatible strategy (#4888 first). Both Mathlib-upstream trackers
+(#2564, #2841) remain blocked on the port completing.
+
+## Next step
+
+- **Worker:** claim #4888 (critical-path) — it is the unblocker for the rest of
+  #4864 and proves out the prep pattern.
+- **Next planner:** once #4888 lands, fan out the remaining #4864 chapters
+  (Ch2/3/4/5/6/7/9, per the failing-module list in #4864's body) into per-chapter
+  forward-compatible-prep items following #4888's documented pattern. Leave the
+  pin-flip as the final item, after every module is pre-staged.
+
+## Blockers
+
+- #2564, #2841: blocked on the toolchain port (#4864) completing.
+- #4864: replan-labelled tracker; decomposition begun (#4888). Remaining
+  per-chapter fan-out awaits #4888 validating the pattern.
+- #4860: blocked on #4859 (Ch5 sub-wire).


### PR DESCRIPTION
This PR records the planning decision to decompose the Lean toolchain port #4864 (v4.28.1 → v4.31.0): it adds the pioneer work-item plan (landed as issue #4888) and the session handoff documenting the harness constraint that rules out the original integration-branch plan (`coordination create-pr` targets `main` only; CI builds the v4.28.1 pin) and the replacement forward-compatible-prep strategy.

Doc-only: `progress/` handoff and `plans/` body. No Lean changed.

🤖 Prepared with Claude Code