### PR TITLE
feat(toolchain #4888): CornerRing forward-compatible with Lean v4.31

### DIFF
--- a/EtingofRepresentationTheory/Infrastructure/CornerRing.lean
+++ b/EtingofRepresentationTheory/Infrastructure/CornerRing.lean
@@ -124,7 +124,14 @@ variable {e : A} (he : IsIdempotentElem e)
 -- The ring axioms (associativity, distributivity) follow from A's ring axioms.
 -- The only non-trivial part is that e acts as an identity: e * x = x = x * e
 -- for x ∈ eAe, which is cornerSubmodule_left_mul and cornerSubmodule_right_mul.
-noncomputable instance instRing : Ring (CornerRing (k := k) e) :=
+--
+-- This is a `def`, not an `instance`: it depends on the idempotency proof `he`,
+-- which is not instance-implicit and cannot be synthesised. (Lean v4.31 rejects
+-- such an `instance` outright; under v4.28.1 it was a latent lint warning.) All
+-- consumers already pass `he` explicitly via `letI := CornerRing.instRing he`.
+-- `@[reducible]` silences v4.31's "class-typed def must be reducible" warning and
+-- is a no-op on v4.28.1.
+@[reducible] noncomputable def instRing : Ring (CornerRing (k := k) e) :=
   { (inferInstance : AddCommGroup (CornerRing (k := k) e)) with
     mul := fun x y => ⟨(x : A) * (y : A), cornerSubmodule_mul_mem x.prop y.prop⟩
     one := ⟨e, mem_cornerSubmodule_self e he⟩
@@ -142,9 +149,14 @@ noncomputable instance instRing : Ring (CornerRing (k := k) e) :=
 --                                        = (algebraMap k A r) • e  (using he.eq).
 -- Commutativity of the algebra map with multiplication follows from
 -- r • (eae) = e(ra)e = (eae) • r for elements of eAe.
-noncomputable instance instAlgebra :
+-- A `def` for the same reason as `instRing`: it depends on the explicit `he`.
+@[reducible] noncomputable def instAlgebra :
     @Algebra k (CornerRing (k := k) e) _ (instRing he).toSemiring :=
-  @Algebra.ofModule k (CornerRing (k := k) e) _ (instRing he).toSemiring _
+  -- The `k`-module on `CornerRing e` is the one inherited from `cornerSubmodule e`,
+  -- passed positionally: v4.31 instance synthesis no longer unfolds the
+  -- semireducible `CornerRing` wrapper to discover it (v4.28.1 did).
+  @Algebra.ofModule k (CornerRing (k := k) e) _ (instRing he).toSemiring
+    (inferInstanceAs (Module k (cornerSubmodule (k := k) e)))
     (fun r x y => Subtype.ext (Algebra.smul_mul_assoc r (x : A) (y : A)))
     (fun r x y => Subtype.ext (Algebra.mul_smul_comm r (x : A) (y : A)))
 

--- a/progress/2026-06-21T15-16-42Z_4f7e4bc3.md
+++ b/progress/2026-06-21T15-16-42Z_4f7e4bc3.md
@@ -1,0 +1,49 @@
+## Accomplished
+
+Worked the toolchain-port pioneer **#4888** (v4.28.1 → v4.31.0). Established and
+exercised the forward-compatible-prep pattern, and landed the first of the two
+Infrastructure modules.
+
+- **CornerRing.lean (deliverable 1, done).** Reproduced the exact v4.31 failure
+  in a fresh `/tmp` clone (`lean-toolchain` → v4.31.0, `lake update mathlib`,
+  `lake exe cache get`). Root cause: v4.31 rejects an `instance` whose explicit
+  `he : IsIdempotentElem e` argument cannot be inferred by typeclass synthesis
+  (latent in v4.28.1). Fix: demote `CornerRing.instRing` / `CornerRing.instAlgebra`
+  from `instance` to `@[reducible] def` (every consumer already passes `he`
+  explicitly via `letI := CornerRing.instRing he`), and pass the inherited
+  `Module k (cornerSubmodule e)` positionally to `Algebra.ofModule` because v4.31
+  no longer unfolds the semireducible `CornerRing` wrapper during synthesis.
+  Verified green on **both** v4.31.0 (scratch clone) and v4.28.1 (worktree),
+  including downstream consumers BasicAlgebraExistence / MoritaStructural /
+  Corollary9_7_3 on v4.28.1. No new sorries, no new warnings.
+
+- **IrreducibleEnumeration.lean (deliverable 2, deferred to #4892).** Diagnosed
+  on v4.31: 7 errors, all simp-normal-form drift (NOT signature-incompatible —
+  the `f.hom.hom` / `FGModuleCat.ofHom` / `ConcreteCategory` term structure is
+  identical across both toolchains). Unwrap lemmas needed (all present in both):
+  `ModuleCat.hom_ofHom`, `ConcreteCategory.hom_ofHom`, `LinearEquiv.symm_apply_apply`,
+  `Module.finrank_fin_fun`. Filed **#4892** with per-line diagnosis and the
+  v4.28.1 `unusedSimpArgs`-linter caveat. Split out as its own unit to avoid a
+  broken intermediate state in this session.
+
+## Current frontier
+
+Pioneer pattern is proven and the CornerRing module is forward-compatible.
+IrreducibleEnumeration fully diagnosed and queued as #4892.
+
+## Overall project progress
+
+Stage 3 ongoing. Toolchain port #4864 now has a working forward-compatible-prep
+recipe (reproduce-on-v4.31 / fix-both / verify-on-v4.28.1) demonstrated on a real
+module; pin stays v4.28.1 until the final flip PR.
+
+## Next step
+
+Claim **#4892** (IrreducibleEnumeration, fully diagnosed). After that, continue
+per-chapter modules under #4864 using the same recipe.
+
+## Blockers
+
+None. The `.lake/packages` directory is shared across worktrees, so the v4.31
+reproduction must be done in a `/tmp` clone (as here), never via `lake update`
+in a worktree.


### PR DESCRIPTION
Partial progress on #4888

Session: `4f7e4bc3-b1cc-441f-bf1f-c4576b3c0a85`

8c1fff2b doc(progress): #4888 pioneer — CornerRing v4.31-compatible; IrreducibleEnumeration → #4892
599cfc9b feat(toolchain #4888): make CornerRing instRing/instAlgebra v4.31-compatible

🤖 Prepared with Claude Code