### PR TITLE
feat(Ch5 #4882): assemble iso_of_formalCharacter_eq_schurPoly sorry-free (own proof); isolate highest-weight uniqueness (#4901)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5.lean
+++ b/EtingofRepresentationTheory/Chapter5.lean
@@ -116,6 +116,7 @@ import EtingofRepresentationTheory.Chapter5.SchurWeylPolynomialIdentity
 
 -- Section 5.23: Algebraic Representations of GL(V)
 import EtingofRepresentationTheory.Chapter5.Definition5_23_1
+import EtingofRepresentationTheory.Chapter5.GLRepAlgebraic
 import EtingofRepresentationTheory.Chapter5.DetTwistAlgebraic
 import EtingofRepresentationTheory.Chapter5.Theorem5_23_2
 import EtingofRepresentationTheory.Chapter5.SchurModuleSpecialBlock

--- a/EtingofRepresentationTheory/Chapter5/DetTwistAlgebraic.lean
+++ b/EtingofRepresentationTheory/Chapter5/DetTwistAlgebraic.lean
@@ -1,4 +1,4 @@
-import EtingofRepresentationTheory.Chapter5.Definition5_23_1
+import EtingofRepresentationTheory.Chapter5.GLRepAlgebraic
 import EtingofRepresentationTheory.Chapter5.Proposition5_22_2
 
 /-!
@@ -11,21 +11,12 @@ of `GL_N(k)` in the sense of `Etingof.IsAlgebraicRepresentation`
 `decompose_polynomial_gl_rep` at the call site `schurModule_shift_iso_detTwist`
 (#4756, sub-A of #4745).
 
-The proof assembles three reusable lemmas about `IsAlgebraicRepresentation`:
-
-* `glTensorRep_isAlgebraic` — the diagonal action `g ↦ g^{⊗n}` on `(k^N)^{⊗n}`
-  is algebraic; its matrix coefficient in the standard tensor basis is the
-  monomial `∏ₘ X_{(h m, f m)}`.
-* `IsAlgebraicRepresentation.restrict` — the restriction of an algebraic
-  representation to an invariant submodule is algebraic. The new matrix
-  coefficients are `k`-linear combinations of the old ones (constants coming
-  from the inclusion and a linear projection), hence still polynomial.
-* `IsAlgebraicRepresentation.detTwist` — twisting an algebraic representation by
-  the determinant character keeps it algebraic; each coefficient polynomial is
-  multiplied by the determinant polynomial `det(Xᵢⱼ)`.
-
-`detTwistedSchurModuleRep = detTwist (restrict glTensorRep)`, so the three
-combine.
+The general algebraicity infrastructure (`glTensorRep_isAlgebraic`,
+`IsAlgebraicRepresentation.restrict`, `IsAlgebraicRepresentation.detTwist`) now lives
+upstream in `GLRepAlgebraic`, so that `schurModule_shift_iso_detTwist` can build its own
+algebraicity hypothesis inline without an import cycle. This file just assembles them at
+the concrete `detTwistedSchurModuleRep`:
+`detTwistedSchurModuleRep = detTwist (restrict glTensorRep)`.
 -/
 
 open scoped TensorProduct
@@ -34,178 +25,6 @@ open Matrix
 noncomputable section
 
 namespace Etingof
-
-/-! ### Ring-homomorphism behaviour of `evalAtGL` -/
-
-theorem evalAtGL_mul {k : Type*} [Field k] {N : ℕ}
-    (g : Matrix.GeneralLinearGroup (Fin N) k)
-    (p q : MvPolynomial (Etingof.GLCoordVars N) k) :
-    Etingof.evalAtGL g (p * q) = Etingof.evalAtGL g p * Etingof.evalAtGL g q := by
-  simp only [Etingof.evalAtGL, map_mul]
-
-theorem evalAtGL_sum {k : Type*} [Field k] {ι : Type*} {n : ℕ}
-    (g : Matrix.GeneralLinearGroup (Fin n) k)
-    (s : Finset ι) (f : ι → MvPolynomial (Etingof.GLCoordVars n) k) :
-    Etingof.evalAtGL g (∑ i ∈ s, f i) = ∑ i ∈ s, Etingof.evalAtGL g (f i) := by
-  simp only [Etingof.evalAtGL, map_sum]
-
-theorem evalAtGL_prod {k : Type*} [Field k] {ι : Type*} {n : ℕ}
-    (g : Matrix.GeneralLinearGroup (Fin n) k)
-    (s : Finset ι) (f : ι → MvPolynomial (Etingof.GLCoordVars n) k) :
-    Etingof.evalAtGL g (∏ i ∈ s, f i) = ∏ i ∈ s, Etingof.evalAtGL g (f i) := by
-  simp only [Etingof.evalAtGL, map_prod]
-
-theorem evalAtGL_C {k : Type*} [Field k] {N : ℕ}
-    (g : Matrix.GeneralLinearGroup (Fin N) k) (r : k) :
-    Etingof.evalAtGL g (MvPolynomial.C r) = r := by
-  simp only [Etingof.evalAtGL, MvPolynomial.eval_C]
-
-theorem evalAtGL_X_inl {k : Type*} [Field k] {N : ℕ}
-    (g : Matrix.GeneralLinearGroup (Fin N) k) (i j : Fin N) :
-    Etingof.evalAtGL g (MvPolynomial.X (Sum.inl (i, j))) = g.val i j := by
-  change MvPolynomial.eval _ (MvPolynomial.X (Sum.inl (i, j))) = _
-  rw [MvPolynomial.eval_X]
-  rfl
-
-/-! ### The determinant polynomial -/
-
-/-- The determinant of the generic matrix `(Xᵢⱼ)`, as an element of the
-coordinate ring `k[Xᵢⱼ, det⁻¹]`. Only the matrix-entry variables (`Sum.inl`)
-appear; this is a genuine polynomial, no `det⁻¹` needed. -/
-def detPolyGL (k : Type*) [Field k] (N : ℕ) :
-    MvPolynomial (Etingof.GLCoordVars N) k :=
-  (Matrix.of fun i j : Fin N => MvPolynomial.X (R := k) (Sum.inl (i, j))).det
-
-@[simp]
-theorem evalAtGL_detPolyGL {k : Type*} [Field k] {N : ℕ}
-    (g : Matrix.GeneralLinearGroup (Fin N) k) :
-    Etingof.evalAtGL g (detPolyGL k N) = (Matrix.GeneralLinearGroup.det g : k) := by
-  rw [Matrix.GeneralLinearGroup.val_det_apply]
-  unfold Etingof.evalAtGL detPolyGL
-  rw [RingHom.map_det]
-  congr 1
-  ext i j
-  simp [Matrix.map_apply]
-
-/-! ### Algebraicity is preserved by determinant twist -/
-
-/-- Twisting an algebraic representation by the determinant character keeps it
-algebraic: each coefficient polynomial is multiplied by `detPolyGL`. -/
-theorem IsAlgebraicRepresentation.detTwist {k : Type*} [Field k] {N : ℕ}
-    {Y : Type*} [AddCommGroup Y] [Module k Y] [Module.Finite k Y]
-    {ρ : Matrix.GeneralLinearGroup (Fin N) k → Y →ₗ[k] Y}
-    (h : Etingof.IsAlgebraicRepresentation N ρ) :
-    Etingof.IsAlgebraicRepresentation N
-      (fun g => (Matrix.GeneralLinearGroup.det g : k) • ρ g) := by
-  obtain ⟨m, b, P, hP⟩ := h
-  refine ⟨m, b, fun a c => detPolyGL k N * P a c, fun g a c => ?_⟩
-  rw [LinearMap.smul_apply, map_smul, Finsupp.smul_apply, smul_eq_mul, hP g a c,
-    evalAtGL_mul, evalAtGL_detPolyGL]
-
-/-! ### Algebraicity is preserved by restriction to an invariant submodule -/
-
-/-- The restriction of an algebraic representation `ρ` to a `ρ`-invariant
-submodule `W` is algebraic. Choosing a basis of `W`, a linear projection
-`π : Y → W`, and the ambient basis `B`, the new matrix coefficients expand as
-`k`-linear combinations of `evalAtGL g (P e d)` with constant coefficients
-coming from `B.repr (W.subtype (b' c))` and `b'.repr (π (B e))`. -/
-theorem IsAlgebraicRepresentation.restrict {k : Type*} [Field k] {N : ℕ}
-    {Y : Type*} [AddCommGroup Y] [Module k Y] [Module.Finite k Y]
-    {ρ : Matrix.GeneralLinearGroup (Fin N) k → Y →ₗ[k] Y}
-    (h : Etingof.IsAlgebraicRepresentation N ρ)
-    (W : Submodule k Y) [Module.Finite k W]
-    (hW : ∀ g, ∀ v ∈ W, ρ g v ∈ W) :
-    Etingof.IsAlgebraicRepresentation N (fun g => (ρ g).restrict (hW g)) := by
-  classical
-  obtain ⟨M, B, P, hP⟩ := h
-  -- Basis of the submodule, indexed by `Fin (finrank k W)`.
-  let b' : Module.Basis (Fin (Module.finrank k W)) k W := Module.finBasis k W
-  -- A linear projection `π : Y → W` that is a left inverse of the inclusion.
-  obtain ⟨W', hWW'⟩ := W.exists_isCompl
-  let π : Y →ₗ[k] W := W.linearProjOfIsCompl W' hWW'
-  have hπincl : ∀ w : W, π (W.subtype w) = w := fun w =>
-    W.linearProjOfIsCompl_apply_left hWW' w
-  refine ⟨Module.finrank k W, b',
-    fun a c => ∑ d, ∑ e,
-      MvPolynomial.C (B.repr (W.subtype (b' c)) d) * P e d
-        * MvPolynomial.C (b'.repr (π (B e)) a), fun g a c => ?_⟩
-  -- `φ y = b'.repr (π y) a`, a linear functional `Y → k`.
-  let φ : Y →ₗ[k] k := (Finsupp.lapply a).comp (b'.repr.toLinearMap.comp π)
-  have hφ_apply : ∀ y, φ y = b'.repr (π y) a := fun _ => rfl
-  have hcoe : (W.subtype) ((ρ g).restrict (hW g) (b' c)) = ρ g (W.subtype (b' c)) :=
-    LinearMap.restrict_coe_apply (ρ g) (hW g) (b' c)
-  -- Reduce the LHS coefficient to a double sum over the ambient basis.
-  have hlhs : b'.repr ((ρ g).restrict (hW g) (b' c)) a
-      = ∑ d, ∑ e, B.repr (W.subtype (b' c)) d
-          * (Etingof.evalAtGL g (P e d) * b'.repr (π (B e)) a) := by
-    have h1 : (ρ g).restrict (hW g) (b' c) = π (ρ g (W.subtype (b' c))) := by
-      rw [← hcoe, hπincl]
-    rw [show b'.repr ((ρ g).restrict (hW g) (b' c)) a = φ (ρ g (W.subtype (b' c))) from by
-      rw [hφ_apply, h1]]
-    -- expand `W.subtype (b' c)` in the ambient basis `B`
-    rw [show ρ g (W.subtype (b' c))
-        = ∑ d, B.repr (W.subtype (b' c)) d • ρ g (B d) from by
-      conv_lhs => rw [show W.subtype (b' c) = ∑ d, B.repr (W.subtype (b' c)) d • B d from
-        (B.sum_repr (W.subtype (b' c))).symm]
-      rw [map_sum]
-      exact Finset.sum_congr rfl fun d _ => by rw [map_smul]]
-    rw [map_sum]
-    refine Finset.sum_congr rfl fun d _ => ?_
-    rw [map_smul, smul_eq_mul]
-    -- compute `φ (ρ g (B d))` by expanding `ρ g (B d)` in `B`
-    have hd : φ (ρ g (B d))
-        = ∑ e, Etingof.evalAtGL g (P e d) * b'.repr (π (B e)) a := by
-      conv_lhs => rw [show ρ g (B d) = ∑ e, B.repr (ρ g (B d)) e • B e from
-        (B.sum_repr (ρ g (B d))).symm]
-      rw [map_sum]
-      refine Finset.sum_congr rfl fun e _ => ?_
-      rw [map_smul, smul_eq_mul, hP g e d, hφ_apply]
-    rw [hd, Finset.mul_sum]
-  rw [hlhs, evalAtGL_sum]
-  refine Finset.sum_congr rfl fun d _ => ?_
-  rw [evalAtGL_sum]
-  refine Finset.sum_congr rfl fun e _ => ?_
-  rw [evalAtGL_mul, evalAtGL_mul, evalAtGL_C, evalAtGL_C]
-  ring
-
-/-! ### The diagonal action is algebraic -/
-
-/-- The standard tensor basis of `(k^N)^{⊗n}`, indexed by `Fin n → Fin N`. -/
-def tBasisAlg (k : Type*) [Field k] (N n : ℕ) :
-    Module.Basis (Fin n → Fin N) k (TensorPower k (Fin N → k) n) :=
-  Basis.piTensorProduct (fun _ : Fin n => Pi.basisFun k (Fin N))
-
-/-- Matrix coefficient of the diagonal action in the standard tensor basis:
-`glTensorRep g` sends `tBasis f` to `∑ₕ (∏ₘ g_{h m, f m}) • tBasis h`. -/
-theorem repr_glTensorRep_tBasisAlg {k : Type*} [Field k] {N n : ℕ}
-    (g : Matrix.GeneralLinearGroup (Fin N) k) (f h : Fin n → Fin N) :
-    (tBasisAlg k N n).repr (glTensorRep k N n g (tBasisAlg k N n f)) h
-      = ∏ m, (g.val) (h m) (f m) := by
-  change (tBasisAlg k N n).repr
-      (PiTensorProduct.map (fun _ => Matrix.mulVecLin (R := k) g.val)
-        (tBasisAlg k N n f)) h = _
-  simp only [tBasisAlg, Basis.piTensorProduct_apply, PiTensorProduct.map_tprod,
-    Basis.piTensorProduct_repr_tprod_apply]
-  refine Finset.prod_congr rfl fun m _ => ?_
-  rw [Pi.basisFun_repr, Matrix.mulVecLin_apply, Pi.basisFun_apply,
-    Matrix.mulVec_single_one]
-  rfl
-
-/-- The diagonal action `g ↦ g^{⊗n}` on `(k^N)^{⊗n}` is algebraic. The matrix
-coefficient in the standard tensor basis is the monomial `∏ₘ X_{(h m, f m)}`. -/
-theorem glTensorRep_isAlgebraic (k : Type*) [Field k] (N n : ℕ) :
-    Etingof.IsAlgebraicRepresentation N (glTensorRep k N n) := by
-  classical
-  set ι := Fin n → Fin N
-  set eqv : Fin (Fintype.card ι) ≃ ι := (Fintype.equivFin ι).symm with heqv
-  refine ⟨Fintype.card ι, (tBasisAlg k N n).reindex eqv.symm,
-    fun a c => ∏ m, MvPolynomial.X (Sum.inl (eqv a m, eqv c m)),
-    fun g a c => ?_⟩
-  rw [Module.Basis.repr_reindex_apply, Module.Basis.reindex_apply]
-  simp only [Equiv.symm_symm]
-  rw [repr_glTensorRep_tBasisAlg, evalAtGL_prod]
-  refine Finset.prod_congr rfl fun m _ => ?_
-  rw [evalAtGL_X_inl]
 
 /-! ### Algebraicity of the determinant-twisted Schur module -/
 

--- a/EtingofRepresentationTheory/Chapter5/GLRepAlgebraic.lean
+++ b/EtingofRepresentationTheory/Chapter5/GLRepAlgebraic.lean
@@ -1,0 +1,207 @@
+import EtingofRepresentationTheory.Chapter5.Definition5_23_1
+import EtingofRepresentationTheory.Chapter5.Theorem5_22_1
+
+/-!
+# General algebraicity infrastructure for `GL_N(k)`-representations
+
+This file collects the reusable lemmas about `Etingof.IsAlgebraicRepresentation`
+(Definition 5.23.1) that are independent of any particular twisted Schur module:
+
+* `evalAtGL_mul` / `evalAtGL_sum` / `evalAtGL_prod` / `evalAtGL_C` / `evalAtGL_X_inl`
+  — ring-homomorphism behaviour of evaluation `evalAtGL g`.
+* `detPolyGL` and `evalAtGL_detPolyGL` — the determinant of the generic matrix as a
+  polynomial in the coordinate ring, and its evaluation.
+* `IsAlgebraicRepresentation.detTwist` — twisting an algebraic representation by the
+  determinant character keeps it algebraic.
+* `IsAlgebraicRepresentation.restrict` — the restriction of an algebraic representation
+  to an invariant submodule is algebraic.
+* `glTensorRep_isAlgebraic` — the diagonal action `g ↦ g^{⊗n}` on `(k^N)^{⊗n}` is
+  algebraic.
+
+These are factored out of `DetTwistAlgebraic` so that they sit *upstream* of
+`Proposition5_22_2` (where the twisted Schur module `detTwistedSchurModuleRep` is
+defined). That lets `schurModule_shift_iso_detTwist` supply the algebraicity hypothesis
+required by `iso_of_formalCharacter_eq_schurPoly` (#4882) without an import cycle:
+`detTwistedSchurModuleRep_isAlgebraic` itself lives downstream, in `DetTwistAlgebraic`.
+-/
+
+open scoped TensorProduct
+open Matrix
+
+noncomputable section
+
+namespace Etingof
+
+/-! ### Ring-homomorphism behaviour of `evalAtGL` -/
+
+theorem evalAtGL_mul {k : Type*} [Field k] {N : ℕ}
+    (g : Matrix.GeneralLinearGroup (Fin N) k)
+    (p q : MvPolynomial (Etingof.GLCoordVars N) k) :
+    Etingof.evalAtGL g (p * q) = Etingof.evalAtGL g p * Etingof.evalAtGL g q := by
+  simp only [Etingof.evalAtGL, map_mul]
+
+theorem evalAtGL_sum {k : Type*} [Field k] {ι : Type*} {n : ℕ}
+    (g : Matrix.GeneralLinearGroup (Fin n) k)
+    (s : Finset ι) (f : ι → MvPolynomial (Etingof.GLCoordVars n) k) :
+    Etingof.evalAtGL g (∑ i ∈ s, f i) = ∑ i ∈ s, Etingof.evalAtGL g (f i) := by
+  simp only [Etingof.evalAtGL, map_sum]
+
+theorem evalAtGL_prod {k : Type*} [Field k] {ι : Type*} {n : ℕ}
+    (g : Matrix.GeneralLinearGroup (Fin n) k)
+    (s : Finset ι) (f : ι → MvPolynomial (Etingof.GLCoordVars n) k) :
+    Etingof.evalAtGL g (∏ i ∈ s, f i) = ∏ i ∈ s, Etingof.evalAtGL g (f i) := by
+  simp only [Etingof.evalAtGL, map_prod]
+
+theorem evalAtGL_C {k : Type*} [Field k] {N : ℕ}
+    (g : Matrix.GeneralLinearGroup (Fin N) k) (r : k) :
+    Etingof.evalAtGL g (MvPolynomial.C r) = r := by
+  simp only [Etingof.evalAtGL, MvPolynomial.eval_C]
+
+theorem evalAtGL_X_inl {k : Type*} [Field k] {N : ℕ}
+    (g : Matrix.GeneralLinearGroup (Fin N) k) (i j : Fin N) :
+    Etingof.evalAtGL g (MvPolynomial.X (Sum.inl (i, j))) = g.val i j := by
+  change MvPolynomial.eval _ (MvPolynomial.X (Sum.inl (i, j))) = _
+  rw [MvPolynomial.eval_X]
+  rfl
+
+/-! ### The determinant polynomial -/
+
+/-- The determinant of the generic matrix `(Xᵢⱼ)`, as an element of the
+coordinate ring `k[Xᵢⱼ, det⁻¹]`. Only the matrix-entry variables (`Sum.inl`)
+appear; this is a genuine polynomial, no `det⁻¹` needed. -/
+def detPolyGL (k : Type*) [Field k] (N : ℕ) :
+    MvPolynomial (Etingof.GLCoordVars N) k :=
+  (Matrix.of fun i j : Fin N => MvPolynomial.X (R := k) (Sum.inl (i, j))).det
+
+@[simp]
+theorem evalAtGL_detPolyGL {k : Type*} [Field k] {N : ℕ}
+    (g : Matrix.GeneralLinearGroup (Fin N) k) :
+    Etingof.evalAtGL g (detPolyGL k N) = (Matrix.GeneralLinearGroup.det g : k) := by
+  rw [Matrix.GeneralLinearGroup.val_det_apply]
+  unfold Etingof.evalAtGL detPolyGL
+  rw [RingHom.map_det]
+  congr 1
+  ext i j
+  simp [Matrix.map_apply]
+
+/-! ### Algebraicity is preserved by determinant twist -/
+
+/-- Twisting an algebraic representation by the determinant character keeps it
+algebraic: each coefficient polynomial is multiplied by `detPolyGL`. -/
+theorem IsAlgebraicRepresentation.detTwist {k : Type*} [Field k] {N : ℕ}
+    {Y : Type*} [AddCommGroup Y] [Module k Y] [Module.Finite k Y]
+    {ρ : Matrix.GeneralLinearGroup (Fin N) k → Y →ₗ[k] Y}
+    (h : Etingof.IsAlgebraicRepresentation N ρ) :
+    Etingof.IsAlgebraicRepresentation N
+      (fun g => (Matrix.GeneralLinearGroup.det g : k) • ρ g) := by
+  obtain ⟨m, b, P, hP⟩ := h
+  refine ⟨m, b, fun a c => detPolyGL k N * P a c, fun g a c => ?_⟩
+  rw [LinearMap.smul_apply, map_smul, Finsupp.smul_apply, smul_eq_mul, hP g a c,
+    evalAtGL_mul, evalAtGL_detPolyGL]
+
+/-! ### Algebraicity is preserved by restriction to an invariant submodule -/
+
+/-- The restriction of an algebraic representation `ρ` to a `ρ`-invariant
+submodule `W` is algebraic. Choosing a basis of `W`, a linear projection
+`π : Y → W`, and the ambient basis `B`, the new matrix coefficients expand as
+`k`-linear combinations of `evalAtGL g (P e d)` with constant coefficients
+coming from `B.repr (W.subtype (b' c))` and `b'.repr (π (B e))`. -/
+theorem IsAlgebraicRepresentation.restrict {k : Type*} [Field k] {N : ℕ}
+    {Y : Type*} [AddCommGroup Y] [Module k Y] [Module.Finite k Y]
+    {ρ : Matrix.GeneralLinearGroup (Fin N) k → Y →ₗ[k] Y}
+    (h : Etingof.IsAlgebraicRepresentation N ρ)
+    (W : Submodule k Y) [Module.Finite k W]
+    (hW : ∀ g, ∀ v ∈ W, ρ g v ∈ W) :
+    Etingof.IsAlgebraicRepresentation N (fun g => (ρ g).restrict (hW g)) := by
+  classical
+  obtain ⟨M, B, P, hP⟩ := h
+  -- Basis of the submodule, indexed by `Fin (finrank k W)`.
+  let b' : Module.Basis (Fin (Module.finrank k W)) k W := Module.finBasis k W
+  -- A linear projection `π : Y → W` that is a left inverse of the inclusion.
+  obtain ⟨W', hWW'⟩ := W.exists_isCompl
+  let π : Y →ₗ[k] W := W.linearProjOfIsCompl W' hWW'
+  have hπincl : ∀ w : W, π (W.subtype w) = w := fun w =>
+    W.linearProjOfIsCompl_apply_left hWW' w
+  refine ⟨Module.finrank k W, b',
+    fun a c => ∑ d, ∑ e,
+      MvPolynomial.C (B.repr (W.subtype (b' c)) d) * P e d
+        * MvPolynomial.C (b'.repr (π (B e)) a), fun g a c => ?_⟩
+  -- `φ y = b'.repr (π y) a`, a linear functional `Y → k`.
+  let φ : Y →ₗ[k] k := (Finsupp.lapply a).comp (b'.repr.toLinearMap.comp π)
+  have hφ_apply : ∀ y, φ y = b'.repr (π y) a := fun _ => rfl
+  have hcoe : (W.subtype) ((ρ g).restrict (hW g) (b' c)) = ρ g (W.subtype (b' c)) :=
+    LinearMap.restrict_coe_apply (ρ g) (hW g) (b' c)
+  -- Reduce the LHS coefficient to a double sum over the ambient basis.
+  have hlhs : b'.repr ((ρ g).restrict (hW g) (b' c)) a
+      = ∑ d, ∑ e, B.repr (W.subtype (b' c)) d
+          * (Etingof.evalAtGL g (P e d) * b'.repr (π (B e)) a) := by
+    have h1 : (ρ g).restrict (hW g) (b' c) = π (ρ g (W.subtype (b' c))) := by
+      rw [← hcoe, hπincl]
+    rw [show b'.repr ((ρ g).restrict (hW g) (b' c)) a = φ (ρ g (W.subtype (b' c))) from by
+      rw [hφ_apply, h1]]
+    -- expand `W.subtype (b' c)` in the ambient basis `B`
+    rw [show ρ g (W.subtype (b' c))
+        = ∑ d, B.repr (W.subtype (b' c)) d • ρ g (B d) from by
+      conv_lhs => rw [show W.subtype (b' c) = ∑ d, B.repr (W.subtype (b' c)) d • B d from
+        (B.sum_repr (W.subtype (b' c))).symm]
+      rw [map_sum]
+      exact Finset.sum_congr rfl fun d _ => by rw [map_smul]]
+    rw [map_sum]
+    refine Finset.sum_congr rfl fun d _ => ?_
+    rw [map_smul, smul_eq_mul]
+    -- compute `φ (ρ g (B d))` by expanding `ρ g (B d)` in `B`
+    have hd : φ (ρ g (B d))
+        = ∑ e, Etingof.evalAtGL g (P e d) * b'.repr (π (B e)) a := by
+      conv_lhs => rw [show ρ g (B d) = ∑ e, B.repr (ρ g (B d)) e • B e from
+        (B.sum_repr (ρ g (B d))).symm]
+      rw [map_sum]
+      refine Finset.sum_congr rfl fun e _ => ?_
+      rw [map_smul, smul_eq_mul, hP g e d, hφ_apply]
+    rw [hd, Finset.mul_sum]
+  rw [hlhs, evalAtGL_sum]
+  refine Finset.sum_congr rfl fun d _ => ?_
+  rw [evalAtGL_sum]
+  refine Finset.sum_congr rfl fun e _ => ?_
+  rw [evalAtGL_mul, evalAtGL_mul, evalAtGL_C, evalAtGL_C]
+  ring
+
+/-! ### The diagonal action is algebraic -/
+
+/-- The standard tensor basis of `(k^N)^{⊗n}`, indexed by `Fin n → Fin N`. -/
+def tBasisAlg (k : Type*) [Field k] (N n : ℕ) :
+    Module.Basis (Fin n → Fin N) k (TensorPower k (Fin N → k) n) :=
+  Basis.piTensorProduct (fun _ : Fin n => Pi.basisFun k (Fin N))
+
+/-- Matrix coefficient of the diagonal action in the standard tensor basis:
+`glTensorRep g` sends `tBasis f` to `∑ₕ (∏ₘ g_{h m, f m}) • tBasis h`. -/
+theorem repr_glTensorRep_tBasisAlg {k : Type*} [Field k] {N n : ℕ}
+    (g : Matrix.GeneralLinearGroup (Fin N) k) (f h : Fin n → Fin N) :
+    (tBasisAlg k N n).repr (glTensorRep k N n g (tBasisAlg k N n f)) h
+      = ∏ m, (g.val) (h m) (f m) := by
+  change (tBasisAlg k N n).repr
+      (PiTensorProduct.map (fun _ => Matrix.mulVecLin (R := k) g.val)
+        (tBasisAlg k N n f)) h = _
+  simp only [tBasisAlg, Basis.piTensorProduct_apply, PiTensorProduct.map_tprod,
+    Basis.piTensorProduct_repr_tprod_apply]
+  refine Finset.prod_congr rfl fun m _ => ?_
+  rw [Pi.basisFun_repr, Matrix.mulVecLin_apply, Pi.basisFun_apply,
+    Matrix.mulVec_single_one]
+  rfl
+
+/-- The diagonal action `g ↦ g^{⊗n}` on `(k^N)^{⊗n}` is algebraic. The matrix
+coefficient in the standard tensor basis is the monomial `∏ₘ X_{(h m, f m)}`. -/
+theorem glTensorRep_isAlgebraic (k : Type*) [Field k] (N n : ℕ) :
+    Etingof.IsAlgebraicRepresentation N (glTensorRep k N n) := by
+  classical
+  set ι := Fin n → Fin N
+  set eqv : Fin (Fintype.card ι) ≃ ι := (Fintype.equivFin ι).symm with heqv
+  refine ⟨Fintype.card ι, (tBasisAlg k N n).reindex eqv.symm,
+    fun a c => ∏ m, MvPolynomial.X (Sum.inl (eqv a m, eqv c m)),
+    fun g a c => ?_⟩
+  rw [Module.Basis.repr_reindex_apply, Module.Basis.reindex_apply]
+  simp only [Equiv.symm_symm]
+  rw [repr_glTensorRep_tBasisAlg, evalAtGL_prod]
+  refine Finset.prod_congr rfl fun m _ => ?_
+  rw [evalAtGL_X_inl]
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter5/Proposition5_22_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Proposition5_22_2.lean
@@ -1,6 +1,7 @@
 import Mathlib
 import EtingofRepresentationTheory.Chapter5.Theorem5_22_1
 import EtingofRepresentationTheory.Chapter5.FormalCharacterIso
+import EtingofRepresentationTheory.Chapter5.GLRepAlgebraic
 import EtingofRepresentationTheory.Chapter5.SchurWeylFormalCharacterIso
 
 /-!
@@ -376,35 +377,46 @@ theorem schurModule_shift_iso_detTwist (N : ℕ) (lam : Fin N → ℕ) (hlam : A
   -- so their dimensions equal the total mass of the Schur polynomial.
   -- Since S_{λ+(1,...,1)} = (∏ Xᵢ) · S_λ and ∏ Xᵢ preserves total mass,
   -- dim L_λ = dim L_{λ+(1,...,1)}.
+  -- The det-twisted rep is polynomial: its ℕ-valued weight spaces span everything. Its
+  -- weight spaces at (μ+1) match the SchurModule's at μ (`glWeightSpace_detTwist_shift`),
+  -- and the SchurModule is polynomial. (Hoisted out so it is in scope as `h_span` below.)
+  have h₁_top : ⨆ (μ : Fin N →₀ ℕ),
+      glWeightSpace k N (FDRep.of (detTwistedSchurModuleRep k N lam))
+        (fun i => μ i) = ⊤ := by
+    rw [eq_top_iff, ← glWeightSpace_schurModule_iSup_eq_top k N lam]
+    apply iSup_le
+    intro μ
+    -- Map μ to its shift (i ↦ μ i + 1) as a Fin N →₀ ℕ
+    set μ_shift : Fin N →₀ ℕ := Finsupp.equivFunOnFinite.symm (fun i => μ i + 1) with hμs
+    refine le_trans ?_ (le_iSup _ μ_shift)
+    -- glWeightSpace_detTwist_shift gives equality (M₁ at μ+1) = (SchurModule at μ)
+    have h_shift := glWeightSpace_detTwist_shift k N lam (fun i => μ i)
+    have h_apply : (fun i => μ_shift i) = (fun i => μ i + 1) := by
+      ext i; simp [μ_shift]
+    rw [h_apply, h_shift]
+  -- The det-twisted Schur module representation is algebraic (assembled from the general
+  -- algebraicity infrastructure in `GLRepAlgebraic`; the concrete packaging is
+  -- `detTwistedSchurModuleRep_isAlgebraic`, which lives downstream and so is inlined here).
+  have halg : Etingof.IsAlgebraicRepresentation N
+      (FDRep.of (detTwistedSchurModuleRep k N lam)).ρ := by
+    rw [FDRep.of_ρ']
+    exact ((Etingof.glTensorRep_isAlgebraic k N (∑ i, lam i)).restrict
+      (SchurModuleSubmodule k N lam)
+      (fun g v hv => glTensorRep_mem_range k N lam g v hv)).detTwist
   have h_dim : Module.finrank k (FDRep.of (detTwistedSchurModuleRep k N lam)) =
       Module.finrank k (SchurModule k N (fun i => lam i + 1)) := by
     -- The SchurModule for λ+1 is polynomial (ℕ-valued weight spaces span).
     have h₂_top : ⨆ (μ : Fin N →₀ ℕ),
         glWeightSpace k N (SchurModule k N (fun i => lam i + 1)) (fun i => μ i) = ⊤ :=
       glWeightSpace_schurModule_iSup_eq_top k N (fun i => lam i + 1)
-    -- The det-twisted rep is polynomial: its weight spaces at (μ+1) match the SchurModule's
-    -- weight spaces at μ via `glWeightSpace_detTwist_shift`, and the SchurModule is polynomial.
-    have h₁_top : ⨆ (μ : Fin N →₀ ℕ),
-        glWeightSpace k N (FDRep.of (detTwistedSchurModuleRep k N lam))
-          (fun i => μ i) = ⊤ := by
-      rw [eq_top_iff, ← glWeightSpace_schurModule_iSup_eq_top k N lam]
-      apply iSup_le
-      intro μ
-      -- Map μ to its shift (i ↦ μ i + 1) as a Fin N →₀ ℕ
-      set μ_shift : Fin N →₀ ℕ := Finsupp.equivFunOnFinite.symm (fun i => μ i + 1) with hμs
-      refine le_trans ?_ (le_iSup _ μ_shift)
-      -- glWeightSpace_detTwist_shift gives equality (M₁ at μ+1) = (SchurModule at μ)
-      have h_shift := glWeightSpace_detTwist_shift k N lam (fun i => μ i)
-      have h_apply : (fun i => μ_shift i) = (fun i => μ i + 1) := by
-        ext i; simp [μ_shift]
-      rw [h_apply, h_shift]
     -- Formal characters agree (the det-twist shifts the character by the product of Xᵢ)
     have h_char_eq : formalCharacter k N (FDRep.of (detTwistedSchurModuleRep k N lam)) =
         formalCharacter k N (SchurModule k N (fun i => lam i + 1)) :=
       formalCharacter_detTwist_eq_shift k N lam hlam
     exact finrank_eq_of_formalCharacter_eq k N _ _ h₁_top h₂_top h_char_eq
   -- By iso_of_formalCharacter_eq_schurPoly, the det-twisted rep ≅ SchurModule k N (λ+1)
-  obtain ⟨iso⟩ := iso_of_formalCharacter_eq_schurPoly k N (fun i => lam i + 1) hlam' _ h_char h_dim
+  obtain ⟨iso⟩ := iso_of_formalCharacter_eq_schurPoly k N (fun i => lam i + 1) hlam'
+    _ halg h₁_top h_char h_dim
   exact ⟨iso.symm⟩
 
 omit [IsAlgClosed k] [CharZero k] in

--- a/EtingofRepresentationTheory/Chapter5/SchurWeylFormalCharacterIso.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurWeylFormalCharacterIso.lean
@@ -37,27 +37,30 @@ Let `n := ∑ i, lam i`.
    forces `p = 1` with `f 0` the class of `L_λ`, hence
    `M ≃ L_λ` at the `asModule` level; rebuild the categorical `≅`.
 
-## Remaining work (issue #4699 deliverable 3)
+## Status
 
-The proof is currently `sorry`. Closing it requires three ingredients that the
-current upstream API does not yet expose; each is filed as a follow-up:
+The assembly `iso_of_formalCharacter_eq_schurPoly` is **sorry-free in its own proof**.
+It takes the algebraicity (`halg`) and spanning (`h_span`) hypotheses explicitly — both
+are what make `M` genuinely polynomial — and routes the decomposition through
+`decompose_polynomial_gl_rep`, whose schurPoly-classification of the abstract simples it
+matches against `S_λ` via `schurPoly_linearIndependent` to force a single summand.
 
-* **Algebraicity.** `decompose_polynomial_gl_rep` needs
-  `halg : Etingof.IsAlgebraicRepresentation N M.ρ`, which is *not* implied by
-  `formalCharacter M = schurPoly N lam` + `h_dim` (algebraicity is the structural
-  "matrix entries are polynomials" property, not a character-level one). The
-  signature must gain `halg`, and the sole consumer (`schurModule_shift_iso_detTwist`,
-  `Proposition5_22_2`) must supply algebraicity of `detTwistedSchurModuleRep`.
-* **`h_span` from `h_dim`.** `decompose_polynomial_gl_rep` needs
-  `h_span : ⨆ μ, glWeightSpace … = ⊤`. The consumer already proves this
-  (`Proposition5_22_2` `h₁_top`), so threading `h_span` through the signature is
-  the clean route.
-* **Character classification of the abstract simples.** `decompose_polynomial_gl_rep`
-  hides the tensor-power decomposition data `(e, he)` that
-  `SchurWeylSimplesClassification.glTensorRep_schurWeyl_simples_formalCharacter_linearIndependent`
-  consumes. Either `decompose_polynomial_gl_rep` must additionally expose that
-  its abstract simples have characters `= schurPoly` of distinct antitone
-  partitions, or a bridge lemma to that effect is needed before step 4 applies.
+Two pieces of deferred (Tier-4) content are isolated as `sorry`s and consumed
+transitively:
+
+* `simpleRep_iso_schurModule_of_formalCharacter_eq` (this file): the iso-strength
+  highest-weight uniqueness "a simple polynomial `GL_N`-rep with character `S_λ` is `L_λ`".
+  This is the natural strengthening of `schurWeyl_simples_formalCharacter_classification_core`
+  (#4721), which only classifies characters.
+* The classification crux itself (#4721) and pairwise distinctness (#4731), reached
+  through `decompose_polynomial_gl_rep`.
+
+The reusable glue `Representation.kEquivOfAsModuleEquiv` (the reverse of
+`asModuleEquivOfIntertwiner`) bridges the module-level `≃ₗ[MonoidAlgebra]` output of the
+decomposition to a `k`-linear GL-equivariant equivalence, feeding both the character
+computation (via `formalCharacter_eq_of_rep_iso`) and the categorical iso (via
+`Action.mkIso`). (The ℂ-side file `SchurWeylSimplesClassificationComplex` independently
+packages the character half as `formalCharacter_eq_of_asModule_linearEquiv`.)
 -/
 
 open CategoryTheory MvPolynomial
@@ -68,43 +71,181 @@ noncomputable section
 
 universe u
 
+namespace Representation
+
+variable {k G : Type*} [CommSemiring k] [Monoid G]
+variable {V W : Type*} [AddCommMonoid V] [Module k V] [AddCommMonoid W] [Module k W]
+
+/-- **Reverse glue (the `k`-linear equivalence underlying a `MonoidAlgebra`-linear
+equivalence of `asModule`s).** A `MonoidAlgebra k G`-linear equivalence between the
+`asModule`s of two representations restricts, via `asModuleEquiv`, to a `k`-linear
+equivalence between their carriers. This is the inverse direction of
+`asModuleEquivOfIntertwiner`: it extracts the carrier-level equivalence from the
+module-level one. -/
+def kEquivOfAsModuleEquiv {ρ : Representation k G V} {σ : Representation k G W}
+    (φ : Representation.asModule ρ ≃ₗ[MonoidAlgebra k G] Representation.asModule σ) :
+    V ≃ₗ[k] W :=
+  ρ.asModuleEquiv.symm ≪≫ₗ φ.restrictScalars k ≪≫ₗ σ.asModuleEquiv
+
+/-- The `k`-linear equivalence `kEquivOfAsModuleEquiv φ` intertwines `ρ` and `σ`.
+The `MonoidAlgebra` action records the group action (`asModuleEquiv_symm_map_rho`,
+`asModuleEquiv_map_smul`), so transporting `φ`'s `MonoidAlgebra`-linearity back to the
+carriers turns it into `G`-equivariance. -/
+theorem kEquivOfAsModuleEquiv_intertwines {ρ : Representation k G V}
+    {σ : Representation k G W}
+    (φ : Representation.asModule ρ ≃ₗ[MonoidAlgebra k G] Representation.asModule σ)
+    (g : G) (v : V) :
+    kEquivOfAsModuleEquiv φ (ρ g v) = σ g (kEquivOfAsModuleEquiv φ v) := by
+  simp only [kEquivOfAsModuleEquiv, LinearEquiv.trans_apply, LinearEquiv.restrictScalars_apply]
+  rw [ρ.asModuleEquiv_symm_map_rho, map_smul, σ.asModuleEquiv_map_smul,
+    MonoidAlgebra.of_apply, σ.asAlgebraHom_single, one_smul]
+
+end Representation
+
 namespace Etingof
 
 variable (k : Type u) [Field k] [IsAlgClosed k] [CharZero k]
 
-/-- A `GL_N(k)`-representation whose formal character equals a Schur polynomial
-`S_λ` and whose dimension matches the Schur module is isomorphic to `L_λ`.
+/-- The formal character only depends on the underlying representation: rebuilding
+`M` as `FDRep.of M.ρ` does not change its character. -/
+theorem formalCharacter_FDRep_of_ρ (N : ℕ)
+    (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k)) :
+    formalCharacter k N (FDRep.of M.ρ) = formalCharacter k N M :=
+  formalCharacter_eq_of_rep_iso k N M.ρ M.ρ (LinearEquiv.refl k M) (fun _ _ => rfl)
 
-The dimension hypothesis `h_dim` is necessary: without it, one could take
-`M = L_λ ⊕ det⁻¹`, which has `formalCharacter M = schurPoly N lam` (since
-`det⁻¹` has no `ℕ`-valued weight spaces and is invisible to `formalCharacter`),
-yet `M ≇ L_λ` due to the dimension mismatch. The hypothesis ensures `M` is
-"polynomial" — its `ℕ`-valued weight spaces account for all of `M`.
 
-The proof requires GL_N-equivariant complete reducibility: every polynomial
-`GL_N`-representation decomposes into a direct sum of Schur modules
-(`decompose_polynomial_gl_rep`). Combined with the Weyl character formula and the
-linear independence of the abstract simple characters
-(`SchurWeylSimplesClassification`), this forces `M ≅ L_λ`. See the module
-docstring for the remaining proof gaps (issue #4699 deliverable 3).
+/-- **Highest-weight uniqueness (isolated `sorry`, issue #4721).** A *simple* polynomial
+`GL_N(k)`-representation whose formal character is the Schur polynomial `S_λ` (for an
+antitone `λ`) is isomorphic to the Schur module `L_λ`.
 
-The downstream use is in `schurModule_shift_iso_detTwist` (Proposition 5.22.2),
-where both representations are polynomial and have character equal to
-`schurPoly N (λ + 1^N)`. -/
+This is the iso-strength form of the highest-weight classification. The existing
+`schurWeyl_simples_formalCharacter_classification_core` (#4721) only pins the *character*
+of an abstract simple to a Schur polynomial; identifying the simple itself with the
+concrete `SchurModule` is the same deferred Tier-4 content ("a simple polynomial
+`GL_N`-rep is determined by its character"), isolated here as a single `sorry` so the
+assembly `iso_of_formalCharacter_eq_schurPoly` below is otherwise sorry-free. -/
+theorem simpleRep_iso_schurModule_of_formalCharacter_eq (N : ℕ)
+    (lam : Fin N → ℕ) (hlam : Antitone lam)
+    (L : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
+    (hLsimp : IsSimpleModule (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
+      (Representation.asModule L.ρ))
+    (h : formalCharacter k N L = schurPoly N lam) :
+    Nonempty (L ≅ SchurModule k N lam) := by
+  sorry
+
+/-- A polynomial `GL_N(k)`-representation whose formal character equals a Schur
+polynomial `S_λ` is isomorphic to the Schur module `L_λ`.
+
+The hypotheses `halg` (algebraicity) and `h_span` (the `ℕ`-valued weight spaces span all
+of `M`) are what make `M` genuinely *polynomial*: together they exclude the would-be
+counterexample `M = L_λ ⊕ det⁻¹` (whose `det⁻¹`-summand contributes no `ℕ`-valued weight
+space, so it is invisible to `formalCharacter` and violates `h_span`). The dimension
+hypothesis (`_h_dim`) is retained for the consumer's interface and the historical
+statement, but is not needed for the proof: `h_span` already pins `M` down.
+
+Proof: `decompose_polynomial_gl_rep` (GL_N-equivariant complete reducibility) writes
+`M.asModule` as a direct sum of abstract simples `L (f j)`, each with character a Schur
+polynomial `schurPoly N (lam_cl (f j))` along an injective assignment `lam_cl`. Pushing
+`formalCharacter` through the decomposition and matching against `S_λ`, linear independence
+of the Schur polynomials (`schurPoly_linearIndependent`) forces a single summand whose
+class is `λ`. The resulting simple `L (f 0)` is then identified with `L_λ` via the
+highest-weight uniqueness `simpleRep_iso_schurModule_of_formalCharacter_eq`.
+
+The downstream use is in `schurModule_shift_iso_detTwist` (Proposition 5.22.2). -/
 theorem iso_of_formalCharacter_eq_schurPoly (N : ℕ)
     (lam : Fin N → ℕ) (hlam : Antitone lam)
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
+    (halg : Etingof.IsAlgebraicRepresentation N M.ρ)
+    (h_span : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M (fun i => μ i) = ⊤)
     (h : formalCharacter k N M = schurPoly N lam)
-    (h_dim : Module.finrank k M = Module.finrank k (SchurModule k N lam)) :
+    (_h_dim : Module.finrank k M = Module.finrank k (SchurModule k N lam)) :
     Nonempty (M ≅ SchurModule k N lam) := by
-  -- Proof outline (see module docstring for the precise remaining gaps):
-  -- 1. From h: weight space dims match at every ℕ-valued weight; M is homogeneous
-  --    of degree ∑ lam (`weight_magnitude_of_formalCharacter_eq_schurPoly`).
-  -- 2. By GL_N-equivariant complete reducibility (`decompose_polynomial_gl_rep`):
-  --    M.asModule ≃ ⨁_{j} (L (f j)).asModule for abstract simples L.
-  -- 3. Character additivity + linear independence of the abstract simple
-  --    characters (#4698): the multiset {f j} is a single class, that of L_λ.
-  -- 4. Therefore M ≅ L_λ.
-  sorry
+  classical
+  set n := ∑ i, lam i with hn
+  -- (1) `M` is homogeneous of degree `n`: any nonzero `ℕ`-weight space has `∑ μ = ∑ lam`.
+  have h_homog : ∀ μ : Fin N → ℕ, glWeightSpace k N M μ ≠ ⊥ → ∑ i, μ i = n := by
+    intro μ hμ
+    have hpos : 0 < Module.finrank k (glWeightSpace k N M μ) :=
+      Module.finrank_pos_iff.mpr (Submodule.nontrivial_iff_ne_bot.mpr hμ)
+    exact weight_magnitude_of_formalCharacter_eq_schurPoly k N lam M h μ hpos
+  -- (2) Decompose `M.asModule` into abstract simples, schurPoly-classified.
+  obtain ⟨ι, hιFin, hιDec, L, hLsimp, ⟨lam_cl, lam_inj, hchar⟩, p, f, ⟨eM⟩⟩ :=
+    Etingof.PolynomialGLDecomposition.decompose_polynomial_gl_rep k N n M halg h_span h_homog
+  -- (3) Character match: `S_λ = ∑_j schurPoly N (lam_cl (f j))`.
+  have hφ : Representation.asModule M.ρ ≃ₗ[MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k)]
+      Representation.asModule (Representation.directSum (fun j : Fin p => (L (f j)).ρ)) :=
+    eM ≪≫ₗ (Representation.asModule_directSum_equiv (fun j : Fin p => (L (f j)).ρ)).symm
+  have hM_sum : formalCharacter k N M = ∑ j : Fin p, schurPoly N (lam_cl (f j)).val := by
+    -- Push `formalCharacter` through the decomposition: bridge the `MonoidAlgebra`-linear
+    -- `asModule` equivalence `hφ` to a `k`-linear GL-equivariant equivalence, then split
+    -- the resulting direct sum and read off each Schur-polynomial character via `hchar`.
+    have hchar_eq : formalCharacter k N M
+        = formalCharacter k N
+          (FDRep.of (Representation.directSum (fun j : Fin p => (L (f j)).ρ))) := by
+      have h0 := formalCharacter_eq_of_rep_iso k N M.ρ
+        (Representation.directSum (fun j : Fin p => (L (f j)).ρ))
+        (Representation.kEquivOfAsModuleEquiv hφ)
+        (fun g v => Representation.kEquivOfAsModuleEquiv_intertwines hφ g v)
+      rwa [formalCharacter_FDRep_of_ρ] at h0
+    rw [hchar_eq,
+      formalCharacter_directSum k N (fun j : Fin p => (L (f j) : Type u))
+        (fun j : Fin p => (L (f j)).ρ)]
+    refine Finset.sum_congr rfl (fun j _ => ?_)
+    rw [formalCharacter_FDRep_of_ρ, hchar (f j)]
+  have hrel : schurPoly N lam = ∑ j : Fin p, schurPoly N (lam_cl (f j)).val := by
+    rw [← h, hM_sum]
+  -- (4) Linear independence of Schur polynomials forces a single summand of class `λ`.
+  have hsum_eq : Finsupp.single (⟨lam, hlam⟩ : {l : Fin N → ℕ // Antitone l}) (1 : ℚ)
+      = ∑ j : Fin p, Finsupp.single (lam_cl (f j)) (1 : ℚ) := by
+    apply schurPoly_linearIndependent N
+    rw [Finsupp.linearCombination_single, map_sum]
+    simp only [Finsupp.linearCombination_single, one_smul]
+    exact hrel
+  -- The total coefficient mass: `1 = p`, hence `p = 1`.
+  have hp1 : p = 1 := by
+    have hmass := congrArg
+      (Finsupp.linearCombination ℚ (fun _ : {l : Fin N → ℕ // Antitone l} => (1 : ℚ))) hsum_eq
+    simp only [map_sum, Finsupp.linearCombination_single, smul_eq_mul, mul_one,
+      Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul] at hmass
+    exact_mod_cast hmass.symm
+  subst hp1
+  -- The single class is `λ`.
+  have hclass0 : lam_cl (f 0) = (⟨lam, hlam⟩ : {l : Fin N → ℕ // Antitone l}) := by
+    rw [Fin.sum_univ_one] at hsum_eq
+    exact (Finsupp.single_left_inj (by norm_num)).mp hsum_eq.symm
+  -- (5) Collapse the `Fin 1` direct sum onto its single summand and rebuild the iso.
+  let e_collapse :
+      DirectSum (Fin 1) (fun j : Fin 1 => Representation.asModule (L (f j)).ρ)
+        ≃ₗ[MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k)]
+          Representation.asModule (L (f 0)).ρ :=
+    LinearEquiv.ofLinear
+      (DirectSum.component (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k)) (Fin 1)
+        (fun j : Fin 1 => Representation.asModule (L (f j)).ρ) 0)
+      (DirectSum.lof (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k)) (Fin 1)
+        (fun j : Fin 1 => Representation.asModule (L (f j)).ρ) 0)
+      (by ext x; simp [DirectSum.component.lof_self])
+      (by
+        refine DirectSum.linearMap_ext
+          (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k)) (fun i => ?_)
+        fin_cases i
+        ext b
+        simp [DirectSum.component.lof_self])
+  have hφ' : Representation.asModule M.ρ
+      ≃ₗ[MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k)]
+        Representation.asModule (L (f 0)).ρ :=
+    eM ≪≫ₗ e_collapse
+  -- `M ≅ L (f 0)` as `GL_N`-representations.
+  have hML : Nonempty (M ≅ L (f 0)) :=
+    ⟨Action.mkIso (Representation.kEquivOfAsModuleEquiv hφ').toFGModuleCatIso (fun g => by
+      ext x
+      exact Representation.kEquivOfAsModuleEquiv_intertwines hφ' g x)⟩
+  -- `L (f 0) ≅ L_λ` by highest-weight uniqueness.
+  have hchar0 : formalCharacter k N (L (f 0)) = schurPoly N lam := by
+    rw [hchar (f 0), hclass0]
+  have hLS : Nonempty (L (f 0) ≅ SchurModule k N lam) :=
+    simpleRep_iso_schurModule_of_formalCharacter_eq k N lam hlam (L (f 0)) (hLsimp (f 0)) hchar0
+  obtain ⟨isoML⟩ := hML
+  obtain ⟨isoLS⟩ := hLS
+  exact ⟨isoML ≪≫ isoLS⟩
 
 end Etingof

--- a/progress/2026-06-21T15-58-02Z_52dc744f.md
+++ b/progress/2026-06-21T15-58-02Z_52dc744f.md
@@ -1,0 +1,60 @@
+## Accomplished
+
+Worked issue #4882 (feature): assemble `iso_of_formalCharacter_eq_schurPoly`
+(`Chapter5/SchurWeylFormalCharacterIso.lean`).
+
+- **`iso_of_formalCharacter_eq_schurPoly` is now sorry-free in its own proof**, with
+  the new signature `(N, lam, hlam, M, halg, h_span, h, _h_dim)`. The proof:
+  (1) derives homogeneity `h_homog` from the character equation; (2) decomposes `M`
+  via `decompose_polynomial_gl_rep`; (3) matches `formalCharacter M` against
+  `∑_j schurPoly N (lam_cl (f j))` through new reusable glue; (4) uses
+  `schurPoly_linearIndependent` to force `p = 1` and `lam_cl (f 0) = λ`; (5) collapses
+  the `Fin 1` direct sum, rebuilds the categorical iso `M ≅ L (f 0)` via `Action.mkIso`,
+  and finishes through the bridge lemma.
+- **New reusable glue (sorry-free):** `Representation.kEquivOfAsModuleEquiv` (+
+  `_intertwines`) and `formalCharacter_eq_of_asModule_linearEquiv` — the reverse
+  direction of `asModuleEquivOfIntertwiner`, turning a `≃ₗ[MonoidAlgebra]` `asModule`
+  equivalence into character equality. Also `formalCharacter_FDRep_of_ρ`.
+- **One new isolated `sorry`:** `simpleRep_iso_schurModule_of_formalCharacter_eq`
+  (iso-strength highest-weight uniqueness). The existing classification (#4721) only
+  exposes *characters* of the abstract simples, not their iso to `SchurModule`; the
+  #4882 body silently assumed the iso. Filed as **#4901**.
+- **Resolved an import-cycle blocker in the #4882 plan.** The plan said the consumer
+  should supply `detTwistedSchurModuleRep_isAlgebraic`, but that lemma lives in
+  `DetTwistAlgebraic`, which *imports* `Proposition5_22_2` (where `detTwistedSchurModuleRep`
+  is defined) — a cycle. Fix: extracted the general algebraicity infrastructure
+  (`evalAtGL_*`, `detPolyGL`, `IsAlgebraicRepresentation.detTwist`/`.restrict`,
+  `glTensorRep_isAlgebraic`, `tBasisAlg`) into a new upstream file
+  `Chapter5/GLRepAlgebraic.lean`; `DetTwistAlgebraic` now imports it and keeps only
+  `detTwistedSchurModuleRep_isAlgebraic`.
+- **Updated the consumer** `schurModule_shift_iso_detTwist` (`Proposition5_22_2`):
+  hoisted `h₁_top` out as `h_span`, built `halg` inline from the upstream infra, and
+  passed the new arguments. Added `GLRepAlgebraic` to the `Chapter5` aggregator.
+
+Build: `lake build EtingofRepresentationTheory.Chapter5.DetTwistAlgebraic` green
+(8063 jobs); the only `sorry` in the touched files is the bridge lemma (line 140).
+
+## Current frontier
+
+`iso_of_formalCharacter_eq_schurPoly` bottoms out in one deep lemma
+(`simpleRep_iso_schurModule_of_formalCharacter_eq`, #4901) plus the pre-existing
+transitive classification sorries (#4721/#4731) reached via
+`decompose_polynomial_gl_rep`.
+
+## Overall project progress
+
+Chapter 5 Schur-Weyl #6 capstone assembled; Proposition 5.22.2 chain compiles with
+the strengthened `iso_of_formalCharacter_eq_schurPoly` interface. Remaining Ch5
+character-side sorries: #4721 (classification crux), #4731 (pairwise distinctness),
+#4901 (iso-strength highest-weight uniqueness), plus #4875 (character independence).
+
+## Next step
+
+Claim #4901 and prove the bridge lemma (iso-strength highest-weight uniqueness) —
+either by strengthening #4721's classification to expose `L i ≅ SchurModule N (lam_cl i)`
+or by a direct highest-weight uniqueness argument using `schurModule_isSimple`.
+
+## Blockers
+
+None new. #4901 carries the residual deep content; #4721/#4731 remain the upstream
+classification sorries.


### PR DESCRIPTION
This PR assembles the Schur-Weyl #6 capstone `iso_of_formalCharacter_eq_schurPoly`
(`Chapter5/SchurWeylFormalCharacterIso.lean`) so that its own proof is sorry-free: a
polynomial `GL_N(k)`-representation whose formal character is a Schur polynomial is
isomorphic to the corresponding Schur module. Building on the now degree-unrestricted
`decompose_polynomial_gl_rep`, the theorem gains the `halg` (algebraicity) and `h_span`
hypotheses that make `M` genuinely polynomial, decomposes `M` into abstract simples,
matches characters against `schurPoly N lam` via `schurPoly_linearIndependent` to force a
single summand of class `λ`, rebuilds the categorical iso, and concludes through a single
isolated highest-weight-uniqueness lemma.

Along the way it adds the reusable glue `Representation.kEquivOfAsModuleEquiv` (with
`_intertwines`) and `formalCharacter_eq_of_asModule_linearEquiv` — the reverse direction
of `asModuleEquivOfIntertwiner`, turning a `MonoidAlgebra`-linear `asModule` equivalence
into formal-character equality.

Two findings beyond the issue's plan:

- The plan's claim that "`L (f 0) ≅ L_λ` at the asModule level" follows from the
  decomposition is not derivable: the existing classification (#4721) exposes only the
  *characters* of the abstract simples, not their isomorphism to `SchurModule`. The
  iso-strength highest-weight uniqueness is isolated as the lone new `sorry`,
  `simpleRep_iso_schurModule_of_formalCharacter_eq`, and filed as #4901.
- Supplying `detTwistedSchurModuleRep_isAlgebraic` in the consumer (as the plan
  suggested) is impossible: that lemma lives in `DetTwistAlgebraic`, which imports
  `Proposition5_22_2` (where `detTwistedSchurModuleRep` is defined) — an import cycle.
  The general algebraicity infrastructure (`evalAtGL_*`, `detPolyGL`,
  `IsAlgebraicRepresentation.detTwist`/`.restrict`, `glTensorRep_isAlgebraic`) is
  extracted into a new upstream file `Chapter5/GLRepAlgebraic.lean`, letting the consumer
  `schurModule_shift_iso_detTwist` build `halg` inline.

The consumer `schurModule_shift_iso_detTwist` (`Proposition5_22_2`) is updated to hoist
`h_span`, build `halg` inline, and pass the new arguments. `iso_of_formalCharacter_eq_schurPoly`
is sorry-free in its own proof; the remaining transitive sorries are the classification
crux (#4721), pairwise distinctness (#4731), and the isolated highest-weight uniqueness
(#4901).

🤖 Prepared with Claude Code
