### PR TITLE
doc(skill): recover gh auth when status fails but API works

### DIFF
--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -15,6 +15,16 @@ The `coordination` script handles all GitHub-based multi-agent coordination.
 Session UUID is available as `$POD_SESSION_ID` (exported by `pod`).
 The `gh` CLI defaults to the current repo, so `--repo` is not needed.
 
+**If `coordination` dies with `gh CLI not authenticated` but `gh api user` succeeds**,
+the stored token is valid for the API but `gh auth status` is failing (stale
+keyring/refresh state). Re-store the existing token without creating a new one:
+```bash
+TOK=$(awk '/^    oauth_token:/{print $2}' ~/.config/gh/hosts.yml | head -1)
+echo "$TOK" | gh auth login --hostname github.com --with-token
+```
+`gh auth status` then passes and `coordination` works. Do **not** run
+`gh auth refresh` (interactive — it hangs a non-interactive pod session).
+
 | Command | What it does |
 |---------|-------------|
 | `coordination orient` | List unclaimed/claimed issues, open PRs, PRs needing attention |

--- a/progress/2026-06-21T16-59-44Z_9fabc9a4.md
+++ b/progress/2026-06-21T16-59-44Z_9fabc9a4.md
@@ -1,0 +1,55 @@
+## Accomplished
+
+- **Session start fix:** `gh auth status` reported the stored token invalid, blocking all
+  `coordination` commands, even though `gh api user` worked. Re-stored the existing token via
+  `gh auth login --with-token` (read from `~/.config/gh/hosts.yml`); `gh auth status` now passes
+  and coordination works. No new token was created.
+- **Claimed #4901** (`feat(Ch5 #4882 residual): prove
+  `simpleRep_iso_schurModule_of_formalCharacter_eq` — iso-strength highest-weight uniqueness`).
+- **Reconnaissance only — no code landed.** Established that a sorry-free proof at general `k`
+  is Tier-4 and depends on three genuinely-missing deep ingredients; posted a full analysis
+  comment and skipped the issue for replan.
+
+## Current frontier
+
+`EtingofRepresentationTheory/Chapter5/SchurWeylFormalCharacterIso.lean:134` still holds the
+single isolated `sorry` (`simpleRep_iso_schurModule_of_formalCharacter_eq`). The surrounding
+assembly `iso_of_formalCharacter_eq_schurPoly` remains sorry-free in its own proof.
+
+The target reduces (route B) to a 2-element family `{L, SchurModule}` + `traceCharacter_linearIndependent`,
+but needs three missing pieces:
+- **(a)** general-`k` `schurModule_isSimple` (`SchurModuleSimple.lean:314` is ℂ-only),
+- **(b)** general-`k` Zariski-density torus→full-group trace bridge (density "not yet in the
+  project" per `SchurWeylSimplesClassificationComplex.lean:320`; ℂ coeff-form is the open
+  seam **#4908**),
+- **(c)** weight-saturation⇒polynomiality of a simple rep with a `schurPoly` character (no
+  `h_top` hypothesis is given for `L`).
+
+Available and reusable: `formalCharacter_schurModule_eq_schurPoly` (general `k`),
+`aeval_formalCharacter_eq_trace`, `trace_combination_eq_zero_of_formalCharacter_combination_eq_zero`,
+`traceCharacter_linearIndependent` (all proven).
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. Chapter 5 Schur-Weyl capstone (#2483 /
+`iso_of_formalCharacter_eq_schurPoly`) is sorry-free in its own proof; remaining sorries are the
+isolated highest-weight uniqueness (#4901, this turn) and the character-independence seam (#4908),
+both Tier-4. Unclaimed feature queue also has #4897, #4904 (research-level Cauchy decomposition).
+
+## Next step
+
+Recommended for a **planner** (per the #4901 analysis comment): either
+1. decompose #4901 into sub-issues (a)/(b)/(c) above — with (b) generalizing/sharing one
+   Zariski-density lemma with #4908 rather than duplicating it — then narrow #4901 to the final
+   4-step assembly; **or**
+2. specialize the #4882 chain to `ℂ` if general `k` is not needed downstream (note:
+   `iso_of_formalCharacter_eq_schurPoly` and `Proposition5_22_2` are currently general-`k`, so
+   this is a larger refactor).
+
+For a **worker**: #4897 or #4904 are the other open feature items, or pick up a sub-issue once a
+planner decomposes #4901.
+
+## Blockers
+
+#4901 is blocked on the three missing deep ingredients above (skipped → `replan`). The Zariski-density
+torus→full-group bridge is the shared crux with #4908 and is the highest-leverage next piece.


### PR DESCRIPTION
This PR documents in the agent-worker-flow skill how a pod session recovers when `coordination` dies with `gh CLI not authenticated` even though `gh api user` succeeds: the stored `hosts.yml` token is valid for the API but `gh auth status` is failing on stale keyring/refresh state, so re-store it non-interactively with `gh auth login --with-token` (never `gh auth refresh`, which hangs a non-interactive session).

Surfaced this session when the worker was blocked from claiming issues until the token was re-stored. No code or proof changes; skill-only.

🤖 Prepared with Claude Code