### PR TITLE
feat(toolchain): make PowerSumCauchyIdentity forward-compatible

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/PowerSumCauchyIdentity.lean
+++ b/EtingofRepresentationTheory/Chapter5/PowerSumCauchyIdentity.lean
@@ -207,7 +207,7 @@ private theorem partialTarget_empty_eq_one (σ : Equiv.Perm (Fin N)) :
     | inl j => exact (h j).1
     | inr i =>
       have := (h (σ⁻¹ i)).2
-      rwa [Equiv.Perm.apply_inv_self] at this
+      simpa only [Equiv.Perm.inv_def, Equiv.apply_symm_apply, Finsupp.zero_apply] using this
   · intro h; subst h; exact ⟨fun _ => trivial, fun j => ⟨Finsupp.zero_apply, Finsupp.zero_apply⟩⟩
 
 private theorem partialTarget_univ_eq (σ : Equiv.Perm (Fin N)) :


### PR DESCRIPTION
Partial progress on #4864.

This is a small forward-compatible proof-script adjustment for the Lean v4.31 port.

The proof of `partialTarget_empty_eq_one` used `Equiv.Perm.apply_inv_self`, which is brittle under the v4.31 port. Rewriting the step via `Equiv.Perm.inv_def`, `Equiv.apply_symm_apply`, and `Finsupp.zero_apply` keeps the same proof content while avoiding the removed/renamed permutation lemma.

No theorem statements or mathematical content change.

Validation:
- `lake build EtingofRepresentationTheory.Chapter5.PowerSumCauchyIdentity` on current `main` with `leanprover/lean4:v4.28.1`
- `lake build EtingofRepresentationTheory.Chapter5.PowerSumCauchyIdentity` on the v4.31 port branch