### PR TITLE
feat(Ch5 #4897): glWeightSpaceℤ_quotDetTwist weight-shift; decompose assembly

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/KernelLemmaKPrime.lean
+++ b/EtingofRepresentationTheory/Chapter5/KernelLemmaKPrime.lean
@@ -245,6 +245,46 @@ theorem glWeightSpaceℤ_neg_not_mem_nonneg_span (k : Type*) [Field k] [CharZero
     hbot ▸ Submodule.mem_inf.2 ⟨hμ_eig, hsup_le hv_sup⟩
   exact hv0 ((Submodule.mem_bot _).1 this)
 
+/-- **Weight-space shift under the `χ⁻ʳ` twist.** Twisting `A/det` by `detChar⁻ʳ`
+shifts every torus weight down by `(r,…,r)`: a vector is a weight-`μ` vector of the
+twisted rep `(A/det) ⊗ χ⁻ʳ` exactly when it is a weight-`(μ + r)` vector of the
+untwisted quotient `A/det`. Indeed `det (diagUnit i t) = t`, so the twist rescales
+the diagonal action `diagUnit i t` by the scalar `t⁻ʳ` uniformly in `i`, sending a
+`t^{μ i + r}`-eigenvector of `quotDetRep` to a `t^{μ i}`-eigenvector of the twist.
+
+This is the bookkeeping ingredient that the lowest/highest-weight realization core
+(`quotDetTwist_nonzero_subrep_has_neg_weight`) uses to convert a weight-`ν` vector
+of `A/det` (with `ν ∈ ℕ^N`, `ν_N = 0`) into a weight-`(ν − r)` vector of the twist
+whose last coordinate `ν_N − r = −r` is negative. -/
+theorem glWeightSpaceℤ_quotDetTwist (k : Type*) [Field k] (N : ℕ) (r : ℕ)
+    (μ : Fin N → ℤ) :
+    glWeightSpaceℤ k N (quotDetTwistRep k N r) μ =
+      glWeightSpaceℤ k N (quotDetRep k N) (fun i => μ i + r) := by
+  simp only [glWeightSpaceℤ]
+  refine iInf_congr fun i => iInf_congr fun t => ?_
+  set g := diagUnit k N i t with hg
+  -- `det (diagUnit i t) = t`, so the twist evaluates to `t⁻ʳ • quotDetRep g`.
+  have hdet : detChar k N g = t := by
+    ext
+    change Matrix.det g.val = (t : k)
+    simp only [hg, diagUnit, Matrix.det_diagonal,
+      Finset.prod_update_of_mem (Finset.mem_univ i), Pi.one_apply]
+    simp [Finset.prod_eq_one (fun j _ => rfl)]
+  set c : k := ((t ^ (-(r : ℤ)) : kˣ) : k) with hc
+  have hcne : c ≠ 0 := Units.ne_zero _
+  have htwist : quotDetTwistRep k N r g = c • quotDetRep k N g := by
+    show ((detChar k N ^ (-(r : ℤ))) g : k) • quotDetRep k N g = _
+    rw [MonoidHom.zpow_apply, hdet]
+  -- The two diagonal-action eigenscalars are related by `c`: `c · t^{μ i + r} = t^{μ i}`.
+  have hscal : c * ((t ^ (μ i + (r : ℤ)) : kˣ) : k) = ((t ^ μ i : kˣ) : k) := by
+    have hexp : (-(r : ℤ)) + (μ i + (r : ℤ)) = μ i := by ring
+    rw [hc, ← Units.val_mul, ← zpow_add, hexp]
+  -- Factor the twisted operator through `c`, then strip the nonzero scalar off the kernel.
+  have factored : quotDetTwistRep k N r g - ((t ^ μ i : kˣ) : k) • LinearMap.id =
+      c • (quotDetRep k N g - ((t ^ (μ i + (r : ℤ)) : kˣ) : k) • LinearMap.id) := by
+    rw [htwist, smul_sub, smul_smul, hscal]
+  rw [factored, LinearMap.ker_smul _ _ hcne]
+
 /-- **The genuine core of (K′).** For `r ≥ 1`, every *nonzero* subrepresentation
 `W` of the twisted quotient `(A/det) ⊗ χ⁻ʳ` contains a nonzero torus-weight vector
 whose weight has a negative coordinate.

--- a/progress/2026-06-21T17-26-43Z_d22099f3.md
+++ b/progress/2026-06-21T17-26-43Z_d22099f3.md
@@ -1,0 +1,55 @@
+## Accomplished
+
+Worked issue #4897 (`quotDetTwist_nonzero_subrep_has_neg_weight`, the lone
+remaining `sorry` in `Chapter5/KernelLemmaKPrime.lean`). After thorough
+reconnaissance the lemma proved to be genuinely multi-piece infrastructure, so
+this turn lands the most self-contained needed ingredient sorry-free and
+decomposes the rest.
+
+- **Landed (sorry-free):** `glWeightSpaceℤ_quotDetTwist`
+  (`Chapter5/KernelLemmaKPrime.lean`). For any `μ : Fin N → ℤ`,
+  `glWeightSpaceℤ k N (quotDetTwistRep k N r) μ
+     = glWeightSpaceℤ k N (quotDetRep k N) (fun i => μ i + r)`.
+  The `χ⁻ʳ` twist shifts every torus weight down by `(r,…,r)` because
+  `det (diagUnit i t) = t`, so the twist rescales the diagonal action uniformly
+  by `t⁻ʳ`. Proof mirrors `glWeightSpace_detTwist_shift` (Proposition5_22_2):
+  factor the twisted operator through the nonzero scalar `c = t⁻ʳ`, then
+  `LinearMap.ker_smul`. Key lemma found: `MonoidHom.zpow_apply` evaluates the
+  pointwise zpow of the determinant character.
+- `lake build …KernelLemmaKPrime` succeeds; only `sorry` left in the file is the
+  target assembly itself.
+
+## Current frontier
+
+`quotDetTwist_nonzero_subrep_has_neg_weight` still `sorry`. The remaining proof
+is decomposed into:
+
+- **#4922 (keystone, reusable):** extract a simple `FDRep` constituent with
+  injective equivariant embedding from a nonzero invariant submodule of
+  `quotDetRep`. Needed because `Theorem5_23_2_i` only gives vacuous
+  vector-space semisimplicity — must instead take a *minimal nonzero invariant
+  submodule* (atom of the invariant-submodule lattice), after reducing to a
+  finite-dimensional invariant piece via the degree-grading of `polyRightRep`.
+- **#4923 (assembly, depends on #4922):** untwist `W`, extract simple `L` via
+  #4922, get `ν_N = 0` from part-(a)
+  (`quotDetRep_irreducible_constituent_lastWeight_zero`, `CauchyDetQuotient.lean`,
+  still a `sorry` — OK to use), realize the highest-weight vector (weight `ν`,
+  via `formalCharacter_coeff` + `(schurPoly N ν).coeff ν = 1`), push through `φ`,
+  and apply the landed twist-shift to land in weight `↑ν − r` with last
+  coordinate `−r < 0`.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing on Chapter 5 Schur–Weyl / kernel-lemma frontier.
+`KernelLemmaKPrime.lean`: glue lemmas + twist-shift now sorry-free; one assembly
+`sorry` remains, fully decomposed into #4922 → #4923. Several sibling Ch5
+research items in flight (#4901, #4904, #4859, claimed #4903/#4908/#4909).
+
+## Next step
+
+A worker should claim **#4922** (the extraction keystone — unblocked, reusable).
+Once it lands, **#4923** auto-unblocks and closes `KernelLemmaKPrime.lean`.
+
+## Blockers
+
+None for #4922 (independent of part-(a)'s proof). #4923 is blocked on #4922.


### PR DESCRIPTION
Partial progress on #4897

Session: `d22099f3-d6df-4afd-bcff-42f6ec3e7dd9`

06b34b0d doc(progress): #4897 twist-shift landed; decomposed into #4922, #4923
90c0a073 feat(Ch5 #4897): add glWeightSpaceℤ_quotDetTwist weight-shift lemma

🤖 Prepared with Claude Code