### PR TITLE
feat(toolchain): use Rep.resFunctor for restriction

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_10_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_10_1.lean
@@ -11,7 +11,7 @@ there is a natural isomorphism:
 This is the fundamental adjunction between induction and restriction functors.
 
 Mathlib's `Rep.indResHomEquiv` provides a k-linear equivalence between
-`(Rep.ind H.subtype W ⟶ V)` and `(W ⟶ (Action.res _ H.subtype).obj V)`,
+`(Rep.ind H.subtype W ⟶ V)` and `(W ⟶ (Rep.resFunctor H.subtype).obj V)`,
 which is precisely Frobenius reciprocity stated as Ind ⊣ Res.
 
 ## Mathlib correspondence
@@ -19,7 +19,7 @@ which is precisely Frobenius reciprocity stated as Ind ⊣ Res.
 - `Rep.indResHomEquiv` — the k-linear equivalence (Frobenius reciprocity)
 - `Rep.indResAdjunction` — the categorical adjunction Ind ⊣ Res
 - `Rep.ind` — the induced representation functor
-- `Action.res` — the restriction functor
+- `Rep.resFunctor` — the restriction functor
 -/
 
 open CategoryTheory
@@ -32,5 +32,5 @@ theorem Etingof.Theorem5_10_1
     (k G : Type) [Field k] [Group G]
     (H : Subgroup G)
     (V : Rep k G) (W : Rep k ↥H) :
-    Nonempty ((Rep.ind H.subtype W ⟶ V) ≃ₗ[k] (W ⟶ (Action.res _ H.subtype).obj V)) :=
+    Nonempty ((Rep.ind H.subtype W ⟶ V) ≃ₗ[k] (W ⟶ (Rep.resFunctor H.subtype).obj V)) :=
   ⟨Rep.indResHomEquiv H.subtype W V⟩

--- a/EtingofRepresentationTheory/Chapter7/Example7_6_3.lean
+++ b/EtingofRepresentationTheory/Chapter7/Example7_6_3.lean
@@ -21,15 +21,17 @@ property is captured by `UniversalEnvelopingAlgebra.lift`.
 
 open CategoryTheory
 
+attribute [local instance 100] LieRing.ofAssociativeRing
+
 /-- Frobenius reciprocity: induction is left adjoint to restriction for
 representations of finite groups. (Etingof Example 7.6.3(2))
 
 Given a group homomorphism φ : G →* H over a commutative ring k,
 the induction functor `Rep.indFunctor k φ` is left adjoint to the
-restriction functor `Action.res _ φ`. -/
+restriction functor `Rep.resFunctor φ`. -/
 noncomputable def Etingof.frobenius_reciprocity
     (k : Type u) {G H : Type u} [CommRing k] [Group G] [Group H] (φ : G →* H) :
-    Rep.indFunctor k φ ⊣ Action.res _ φ :=
+    Rep.indFunctor k φ ⊣ Rep.resFunctor φ :=
   Rep.indResAdjunction k φ
 
 /-- The universal enveloping algebra functor is left adjoint to the "underlying


### PR DESCRIPTION
## Summary

This stacked v4.31 port repair updates the Frobenius reciprocity references that now use `Rep.resFunctor` instead of `Action.res`:

- `EtingofRepresentationTheory.Chapter5.Theorem5_10_1`
- `EtingofRepresentationTheory.Chapter7.Example7_6_3`

It also makes `LieRing.ofAssociativeRing` explicit locally in `Example7_6_3`, matching the v4.31 instance search behavior.

## Coordination

Part of #4864. This PR targets `stack/toolchain-v4.31.0` because `Rep.resFunctor` is not available on the current v4.28.1 `main` pin. It is therefore intentionally not backwards-compatible and should be treated as awaiting the toolchain flip, per the current porting strategy on #4864.

The stack base contains the three toolchain bump commits and stack-only CI that validates changed Lean modules rather than the whole repository while the port is incomplete.

## Validation

- v4.31 stack: `lake build EtingofRepresentationTheory.Chapter5.Theorem5_10_1 EtingofRepresentationTheory.Chapter7.Example7_6_3` passed.
- v4.28.1 current pin: the same repair fails with `Unknown constant Rep.resFunctor` in both modules, confirming that this belongs on the v4.31 stack rather than a dual-compatible `main` PR.