### PR TITLE
feat(Ch5 #4925 partial): MvPolynomial Zariski-density engine; decompose density core into #4930/#4931/#4932

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/EvalEqOnGL.lean
+++ b/EtingofRepresentationTheory/Chapter5/EvalEqOnGL.lean
@@ -75,4 +75,33 @@ lemma eq_of_eval_eq_on_gl
     (mul_eq_zero.mp hprod).resolve_right hdet_ne
   exact sub_eq_zero.mp hpq_zero
 
+/-- **Vanishing off the zero-locus of a nonzero polynomial forces vanishing
+everywhere (Zariski-density engine).** Over an infinite integral domain, a
+polynomial `P` that evaluates to `0` at every point where a *nonzero* polynomial
+`Q` does not vanish is identically zero.
+
+Proof: `P * Q` vanishes at every point — where `Q ≠ 0` we use the hypothesis on
+`P`, and where `Q = 0` the product is `0` — so `P * Q = 0` as a polynomial by
+`MvPolynomial.funext`. Since `MvPolynomial σ R` is a domain and `Q ≠ 0`, this
+forces `P = 0`.
+
+This is the generic form of the `(p - q) * det = 0` argument used in
+`eq_of_eval_eq_on_gl` (there `Q` is the generic determinant). It is the density
+primitive for "a regular function vanishing on a Zariski-dense set vanishes
+everywhere": take `Q` cutting out the complement of the dense set (e.g.
+`det · discr` for the distinct-eigenvalue locus in `GL_N`). -/
+lemma eq_zero_of_eval_eq_zero_off_zeroLocus
+    {σ R : Type*} [CommRing R] [IsDomain R] [Infinite R]
+    {P Q : MvPolynomial σ R} (hQ : Q ≠ 0)
+    (h : ∀ x : σ → R, MvPolynomial.eval x Q ≠ 0 → MvPolynomial.eval x P = 0) :
+    P = 0 := by
+  have hprod : P * Q = 0 := by
+    apply MvPolynomial.funext
+    intro x
+    rw [map_mul, map_zero]
+    by_cases hx : MvPolynomial.eval x Q = 0
+    · rw [hx, mul_zero]
+    · rw [h x hx, zero_mul]
+  exact (mul_eq_zero.mp hprod).resolve_right hQ
+
 end MvPolynomial

--- a/progress/2026-06-21T17-46-21Z_cb9dd6cb.md
+++ b/progress/2026-06-21T17-46-21Z_cb9dd6cb.md
@@ -1,0 +1,46 @@
+## Accomplished
+
+Claimed #4925 (geometric density core of the character-independence seam:
+`trace_combination_vanishes_of_torus_vanishes`). On reconnaissance this is a
+genuine research-level task spanning three deep pieces missing from both Mathlib
+and the project, and its target lemma only exists in the still-open PR #4928.
+Took the worker-flow decomposition success path:
+
+- **Landed** the reusable Zariski-density engine
+  `MvPolynomial.eq_zero_of_eval_eq_zero_off_zeroLocus` in
+  `EtingofRepresentationTheory/Chapter5/EvalEqOnGL.lean` (builds clean): over an
+  infinite integral domain, a polynomial vanishing off the zero-locus of a
+  nonzero polynomial `Q` is identically zero (`P*Q = 0` + `MvPolynomial.funext`).
+  This is the generic form of the existing `(p-q)*det = 0` density argument and
+  the engine the assembly needs after clearing the `det⁻¹` denominator.
+- **Decomposed** #4925 into three self-contained sub-issues:
+  - #4930 (sub-A): distinct-eigenvalue `GL_N(ℂ)` matrix is conjugate to a
+    `diagTorus` element (pure linear algebra via `eigenvectors_linearIndependent`).
+  - #4931 (sub-B): charpoly discriminant is a nonzero entry-wise polynomial +
+    `discr ≠ 0 ⟹ N distinct eigenvalues` (hardest piece; the
+    `discr ≠ 0 ⟹ separable` link is a genuine Mathlib gap).
+  - #4932 (sub-C, blocked on #4928/#4930/#4931): the assembly of
+    `trace_combination_vanishes_of_torus_vanishes` from regularity + conjugation
+    invariance + sub-A + sub-B.
+
+## Current frontier
+
+Density engine landed; foundational sub-lemmas (#4930, #4931) are open and ready
+to claim independently. Assembly (#4932) is blocked until they and #4928 land.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. This turn isolated and partially attacked the
+Zariski-density research core shared by the #4908 character-independence chain
+and #4901 ingredient (b). Density primitive now exists in the codebase.
+
+## Next step
+
+Claim #4930 (most tractable, no dependencies) or #4931. After both land plus
+#4928 merges, claim #4932 to finish #4925.
+
+## Blockers
+
+#4932 (assembly) blocked on #4928 (in-flight refactor introducing the lemma) plus
+sub-A/sub-B. The `discr ≠ 0 ⟹ distinct roots` step in #4931 is the genuine
+research risk; #4931 notes a further split if it overruns one session.


### PR DESCRIPTION
Partial progress on #4925

Session: `cb9dd6cb-a2de-4bea-9fd9-eb7d8e3bb07e`

76e3cbfe doc(progress): #4925 decomposed into #4930/#4931/#4932; density engine landed
8fe6300a feat(Ch5 #4925 density engine): MvPolynomial.eq_zero_of_eval_eq_zero_off_zeroLocus

🤖 Prepared with Claude Code