### PR TITLE
feat(Ch5 #4849 biduality core): prove multiplicitySpace_biduality_Aiso (symmetric double-centralizer ↥S ≃ₗ[A] (M_S →ₗ[C] E))

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -16,6 +16,18 @@ lake exe cache get
 ```
 This downloads pre-built Mathlib oleans. Skipping it triggers a full Mathlib rebuild (1800+ jobs).
 
+**Typecheck with `lake build EtingofRepresentationTheory.<Module>`, NOT `lake env lean
+<file>`.** `lake env lean` does **not** apply the lakefile's `[leanOptions]` — in
+particular `maxSynthPendingDepth = 3` (lakefile.toml; the Lean default is 2). Deep
+instance chains in this project (e.g. the `Subalgebra → Module.End` centralizer-module
+instances: `Module ↥(centralizer A) (V →ₗ[A] E)` from `centralizerModuleHom`) need depth
+3, so under `lake env lean` they throw **spurious** `synthInstanceFailed` errors that do
+not occur under `lake build`. If a file fails `lake env lean` with instance-synthesis
+errors on centralizer/Subalgebra hom-spaces but you suspect the proof is fine, re-check
+with `lake build <Module>` before debugging — the on-`main` file fails `lake env lean`
+too. (Some places below still say `lake env lean`; prefer `lake build` when the file uses
+these instances.)
+
 **Build-environment recovery (shared `.lake/packages` across pod worktrees):**
 - `Lean exited with code 139` (SIGSEGV) on *dependency* files you did not touch has
   two distinct causes. (a) Corrupted Mathlib oleans from a concurrent `lake exe cache

--- a/EtingofRepresentationTheory/Chapter5/MultiplicitySpaceBiduality.lean
+++ b/EtingofRepresentationTheory/Chapter5/MultiplicitySpaceBiduality.lean
@@ -66,6 +66,22 @@ noncomputable def homCongrLeftOverSubring
   map_add' f g := by ext v; simp
   map_smul' c f := by ext v; simp [LinearMap.smul_apply, LinearMap.comp_apply]
 
+/-- Restricting a simple `S`-module along a **surjective** ring homomorphism
+`σ : R →+* S` (with the `R`-action obtained by `σ`-restriction, `r • x = σ r • x`)
+keeps it simple: the `R`- and `S`-submodules coincide because every `S`-scalar is
+a `σ`-image. This is the transport tool for the double-centralizer identification
+`centralizer(centralizer A) = A`, where the inclusion `↥A → ↥(centralizer C)` is a
+bijective (hence surjective) ring hom. -/
+theorem isSimpleModule_of_surjective_ringHom
+    {R S : Type*} [Ring R] [Ring S] (σ : R →+* S) [RingHomSurjective σ]
+    {X : Type*} [AddCommGroup X] [Module R X] [Module S X]
+    (hcompat : ∀ (r : R) (x : X), r • x = σ r • x)
+    [IsSimpleModule S X] : IsSimpleModule R X :=
+  (LinearMap.isSimpleModule_iff_of_bijective
+    ({ toFun := id, map_add' := fun _ _ => rfl,
+        map_smul' := fun r x => (hcompat r x) } : X →ₛₗ[σ] X)
+    Function.bijective_id).mpr ‹_›
+
 -- Heartbeats bumped: even synthesizing the `SMul (↥centralizer A) (V →ₗ[A] E)`
 -- in this instance's statement runs the deep `centralizerModuleHom`
 -- `Subalgebra → Module.End` chain, overrunning the default 20000 synth budget
@@ -115,8 +131,122 @@ theorem multiplicitySpace_double_hom_finrank
     (S : Submodule A E) [IsSimpleModule A S] :
     Module.finrank k ↥S =
       Module.finrank k ((↥S →ₗ[A] E) →ₗ[Subalgebra.centralizer k
-        (A : Set (Module.End k E))] E) :=
-  sorry
+        (A : Set (Module.End k E))] E) := by
+  classical
+  -- Semisimplicity facts on both sides.
+  haveI : IsSemisimpleModule A E := IsSemisimpleRing.isSemisimpleModule
+  haveI hCss : IsSemisimpleRing (Subalgebra.centralizer k (A : Set (Module.End k E))) :=
+    Theorem5_18_1_commutant_semisimple k E A
+  haveI : IsSemisimpleModule (Subalgebra.centralizer k (A : Set (Module.End k E))) E :=
+    IsSemisimpleRing.isSemisimpleModule
+  -- `M_S := ↥S →ₗ[A] E` is a simple `C`-module (`C = centralizer A`).
+  haveI hMS : IsSimpleModule (Subalgebra.centralizer k (A : Set (Module.End k E)))
+      (↥S →ₗ[A] E) := isSimpleModule_homA_centralizer k E A S
+  -- Pick a nonzero `s0 ∈ S`.
+  haveI : Nontrivial ↥S := IsSimpleModule.nontrivial A ↥S
+  obtain ⟨s0, hs0⟩ := exists_ne (0 : ↥S)
+  -- Evaluation at `s0`: a nonzero `C`-linear map `M_S → E`, hence injective.
+  let evs0 : (↥S →ₗ[A] E) →ₗ[Subalgebra.centralizer k (A : Set (Module.End k E))] E :=
+    { toFun := fun l => l s0
+      map_add' := fun _ _ => rfl
+      map_smul' := fun _ _ => rfl }
+  have hevs0_ne : evs0 ≠ 0 := by
+    intro h
+    apply hs0
+    have h1 : (s0 : E) = 0 := by
+      have := LinearMap.congr_fun h S.subtype
+      simpa [evs0] using this
+    exact Subtype.ext (by simpa using h1)
+  have hinjE : Function.Injective evs0 := LinearMap.injective_of_ne_zero hevs0_ne
+  -- Its range `W` is a simple `C`-submodule of `E`, `C`-iso to `M_S`.
+  let W : Submodule (Subalgebra.centralizer k (A : Set (Module.End k E))) E :=
+    LinearMap.range evs0
+  let eMW : (↥S →ₗ[A] E) ≃ₗ[Subalgebra.centralizer k (A : Set (Module.End k E))] ↥W :=
+    LinearEquiv.ofInjective evs0 hinjE
+  haveI hWsimple : IsSimpleModule (Subalgebra.centralizer k (A : Set (Module.End k E))) ↥W :=
+    IsSimpleModule.congr eMW.symm
+  -- `W →ₗ[C] E` is simple over `centralizer C` (`= A`).
+  haveI hWE : IsSimpleModule
+      (Subalgebra.centralizer k
+        ((Subalgebra.centralizer k (A : Set (Module.End k E))) : Set (Module.End k E)))
+      (↥W →ₗ[Subalgebra.centralizer k (A : Set (Module.End k E))] E) :=
+    isSimpleModule_homA_centralizer k E (Subalgebra.centralizer k (A : Set (Module.End k E))) W
+  -- Transport simplicity to the double-hom space along precomposition with `eMW`.
+  let preD : (↥W →ₗ[Subalgebra.centralizer k (A : Set (Module.End k E))] E)
+      ≃ₗ[Subalgebra.centralizer k
+        ((Subalgebra.centralizer k (A : Set (Module.End k E))) : Set (Module.End k E))]
+      ((↥S →ₗ[A] E) →ₗ[Subalgebra.centralizer k (A : Set (Module.End k E))] E) :=
+    { toFun := fun f => f.comp eMW.toLinearMap
+      invFun := fun f => f.comp eMW.symm.toLinearMap
+      left_inv := fun f => by ext m; simp
+      right_inv := fun f => by ext m; simp
+      map_add' := fun f g => by ext m; simp
+      map_smul' := fun b f => by ext m; rfl }
+  haveI hsimpD : IsSimpleModule
+      (Subalgebra.centralizer k
+        ((Subalgebra.centralizer k (A : Set (Module.End k E))) : Set (Module.End k E)))
+      ((↥S →ₗ[A] E) →ₗ[Subalgebra.centralizer k (A : Set (Module.End k E))] E) :=
+    IsSimpleModule.congr preD.symm
+  -- Double centralizer: `centralizer C = A`. Build the (bijective) inclusion ring hom
+  -- `↥A → ↥(centralizer C)` and transport simplicity down to `A`.
+  have hCC : Subalgebra.centralizer k
+      ((Subalgebra.centralizer k (A : Set (Module.End k E))) : Set (Module.End k E)) = A :=
+    Theorem5_18_1_double_centralizer k E A
+  have hAle : A ≤ Subalgebra.centralizer k
+      ((Subalgebra.centralizer k (A : Set (Module.End k E))) : Set (Module.End k E)) :=
+    le_of_eq hCC.symm
+  let σ : (↥A) →+* ↥(Subalgebra.centralizer k
+      ((Subalgebra.centralizer k (A : Set (Module.End k E))) : Set (Module.End k E))) :=
+    (Subalgebra.inclusion hAle).toRingHom
+  haveI hσsurj : RingHomSurjective σ :=
+    ⟨fun y => ⟨⟨y.val, hCC.le y.2⟩, Subtype.ext rfl⟩⟩
+  letI instA : Module (↥A)
+      ((↥S →ₗ[A] E) →ₗ[Subalgebra.centralizer k (A : Set (Module.End k E))] E) :=
+    Module.compHom _ σ
+  haveI hsimpA : IsSimpleModule (↥A)
+      ((↥S →ₗ[A] E) →ₗ[Subalgebra.centralizer k (A : Set (Module.End k E))] E) :=
+    isSimpleModule_of_surjective_ringHom σ (fun _ _ => rfl)
+  -- The curried-evaluation map `v ↦ (l ↦ l v)`, both as a `k`-map and an `A`-map.
+  let ev : ↥S → ((↥S →ₗ[A] E) →ₗ[Subalgebra.centralizer k (A : Set (Module.End k E))] E) :=
+    fun v =>
+    { toFun := fun l => l v
+      map_add' := fun _ _ => rfl
+      map_smul' := fun _ _ => rfl }
+  let biSk : ↥S →ₗ[k]
+      ((↥S →ₗ[A] E) →ₗ[Subalgebra.centralizer k (A : Set (Module.End k E))] E) :=
+    { toFun := ev
+      map_add' := fun v w => by ext l; exact l.map_add v w
+      map_smul' := fun c v => by ext l; exact l.map_smul_of_tower c v }
+  let biSA : ↥S →ₗ[A]
+      ((↥S →ₗ[A] E) →ₗ[Subalgebra.centralizer k (A : Set (Module.End k E))] E) :=
+    { toFun := ev
+      map_add' := fun v w => by ext l; exact l.map_add v w
+      map_smul' := fun a v => by
+        ext l
+        show l (a • v) = (σ a).val (l v)
+        rw [l.map_smul a v]; rfl }
+  -- `biSk` is injective (evaluating at `S.subtype` recovers `↑v`).
+  have hinj : Function.Injective biSk := by
+    rw [injective_iff_map_eq_zero]
+    intro v hv
+    have h1 : (v : E) = 0 := by
+      have := LinearMap.congr_fun hv S.subtype
+      simpa [biSk, ev] using this
+    exact Subtype.ext (by simpa using h1)
+  -- `biSA` is nonzero, hence surjective by Schur (target simple over `A`).
+  have hbiSA_ne : biSA ≠ 0 := by
+    obtain ⟨v, hv⟩ := exists_ne (0 : ↥S)
+    intro h
+    apply hv
+    have hv0 : biSk v = 0 := by
+      have : biSA v = 0 := by rw [h]; rfl
+      exact this
+    exact (injective_iff_map_eq_zero biSk).mp hinj v hv0
+  have hsurjA : Function.Surjective biSA :=
+    LinearMap.surjective_of_ne_zero hbiSA_ne
+  have hsurj : Function.Surjective biSk := hsurjA
+  -- Equal `k`-dimension via the resulting `k`-linear equivalence.
+  exact LinearEquiv.finrank_eq (LinearEquiv.ofBijective biSk ⟨hinj, hsurj⟩)
 
 -- Heartbeats bumped: stating and proving over the double hom-space
 -- `(↥S →ₗ[A] E) →ₗ[C] E` runs the deep `centralizerModuleHom`

--- a/progress/2026-06-21T18-54-48Z_58424dc5.md
+++ b/progress/2026-06-21T18-54-48Z_58424dc5.md
@@ -1,0 +1,71 @@
+## Accomplished
+
+Closed issue #4926 (Ch5 #4849 biduality core): proved
+`multiplicitySpace_double_hom_finrank` **sorry-free**, the lone residual `k`-dimension
+count that `MultiplicitySpaceBiduality.lean` had been reduced to. The file
+(`EtingofRepresentationTheory/Chapter5/MultiplicitySpaceBiduality.lean`) is now
+fully sorry-free, and `#print axioms` confirms `multiplicitySpace_double_hom_finrank`,
+`multiplicitySpace_biduality_Aiso`, and `multiplicitySpace_Cdistinct` depend only on
+`[propext, Classical.choice, Quot.sound]` (no `sorryAx`).
+
+### Proof strategy (dimension-counting-free, via Schur)
+
+Rather than match the `A`-side and `C`-side bimodule decompositions block-by-block
+(the genuinely deep route the issue anticipated), the proof shows
+`(M_S →ₗ[C] E)` is a **simple `A`-module** and exhibits an injective `A`-linear
+curried-evaluation `S → (M_S →ₗ[C] E)`; Schur then upgrades it to an iso, giving
+equal `k`-dimension. Concretely, with `C = centralizer A`:
+
+1. `M_S := ↥S →ₗ[A] E` is a simple `C`-module (`isSimpleModule_homA_centralizer`).
+2. Evaluation at a nonzero `s0 ∈ S`, `evs0 : M_S →ₗ[C] E, l ↦ l s0`, is nonzero
+   (`evs0 S.subtype = ↑s0`) hence injective; its range `W ≤ E` is a simple
+   `C`-submodule with `M_S ≃ₗ[C] ↥W`.
+3. `↥W →ₗ[C] E` is simple over `centralizer C` (`isSimpleModule_homA_centralizer`
+   applied to `C`); transport along precomposition with the `C`-iso gives
+   `(M_S →ₗ[C] E)` simple over `centralizer C`.
+4. Double centralizer (`Theorem5_18_1_double_centralizer`, `centralizer C = A`):
+   the inclusion `↥A → ↥(centralizer C)` is a surjective ring hom, so restricting
+   scalars keeps the double-hom space simple over `A`.
+5. The curried-eval `S → (M_S →ₗ[C] E)` is injective `A`-linear; `surjective_of_ne_zero`
+   (Schur, target simple over `A`) makes it bijective. The same underlying function,
+   packaged `k`-linearly, gives the `k`-equiv and the finrank equality.
+
+### Reusable lemma added
+
+`isSimpleModule_of_surjective_ringHom`: restricting a simple `S`-module along a
+**surjective** ring hom `σ : R →+* S` (with `r • x = σ r • x`) keeps it simple. Built
+on Mathlib's `LinearMap.isSimpleModule_iff_of_bijective`. This is the transport tool
+for the double-centralizer ring identification.
+
+### Key gotcha recorded
+
+`lake env lean <file>` does NOT reproduce the build environment (the unmodified
+on-`main` file fails it). Always use
+`lake build EtingofRepresentationTheory.Chapter5.<Module>` to typecheck; it applies
+the lakefile's lean options.
+
+Also: never bind `C := centralizer ...` with `set`/`let` when it sits in the *algebra*
+position of a hom-space — instance search will not unfold the local definition to match
+`centralizerModuleHom`'s head, so the `Module ↥C (V →ₗ[A] E)` instance fails. Spell the
+centralizer out (the file's own convention).
+
+## Current frontier
+
+`MultiplicitySpaceBiduality.lean` is complete and sorry-free. Part 2 of the
+Schur-Weyl GL-side distinctness output (`multiplicitySpace_Cdistinct`, parent #4849)
+is now fully available to downstream consumers (currently none import it yet).
+
+## Overall project progress
+
+Stage 3 formalization, Chapter 5. The biduality / double-centralizer Part-2 chain is
+done. `multiplicitySpace_Cdistinct` is ready to feed the GL-equivariant Schur-Weyl
+decomposition distinctness (parent #4849, e.g. via #4860).
+
+## Next step
+
+Wire `multiplicitySpace_Cdistinct` into the parent #4849 chain (#4860:
+emit `Pairwise (¬ L i ≅ L j)` from `glTensorRep_equivariant_schurWeyl_decomposition`).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4926

Session: `58424dc5-3347-4ce5-9cb4-e8dbfdf13a16`

e36c80ec feat(Ch5 #4926): prove multiplicitySpace_double_hom_finrank sorry-free

🤖 Prepared with Claude Code