### PR TITLE
feat(Ch5 #4860): emit GL-side distinctness and discharge hLdist

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -207,6 +207,11 @@ When working over a *family* `(M : ι → Type*) [∀ i, Module A (M i)] [∀ i,
 
 General rule: if an implicit type/ring/field appears only *inside* a definition's body (not in any argument or result type visible at the call site), pin it explicitly. Test a suspect term in isolation in `/tmp/foo.lean` — it compiles there when the surrounding context determines the implicit, which localizes the bug fast.
 
+**A heavy instance (e.g. `centralizerModuleHom : Module ↥(centralizer …) (V →ₗ[A] E)`) that resolves for an *abstract* carrier `V` can fail fresh typeclass search for a *concrete* one (`V = Fin N → k`), at the same `synthInstance.maxHeartbeats` — it is structural, not a heartbeat shortfall (diagnosed across ~7 build cycles in #4860, `SchurWeylLDistinct.lean`).** Symptom: `failed to synthesize HSMul … ?m` (an `outParam` output stuck as a metavar) on a `•`/instance you wrote *freshly* in the concrete proof, while the *same* `•` typechecks when it comes from *specializing* a polymorphic lemma's signature. Two non-fixes and the fix:
+- `haveI hI : Module … := …` registers the instance but makes it **opaque** — the `•` no longer reduces (`show (c • f) v = c.val (f v)` fails defeq), and it **shadows** the canonical instance so APIs expecting the canonical one mismatch.
+- `letI hI := …` keeps it transparent (reduces) but **still shadows** — passing your term to a lemma whose signature used the canonical instance gives an "application type mismatch" unless your `letI` body is syntactically the canonical instance.
+- **Fix:** never write the offending notation freshly in the concrete proof. (a) Obtain the goal *by specialization* — `refine polymorphicLemma … ?_` so the `•` in the `?_` goal is substituted from the lemma's signature, not searched. (b) Add an **abstract** `:= rfl` rewrite lemma over a general `V` (where the instance resolves), e.g. `theorem c_smul_eq (f) : c • f = (centralizerToEndA … c).comp f := rfl`, and `simp only [c_smul_eq]` in the concrete proof to eliminate the `•` entirely. The concrete proof then stays instance-notation-free.
+
 ### Tactic Selection Guide
 
 | Goal Shape | Try First | Then Try |

--- a/EtingofRepresentationTheory/Chapter5/PolynomialGLDecomposition.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialGLDecomposition.lean
@@ -3,6 +3,7 @@ import EtingofRepresentationTheory.Chapter5.SchurWeylGLTransfer
 import EtingofRepresentationTheory.Chapter5.PolynomialRepEmbedding
 import EtingofRepresentationTheory.Chapter5.SemisimpleIsotypic
 import EtingofRepresentationTheory.Chapter5.SchurWeylSimplesClassification
+import EtingofRepresentationTheory.Chapter5.SchurWeylLDistinct
 
 /-!
 # Schur-Weyl #5, Step E: a polynomial `GL_N`-rep is a direct sum of abstract simples
@@ -312,7 +313,8 @@ theorem glTensorRep_schurWeyl_decomposition_equivariant_simple
       (_ : ∀ i, Module k (S i))
       (_ : ∀ i, Module.Finite k (S i))
       (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
-      (_ : ∀ i, IsSimpleModule (GLAlg k N) (Representation.asModule (L i).ρ)),
+      (_ : ∀ i, IsSimpleModule (GLAlg k N) (Representation.asModule (L i).ρ))
+      (_ : Pairwise (fun i j => ¬ Nonempty ((L i) ≅ (L j)))),
       ∃ (e : TensorPower k (Fin N → k) n ≃ₗ[k]
           (DirectSum ι (fun i => S i ⊗[k] (L i : Type u)))),
         ∀ (g : Matrix.GeneralLinearGroup (Fin N) k)
@@ -331,7 +333,9 @@ theorem glTensorRep_schurWeyl_decomposition_equivariant_simple
     Theorem5_18_4_GL_rep_decomposition_explicit_simple k N n
   refine ⟨ι, hιFin, hιDec, fun i => ↥(S' i),
     fun _ => inferInstance, fun _ => inferInstance,
-    fun i => hSi_fin i, L, hL_simple, ?_, ?_⟩
+    fun i => hSi_fin i, L, hL_simple,
+    schurWeyl_L_pairwise_distinct_of_explicit N n S' hS'_simp hS'_dist L L_carrier h_act,
+    ?_, ?_⟩
   · exact e
   intro g v
   -- Reduce equivariance to: (glTensorRep g) ∘ e.symm = e.symm ∘ directSum_action g.
@@ -416,14 +420,14 @@ theorem polynomial_homog_rep_asModule_embeds_directSum_simple
     Etingof.PolynomialRepEmbedding.polynomial_homog_rep_equivariant_embedding
       (M := M) (halg := halg) (h_span := h_span) (h_homog := h_homog)
   -- (2) unified equivariant + simple Schur–Weyl decomposition of `V^{⊗n}`.
-  obtain ⟨ι, hιFin, hιDec, S, hSacg, hSmod, hSfin, L, hLsimp, e, he⟩ :=
+  obtain ⟨ι, hιFin, hιDec, S, hSacg, hSmod, hSfin, L, hLsimp, hLdist, e, he⟩ :=
     glTensorRep_schurWeyl_decomposition_equivariant_simple (k := k) (N := N) n
-  -- schurPoly-classification of the abstract simples (#4758), read off the bare
-  -- decomposition data `(e, he, hLsimp)` via the classification crux (#4732) and
-  -- the deferred distinctness (#4731 / #4849-chain).
+  -- schurPoly-classification of the abstract simples (#4758), read off the
+  -- decomposition data `(e, he, hLsimp, hLdist)` via the classification crux
+  -- (#4732) and the now-discharged GL-side distinctness (#4860).
   have hclass : ∃ lam : ι → {l : Fin N → ℕ // Antitone l}, Function.Injective lam ∧
       ∀ i, formalCharacter k N (L i) = schurPoly N (lam i).val :=
-    Etingof.glTensorRep_schurWeyl_simples_schurPoly_classified k N n L e he hLsimp
+    Etingof.glTensorRep_schurWeyl_simples_schurPoly_classified k N n L e he hLsimp hLdist
   haveI iSfree : ∀ i, Module.Free k (S i) := fun i => Module.Free.of_divisionRing k (S i)
   -- basis index of each multiplicity space, in `Type 0` so `κ` stays small.
   set β : ι → Type := fun i => Fin (Module.finrank k (S i)) with hβ

--- a/EtingofRepresentationTheory/Chapter5/SchurWeylLDistinct.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurWeylLDistinct.lean
@@ -1,5 +1,6 @@
 import Mathlib
 import EtingofRepresentationTheory.Chapter5.SchurWeylGLTransfer
+import EtingofRepresentationTheory.Chapter5.MultiplicitySpaceBiduality
 
 /-!
 # Schur-Weyl L_i distinctness (Part 1): GL-equivariant ⟹ centralizer-linear
@@ -69,7 +70,6 @@ drives an `Algebra.adjoin_induction`: the intertwining property is closed under
 generators by hypothesis. -/
 theorem homA_centralizer_smul_comm_of_unitTensorPow_intertwine
     [Module.Finite k V] [Infinite k] [CharZero k] {n : ℕ}
-    (_hN : n ≤ Module.finrank k V)
     {S W : Submodule (symGroupImage k V n) (TensorPower k V n)}
     (ψ : (↥S →ₗ[symGroupImage k V n] TensorPower k V n) ≃ₗ[k]
         (↥W →ₗ[symGroupImage k V n] TensorPower k V n))
@@ -161,7 +161,6 @@ that intertwines post-composition by every `g^{⊗n}` to a `C`-linear equiv over
 the centralizer `C = centralizer(symGroupImage k V n)`. -/
 noncomputable def homACentralizerLinearEquivOfUnitTensorPowIntertwine
     [Module.Finite k V] [Infinite k] [CharZero k] {n : ℕ}
-    (_hN : n ≤ Module.finrank k V)
     {S W : Submodule (symGroupImage k V n) (TensorPower k V n)}
     (ψ : (↥S →ₗ[symGroupImage k V n] TensorPower k V n) ≃ₗ[k]
         (↥W →ₗ[symGroupImage k V n] TensorPower k V n))
@@ -175,10 +174,146 @@ noncomputable def homACentralizerLinearEquivOfUnitTensorPowIntertwine
   invFun := ψ.symm
   map_add' := ψ.map_add
   map_smul' c l :=
-    homA_centralizer_smul_comm_of_unitTensorPow_intertwine _hN ψ h_int c l
+    homA_centralizer_smul_comm_of_unitTensorPow_intertwine ψ h_int c l
   left_inv := ψ.left_inv
   right_inv := ψ.right_inv
 
+set_option maxHeartbeats 6400000 in
+set_option synthInstance.maxHeartbeats 3200000 in
+/-- The centralizer post-composition action `unitTensorPowCentralizer g n • f`
+is, by definition of `centralizerModuleHom`, composition with
+`centralizerToEndA … (g^{⊗n})`. Stated abstractly (over a general carrier `V`) so
+that the centralizer `•` is resolved here once; downstream uses with the concrete
+carrier `V = Fin N → k` rewrite with this lemma instead of re-synthesizing the
+centralizer action, whose typeclass search does not go through for `Fin N → k`. -/
+theorem unitTensorPowCentralizer_smul_eq [Module.Finite k V] {n : ℕ}
+    {S : Submodule (symGroupImage k V n) (TensorPower k V n)}
+    (g : (Module.End k V)ˣ)
+    (f : ↥S →ₗ[symGroupImage k V n] TensorPower k V n) :
+    unitTensorPowCentralizer g n • f
+      = (centralizerToEndA k (TensorPower k V n) (symGroupImage k V n)
+          (unitTensorPowCentralizer g n)).comp f := rfl
+
 end
+
+/-! ### Part 2 wiring: GL-side pairwise distinctness of the Schur-Weyl simples
+
+Assembling Part 1 (the GL-equivariant ⟹ centralizer-linear upgrade above) with
+the B-side distinctness `multiplicitySpace_Cdistinct`
+(`MultiplicitySpaceBiduality.lean`) yields the GL-side output targeted by issue
+#4849/#4860: the abstract simple summands `L i` of `V^{⊗n}` produced by the
+explicit Schur-Weyl decomposition are pairwise non-isomorphic. -/
+
+section GLDistinct
+
+variable [IsAlgClosed k] [CharZero k]
+
+open scoped TensorProduct
+
+/-- Every unit of `End k (Fin N → k)` is `Matrix.mulVecLin` of a `GL_N(k)`
+matrix (the units of `End k (Fin N → k)` are exactly the general linear group,
+via `Matrix.GeneralLinearGroup.toLin`). -/
+theorem exists_gl_mulVecLin_eq {N : ℕ} (g : (Module.End k (Fin N → k))ˣ) :
+    ∃ h : Matrix.GeneralLinearGroup (Fin N) k,
+      Matrix.mulVecLin (R := k) (h : Matrix (Fin N) (Fin N) k)
+        = (g : Module.End k (Fin N → k)) := by
+  refine ⟨Matrix.GeneralLinearGroup.toLin.symm g, ?_⟩
+  rw [← Matrix.GeneralLinearGroup.coe_toLin, MulEquiv.apply_symm_apply]
+
+set_option maxHeartbeats 6400000 in
+set_option synthInstance.maxHeartbeats 3200000 in
+/-- **GL-side distinctness (Part 2 wiring).** Given the explicit Schur-Weyl
+decomposition data of `V^{⊗n}` (`V = Fin N → k`) from
+`Theorem5_18_4_GL_rep_decomposition_explicit_simple` — the Specht submodules
+`S' i` (simple and pairwise non-isomorphic over `A = symGroupImage k V n`), the
+abstract simple polynomial `GL_N`-reps `L i`, the carrier identifications
+`L_carrier i : L i ≃ₗ[k] (↥(S' i) →ₗ[A] V^{⊗n})`, and the action formula
+`h_act` — the `L i` are pairwise non-isomorphic as `GL_N`-representations.
+
+The proof transports an FDRep iso `L i ≅ L j` through `L_carrier i`, `L_carrier
+j` to a `k`-linear equiv `ψ` of multiplicity spaces, shows `ψ` intertwines
+post-composition by every `g^{⊗n}` (from `h_act` and the FDRep-iso equivariance,
+using that every unit of `End k V` comes from `GL_N`), upgrades it to a
+`C`-linear equiv via `homACentralizerLinearEquivOfUnitTensorPowIntertwine`
+(Part 1), and concludes `i = j` from `multiplicitySpace_Cdistinct` (Part 2). -/
+theorem schurWeyl_L_pairwise_distinct_of_explicit
+    (N n : ℕ)
+    {ι : Type}
+    (S' : ι → Submodule (symGroupImage k (Fin N → k) n)
+      (TensorPower k (Fin N → k) n))
+    (hS'_simp : ∀ i, IsSimpleModule (symGroupImage k (Fin N → k) n) (S' i))
+    (hS'_dist : ∀ i j,
+      Nonempty (↥(S' i) ≃ₗ[symGroupImage k (Fin N → k) n] ↥(S' j)) → i = j)
+    (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
+    (L_carrier : ∀ i, (L i : Type u) ≃ₗ[k]
+      (↥(S' i) →ₗ[symGroupImage k (Fin N → k) n] TensorPower k (Fin N → k) n))
+    (h_act : ∀ (i : ι) (g : Matrix.GeneralLinearGroup (Fin N) k)
+        (l : (L i : Type u)) (v : ↥(S' i)),
+        (L_carrier i ((L i).ρ g l)) v =
+          PiTensorProduct.map (fun _ : Fin n => Matrix.mulVecLin (R := k) g.val)
+            ((L_carrier i l) v)) :
+    Pairwise (fun i j => ¬ Nonempty ((L i) ≅ (L j))) := by
+  classical
+  haveI : FaithfulSMul (symGroupImage k (Fin N → k) n)
+      (TensorPower k (Fin N → k) n) := symGroupImage_faithfulSMul k (Fin N → k) n
+  haveI hsimp : ∀ i, IsSimpleModule (symGroupImage k (Fin N → k) n) (S' i) := hS'_simp
+  intro i j hij
+  rintro ⟨f⟩
+  apply hij
+  -- Underlying `k`-linear equiv of the FDRep iso, with its `g`-equivariance.
+  set φ : (L i : Type u) ≃ₗ[k] (L j : Type u) := FDRep.isoToLinearEquiv f with hφdef
+  have hφ : ∀ (h : Matrix.GeneralLinearGroup (Fin N) k) (x : (L i : Type u)),
+      φ ((L i).ρ h x) = (L j).ρ h (φ x) := by
+    intro h x
+    have hc := FDRep.Iso.conj_ρ f h
+    have hconj : (FDRep.isoToLinearEquiv f).conj ((L i).ρ h) (φ x) = φ ((L i).ρ h x) := by
+      simp only [LinearEquiv.conj_apply, LinearMap.comp_apply, LinearEquiv.coe_coe]
+      change φ (((L i).ρ h) (φ.symm (φ x))) = φ (((L i).ρ h) x)
+      rw [φ.symm_apply_apply]
+    rw [← hconj, hc]
+  -- The transported `k`-linear equiv of multiplicity spaces.
+  set ψ : (↥(S' i) →ₗ[symGroupImage k (Fin N → k) n] TensorPower k (Fin N → k) n)
+      ≃ₗ[k] (↥(S' j) →ₗ[symGroupImage k (Fin N → k) n] TensorPower k (Fin N → k) n) :=
+    (L_carrier i).symm.trans (φ.trans (L_carrier j)) with hψdef
+  -- Upgrade `ψ` to a `C`-linear equiv (Part 1) and conclude `i = j` (Part 2). The
+  -- intertwining goal is produced by *specializing* Part 1's `•` signature
+  -- (`refine … ?_`), so the centralizer `•` is never synthesized freshly here;
+  -- the proof of that goal stays entirely `•`-free via `unitTensorPowCentralizer_smul_eq`.
+  refine multiplicitySpace_Cdistinct k (TensorPower k (Fin N → k) n)
+    (symGroupImage k (Fin N → k) n) S' hS'_dist i j
+    ⟨homACentralizerLinearEquivOfUnitTensorPowIntertwine ψ ?_⟩
+  intro g l
+  obtain ⟨h, hgh⟩ := exists_gl_mulVecLin_eq g
+  -- The `•`-free key relation: post-composition by `D = centralizerToEndA … g^{⊗n}`
+  -- corresponds under `L_carrier m` to the `GL_N` action `(L m).ρ h`.
+  have hrel : ∀ (m : ι) (y : (L m : Type u)),
+      (centralizerToEndA k (TensorPower k (Fin N → k) n) (symGroupImage k (Fin N → k) n)
+          (unitTensorPowCentralizer g n)).comp (L_carrier m y)
+        = L_carrier m ((L m).ρ h y) := by
+    intro m y
+    refine LinearMap.ext fun v => ?_
+    rw [h_act m h y v]
+    -- `(D.comp (L_carrier m y)) v = D ((L_carrier m y) v) = g^{⊗n} ((L_carrier m y) v)`
+    -- (defeq through `centralizerToEndA`/`unitTensorPowCentralizer`), then match the
+    -- diagonal-action map functions via `hgh : mulVecLin h.val = g`.
+    show PiTensorProduct.map (R := k) (fun _ : Fin n => (g : Module.End k (Fin N → k)))
+          ((L_carrier m y) v)
+        = PiTensorProduct.map (R := k)
+            (fun _ : Fin n => Matrix.mulVecLin (R := k) (h : Matrix (Fin N) (Fin N) k))
+            ((L_carrier m y) v)
+    rw [show (fun _ : Fin n => Matrix.mulVecLin (R := k) (h : Matrix (Fin N) (Fin N) k))
+        = (fun _ : Fin n => (g : Module.End k (Fin N → k))) from funext fun _ => hgh]
+  -- Reduce the centralizer `•` goal to its `•`-free form and chain the relations.
+  simp only [unitTensorPowCentralizer_smul_eq, hψdef, LinearEquiv.trans_apply]
+  have e1 : (L_carrier i).symm
+        ((centralizerToEndA k (TensorPower k (Fin N → k) n) (symGroupImage k (Fin N → k) n)
+            (unitTensorPowCentralizer g n)).comp l)
+      = (L i).ρ h ((L_carrier i).symm l) := by
+    apply (L_carrier i).injective
+    rw [LinearEquiv.apply_symm_apply, ← hrel i ((L_carrier i).symm l),
+      LinearEquiv.apply_symm_apply]
+  rw [e1, hφ h ((L_carrier i).symm l), ← hrel j (φ ((L_carrier i).symm l))]
+
+end GLDistinct
 
 end Etingof

--- a/EtingofRepresentationTheory/Chapter5/SchurWeylLDistinct.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurWeylLDistinct.lean
@@ -210,6 +210,7 @@ variable [IsAlgClosed k] [CharZero k]
 
 open scoped TensorProduct
 
+omit [IsAlgClosed k] [CharZero k] in
 /-- Every unit of `End k (Fin N → k)` is `Matrix.mulVecLin` of a `GL_N(k)`
 matrix (the units of `End k (Fin N → k)` are exactly the general linear group,
 via `Matrix.GeneralLinearGroup.toLin`). -/

--- a/EtingofRepresentationTheory/Chapter5/SchurWeylSimplesClassification.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurWeylSimplesClassification.lean
@@ -131,54 +131,19 @@ theorem schurWeyl_simples_formalCharacter_classification_core
   -- character-determined ⇒ `char = schurPoly`" is the deferred Tier-4 content.
   sorry
 
-/-- **Pairwise distinctness of the Schur-Weyl simples (deferred, isolated
-`sorry`).** The abstract simple summands `L i` of `V^{⊗n}` produced by the
-equivariant decomposition `glTensorRep_equivariant_schurWeyl_decomposition` are
-pairwise non-isomorphic.
-
-This is the GL-side distinctness output targeted by issue #4731. Part 1
-(`SchurWeylLDistinct.lean`, the GL-equivariant ⟹ centralizer-linear reduction)
-has landed; the remaining B-side step `M_i ≅_C M_j ⟹ i = j` (the symmetric
-double-centralizer argument) is in flight as #4849/#4859/#4862. Until that chain
-lands, the `Pairwise` conclusion is isolated here as a single `sorry`, mirroring
-`schurWeyl_simples_formalCharacter_classification_core`, so the downstream
-schurPoly-classification API (`decompose_polynomial_gl_rep`, issue #4758) stays
-otherwise sorry-free. -/
-theorem glTensorRep_schurWeyl_simples_pairwise_distinct
-    (N n : ℕ)
-    {ι : Type} [Fintype ι] [DecidableEq ι]
-    {S : ι → Type u} [∀ i, AddCommGroup (S i)] [∀ i, Module k (S i)]
-    [∀ i, Module.Finite k (S i)]
-    (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
-    (e : TensorPower k (Fin N → k) n ≃ₗ[k]
-        (DirectSum ι (fun i => S i ⊗[k] (L i : Type u))))
-    (he : ∀ (g : Matrix.GeneralLinearGroup (Fin N) k)
-          (v : TensorPower k (Fin N → k) n),
-          e (glTensorRep k N n g v) =
-            Representation.directSum (fun i =>
-              (Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
-                (S i)).tprod (L i).ρ) g (e v))
-    (hLsimp : ∀ i, IsSimpleModule
-        (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
-        (Representation.asModule (L i).ρ)) :
-    Pairwise (fun i j => ¬ Nonempty ((L i) ≅ (L j))) := by
-  -- Deferred: the B-side distinctness `M_i ≅_C M_j ⟹ i = j` (#4849/#4859/#4862)
-  -- transported to the GL-side `L i ≇ L j` via the Part-1 centralizer-linear
-  -- reduction (`SchurWeylLDistinct.lean`, #4731). Isolated here as one `sorry`.
-  sorry
-
-/-- **schurPoly-classification of the Schur-Weyl simples (from the bare
-equivariance data).** Combines the deferred distinctness
-(`glTensorRep_schurWeyl_simples_pairwise_distinct`) with the classification crux
-(`schurWeyl_simples_formalCharacter_classification_core`) to produce, from only
-the decomposition data `(e, he)` and per-summand simplicity `hLsimp`, an
-injective antitone-partition assignment `lam` with
+/-- **schurPoly-classification of the Schur-Weyl simples.** Combines the GL-side
+distinctness `hLdist` (now discharged by `schurWeyl_L_pairwise_distinct_of_explicit`
+in `SchurWeylLDistinct.lean`, issue #4860) with the classification crux
+(`schurWeyl_simples_formalCharacter_classification_core`) to produce, from the
+decomposition data `(e, he)`, per-summand simplicity `hLsimp`, and distinctness
+`hLdist`, an injective antitone-partition assignment `lam` with
 `char(L i) = schurPoly N (lam i)`.
 
 This is the form consumed by `decompose_polynomial_gl_rep` (issue #4758): it lets
 the Schur-Weyl #6 assembly read the partition classification of the abstract
-simples without re-deriving the tensor-power decomposition data `(e, he, hLsimp,
-hLdist)` itself. -/
+simples without re-deriving the tensor-power decomposition data. The distinctness
+`hLdist` is supplied by `glTensorRep_schurWeyl_decomposition_equivariant_simple`,
+which now emits it alongside `(e, he, hLsimp)`. -/
 theorem glTensorRep_schurWeyl_simples_schurPoly_classified
     (N n : ℕ)
     {ι : Type} [Fintype ι] [DecidableEq ι]
@@ -195,12 +160,12 @@ theorem glTensorRep_schurWeyl_simples_schurPoly_classified
                 (S i)).tprod (L i).ρ) g (e v))
     (hLsimp : ∀ i, IsSimpleModule
         (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
-        (Representation.asModule (L i).ρ)) :
+        (Representation.asModule (L i).ρ))
+    (hLdist : Pairwise (fun i j => ¬ Nonempty ((L i) ≅ (L j)))) :
     ∃ lam : ι → {l : Fin N → ℕ // Antitone l},
       Function.Injective lam ∧
       ∀ i, formalCharacter k N (L i) = schurPoly N (lam i).val :=
-  schurWeyl_simples_formalCharacter_classification_core k N n L e he hLsimp
-    (glTensorRep_schurWeyl_simples_pairwise_distinct k N n L e he hLsimp)
+  schurWeyl_simples_formalCharacter_classification_core k N n L e he hLsimp hLdist
 
 /-- **Headline (sorry-free given the crux).** The formal characters of the
 abstract simple summands `L i` of `V^{⊗n}` (from

--- a/progress/2026-06-21T19-58-57Z_7b23906f.md
+++ b/progress/2026-06-21T19-58-57Z_7b23906f.md
@@ -1,0 +1,72 @@
+## Accomplished
+
+Completed #4860 (Ch5 #4849 sub-wire): emit GL-side pairwise distinctness
+`Pairwise (¬ Nonempty (L i ≅ L j))` and discharge the `hLdist` hypothesis,
+removing the dedicated distinctness `sorry`.
+
+In `Chapter5/SchurWeylLDistinct.lean`:
+- **`exists_gl_mulVecLin_eq`** — every unit of `End k (Fin N → k)` is
+  `Matrix.mulVecLin` of a `GL_N(k)` matrix (via `Matrix.GeneralLinearGroup.toLin`).
+- **`unitTensorPowCentralizer_smul_eq`** — abstract `:= rfl` lemma unfolding the
+  centralizer `•` to composition with `centralizerToEndA … (g^{⊗n})`. Stated over
+  a general carrier `V` so the centralizer `•` resolves once here.
+- **`schurWeyl_L_pairwise_distinct_of_explicit`** — the Part-2 wiring: given the
+  explicit `Theorem5_18_4_GL_rep_decomposition_explicit_simple` data (Specht
+  submodules `S'`, carrier equivs `L_carrier`, action formula `h_act`), transports
+  an FDRep iso `L i ≅ L j` through `L_carrier` to a `k`-linear equiv of
+  multiplicity spaces, upgrades it to a `C`-linear equiv via Part 1
+  (`homACentralizerLinearEquivOfUnitTensorPowIntertwine`), and concludes `i = j`
+  via `multiplicitySpace_Cdistinct` (Part 2). Sorry-free.
+- Dropped the vestigial unused `n ≤ finrank` hypothesis from the two Part-1 lemmas.
+
+In `Chapter5/PolynomialGLDecomposition.lean`:
+- `glTensorRep_schurWeyl_decomposition_equivariant_simple` now also outputs
+  `Pairwise (¬ Nonempty (L i ≅ L j))`, proven via the new theorem on the explicit
+  data it already destructures.
+- Updated `polynomial_homog_rep_asModule_embeds_directSum_simple` to thread the
+  new `hLdist` into the classification.
+
+In `Chapter5/SchurWeylSimplesClassification.lean`:
+- `glTensorRep_schurWeyl_simples_schurPoly_classified` now takes `hLdist` as a
+  hypothesis (instead of deriving it from the sorried abstract theorem) and feeds
+  it to the crux.
+- **Removed `glTensorRep_schurWeyl_simples_pairwise_distinct`** (the abstract
+  `sorry`) — it could not be proven from its abstract `(L, e, he)` data; the
+  distinctness now flows from the explicit carrier/action data.
+
+Key Lean pattern (recorded in `lean-formalization` skill): the centralizer `•`
+typeclass does not resolve via *fresh* search for the concrete carrier
+`Fin N → k` (only via specialization), so the concrete proof is kept entirely
+`•`-free — every `•` is obtained by `refine`-specializing Part 1's signature or
+rewritten away with the abstract `unitTensorPowCentralizer_smul_eq`.
+
+Full `lake build` green (8350 jobs, 0 errors).
+
+## Current frontier
+
+`hLdist` is discharged end-to-end. The Schur-Weyl GL-side distinctness chain
+(#4849) now has only two upstream `sorry`s left, both pre-existing and tracked
+separately:
+- `multiplicitySpace_double_hom_finrank` (`MultiplicitySpaceBiduality.lean:112`,
+  #4926/#4934 residual) — the `k`-dimension count feeding `multiplicitySpace_Cdistinct`.
+- `schurWeyl_simples_formalCharacter_classification_core`
+  (`SchurWeylSimplesClassification.lean`, #4721) — the highest-weight classification crux.
+
+## Overall project progress
+
+Chapter 5 Schur-Weyl. Part 1 (centralizer-linear upgrade) and Part 2
+(`multiplicitySpace_Cdistinct`) landed earlier; this turn assembles them into the
+GL-side distinctness output and wires it through the classification API, removing
+one `sorry`.
+
+## Next step
+
+Prove `multiplicitySpace_double_hom_finrank` (unclaimed #4934 / #4926 residual) —
+the standalone `k`-dimension equality `finrank k ↥S = finrank k ((↥S →ₗ[A] E) →ₗ[C] E)`,
+the last research kernel under `multiplicitySpace_Cdistinct`. Separately, #4721
+(highest-weight classification crux) remains the other GL-side `sorry`.
+
+## Blockers
+
+None. The remaining `sorry`s are pre-existing and tracked by their own issues
+(#4934/#4926, #4721); a sorry'd dependency is not a blocker for this wiring item.


### PR DESCRIPTION
Closes #4860

Session: `7b23906f-0732-4ec1-94aa-0302e9661dfe`

80b44991 doc(skill+progress): record concrete-vs-abstract instance pattern; #4860 handoff
15443a2c feat(Ch5 #4860 wiring): discharge hLdist; remove sorried abstract distinctness
4ed32359 feat(Ch5 #4860 part 2): schurWeyl_L_pairwise_distinct_of_explicit (GL-side distinctness from explicit data)

🤖 Prepared with Claude Code