### PR TITLE
fix(Ch5 #4944): correct false multiplicity-one Cauchy character identity to true multiplicity-bearing form

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/CauchyCharacterRight.lean
+++ b/EtingofRepresentationTheory/Chapter5/CauchyCharacterRight.lean
@@ -23,23 +23,42 @@ it as a genuine `FDRep` (`polyRightDegreeFDRep`). This is the finite-dimensional
 object on which `formalCharacter` (`Theorem5_22_1.lean`) is defined, so the
 Cauchy decomposition can be stated as a formal-character identity.
 
-## The multiplicity-one statement (the research core)
+## The Cauchy character statement (the research core)
 
-As a right-`GL_N`-representation, the degree-`d` part of `A` decomposes with
-**multiplicity one** over the dominant weights `ν ∈ ℕ^N` of total size `d`:
+As a right-`GL_N`-representation, the degree-`d` part of `A` is the
+`GL_N × GL_N`-equivariant Cauchy decomposition of `Sym^d(V ⊗ W)` (with
+`V = W = k^N` the left/right copies) read off on the right factor:
 
-  `A_d ≅ ⊕_{ν ∈ ℕ^N dom, |ν| = d} V_ν`   (each `ν` exactly once),
+  `A_d ≅ ⊕_{ν ∈ ℕ^N dom, |ν| = d} S_ν(V) ⊗ S_ν(W)`   (each `ν` exactly once
+  as a *bi*-representation),
 
-equivalently, on formal characters,
+so, forgetting the left `GL_N`-action, each right-irreducible `V_ν = S_ν(W)`
+occurs with multiplicity `dim S_ν(V) = s_ν(1, …, 1)` (the number of SSYT of
+shape `ν` with entries in `[N]`). On formal characters this is the Cauchy
+identity specialised at `x = (1, …, 1)`:
 
-  `formalCharacter k N (A_d) = ∑_{ν ∈ ℕ^N dom, |ν| = d} S_ν`.
+  `formalCharacter k N (A_d) = ∑_{ν ∈ ℕ^N dom, |ν| = d} s_ν(1,…,1) · S_ν`,
+
+equivalently `∏_j (1 - t_j)^{-N}` restricted to total degree `d`.
+
+**The multiplicity is `s_ν(1,…,1)`, NOT one.** A *multiplicity-one* form
+`formalCharacter k N (A_d) = ∑_ν S_ν` is false already on dimensions: for
+`N = 2, d = 1`, `dim A_1 = 4` (the four `X_{ij}`) but `∑_{ν} dim V_ν =
+dim V_{(1,0)} = 2`. The two sides disagree, because `A_d` carries the full
+`dim V_ν`-fold right-multiplicity of the bi-rep, not the multiplicity-free
+right factor. (See #4944 for the history; this corrected a previously false
+`= ∑_ν S_ν` statement.)
 
 The dominant weights `ν ∈ ℕ^N` with `|ν| = d` are exactly the `BoundedPartition N d`
 (`Proposition5_21_1.lean`: an antitone `ν : Fin N → ℕ` with `∑ i, ν i = d`), a
 finite indexing set. The identity is `polyRightDegreeFDRep_formalCharacter`,
 stated here with its proof deferred to the genuine Cauchy/Schur-Weyl core
-(multiplicity-one + the highest-weight ⟺ `ν ∈ ℕ^N` theory; overlaps
-`iso_of_formalCharacter_eq_schurPoly`, #4699/#4882).
+(the Cauchy identity + the highest-weight ⟺ `ν ∈ ℕ^N` theory; overlaps
+`iso_of_formalCharacter_eq_schurPoly`, #4699/#4882). An elementary intermediate
+form available without Schur-Weyl: the `μ`-weight space of `A_d` has dimension
+`∏_j C(μ_j + N - 1, N - 1)` (monomials with column-degree vector `μ`), so
+`formalCharacter k N (A_d) = ∑_{|μ| = d} (∏_j C(μ_j + N-1, N-1)) · x^μ`; the
+content is rewriting this in the Schur basis.
 
 ## How the kernel lemma consumes this
 
@@ -50,9 +69,14 @@ per-degree short exact sequence
 `PolyRightGrading.lean`, sorry-free) is right-`GL_N`-equivariant. Hence the
 multiplicity of `ν` in `(A/det)_d` is
 
-  `mult_{A_d}(ν) − mult_{A_{d-N}}(ν − (1,…,1)) = [ν ∈ ℕ^N] − [ν − 1 ∈ ℕ^N] = [ν_N = 0]`,
+  `mult_{A_d}(ν) − mult_{A_{d-N}}(ν − (1,…,1))`
+    `= s_ν(1,…,1)·[ν ∈ ℕ^N] − s_{ν-1}(1,…,1)·[ν − 1 ∈ ℕ^N]`
+    `= s_ν(1,…,1)·([ν ∈ ℕ^N] − [ν − 1 ∈ ℕ^N]) = s_ν(1,…,1)·[ν_N = 0]`,
 
-so every irreducible constituent of `A/det` has `ν_N = 0`. This is exactly the
+using `dim V_{ν - (1,…,1)} = dim V_ν` (tensoring by the 1-dimensional `det`
+character preserves dimension). So every irreducible constituent of `A/det`
+has `ν_N = 0` — the qualitative conclusion is unchanged by the corrected
+multiplicities, since they cancel termwise for `ν_N > 0`. This is exactly the
 `CauchyDetQuotient.lean` deliverable
 `quotDetRep_irreducible_constituent_lastWeight_zero` (#4896 part (a)); the
 assembly of *this* character identity with the (already sorry-free) SES and
@@ -81,7 +105,7 @@ instance finiteDimensional_homogeneousSubmodule (d : ℕ) :
 `GL_N(k)` under right translation. The carrier is the right-`GL_N`-subrepresentation
 `polyRightHomogeneousSubrep k N d` (`PolyRightGrading.lean`), which is
 finite-dimensional by `finiteDimensional_homogeneousSubmodule`. This is the
-finite-dimensional object on which the Cauchy multiplicity-one character identity
+finite-dimensional object on which the Cauchy character identity
 `polyRightDegreeFDRep_formalCharacter` is stated. -/
 noncomputable def polyRightDegreeFDRep (k : Type*) [Field k] (N d : ℕ) :
     FDRep k (Matrix.GeneralLinearGroup (Fin N) k) :=
@@ -89,24 +113,35 @@ noncomputable def polyRightDegreeFDRep (k : Type*) [Field k] (N d : ℕ) :
     finiteDimensional_homogeneousSubmodule d
   FDRep.of (polyRightHomogeneousSubrep k N d).toRepresentation
 
-/-- **The right-`GL_N` Cauchy multiplicity-one character identity.** As a
-right-`GL_N`-representation, the total-degree-`d` part of `A = k[Xᵢⱼ]` is the sum,
-each with multiplicity one, of the irreducibles `V_ν` over the dominant weights
-`ν ∈ ℕ^N` of size `d` (`BoundedPartition N d`):
+/-- **The right-`GL_N` Cauchy character identity.** As a right-`GL_N`-representation,
+the total-degree-`d` part of `A = k[Xᵢⱼ]` is the sum, over the dominant weights
+`ν ∈ ℕ^N` of size `d` (`BoundedPartition N d`), of the irreducibles `V_ν` each
+with multiplicity `dim S_ν(k^N) = s_ν(1,…,1)`:
 
-  `formalCharacter k N (A_d) = ∑_{ν : BoundedPartition N d} S_ν`.
+  `formalCharacter k N (A_d) = ∑_{ν : BoundedPartition N d} s_ν(1,…,1) · S_ν`,
+
+where the multiplicity `s_ν(1,…,1)` is `schurPoly` evaluated at the all-ones
+point (the dimension of the left Schur-module factor, i.e. the number of SSYT
+of shape `ν` with entries in `[N]`).
 
 This is the genuine research core of the `GL_N × GL_N`-equivariant Cauchy
-decomposition `k[Xᵢⱼ] = ⊕_{ν ∈ ℕ^N dom} V_ν^* ⊠ V_ν` (each `ν` once), restricted
-to the right factor and read off on formal characters. Its proof is the
-multiplicity-one Cauchy/Schur-Weyl content together with the highest-weight
-⟺ `ν ∈ ℕ^N` theory; it is tracked as the residual core of #4934 (overlapping
-`iso_of_formalCharacter_eq_schurPoly`, #4699/#4882) and is the sole remaining
-`sorry`. -/
+decomposition `k[Xᵢⱼ] = ⊕_{ν ∈ ℕ^N dom} V_ν^* ⊠ V_ν` (each `ν` once *as a
+bi-representation*), restricted to the right factor and read off on formal
+characters. Forgetting the left action, each right-irreducible `V_ν` occurs
+`dim V_ν^* = dim V_ν` times — **not** once. (A `= ∑_ν S_ν` form is false: for
+`N = 2, d = 1`, `dim A_1 = 4 ≠ 2 = ∑_ν dim V_ν`. See the file header and #4944.)
+
+Its proof is the Cauchy/Schur-Weyl content (the Cauchy identity, or the
+GL×GL-equivariant decomposition of `Sym^d(V ⊗ W)`) together with the
+highest-weight ⟺ `ν ∈ ℕ^N` theory; it is tracked as the residual core of #4934
+(overlapping `iso_of_formalCharacter_eq_schurPoly`, #4699/#4882) and is the sole
+remaining `sorry`. -/
 theorem polyRightDegreeFDRep_formalCharacter
     (k : Type*) [Field k] [IsAlgClosed k] [CharZero k] (N d : ℕ) :
     formalCharacter k N (polyRightDegreeFDRep k N d)
-      = ∑ ν : BoundedPartition N d, schurPoly N ν.parts := by
+      = ∑ ν : BoundedPartition N d,
+          (MvPolynomial.eval (fun _ => (1 : ℚ)) (schurPoly N ν.parts)) •
+            schurPoly N ν.parts := by
   sorry
 
 end Etingof.CauchyCharacterRight

--- a/progress/2026-06-21T20-20-37Z_e26a9439.md
+++ b/progress/2026-06-21T20-20-37Z_e26a9439.md
@@ -1,0 +1,74 @@
+## Accomplished
+
+Claimed #4944 (prove `polyRightDegreeFDRep_formalCharacter`, the right-`GL_N`
+Cauchy character identity in `Chapter5/CauchyCharacterRight.lean`).
+
+**Finding: the issue's deliverable statement was mathematically false.** It
+asserted, with multiplicity one,
+
+  `formalCharacter k N (polyRightDegreeFDRep k N d) = ∑_{ν : BoundedPartition N d} schurPoly N ν.parts`.
+
+As a right-`GL_N`-representation, the degree-`d` part `A_d` of `k[Xᵢⱼ]` is the
+right factor of the `GL_N × GL_N`-equivariant Cauchy decomposition
+`Sym^d(V ⊗ W) = ⊕_ν S_ν(V) ⊗ S_ν(W)`, so each right-irreducible `V_ν = S_ν(W)`
+occurs with multiplicity `dim S_ν(V) = s_ν(1,…,1)`, **not** once.
+
+Decisive disproof on dimensions: `formalCharacter` is the honest trace character
+`∑_μ (dim weight-space_μ) x^μ` (`Theorem5_22_1.lean:495`), and `schurPoly` is the
+genuine Schur polynomial (alternant ratio, `Proposition5_21_1.lean:305`). For
+`N = 2, d = 1`: `dim A_1 = 4` (the four `Xᵢⱼ`, weights `(1,0)` and `(0,1)` each
+with a 2-dim weight space), but `∑_{ν : BoundedPartition 2 1} dim V_ν =
+dim V_{(1,0)} = 2`. The two sides have unequal total dimension, so the identity
+cannot hold.
+
+**Action taken** (commit `5d387d99`): corrected the statement to the true,
+multiplicity-bearing Cauchy identity
+
+  `formalCharacter k N (A_d) = ∑_ν (eval (fun _ => 1) (schurPoly N ν.parts)) • schurPoly N ν.parts`,
+
+i.e. the Cauchy identity specialised at `x = (1,…,1)`
+(`∏_j (1 - t_j)^{-N}` truncated to degree `d`). Rewrote the file header and the
+theorem/def docstrings (removing all "multiplicity one" claims), recorded the
+disproof, and noted that the kernel-lemma consumer's `ν_N = 0` conclusion is
+**unaffected** by the corrected multiplicities (they cancel termwise for
+`ν_N > 0`, since `dim V_{ν-(1,…,1)} = dim V_ν`). Nothing currently consumes this
+theorem (grep: only self-references), so no downstream breakage.
+
+Build green (`lake build EtingofRepresentationTheory.Chapter5.CauchyCharacterRight`),
+exactly one `sorry` (the corrected, now-true statement).
+
+## Current frontier
+
+The corrected statement is now a true `sorry`. Its proof is the genuine
+Cauchy/Schur-Weyl content (the Cauchy identity, or the GL×GL-equivariant
+`Sym^d(V⊗W)` decomposition) plus the highest-weight ⟺ `ν ∈ ℕ^N` theory —
+research-level, not in Mathlib, out of scope for one session.
+
+A proof hint recorded in the file header: the elementary intermediate form
+`formalCharacter k N (A_d) = ∑_{|μ|=d} (∏_j C(μ_j + N-1, N-1)) · x^μ` (weight
+space `μ` = monomials with column-degree vector `μ`) is provable without
+Schur-Weyl; the remaining content is rewriting it in the Schur basis (= Cauchy
+at `1^N`).
+
+## Overall project progress
+
+Chapter 5 right-`GL_N` Cauchy infrastructure (#4904/#4934, kernel-lemma-K′).
+Interface + finite-dimensional carrier already sorry-free on `main`. This turn
+corrected a false character-identity statement; the proof is deferred to replan.
+
+## Next step
+
+Planner: re-scope #4944's proof against the **corrected** statement. The proof
+needs the Cauchy identity at `1^N` (or the GL×GL `Sym^d(V⊗W)` decomposition).
+Consider first landing the elementary column-degree weight-space formula as a
+named lemma, then the Schur-basis rewrite. Also re-check #4896/#4905
+(`CauchyDetQuotient`, `quotDetRep_irreducible_constituent_lastWeight_zero`):
+their design assumed multiplicity one; the `ν_N = 0` support conclusion still
+holds, but any step using literal coefficient-one must be updated to
+`s_ν(1,…,1)`.
+
+## Blockers
+
+The original deliverable (multiplicity-one identity) is impossible — it is
+false. The replacement (multiplicity-bearing identity) is a research-level
+Cauchy proof. Routed to replan via `--partial`.


### PR DESCRIPTION
Partial progress on #4944

Session: `e26a9439-a12f-4242-a343-23f386510416`

a8f25ec8 doc(progress): record #4944 false-statement correction (2026-06-21T20-20-37Z)
5d387d99 fix(Ch5 #4944): correct false multiplicity-one Cauchy character identity

🤖 Prepared with Claude Code