### PR TITLE
ci: raise Lean build timeout

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - name: Add swap space
         uses: actionhippie/swap-space@v1


### PR DESCRIPTION
## Summary

Increase the Lean Action CI job timeout from 60 minutes to 90 minutes.

## Why

Current main-target PR builds are reaching the old 60 minute job limit near the end of the module list and are killed with exit code 143, without a Lean compilation error. I observed this on the toolchain repair PRs and on unrelated PR #4928, so the failure mode is CI capacity rather than the focused repair diffs.

This keeps the existing full-module validation model for `main` PRs; it only gives the job enough time to finish after recent module growth.

## Validation

- `actionlint .github/workflows/lean.yml` passed locally. The local environment printed only its unrelated `LD_PRELOAD` warning.

Part of keeping #4864 repair PRs validating cleanly.