### PR TITLE
doc(Ch5 #4946): decompose general-k schurModule_isSimple into #4973-#4976

### DIFF
--- a/progress/2026-06-21T22-24-17Z_8c24f446.md
+++ b/progress/2026-06-21T22-24-17Z_8c24f446.md
@@ -1,0 +1,52 @@
+## Accomplished
+
+Claimed #4946 (general-`k` Schur-module simplicity, ingredient (a) of #4901) as a feature
+session. After a thorough dependency investigation, determined the issue is **mis-scoped as a
+single ingredient** and decomposed it.
+
+Findings:
+- `schurModule_isSimple` (ℂ, `SchurModuleSimple.lean:314`) bottoms out at the entire ℂ-based
+  symmetric-group representation theory: `abbrev SymGroupAlgebra n := MonoidAlgebra ℂ (Perm)`
+  and `SpechtModule` over ℂ (`Theorem5_12_2_Irreducible.lean:22,26`), the §5.12 classification,
+  §5.15 characters, and the §5.22 Young-symmetrizer special-block analysis. ~20 files reference
+  `SymGroupAlgebra`/`SpechtModule` over ℂ.
+- **No genuine ℂ-specifics** anywhere in the chain (the `conj`/`trace_conj'` are linear-algebra
+  conjugation, not complex). It is a careful but mechanical ℂ→`k` generalization.
+- The GL transfer (`SchurWeylGLTransfer.lean`) and double-centralizer
+  (`Theorem5_18_4_centralizers`) are **already generic over `k`**.
+- A generic-`k` Specht/Young track already exists to build on: `SpechtModuleK`,
+  `YoungSymmetrizerK`, `YoungSymmetrizerK_sq_scalar`, and `SpechtModuleK_isSimpleModule`
+  (proved over ℚ, sorry-free). The general-`k` path should extend this, not rewrite ℂ files.
+
+Wrote route doc `progress/schurModule-isSimple-general-route.md` and decomposed #4946 into a
+layered chain:
+- #4973 (Sub-A, root, ready): general-`k` S_n simple-module classification.
+- #4974 (Sub-B, blocked on A): general-`k` Specht character bridge.
+- #4975 (Sub-C, blocked on B): general-`k` special-block analysis.
+- #4976 (Sub-D, blocked on C): general-`k` `schurModule_isSimple_general` assembly + resolve `hN`.
+
+Left a `Decomposed into …` breadcrumb on #4946 and `coordination skip`ped it (now `replan`).
+
+## Current frontier
+
+Decomposition complete. The actionable root is #4973 (Sub-A); the rest of the chain is blocked
+behind it. No Lean code was changed this session (analysis + decomposition only).
+
+## Overall project progress
+
+Chapter 5 Schur-Weyl / formal-character classification (#4901, route B) is the active frontier.
+#4901 has three ingredients: (a) #4946 simplicity [now decomposed → #4973–#4976], (b) #4947
+density seam (open), (c) retired via #4969. Sorry baseline unchanged at this session's branch
+point.
+
+## Next step
+
+A worker should claim **#4973** (general-`k` `SpechtModuleK_isSimpleModule` + general-`k`
+`Theorem5_12_2_classification`), building on `Infrastructure/SpechtModuleSimple.lean`. It may
+itself warrant a further split (semisimplicity/sandwich generalization vs. the classification).
+
+## Blockers
+
+None for #4973 (ready). #4974/#4975/#4976 are correctly blocked on their predecessors and will
+auto-unblock as each lands. #4946 awaits planner triage (sub-issues fully cover it → planner can
+close it with a forward link).

--- a/progress/schurModule-isSimple-general-route.md
+++ b/progress/schurModule-isSimple-general-route.md
@@ -1,0 +1,82 @@
+# Route: `schurModule_isSimple_general` (general-`k` Schur-module simplicity, #4946)
+
+## Summary
+
+Issue #4946 asks to lift `schurModule_isSimple` (Schur-module simplicity, currently
+proved only for `k = ℂ` in `SchurModuleSimple.lean:314`) to a general algebraically
+closed characteristic-zero field `k`. After investigation this is **not a single
+ingredient**: it requires generalizing essentially the entire ℂ-based symmetric-group /
+Specht-module / Schur-Weyl simple-module foundation of Chapter 5 from ℂ to general `k`.
+The parent was decomposed into the layered sub-issue chain below.
+
+## Why it is large
+
+`schurModule_isSimple` (ℂ) reduces to two halves:
+
+- **GL transfer** `isSimpleModule_monoidAlgebra_GL_of_centralizer_simple`
+  (`SchurWeylGLTransfer.lean`) — **already generic over `k` with `[IsAlgClosed k]`**. ✓
+- **Centralizer-simplicity core** `schurModuleSubmodule_isSimple_centralizer`
+  (`SchurModuleSimple.lean:254`) — ℂ-hardcoded. It uses:
+  - `Theorem5_18_4_centralizers` (double centralizer) — **already generic over `k`,
+    `[CharZero k]`**. ✓
+  - `schurBlock_imageSubmoduleB_isSimple` (`SchurModuleSimple.lean:167`, ℂ) — the special-
+    block analysis, which pulls in:
+    - `exists_unique_special_block` (`SchurModuleSpecialBlock.lean:148`, ℂ)
+    - `youngSym_action_vanishes_off_block`,
+      `youngSym_action_on_special_block_rank_one_scaled_proj` (`Theorem5_22_1.lean`, ℂ)
+    - `trace_symGroupAction_eq_spechtModuleCharacter`,
+      `simpleSubmodule_iso_of_spechtCharacter_eq` (`Theorem5_22_1.lean`, ℂ) — the Specht
+      character bridge, which rests on
+    - `Theorem5_12_2_classification` (`Theorem5_12_2_Classification.lean`, ℂ): every simple
+      `ℂ[S_n]`-module is a Specht module, and
+    - `SpechtModule`, `SymGroupAlgebra := MonoidAlgebra ℂ (Equiv.Perm (Fin n))`
+      (`Theorem5_12_2_Irreducible.lean:22,26`) — **the ℂ root**.
+
+`SymGroupAlgebra`/`SpechtModule` over ℂ are referenced by ~20 files (the whole §5.12–5.17
+tabloid/polytabloid/Specht/hook-formula development). There is **no genuinely ℂ-specific
+fact** anywhere in the chain (the `conj`/`trace_conj'` occurrences are linear-algebra
+conjugation, not complex conjugation); ℂ is used purely as "an algebraically closed field
+of characteristic zero." So the work is a careful but mechanical ℂ→`k` generalization.
+
+## The crucial shortcut: build on the existing generic track
+
+The project **already has a generic-`k` Specht/Young infrastructure**, so the general-`k`
+path should extend it rather than ℂ→`k`-editing the §5.12–5.17 ℂ files:
+
+- `SpechtModuleK (k) [CommRing k] n la` — `Infrastructure/SpechtModuleSimple.lean:28`
+- `YoungSymmetrizerK (k) [CommRing k] n la` — `Theorem5_22_1.lean:50`
+- `YoungSymmetrizerK_sq_scalar (k) [CommRing k] [CharZero k]` — `Theorem5_22_1.lean:165`
+- `SpechtModuleK_isSimpleModule` — `Infrastructure/SpechtModuleSimple.lean:172`, **proved
+  over ℚ, sorry-free**. Its proof only needs `k[S_n]` semisimple + the sandwich property,
+  both of which hold for any characteristic-zero field; extending ℚ → general char-0 `k`
+  should be light.
+
+## Recommended layered chain (sub-issues)
+
+1. **Sub-A (root):** general-`k` `SpechtModuleK_isSimpleModule` (extend the ℚ proof to any
+   char-0 field) and a general-`k` simple-module classification
+   (`Theorem5_12_2_classification` over `k`: every simple `k[S_n]`-module ≅ `SpechtModuleK k n la`).
+2. **Sub-B:** general-`k` Specht character bridge —
+   `trace_symGroupAction_eq_spechtModuleCharacter`,
+   `simpleSubmodule_iso_of_spechtCharacter_eq` over `k`. (`spechtModuleCharacter` is
+   field-independent, integer-valued.) Depends on Sub-A.
+3. **Sub-C:** general-`k` special-block analysis — `youngSym_action_vanishes_off_block`,
+   `youngSym_action_on_special_block_rank_one_scaled_proj` (`Theorem5_22_1.lean`),
+   `exists_unique_special_block` + helpers (`SchurModuleSpecialBlock.lean`). Depends on Sub-B.
+4. **Sub-D (residual #4946):** general-`k` `schurBlock_imageSubmoduleB_isSimple` →
+   `schurModuleSubmodule_isSimple_centralizer` → **`schurModule_isSimple_general`**
+   (`SchurModuleSimple.lean`). Depends on Sub-C.
+
+## The `hN` question (carry into Sub-D)
+
+The ℂ result `schurModule_isSimple` carries `hN : (∑ i, lam i) ≤ N`, but the assembly
+statement `schurModule_isSimple_general` (and its consumer
+`simpleRep_iso_schurModule_of_formalCharacter_eq`, #4901) omits it. Sub-D must determine
+whether `hN` is genuinely required for the general-`k` simplicity argument; if it is, this
+forces a statement change to the #4901 assembly and must be coordinated there.
+
+## Pointers
+
+- Target sorry: `schurModule_isSimple_general`, `SchurWeylFormalCharacterIso.lean:131`.
+- ℂ proof to lift: `schurModule_isSimple`, `SchurModuleSimple.lean:314`.
+- Consumer: `simpleRep_iso_schurModule_of_formalCharacter_eq` (#4901).


### PR DESCRIPTION
This PR records the dependency analysis and decomposition of #4946 (general-`k` Schur-module simplicity, ingredient (a) of #4901). Investigation showed `schurModule_isSimple_general` over a general algebraically-closed characteristic-zero field is not a single ingredient: it requires generalizing the entire ℂ-based S_n / Specht-module / Schur-Weyl simple-module foundation of Chapter 5 (rooted at `abbrev SymGroupAlgebra := MonoidAlgebra ℂ (Perm)` and `SpechtModule` over ℂ, ~20 files), with no genuine ℂ-specifics. It adds `progress/schurModule-isSimple-general-route.md` capturing the full analysis (including the existing generic-`k` Specht/Young track to build on) and the layered sub-issue chain #4973 (root) → #4974 → #4975 → #4976. #4946 has been skipped (`replan`) with a `Decomposed into …` breadcrumb for planner closure.

This PR contains documentation only; no Lean code changes.

🤖 Prepared with Claude Code