### PR TITLE
feat(Ch5 #4947): generalize density core to alg-closed char-0 k + general-k algebraic character-independence seam

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/DiagonalizableConj.lean
+++ b/EtingofRepresentationTheory/Chapter5/DiagonalizableConj.lean
@@ -7,8 +7,12 @@ import EtingofRepresentationTheory.Chapter5.FormalCharacterTorusTrace
 This file proves the pure-linear-algebra conjugacy fact needed by the geometric
 density core of the character-independence seam (issue #4925, sub-piece (ii)):
 
-> A complex `N × N` invertible matrix whose characteristic polynomial has `N`
-> distinct roots is conjugate (in `GL_N(ℂ)`) to a `diagTorus` element.
+> An `N × N` invertible matrix over a field `k` whose characteristic polynomial has
+> `N` distinct roots is conjugate (in `GL_N(k)`) to a `diagTorus` element.
+
+The statement and proof are field-agnostic (the distinct-roots hypothesis is taken
+as given), so they apply over any field `k`; the `ℂ` consumers (issue #4925) and the
+general algebraically-closed `k` consumers (issue #4947) both specialise this lemma.
 
 The strategy is the classical eigenbasis construction:
 
@@ -34,31 +38,34 @@ namespace Etingof
 
 noncomputable section
 
-/-- A `GL_N(ℂ)` matrix whose characteristic polynomial has `N` distinct roots is
+variable {k : Type*} [Field k] [DecidableEq k]
+
+/-- A `GL_N(k)` matrix whose characteristic polynomial has `N` distinct roots is
 conjugate to a diagonal torus element: there is a tuple of nonzero eigenvalues
-`t : Fin N → ℂˣ` and a base change `h ∈ GL_N(ℂ)` with `g = h * diag(t) * h⁻¹`. -/
+`t : Fin N → kˣ` and a base change `h ∈ GL_N(k)` with `g = h * diag(t) * h⁻¹`. The
+proof is field-agnostic; the distinct-roots hypothesis is taken as given. -/
 theorem gl_conj_diagTorus_of_distinct_eigenvalues
-    (N : ℕ) (g : Matrix.GeneralLinearGroup (Fin N) ℂ)
-    (hdist : (g : Matrix (Fin N) (Fin N) ℂ).charpoly.roots.toFinset.card = N) :
-    ∃ (t : Fin N → ℂˣ) (h : Matrix.GeneralLinearGroup (Fin N) ℂ),
-      g = h * diagTorus ℂ N t * h⁻¹ := by
-  -- `N = 0` is degenerate: `GL_0(ℂ)` is a subsingleton.
+    (N : ℕ) (g : Matrix.GeneralLinearGroup (Fin N) k)
+    (hdist : (g : Matrix (Fin N) (Fin N) k).charpoly.roots.toFinset.card = N) :
+    ∃ (t : Fin N → kˣ) (h : Matrix.GeneralLinearGroup (Fin N) k),
+      g = h * diagTorus k N t * h⁻¹ := by
+  -- `N = 0` is degenerate: `GL_0(k)` is a subsingleton.
   rcases Nat.eq_zero_or_pos N with hN0 | hNpos
   · subst hN0
     exact ⟨fun i => i.elim0, 1, Subsingleton.elim _ _⟩
   have : NeZero N := ⟨hNpos.ne'⟩
-  set A : Matrix (Fin N) (Fin N) ℂ := (g : Matrix (Fin N) (Fin N) ℂ) with hA_def
+  set A : Matrix (Fin N) (Fin N) k := (g : Matrix (Fin N) (Fin N) k) with hA_def
   -- `A` is a unit, hence `0` is not in its spectrum.
   have hAunit : IsUnit A := ⟨g, rfl⟩
   -- Enumerate the `N` distinct roots of the characteristic polynomial.
-  set s : Finset ℂ := A.charpoly.roots.toFinset with hs_def
+  set s : Finset k := A.charpoly.roots.toFinset with hs_def
   have hcard_s : Fintype.card s = N := by rw [Fintype.card_coe]; exact hdist
   let e : Fin N ≃ s := (Fintype.equivFinOfCardEq hcard_s).symm
-  let t : Fin N → ℂ := fun i => (e i : ℂ)
+  let t : Fin N → k := fun i => (e i : k)
   have ht_inj : Function.Injective t :=
     fun i j h => e.injective (Subtype.ext h)
   -- Each `t i` is a root of `charpoly`, hence in the spectrum of `A`.
-  have ht_mem : ∀ i, t i ∈ spectrum ℂ A := by
+  have ht_mem : ∀ i, t i ∈ spectrum k A := by
     intro i
     have hroot : A.charpoly.IsRoot (t i) := by
       have hmem : t i ∈ A.charpoly.roots.toFinset := (e i).2
@@ -66,7 +73,7 @@ theorem gl_conj_diagTorus_of_distinct_eigenvalues
       exact hmem.2
     exact (Matrix.mem_spectrum_iff_isRoot_charpoly).mpr hroot
   -- The associated endomorphism and its eigenvalues.
-  let f : Module.End ℂ (Fin N → ℂ) := Matrix.toLin' A
+  let f : Module.End k (Fin N → k) := Matrix.toLin' A
   have hf_eig : ∀ i, f.HasEigenvalue (t i) := by
     intro i
     rw [Module.End.hasEigenvalue_iff_mem_spectrum, Matrix.spectrum_toLin']
@@ -74,26 +81,26 @@ theorem gl_conj_diagTorus_of_distinct_eigenvalues
   -- Eigenvalues of a unit are nonzero.
   have ht_ne : ∀ i, t i ≠ 0 := by
     intro i hzero
-    have : (0 : ℂ) ∈ spectrum ℂ A := hzero ▸ ht_mem i
-    exact ((spectrum.zero_mem_iff ℂ).mp this) hAunit
+    have : (0 : k) ∈ spectrum k A := hzero ▸ ht_mem i
+    exact ((spectrum.zero_mem_iff k).mp this) hAunit
   -- Choose one eigenvector per eigenvalue.
-  let v : Fin N → (Fin N → ℂ) := fun i => (hf_eig i).exists_hasEigenvector.choose
+  let v : Fin N → (Fin N → k) := fun i => (hf_eig i).exists_hasEigenvector.choose
   have hvspec : ∀ i, f.HasEigenvector (t i) (v i) := fun i =>
     (hf_eig i).exists_hasEigenvector.choose_spec
   -- The eigenvectors are linearly independent (distinct eigenvalues), hence a basis.
-  have hli : LinearIndependent ℂ v :=
+  have hli : LinearIndependent k v :=
     Module.End.eigenvectors_linearIndependent' f t ht_inj v hvspec
-  have hcard_eq : Fintype.card (Fin N) = Module.finrank ℂ (Fin N → ℂ) := by
+  have hcard_eq : Fintype.card (Fin N) = Module.finrank k (Fin N → k) := by
     rw [Module.finrank_fintype_fun_eq_card]
-  let b : Basis (Fin N) ℂ (Fin N → ℂ) := basisOfLinearIndependentOfCardEqFinrank hli hcard_eq
+  let b : Basis (Fin N) k (Fin N → k) := basisOfLinearIndependentOfCardEqFinrank hli hcard_eq
   have hb : ⇑b = v := coe_basisOfLinearIndependentOfCardEqFinrank hli hcard_eq
   -- The change-of-basis matrix: eigenvectors as columns.
-  let V : Matrix (Fin N) (Fin N) ℂ := (Pi.basisFun ℂ (Fin N)).toMatrix ⇑b
+  let V : Matrix (Fin N) (Fin N) k := (Pi.basisFun k (Fin N)).toMatrix ⇑b
   have hVentry : ∀ i j, V i j = v j i := by
     intro i j
-    change (Pi.basisFun ℂ (Fin N)).toMatrix ⇑b i j = v j i
+    change (Pi.basisFun k (Fin N)).toMatrix ⇑b i j = v j i
     rw [Basis.toMatrix_apply, Pi.basisFun_repr, hb]
-  haveI hVinv : Invertible V := Basis.invertibleToMatrix (Pi.basisFun ℂ (Fin N)) b
+  haveI hVinv : Invertible V := Basis.invertibleToMatrix (Pi.basisFun k (Fin N)) b
   -- The eigenvector equation in matrix form.
   have hcol : ∀ j, A *ᵥ (v j) = (t j) • v j := by
     intro j
@@ -101,7 +108,7 @@ theorem gl_conj_diagTorus_of_distinct_eigenvalues
     change A *ᵥ (v j) = (t j) • v j at h2
     exact h2
   -- `A * V = V * D`, columnwise from the eigenvector equation.
-  set D : Matrix (Fin N) (Fin N) ℂ := Matrix.diagonal (fun i => t i) with hD_def
+  set D : Matrix (Fin N) (Fin N) k := Matrix.diagonal (fun i => t i) with hD_def
   have hAV : A * V = V * D := by
     ext i j
     have lhs : (A * V) i j = (A *ᵥ (v j)) i := by
@@ -115,14 +122,14 @@ theorem gl_conj_diagTorus_of_distinct_eigenvalues
   have hA_conj : A = V * D * V⁻¹ := by
     rw [← hAV, Matrix.mul_assoc, hVVinv, Matrix.mul_one]
   -- Package the eigenvalues as units and the base change as a `GL` element.
-  let t' : Fin N → ℂˣ := fun i => Units.mk0 (t i) (ht_ne i)
-  have ht'_val : ∀ i, (t' i : ℂ) = t i := fun _ => rfl
-  let h : Matrix.GeneralLinearGroup (Fin N) ℂ := unitOfInvertible V
+  let t' : Fin N → kˣ := fun i => Units.mk0 (t i) (ht_ne i)
+  have ht'_val : ∀ i, (t' i : k) = t i := fun _ => rfl
+  let h : Matrix.GeneralLinearGroup (Fin N) k := unitOfInvertible V
   refine ⟨t', h, ?_⟩
   -- Reduce the `GL` equation to the underlying matrix equation.
   refine Units.ext ?_
-  have hh_val : (h : Matrix (Fin N) (Fin N) ℂ) = V := rfl
-  have hdiag_val : (diagTorus ℂ N t' : Matrix (Fin N) (Fin N) ℂ) = D := by
+  have hh_val : (h : Matrix (Fin N) (Fin N) k) = V := rfl
+  have hdiag_val : (diagTorus k N t' : Matrix (Fin N) (Fin N) k) = D := by
     rw [hD_def]
     exact congrArg Matrix.diagonal (funext ht'_val)
   rw [Matrix.GeneralLinearGroup.coe_mul, Matrix.GeneralLinearGroup.coe_mul,

--- a/EtingofRepresentationTheory/Chapter5/DistinctEigenvalueDensity.lean
+++ b/EtingofRepresentationTheory/Chapter5/DistinctEigenvalueDensity.lean
@@ -106,11 +106,11 @@ namespace Matrix
 
 open Polynomial MvPolynomial
 
-variable {N : ℕ}
+variable {N : ℕ} {k : Type*} [Field k]
 
-/-- Over `ℂ`, a matrix whose discriminant is nonzero has separable
-characteristic polynomial. -/
-theorem charpoly_separable_of_discr_ne_zero (M : Matrix (Fin N) (Fin N) ℂ)
+/-- Over a characteristic-zero field, a matrix whose discriminant is nonzero has
+separable characteristic polynomial. -/
+theorem charpoly_separable_of_discr_ne_zero [CharZero k] (M : Matrix (Fin N) (Fin N) k)
     (hN : 0 < N) (h : M.discr ≠ 0) : M.charpoly.Separable := by
   have hpos : 0 < M.charpoly.natDegree := by
     rw [M.charpoly_natDegree_eq_dim]; simpa using hN
@@ -118,35 +118,36 @@ theorem charpoly_separable_of_discr_ne_zero (M : Matrix (Fin N) (Fin N) ℂ)
     natDegree_eq_of_degree_eq_some (degree_derivative_eq _ hpos)
   exact (discr_ne_zero_iff_separable hpos hd).mp h
 
-/-- Over `ℂ`, the eigenvalues (roots of the characteristic polynomial) of a
-matrix with nonzero discriminant are distinct. -/
-theorem charpoly_roots_nodup_of_discr_ne_zero (M : Matrix (Fin N) (Fin N) ℂ)
+/-- Over a characteristic-zero field, the eigenvalues (roots of the characteristic
+polynomial) of a matrix with nonzero discriminant are distinct. -/
+theorem charpoly_roots_nodup_of_discr_ne_zero [CharZero k] (M : Matrix (Fin N) (Fin N) k)
     (hN : 0 < N) (h : M.discr ≠ 0) : M.charpoly.roots.Nodup :=
   Polynomial.nodup_roots (charpoly_separable_of_discr_ne_zero M hN h)
 
-/-- Over `ℂ`, a matrix with nonzero discriminant has exactly `N` distinct
-eigenvalues. -/
-theorem card_roots_charpoly_of_discr_ne_zero (M : Matrix (Fin N) (Fin N) ℂ)
+/-- Over an algebraically closed characteristic-zero field, a matrix with nonzero
+discriminant has exactly `N` distinct eigenvalues. -/
+theorem card_roots_charpoly_of_discr_ne_zero [IsAlgClosed k] [CharZero k] [DecidableEq k]
+    (M : Matrix (Fin N) (Fin N) k)
     (hN : 0 < N) (h : M.discr ≠ 0) : M.charpoly.roots.toFinset.card = N := by
   rw [Multiset.toFinset_card_of_nodup (charpoly_roots_nodup_of_discr_ne_zero M hN h),
     ← (IsAlgClosed.splits M.charpoly).natDegree_eq_card_roots, M.charpoly_natDegree_eq_dim,
     Fintype.card_fin]
 
 /-- The discriminant of the characteristic polynomial, as a polynomial in the
-matrix entries `Xᵢⱼ`: the evaluation of `discrPoly N` at a matrix `M` is
+matrix entries `Xᵢⱼ`: the evaluation of `discrPoly k N` at a matrix `M` is
 `M.discr` (`Matrix.eval_discrPoly`). -/
-noncomputable def discrPoly (N : ℕ) : MvPolynomial (Fin N × Fin N) ℂ :=
-  (mvPolynomialX (Fin N) (Fin N) ℂ).discr
+noncomputable def discrPoly (k : Type*) [Field k] (N : ℕ) : MvPolynomial (Fin N × Fin N) k :=
+  (mvPolynomialX (Fin N) (Fin N) k).discr
 
-/-- Evaluating `discrPoly N` at the entries of a matrix `M` returns `M.discr`. -/
-theorem eval_discrPoly (N : ℕ) (x : Fin N × Fin N → ℂ) :
-    MvPolynomial.eval x (discrPoly N) = (Matrix.of fun i j => x (i, j)).discr := by
-  set M : Matrix (Fin N) (Fin N) ℂ := Matrix.of fun i j => x (i, j) with hM
-  have hMmap : (mvPolynomialX (Fin N) (Fin N) ℂ).map (MvPolynomial.eval x) = M := by
+/-- Evaluating `discrPoly k N` at the entries of a matrix `M` returns `M.discr`. -/
+theorem eval_discrPoly (N : ℕ) (x : Fin N × Fin N → k) :
+    MvPolynomial.eval x (discrPoly k N) = (Matrix.of fun i j => x (i, j)).discr := by
+  set M : Matrix (Fin N) (Fin N) k := Matrix.of fun i j => x (i, j) with hM
+  have hMmap : (mvPolynomialX (Fin N) (Fin N) k).map (MvPolynomial.eval x) = M := by
     ext i j
     simp only [Matrix.map_apply, mvPolynomialX_apply, MvPolynomial.eval_X, hM, Matrix.of_apply]
   have hchar : M.charpoly
-      = (mvPolynomialX (Fin N) (Fin N) ℂ).charpoly.map (MvPolynomial.eval x) := by
+      = (mvPolynomialX (Fin N) (Fin N) k).charpoly.map (MvPolynomial.eval x) := by
     rw [← hMmap, charpoly_map]
   rw [discrPoly]
   simp only [Matrix.discr]
@@ -154,20 +155,22 @@ theorem eval_discrPoly (N : ℕ) (x : Fin N × Fin N → ℂ) :
 
 /-- **The entry-wise charpoly-discriminant is a nonzero polynomial.** Hence the
 distinct-eigenvalue locus is the complement of a proper hypersurface, i.e.
-Zariski-dense, in the space of `N × N` matrices. -/
-theorem discrPoly_ne_zero (N : ℕ) (hN : 0 < N) : discrPoly N ≠ 0 := by
+Zariski-dense, in the space of `N × N` matrices. (Characteristic zero is used both
+for the witness `diag(0,1,…,N-1)` to have distinct entries and for the derivative
+degree to drop by exactly one.) -/
+theorem discrPoly_ne_zero [CharZero k] (N : ℕ) (hN : 0 < N) : discrPoly k N ≠ 0 := by
   intro hzero
-  set d : Fin N → ℂ := fun i => (i.val : ℂ) with hd
-  set x : Fin N × Fin N → ℂ := fun p => if p.1 = p.2 then d p.1 else 0 with hx
+  set d : Fin N → k := fun i => (i.val : k) with hd
+  set x : Fin N × Fin N → k := fun p => if p.1 = p.2 then d p.1 else 0 with hx
   have hM : (Matrix.of fun i j => x (i, j)) = Matrix.diagonal d := by
     ext i j; simp [hx, Matrix.diagonal_apply, Matrix.of_apply]
-  have heval : MvPolynomial.eval x (discrPoly N) = (Matrix.diagonal d).discr := by
+  have heval : MvPolynomial.eval x (discrPoly k N) = (Matrix.diagonal d).discr := by
     rw [eval_discrPoly, hM]
   rw [hzero, map_zero] at heval
   have hinj : Function.Injective d := by
     intro a b hab
     apply Fin.val_injective
-    have : (a.val : ℂ) = (b.val : ℂ) := hab
+    have : (a.val : k) = (b.val : k) := hab
     exact_mod_cast this
   have hsep : (Matrix.diagonal d).charpoly.Separable := by
     rw [charpoly_diagonal]

--- a/EtingofRepresentationTheory/Chapter5/SchurWeylFormalCharacterIso.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurWeylFormalCharacterIso.lean
@@ -1,6 +1,8 @@
 import EtingofRepresentationTheory.Chapter5.PolynomialGLDecomposition
 import EtingofRepresentationTheory.Chapter5.SchurWeylSimplesClassification
 import EtingofRepresentationTheory.Chapter5.FormalCharacterTorusTrace
+import EtingofRepresentationTheory.Chapter5.CharacterIndependence
+import EtingofRepresentationTheory.Chapter5.TraceVanishingDensity
 
 /-!
 # Schur-Weyl #6: the formal character determines the isomorphism class
@@ -133,17 +135,95 @@ theorem schurModule_isSimple_general (N : ℕ) (lam : Fin N → ℕ) (hlam : Ant
       (Representation.asModule (SchurModule k N lam).ρ) := by
   sorry
 
-/-- **Ingredient (b): general-`k` torus→full-group character independence (isolated
-`sorry`, issue #4947).** For a finite family of pairwise non-isomorphic simple polynomial
+/-- **General-`k` torus→full-group character independence (algebraic hypothesis,
+issue #4947).** For a finite family of pairwise non-isomorphic simple **algebraic**
+`GL_N(k)`-representations `L i`, a `ℚ`-combination `c` of their characters whose
+corresponding combination of *torus* traces vanishes at every diagonal torus element
+has all coefficients zero.
+
+This is the general algebraically-closed characteristic-zero `k` analogue of the ℂ
+seam `formalCharacter_simples_coeff_eq_zero_of_torus_trace_eq_zero`
+(`SchurWeylSimplesClassificationComplex.lean`, #4908): same proof (Dedekind/Artin
+independence of characters + the Zariski-density bridge), now driven by the general-`k`
+density core `trace_combination_vanishes_of_torus_vanishes_of_algebraic`
+(`TraceVanishingDensity.lean`). The `ℂ` seam is the `k = ℂ` specialisation.
+
+The hypothesis is `hLalg` (regularity of each character), **not** `hLtop`
+(spanning `ℕ`-weight spaces): the density step requires the character combination to be
+a *regular* function, which `hLtop` does not provide for an abstract-group
+representation. See `TraceVanishingDensity.lean` and the `_general` wrapper below. -/
+theorem formalCharacter_simples_coeff_eq_zero_of_torus_trace_eq_zero_general_of_algebraic
+    (N : ℕ) {ι : Type} [Fintype ι] [DecidableEq ι]
+    (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
+    (hLalg : ∀ i, Etingof.IsAlgebraicRepresentation N (L i).ρ)
+    (hLsimp : ∀ i, IsSimpleModule (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
+        (Representation.asModule (L i).ρ))
+    (hLdist : Pairwise (fun i j => ¬ Nonempty ((L i) ≅ (L j))))
+    (c : ι → ℚ)
+    (htorus : ∀ t : Fin N → kˣ,
+        ∑ i, (c i : k) • LinearMap.trace k (L i) ((L i).ρ (diagTorus k N t)) = 0) :
+    ∀ i, c i = 0 := by
+  classical
+  -- (a) Pairwise non-isomorphic as `A := MonoidAlgebra k (GL_N k)`-modules.
+  have hdist : Pairwise (fun i j => ¬ Nonempty (Representation.asModule (L i).ρ
+      ≃ₗ[MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k)]
+        Representation.asModule (L j).ρ)) := by
+    intro i j hij hcon
+    obtain ⟨φ⟩ := hcon
+    exact hLdist hij ⟨Action.mkIso (Representation.kEquivOfAsModuleEquiv φ).toFGModuleCatIso
+      (fun g => by ext x; exact Representation.kEquivOfAsModuleEquiv_intertwines φ g x)⟩
+  -- (b) Dedekind/Artin: the trace functionals are `k`-independent.
+  have hLI := traceCharacter_linearIndependent (𝕜 := k)
+    (A := MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
+    (fun i => Representation.asModule (L i).ρ) hLsimp hdist
+  -- (c) Trace functional at a group element evaluates to the representation trace.
+  have hbridge : ∀ (i : ι) (g : Matrix.GeneralLinearGroup (Fin N) k),
+      traceChar (fun i => Representation.asModule (L i).ρ) i (MonoidAlgebra.of k _ g)
+        = LinearMap.trace k (L i) ((L i).ρ g) := by
+    intro i g
+    have hmap : (repEnd (fun i => Representation.asModule (L i).ρ) i
+        (MonoidAlgebra.of k _ g) :
+          Representation.asModule (L i).ρ →ₗ[k] Representation.asModule (L i).ρ)
+          = (L i).ρ g := by
+      ext v
+      rw [repEnd_apply, ← Representation.asAlgebraHom_of (L i).ρ g]
+      rfl
+    rw [traceChar_apply, hmap]
+    rfl
+  -- (d) The functional combination vanishes on every group element by the density core.
+  have hF0 : ∀ a, (∑ i, (c i : k) • (traceChar (fun i => Representation.asModule (L i).ρ) i :
+      MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k) →ₗ[k] k)) a = 0 := by
+    intro a
+    induction a using MonoidAlgebra.induction_on with
+    | hM g =>
+        have hg0 := trace_combination_vanishes_of_torus_vanishes_of_algebraic N L hLalg
+          (fun i => (c i : k)) htorus g
+        rw [LinearMap.sum_apply]
+        simpa only [LinearMap.smul_apply, hbridge] using hg0
+    | hadd x y hx hy => simp only [map_add, hx, hy, add_zero]
+    | hsmul r x hx => simp only [map_smul, hx, smul_zero]
+  have hfun : (∑ i, (c i : k) • (traceChar (fun i => Representation.asModule (L i).ρ) i :
+      MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k) →ₗ[k] k)) = 0 :=
+    LinearMap.ext hF0
+  -- (e) Independence forces every coefficient to vanish.
+  intro i
+  have : (c i : k) = 0 := Fintype.linearIndependent_iff.mp hLI (fun i => (c i : k)) hfun i
+  exact_mod_cast this
+
+/-- **Ingredient (b): general-`k` torus→full-group character independence (issue #4947).**
+For a finite family of pairwise non-isomorphic simple polynomial
 (weight-space-spanning) `GL_N(k)`-representations, a `ℚ`-combination of their characters
 whose corresponding combination of *torus* traces vanishes at every diagonal torus element
 has all coefficients zero.
 
-This is the general-`k` analogue of the ℂ seam
-`formalCharacter_simples_coeff_eq_zero_of_torus_trace_eq_zero`
-(`SchurWeylSimplesClassificationComplex.lean`, the open seam #4908). The genuine content is
-the Zariski-density bridge extending torus-trace vanishing to all of `GL_N(k)`; a single
-shared density lemma should serve both this and #4908. -/
+The genuine content — the Zariski-density bridge extending torus-trace vanishing to all of
+`GL_N(k)` — is discharged by `..._general_of_algebraic` above (general-`k` density core,
+`TraceVanishingDensity.lean`). The **only** remaining gap is the algebraicity bridge: that
+each weight-space-spanning simple `L i` is an *algebraic* (regular) representation. This is
+genuinely stronger than `hLtop` for an abstract-group representation and is the open residual
+of #4947 (see the progress note / follow-up issue). At the genuine call site each `L i` is a
+polynomial constituent, so this bridge will be supplied from the algebraic source rather than
+manufactured from `hLtop` alone. -/
 theorem formalCharacter_simples_coeff_eq_zero_of_torus_trace_eq_zero_general
     (N : ℕ) {ι : Type} [Fintype ι] [DecidableEq ι]
     (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
@@ -155,7 +235,13 @@ theorem formalCharacter_simples_coeff_eq_zero_of_torus_trace_eq_zero_general
     (htorus : ∀ t : Fin N → kˣ,
         ∑ i, (c i : k) • LinearMap.trace k (L i) ((L i).ρ (diagTorus k N t)) = 0) :
     ∀ i, c i = 0 := by
-  sorry
+  -- Algebraicity bridge: a weight-space-spanning simple representation is regular.
+  -- This is the open residual of #4947 (strictly stronger than `hLtop`); everything
+  -- downstream is discharged by the general-`k` density core.
+  have hLalg : ∀ i, Etingof.IsAlgebraicRepresentation N (L i).ρ := by
+    sorry
+  exact formalCharacter_simples_coeff_eq_zero_of_torus_trace_eq_zero_general_of_algebraic
+    k N L hLalg hLsimp hLdist c htorus
 
 /-- **Ingredient (c): weight saturation / polynomiality (isolated `sorry`, issue #4948).**
 A *simple* `GL_N(k)`-representation whose formal character equals `schurPoly N lam` (antitone

--- a/EtingofRepresentationTheory/Chapter5/TraceVanishingDensity.lean
+++ b/EtingofRepresentationTheory/Chapter5/TraceVanishingDensity.lean
@@ -9,9 +9,11 @@ import EtingofRepresentationTheory.Chapter5.FormalCharacterTorusTrace
 # Torus-trace vanishing forces full-group trace vanishing (geometric density core)
 
 This file proves the genuinely geometric step of the character-independence seam
-(#4925, sub-issue #4932): a `ℂ`-combination of the characters of finitely many
-**algebraic** `GL_N(ℂ)`-representations `L i` that vanishes at every diagonal
-torus element `diag(t)` vanishes at *every* group element `g`.
+(#4925, sub-issue #4932; generalised to arbitrary algebraically-closed
+characteristic-zero `k` for #4947): a `k`-combination of the characters of finitely
+many **algebraic** `GL_N(k)`-representations `L i` that vanishes at every diagonal
+torus element `diag(t)` vanishes at *every* group element `g`. The `ℂ` consumers of
+#4925 are recovered as the `k = ℂ` specialisation.
 
 The character `g ↦ trace_ℂ ((L i).ρ g)` of an algebraic representation is a
 *regular* (polynomial-in-the-entries-with-`det⁻¹`) function of `g`
@@ -36,52 +38,59 @@ open Etingof.DetLocalization
 
 namespace Etingof
 
-variable {N : ℕ}
+variable {N : ℕ} {k : Type*} [Field k] [IsAlgClosed k] [CharZero k] [DecidableEq k]
 
 /-- **The character of an algebraic representation is a regular function.** For an
-algebraic `GL_N`-representation `M`, the character `g ↦ trace_ℂ (M.ρ g)` equals
+algebraic `GL_N`-representation `M`, the character `g ↦ trace_k (M.ρ g)` equals
 `evalAtGL g T` for the polynomial `T = ∑ₐ P a a` (the trace of the
-matrix-coefficient polynomials in any algebraic-rep basis). -/
+matrix-coefficient polynomials in any algebraic-rep basis). Field-agnostic. -/
 theorem trace_eq_evalAtGL_of_algebraic
-    (M : FDRep ℂ (Matrix.GeneralLinearGroup (Fin N) ℂ))
+    (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
     (hM : Etingof.IsAlgebraicRepresentation N M.ρ) :
-    ∃ T : MvPolynomial (Etingof.GLCoordVars N) ℂ,
-      ∀ g, LinearMap.trace ℂ M (M.ρ g) = Etingof.evalAtGL g T := by
+    ∃ T : MvPolynomial (Etingof.GLCoordVars N) k,
+      ∀ g, LinearMap.trace k M (M.ρ g) = Etingof.evalAtGL g T := by
   obtain ⟨m, b, P, hP⟩ := hM
   refine ⟨∑ a, P a a, fun g => ?_⟩
-  rw [LinearMap.trace_eq_matrix_trace ℂ b (M.ρ g)]
+  rw [LinearMap.trace_eq_matrix_trace k b (M.ρ g)]
   have hsum : Etingof.evalAtGL g (∑ a, P a a) = ∑ a, Etingof.evalAtGL g (P a a) := by
     simp only [Etingof.evalAtGL, map_sum]
   rw [hsum, Matrix.trace]
   refine Finset.sum_congr rfl (fun a _ => ?_)
   rw [Matrix.diag_apply, LinearMap.toMatrix_apply, hP g a a]
 
-/-- **Geometric density core (algebraic version).** A `ℂ`-combination of the
-characters of finitely many *algebraic* `GL_N(ℂ)`-representations `L i` that
-vanishes at every diagonal torus element vanishes at every group element. -/
+/-- **Geometric density core (algebraic version, general algebraically-closed
+characteristic-zero field).** A `k`-combination of the characters of finitely many
+*algebraic* `GL_N(k)`-representations `L i` that vanishes at every diagonal torus
+element vanishes at every group element.
+
+The diagonalizable matrices are Zariski-dense (their complement is the zero locus of
+`det · discr`, which needs `IsAlgClosed k` for splitting and `CharZero k` for the
+discriminant witness), and the character of an algebraic representation is a regular
+function, so vanishing on that dense set forces vanishing everywhere. The `ℂ` density
+core consumed by issue #4925 is the `k = ℂ` specialisation. -/
 theorem trace_combination_vanishes_of_torus_vanishes_of_algebraic
     (N : ℕ) {ι : Type} [Fintype ι]
-    (L : ι → FDRep ℂ (Matrix.GeneralLinearGroup (Fin N) ℂ))
+    (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
     (hLalg : ∀ i, Etingof.IsAlgebraicRepresentation N (L i).ρ)
-    (c : ι → ℂ)
-    (htorus : ∀ t : Fin N → ℂˣ,
-        ∑ i, c i • LinearMap.trace ℂ (L i) ((L i).ρ (diagTorus ℂ N t)) = 0)
-    (g : Matrix.GeneralLinearGroup (Fin N) ℂ) :
-    ∑ i, c i • LinearMap.trace ℂ (L i) ((L i).ρ g) = 0 := by
+    (c : ι → k)
+    (htorus : ∀ t : Fin N → kˣ,
+        ∑ i, c i • LinearMap.trace k (L i) ((L i).ρ (diagTorus k N t)) = 0)
+    (g : Matrix.GeneralLinearGroup (Fin N) k) :
+    ∑ i, c i • LinearMap.trace k (L i) ((L i).ρ g) = 0 := by
   classical
   -- Abbreviation for the character combination `χ`.
-  set χ : Matrix.GeneralLinearGroup (Fin N) ℂ → ℂ :=
-    fun g => ∑ i, c i • LinearMap.trace ℂ (L i) ((L i).ρ g) with hχdef
+  set χ : Matrix.GeneralLinearGroup (Fin N) k → k :=
+    fun g => ∑ i, c i • LinearMap.trace k (L i) ((L i).ρ g) with hχdef
   -- `N = 0`: `GL_0` is trivial, so `g` is a diagonal torus element and `htorus` applies.
   rcases Nat.eq_zero_or_pos N with hN0 | hN
   · subst hN0
-    have hg : g = diagTorus ℂ 0 (fun _ => 1) := by
+    have hg : g = diagTorus k 0 (fun _ => 1) := by
       apply Units.ext; ext i; exact i.elim0
     rw [hg]; exact htorus (fun _ => 1)
   -- Conjugation invariance of each character: trace is a class function.
-  have hconj : ∀ (i : ι) (h gg : Matrix.GeneralLinearGroup (Fin N) ℂ),
-      LinearMap.trace ℂ (L i) ((L i).ρ (h * gg * h⁻¹))
-        = LinearMap.trace ℂ (L i) ((L i).ρ gg) := by
+  have hconj : ∀ (i : ι) (h gg : Matrix.GeneralLinearGroup (Fin N) k),
+      LinearMap.trace k (L i) ((L i).ρ (h * gg * h⁻¹))
+        = LinearMap.trace k (L i) ((L i).ρ gg) := by
     intro i h gg
     have hρ : (L i).ρ (h * gg * h⁻¹) = (L i).ρ h * (L i).ρ gg * (L i).ρ h⁻¹ := by
       rw [map_mul, map_mul]
@@ -89,14 +98,14 @@ theorem trace_combination_vanishes_of_torus_vanishes_of_algebraic
       rw [← map_mul, inv_mul_cancel, map_one]
     rw [hρ, LinearMap.trace_mul_comm, ← mul_assoc, hinv, one_mul]
   -- `χ` vanishes at every matrix conjugate to a torus element.
-  have hχconj : ∀ (h gg : Matrix.GeneralLinearGroup (Fin N) ℂ),
+  have hχconj : ∀ (h gg : Matrix.GeneralLinearGroup (Fin N) k),
       χ (h * gg * h⁻¹) = χ gg := by
     intro h gg
     simp only [hχdef]
     exact Finset.sum_congr rfl (fun i _ => by rw [hconj i h gg])
   -- The character combination is regular: `χ g = evalAtGL g T` for a polynomial `T`.
   choose T hT using fun i => trace_eq_evalAtGL_of_algebraic (L i) (hLalg i)
-  set Tsum : MvPolynomial (Etingof.GLCoordVars N) ℂ := ∑ i, c i • T i with hTsum
+  set Tsum : MvPolynomial (Etingof.GLCoordVars N) k := ∑ i, c i • T i with hTsum
   have hχeval : ∀ gg, χ gg = Etingof.evalAtGL gg Tsum := by
     intro gg
     simp only [hχdef, hTsum, Etingof.evalAtGL, map_sum]
@@ -104,19 +113,19 @@ theorem trace_combination_vanishes_of_torus_vanishes_of_algebraic
     rw [MvPolynomial.smul_eq_C_mul, map_mul, MvPolynomial.eval_C, smul_eq_mul,
       ← Etingof.evalAtGL, ← hT i gg]
   -- Realise `χ` through the localization `A[det⁻¹]`.
-  set F : Localization.Away (detPoly ℂ N) := coordToAway Tsum with hF
+  set F : Localization.Away (detPoly k N) := coordToAway Tsum with hF
   have hχF : ∀ gg, χ gg = evalGLAway F gg := by
     intro gg
     rw [hχeval gg, hF, evalAtGL_eq_evalGLAway_coordToAway]
   -- Det-power normal form `F = Q · det⁻ʳ`, then clear the denominator.
   obtain ⟨r, Q, hQ⟩ := exists_invSelf_normalForm F
-  have hnum : (algebraMap _ (Localization.Away (detPoly ℂ N)) Q)
-      = F * (algebraMap _ (Localization.Away (detPoly ℂ N)) (detPoly ℂ N)) ^ r :=
+  have hnum : (algebraMap _ (Localization.Away (detPoly k N)) Q)
+      = F * (algebraMap _ (Localization.Away (detPoly k N)) (detPoly k N)) ^ r :=
     algebraMap_num_eq hQ
   -- The cleared-denominator identity: `eval(entries g) Q = χ g · (det g)^r`.
-  have hstar : ∀ gg : Matrix.GeneralLinearGroup (Fin N) ℂ,
-      MvPolynomial.eval (fun ij : Fin N × Fin N => (gg : Matrix (Fin N) (Fin N) ℂ) ij.1 ij.2) Q
-        = χ gg * (gg : Matrix (Fin N) (Fin N) ℂ).det ^ r := by
+  have hstar : ∀ gg : Matrix.GeneralLinearGroup (Fin N) k,
+      MvPolynomial.eval (fun ij : Fin N × Fin N => (gg : Matrix (Fin N) (Fin N) k) ij.1 ij.2) Q
+        = χ gg * (gg : Matrix (Fin N) (Fin N) k).det ^ r := by
     intro gg
     have hfun := congrArg evalGLAway hnum
     rw [map_mul, map_pow] at hfun
@@ -124,8 +133,8 @@ theorem trace_combination_vanishes_of_torus_vanishes_of_algebraic
     simp only [Pi.mul_apply, Pi.pow_apply, evalGLAway_algebraMap, evalGLHom_apply] at hpt
     rw [hpt, hχF gg, ← evalGLHom_apply, evalGLHom_detPoly_apply]
   -- Evaluating `detPoly` at the entries of a matrix returns its determinant.
-  have eval_detPoly : ∀ x : Fin N × Fin N → ℂ,
-      MvPolynomial.eval x (detPoly ℂ N) = (Matrix.of fun i j => x (i, j)).det := by
+  have eval_detPoly : ∀ x : Fin N × Fin N → k,
+      MvPolynomial.eval x (detPoly k N) = (Matrix.of fun i j => x (i, j)).det := by
     intro x
     rw [detPoly, (MvPolynomial.eval x).map_det]
     congr 1
@@ -134,37 +143,37 @@ theorem trace_combination_vanishes_of_torus_vanishes_of_algebraic
   -- The numerator polynomial vanishes everywhere (Zariski density).
   have hQ0 : Q = 0 := by
     refine MvPolynomial.eq_zero_of_eval_eq_zero_off_zeroLocus
-      (Q := detPoly ℂ N * Matrix.discrPoly N) (mul_ne_zero detPoly_ne_zero
+      (Q := detPoly k N * Matrix.discrPoly k N) (mul_ne_zero detPoly_ne_zero
         (Matrix.discrPoly_ne_zero N hN)) ?_
     intro x hx
     rw [map_mul, mul_ne_zero_iff] at hx
     obtain ⟨hdet, hdiscr⟩ := hx
     -- `x` is the entry-list of an invertible matrix `g ∈ GL_N`.
     rw [eval_detPoly] at hdet
-    set Mx : Matrix (Fin N) (Fin N) ℂ := Matrix.of fun i j => x (i, j) with hMx
-    set g : Matrix.GeneralLinearGroup (Fin N) ℂ :=
+    set Mx : Matrix (Fin N) (Fin N) k := Matrix.of fun i j => x (i, j) with hMx
+    set g : Matrix.GeneralLinearGroup (Fin N) k :=
       Matrix.GeneralLinearGroup.mkOfDetNeZero Mx hdet with hg
-    have hgcoe : (g : Matrix (Fin N) (Fin N) ℂ) = Mx := by
+    have hgcoe : (g : Matrix (Fin N) (Fin N) k) = Mx := by
       rw [hg]; rfl
-    have hentries : (fun ij : Fin N × Fin N => (g : Matrix (Fin N) (Fin N) ℂ) ij.1 ij.2) = x := by
+    have hentries : (fun ij : Fin N × Fin N => (g : Matrix (Fin N) (Fin N) k) ij.1 ij.2) = x := by
       funext ij; rw [hgcoe, hMx]; simp
     -- `g` has `N` distinct eigenvalues, hence is conjugate to a torus element.
     rw [Matrix.eval_discrPoly] at hdiscr
-    have hcard : (g : Matrix (Fin N) (Fin N) ℂ).charpoly.roots.toFinset.card = N := by
+    have hcard : (g : Matrix (Fin N) (Fin N) k).charpoly.roots.toFinset.card = N := by
       rw [hgcoe]
       exact Matrix.card_roots_charpoly_of_discr_ne_zero Mx hN hdiscr
     obtain ⟨t, h, hgconj⟩ := gl_conj_diagTorus_of_distinct_eigenvalues N g hcard
     have hχg : χ g = 0 := by
-      rw [hgconj, hχconj h (diagTorus ℂ N t)]
+      rw [hgconj, hχconj h (diagTorus k N t)]
       simp only [hχdef]; exact htorus t
     -- Therefore `eval x Q = χ g · (det g)^r = 0`.
     rw [← hentries, hstar g, hχg, zero_mul]
   -- Conclude: for the given `g`, `χ g · (det g)^r = 0` with `det g ≠ 0`.
-  have hgdet : (g : Matrix (Fin N) (Fin N) ℂ).det ≠ 0 :=
+  have hgdet : (g : Matrix (Fin N) (Fin N) k).det ≠ 0 :=
     ((Matrix.isUnit_iff_isUnit_det _).mp (Units.isUnit g)).ne_zero
   have hfinal := hstar g
   rw [hQ0, map_zero] at hfinal
-  have hzero : χ g * (g : Matrix (Fin N) (Fin N) ℂ).det ^ r = 0 := hfinal.symm
+  have hzero : χ g * (g : Matrix (Fin N) (Fin N) k).det ^ r = 0 := hfinal.symm
   have hχg0 : χ g = 0 :=
     (mul_eq_zero.mp hzero).resolve_right (pow_ne_zero r hgdet)
   simpa only [hχdef] using hχg0

--- a/progress/2026-06-21T22-57-04Z_22ebe2f3.md
+++ b/progress/2026-06-21T22-57-04Z_22ebe2f3.md
@@ -1,0 +1,65 @@
+## Accomplished
+
+Worked #4947 (Ch5 ingredient (b): general-`k` torus→full-group Zariski-density trace
+bridge). Two coherent units landed (branch `agent/22ebe2f3`):
+
+1. **Generalized the geometric density core from ℂ to arbitrary `[Field k]
+   [IsAlgClosed k] [CharZero k]`** (commit `857b7e3e`). The issue asked for "a single
+   shared density lemma" serving both #4908 (ℂ) and #4947 (general `k`); this delivers it.
+   - `DiagonalizableConj.lean`: `gl_conj_diagTorus_of_distinct_eigenvalues` over any
+     field `[Field k] [DecidableEq k]` (proof was already field-agnostic).
+   - `DistinctEigenvalueDensity.lean`: `discrPoly k N`, `eval_discrPoly`,
+     `discrPoly_ne_zero` (CharZero for the `diag(0..N-1)` witness + derivative-degree
+     drop), and the charpoly separability / distinct-eigenvalue lemmas
+     (`card_roots_charpoly_of_discr_ne_zero` needs `[IsAlgClosed k] [CharZero k]
+     [DecidableEq k]`).
+   - `TraceVanishingDensity.lean`: `trace_eq_evalAtGL_of_algebraic` and
+     `trace_combination_vanishes_of_torus_vanishes_of_algebraic` over `k`.
+   - `DetLocalization.lean` and `Definition5_23_1.lean` were *already* general over `k`.
+   - The ℂ consumers (`SchurWeylSimplesClassificationComplex.lean`) recover as the
+     `k = ℂ` specialisation — rebuilt sorry-free, no signature change. No regression.
+
+2. **Proved the general-`k` character-independence seam** (commit `58c6fa4c`,
+   `SchurWeylFormalCharacterIso.lean`):
+   `formalCharacter_simples_coeff_eq_zero_of_torus_trace_eq_zero_general_of_algebraic`
+   is **sorry-free** — the exact general-`k` analogue of the ℂ #4908 seam (Dedekind/Artin
+   independence `traceCharacter_linearIndependent` + the now-generic density core).
+   Added imports `CharacterIndependence`, `TraceVanishingDensity` (no cycle).
+
+## Current frontier
+
+The stated #4947 target `formalCharacter_simples_coeff_eq_zero_of_torus_trace_eq_zero_general`
+(hypothesis `hLtop`) now reduces to the proven algebraic seam, isolating **one** `sorry`
+to the genuine gap — the algebraicity bridge:
+
+```lean
+have hLalg : ∀ i, Etingof.IsAlgebraicRepresentation N (L i).ρ := by sorry
+```
+
+All density + independence machinery is proven; only the regularity of an abstract
+weight-space-spanning simple remains.
+
+## Overall project progress
+
+Phase 3 (formalization), Ch5 Schur-Weyl backbone. The geometric density core is now
+general-`k` (reusable). `SchurWeylFormalCharacterIso.lean` sorry map: `schurModule_isSimple_general`
+(#4946 ingredient a), the new localized `..._general` algebraicity-bridge sorry (#4947 → #4983),
+`glWeightSpace_top_of_simple_formalCharacter_eq_schurPoly` (#4948 ingredient c) — unchanged
+count, but #4947's sorry is now precisely localized rather than monolithic.
+
+## Next step
+
+#4983 (created, depends-on #4947): discharge `hLalg` in `..._general`. The gap is
+`hLtop ⟹ IsAlgebraicRepresentation` for a simple rep, which is strictly stronger than
+`hLtop` for an abstract-group rep — likely **mis-scoped**. Recommended: **Option B** in
+#4983 — re-spec `..._general` to take `hLalg` (matching the ℂ seam), and thread algebraicity
+into the consumer `simpleRep_iso_schurModule_of_formalCharacter_eq` from the polynomial
+source (`glTensorRep_isAlgebraic` for the Schur-module side; the abstract simple `L` may need
+an added algebraicity hypothesis sourced from #4946 / the decomposition data). Verify the
+bridge is even TRUE before grinding (seek a counterexample among abstract group reps).
+
+## Blockers
+
+The full #4947 deliverable (no sorry in `..._general` with the `hLtop` signature) is blocked
+on the algebraicity bridge / re-spec, tracked as #4983. The density-core + algebraic-seam work
+is complete and merge-ready as a partial.


### PR DESCRIPTION
This PR generalizes the geometric trace-vanishing Zariski-density core of the Schur-Weyl character-independence seam from ℂ to an arbitrary algebraically-closed characteristic-zero field `k`, and proves the general-`k` algebraic character-independence seam from it. `gl_conj_diagTorus_of_distinct_eigenvalues` (`DiagonalizableConj`), the discriminant witness `discrPoly k N` with the distinct-eigenvalue lemmas (`DistinctEigenvalueDensity`), and `trace_combination_vanishes_of_torus_vanishes_of_algebraic` (`TraceVanishingDensity`) now hold over any `[Field k] [IsAlgClosed k] [CharZero k]`; the existing ℂ consumers recover as the `k = ℂ` specialisation with no signature change. Building on the generic density core, `formalCharacter_simples_coeff_eq_zero_of_torus_trace_eq_zero_general_of_algebraic` (`SchurWeylFormalCharacterIso`) is proved sorry-free — the general-`k` analogue of the ℂ seam (#4908). This is partial progress on #4947: the `hLtop`-hypothesis target reduces to the algebraic seam, isolating the single remaining `sorry` to the algebraicity bridge `hLtop ⟹ IsAlgebraicRepresentation` (strictly stronger than `hLtop` for an abstract-group representation), tracked as #4983.

🤖 Prepared with Claude Code