### PR TITLE
feat(Ch5): prove schurPoly_coeff_self_ne_zero (Kostka K_λλ=1) — re-open after #4949 closed without landing

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/KernelLemmaKPrimeAssembly.lean
+++ b/EtingofRepresentationTheory/Chapter5/KernelLemmaKPrimeAssembly.lean
@@ -55,27 +55,11 @@ namespace Etingof.KernelLemmaKPrime
 
 variable {k : Type*} [Field k] {N : ℕ}
 
-/-! ### The highest-weight multiplicity-one coefficient -/
+/-! ### The genuine core of (K′)
 
-/-- **The highest weight occurs with coefficient one.** For an antitone partition
-`lam : Fin N → ℕ`, the coefficient of `x^lam` in the Schur polynomial
-`schurPoly N lam` is nonzero (in fact `1`, the Kostka number `K_{lam,lam}`).
-
-This is the leading-term content of the Weyl character formula: the highest
-weight `lam` of the irreducible `GL_N`-representation `L_lam` has multiplicity
-one in its character `schurPoly N lam`.
-
-Proof route (issue #4949): with a monomial order `m` (e.g. `degLex`), the degree
-of `(alternantMatrix N e).det` is `symm e` for strictly-anti `e` (its sorted
-leading monomial, coeff `1` by `alternant_coeff_kronecker`); applying
-`degree_mul` to `schurPoly N lam * Δ = D_{lam+δ}` (`schurPoly_mul_vandermonde`)
-yields `m.degree (schurPoly N lam) = symm lam`, whence the coefficient there is
-nonzero by `coeff_degree_ne_zero_iff` and `schurPoly_ne_zero`. -/
-theorem schurPoly_coeff_self_ne_zero (N : ℕ) (lam : Fin N → ℕ) (hlam : Antitone lam) :
-    (schurPoly N lam).coeff (Finsupp.equivFunOnFinite.symm lam) ≠ 0 := by
-  sorry -- issue #4949: highest-weight multiplicity-one (Kostka K_λλ = 1)
-
-/-! ### The genuine core of (K′) -/
+The highest-weight multiplicity-one coefficient `x^λ` of `schurPoly N λ` is
+nonzero (the Kostka number `K_{λλ} = 1`); this is `Etingof.schurPoly_coeff_self_ne_zero`
+(`Proposition5_21_1.lean`, issue #4949), used directly in step 4 below. -/
 
 /-- **The genuine core of (K′).** For `r ≥ 1`, every *nonzero* subrepresentation
 `W` of the twisted quotient `(A/det) ⊗ χ⁻ʳ` contains a nonzero torus-weight vector
@@ -119,7 +103,7 @@ theorem quotDetTwist_nonzero_subrep_has_neg_weight (k : Type*) [Field k]
   obtain ⟨i₀, hi₀⟩ := hν_zero
   -- The highest-weight space is nonzero.
   have hcoeff : (schurPoly N ν).coeff (Finsupp.equivFunOnFinite.symm ν) ≠ 0 :=
-    schurPoly_coeff_self_ne_zero N ν hν_anti
+    Etingof.schurPoly_coeff_self_ne_zero N ν hν_anti
   have hfin_ne : Module.finrank k
       (glWeightSpace k N L (fun i => (Finsupp.equivFunOnFinite.symm ν) i)) ≠ 0 := by
     have hcc := formalCharacter_coeff k N L (Finsupp.equivFunOnFinite.symm ν)

--- a/progress/2026-06-21T23-33-54Z_3cbf5c8d.md
+++ b/progress/2026-06-21T23-33-54Z_3cbf5c8d.md
@@ -1,0 +1,36 @@
+## Accomplished
+
+Closed issue #4986: eliminated the live `sorry` for `schurPoly_coeff_self_ne_zero`
+in `Chapter5/KernelLemmaKPrimeAssembly.lean` (Kostka `K_{λλ} = 1`, highest-weight
+multiplicity one).
+
+The issue premise ("the proof never landed on main") turned out to be outdated:
+PR #4951 (commit 8c2586b8, issue #4949) **did** land a complete, sorry-free proof
+as `Etingof.schurPoly_coeff_self_ne_zero` in `Proposition5_21_1.lean:780`. The
+assembly file merely held a stale sorry'd **duplicate** of the same statement.
+
+Fix: deleted the redundant sorry'd duplicate (docstring + theorem) from
+`KernelLemmaKPrimeAssembly.lean` and pointed its single use site (step 4 of
+`quotDetTwist_nonzero_subrep_has_neg_weight`) at the canonical
+`Etingof.schurPoly_coeff_self_ne_zero`. Net −16 lines.
+
+## Current frontier
+
+`lake build EtingofRepresentationTheory.Chapter5.KernelLemmaKPrimeAssembly`
+completes successfully (8061 jobs). The assembly module builds with no `sorry`
+warning. The only remaining sorry in that import subtree is the pre-existing,
+unrelated `CauchyDetQuotient.lean:112` (tracked separately).
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. This removes one more live sorry on the
+det⁻¹-elimination critical path (`kernelLemmaK'` assembly → Proposition 5.22.2).
+
+## Next step
+
+The `CauchyDetQuotient.lean:112` sorry remains on the same critical path; if it
+lacks a tracking issue it should get one.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #4986

Session: `3cbf5c8d-d109-4159-8ca2-baed6039a8c8`

dca43f3f feat(Ch5 #4986): retire stale schurPoly_coeff_self_ne_zero sorry (use landed proof)

🤖 Prepared with Claude Code