### PR TITLE
feat(Ch5 #4995): general-support exists_dominance_maximal_tabloid (step 1 of Garnir straightening crux)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/TabloidModule.lean
+++ b/EtingofRepresentationTheory/Chapter5/TabloidModule.lean
@@ -919,6 +919,89 @@ lemma exists_dominance_maximal
     · exact hfT'
     · rfl
 
+/-- Mutual dominance forces the same tabloid (antisymmetry of dominance at the
+tabloid level): if `σ₁` dominates `σ₂` and `σ₂` dominates `σ₁`, then they define
+the same tabloid. Special case of the squeeze lemma
+`tabloidDominates_antisymm_toTabloid` with `σ₃ := σ₁`. -/
+theorem tabloidDominates_antisymm {σ₁ σ₂ : Equiv.Perm (Fin n)}
+    (h₁₂ : tabloidDominates la σ₁ σ₂) (h₂₁ : tabloidDominates la σ₂ σ₁) :
+    toTabloid n la σ₂ = toTabloid n la σ₁ :=
+  tabloidDominates_antisymm_toTabloid h₁₂ h₂₁ rfl
+
+/-- `toTabloid` of a quotient representative recovers the tabloid: `[t.out] = t`. -/
+theorem toTabloid_out (t : Tabloid n la) :
+    toTabloid n la (Quotient.out t) = t :=
+  Quotient.out_eq t
+
+/-- **General-support dominance-maximal tabloid.** Among the tabloids in any
+nonempty `Finset (Tabloid n la)` (e.g. the support of a nonzero
+`X : TabloidRepresentation n la`), there is a dominance-maximal one `t₁`: every
+support tabloid `t'` that dominates `t₁` (comparing chosen representatives
+`Quotient.out`) is in fact equal to `t₁`.
+
+This is the general-`Finsupp`-support analogue of `exists_dominance_maximal`
+(which is stated for finsets of standard Young tableaux). It is the entry point
+for the leading-term elimination in the Garnir column-straightening crux: pick a
+dominance-maximal tabloid of the residual support, subtract the matching standard
+polytabloid, and recurse. Dominance is compared on the canonical representatives
+`Quotient.out t`; since dominance is well-defined on tabloids
+(`tabloidDominates_congr`), any other representatives agree via `toTabloid_out`. -/
+lemma exists_dominance_maximal_tabloid
+    (S : Finset (Tabloid n la)) (t₀ : Tabloid n la) (ht₀ : t₀ ∈ S) :
+    ∃ t₁ ∈ S, ∀ t' ∈ S,
+      tabloidDominates la (Quotient.out t') (Quotient.out t₁) → t' = t₁ := by
+  classical
+  -- Antisymmetry transported to tabloids via their `Quotient.out` representatives.
+  have hAntisymm : ∀ a b : Tabloid n la,
+      tabloidDominates la (Quotient.out a) (Quotient.out b) →
+      tabloidDominates la (Quotient.out b) (Quotient.out a) → a = b := by
+    intro a b hab hba
+    have := tabloidDominates_antisymm (la := la) hab hba
+    rw [toTabloid_out, toTabloid_out] at this
+    exact this.symm
+  -- Measure: count strict dominators of `t` inside `S`. Strong induction on it.
+  suffices hmain : ∀ (m : ℕ) (t : Tabloid n la), t ∈ S →
+      (S.filter fun t' =>
+        tabloidDominates la (Quotient.out t') (Quotient.out t) ∧ t' ≠ t).card = m →
+      ∃ t₁ ∈ S, ∀ t' ∈ S,
+        tabloidDominates la (Quotient.out t') (Quotient.out t₁) → t' = t₁ by
+    exact hmain _ t₀ ht₀ rfl
+  intro m
+  induction m using Nat.strongRecOn with
+  | ind m ih =>
+  intro t htS hcard
+  by_cases hmax : ∀ t' ∈ S,
+      tabloidDominates la (Quotient.out t') (Quotient.out t) → t' = t
+  · exact ⟨t, htS, hmax⟩
+  · -- `t` is not maximal: some `t'` strictly dominates it.
+    push_neg at hmax
+    obtain ⟨t', ht'S, hdom, hne⟩ := hmax
+    apply ih (S.filter fun t'' =>
+        tabloidDominates la (Quotient.out t'') (Quotient.out t') ∧ t'' ≠ t').card
+    · -- Strict decrease: badSet(t') ⊊ badSet(t).
+      rw [← hcard]
+      apply Finset.card_lt_card
+      rw [Finset.ssubset_iff_of_subset]
+      · -- `t'` is in badSet(t) but not in badSet(t').
+        refine ⟨t', ?_, ?_⟩
+        · simp only [Finset.mem_filter]
+          exact ⟨ht'S, hdom, hne⟩
+        · intro hmem
+          rw [Finset.mem_filter] at hmem
+          exact hmem.2.2 rfl
+      · -- badSet(t') ⊆ badSet(t).
+        intro t'' ht''
+        simp only [Finset.mem_filter] at ht'' ⊢
+        refine ⟨ht''.1, tabloidDominates_trans ht''.2.1 hdom, ?_⟩
+        intro heq
+        -- If t'' = t, then t dom t' and t' dom t force t' = t, contradicting hne.
+        apply hne
+        have hother : tabloidDominates la (Quotient.out t) (Quotient.out t') :=
+          heq ▸ ht''.2.1
+        exact hAntisymm t' t hdom hother
+    · exact ht'S
+    · rfl
+
 /-! ### Tabloid representation (free ℂ-module on tabloids)
 
 The tabloid representation M^λ is the free ℂ-module with basis indexed by tabloids.

--- a/progress/2026-06-22T00-41-06Z_b7af40c5.md
+++ b/progress/2026-06-22T00-41-06Z_b7af40c5.md
@@ -1,0 +1,39 @@
+## Accomplished
+- **Triage on #4975** (general-k Schur-Weyl special-block, sub-C): discovered its core
+  deliverable `exists_unique_special_block` consumes two bridge lemmas
+  (`trace_symGroupAction_eq_spechtModuleCharacter`, `simpleSubmodule_iso_of_spechtCharacter_eq`)
+  that are still ℂ-only — the un-landed Sub-B2 (#4992, blocked on in-progress #4991).
+  The declared `depends-on: #4974` was satisfied on paper (closed after B1/B2 decomposition)
+  but the real dependency on #4992 was lost. Skipped #4975 (replan) with a precise
+  dependency-correction comment + scope-split suggestion.
+- **#4995** (Garnir column-straightening crux): landed the validated route's step 1 —
+  `exists_dominance_maximal_tabloid` in `TabloidModule.lean`, generalizing
+  `exists_dominance_maximal` from SYT finsets to a general `Finset (Tabloid n la)`
+  (hence any `Finsupp` support). Added helpers `tabloidDominates_antisymm`,
+  `toTabloid_out`. Sorry-free; `lake build EtingofRepresentationTheory.Chapter5.TabloidModule`
+  green (8038 jobs).
+- Created residual sub-issue **#4998** for the column-straightening invariant +
+  leading-term elimination that actually discharges `twistedPolytabloid_residual_in_V`.
+
+## Current frontier
+- `twistedPolytabloid_residual_in_V` (`SpechtModuleBasis.lean:2177`) is still the single
+  `sorry` of the standard-basis development. Step 1 (maximal-tabloid existence) is now a
+  reusable building block; steps 2-3 (corrected invariant + elimination) remain, tracked in #4998.
+
+## Overall project progress
+- Stage 3 formalization. Chapter 5 Schur-Weyl / Specht line. Two parallel threads:
+  general-k Schur-module simplicity (#4946 chain: B1 #4991 in-progress → B2 #4992 blocked →
+  C #4975 now correctly blocked on #4992), and the Specht standard-basis Garnir crux
+  (#4881 → #4995 → #4998).
+
+## Next step
+- A worker should claim **#4998** to attempt the column-straightening invariant + elimination,
+  now that `exists_dominance_maximal_tabloid` is available.
+- A planner should add `depends-on: #4992` to #4975 (and consider the scope split noted in
+  the #4975 comment: the two `youngSym_action_*` lemmas don't need the bridge and could
+  proceed in parallel).
+
+## Blockers
+- #4975 genuinely blocked on #4992 (general-k character bridge), itself blocked on #4991.
+- Mathlib pin-bump issues #2564/#2841 are now unblocked upstream (mathlib4#38583 merged) but
+  a pin bump is repo-wide-disruptive with 6 agents in flight; left for coordinated handling.


### PR DESCRIPTION
Partial progress on #4995

Session: `b7af40c5-a2c1-4e8e-b7c7-1a657ddee5e0`

08379ee2 doc(#4995): progress entry — land step-1 maximal-tabloid lemma; #4975 triage; #4998 residual sub-issue
e1143ca8 feat(Ch5 #4995): general-support exists_dominance_maximal_tabloid + tabloidDominates_antisymm

🤖 Prepared with Claude Code