### PR TITLE
chore(skill): guard git reset --hard with a git status check in agent-worker-flow

### DIFF
--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -144,6 +144,16 @@ open PR on it first (`gh pr list --head agent/<id>`). If a PR exists, create
 a new branch with a suffix (`agent/<id>-v2`). If no PR exists, reset it to
 master: `git checkout agent/<id> && git reset --hard origin/master`.
 
+**Before any `git reset --hard` (or `git checkout -- .`), run `git status`
+first.** A reused worktree often carries uncommitted edits (e.g. a prior
+session's in-progress skill tweak); `reset --hard` discards unstaged changes
+permanently — they are *not* recoverable via `git fsck`, since unstaged
+content is never hashed into an object. If `git status` shows anything you did
+not create this session, stash or commit it (never `git stash -u`) before
+resetting. The same caution applies later if a rebase reveals `main` has
+diverged from the branch you based on: resetting to `origin/main` is correct,
+but check `git status` first.
+
 Record any project-specific quality metrics (e.g. sorry count, test coverage)
 as described in the project's CLAUDE.md.
 


### PR DESCRIPTION
This PR adds an explicit `git status` safety check before the `git reset --hard origin/master` instruction in the `agent-worker-flow` skill's reused-worktree setup step. A reused worktree often carries a prior session's unstaged edits, which `reset --hard` discards permanently — unstaged content is never hashed into a git object, so it is not recoverable via `git fsck`. The guard also covers the later rebase-divergence reset to `origin/main`. Discovered during #4983 when an unstaged skill edit was lost this way.

🤖 Prepared with Claude Code