### PR TITLE
feat(Ch5 #4998): prove twistedPolytabloid_residual_in_V via leading-term elimination

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/SpechtModuleBasis.lean
+++ b/EtingofRepresentationTheory/Chapter5/SpechtModuleBasis.lean
@@ -2134,32 +2134,196 @@ private theorem twistedPolytabloid_per_q_decomp
     · simp only [perQ_eq, Finset.mem_filter, Finset.mem_univ, true_and] at hq_eq
       exact tabloidDominates_congr hq_eq.1 rfl h_dom_τα
 
+/-! ### Leading-term elimination measure (R2.b)
+
+The residual `X := f_w(σ) − M` (with `M ∈ V`) is straightened by repeatedly
+subtracting `c·ψ_{β'}` for the column-standardization `β'` of a
+dominance-maximal support tabloid. Each subtraction kills the maximal tabloid
+and only introduces strictly-lower ones, so the lexicographic measure
+`(maxSrRankSupp X, cardAtMaxSrRank X)` strictly decreases. We encode the lex
+pair as a single `ℕ` via the bound `cardAtMaxSrRank ≤ #(Tabloid n la)`. -/
+
+/-- The maximal `srRank` over the tabloid support of `X` (0 if `X = 0`). -/
+private noncomputable def maxSrRankSupp (X : TabloidRepresentation n la) : ℕ :=
+  X.support.sup (fun t => srRank la (Quotient.out t))
+
+/-- The number of support tabloids of `X` attaining the maximal `srRank`. -/
+private noncomputable def cardAtMaxSrRank (X : TabloidRepresentation n la) : ℕ :=
+  (X.support.filter (fun t => srRank la (Quotient.out t) = maxSrRankSupp X)).card
+
+/-- The single-`ℕ` lexicographic termination measure for leading-term
+elimination: `maxSrRankSupp` is the high word, `cardAtMaxSrRank` the low word
+(bounded by `#(Tabloid n la)`). -/
+private noncomputable def resMeasure (X : TabloidRepresentation n la) : ℕ :=
+  maxSrRankSupp X * (Fintype.card (Tabloid n la) + 1) + cardAtMaxSrRank X
+
+/-- **Leading-term elimination decreases the measure.** If `t₁` is a support
+tabloid of `X` of maximal `srRank`, `ψ`'s support below `t₁` (everything except
+`t₁` is strictly `srRank`-lower than `t₁`'s level), and the subtraction
+`X − c•ψ` annihilates `t₁`, then `resMeasure (X − c•ψ) < resMeasure X`. -/
+private theorem resMeasure_sub_lt
+    (X ψ : TabloidRepresentation n la) (c : ℂ) (t₁ : Tabloid n la)
+    (ht₁ : t₁ ∈ X.support)
+    (ht₁max : srRank la (Quotient.out t₁) = maxSrRankSupp X)
+    (hsub : (X - c • ψ) t₁ = 0)
+    (hψ_below : ∀ t, t ≠ t₁ → ψ t ≠ 0 →
+        srRank la (Quotient.out t) < maxSrRankSupp X) :
+    resMeasure (X - c • ψ) < resMeasure X := by
+  classical
+  set R := maxSrRankSupp X with hR
+  -- `ψ` vanishes on level-`R` tabloids other than `t₁`.
+  have hψ_zero_at_R : ∀ t, t ≠ t₁ → srRank la (Quotient.out t) = R → ψ t = 0 := by
+    intro t hne hlev
+    by_contra hne0
+    have := hψ_below t hne hne0
+    omega
+  -- The max level of `X − c•ψ` is `≤ R`.
+  have hmax_le : maxSrRankSupp (X - c • ψ) ≤ R := by
+    unfold maxSrRankSupp
+    apply Finset.sup_le
+    intro t ht
+    simp only [Finsupp.mem_support_iff, Finsupp.sub_apply, Finsupp.smul_apply,
+      smul_eq_mul] at ht
+    by_cases hXt : X t = 0
+    · have hψt : ψ t ≠ 0 := by
+        intro h; apply ht; rw [hXt, h, mul_zero, sub_zero]
+      by_cases htt₁ : t = t₁
+      · rw [htt₁]; omega
+      · exact le_of_lt (hψ_below t htt₁ hψt)
+    · have htmem : t ∈ X.support := Finsupp.mem_support_iff.mpr hXt
+      rw [hR]
+      exact Finset.le_sup (f := fun t => srRank la (Quotient.out t)) htmem
+  -- The level-`R` support of `X − c•ψ` is the level-`R` support of `X` minus `t₁`.
+  have hfilter : ((X - c • ψ).support.filter
+        (fun t => srRank la (Quotient.out t) = R)) =
+      (X.support.filter (fun t => srRank la (Quotient.out t) = R)).erase t₁ := by
+    apply Finset.ext
+    intro t
+    obtain ⟨a, rfl⟩ : ∃ a : Equiv.Perm (Fin n), toTabloid n la a = t :=
+      ⟨Quotient.out t, toTabloid_out t⟩
+    simp only [Finset.mem_filter, Finset.mem_erase, Finsupp.mem_support_iff]
+    constructor
+    · rintro ⟨hne0, hlev⟩
+      have htt₁ : toTabloid n la a ≠ t₁ := by
+        intro heq; rw [heq] at hne0; exact hne0 hsub
+      have hψ0 : ψ (toTabloid n la a) = 0 := hψ_zero_at_R _ htt₁ hlev
+      have hcψ0 : (c • ψ) (toTabloid n la a) = 0 := by
+        show c • ψ (toTabloid n la a) = 0
+        rw [hψ0, smul_zero]
+      have hXt : X (toTabloid n la a) ≠ 0 := by
+        have hXeq : X (toTabloid n la a) = (X - c • ψ) (toTabloid n la a) := by
+          rw [Finsupp.sub_apply, hcψ0, sub_zero]
+        rw [hXeq]; exact hne0
+      exact ⟨htt₁, hXt, hlev⟩
+    · rintro ⟨htt₁, hXt, hlev⟩
+      have hψ0 : ψ (toTabloid n la a) = 0 := hψ_zero_at_R _ htt₁ hlev
+      have hcψ0 : (c • ψ) (toTabloid n la a) = 0 := by
+        show c • ψ (toTabloid n la a) = 0
+        rw [hψ0, smul_zero]
+      refine ⟨?_, hlev⟩
+      show (X - c • ψ) (toTabloid n la a) ≠ 0
+      have hXeq : (X - c • ψ) (toTabloid n la a) = X (toTabloid n la a) := by
+        rw [Finsupp.sub_apply, hcψ0, sub_zero]
+      rw [hXeq]; exact hXt
+  have ht₁_in : t₁ ∈ X.support.filter (fun t => srRank la (Quotient.out t) = R) := by
+    rw [Finset.mem_filter]; exact ⟨ht₁, ht₁max⟩
+  have hReq : maxSrRankSupp X = R := hR.symm
+  -- Three facts feeding the lexicographic arithmetic comparison.
+  have fact3 : 0 < cardAtMaxSrRank X := by
+    unfold cardAtMaxSrRank
+    refine Finset.card_pos.mpr ⟨t₁, ?_⟩
+    rw [Finset.mem_filter]; exact ⟨ht₁, ht₁max.trans hR⟩
+  have fact4 : cardAtMaxSrRank (X - c • ψ) ≤ Fintype.card (Tabloid n la) := by
+    unfold cardAtMaxSrRank; exact Finset.card_le_univ _
+  have fact2 : maxSrRankSupp (X - c • ψ) = R →
+      cardAtMaxSrRank (X - c • ψ) = cardAtMaxSrRank X - 1 := by
+    intro hmeq
+    unfold cardAtMaxSrRank
+    simp only [hmeq, hReq]
+    rw [hfilter]
+    exact Finset.card_erase_of_mem ht₁_in
+  -- Generic comparison of the single-`ℕ` lex measure.
+  have harith : ∀ (a b m Q F : ℕ), m < Q → a ≤ F →
+      m * (F + 1) + a < Q * (F + 1) + b := by
+    intro a b m Q F hmQ haF
+    have h1 : m + 1 ≤ Q := hmQ
+    calc m * (F + 1) + a
+        ≤ m * (F + 1) + F := by omega
+      _ < m * (F + 1) + (F + 1) := by omega
+      _ = (m + 1) * (F + 1) := by ring
+      _ ≤ Q * (F + 1) := by gcongr
+      _ ≤ Q * (F + 1) + b := by omega
+  rcases eq_or_lt_of_le hmax_le with heq | hlt
+  · -- `maxSrRankSupp (X − c•ψ) = R`: the low word drops by one.
+    have hc2 := fact2 heq
+    unfold resMeasure
+    have hmeq' : maxSrRankSupp (X - c • ψ) = maxSrRankSupp X := by rw [heq, hReq]
+    rw [hmeq']
+    omega
+  · -- `maxSrRankSupp (X − c•ψ) < R`: the high word drops.
+    unfold resMeasure
+    have hmlt : maxSrRankSupp (X - c • ψ) < maxSrRankSupp X := by rw [hReq]; exact hlt
+    exact harith _ _ _ _ _ hmlt fact4
+
+/-- **R2.b invariant — the genuine James/Fulton column-straightening nut.**
+For column-standard `σ`, any `w`, and any `M ∈ V` with the residual
+`X := f_w(σ) − M` having support bounded by `[σ]`, every dominance-maximal
+tabloid `t₁` of `X` is column-standardizable: there is a column-standard
+`β'` with `[β'] = t₁` that is IH-available, i.e. either `[β']` is strictly
+dominated by `[σ]` (so `srRank β' < srRank σ`), or `[β'] = [σ]` with strictly
+fewer row inversions.
+
+This is the validated-true crux (route 1 of #4881) isolated as its own lemma;
+it is consumed by `twistedPolytabloid_residual_in_V` via leading-term
+elimination. Refuted routes (pointwise vanishing of `Δ`, cross-region
+involution, column-antisymmetry via the global stabiliser, and circular
+application of `tabloidSupport_straightening`) must NOT be re-attempted — see
+`progress/r2b-crux-strategy-refuted.md`,
+`progress/r2b-crux-is-column-antisymmetry.md`,
+`progress/r2b-redesign-direct-polytabloid.md`. -/
+private theorem twistedPolytabloid_residual_invariant
+    (σ : Equiv.Perm (Fin n)) (hcs : isColumnStandard' n la σ)
+    (hrp : 0 < rowInvCount' (la := la) σ)
+    (w : Equiv.Perm (Fin n))
+    (M : TabloidRepresentation n la)
+    (hM : M ∈ Submodule.span ℂ (Set.range (fun T : StandardYoungTableau n la =>
+        polytabloidTab (n := n) (la := la) T)))
+    (hsupp : ∀ α : Equiv.Perm (Fin n),
+        (twistedPolytabloid (la := la) w σ - M) (toTabloid n la α) ≠ 0 →
+        tabloidDominates la σ α)
+    (t₁ : Tabloid n la)
+    (ht₁ : t₁ ∈ (twistedPolytabloid (la := la) w σ - M).support)
+    (hmax : ∀ t' ∈ (twistedPolytabloid (la := la) w σ - M).support,
+        tabloidDominates la (Quotient.out t') (Quotient.out t₁) → t' = t₁) :
+    ∃ β' : Equiv.Perm (Fin n), isColumnStandard' n la β' ∧
+      toTabloid n la β' = t₁ ∧
+      (srRank la β' < srRank la σ ∨
+        (srRank la β' = srRank la σ ∧
+          rowInvCount' (la := la) β' < rowInvCount' (la := la) σ)) := by
+  sorry
+
 /-- **R2.b — The residual lies in `V`** (the genuine crux of the Garnir
-straightening, validated but not yet formalized).
+straightening).
 
 From `twistedPolytabloid_per_q_decomp`, `f_w(σ) = twistedIHPart σ w + Δ` where
 `Δ := f_w(σ) − twistedIHPart σ w` has tabloid support bounded by `[σ]`. This
-lemma asserts the remaining content: `Δ ∈ V` (the SYT-polytabloid span).
+lemma establishes the remaining content: `Δ ∈ V` (the SYT-polytabloid span).
 Combined with `twistedIHPart_mem_span` it gives `f_w(σ) ∈ V`, which together
 with the support bound and the R1 bridge `in_L_of_in_V_of_supp_bounded`
 discharges `garnir_twisted_in_lower_span` (see directly below).
 
-**Status: the single remaining `sorry` of the standard-basis development.**
-This is the validated-true crux that has resisted every shortcut; do NOT
-re-attempt a refuted route (see `progress/r2b-crux-strategy-refuted.md`,
-`progress/r2b-crux-is-column-antisymmetry.md`, `progress/r2b-redesign-direct-polytabloid.md`).
-The validated route (route 1 in issue #4881) is leading-term elimination over
-`Δ`'s `Finsupp (Tabloid) ℂ` support using the corrected invariant:
-
-> For col-std σ, any w, and any `M ∈ V` with `supp(f_w σ − M) ≼ [σ]`, every
-> dominance-maximal tabloid of `X := f_w σ − M` is column-standardizable, with
-> an IH-available representative `β'` (`[β'] ≼ [σ]`).
-
-Subtract `c·ψ_{β'}` for the dominance-maximal `β'` (discharged by `ih` since
-`β'` is col-std and lex-below σ), repeat. Termination measure: lex
-`(maxSrRankOfSupport X, cardOfSupportAtMaxSrRank X)`. Needs
-`exists_dominance_maximal` extended from SYT finsets to a general tabloid
-`Finsupp` support. -/
+**The leading-term elimination assembly is now proved here**, by strong
+induction on the single-`ℕ` lexicographic `resMeasure`
+`= maxSrRankSupp X * (#Tabloid + 1) + cardAtMaxSrRank X`. At each step we pick a
+maximal-`srRank` support tabloid `t₁` (automatically dominance-maximal), invoke
+the column-straightening invariant `twistedPolytabloid_residual_invariant` to
+obtain its column-standard representative `β'` (`[β'] = [t₁]`, IH-available),
+subtract `c·ψ_{β'}` (in `V` by `ih`), and recurse: `resMeasure_sub_lt` shows the
+measure strictly drops. The only remaining `sorry` is the isolated invariant
+itself (the genuine James/Fulton nut). Do NOT re-attempt a refuted route (see
+`progress/r2b-crux-strategy-refuted.md`,
+`progress/r2b-crux-is-column-antisymmetry.md`,
+`progress/r2b-redesign-direct-polytabloid.md`). -/
 private theorem twistedPolytabloid_residual_in_V
     (σ : Equiv.Perm (Fin n)) (hcs : isColumnStandard' n la σ)
     (hrp : 0 < rowInvCount' (la := la) σ)
@@ -2174,7 +2338,122 @@ private theorem twistedPolytabloid_residual_in_V
     (twistedPolytabloid (la := la) w σ - twistedIHPart (la := la) σ w) ∈
       Submodule.span ℂ (Set.range (fun T : StandardYoungTableau n la =>
         polytabloidTab (n := n) (la := la) T)) := by
-  sorry
+  classical
+  set V := Submodule.span ℂ (Set.range (fun T : StandardYoungTableau n la =>
+      polytabloidTab (n := n) (la := la) T)) with hV
+  -- Generalized claim: any `f_w σ − M` with `M ∈ V` and support `≼ [σ]` lies in
+  -- `V`, proved by strong induction on `resMeasure`.
+  suffices hmain : ∀ (N : ℕ) (M : TabloidRepresentation n la), M ∈ V →
+      (∀ α : Equiv.Perm (Fin n),
+          (twistedPolytabloid (la := la) w σ - M) (toTabloid n la α) ≠ 0 →
+          tabloidDominates la σ α) →
+      resMeasure (twistedPolytabloid (la := la) w σ - M) = N →
+      (twistedPolytabloid (la := la) w σ - M) ∈ V by
+    -- Apply with `M = twistedIHPart σ w`, whose residual support bound comes
+    -- from `twistedPolytabloid_per_q_decomp`.
+    obtain ⟨Δ, hΔeq, _hΔIH, hΔsupp⟩ := twistedPolytabloid_per_q_decomp σ hcs hrp w ih
+    have hΔval : twistedPolytabloid (la := la) w σ - twistedIHPart (la := la) σ w = Δ := by
+      rw [hΔeq]; abel
+    have hIH_V : twistedIHPart (la := la) σ w ∈ V := twistedIHPart_mem_span σ w ih
+    have hsupp : ∀ α : Equiv.Perm (Fin n),
+        (twistedPolytabloid (la := la) w σ - twistedIHPart (la := la) σ w)
+          (toTabloid n la α) ≠ 0 → tabloidDominates la σ α := by
+      intro α hα; rw [hΔval] at hα; exact hΔsupp α hα
+    exact hmain _ _ hIH_V hsupp rfl
+  intro N
+  induction N using Nat.strongRecOn with
+  | ind N IH =>
+  intro M hM hsupp hμ
+  by_cases hzero : twistedPolytabloid (la := la) w σ - M = 0
+  · rw [hzero]; exact Submodule.zero_mem V
+  · -- The support is nonempty; pick a maximal-`srRank` support tabloid `t₁`.
+    set X := twistedPolytabloid (la := la) w σ - M with hX
+    have hne : X.support.Nonempty := by
+      rw [Finsupp.support_nonempty_iff]; exact hzero
+    obtain ⟨t₁, ht₁, ht₁eq⟩ :=
+      Finset.exists_mem_eq_sup X.support hne (fun t => srRank la (Quotient.out t))
+    -- `ht₁eq : maxSrRankSupp X = srRank la (out t₁)`.
+    have ht₁max : srRank la (Quotient.out t₁) = maxSrRankSupp X := ht₁eq.symm
+    -- A maximal-`srRank` tabloid is dominance-maximal.
+    have hmax : ∀ t' ∈ X.support,
+        tabloidDominates la (Quotient.out t') (Quotient.out t₁) → t' = t₁ := by
+      intro t' ht' hdom
+      by_contra hne'
+      have hstrict : tabloidStrictDominates la (Quotient.out t') (Quotient.out t₁) := by
+        refine ⟨hdom, ?_⟩
+        rw [toTabloid_out, toTabloid_out]; exact hne'
+      have hlt := srRank_lt_of_tabloidStrictDominates hstrict
+      have hle : srRank la (Quotient.out t') ≤ maxSrRankSupp X := by
+        rw [maxSrRankSupp]
+        exact Finset.le_sup (f := fun t => srRank la (Quotient.out t)) ht'
+      omega
+    -- Invoke the column-straightening invariant.
+    obtain ⟨β', hβcs, hβtab, hβrank⟩ :=
+      twistedPolytabloid_residual_invariant σ hcs hrp w M hM hsupp t₁ ht₁ hmax
+    set ψ := generalizedPolytabloidTab (n := n) (la := la) β' with hψ
+    have hψV : ψ ∈ V := ih β' hβcs hβrank
+    -- Leading coefficient of `ψ` at `t₁` is `1`.
+    have hψ_t₁ : ψ t₁ = 1 := by
+      rw [hψ, ← hβtab]; exact generalizedPolytabloidTab_coeff_self β'
+    set c := X t₁ with hc
+    have hc_ne : c ≠ 0 := by
+      rw [hc]; exact Finsupp.mem_support_iff.mp ht₁
+    -- `dominates σ β'`: `t₁ = [β']` is in `supp X`.
+    have hdom_σβ' : tabloidDominates la σ β' := by
+      apply hsupp β'
+      rw [hβtab, ← hc]; exact hc_ne
+    -- The subtraction `X − c•ψ` annihilates `t₁`.
+    have hsub_t₁ : (X - c • ψ) t₁ = 0 := by
+      rw [Finsupp.sub_apply, Finsupp.smul_apply, smul_eq_mul, hψ_t₁, mul_one, ← hc,
+        sub_self]
+    -- Below `t₁`: every other support tabloid of `ψ` is strictly `srRank`-lower.
+    have hβ_lead := generalizedPolytabloidTab_leading_tabloid β' hβcs
+    have hψ_below : ∀ t, t ≠ t₁ → ψ t ≠ 0 →
+        srRank la (Quotient.out t) < maxSrRankSupp X := by
+      intro t htt₁ hψt
+      have hne_tab : toTabloid n la (Quotient.out t) ≠ toTabloid n la β' := by
+        rw [toTabloid_out, hβtab]; exact htt₁
+      have hψ_ne0 : ψ (toTabloid n la (Quotient.out t)) ≠ 0 := by
+        rw [toTabloid_out]; exact hψt
+      have hstrict := hβ_lead.2 (Quotient.out t) hne_tab hψ_ne0
+      have hlt := srRank_lt_of_tabloidStrictDominates hstrict
+      -- `srRank β' = srRank (out t₁)` since `[β'] = t₁`.
+      have hrankβ' : srRank la β' = srRank la (Quotient.out t₁) := by
+        apply srRank_eq_of_toTabloid_eq
+        rw [hβtab, toTabloid_out]
+      omega
+    -- Define `M' := M + c•ψ ∈ V`; then `X − c•ψ = f_w σ − M'`.
+    have hM'V : M + c • ψ ∈ V := add_mem hM (Submodule.smul_mem V c hψV)
+    have hX'eq : X - c • ψ = twistedPolytabloid (la := la) w σ - (M + c • ψ) := by
+      rw [hX]; abel
+    -- Support of `X − c•ψ` is still bounded by `[σ]`.
+    have hsupp' : ∀ α : Equiv.Perm (Fin n),
+        (twistedPolytabloid (la := la) w σ - (M + c • ψ)) (toTabloid n la α) ≠ 0 →
+        tabloidDominates la σ α := by
+      intro α hα
+      rw [← hX'eq, Finsupp.sub_apply, Finsupp.smul_apply, smul_eq_mul] at hα
+      by_cases hXα : X (toTabloid n la α) = 0
+      · -- then `ψ (toTabloid α) ≠ 0`, so `dominates β' α`, and `dominates σ β'`.
+        have hψα : ψ (toTabloid n la α) ≠ 0 := by
+          intro h; apply hα; rw [hXα, h, mul_zero, sub_zero]
+        have hdom_β'α := generalizedPolytabloidTab_coeff_dominance β' hβcs α hψα
+        exact tabloidDominates_trans hdom_σβ' hdom_β'α
+      · exact hsupp α hXα
+    -- The measure strictly decreases.
+    have hlt_measure : resMeasure (X - c • ψ) < resMeasure X :=
+      resMeasure_sub_lt X ψ c t₁ ht₁ ht₁max hsub_t₁ hψ_below
+    -- Apply the inductive hypothesis to `X − c•ψ = f_w σ − M'`.
+    have hX'V : twistedPolytabloid (la := la) w σ - (M + c • ψ) ∈ V := by
+      apply IH (resMeasure (twistedPolytabloid (la := la) w σ - (M + c • ψ)))
+      · rw [← hX'eq]; rw [hμ] at hlt_measure; exact hlt_measure
+      · exact hM'V
+      · exact hsupp'
+      · rfl
+    -- Reassemble: `X = (X − c•ψ) + c•ψ ∈ V`.
+    have hreassemble : X = (twistedPolytabloid (la := la) w σ - (M + c • ψ)) + c • ψ := by
+      rw [hX]; abel
+    rw [hreassemble]
+    exact add_mem hX'V (Submodule.smul_mem V c hψV)
 
 /-- **Twisted polytabloid in lower span** (sub-sorry 2 of 2):
 For column-standard σ with row inversion, each Garnir permutation w that is

--- a/progress/2026-06-22T01-37-42Z_7a412918.md
+++ b/progress/2026-06-22T01-37-42Z_7a412918.md
@@ -1,0 +1,78 @@
+## Accomplished
+
+Worked issue #4998 (Ch5 #4995 residual: discharge `twistedPolytabloid_residual_in_V`
+via column-straightening + leading-term elimination).
+
+**The leading-term elimination assembly is now fully proved, sorry-free.**
+`twistedPolytabloid_residual_in_V` (`Chapter5/SpechtModuleBasis.lean`) no longer
+contains a `sorry`: it is discharged by strong induction on a single-`ℕ`
+lexicographic termination measure. The single remaining `sorry` in the file has
+been moved into a sharply-stated, isolated invariant lemma.
+
+New infrastructure in `Chapter5/SpechtModuleBasis.lean`:
+
+- `maxSrRankSupp`, `cardAtMaxSrRank`, `resMeasure` — the lex measure
+  `resMeasure X = maxSrRankSupp X * (#Tabloid + 1) + cardAtMaxSrRank X`,
+  encoding the lex pair `(maxSrRankSupp, cardAtMaxSrRank)` as one `ℕ`.
+- `resMeasure_sub_lt` (proved) — subtracting `c·ψ` that annihilates a
+  maximal-`srRank` support tabloid `t₁`, where `ψ` only contributes strictly
+  below `t₁`'s level, strictly drops `resMeasure`. Case split on whether the
+  high word stays equal (low word drops by one) or drops.
+- `twistedPolytabloid_residual_invariant` (the one remaining `sorry`) — the
+  genuine James/Fulton column-straightening nut: for col-std σ, `M ∈ V` with
+  `supp(f_w σ − M) ≼ [σ]`, every dominance-maximal tabloid `t₁` of `f_w σ − M`
+  has a column-standard `β'` with `[β'] = t₁` that is IH-available
+  (`srRank β' < srRank σ`, or `[β'] = [σ]` with fewer row inversions).
+- `twistedPolytabloid_residual_in_V` (proved) — strong-induction assembly:
+  pick a max-`srRank` support tabloid (automatically dominance-maximal via
+  `srRank_lt_of_tabloidStrictDominates`), straighten it with the invariant,
+  subtract `c·ψ_{β'}` (in `V` by `ih`, leading coeff 1 at `t₁` by
+  `generalizedPolytabloidTab_coeff_self`), recurse via `resMeasure_sub_lt`.
+
+`lake build EtingofRepresentationTheory.Chapter5.SpechtModuleBasis` is green
+(8039 jobs).
+
+## Key patterns discovered
+
+- **Coercion-match gremlin over `Tabloid = Quotient (TabloidSetoid …)`.** `rw`
+  and `simp only` need *syntactic* matches at reducible transparency, where the
+  `def Tabloid` does not unfold; a Finsupp value `ψ t` written by hand vs.
+  produced by `Finsupp.smul_apply` over a raw `Quotient` element fail to match,
+  even though they are defeq. Workarounds that succeeded:
+  - introduce an explicit representative `obtain ⟨a, rfl⟩ : ∃ a, toTabloid n la a = t`
+    so Finsupp applications are over `toTabloid n la a` (rw-friendly, like the
+    `per_q_decomp` proof);
+  - use `Finsupp.smul_apply` being `rfl`: `show c • ψ (toTabloid n la a) = 0`
+    to reach a defeq goal whose hand-written `ψ (…)` then matches `hψ0`;
+  - prefer `exact`/function application (defeq-tolerant) over `rw`; use `show`
+    to convert a simp-normalized goal back to the hand-written form.
+- `Finset.le_sup`/`exists_mem_eq_sup` need the `(f := …)` named argument to
+  avoid a stuck `OrderBot ?m` instance.
+
+## Current frontier
+
+One `sorry` remains in `Chapter5/SpechtModuleBasis.lean`:
+`twistedPolytabloid_residual_invariant` (the column-straightening invariant).
+Everything that consumes it is proved.
+
+## Overall project progress
+
+Stage 3 formalization. `SpechtModuleBasis.lean` went from 1 deep `sorry`
+(`twistedPolytabloid_residual_in_V`, the whole crux) to 1 isolated `sorry`
+(`twistedPolytabloid_residual_invariant`, the combinatorial James/Fulton nut),
+with the entire leading-term elimination engine now proved.
+
+## Next step
+
+Prove `twistedPolytabloid_residual_invariant`. This is the genuine
+James/Fulton column-straightening theorem: a dominance-maximal tabloid of
+`f_w σ − M` (`M ∈ V`, support `≼ [σ]`) is column-standardizable *preserving the
+tabloid* (`[β'] = t₁`), with IH-available `β'`. The tabloid-preservation is the
+heart — column standardization in general raises dominance
+(`colStd_column_perm_dominance`); maximality forces equality. Tracked in a new
+sub-issue (see below).
+
+## Blockers
+
+None. The remaining invariant is a self-contained combinatorial lemma with all
+consuming machinery proved; it is filed as a sub-issue.


### PR DESCRIPTION
Partial progress on #4998

Session: `7a412918-41ab-4084-a51e-9dfedfd4414f`

e7868152 feat(Ch5 #4998 partial): prove twistedPolytabloid_residual_in_V via leading-term elimination; isolate column-straightening invariant (#5010)

🤖 Prepared with Claude Code