### PR TITLE
chore: queue-hygiene for blocked Ch5 #4905 cluster + worker-flow guard

### DIFF
--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -169,12 +169,24 @@ Check that the plan's assumptions still hold:
 - Quality metrics match what the issue says
 - Files mentioned in the issue still exist and haven't been restructured
 - No recently merged PR invalidates the plan
+- **An issue citing infrastructure as "landed in PR #N" is not proof it is on
+  `main`.** The PR may still be open with failing CI. Before starting, `grep`
+  `main` for the named symbols (defs/lemmas the issue says you can build on). If
+  they are absent, the issue is blocked on that PR, not ready — skip it.
 
 If stale:
 ```
 coordination skip <issue-number> "reason: <what changed>"
 ```
 Go back to Step 1 and try the next issue.
+
+**When you skip an issue as blocked on an unmerged PR, spare the next worker:**
+check the sibling unclaimed issues for the same blocker and wire it in so they
+drop out of `list-unclaimed`. Use `coordination add-dep <sibling> <openIssue>`
+when an *open* issue tracks the blocker; if the blocker's tracking issue is
+already closed (e.g. a `replan`'d parent whose PR is still open), leave a short
+comment on the sibling naming the blocking PR instead, since `add-dep` only
+applies the `blocked` label for open dependencies.
 
 **PR fix plans**: If the plan asks you to fix a broken PR, use judgement. If the
 PR is low quality or not worth salvaging:

--- a/progress/2026-06-22T01-44-10Z_ee6a5806.md
+++ b/progress/2026-06-22T01-44-10Z_ee6a5806.md
@@ -1,0 +1,62 @@
+## Accomplished
+
+`/work` (meta) session. Claimed **#5003** (`quotDetDegreeFDRep_formalCharacter`,
+the residual of Ch5 #4960 part-B) but found its entire foundation missing from
+`main`, then did queue hygiene across the blocked Ch5 #4905 cluster so successor
+worker sessions don't repeat the wasted claim.
+
+- **Diagnosed #5003 as blocked and skipped it** (`replan`). The issue's premise
+  ("Deliverable 1 + infra landed sorry-free in PR #4997") is false on `main`:
+  `quotDetDegreeFDRep` (the FDRep packaging), `formalCharacter_add_of_shortExact`,
+  `polyRight_iSup_glWeightSpace_eq_top`, `twistFDRep`, `formalCharacter_twistFDRep`
+  are all **absent** — they live only in PR **#4997** (head `agent/8063b0cd`,
+  closes the now-CLOSED/`replan` #4960), which is OPEN with **FAILED CI**. The
+  target theorem is not even stubbed on main. Skip reason records the full list.
+- **Queue hygiene** (so blocked issues stop draining worker sessions — they sat
+  in `list-unclaimed` because they carried no `depends-on:` lines):
+  - **#4976** → `add-dep` #5004 + #5005 (Sub-C1/C2). Its deliverable needs
+    general-`k` special-block lemmas, but `exists_unique_special_block` is still
+    ℂ-only on main; the general-`k` versions are in-progress (#5004 claimed) /
+    blocked (#5005). Now `blocked`.
+  - **#4905** → already had `depends-on: #4961`; `add-dep` applied the missing
+    `blocked` label. Now `blocked`.
+  - **#4961** → `add-dep` #5003 (+ explanatory comment). Both its deliverables
+    reference `quotDetDegreeFDRep`, which is not on main (same #4997 root cause).
+    #4960 is closed so it could not be the dep target; #5003 (open, `replan`) is
+    the live tracker for the same "(A/det)_d not on main" blocker. Now `blocked`.
+- Restored a stray uncommitted revert of `.claude/skills/agent-worker-flow/SKILL.md`
+  (a reused-worktree artifact that would have reverted merged #5008 guidance);
+  reset the branch cleanly to `origin/main`. No code changes landed.
+
+## Current frontier
+
+Ch5 #4905 cluster (`quotDetRep_irreducible_constituent_lastWeight_zero`) is fully
+gated on PR **#4997** being repaired and merged. The general-`k` Schur-module
+simplicity track (#4976) is gated on Sub-C (#5004/#5005).
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing, Chapter 5. After this session's hygiene, the
+unclaimed **feature** queue contains only:
+- **#2564** — Mathlib-upstream tracker, blocked on external mathlib4 PR #38583 merge.
+- **#2841** — the coordinated atomic Mathlib pin-bump (v4.28.1 → v4.31.0, ~120
+  errors across ~20 modules) on dedicated branch `agent/64f2e40f-bump`. Not a
+  single-session auto-merge task; the shared `.lake/packages/mathlib` symlink
+  means it must be built/verified in an isolated `/tmp` clone.
+
+Everything else actionable is blocked on in-flight PRs (#4997, #5004, #5005,
+#4991, #4992, #4993).
+
+## Next step
+
+For a feature worker: the actionable queue is effectively empty until in-flight
+PRs land. Highest-leverage unblock is **repairing PR #4997** (CI FAILED) — that
+single PR unblocks #5003, #4961, and #4905. That is the `repair` agent's job, not
+a worker's. A planner should, once #4997 lands, re-block/re-scope #5003, #4961,
+#4905 onto the landed (A/det)_d packaging.
+
+## Blockers
+
+- PR #4997 (FAILED CI, unmerged) blocks the entire Ch5 #4905 cluster.
+- Sub-C (#5004 in-progress, #5005 blocked on #4992) blocks #4976.
+- External mathlib4 merge + the #2841 coordinated bump block #2564/#2841.


### PR DESCRIPTION
This PR records a `/work` session that found the actionable feature queue drained: the top candidate #5003 (and siblings #4961, #4905) depend on `quotDetDegreeFDRep` packaging + formal-character infrastructure that is **not on `main`** — it lives only in PR #4997 (closes #4960), which is open with FAILED CI. The session skipped #5003 (`replan`) and wired the sibling blocked issues out of the unclaimed queue (#4976→#5004/#5005, #4905→#4961, #4961→#5003) so successor workers don't repeat the wasted claim.

It also adds a Step 4 note to the `agent-worker-flow` skill: an issue citing infrastructure as "landed in PR #N" is not proof it is on `main` (grep the named symbols first), and when skipping a blocked issue, dep-link or comment the siblings sharing the blocker. Includes the session progress file. No Lean code changes.

🤖 Prepared with Claude Code