### PR TITLE
doc(skill): distinguish stray clobber from in-progress work in reused worktrees

### DIFF
--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -149,10 +149,15 @@ first.** A reused worktree often carries uncommitted edits (e.g. a prior
 session's in-progress skill tweak); `reset --hard` discards unstaged changes
 permanently — they are *not* recoverable via `git fsck`, since unstaged
 content is never hashed into an object. If `git status` shows anything you did
-not create this session, stash or commit it (never `git stash -u`) before
-resetting. The same caution applies later if a rebase reveals `main` has
-diverged from the branch you based on: resetting to `origin/main` is correct,
-but check `git status` first.
+not create this session, judge what it is before acting: genuine in-progress
+work (e.g. a half-finished skill tweak) should be stashed or committed (never
+`git stash -u`) before resetting; but a *stray clobber* — uncommitted deletions
+or reverts of committed content you did not make (a known hazard of reused
+worktrees; seen on `.claude/` files) — should be reverted with
+`git restore <files>` to HEAD, not stashed or committed, so the loss does not
+ride along into your PR or get hidden. The same caution applies later if a
+rebase reveals `main` has diverged from the branch you based on: resetting to
+`origin/main` is correct, but check `git status` first.
 
 Record any project-specific quality metrics (e.g. sorry count, test coverage)
 as described in the project's CLAUDE.md.


### PR DESCRIPTION
This PR refines the agent-worker-flow reused-worktree guidance to distinguish a *stray clobber* (uncommitted deletions or reverts of committed content the agent did not make) from genuine in-progress work. The existing "stash or commit it" advice is wrong for a clobber — it propagates or hides the loss; such cases should be reverted with `git restore <files>` to HEAD instead. Reflect output from the #5034 review session, where this worktree carried a 97-line deletion of `.claude/` safety/audit guidance (a hazard a prior session hit too, #5032).

🤖 Prepared with Claude Code