### PR TITLE
progress(planner e1b5f339): refill queue with review #5043 + #5044

### DIFF
--- a/plans/e1b5f339-1.md
+++ b/plans/e1b5f339-1.md
@@ -1,0 +1,62 @@
+## Current state
+
+`CauchyCharDiff.lean` (146 lines, **0 sorries**) is the sorry-free file that
+discharges the subtraction term of the now-completed right-`GL_N` Cauchy
+character identity `polyRightDegreeFDRep_formalCharacter`
+(`CauchyCharacterRightAssembly.lean:92`, itself now sorry-free). It is **not**
+covered by the earlier Cauchy audit #5019: at the time of #5019 the assembly
+still carried 6 deferred sorries, and `CauchyCharDiff.lean` was not in that
+issue's four-file scope (`CauchySchurBasis`, `CauchyWeightSpaceDimension`,
+`CauchyCharacterRight`, `CauchyCharacterRightAssembly`). The proofs that closed
+those deferred sorries landed afterward and are unaudited.
+
+It is load-bearing: `cauchyMult_mul_prodX_eq_lastPart_pos` is the explicit
+ingredient that issue #5003 (degree-`d` `A/det` character identity) cites to
+collapse the det-twisted subtracted term, feeding the #4960 → #4905 det-quotient
+chain.
+
+Top-level decls to audit:
+- `bddPartShift` (`:45`, `def`) and `bddPartUnshift` (`:57`, `def`) — the
+  `BoundedPartition N (d-N) ↔ BoundedPartition N d` reindexing (insert/remove a
+  full column of `N`). **Both are real `def`s — confirm neither has a vacuous or
+  placeholder body and that they are genuine mutual inverses where used.**
+- `bddPart_ext` (`:39`), `eval_one_prod_X` (`:76`),
+  `eval_one_schurPoly_bddPartShift` (`:84`) — the `eval (1,…,1)` bookkeeping.
+- `cauchyMult_mul_prodX_eq_lastPart_pos` (`:100`) — the headline identity:
+  multiplying the full Cauchy sum by `∏ⱼ Xⱼ` reindexes onto the `0 ∈ range ν`
+  ("last part positive") sub-sum.
+
+## Deliverables
+
+This is a **review** work item — no code changes.
+
+1. Soundness audit of all six decls above. For each confirm:
+   - No `def`/`noncomputable def`/`instance`/`abbrev` has a `sorry` or
+     vacuous/placeholder body; `bddPartShift`/`bddPartUnshift` construct real
+     partitions with correct bounds and sums.
+   - No `True` stands in for a real proposition.
+   - Each statement faithfully matches the source combinatorics — correct
+     column-degree indexing, correct `∏ⱼ Xⱼ` shift, correct
+     `0 ∈ Set.range ν.parts` filter, no quietly-weakened hypotheses (e.g. the
+     `hd : N ≤ d` guard is genuinely required, not silently trivializing).
+2. Run `#print axioms cauchyMult_mul_prodX_eq_lastPart_pos` (and the two defs)
+   to confirm sorry-free and no unexpected axioms.
+3. Post one audit comment with a PASS / PASS-WITH-NOTES / FAIL verdict and
+   file:line for any finding; open follow-up issues for anything unsound.
+
+## Context
+
+- Read the relevant `blobs/Chapter5/` Cauchy-identity / character-computation
+  blobs (`Discussion_character_computation_setup.md`,
+  `Discussion_computing_characters_of_L_lambda.md`) so faithfulness is judged
+  against the book, not reconstructed.
+- Predecessor audit (statements + the two zero-sorry combinatorial files):
+  #5019. This issue covers the **newly-landed proof** that #5019 could not.
+- Downstream consumer: #5003 (`quotDetDegreeFDRep_formalCharacter`).
+- Use the `lean-formalization` skill.
+
+## Verification
+
+`lake build EtingofRepresentationTheory.Chapter5.CauchyCharDiff` green;
+`#print axioms` clean on the headline lemma and the two defs; audit comment
+posted with an explicit verdict.

--- a/plans/e1b5f339-2.md
+++ b/plans/e1b5f339-2.md
@@ -1,0 +1,60 @@
+## Current state
+
+The right-torus eigenbasis lemmas in `PolynomialGLRightAction.lean` (landed
+**sorry-free** by commit `5310e606`, #4944/#4959 partial) are the
+representation-theoretic core under the weight-space dimension count and the
+right-`GL_N` Cauchy character identity. They establish that a **diagonal**
+matrix `diag(v)` acts diagonally on monomials, so each monomial `X^s` is a
+right-torus eigenvector with eigenvalue `∏ⱼ vⱼ^{μⱼ}` where `μⱼ = ∑ᵢ s(i,j)` is
+the column-degree weight. This eigenbasis is what makes `formalCharacter` of the
+degree-`d` component computable, feeding `polyRightDegreeFDRep_formalCharacter`.
+
+These lemmas are **not** covered by the earlier Cauchy audit #5019, whose scope
+was the four `Cauchy*` files — not `PolynomialGLRightAction.lean`.
+
+Decls to audit (the "diagonal torus acts diagonally" block, `:145`–`~200`):
+- `rTransAlgHom_diagonal_X` (`:157`, `@[simp]`) —
+  `R_{diag v} X_{ij} = vⱼ • X_{ij}` (the diagonal entry of the **column** index
+  `j` is the eigenvalue, since the right action mixes columns).
+- `rTransAlgHom_diagonal_monomial` (`:172`) —
+  `R_{diag v} (monomial s c) = (∏_{(i,j)} vⱼ^{s(i,j)}) • monomial s c`, the
+  eigenvector/eigenvalue statement whose weight is the vector of column degrees.
+
+Verify these against the already-audited `rTransAlgHom` foundation (`:49`–`:135`,
+covered by earlier toolchain/foundation work) only as needed for context.
+
+## Deliverables
+
+This is a **review** work item — no code changes.
+
+1. Soundness audit of `rTransAlgHom_diagonal_X` and
+   `rTransAlgHom_diagonal_monomial`. Confirm:
+   - The eigenvalue is indexed by the **column** entry `vⱼ` (not the row),
+     consistent with `rTransAlgHom`'s column-mixing convention — a row/column
+     transpose error here would silently corrupt every downstream weight.
+   - The monomial eigenvalue `∏_{(i,j)} vⱼ^{s(i,j)}` correctly collects to the
+     column-degree weight `∏ⱼ vⱼ^{(∑ᵢ s(i,j))}`; no off-by-one or mis-collected
+     product.
+   - No `True`-placeholder, no quietly-weakened hypothesis, statements faithful
+     to the right-action definition.
+2. Run `#print axioms rTransAlgHom_diagonal_monomial` to confirm sorry-free and
+   no unexpected axioms.
+3. Post one audit comment with a PASS / PASS-WITH-NOTES / FAIL verdict and
+   file:line for any finding; open follow-up issues for anything unsound.
+
+## Context
+
+- Read `blobs/Chapter5/` character-computation blobs
+  (`Discussion_character_computation_setup.md`) so the weight/eigenvalue
+  convention is judged against the book.
+- This eigenbasis underpins the weight-space dimension (#4957) and the right
+  Cauchy character identity (`polyRightDegreeFDRep_formalCharacter`); a faulty
+  weight propagates silently into the Schur-Weyl multiplicity counting.
+- Predecessor (statements + zero-sorry combinatorial files, different files):
+  #5019. Use the `lean-formalization` skill.
+
+## Verification
+
+`lake build EtingofRepresentationTheory.Chapter5.PolynomialGLRightAction` green;
+`#print axioms` clean on `rTransAlgHom_diagonal_monomial`; audit comment posted
+with an explicit verdict.

--- a/progress/20260622T032739Z_e1b5f339.md
+++ b/progress/20260622T032739Z_e1b5f339.md
@@ -1,0 +1,57 @@
+## Accomplished
+
+`/plan` session `e1b5f339`. Oriented (queue deficit = 2, min_queue = 3,
+depth = 1). Confirmed `main` is green (#5021/#5022 merged). PR #4929 is a draft
+(not mergeable); PR #4997 is repair-claimed (no fix issue needed). No open
+`directive` issues.
+
+Mapped the frontier: only **4 real sorries remain in Chapter 5**, and **all four
+are already tracked** by open issues —
+- `SpechtModuleBasis.lean:2345` (James epic) → #5037 (unclaimed, fact 1);
+- `SchurWeylFormalCharacterIso.lean:200` (`schurModule_isSimple_general` seam) → #4976 (blocked);
+- `SchurWeylSimplesClassification.lean:132` (false crux, to be deleted) → #5024 (blocked on #5023);
+- `CauchyDetQuotient.lean:124` (det-quotient assembly) → #4905/#5003 (blocked on #4961/#4997).
+
+So there is **no uncovered, actionable feature sorry** — the frontier is
+serialized behind claimed (#5023, #5005) and blocked work. The honest refill is
+review of recently-landed, sorry-free, load-bearing work that post-dates the last
+relevant audit (#5019).
+
+Created two non-overlapping review issues (deficit = 2 → 2 created):
+- **#5043** — soundness audit of `CauchyCharDiff.lean` (partition-shift `def`s
+  `bddPartShift`/`bddPartUnshift` + `cauchyMult_mul_prodX_eq_lastPart_pos`). This
+  file discharges the now-sorry-free `polyRightDegreeFDRep_formalCharacter` and is
+  the explicit ingredient #5003 cites; it was **not** in #5019's four-file scope.
+- **#5044** — soundness audit of the #4944 right-torus eigenbasis lemmas
+  (`rTransAlgHom_diagonal_X`/`_monomial` in `PolynomialGLRightAction.lean`,
+  commit 5310e606) — the diagonal-action eigenbasis under the weight/character
+  computation; also outside #5019's scope.
+
+(Discovered en route: `polyRightDegreeFDRep_formalCharacter` is now fully
+sorry-free — the "may still be a cited sorry" note in #5003's body is stale.)
+
+## Current frontier
+
+Queue refilled to min_queue: 3 unclaimed (#5037, #5043, #5044). General-`k`
+Schur-Weyl classification chain in flight (#5023 → #5024; #5005 → #4976) and the
+det-quotient chain blocked behind PR #4997 (repair-claimed) → #5003 → #4961 → #4905.
+
+## Overall project progress
+
+Etingof draft 1, Stage 3, Chapter 5. Two live streams: (a) general-`k` Schur-Weyl
+classification (core relocation #5023, special-block #5005, simplicity seam #4976);
+(b) det-quotient last-weight-zero assembly (#4905 chain). Only 4 tracked sorries
+remain in Ch5. Recent Cauchy right-`GL_N` character work (#4904/#4934/#4944) is
+landed sorry-free; `polyRightDegreeFDRep_formalCharacter` is complete.
+
+## Next step
+
+- **Worker:** claim #5037 (James fact 1) — the only actionable feature target.
+- **Worker:** claim review #5043 / #5044 (both unblocked, parallelizable).
+- **Repair:** land PR #4997 to unblock #5003 → #4961 → #4905.
+- Sibling general-`k` work (#5024) auto-unblocks when #5023 (claimed) lands.
+
+## Blockers
+
+None for the planner. The feature frontier is serialized behind claimed/blocked
+work; reviews keep workers busy in parallel until those land.


### PR DESCRIPTION
This PR records the planner handoff for session \`e1b5f339\` and the two review plan bodies it posted. The queue was below \`min_queue\` (deficit 2); all four remaining Chapter 5 sorries are already tracked, so the refill is review of recently-landed, sorry-free, load-bearing work that post-dates audit #5019: #5043 (\`CauchyCharDiff\` partition-shift defs + \`cauchyMult_mul_prodX_eq_lastPart_pos\`) and #5044 (the #4944 right-torus eigenbasis lemmas in \`PolynomialGLRightAction\`).

🤖 Prepared with Claude Code