### PR TITLE
feat(toolchain): make Proposition4_1_2 forward-compatible

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Proposition4_1_2.lean
+++ b/EtingofRepresentationTheory/Chapter4/Proposition4_1_2.lean
@@ -50,11 +50,17 @@ theorem Etingof.Proposition4_1_2
   -- Λ ≠ 0
   have hΛne : Λ ≠ 0 := by
     intro heq
-    have h1 : (Λ : G →₀ k) 1 = 0 := by rw [heq]; rfl
-    rw [hΛ_def, Finsupp.coe_finset_sum, Finset.sum_apply] at h1
-    simp only [Finsupp.single_apply] at h1
-    rw [Finset.sum_ite_eq'] at h1
-    simp at h1
+    let evalOne : MonoidAlgebra k G →+ k :=
+      { toFun := fun x => x 1
+        map_zero' := rfl
+        map_add' := by intro x y; rfl }
+    have h1 : evalOne Λ = 0 := by rw [heq]; rfl
+    have hΛ1 : evalOne Λ = 1 := by
+      rw [hΛ_def]
+      rw [map_sum]
+      simp [evalOne, MonoidAlgebra.single_apply]
+    rw [hΛ1] at h1
+    exact one_ne_zero h1
   -- Centrality: Λ is in the center
   have hΛcentral : ∀ x : MonoidAlgebra k G, Λ * x = x * Λ := by
     intro x


### PR DESCRIPTION
## Summary

- Replace the fragile `Finsupp.coe_finset_sum` / `Finset.sum_apply` rewrite in `Chapter4.Proposition4_1_2`.
- Evaluate the averaging element at `1` through a local additive hom, so `map_sum` handles the finite sum without depending on `MonoidAlgebra`/`Finsupp` coercion transparency.

## Porting Notes

This is part of the v4.31 port tracked in #4864.

The old proof works on the current v4.28 line but fails on the v4.31 stack after rewriting `hΛ_def`: Lean sees an application of a `MonoidAlgebra` sum where the Finsupp finite-sum application lemmas expect a raw `G →₀ k` sum. The replacement avoids that mismatch and remains compatible with the current pinned toolchain.

This PR is intentionally small and forward-compatible, so it targets `main` rather than the v4.31-only stack.

## Validation

- `lake build EtingofRepresentationTheory.Chapter4.Proposition4_1_2` on current `main` / Lean v4.28.1.
- `lake build EtingofRepresentationTheory.Chapter4.Proposition4_1_2` on local `stack/toolchain-v4.31.0` after applying the same source diff / Lean v4.31.0.

Both builds complete successfully. The existing unused `[DecidableEq G]` theorem-type warning is still present.