### PR TITLE
feat(toolchain): make Corollary4_2_4 forward-compatible

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Corollary4_2_4.lean
+++ b/EtingofRepresentationTheory/Chapter4/Corollary4_2_4.lean
@@ -98,7 +98,7 @@ private lemma finrank_biprod
       have hzero : ∀ (A B : FDRep ℂ G) (x : A.V), (0 : A ⟶ B).hom.hom.hom x = 0 := by
         intro A B x
         show (0 : A.V.obj ⟶ B.V.obj).hom x = 0
-        simp [ModuleCat.Hom.hom]
+        change (0 : A.V.obj →ₗ[ℂ] B.V.obj) x = 0
         exact LinearMap.zero_apply x
       have hid : ∀ (A : FDRep ℂ G) (x : A.V), (𝟙 A : A ⟶ A).hom.hom.hom x = x := fun _ _ => rfl
       ext <;> dsimp only


### PR DESCRIPTION
## Summary

- Replace a brittle `simp [ModuleCat.Hom.hom]` step in `Chapter4.Corollary4_2_4` with an explicit change to the underlying zero linear map.
- This avoids the v4.31 behavior where `simp` closes the goal before the following `exact`, while preserving the current v4.28 proof behavior.

## Porting Notes

This is part of the v4.31 port tracked in #4864.

On the v4.31 stack, the old proof failed with `No goals to be solved` at the trailing `exact LinearMap.zero_apply x`, because the preceding `simp` had already closed the goal. The replacement makes the intended coercion explicit and then applies `LinearMap.zero_apply`, so it is stable across both toolchains.

This PR is intentionally small and forward-compatible, so it targets `main` rather than the v4.31-only stack.

## Validation

- `lake build EtingofRepresentationTheory.Chapter4.Corollary4_2_4` on current `main` / Lean v4.28.1.
- `lake build EtingofRepresentationTheory.Chapter4.Corollary4_2_4` on local `stack/toolchain-v4.31.0` after applying the same source diff / Lean v4.31.0.

Both builds complete successfully. Existing theorem-type/style/deprecation warnings in this file remain.