### PR TITLE
refactor(Ch5 #5075 B0): DetInvElim-clean base for constituent-character extraction

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/CleanCharacterExtractionBase.lean
+++ b/EtingofRepresentationTheory/Chapter5/CleanCharacterExtractionBase.lean
@@ -1,0 +1,179 @@
+import EtingofRepresentationTheory.Chapter5.FormalCharacterIso
+import EtingofRepresentationTheory.Chapter5.SchurModuleSimple
+import EtingofRepresentationTheory.Chapter5.FormalCharacterTorusTrace
+import EtingofRepresentationTheory.Chapter5.CharacterIndependence
+import EtingofRepresentationTheory.Chapter5.TraceVanishingDensity
+import EtingofRepresentationTheory.Chapter5.GLRepAlgebraic
+
+/-!
+# DetInvElim-clean base for constituent-character extraction (issue #5075)
+
+This file is the **DetInvElim-clean** home of the reusable glue and the two character
+ingredients underlying the constituent-character extraction step of the `#4905`/`#4896`
+part-(a) assembly. They previously lived in `SchurWeylFormalCharacterIso.lean`, which is
+*polluted* — it transitively imports `DetInvElim` via `PolynomialGLDecomposition`. Because
+the `#4896` assembly (`KernelLemmaKPrimeAssembly`) feeds back into `DetInvElim`, using the
+polluted extractor to prove part-(a) is a genuine build cycle (#5072). The proofs here use
+**only** DetInvElim-clean dependencies (`FormalCharacterIso`, `SchurModuleSimple`,
+`CharacterIndependence`, `TraceVanishingDensity`, `FormalCharacterTorusTrace`,
+`GLRepAlgebraic`), so the clean extractor built on top (`CleanConstituentExtraction.lean`)
+avoids the cycle.
+
+The five relocated items (identical statements and proofs to the former
+`SchurWeylFormalCharacterIso` versions):
+
+* `Representation.kEquivOfAsModuleEquiv` / `_intertwines` — the reverse glue extracting the
+  `k`-linear `GL`-equivariant equivalence underlying a `MonoidAlgebra`-linear equivalence of
+  `asModule`s.
+* `Etingof.formalCharacter_FDRep_of_ρ` — rebuilding `M` as `FDRep.of M.ρ` does not change its
+  character.
+* `Etingof.schurModule_isSimple_general` — general-`k` Schur-module simplicity (#4946, #5054).
+* `Etingof.formalCharacter_simples_coeff_eq_zero_of_torus_trace_eq_zero_general` — the
+  general-`k` torus→full-group Zariski-density character-independence seam (#4947, #4983).
+
+`SchurWeylFormalCharacterIso.lean` now `import`s this file and re-exports these names, so its
+own downstream theorems are unchanged.
+-/
+
+open CategoryTheory MvPolynomial
+
+noncomputable section
+
+namespace Representation
+
+variable {k G : Type*} [CommSemiring k] [Monoid G]
+variable {V W : Type*} [AddCommMonoid V] [Module k V] [AddCommMonoid W] [Module k W]
+
+/-- **Reverse glue (the `k`-linear equivalence underlying a `MonoidAlgebra`-linear
+equivalence of `asModule`s).** A `MonoidAlgebra k G`-linear equivalence between the
+`asModule`s of two representations restricts, via `asModuleEquiv`, to a `k`-linear
+equivalence between their carriers. This is the inverse direction of
+`asModuleEquivOfIntertwiner`: it extracts the carrier-level equivalence from the
+module-level one. -/
+def kEquivOfAsModuleEquiv {ρ : Representation k G V} {σ : Representation k G W}
+    (φ : Representation.asModule ρ ≃ₗ[MonoidAlgebra k G] Representation.asModule σ) :
+    V ≃ₗ[k] W :=
+  ρ.asModuleEquiv.symm ≪≫ₗ φ.restrictScalars k ≪≫ₗ σ.asModuleEquiv
+
+/-- The `k`-linear equivalence `kEquivOfAsModuleEquiv φ` intertwines `ρ` and `σ`.
+The `MonoidAlgebra` action records the group action (`asModuleEquiv_symm_map_rho`,
+`asModuleEquiv_map_smul`), so transporting `φ`'s `MonoidAlgebra`-linearity back to the
+carriers turns it into `G`-equivariance. -/
+theorem kEquivOfAsModuleEquiv_intertwines {ρ : Representation k G V}
+    {σ : Representation k G W}
+    (φ : Representation.asModule ρ ≃ₗ[MonoidAlgebra k G] Representation.asModule σ)
+    (g : G) (v : V) :
+    kEquivOfAsModuleEquiv φ (ρ g v) = σ g (kEquivOfAsModuleEquiv φ v) := by
+  simp only [kEquivOfAsModuleEquiv, LinearEquiv.trans_apply, LinearEquiv.restrictScalars_apply]
+  rw [ρ.asModuleEquiv_symm_map_rho, map_smul, σ.asModuleEquiv_map_smul,
+    MonoidAlgebra.of_apply, σ.asAlgebraHom_single, one_smul]
+
+end Representation
+
+namespace Etingof
+
+variable (k : Type) [Field k] [IsAlgClosed k] [CharZero k]
+
+/-- The formal character only depends on the underlying representation: rebuilding
+`M` as `FDRep.of M.ρ` does not change its character. -/
+theorem formalCharacter_FDRep_of_ρ (N : ℕ)
+    (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k)) :
+    formalCharacter k N (FDRep.of M.ρ) = formalCharacter k N M :=
+  formalCharacter_eq_of_rep_iso k N M.ρ M.ρ (LinearEquiv.refl k M) (fun _ _ => rfl)
+
+/-- **Ingredient (a): general-`k` Schur-module simplicity (issue #4946, #5054).**
+The Schur module `L_λ = SchurModule k N lam` is a simple
+`MonoidAlgebra k (GL_N(k))`-module for any antitone `lam`.
+
+The centralizer-level core is proved over a general algebraically-closed
+characteristic-zero field as `schurModuleSubmodule_isSimple_centralizer_general`
+(`SchurModuleSimple.lean`), and the `hN : (∑ i, lam i) ≤ N` guard is **not** needed.
+This assembly is a one-line mirror of the ℂ `schurModule_isSimple` final
+assembly: `schurModuleSubmodule_isSimple_centralizer_general` + the generic GL transfer
+`isSimpleModule_monoidAlgebra_GL_of_centralizer_simple`. -/
+theorem schurModule_isSimple_general (N : ℕ) (lam : Fin N → ℕ) (hlam : Antitone lam) :
+    IsSimpleModule (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
+      (Representation.asModule (SchurModule k N lam).ρ) := by
+  -- One-line mirror of the ℂ `schurModule_isSimple` assembly, driven by the
+  -- general-`k` centralizer core (`SchurModuleSimple.lean`). No `hN` guard needed.
+  haveI := schurModuleSubmodule_isSimple_centralizer_general (k := k) N lam hlam
+  refine isSimpleModule_monoidAlgebra_GL_of_centralizer_simple k
+    (N := N) (n := ∑ i, lam i)
+    (M := ↥(SchurModuleSubmodule k N lam))
+    (schurModuleRep k N lam) ?_
+  intro g x
+  apply Subtype.ext
+  rfl
+
+/-- **Ingredient (b): general-`k` torus→full-group character independence (issue #4947,
+algebraicity bridge #4983).** For a finite family of pairwise non-isomorphic simple
+**algebraic** `GL_N(k)`-representations `L i`, a `ℚ`-combination `c` of their characters
+whose corresponding combination of *torus* traces vanishes at every diagonal torus element
+has all coefficients zero.
+
+This is the general algebraically-closed characteristic-zero `k` analogue of the ℂ
+seam `formalCharacter_simples_coeff_eq_zero_of_torus_trace_eq_zero` (#4908): same proof
+(Dedekind/Artin independence of characters + the Zariski-density bridge), now driven by the
+general-`k` density core `trace_combination_vanishes_of_torus_vanishes_of_algebraic`
+(`TraceVanishingDensity.lean`). -/
+theorem formalCharacter_simples_coeff_eq_zero_of_torus_trace_eq_zero_general
+    (N : ℕ) {ι : Type} [Fintype ι] [DecidableEq ι]
+    (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
+    (hLalg : ∀ i, Etingof.IsAlgebraicRepresentation N (L i).ρ)
+    (hLsimp : ∀ i, IsSimpleModule (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
+        (Representation.asModule (L i).ρ))
+    (hLdist : Pairwise (fun i j => ¬ Nonempty ((L i) ≅ (L j))))
+    (c : ι → ℚ)
+    (htorus : ∀ t : Fin N → kˣ,
+        ∑ i, (c i : k) • LinearMap.trace k (L i) ((L i).ρ (diagTorus k N t)) = 0) :
+    ∀ i, c i = 0 := by
+  classical
+  -- (a) Pairwise non-isomorphic as `A := MonoidAlgebra k (GL_N k)`-modules.
+  have hdist : Pairwise (fun i j => ¬ Nonempty (Representation.asModule (L i).ρ
+      ≃ₗ[MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k)]
+        Representation.asModule (L j).ρ)) := by
+    intro i j hij hcon
+    obtain ⟨φ⟩ := hcon
+    exact hLdist hij ⟨Action.mkIso (Representation.kEquivOfAsModuleEquiv φ).toFGModuleCatIso
+      (fun g => by ext x; exact Representation.kEquivOfAsModuleEquiv_intertwines φ g x)⟩
+  -- (b) Dedekind/Artin: the trace functionals are `k`-independent.
+  have hLI := traceCharacter_linearIndependent (𝕜 := k)
+    (A := MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
+    (fun i => Representation.asModule (L i).ρ) hLsimp hdist
+  -- (c) Trace functional at a group element evaluates to the representation trace.
+  have hbridge : ∀ (i : ι) (g : Matrix.GeneralLinearGroup (Fin N) k),
+      traceChar (fun i => Representation.asModule (L i).ρ) i (MonoidAlgebra.of k _ g)
+        = LinearMap.trace k (L i) ((L i).ρ g) := by
+    intro i g
+    have hmap : (repEnd (fun i => Representation.asModule (L i).ρ) i
+        (MonoidAlgebra.of k _ g) :
+          Representation.asModule (L i).ρ →ₗ[k] Representation.asModule (L i).ρ)
+          = (L i).ρ g := by
+      ext v
+      rw [repEnd_apply, ← Representation.asAlgebraHom_of (L i).ρ g]
+      rfl
+    rw [traceChar_apply, hmap]
+    rfl
+  -- (d) The functional combination vanishes on every group element by the density core.
+  have hF0 : ∀ a, (∑ i, (c i : k) • (traceChar (fun i => Representation.asModule (L i).ρ) i :
+      MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k) →ₗ[k] k)) a = 0 := by
+    intro a
+    induction a using MonoidAlgebra.induction_on with
+    | hM g =>
+        have hg0 := trace_combination_vanishes_of_torus_vanishes_of_algebraic N L hLalg
+          (fun i => (c i : k)) htorus g
+        rw [LinearMap.sum_apply]
+        simpa only [LinearMap.smul_apply, hbridge] using hg0
+    | hadd x y hx hy => simp only [map_add, hx, hy, add_zero]
+    | hsmul r x hx => simp only [map_smul, hx, smul_zero]
+  have hfun : (∑ i, (c i : k) • (traceChar (fun i => Representation.asModule (L i).ρ) i :
+      MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k) →ₗ[k] k)) = 0 :=
+    LinearMap.ext hF0
+  -- (e) Independence forces every coefficient to vanish.
+  intro i
+  have : (c i : k) = 0 := Fintype.linearIndependent_iff.mp hLI (fun i => (c i : k)) hfun i
+  exact_mod_cast this
+
+end Etingof
+
+end

--- a/EtingofRepresentationTheory/Chapter5/SchurWeylFormalCharacterIso.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurWeylFormalCharacterIso.lean
@@ -1,5 +1,6 @@
 import EtingofRepresentationTheory.Chapter5.PolynomialGLDecomposition
 import EtingofRepresentationTheory.Chapter5.SchurWeylSimplesClassification
+import EtingofRepresentationTheory.Chapter5.CleanCharacterExtractionBase
 import EtingofRepresentationTheory.Chapter5.SchurModuleSimple
 import EtingofRepresentationTheory.Chapter5.SemisimpleIsotypic
 import EtingofRepresentationTheory.Chapter5.FormalCharacterTorusTrace
@@ -97,47 +98,16 @@ open scoped TensorProduct
 noncomputable section
 
 
-namespace Representation
-
-variable {k G : Type*} [CommSemiring k] [Monoid G]
-variable {V W : Type*} [AddCommMonoid V] [Module k V] [AddCommMonoid W] [Module k W]
-
-/-- **Reverse glue (the `k`-linear equivalence underlying a `MonoidAlgebra`-linear
-equivalence of `asModule`s).** A `MonoidAlgebra k G`-linear equivalence between the
-`asModule`s of two representations restricts, via `asModuleEquiv`, to a `k`-linear
-equivalence between their carriers. This is the inverse direction of
-`asModuleEquivOfIntertwiner`: it extracts the carrier-level equivalence from the
-module-level one. -/
-def kEquivOfAsModuleEquiv {ρ : Representation k G V} {σ : Representation k G W}
-    (φ : Representation.asModule ρ ≃ₗ[MonoidAlgebra k G] Representation.asModule σ) :
-    V ≃ₗ[k] W :=
-  ρ.asModuleEquiv.symm ≪≫ₗ φ.restrictScalars k ≪≫ₗ σ.asModuleEquiv
-
-/-- The `k`-linear equivalence `kEquivOfAsModuleEquiv φ` intertwines `ρ` and `σ`.
-The `MonoidAlgebra` action records the group action (`asModuleEquiv_symm_map_rho`,
-`asModuleEquiv_map_smul`), so transporting `φ`'s `MonoidAlgebra`-linearity back to the
-carriers turns it into `G`-equivariance. -/
-theorem kEquivOfAsModuleEquiv_intertwines {ρ : Representation k G V}
-    {σ : Representation k G W}
-    (φ : Representation.asModule ρ ≃ₗ[MonoidAlgebra k G] Representation.asModule σ)
-    (g : G) (v : V) :
-    kEquivOfAsModuleEquiv φ (ρ g v) = σ g (kEquivOfAsModuleEquiv φ v) := by
-  simp only [kEquivOfAsModuleEquiv, LinearEquiv.trans_apply, LinearEquiv.restrictScalars_apply]
-  rw [ρ.asModuleEquiv_symm_map_rho, map_smul, σ.asModuleEquiv_map_smul,
-    MonoidAlgebra.of_apply, σ.asAlgebraHom_single, one_smul]
-
-end Representation
+-- `Representation.kEquivOfAsModuleEquiv` and `Representation.kEquivOfAsModuleEquiv_intertwines`
+-- are now in the DetInvElim-clean base `CleanCharacterExtractionBase` (#5075) and re-exported
+-- via the import above.
 
 namespace Etingof
 
 variable (k : Type) [Field k] [IsAlgClosed k] [CharZero k]
 
-/-- The formal character only depends on the underlying representation: rebuilding
-`M` as `FDRep.of M.ρ` does not change its character. -/
-theorem formalCharacter_FDRep_of_ρ (N : ℕ)
-    (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k)) :
-    formalCharacter k N (FDRep.of M.ρ) = formalCharacter k N M :=
-  formalCharacter_eq_of_rep_iso k N M.ρ M.ρ (LinearEquiv.refl k M) (fun _ _ => rfl)
+-- `Etingof.formalCharacter_FDRep_of_ρ` is now in `CleanCharacterExtractionBase` (#5075),
+-- re-exported via the import above.
 
 omit [CharZero k] in
 /-- **Weight saturation transfers along equivariant surjections.** A `GL_N`-equivariant
@@ -191,7 +161,9 @@ theorem glWeightSpace_schurModule_iSup_eq_top (N : ℕ) (lam : Fin N → ℕ) :
   rw [FDRep.of_ρ']
   exact (LinearMap.ext_iff.mp (glTensor_comm_youngSym k N lam g) v).symm
 
-/-- **Ingredient (a): general-`k` Schur-module simplicity (issue #4946, #5054).**
+/- **Ingredient (a): general-`k` Schur-module simplicity (issue #4946, #5054).**
+(The theorem `schurModule_isSimple_general` itself now lives in the DetInvElim-clean
+`CleanCharacterExtractionBase` (#5075); this note is retained for the universe context.)
 The Schur module `L_λ = SchurModule k N lam` is a simple
 `MonoidAlgebra k (GL_N(k))`-module for any antitone `lam`.
 
@@ -213,98 +185,12 @@ this file (this theorem, `schurWeyl_simples_isotypic_matching_general`,
 `simpleRep_iso_schurModule_of_formalCharacter_eq`, `iso_of_formalCharacter_eq_schurPoly`)
 and its external consumers across Ch 5/6/9 down to `Type 0`; the section variable here is
 accordingly `k : Type` (#5054). -/
-theorem schurModule_isSimple_general (N : ℕ) (lam : Fin N → ℕ) (hlam : Antitone lam) :
-    IsSimpleModule (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
-      (Representation.asModule (SchurModule k N lam).ρ) := by
-  -- One-line mirror of the ℂ `schurModule_isSimple` assembly, driven by the
-  -- general-`k` centralizer core (`SchurModuleSimple.lean`). No `hN` guard needed.
-  haveI := schurModuleSubmodule_isSimple_centralizer_general (k := k) N lam hlam
-  refine isSimpleModule_monoidAlgebra_GL_of_centralizer_simple k
-    (N := N) (n := ∑ i, lam i)
-    (M := ↥(SchurModuleSubmodule k N lam))
-    (schurModuleRep k N lam) ?_
-  intro g x
-  apply Subtype.ext
-  rfl
+-- (`schurModule_isSimple_general` is now in `CleanCharacterExtractionBase` (#5075),
+-- re-exported via the import above.)
 
-/-- **Ingredient (b): general-`k` torus→full-group character independence (issue #4947,
-algebraicity bridge #4983).** For a finite family of pairwise non-isomorphic simple
-**algebraic** `GL_N(k)`-representations `L i`, a `ℚ`-combination `c` of their characters
-whose corresponding combination of *torus* traces vanishes at every diagonal torus element
-has all coefficients zero.
+-- (`formalCharacter_simples_coeff_eq_zero_of_torus_trace_eq_zero_general` is now in
+-- `CleanCharacterExtractionBase` (#5075), re-exported via the import above.)
 
-This is the general algebraically-closed characteristic-zero `k` analogue of the ℂ
-seam `formalCharacter_simples_coeff_eq_zero_of_torus_trace_eq_zero` (#4908): same proof
-(Dedekind/Artin
-independence of characters + the Zariski-density bridge), now driven by the general-`k`
-density core `trace_combination_vanishes_of_torus_vanishes_of_algebraic`
-(`TraceVanishingDensity.lean`). The `ℂ` seam is the `k = ℂ` specialisation.
-
-The hypothesis is `hLalg` (regularity of each character), **not** `hLtop` (spanning
-`ℕ`-weight spaces): the density step requires the character combination to be a *regular*
-function, which `hLtop` does not provide for an abstract-group representation. This matches
-the ℂ seam exactly. At the genuine call site (`simpleRep_iso_schurModule_of_formalCharacter_eq`
-below) each `L i` is supplied from its polynomial source — the Schur module via
-`schurModule_isAlgebraic`, the abstract simple via `IsAlgebraicRepresentation.of_linearEquiv`
-transport from the algebraic ambient rep — rather than manufactured from `hLtop` alone
-(which would be strictly stronger, hence false; see #4983). -/
-theorem formalCharacter_simples_coeff_eq_zero_of_torus_trace_eq_zero_general
-    (N : ℕ) {ι : Type} [Fintype ι] [DecidableEq ι]
-    (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
-    (hLalg : ∀ i, Etingof.IsAlgebraicRepresentation N (L i).ρ)
-    (hLsimp : ∀ i, IsSimpleModule (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
-        (Representation.asModule (L i).ρ))
-    (hLdist : Pairwise (fun i j => ¬ Nonempty ((L i) ≅ (L j))))
-    (c : ι → ℚ)
-    (htorus : ∀ t : Fin N → kˣ,
-        ∑ i, (c i : k) • LinearMap.trace k (L i) ((L i).ρ (diagTorus k N t)) = 0) :
-    ∀ i, c i = 0 := by
-  classical
-  -- (a) Pairwise non-isomorphic as `A := MonoidAlgebra k (GL_N k)`-modules.
-  have hdist : Pairwise (fun i j => ¬ Nonempty (Representation.asModule (L i).ρ
-      ≃ₗ[MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k)]
-        Representation.asModule (L j).ρ)) := by
-    intro i j hij hcon
-    obtain ⟨φ⟩ := hcon
-    exact hLdist hij ⟨Action.mkIso (Representation.kEquivOfAsModuleEquiv φ).toFGModuleCatIso
-      (fun g => by ext x; exact Representation.kEquivOfAsModuleEquiv_intertwines φ g x)⟩
-  -- (b) Dedekind/Artin: the trace functionals are `k`-independent.
-  have hLI := traceCharacter_linearIndependent (𝕜 := k)
-    (A := MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
-    (fun i => Representation.asModule (L i).ρ) hLsimp hdist
-  -- (c) Trace functional at a group element evaluates to the representation trace.
-  have hbridge : ∀ (i : ι) (g : Matrix.GeneralLinearGroup (Fin N) k),
-      traceChar (fun i => Representation.asModule (L i).ρ) i (MonoidAlgebra.of k _ g)
-        = LinearMap.trace k (L i) ((L i).ρ g) := by
-    intro i g
-    have hmap : (repEnd (fun i => Representation.asModule (L i).ρ) i
-        (MonoidAlgebra.of k _ g) :
-          Representation.asModule (L i).ρ →ₗ[k] Representation.asModule (L i).ρ)
-          = (L i).ρ g := by
-      ext v
-      rw [repEnd_apply, ← Representation.asAlgebraHom_of (L i).ρ g]
-      rfl
-    rw [traceChar_apply, hmap]
-    rfl
-  -- (d) The functional combination vanishes on every group element by the density core.
-  have hF0 : ∀ a, (∑ i, (c i : k) • (traceChar (fun i => Representation.asModule (L i).ρ) i :
-      MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k) →ₗ[k] k)) a = 0 := by
-    intro a
-    induction a using MonoidAlgebra.induction_on with
-    | hM g =>
-        have hg0 := trace_combination_vanishes_of_torus_vanishes_of_algebraic N L hLalg
-          (fun i => (c i : k)) htorus g
-        rw [LinearMap.sum_apply]
-        simpa only [LinearMap.smul_apply, hbridge] using hg0
-    | hadd x y hx hy => simp only [map_add, hx, hy, add_zero]
-    | hsmul r x hx => simp only [map_smul, hx, smul_zero]
-  have hfun : (∑ i, (c i : k) • (traceChar (fun i => Representation.asModule (L i).ρ) i :
-      MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k) →ₗ[k] k)) = 0 :=
-    LinearMap.ext hF0
-  -- (e) Independence forces every coefficient to vanish.
-  intro i
-  have : (c i : k) = 0 := Fintype.linearIndependent_iff.mp hLI (fun i => (c i : k)) hfun i
-  exact_mod_cast this
 
 /-- **Numerical identity for the Schur-Weyl decomposition (sorry-free).**
 

--- a/progress/2026-06-23T02-03-24Z_6afd1d98.md
+++ b/progress/2026-06-23T02-03-24Z_6afd1d98.md
@@ -1,0 +1,46 @@
+## Accomplished
+
+Worked issue #5075 (DetInvElim-clean constituent-character extractor). Completed
+sub-task **B0** (relocation) and decomposed the remaining work:
+
+- Created `EtingofRepresentationTheory/Chapter5/CleanCharacterExtractionBase.lean`, a
+  DetInvElim-CLEAN file holding the five glue/ingredient items previously stranded in the
+  polluted `SchurWeylFormalCharacterIso.lean`:
+  `Representation.kEquivOfAsModuleEquiv(_intertwines)`, `formalCharacter_FDRep_of_ρ`,
+  `schurModule_isSimple_general`, and
+  `formalCharacter_simples_coeff_eq_zero_of_torus_trace_eq_zero_general`.
+  Cleanliness verified by transitive-import trace (imports only FormalCharacterIso,
+  SchurModuleSimple, CharacterIndependence, TraceVanishingDensity, FormalCharacterTorusTrace,
+  GLRepAlgebraic).
+- Updated `SchurWeylFormalCharacterIso.lean` to import and re-export the relocated names
+  (no behavioural change). Both files build; `ConstituentCharacterExtraction` (downstream)
+  still builds.
+- Created sub-issue **#5078** for B1 (the extractor proof) with a detailed route correction.
+- Left a `Decomposed into #5078` breadcrumb on #5075.
+
+## Current frontier
+
+`clean_simple_constituent_formalCharacter_eq_schurPoly_mem` (B1) is unstarted. Its clean
+base now exists.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing in Chapter 5; the #4896/#4905 det-quotient highest-weight
+assembly. B0 unblocks the clean extractor by giving it a DetInvElim-clean foundation.
+
+## Next step
+
+Pick up **#5078**. Key finding: the #5075-sketched route (use `Theorem5_23_2_i` for
+semisimplicity, decompose into a direct sum of simples) does NOT work — `Theorem5_23_2_i`
+only gives k-vector-space semisimplicity, and there is no clean equivariant semisimple
+decomposition (the only one is DetInvElim-polluted `decompose_polynomial_gl_rep`). Use the
+composition-series + character-additivity route instead (Jordan-Hölder + `formalCharacter_
+add_of_shortExact`, extracting simples via clean `exists_isSimpleModule_le`). Caveats:
+character additivity needs weight-spanning hypotheses, so strongly consider re-adding
+`h_span`/`h_homog` to the extractor signature (the #5076 call site `M = quotDetDegreeFDRep`
+satisfies them); and relocate `formalCharacter_add_of_shortExact` (clean proof, polluted
+file) + `glWeightSpace_map_le` into a clean file. Full analysis in #5078.
+
+## Blockers
+
+None for B0 (landed). B1 (#5078) is substantial research-level work, not blocked but large.


### PR DESCRIPTION
This PR relocates the DetInvElim-clean glue and character ingredients used by the #4896 part-a / #4905 constituent-character extraction out of the DetInvElim-polluted `SchurWeylFormalCharacterIso.lean` into a new clean file `CleanCharacterExtractionBase.lean`, so a clean extractor can be built on top without re-entering the #5072 build cycle. The five relocated items — `Representation.kEquivOfAsModuleEquiv`/`_intertwines`, `formalCharacter_FDRep_of_ρ`, `schurModule_isSimple_general`, and `formalCharacter_simples_coeff_eq_zero_of_torus_trace_eq_zero_general` — keep identical statements and proofs; `SchurWeylFormalCharacterIso.lean` now imports and re-exports them with no behavioural change. The new base imports only verified-clean files (FormalCharacterIso, SchurModuleSimple, CharacterIndependence, TraceVanishingDensity, FormalCharacterTorusTrace, GLRepAlgebraic), confirmed DetInvElim-free by a transitive-import trace.

This is sub-task B0 of #5075; the remaining extractor proof (B1) is tracked in #5078, which also records a route correction found here (the sketched `Theorem5_23_2_i` semisimplicity step only yields k-vector-space semisimplicity, so B1 must take the composition-series + character-additivity route). Partial completion: #5075 is marked replan for a planner to narrow to the B1 residual.

🤖 Prepared with Claude Code