### PR TITLE
review(Ch5 #5068): soundness audit of degree-d A/det character foundation — PASS

### DIFF
--- a/progress/2026-06-23T05-21-49Z_51162aee.md
+++ b/progress/2026-06-23T05-21-49Z_51162aee.md
@@ -1,0 +1,109 @@
+## Accomplished
+
+Two items this session.
+
+### 1. Review — soundness audit of issue #5068 (the degree-`d` A/det character foundation)
+
+Audited `EtingofRepresentationTheory/Chapter5/CauchyDetQuotientDegree.lean`
+(822 lines; the lone `sorry` token is in the line-21 docstring, "sorry-free").
+
+**Verdict: PASS** on all three deliverables. Audit comment posted on #5068.
+
+- **Definition soundness (PASS).** All five `def`s have real bodies, no sorried
+  `def`/`instance`:
+  - `quotDetDegreeSubrep` (`:288`) — a genuine `Subrepresentation (quotDetRep)`
+    with carrier `(homogeneousSubmodule d).map mkQ` (the image of `A_d` in
+    `A/det`) and an honest `apply_mem_toSubmodule` proof.
+  - `quotDetDegreeFDRep` (`:302`) — `FDRep.of (quotDetDegreeSubrep).toRepresentation`.
+    Both `FiniteDimensional` instances are honest: the homogeneous submodule is
+    finite-dimensional (`finiteDimensional_homogeneousSubmodule`), and its image
+    under `mkQ` is finite-dimensional as the image of a finite-dim space.
+  - `twistFDRep` (`:425`) — `FDRep.of (charTwistRep (detChar) (polyRightHomogeneousSubrep e))`;
+    carrier `A_e`, action genuinely scaled by `det g`, matching `A_e ⊗ χ`.
+  - `quotDetDegreeProj` (`:322`), `boundedToAntitone` (`:702`) — real.
+- **Statement faithfulness (PASS).**
+  - `quotDetDegreeFDRep_formalCharacter` (`:547`) states the correct degree-`d`
+    character: `∑` over `ν : BoundedPartition N d` with `0 ∈ range ν.parts`.
+    Since `BoundedPartition.parts` is `Antitone`, the minimum part is the last,
+    so `0 ∈ range ν.parts ⟺ ν_N = 0` — faithful to the book's last-weight-zero
+    constituent condition.
+  - The `N ≤ d` hypothesis is **genuinely required, not masking a gap**: it is
+    consumed by `detSubmodule_inf_homogeneous d hd` (SES exactness) and
+    `cauchyMult_mul_prodX_eq_lastPart_pos hd`, and the complementary `d < N`
+    case is separately and honestly proved in
+    `quotDetDegree_formalCharacter_eq_polyRight_of_lt` (`:741`, via
+    `detSubmodule_inf_homogeneous_lt`).
+  - `formalCharacter_add_of_shortExact` (`:93`) has correct exactness
+    hypotheses (`ι` injective + equivariant, `π` surjective + equivariant,
+    `range ι = ker π`) plus the spanning hypotheses `hUtop`/`hVtop`; the proof
+    is a sound per-weight rank-nullity (`dim V_μ = dim(V_μ.map π) + dim U_μ`)
+    upgraded to equality by the global count. `hWtop` is correctly derived.
+  - `formalCharacter_twistFDRep` (`:506`) correctly states the determinant-twist
+    weight shift `char(A_e ⊗ χ) = (∏ᵢ Xᵢ) · char A_e`.
+  - The weight-space spanning lemmas (`polyRight_iSup_glWeightSpace_eq_top`
+    `:220`, `quotDetDegree_iSup_glWeightSpace_eq_top` `:358`) and homogeneity
+    lemmas (`polyRight_glWeightSpace_homog` `:266`, `quotDetDegree_homog` `:384`)
+    are non-vacuous (assert `⨆ = ⊤` / nonzero weight space forces `∑μ = d`).
+- **Axiom hygiene (PASS).** `#print axioms` on all top-level results
+  (`quotDetDegreeFDRep_formalCharacter`, `formalCharacter_add_of_shortExact`,
+  `formalCharacter_twistFDRep`, `quotDetDegree_iSup_glWeightSpace_eq_top`,
+  `quotDetDegree_homog`, `quotDetDegree_char_as_antitone_sum`,
+  `quotDetDegree_formalCharacter_eq_polyRight_of_lt`,
+  `polyRight_iSup_glWeightSpace_eq_top`, `polyRight_glWeightSpace_homog`,
+  `quotDetDegreeProj_equivariant`) →
+  `[propext, Classical.choice, Quot.sound]` only. **No `sorryAx`, no custom
+  axioms.** `lake build …CauchyDetQuotientDegree` green on a fresh
+  `lake exe cache get` checkout (toolchain `v4.29.0-rc6`).
+
+No code changes to the audited file (review item). No follow-up issues opened —
+the foundation is sound; the in-flight glue-3 (#5064) and #4905 assembly may
+consume these results with confidence.
+
+### 2. Released stale feature issue #5074 (`exists_degree_embedding`) → `replan`
+
+While first claimed via `/work`, #5074 (the part-A grading reduction
+`exists_degree_embedding`) proved to be already delivered on `main`. All three of
+its deliverables exist sorry-free in
+`EtingofRepresentationTheory/Chapter5/CauchyDetQuotientGrading.lean`, landed by
+the equivalent issue #4961 (PR #5058, commit `58d3fa07`, merged
+2026-06-22T19:12Z — ~6h **before** #5074 was created):
+
+- `homogeneousComponent_mem_detSubmodule` (`:86`, exact requested name),
+- the descended projection `quotDetProj` (`:113`) + `quotDetProj_equivariant`
+  (`:134`), with the codRestrict into `quotDetDegreeFDRep` done inside the main
+  theorem,
+- `exists_degree_embedding_of_simple` (`:204`) — signature identical to #5074's
+  requested `exists_degree_embedding`.
+
+Consumer #5076 step 1 ("Apply #5074 `exists_degree_embedding` to
+`(L, hLsimp, φ, hφ_inj, hφ_equiv)`") is satisfied verbatim by
+`exists_degree_embedding_of_simple`. Skipped #5074 with a detailed reason
+recommending a planner CLOSE it and drop the `depends-on: #5074` line from #5076
+so `check-blocked` can unblock it.
+
+## Current frontier
+
+Audit of #5068 closed PASS. The degree-`d` A/det character foundation
+(`quotDetDegreeFDRep_formalCharacter` + algebraicity + weight-space spanning) is
+verified sound and ready for downstream consumption.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. The Ch5 `#4905` det-quotient highest-weight
+chain is being assembled; this audit clears the soundness check on its degree-`d`
+character foundation (PR #5057/#5065/#5066). Sibling audits #5060 (CauchyCharDiff)
+and #5067 (right-torus eigenbasis) previously cleared adjacent lemmas.
+
+## Next step
+
+Open feature work is currently awkward for a single session: #2841 is a large
+multi-module v4.31.0 migration (now also needing a rebase onto the freshly-bumped
+v4.29.0-rc6 `main`); #5037 is the hard James leading-term combinatorial epic
+(4+ prior failed sessions); #5086 ("sub-of-spanning-is-spanning" crux) is
+premature — it depends on `subFDRep`/`CleanInductionHelpers.lean` from the still
+in-flight, unmerged #5081. A planner should (a) close #5074 and unblock #5076,
+and (b) re-scope #2841 given the v4.29.0-rc6 bump already on `main`.
+
+## Blockers
+
+None for this session. Note: #5086 is effectively blocked on the unmerged #5081.


### PR DESCRIPTION
This PR records the soundness audit of issue #5068: the degree-`d` A/det character foundation in `EtingofRepresentationTheory/Chapter5/CauchyDetQuotientDegree.lean` (PRs #5057/#5065/#5066). It changes no Lean source in the audited file; it adds only the verdict progress note.

**Verdict: PASS** on all three deliverables.

- **Definition soundness.** All five `def`s (`quotDetDegreeSubrep`, `quotDetDegreeFDRep`, `twistFDRep`, `quotDetDegreeProj`, `boundedToAntitone`) have real bodies — no sorried `def`/`instance`. The `FiniteDimensional` instances on `quotDetDegreeFDRep` and `twistFDRep` are honest (homogeneous submodule finite-dim; its `mkQ`-image finite-dim).
- **Statement faithfulness.** `quotDetDegreeFDRep_formalCharacter` states the correct `ν_N = 0` constituent character (`0 ∈ range ν.parts` ⟺ last antitone part is 0). Its `N ≤ d` hypothesis is genuinely used (`detSubmodule_inf_homogeneous`, `cauchyMult_mul_prodX_eq_lastPart_pos`), not masking a gap — the `d < N` case is separately proved. `formalCharacter_add_of_shortExact` has correct exactness + spanning hypotheses with a sound rank-nullity proof; `formalCharacter_twistFDRep` is the correct det-twist shift; the spanning/homogeneity lemmas are non-vacuous.
- **Axiom hygiene.** `#print axioms` on all top-level results → `[propext, Classical.choice, Quot.sound]` only; no `sorryAx`, no custom axioms. `lake build …CauchyDetQuotientDegree` green on a fresh `lake exe cache get` checkout (toolchain v4.29.0-rc6).

No defects found; no follow-up issue filed. Full audit detail in the progress note and in the audit comment on #5068.

Closes #5068.

🤖 Prepared with Claude Code