### PR TITLE
Incremental Lean v4.29 port repairs

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/Theorem3_8_1.lean
+++ b/EtingofRepresentationTheory/Chapter3/Theorem3_8_1.lean
@@ -207,7 +207,8 @@ theorem Etingof.krull_schmidt_existence (k : Type*) (A : Type*) (V : Type*)
       (∀ i, Etingof.IsIndecomposable A (W i)) ∧
       iSup W = ⊤ ∧ iSupIndep W := by
   obtain ⟨n, W, _, hindec, hsup, hind⟩ := krull_schmidt_existence_aux k A V
-    (Module.finrank k V) ⊤ (by simp [Submodule.restrictScalars_top])
+    (Module.finrank k V) ⊤
+    (by exact Submodule.finrank_le (Submodule.restrictScalars k (⊤ : Submodule A V)))
   exact ⟨n, W, hindec, hsup, hind⟩
 
 /-- Key step for Krull-Schmidt uniqueness: given an indecomposable direct summand W₀ in one

--- a/EtingofRepresentationTheory/Chapter5/GL2CharacterValues.lean
+++ b/EtingofRepresentationTheory/Chapter5/GL2CharacterValues.lean
@@ -72,6 +72,10 @@ lemma Etingof.splits_X_pow_sub_X :
 obtained from IsSplittingField.lift. -/
 noncomputable def Etingof.galoisFieldAlgHom :
     GaloisField p n →ₐ[ZMod p] GaloisField p (2 * n) :=
+  letI : IsSplittingField (ZMod p) (GaloisField p n) (X ^ p ^ n - X : (ZMod p)[X]) := by
+    change IsSplittingField (ZMod p) ((X ^ p ^ n - X : (ZMod p)[X]).SplittingField)
+      (X ^ p ^ n - X)
+    infer_instance
   IsSplittingField.lift (GaloisField p n) (X ^ p ^ n - X)
     (Etingof.splits_X_pow_sub_X p n)
 

--- a/EtingofRepresentationTheory/Chapter5/Lemma5_13_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Lemma5_13_1.lean
@@ -158,8 +158,8 @@ theorem pigeonhole_rowCol_dichotomy {n : ℕ} {la : Nat.Partition n}
         row (σ a) ≠ row (σ b) := by
       intro a b hab hcol hrow
       have := h_exists (σ a) (σ b) (by intro h; exact hab (σ.injective h)) hrow
-      simp only [Equiv.Perm.coe_inv, Equiv.symm_apply_apply] at this -- v4.29.0: Equiv.Perm.inv_apply_self renamed/removed
-      exact this hcol
+      have hcol_ne : col a ≠ col b := by simpa using this
+      exact hcol_ne hcol
     exfalso
     apply hσ
     -- We show σ ∈ P_λ · Q_λ by constructing q ∈ Q_λ and p = σ * q⁻¹ ∈ P_λ
@@ -363,8 +363,8 @@ theorem pigeonhole_rowCol_dichotomy {n : ℕ} {la : Nat.Partition n}
         show colOfPos parts k₁.val = colOfPos parts k₂.val
         rw [← hq_col k₁, ← hq_col k₂, hval]
       have h_absurd := h_exists (σ k₁) (σ k₂) hσne hrow_σ
-      simp only [Equiv.Perm.coe_inv, Equiv.symm_apply_apply] at h_absurd -- v4.29.0: Equiv.Perm.inv_apply_self renamed/removed
-      exact h_absurd hcol_k
+      have hcol_ne : col k₁ ≠ col k₂ := by simpa using h_absurd
+      exact hcol_ne hcol_k
     -- q_fun is surjective (injective endomorphism of finite type)
     have q_surj := (Finite.injective_iff_surjective).mp q_inj
     -- Create the permutation q
@@ -451,8 +451,13 @@ private theorem sandwich_not_mem {n : ℕ} {la : Nat.Partition n}
         RowSymmetrizer n la) g = 0 := by
       intro g
       have := Finsupp.ext_iff.mp heq g
-      rw [Finsupp.neg_apply] at this
-      exact (mul_eq_zero.mp (show (2 : ℂ) * _ = 0 by linear_combination this)).resolve_left (by norm_num)
+      have hneg : (ColumnAntisymmetrizer n la * MonoidAlgebra.of ℂ _ σ *
+          RowSymmetrizer n la) g =
+          - (ColumnAntisymmetrizer n la * MonoidAlgebra.of ℂ _ σ *
+            RowSymmetrizer n la) g := by
+        simpa using this
+      exact (mul_eq_zero.mp (show (2 : ℂ) * _ = 0 by linear_combination hneg)).resolve_left
+        (by norm_num)
     exact Finsupp.ext hg
   -- Proof of x = sign(u) • x:
   -- Insert of(t) before a_λ (absorbed), combine of(σ)*of(t)=of(σ*t)=of(u*σ),
@@ -514,8 +519,12 @@ private theorem dual_sandwich_not_mem {n : ℕ} {la : Nat.Partition n}
         ColumnAntisymmetrizer n la) g = 0 := by
       intro g
       have := Finsupp.ext_iff.mp heq g
-      rw [Finsupp.neg_apply] at this
-      exact (mul_eq_zero.mp (show (2 : ℂ) * _ = 0 by linear_combination this)).resolve_left
+      have hneg : (RowSymmetrizer n la * MonoidAlgebra.of ℂ _ σ *
+          ColumnAntisymmetrizer n la) g =
+          - (RowSymmetrizer n la * MonoidAlgebra.of ℂ _ σ *
+            ColumnAntisymmetrizer n la) g := by
+        simpa using this
+      exact (mul_eq_zero.mp (show (2 : ℂ) * _ = 0 by linear_combination hneg)).resolve_left
         (by norm_num)
     exact Finsupp.ext hg
   have h1 : RowSymmetrizer n la * MonoidAlgebra.of ℂ _ σ * ColumnAntisymmetrizer n la =
@@ -559,9 +568,20 @@ theorem Etingof.Lemma5_13_1
     Finsupp.lsum ℂ (fun σ => f σ • (LinearMap.id : ℂ →ₗ[ℂ] ℂ))
   refine ⟨ℓ, fun x => ?_⟩
   induction x using Finsupp.induction_linear with
-  | zero => simp
+  | zero =>
+    have hleft : ColumnAntisymmetrizer n la *
+        (0 : MonoidAlgebra ℂ (Equiv.Perm (Fin n))) * RowSymmetrizer n la = 0 := by
+      simp
+    have hright :
+        ℓ (0 : MonoidAlgebra ℂ (Equiv.Perm (Fin n))) • YoungSymmetrizer n la = 0 := by
+      simp
+    exact hleft.trans hright.symm
   | add x y hx hy =>
-    simp only [mul_add, add_mul, map_add, add_smul]
+    let x' : MonoidAlgebra ℂ (Equiv.Perm (Fin n)) := x
+    let y' : MonoidAlgebra ℂ (Equiv.Perm (Fin n)) := y
+    change ColumnAntisymmetrizer n la * (x' + y') * RowSymmetrizer n la =
+      ℓ (x' + y') • YoungSymmetrizer n la
+    rw [map_add, add_smul, mul_add, add_mul]
     exact congr_arg₂ (· + ·) hx hy
   | single σ r =>
     have hℓ : ℓ (Finsupp.single σ r) = f σ * r := by
@@ -598,9 +618,20 @@ theorem Etingof.Lemma5_13_1_dual
     Finsupp.lsum ℂ (fun σ => f σ • (LinearMap.id : ℂ →ₗ[ℂ] ℂ))
   refine ⟨ℓ, fun x => ?_⟩
   induction x using Finsupp.induction_linear with
-  | zero => simp
+  | zero =>
+    have hleft : RowSymmetrizer n la *
+        (0 : MonoidAlgebra ℂ (Equiv.Perm (Fin n))) * ColumnAntisymmetrizer n la = 0 := by
+      simp
+    have hright : ℓ (0 : MonoidAlgebra ℂ (Equiv.Perm (Fin n))) •
+        (RowSymmetrizer n la * ColumnAntisymmetrizer n la) = 0 := by
+      simp
+    exact hleft.trans hright.symm
   | add x y hx hy =>
-    simp only [mul_add, add_mul, map_add, add_smul]
+    let x' : MonoidAlgebra ℂ (Equiv.Perm (Fin n)) := x
+    let y' : MonoidAlgebra ℂ (Equiv.Perm (Fin n)) := y
+    change RowSymmetrizer n la * (x' + y') * ColumnAntisymmetrizer n la =
+      ℓ (x' + y') • (RowSymmetrizer n la * ColumnAntisymmetrizer n la)
+    rw [map_add, add_smul, mul_add, add_mul]
     exact congr_arg₂ (· + ·) hx hy
   | single σ r =>
     have hℓ : ℓ (Finsupp.single σ r) = f σ * r := by

--- a/EtingofRepresentationTheory/Chapter5/Lemma5_13_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Lemma5_13_2.lean
@@ -460,8 +460,15 @@ theorem Lemma5_13_2
     (x : MonoidAlgebra ℂ (Equiv.Perm (Fin n))) :
     RowSymmetrizer n la * x * ColumnAntisymmetrizer n mu = 0 := by
   induction x using Finsupp.induction_linear with
-  | zero => simp
+  | zero =>
+    have hleft : RowSymmetrizer n la *
+        (0 : MonoidAlgebra ℂ (Equiv.Perm (Fin n))) * ColumnAntisymmetrizer n mu = 0 := by
+      simp
+    exact hleft
   | add x y hx hy =>
+    let x' : MonoidAlgebra ℂ (Equiv.Perm (Fin n)) := x
+    let y' : MonoidAlgebra ℂ (Equiv.Perm (Fin n)) := y
+    change RowSymmetrizer n la * (x' + y') * ColumnAntisymmetrizer n mu = 0
     rw [mul_add, add_mul, hx, hy, add_zero]
   | single g c =>
     have h : (Finsupp.single g c : MonoidAlgebra ℂ (Equiv.Perm (Fin n))) =
@@ -527,8 +534,15 @@ theorem Lemma5_13_2_general
     (x : MonoidAlgebra ℂ (Equiv.Perm (Fin n))) :
     RowSymmetrizer n la * x * ColumnAntisymmetrizer n mu = 0 := by
   induction x using Finsupp.induction_linear with
-  | zero => simp
+  | zero =>
+    have hleft : RowSymmetrizer n la *
+        (0 : MonoidAlgebra ℂ (Equiv.Perm (Fin n))) * ColumnAntisymmetrizer n mu = 0 := by
+      simp
+    exact hleft
   | add x y hx hy =>
+    let x' : MonoidAlgebra ℂ (Equiv.Perm (Fin n)) := x
+    let y' : MonoidAlgebra ℂ (Equiv.Perm (Fin n)) := y
+    change RowSymmetrizer n la * (x' + y') * ColumnAntisymmetrizer n mu = 0
     rw [mul_add, add_mul, hx, hy, add_zero]
   | single g c =>
     have hsg : (Finsupp.single g c : MonoidAlgebra ℂ (Equiv.Perm (Fin n))) =

--- a/EtingofRepresentationTheory/Chapter5/Lemma5_4_5.lean
+++ b/EtingofRepresentationTheory/Chapter5/Lemma5_4_5.lean
@@ -166,7 +166,13 @@ theorem Etingof.Lemma5_4_5
         · positivity
         · positivity
         · intro k _; rw [hnorm_one k]
-      rw [← Finset.smul_sum] at this
-      simp only [one_div, norm_smul, norm_inv, Real.norm_natCast] at this
-      rwa [inv_mul_lt_iff₀ (Nat.cast_pos.mpr hn), mul_one] at this
+      have hsum_mul :
+          (∑ k : Fin n, ((1 : ℝ) / n) • ε k) =
+            (n : ℂ)⁻¹ * ∑ k : Fin n, ε k := by
+        simp [one_div, Finset.mul_sum]
+      rw [hsum_mul] at this
+      simp only [norm_mul, norm_inv, Complex.norm_natCast] at this
+      have hlt_sum : ‖∑ k : Fin n, ε k‖ < (n : ℝ) * 1 :=
+        (inv_mul_lt_iff₀ (Nat.cast_pos.mpr hn)).1 (by simpa using this)
+      simpa [mul_one] using hlt_sum
     exact roots_of_unity_avg_norm_bound n hn ε hε hint hsum hlt

--- a/EtingofRepresentationTheory/Chapter5/PolytabloidBasis.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolytabloidBasis.lean
@@ -236,15 +236,17 @@ private lemma columnAntisymmetrizer_apply_not_mem' (n : ℕ) (la : Nat.Partition
     (ColumnAntisymmetrizer n la : SymGroupAlgebra n) σ = 0 := by
   classical
   simp only [ColumnAntisymmetrizer, MonoidAlgebra.of_apply]
-  rw [Finsupp.finset_sum_apply]
-  apply Finset.sum_eq_zero
-  intro q _
+  change (Finsupp.applyAddHom σ) (∑ q : ↥(ColumnSubgroup n la),
+    ((↑(↑(Equiv.Perm.sign (q : Equiv.Perm (Fin n))) : ℤ) : ℂ) •
+      MonoidAlgebra.single (q : Equiv.Perm (Fin n)) (1 : ℂ))) = 0
+  rw [map_sum]
+  exact Fintype.sum_eq_zero _ (fun q => by
   change ((↑(↑(Equiv.Perm.sign (q : Equiv.Perm (Fin n))) : ℤ) : ℂ) •
     (Finsupp.single (q : Equiv.Perm (Fin n)) (1 : ℂ))) σ = 0
   rw [Finsupp.smul_apply, smul_eq_mul, Finsupp.single_apply]
   split_ifs with h
   · exact absurd (h ▸ q.prop) hσ
-  · ring
+  · ring)
 
 /-- The RowSymmetrizer is zero at permutations outside P_λ. -/
 private lemma rowSymmetrizer_apply_not_mem' (n : ℕ) (la : Nat.Partition n)
@@ -252,13 +254,15 @@ private lemma rowSymmetrizer_apply_not_mem' (n : ℕ) (la : Nat.Partition n)
     (RowSymmetrizer n la : SymGroupAlgebra n) σ = 0 := by
   classical
   simp only [RowSymmetrizer, MonoidAlgebra.of_apply]
-  rw [Finsupp.finset_sum_apply]
-  apply Finset.sum_eq_zero
-  intro p _
-  rw [Finsupp.single_apply]
-  split_ifs with h
-  · exact absurd (h ▸ p.prop) hσ
-  · rfl
+  change (Finsupp.applyAddHom σ) (∑ p : ↥(RowSubgroup n la),
+    MonoidAlgebra.single (p : Equiv.Perm (Fin n)) (1 : ℂ)) = 0
+  rw [map_sum]
+  exact Fintype.sum_eq_zero _ (fun p => by
+    simp only [Finsupp.applyAddHom_apply]
+    rw [Finsupp.single_apply]
+    split_ifs with h
+    · exact absurd (h ▸ p.prop) hσ
+    · rfl)
 
 /-! ### Support characterization of the Young symmetrizer
 
@@ -285,27 +289,13 @@ private theorem youngSymmetrizer_support (n : ℕ) (la : Nat.Partition n)
   obtain ⟨q', hq'_mem, p', hp'_mem, hg_eq⟩ :=
     Finset.mem_mul.mp (MonoidAlgebra.support_mul _ _ hmem)
   have hq'_col : q' ∈ ColumnSubgroup n la := by
-    simp only [ColumnAntisymmetrizer, MonoidAlgebra.of_apply] at hq'_mem
-    rw [Finsupp.mem_support_iff, Finsupp.finset_sum_apply] at hq'_mem
     by_contra h_not
-    apply hq'_mem
-    apply Finset.sum_eq_zero
-    intro ⟨r, hr⟩ _
-    rw [Finsupp.smul_apply, smul_eq_mul, Finsupp.single_apply]
-    split_ifs with heq
-    · exact absurd (heq ▸ hr) h_not
-    · ring
+    exact (Finsupp.mem_support_iff.mp hq'_mem)
+      (columnAntisymmetrizer_apply_not_mem' n la q' h_not)
   have hp'_row : p' ∈ RowSubgroup n la := by
-    simp only [RowSymmetrizer, MonoidAlgebra.of_apply] at hp'_mem
-    rw [Finsupp.mem_support_iff, Finsupp.finset_sum_apply] at hp'_mem
     by_contra h_not
-    apply hp'_mem
-    apply Finset.sum_eq_zero
-    intro ⟨r, hr⟩ _
-    rw [Finsupp.single_apply]
-    split_ifs with heq
-    · exact absurd (heq ▸ hr) h_not
-    · rfl
+    exact (Finsupp.mem_support_iff.mp hp'_mem)
+      (rowSymmetrizer_apply_not_mem' n la p' h_not)
   exact ⟨q', hq'_col, p', hp'_row, hg_eq.symm⟩
 
 /-- The coefficient of g in c_λ = b·a when g = q · p (q ∈ Q_λ, p ∈ P_λ) is sign(q). -/
@@ -328,10 +318,16 @@ private theorem youngSymmetrizer_pq_coeff (n : ℕ) (la : Nat.Partition n)
           (RowSymmetrizer n la : SymGroupAlgebra n) (q'.val⁻¹ * (q * p))) := by
     unfold ColumnAntisymmetrizer
     simp only [MonoidAlgebra.of_apply, Finset.sum_mul]
-    rw [Finsupp.finset_sum_apply (N := ℂ)]
-    congr 1; ext ⟨q', hq'⟩
-    rw [Algebra.smul_mul_assoc, Finsupp.smul_apply, smul_eq_mul,
-        MonoidAlgebra.single_mul_apply, one_mul]
+    change (Finsupp.applyAddHom (q * p)) (∑ q' : ↥(ColumnSubgroup n la),
+      (((↑(↑(Equiv.Perm.sign (q' : Equiv.Perm (Fin n))) : ℤ) : ℂ) •
+        MonoidAlgebra.single (q' : Equiv.Perm (Fin n)) (1 : ℂ)) * RowSymmetrizer n la)) =
+        ∑ q' : ↥(ColumnSubgroup n la),
+          ((↑(↑(Equiv.Perm.sign q'.val) : ℤ) : ℂ) *
+            (RowSymmetrizer n la : SymGroupAlgebra n) (q'.val⁻¹ * (q * p)))
+    rw [map_sum]
+    congr 1; ext q'
+    rw [Algebra.smul_mul_assoc]
+    simp [MonoidAlgebra.single_mul_apply]
   rw [heval]
   -- Only q' = q contributes: q'⁻¹ * (q * p) ∈ P_λ iff q' = q
   rw [Finset.sum_eq_single (⟨q, hq⟩ : ↥(ColumnSubgroup n la))]
@@ -339,10 +335,13 @@ private theorem youngSymmetrizer_pq_coeff (n : ℕ) (la : Nat.Partition n)
     simp only [inv_mul_cancel_left]
     rw [show (RowSymmetrizer n la : SymGroupAlgebra n) p = 1 from by
       simp only [RowSymmetrizer, MonoidAlgebra.of_apply]
-      rw [Finsupp.finset_sum_apply]
+      change (Finsupp.applyAddHom p) (∑ p' : ↥(RowSubgroup n la),
+        MonoidAlgebra.single (p' : Equiv.Perm (Fin n)) (1 : ℂ)) = 1
+      rw [map_sum]
       rw [Finset.sum_eq_single (⟨p, hp⟩ : ↥(RowSubgroup n la))]
       · simp
       · intro ⟨p', _⟩ _ hne
+        simp only [Finsupp.applyAddHom_apply]
         rw [Finsupp.single_apply, if_neg (fun h => hne (Subtype.ext h))]
       · intro h; exact absurd (Finset.mem_univ _) h]
     ring
@@ -351,9 +350,12 @@ private theorem youngSymmetrizer_pq_coeff (n : ℕ) (la : Nat.Partition n)
     suffices h : (RowSymmetrizer n la : SymGroupAlgebra n) (q'⁻¹ * (q * p)) = 0 by
       rw [h, mul_zero]
     simp only [RowSymmetrizer, MonoidAlgebra.of_apply]
-    rw [Finsupp.finset_sum_apply]
-    apply Finset.sum_eq_zero
-    intro ⟨p', hp'⟩ _
+    change (Finsupp.applyAddHom (q'⁻¹ * (q * p))) (∑ p' : ↥(RowSubgroup n la),
+      MonoidAlgebra.single (p' : Equiv.Perm (Fin n)) (1 : ℂ)) = 0
+    rw [map_sum]
+    apply Fintype.sum_eq_zero
+    intro ⟨p', hp'⟩
+    simp only [Finsupp.applyAddHom_apply]
     rw [Finsupp.single_apply]
     rw [if_neg]
     intro heq

--- a/EtingofRepresentationTheory/Chapter5/Proposition5_21_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Proposition5_21_1.lean
@@ -43,6 +43,33 @@ def vandermondeExps (N : ℕ) : Fin N → ℕ := fun j => N - 1 - j
 def shiftedExps (N : ℕ) (lam : Fin N → ℕ) : Fin N → ℕ :=
   fun j => lam j + (N - 1 - j)
 
+private lemma coeff_sign_smul_monomial {N : ℕ} (σ : Equiv.Perm (Fin N)) (s t : Fin N →₀ ℕ) :
+    MvPolynomial.coeff t (Equiv.Perm.sign σ • MvPolynomial.monomial s (1 : ℚ)) =
+      ((↑(Equiv.Perm.sign σ) : ℤ) : ℚ) * (if s = t then 1 else 0) := by
+  rcases Int.units_eq_one_or (Equiv.Perm.sign σ) with hs | hs <;>
+    by_cases h : s = t <;>
+      simp [hs, Units.smul_def, MvPolynomial.coeff_monomial, h]
+
+private lemma coeff_ne_zero_of_sign_smul_ne_zero {N : ℕ} (σ : Equiv.Perm (Fin N))
+    {d : Fin N →₀ ℕ} {p : MvPolynomial (Fin N) ℚ}
+    (h : MvPolynomial.coeff d (Equiv.Perm.sign σ • p) ≠ 0) :
+    MvPolynomial.coeff d p ≠ 0 := by
+  rcases Int.units_eq_one_or (Equiv.Perm.sign σ) with hs | hs <;>
+    simpa [hs, Units.smul_def] using h
+
+private lemma sign_smul_sub {N : ℕ} (σ : Equiv.Perm (Fin N))
+    (p q : MvPolynomial (Fin N) ℚ) :
+    Equiv.Perm.sign σ • (p - q) = Equiv.Perm.sign σ • p - Equiv.Perm.sign σ • q := by
+  rcases Int.units_eq_one_or (Equiv.Perm.sign σ) with hs | hs
+  · simp [hs]
+  · simp [hs, Units.smul_def, sub_eq_add_neg, add_comm]
+
+private lemma degree_sign_smul_monomial {N : ℕ} (m : MonomialOrder (Fin N))
+    (σ : Equiv.Perm (Fin N)) (s : Fin N →₀ ℕ) :
+    m.degree (Equiv.Perm.sign σ • MvPolynomial.monomial s (1 : ℚ)) = s := by
+  rcases Int.units_eq_one_or (Equiv.Perm.sign σ) with hs | hs <;>
+    simp [hs, Units.smul_def, MonomialOrder.degree_monomial]
+
 /-! ### Divisibility of alternants by the Vandermonde
 
 The key algebraic fact: for any exponent sequence `e`, the Vandermonde determinant
@@ -456,7 +483,7 @@ theorem alternant_coeff_kronecker {N : ℕ}
       from rfl, show ∏ j, (X (σ j) : MvPolynomial (Fin N) ℚ) ^ e j =
         ∏ i, X i ^ (e (σ.symm i)) from Fintype.prod_equiv σ _ _ (fun _ => by simp)]
     exact prod_X_pow_eq_monomial' _]
-  simp only [MvPolynomial.coeff_monomial]
+  simp only [coeff_sign_smul_monomial]
   have key : ∀ σ : Equiv.Perm (Fin N),
       (Finsupp.equivFunOnFinite.symm (e ∘ ⇑σ.symm) = Finsupp.equivFunOnFinite.symm e') ↔
       (e ∘ ⇑σ.symm = e') := fun σ => Finsupp.equivFunOnFinite.symm.injective.eq_iff
@@ -479,12 +506,12 @@ theorem alternant_coeff_kronecker {N : ℕ}
       simp [Equiv.Perm.one_symm]
     · intro σ _ hne; simp only [key]; split_ifs with h
       · exact absurd (unique σ h).2 hne
-      · exact smul_zero _
+      · exact mul_zero _
     · intro h; exact absurd (Finset.mem_univ _) h
   · exact Finset.sum_eq_zero fun σ _ => by
       simp only [key]; split_ifs with h
       · exact absurd (unique σ h).1 heq
-      · exact smul_zero _
+      · exact mul_zero _
 
 /-- An antisymmetric polynomial whose coefficients at all strictly anti multi-indices
 are zero must be the zero polynomial. -/
@@ -539,9 +566,9 @@ theorem alternant_isHomogeneous {N : ℕ} (e : Fin N → ℕ) :
     (alternantMatrix N e).det.IsHomogeneous (∑ j : Fin N, e j) := by
   rw [Matrix.det_apply, show ∑ j : Fin N, e j = ∑ j : Fin N, 1 * e j by simp]
   apply MvPolynomial.IsHomogeneous.sum; intro σ _ d hd
-  rw [MvPolynomial.coeff_smul] at hd
   exact (MvPolynomial.IsHomogeneous.prod _ _ _ (fun j _ =>
-    (MvPolynomial.isHomogeneous_X ℚ (σ j)).pow (e j))) (right_ne_zero_of_mul hd)
+    (MvPolynomial.isHomogeneous_X ℚ (σ j)).pow (e j)))
+    (coeff_ne_zero_of_sign_smul_ne_zero σ hd)
 
 /-- Power-sum symmetric polynomials are homogeneous of degree `n`. -/
 theorem psumPart_isHomogeneous {n : ℕ} (N : ℕ) (μ : n.Partition) :
@@ -603,7 +630,9 @@ theorem Proposition5_21_1_univ
   rw [← sub_eq_zero]
   apply antisym_eq_zero
   · -- Antisymmetry of the difference
-    intro σ; rw [map_sub, smul_sub]; congr 1
+    intro σ
+    rw [map_sub, sign_smul_sub]
+    congr 1
     · rw [map_mul, rename_alternant_det, (psumPart_isSymmetric N μ) σ, smul_mul_assoc]
     · -- rename σ (∑ c • D) = sign σ • ∑ c • D
       trans ∑ lam : BoundedPartition N n, Equiv.Perm.sign σ •
@@ -766,7 +795,7 @@ theorem degLex_degree_alternantMatrix_det {N : ℕ} {e : Fin N → ℕ} (he : St
     have hc : (Equiv.Perm.sign σ • (1 : ℚ)) ≠ 0 := by
       rcases Int.units_eq_one_or (Equiv.Perm.sign σ) with hs | hs <;> rw [hs] <;>
         simp [Units.smul_def]
-    rw [smul_monomial, MonomialOrder.degree_monomial, if_neg hc]
+    exact degree_sign_smul_monomial m σ _
   -- Lower bound: `x^e` lies in the support (its coefficient is `1`).
   have hlower : Finsupp.equivFunOnFinite.symm e ≼[m] m.degree (alternantMatrix N e).det := by
     apply m.le_degree

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_12_2_Irreducible.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_12_2_Irreducible.lean
@@ -33,6 +33,12 @@ open scoped Classical
 private abbrev G' (n : ℕ) := Equiv.Perm (Fin n)
 private abbrev A' (n : ℕ) := MonoidAlgebra ℂ (G' n)
 
+private lemma monoidAlgebra_fintype_sum_apply {ι R G : Type*} [Fintype ι] [Semiring R]
+    (f : ι → MonoidAlgebra R G) (a : G) :
+    (∑ i, f i) a = ∑ i, f i a := by
+  classical
+  exact Finsupp.finset_sum_apply Finset.univ f a
+
 instance neZero_card_perm (n : ℕ) : NeZero (Nat.card (G' n) : ℂ) :=
   ⟨by exact_mod_cast Nat.card_pos.ne'⟩
 
@@ -70,7 +76,7 @@ private lemma trace_lmul_monoidAlgebra
     intro g
     -- repr is identity for this basis; lmul a x = a * x
     change (a * MonoidAlgebra.single g 1 : G →₀ ℂ) g = (a : G →₀ ℂ) 1
-    rw [MonoidAlgebra.mul_single_apply, mul_inv_cancel, mul_one]
+    exact (MonoidAlgebra.mul_single_apply a (1 : ℂ) g g).trans (by simp)
   simp only [this, Finset.sum_const, Finset.card_univ]
 
 /-- The sorted parts of a partition of n sum to n. -/
@@ -99,10 +105,8 @@ private lemma columnAntisymmetrizer_apply_mem (n : ℕ) (la : Nat.Partition n) (
     (hσ : σ ∈ ColumnSubgroup n la) :
     (ColumnAntisymmetrizer n la : A' n) σ = ((↑(Equiv.Perm.sign σ) : ℤ) : ℂ) := by
   simp only [ColumnAntisymmetrizer, MonoidAlgebra.of_apply]
-  rw [Finsupp.finset_sum_apply]
-  rw [Finset.sum_congr rfl (fun i _ => show _ = _ from by
-    change ((↑(↑(Equiv.Perm.sign (i : G' n)) : ℤ) : ℂ) • (Finsupp.single (i : G' n) (1 : ℂ))) σ = _
-    rw [Finsupp.smul_apply, smul_eq_mul, Finsupp.single_apply])]
+  rw [monoidAlgebra_fintype_sum_apply]
+  simp only [MonoidAlgebra.smul_single, smul_eq_mul, mul_one]
   rw [Finset.sum_eq_single (⟨σ, hσ⟩ : ↑(ColumnSubgroup n la))]
   · simp
   · intro q _ hq
@@ -115,10 +119,8 @@ private lemma columnAntisymmetrizer_apply_not_mem (n : ℕ) (la : Nat.Partition 
     (hσ : σ ∉ ColumnSubgroup n la) :
     (ColumnAntisymmetrizer n la : A' n) σ = 0 := by
   simp only [ColumnAntisymmetrizer, MonoidAlgebra.of_apply]
-  rw [Finsupp.finset_sum_apply]
-  rw [Finset.sum_congr rfl (fun i _ => show _ = _ from by
-    change ((↑(↑(Equiv.Perm.sign (i : G' n)) : ℤ) : ℂ) • (Finsupp.single (i : G' n) (1 : ℂ))) σ = _
-    rw [Finsupp.smul_apply, smul_eq_mul, Finsupp.single_apply])]
+  rw [monoidAlgebra_fintype_sum_apply]
+  simp only [MonoidAlgebra.smul_single, smul_eq_mul, mul_one]
   apply Finset.sum_eq_zero
   intro q _
   have : (q : G' n) ≠ σ := fun h => hσ (h ▸ q.prop)
@@ -133,31 +135,30 @@ private lemma youngSymmetrizer_identity_coeff (n : ℕ) (la : Nat.Partition n) :
   change (ColumnAntisymmetrizer n la * RowSymmetrizer n la : A' n) 1 = 1
   -- Expand b = ∑_q sign(q) · single q 1
   simp only [ColumnAntisymmetrizer, MonoidAlgebra.of_apply, Finset.sum_mul]
-  rw [Finsupp.finset_sum_apply]
+  rw [monoidAlgebra_fintype_sum_apply]
   -- Each summand: (sign(q) • single(q, 1) * a)(1) = sign(q) * a(q⁻¹)
-  rw [Finset.sum_congr rfl (fun q _ => show _ = _ from by
-    rw [Algebra.smul_mul_assoc, Finsupp.smul_apply, smul_eq_mul,
-      MonoidAlgebra.single_mul_apply, one_mul, mul_one])]
+  simp only [Algebra.smul_mul_assoc]
   rw [Finset.sum_eq_single (⟨1, (ColumnSubgroup n la).one_mem⟩ : ↑(ColumnSubgroup n la))]
   · -- q = 1: sign(1) * a(1) = 1
-    simp only [Subgroup.coe_mk, inv_one, Equiv.Perm.sign_one, Int.cast_one,
-      Complex.ofReal_one, one_mul]
+    simp only [Equiv.Perm.sign_one]
     -- a(1) = RowSymmetrizer(1) = 1
     simp only [RowSymmetrizer, MonoidAlgebra.of_apply]
-    rw [Finsupp.finset_sum_apply,
+    simp only [Units.val_one, Int.cast_one, one_smul, MonoidAlgebra.single_mul_apply,
+      inv_one, mul_one, one_mul]
+    rw [monoidAlgebra_fintype_sum_apply,
       Finset.sum_eq_single (⟨1, (RowSubgroup n la).one_mem⟩ : ↑(RowSubgroup n la))]
-    · simp [Finsupp.single_apply]
+    · simp
     · intro p _ hp
       have hp_ne : (p : G' n) ≠ 1 := fun h => hp (Subtype.ext h)
-      simp [Finsupp.single_apply, hp_ne]
+      simp [hp_ne]
     · intro h; exact absurd (Finset.mem_univ _) h
   · -- q ≠ 1: sign(q) * a(q⁻¹) = 0 because q⁻¹ ∉ P (since P ∩ Q = {1})
     intro q _ hq
     have hq_ne : (q : G' n) ≠ 1 := fun h => hq (Subtype.ext h)
     suffices h : (RowSymmetrizer n la : A' n) (q : G' n)⁻¹ = 0 by
-      rw [h, mul_zero]
+      simp [MonoidAlgebra.smul_apply, MonoidAlgebra.single_mul_apply, h]
     simp only [RowSymmetrizer, MonoidAlgebra.of_apply]
-    rw [Finsupp.finset_sum_apply]
+    rw [monoidAlgebra_fintype_sum_apply]
     apply Finset.sum_eq_zero; intro p _
     rw [Finsupp.single_apply]
     split_ifs with h

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_27_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_27_1.lean
@@ -271,8 +271,10 @@ private lemma sum_right_invariant_eq {G : Type*} [Group G] [Fintype G]
     -- The fiber over q has |H| elements by QuotientGroup.card_preimage_mk
     rw [show (Finset.univ.filter (fun h : G => (h : G ⧸ H) = q)).card =
         Fintype.card (QuotientGroup.mk (s := H) ⁻¹' {q}) from by
-      rw [Fintype.card_ofFinset]
-      congr 1; ext h; simp [Finset.mem_filter]]
+      rw [← Set.toFinset_card (QuotientGroup.mk (s := H) ⁻¹' {q})]
+      congr 1
+      ext h
+      simp [Finset.mem_filter]]
     rw [show Fintype.card (QuotientGroup.mk (s := H) ⁻¹' {q}) =
         Nat.card (QuotientGroup.mk (s := H) ⁻¹' {q}) from by
       rw [Nat.card_eq_fintype_card]]
@@ -524,15 +526,17 @@ open CategoryTheory in
 private noncomputable def simple_of_isSimpleModule_asModule'
     {k : Type} [Field k] {G : Type} [Group G]
     {V : Type} [AddCommGroup V] [Module k V] [Module.Finite k V] [Module.Free k V]
-    (ρ : Representation k G V) [IsSimpleModule (MonoidAlgebra k G) ρ.asModule] :
+    (ρ : Representation k G V)
+    [hρ : @IsSimpleModule (MonoidAlgebra k G) _ ρ.asModule _
+      (Representation.instModuleMonoidAlgebraAsModule ρ)] :
     Simple (FDRep.of ρ) := by
-  haveI : Simple (ModuleCat.of (MonoidAlgebra k G) ρ.asModule) :=
-    simple_of_isSimpleModule
+  letI : Module (MonoidAlgebra k G) ρ.asModule :=
+    Representation.instModuleMonoidAlgebraAsModule ρ
   let E := Rep.equivalenceModuleMonoidAlgebra (k := k) (G := G)
   haveI : Simple
       (E.functor.obj ((forget₂ (FDRep k G) (Rep k G)).obj (FDRep.of ρ))) := by
-    change Simple (ModuleCat.of (MonoidAlgebra k G) ρ.asModule)
-    infer_instance
+    exact @simple_of_isSimpleModule (MonoidAlgebra k G) ρ.asModule _ _
+      (Representation.instModuleMonoidAlgebraAsModule ρ) hρ
   haveI : Simple ((forget₂ (FDRep k G) (Rep k G)).obj (FDRep.of ρ)) :=
     simple_of_full_faithful_preservesMono'' E.functor _
   exact simple_of_full_faithful_preservesMono'' (forget₂ (FDRep k G) (Rep k G)) _
@@ -844,7 +848,10 @@ private lemma inducedRepV_simple {G A : Type} [Group G] [CommGroup A] [Fintype G
     rw [heq]; exact h
   -- Use the IsSimpleModule → Simple bridge
   set ρ := inducedRep_raw φ χ U
-  haveI : IsSimpleModule (MonoidAlgebra ℂ (A ⋊[φ] G)) (Representation.asModule ρ) :=
+  letI : Module (MonoidAlgebra ℂ (A ⋊[φ] G)) (Representation.asModule ρ) :=
+    Representation.instModuleMonoidAlgebraAsModule ρ
+  haveI : @IsSimpleModule (MonoidAlgebra ℂ (A ⋊[φ] G)) _ (Representation.asModule ρ) _
+      (Representation.instModuleMonoidAlgebraAsModule ρ) :=
     (Representation.irreducible_iff_isSimpleModule_asModule ρ).mp <| by
     -- IsIrreducible = IsSimpleOrder (Subrepresentation ρ)
     haveI : Nontrivial (Subrepresentation ρ) := by
@@ -1118,7 +1125,13 @@ private lemma inducedRepV_orbit_injectivity {G A : Type} [Group G] [CommGroup A]
       by_cases hq : q = q₁
       · subst hq; rfl
       · rw [hf_supp q hq, smul_zero, smul_zero]
-    rw [haction_f, map_smul, Pi.smul_apply] at hcomm_q₂
+    rw [haction_f] at hcomm_q₂
+    have hT_smul : T (((χ₁ ((φ q₁.out⁻¹ : MulAut A) a₀) : ℂˣ) : ℂ) • f) q₂ =
+        ((χ₁ ((φ q₁.out⁻¹ : MulAut A) a₀) : ℂˣ) : ℂ) • (T f) q₂ := by
+      change T (((χ₁ ((φ q₁.out⁻¹ : MulAut A) a₀) : ℂˣ) : ℂ) • f) q₂ =
+        (((χ₁ ((φ q₁.out⁻¹ : MulAut A) a₀) : ℂˣ) : ℂ) • (T f)) q₂
+      exact congr_fun (T.map_smul (((χ₁ ((φ q₁.out⁻¹ : MulAut A) a₀) : ℂˣ) : ℂ)) f) q₂
+    rw [hT_smul] at hcomm_q₂
     -- RHS: V₂.ρ ⟨a₀,1⟩ (Tf) at q₂ = c₂ • (Tf)(q₂)
     rw [A_action_scalar φ χ₂ U₂ a₀ (T f) q₂] at hcomm_q₂
     -- hcomm_q₂: c₁ • (Tf)(q₂) = c₂ • (Tf)(q₂)
@@ -1178,18 +1191,35 @@ private lemma exists_character_in_rep {G A : Type} [Group G] [CommGroup A]
         ext x; exact Subsingleton.elim _ _))
   -- Restrict W to A via a ↦ (a,1). By Maschke, the ℂ[A]-module is semisimple.
   let ρ_A : Representation ℂ A W := (FDRep.ρ W).comp SemidirectProduct.inl
+  letI : Module (MonoidAlgebra ℂ A) ρ_A.asModule :=
+    Representation.instModuleMonoidAlgebraAsModule ρ_A
   haveI : NeZero (Nat.card A : ℂ) := ⟨Nat.cast_ne_zero.mpr Nat.card_pos.ne'⟩
   -- Get a simple ℂ[A]-submodule (exists by semisimplicity + nontriviality)
   haveI : Nontrivial ρ_A.asModule := hnt
-  obtain ⟨m, hm⟩ := IsSemisimpleModule.exists_simple_submodule (MonoidAlgebra ℂ A) ρ_A.asModule
+  obtain ⟨m, hm⟩ := @IsSemisimpleModule.exists_simple_submodule (MonoidAlgebra ℂ A) _
+    ρ_A.asModule _ (Representation.instModuleMonoidAlgebraAsModule ρ_A) inferInstance inferInstance
   haveI := hm
   -- m is 1-dimensional over ℂ (A commutative, ℂ algebraically closed)
+  letI : Module ℂ ρ_A.asModule := Representation.instModuleAsModule ρ_A
+  let mℂ : Submodule ℂ ρ_A.asModule :=
+    @Submodule.restrictScalars ℂ (MonoidAlgebra ℂ A) ρ_A.asModule _ _ _
+      (Representation.instModuleAsModule ρ_A) (Representation.instModuleMonoidAlgebraAsModule ρ_A)
+      _ inferInstance m
+  letI : Module ℂ m := mℂ.module
+  haveI : IsScalarTower ℂ (MonoidAlgebra ℂ A) m := by infer_instance
   haveI : FiniteDimensional ℂ m :=
-    Module.Finite.of_injective (m.subtype.restrictScalars ℂ) Subtype.val_injective
+    have hfdρ : @FiniteDimensional ℂ ρ_A.asModule _ _
+        (Representation.instModuleAsModule ρ_A) :=
+      @LinearEquiv.finiteDimensional ℂ W _ _ inferInstance ρ_A.asModule _
+        (Representation.instModuleAsModule ρ_A) ρ_A.asModuleEquiv.symm inferInstance
+    @FiniteDimensional.of_injective ℂ m _ _ mℂ.module ρ_A.asModule _
+      (Representation.instModuleAsModule ρ_A) mℂ.subtype Subtype.val_injective hfdρ
   haveI : IsMulCommutative (MonoidAlgebra ℂ A) := ⟨⟨mul_comm⟩⟩
   haveI : Nontrivial m := IsSimpleModule.nontrivial (MonoidAlgebra ℂ A) ↥m
-  have h_dim : Module.finrank ℂ m = 1 :=
-    IsSimpleModule.finrank_eq_one_of_isMulCommutative (MonoidAlgebra ℂ A) m ℂ
+  have h_dim : Module.finrank ℂ m = 1 := by
+    have htower : IsScalarTower ℂ (MonoidAlgebra ℂ A) m := by infer_instance
+    exact @IsSimpleModule.finrank_eq_one_of_isMulCommutative (MonoidAlgebra ℂ A) m ℂ _ _ _ _
+      mℂ.module (SubmoduleClass.module m) htower hm inferInstance inferInstance inferInstance
   -- Pick nonzero v ∈ m; every element of m is a ℂ-multiple of v
   obtain ⟨v, hv_ne⟩ := exists_ne (0 : m)
   have h_basis := (finrank_eq_one_iff_of_nonzero' v hv_ne).mp h_dim
@@ -1206,7 +1236,12 @@ private lemma exists_character_in_rep {G A : Type} [Group G] [CommGroup A]
     fun a => (h_basis (MonoidAlgebra.of ℂ A a • v)).choose_spec
   -- χ_val 1 = 1
   have hχ_one : χ_val 1 = 1 := by
-    apply h_inj; rw [hχ, map_one, one_smul, one_smul]
+    apply h_inj
+    rw [hχ, map_one]
+    ext
+    change (algebraMap ℂ (MonoidAlgebra ℂ A) (1 : ℂ)) • (v : ρ_A.asModule) =
+      (1 : ℂ) • (v : ρ_A.asModule)
+    rw [algebraMap_smul]
   -- χ_val is multiplicative
   have hχ_mul : ∀ a b, χ_val (a * b) = χ_val a * χ_val b := by
     intro a b; apply h_inj
@@ -1217,11 +1252,15 @@ private lemma exists_character_in_rep {G A : Type} [Group G] [CommGroup A]
       _ = MonoidAlgebra.of ℂ A a • (χ_val b • v) := by rw [← hχ b]
       _ = χ_val b • (MonoidAlgebra.of ℂ A a • v) := smul_comm ..
       _ = χ_val b • (χ_val a • v) := by rw [← hχ a]
-      _ = (χ_val a * χ_val b) • v := by rw [mul_comm, mul_smul]
+      _ = (χ_val a * χ_val b) • v := by
+            ext
+            change χ_val b • (χ_val a • (v : ρ_A.asModule)) =
+              (χ_val a * χ_val b) • (v : ρ_A.asModule)
+            rw [smul_smul, mul_comm]
   -- χ_val a ≠ 0 (since MonoidAlgebra.of a is invertible)
   have hχ_ne : ∀ a, χ_val a ≠ 0 := by
     intro a ha
-    have h1 : χ_val a • v = 0 := by rw [ha, zero_smul]
+    have h1 : χ_val a • v = 0 := by simp [ha]
     rw [hχ] at h1
     have h2 : v = 0 := by
       have := congr_arg (MonoidAlgebra.of ℂ A a⁻¹ • ·) h1
@@ -1342,7 +1381,7 @@ private lemma finrank_biprod' {H : Type} [Group H] [Fintype H]
       (0 : A ⟶ B).hom.hom.hom x = 0 := by
     intro A B x
     show (0 : A.V.obj ⟶ B.V.obj).hom x = 0
-    simp [ModuleCat.Hom.hom] -- v4.29.0: simp now closes goal
+    simp [ModuleCat.Hom.hom]
   have hid : ∀ (A : FDRep ℂ H) (x : A.V),
       (𝟙 A : A ⟶ A).hom.hom.hom x = x := fun _ _ => rfl
   refine {

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_4_4.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_4_4.lean
@@ -312,7 +312,11 @@ private lemma class_sum_scalar_isIntegral
     show φ (∑ h : { h : G // IsConj g h }, MonoidAlgebra.of ℤ G h) = c • LinearMap.id
     rw [map_sum]; simp_rw [hφ_of]; exact hc
   -- φ(e) is integral over ℤ; transfer via ring hom
-  have hφe_int : IsIntegral ℤ (φ e) := he.map φ.toIntAlgHom
+  have hφe_int : IsIntegral ℤ (φ e) := by
+    rw [IsIntegral] at he ⊢
+    convert RingHom.IsIntegralElem.map he φ using 1
+    ext z
+    simp [φ]
   rw [hφe] at hφe_int
   -- Extract c from c • id using injectivity of algebraMap ℂ → End(V)
   haveI : Nontrivial V.V.obj := Module.nontrivial_of_finrank_pos hn

--- a/EtingofRepresentationTheory/Chapter9/KoszulHelpers.lean
+++ b/EtingofRepresentationTheory/Chapter9/KoszulHelpers.lean
@@ -59,10 +59,12 @@ theorem pm_koszul_injective
   have hshift : ∀ k, f k = xAct (f (k + 1)) := by
     intro k
     have := hdf (k + 1)
-    rw [Finsupp.sub_apply, show (Polynomial.X : Polynomial R) = Polynomial.monomial 1 1 from rfl,
+    change ((Polynomial.X : Polynomial R) • f) (k + 1) -
+        (PolynomialModule.map R xAct f) (k + 1) = 0 at this
+    rw [show (Polynomial.X : Polynomial R) = Polynomial.monomial 1 1 from rfl,
         PolynomialModule.monomial_smul_apply,
         if_pos (Nat.one_le_iff_ne_zero.mpr (Nat.succ_ne_zero k))] at this
-    simp only [Nat.add_sub_cancel, one_smul] at this
+    simp only [Nat.add_sub_cancel, one_smul, PolynomialModule.map] at this
     change f k - xAct (f (k + 1)) = 0 at this
     exact sub_eq_zero.mp this
   by_contra hf_ne
@@ -228,4 +230,3 @@ theorem finsupp_eval_sum {M : Type u} [AddCommGroup M] [Module R M]
   have hzero : ∀ k ∈ Finset.range (B + 2), k ∉ f.support → (φ ^ k) (f k) = 0 :=
     fun k _ hk => by simp [Finsupp.mem_support_iff] at hk; rw [hk, map_zero]
   exact (Finset.sum_subset hsub hzero).symm
-

--- a/EtingofRepresentationTheory/Chapter9/ShapiroLemma.lean
+++ b/EtingofRepresentationTheory/Chapter9/ShapiroLemma.lean
@@ -220,7 +220,10 @@ theorem ext_subsingleton_of_extendScalars [Small.{u} R] [Small.{u} S]
       have hg'_cocycle : FP.complex.d (n + 2) (n + 1) ≫ g' = 0 := by
         rw [hg'_def]
         have : FP.complex.d (n + 2) (n + 1) = F.map (P.complex.d (n + 2) (n + 1)) := rfl
-        rw [this, ← Adjunction.homEquiv_naturality_left_symm]
+        rw [this]
+        change (extendScalars f).map (P.complex.d (n + 2) (n + 1)) ≫
+          (adj.homEquiv (P.complex.X (n + 1)) N).symm g = 0
+        rw [← adj.homEquiv_naturality_left_symm (P.complex.d (n + 2) (n + 1)) g]
         simp [hg]
       -- Form the S-side Ext element; by subsingleton it equals 0
       have he' : FP.extMk g' (n + 2) rfl hg'_cocycle = 0 := h.elim _ _
@@ -232,8 +235,11 @@ theorem ext_subsingleton_of_extendScalars [Small.{u} R] [Small.{u} S]
       have hcoboundary : P.complex.d (n + 1) n ≫ φ = g := by
         rw [hφ_def, ← adj_homEquiv_naturality_left f (P.complex.d (n + 1) n) φ']
         have : F.map (P.complex.d (n + 1) n) = FP.complex.d (n + 1) n := rfl
-        rw [this, hφ']
-        rw [hg'_def, Equiv.apply_symm_apply]
+        rw [this]
+        change (adj.homEquiv (P.complex.X (n + 1)) N)
+          (FP.complex.d (n + 1) n ≫ φ') = g
+        exact (congrArg (adj.homEquiv (P.complex.X (n + 1)) N) hφ').trans
+          (by rw [hg'_def, Equiv.apply_symm_apply])
       rw [← hge, P.extMk_eq_zero_iff g (n + 2) rfl hg n rfl]
       exact ⟨φ, hcoboundary⟩
     exact sub_eq_zero.mp hsub

--- a/EtingofRepresentationTheory/Infrastructure/BasicAlgebraExistence.lean
+++ b/EtingofRepresentationTheory/Infrastructure/BasicAlgebraExistence.lean
@@ -789,13 +789,34 @@ private lemma cornerFunctor_full {e : A} (he : IsFullIdempotent e) :
       (∑ p ∈ σ.support, (σ p * p.1) • (φ (toECorner he.1 (p.2 • m₂)) : eCorner he.1 N).val)
     rw [← Finset.sum_add_distrib]
     congr 1; ext p
-    rw [smul_add, toECorner_add, map_add, AddSubgroup.coe_add, smul_add]
+    have hφ : ((ConcreteCategory.hom φ)
+        (toECorner he.1 (p.2 • m₁) + toECorner he.1 (p.2 • m₂)) :
+        eCorner he.1 N).val =
+        ((ConcreteCategory.hom φ) (toECorner he.1 (p.2 • m₁)) :
+          eCorner he.1 N).val +
+        ((ConcreteCategory.hom φ) (toECorner he.1 (p.2 • m₂)) :
+          eCorner he.1 N).val := by
+      rw [← AddSubgroup.coe_add]
+      exact congrArg (fun x : eCorner he.1 N => (x : N))
+        ((ConcreteCategory.hom φ).map_add (toECorner he.1 (p.2 • m₁))
+          (toECorner he.1 (p.2 • m₂)))
+    rw [smul_add, toECorner_add, hφ, smul_add]
   -- Key identity: ∑ σ p * (p.1 * e * p.2) = 1
   have hσ1 : ∑ p ∈ σ.support, σ p * (p.1 * e * p.2) = 1 := by
     have := hσ; simp only [Finsupp.sum, smul_eq_mul] at this; exact this
   -- Coercion helper: (r •_{eAe} x : eCorner).val = (r : A) • (x : N)
   have coe_smul : ∀ (r : CornerRing (k := k) e) (x : eCorner he.1 N),
       ((r • x : eCorner he.1 N) : N) = (r : A) • (x : N) := fun _ _ => rfl
+  have coe_map_smul : ∀ (r : CornerRing (k := k) e) (x : eCorner he.1 M),
+      (φ (r • x) : eCorner he.1 N).val =
+        (r : A) • (φ x : eCorner he.1 N).val := by
+    intro r x
+    have hmap : (φ (r • x) : eCorner he.1 N).val =
+        (r • (φ x : eCorner he.1 N) : eCorner he.1 N).val :=
+      congrArg (fun y : eCorner he.1 N => (y : N))
+        ((ConcreteCategory.hom φ).map_smul r x)
+    rw [hmap]
+    exact coe_smul r ((ConcreteCategory.hom φ) x)
   -- Helper for the generator case: liftFun on e • n
   have lift_eCorner : ∀ (n : M),
       liftFun (e • n) = (φ (toECorner he.1 n) : eCorner he.1 N).val := by
@@ -811,7 +832,13 @@ private lemma cornerFunctor_full {e : A} (he : IsFullIdempotent e) :
       intro p; apply Subtype.ext
       show e • (p.2 • (e • n)) = (e * p.2 * e) • (e • n)
       rw [mul_smul, mul_smul, eCorner_smul_of_idem he.1 n]
-    simp_rw [h1, map_smul, coe_smul, ← mul_smul, ← Finset.sum_smul]
+    rw [show ∑ p ∈ σ.support, (σ p * p.1) •
+        (φ (toECorner he.1 (p.2 • (e • n))) : eCorner he.1 N).val =
+        ∑ p ∈ σ.support, (σ p * p.1 * (e * p.2 * e)) •
+          (φ (toECorner he.1 n) : eCorner he.1 N).val by
+      apply Finset.sum_congr rfl
+      intro p hp
+      rw [h1 p, coe_map_smul, ← mul_smul], ← Finset.sum_smul]
     have hsum_e : ∑ p ∈ σ.support, σ p * p.1 * (e * p.2 * e) = e := by
       have : ∀ p ∈ σ.support, σ p * p.1 * (e * p.2 * e) =
           σ p * (p.1 * e * p.2) * e := fun p _ => by simp only [mul_assoc]
@@ -847,7 +874,13 @@ private lemma cornerFunctor_full {e : A} (he : IsFullIdempotent e) :
         congr 1
         simp only [mul_assoc]
         rw [he.1.eq]
-      simp only [h_toE2, map_smul, coe_smul, ← mul_smul, ← Finset.sum_smul]
+      rw [show ∑ p ∈ σ.support, (σ p * p.1) •
+          (φ (toECorner he.1 ((p.2 * (r * e)) • n)) : eCorner he.1 N).val =
+          ∑ p ∈ σ.support, (σ p * p.1 * (e * (p.2 * r) * e)) •
+            (φ (toECorner he.1 n) : eCorner he.1 N).val by
+        apply Finset.sum_congr rfl
+        intro p hp
+        rw [h_toE2 p, coe_map_smul, ← mul_smul], ← Finset.sum_smul]
       -- Sum: ∑ σ_p * p.1 * (e * (p.2 * r) * e) = r * e
       have hsum_eq : ∑ p ∈ σ.support, σ p * p.1 * (e * (p.2 * r) * e) = r * e := by
         have : ∀ p ∈ σ.support, σ p * p.1 * (e * (p.2 * r) * e) =
@@ -888,10 +921,13 @@ private lemma cornerFunctor_full {e : A} (he : IsFullIdempotent e) :
     intro p; apply Subtype.ext
     show e • (p.2 • m) = (e * p.2 * e) • m
     rw [mul_smul, mul_smul, hm]
-  simp only [htoE, map_smul]
-  simp only [show ∀ (r : CornerRing (k := k) e) (x : eCorner he.1 N),
-      ((r • x : eCorner he.1 N) : N) = (r : A) • (x : N) from fun _ _ => rfl]
-  simp only [← mul_smul, ← Finset.sum_smul]
+  rw [show ∑ p ∈ σ.support, (σ p * p.1) •
+      (φ (toECorner he.1 (p.2 • m)) : eCorner he.1 N).val =
+      ∑ p ∈ σ.support, (σ p * p.1 * (e * p.2 * e)) •
+        (φ ⟨m, hm⟩ : eCorner he.1 N).val by
+    apply Finset.sum_congr rfl
+    intro p hp
+    rw [htoE p, coe_map_smul, ← mul_smul], ← Finset.sum_smul]
   -- Sum collapses: sum(sigma(p) * p.1 * e * p.2 * e) = 1 * e = e
   conv_lhs => arg 1; arg 2; ext p; rw [show σ p * p.1 * (e * p.2 * e) =
     σ p * (p.1 * e * p.2) * e by simp only [mul_assoc]]

--- a/EtingofRepresentationTheory/Infrastructure/CornerRing.lean
+++ b/EtingofRepresentationTheory/Infrastructure/CornerRing.lean
@@ -200,7 +200,9 @@ lemma eval_e_mem_cornerSubmodule (φ : Module.End A ↥(Submodule.span A ({e} : 
   -- e * φ(e) = φ(e) by A-linearity and e² = e
   have he_mem : (⟨e, Submodule.subset_span rfl⟩ : ↥(Submodule.span A ({e} : Set A))) =
       e • ⟨e, Submodule.subset_span rfl⟩ := by
-    ext; simp [smul_eq_mul, he.eq]
+    ext
+    change e = e * e
+    exact he.eq.symm
   have key : φ ⟨e, Submodule.subset_span rfl⟩ =
       e • φ ⟨e, Submodule.subset_span rfl⟩ := by
     conv_lhs => rw [he_mem]
@@ -223,8 +225,14 @@ private lemma rightMul_mem_leftIdeal {c : A} (hc : c ∈ cornerSubmodule (k := k
 noncomputable def rightMulEnd (c : CornerRing (k := k) e) :
     Module.End A ↥(Submodule.span A ({e} : Set A)) where
   toFun x := ⟨x.val * c.val, rightMul_mem_leftIdeal he c.prop x.val⟩
-  map_add' x y := by ext; simp [add_mul]
-  map_smul' a x := by ext; simp [smul_eq_mul, mul_assoc]
+  map_add' x y := by
+    ext
+    change ((x : A) + (y : A)) * (c : A) = (x : A) * (c : A) + (y : A) * (c : A)
+    rw [add_mul]
+  map_smul' a x := by
+    ext
+    change (a * (x : A)) * (c : A) = a * ((x : A) * (c : A))
+    rw [mul_assoc]
 
 /-- The ring anti-isomorphism `End_A(Ae) ≃+* (eAe)ᵒᵖ`.
 
@@ -277,9 +285,13 @@ noncomputable def endLeftIdealRingEquivCornerRingOp :
       have hlhs : (φ (ψ ⟨e, Submodule.subset_span rfl⟩)).val =
           b * (φ ⟨e, Submodule.subset_span rfl⟩).val := by
         have h1 : ψ ⟨e, Submodule.subset_span rfl⟩ = b • ⟨e, Submodule.subset_span rfl⟩ := by
-          ext; simp [smul_eq_mul, hb]
+          ext
+          change (ψ ⟨e, Submodule.subset_span rfl⟩).val = b * e
+          exact hb.symm
         rw [h1, map_smul]
-        simp [smul_eq_mul]
+        change b * (φ ⟨e, Submodule.subset_span rfl⟩).val =
+          b * (φ ⟨e, Submodule.subset_span rfl⟩).val
+        rfl
       -- RHS: (b * e) * φ(e).val = b * (e * φ(e).val) = b * φ(e).val
       have hrhs : (ψ ⟨e, Submodule.subset_span rfl⟩).val *
           (φ ⟨e, Submodule.subset_span rfl⟩).val =

--- a/EtingofRepresentationTheory/Infrastructure/IrreducibleEnumeration.lean
+++ b/EtingofRepresentationTheory/Infrastructure/IrreducibleEnumeration.lean
@@ -239,7 +239,10 @@ private lemma IrrepDecomp.asModule_smul_eq_mulVec [NeZero (Nat.card G : k)]
 /-- The column vector representation's asModule is a simple k[G]-module. -/
 noncomputable instance IrrepDecomp.isSimpleModule_columnRep_asModule [NeZero (Nat.card G : k)]
     (D : IrrepDecomp k G) (i : Fin D.n) :
-    IsSimpleModule (MonoidAlgebra k G) (D.columnRep i).asModule := by
+    @IsSimpleModule (MonoidAlgebra k G) _ (D.columnRep i).asModule _
+      (Representation.instModuleMonoidAlgebraAsModule (D.columnRep i)) := by
+  letI : Module (MonoidAlgebra k G) (D.columnRep i).asModule :=
+    Representation.instModuleMonoidAlgebraAsModule (D.columnRep i)
   haveI := D.d_pos i
   haveI : Nontrivial (D.columnRep i).asModule := by
     change Nontrivial (Fin (D.d i) → k); infer_instance
@@ -261,7 +264,7 @@ noncomputable instance IrrepDecomp.isSimpleModule_columnRep_asModule [NeZero (Na
           exact m.smul_mem a hw }
     cases (Matrix.instIsSimpleModule (D.d i)).eq_bot_or_eq_top m' with
     | inl h =>
-      left; ext x
+      left; apply SetLike.ext; intro x
       simp only [Submodule.mem_bot]
       constructor
       · intro hx
@@ -272,7 +275,7 @@ noncomputable instance IrrepDecomp.isSimpleModule_columnRep_asModule [NeZero (Na
         exact (D.columnRep i).asModuleEquiv.injective hmem
       · intro hx; rw [hx]; exact m.zero_mem
     | inr h =>
-      right; ext x
+      right; apply SetLike.ext; intro x
       simp only [Submodule.mem_top, iff_true]
       have hmem : (D.columnRep i).asModuleEquiv x ∈ m'.carrier := by
         rw [h]; exact Submodule.mem_top
@@ -282,12 +285,17 @@ noncomputable instance IrrepDecomp.isSimpleModule_columnRep_asModule [NeZero (Na
 /-- If `ρ.asModule` is simple over k[G], then `FDRep.of ρ` is Simple in FDRep k G. -/
 private noncomputable instance FDRep.simple_of_isSimpleModule_asModule [NeZero (Nat.card G : k)]
     {V : Type u} [AddCommGroup V] [Module k V] [Module.Finite k V]
-    (ρ : Representation k G V) [IsSimpleModule (MonoidAlgebra k G) ρ.asModule] :
+    (ρ : Representation k G V)
+    [hρ : @IsSimpleModule (MonoidAlgebra k G) _ ρ.asModule _
+      (Representation.instModuleMonoidAlgebraAsModule ρ)] :
     Simple (FDRep.of ρ) := by
+  letI : Module (MonoidAlgebra k G) ρ.asModule :=
+    Representation.instModuleMonoidAlgebraAsModule ρ
+  haveI := hρ
   let E := Rep.equivalenceModuleMonoidAlgebra (k := k) (G := G)
   haveI : Simple (E.functor.obj ((forget₂ (FDRep k G) (Rep k G)).obj (FDRep.of ρ))) := by
-    change Simple (ModuleCat.of (MonoidAlgebra k G) ρ.asModule)
-    exact simple_of_isSimpleModule
+    exact @simple_of_isSimpleModule (MonoidAlgebra k G) ρ.asModule _ _
+      (Representation.instModuleMonoidAlgebraAsModule ρ) hρ
   haveI : Simple ((forget₂ (FDRep k G) (Rep k G)).obj (FDRep.of ρ)) :=
     Simple.of_full_faithful_preservesMono E.functor _
   exact Simple.of_full_faithful_preservesMono (forget₂ (FDRep k G) (Rep k G)) _


### PR DESCRIPTION
## Summary

This is an incremental Lean v4.29 support branch. It bumps the toolchain to v4.29.0 and then records each forward-compatible repair as its own commit so individual fixes can be reviewed, cherry-picked, or superseded independently.

The intended workflow is collaborative: other agents and maintainers are free to cherry-pick commits from this branch and land focused fixes upstream. As upstream porting work lands, we will rebase this branch and drop any commits that have been absorbed or made obsolete.

## Scope

- Bump `lean-toolchain` to `leanprover/lean4:v4.29.0`.
- Update Lake metadata for the v4.29 dependency set.
- Repair proof drift in small, focused commits across Chapters 3-5, Chapter 7, Chapter 9, and shared infrastructure.
- Keep one repair topic per commit where practical.

## Status

This is not a complete 4.29 port yet. It is meant to make the current repair work visible and reusable while the remaining failures are handled incrementally.

Current observed remaining build frontiers include:

- `EtingofRepresentationTheory.Chapter6.Problem6_9_1`
- `EtingofRepresentationTheory.Chapter5.PolytabloidBasis`
- `EtingofRepresentationTheory.Chapter5.Theorem5_14_3`

## Validation

Focused checks run successfully during the repair sequence, including:

- `lake build EtingofRepresentationTheory.Chapter5.Theorem5_27_1`

A broad `lake build` was also run to identify the next failure frontier; it does not pass yet, as expected for this incremental PR.