### PR TITLE
feat(Ch5 #5113): universe-align the kernel-lemma chain to close the last sorry

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/CauchyDetQuotient.lean
+++ b/EtingofRepresentationTheory/Chapter5/CauchyDetQuotient.lean
@@ -2,6 +2,10 @@ import Mathlib
 import EtingofRepresentationTheory.Chapter5.KernelLemmaKPrime
 import EtingofRepresentationTheory.Chapter5.Theorem5_23_2
 import EtingofRepresentationTheory.Chapter5.DetShiftIso
+import EtingofRepresentationTheory.Chapter5.CauchyDetQuotientGrading
+import EtingofRepresentationTheory.Chapter5.CauchyDetQuotientDegree
+import EtingofRepresentationTheory.Chapter5.QuotDetDegreeAlgebraic
+import EtingofRepresentationTheory.Chapter5.CleanConstituentExtraction
 
 /-!
 # Cauchy decomposition of the determinant quotient: constituents have `ν_N = 0`
@@ -78,8 +82,8 @@ build them, and this file fixes the **consumable statement** (top-down):
 3. the `GL_N × GL_N`-equivariant Cauchy multiplicity-one decomposition of
    `k[Xᵢⱼ]` (the research-level epic).
 
-The single `sorry` below is the assembly of (1)+(2)+(3) with the sorry-free
-det-shift; it is tracked by the successor issues filed against #4896.
+The theorem below is the assembly of (1)+(2)+(3) with the sorry-free det-shift,
+discharged sorry-free in #5113 from the four #5076 ingredients.
 -/
 
 namespace Etingof.KernelLemmaKPrime
@@ -108,9 +112,19 @@ twist subtracting `r ≥ 1` from `ν_N = 0`) — to discharge
 `quotDetTwist_nonzero_subrep_has_neg_weight`.
 
 The proof is the residual research-level core of #4896; see the file docstring
-for the decomposition into the three missing infrastructure pieces. -/
+for the decomposition into the three missing infrastructure pieces.
+
+`k` is fixed at `Type` (universe 0) rather than `Type*` because the assembly
+runs through the #5075 constituent-character extractor
+`clean_simple_constituent_formalCharacter_eq_schurPoly_mem`, whose Schur-Weyl /
+Specht / double-centralizer classification foundation is small-universe. The
+whole kernel-lemma consumer chain above this theorem
+(`KernelLemmaKPrimeAssembly`, `KernelLemmaK`, `DetInvElim`,
+`PolynomialRepEmbedding`, `PolynomialGLDecomposition`) is correspondingly
+specialized to `Type`; `k` is always a concrete algebraically-closed char-0
+field, so the universe polymorphism is unused (#5113). -/
 theorem quotDetRep_irreducible_constituent_lastWeight_zero
-    (k : Type*) [Field k] [IsAlgClosed k] [CharZero k] (N : ℕ)
+    (k : Type) [Field k] [IsAlgClosed k] [CharZero k] (N : ℕ)
     (L : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
     (hLsimp : IsSimpleModule
       (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
@@ -121,6 +135,17 @@ theorem quotDetRep_irreducible_constituent_lastWeight_zero
       φ (L.ρ g v) = quotDetRep k N g (φ v)) :
     ∃ ν : Fin N → ℕ, Antitone ν ∧ (0 : ℕ) ∈ Set.range ν ∧
       formalCharacter k N L = schurPoly N ν := by
-  sorry
+  classical
+  obtain ⟨d, ψ, hψ_inj, hψ_equiv⟩ :=
+    Etingof.CauchyDetQuotient.exists_degree_embedding_of_simple k N L hLsimp φ hφ_inj hφ_equiv
+  obtain ⟨S, c, hS0, hchar⟩ :=
+    Etingof.CauchyDetQuotient.quotDetDegree_char_as_antitone_sum (k := k) N d
+  obtain ⟨ν, hνS, _hcpos, hcharL⟩ :=
+    clean_simple_constituent_formalCharacter_eq_schurPoly_mem k N
+      (Etingof.CauchyDetQuotient.quotDetDegreeFDRep k N d)
+      (Etingof.quotDetDegreeFDRep_isAlgebraic k N d)
+      (Etingof.CauchyDetQuotient.quotDetDegree_iSup_glWeightSpace_eq_top (k := k) (N := N) d)
+      S c hchar L hLsimp ψ hψ_inj hψ_equiv
+  exact ⟨ν.val, ν.property, hS0 ν hνS, hcharL⟩
 
 end Etingof.KernelLemmaKPrime

--- a/EtingofRepresentationTheory/Chapter5/DetInvElim.lean
+++ b/EtingofRepresentationTheory/Chapter5/DetInvElim.lean
@@ -39,7 +39,7 @@ namespace Etingof.DetInvElim
 open MvPolynomial Etingof Etingof.DetLocalization Etingof.PolynomialGLAction
   Etingof.LocalizationGLAction Etingof.KernelLemmaKPrime Etingof.KernelLemmaK
 
-variable {k : Type*} [Field k] {N : ℕ}
+variable {k : Type} [Field k] {N : ℕ}
 
 /-! ### Right-translation intertwining -/
 

--- a/EtingofRepresentationTheory/Chapter5/KernelLemmaK.lean
+++ b/EtingofRepresentationTheory/Chapter5/KernelLemmaK.lean
@@ -14,7 +14,7 @@ prerequisites now in place:
   (`DetPowerFiltration.lean`);
 * the representation-theoretic core (K′): for `r ≥ 1` the twisted quotient
   `(A/det) ⊗ χ⁻ʳ` has no nonzero nonneg-weight submodule
-  (`kernelLemmaK'_submodule`, currently a sorry'd dependency tracked by #4832).
+  (`kernelLemmaK'_submodule`, sorry-free as of #5113).
 
 ## (K), det-power-descent form
 
@@ -49,7 +49,7 @@ namespace Etingof.KernelLemmaK
 open MvPolynomial Etingof.PolynomialGLAction Etingof.DetLocalization
   Etingof.LocalizationGLAction Etingof.KernelLemmaKPrime Etingof.DetPowerFiltration
 
-variable {k : Type*} [Field k] {N : ℕ}
+variable {k : Type} [Field k] {N : ℕ}
 
 /-! ### Weight-space bookkeeping -/
 
@@ -89,8 +89,7 @@ weight vectors with weights in `ℕ^N` (`hw`), spanning a right-`GL_N`-stable su
 (`hstable`), consists of honest polynomials: each `w i ∈ range (algebraMap A O)`.
 
 Proved by det-power descent against (K′) (`kernelLemmaK'`); see the module
-docstring. (K′) is currently a sorry'd dependency (#4832), as permitted for this
-assembly. -/
+docstring. (K′) is sorry-free as of #5113. -/
 theorem kernelLemmaK [IsAlgClosed k] [CharZero k] {ι : Type*} [Finite ι]
     (w : ι → Localization.Away (detPoly k N)) (μ : ι → (Fin N → ℕ))
     (hw : ∀ i, w i ∈ glWeightSpaceℤ k N (localRightRep k N) (fun j => (μ i j : ℤ)))

--- a/EtingofRepresentationTheory/Chapter5/KernelLemmaKPrimeAssembly.lean
+++ b/EtingofRepresentationTheory/Chapter5/KernelLemmaKPrimeAssembly.lean
@@ -53,7 +53,7 @@ open MvPolynomial Etingof Etingof.PolynomialGLAction
 
 namespace Etingof.KernelLemmaKPrime
 
-variable {k : Type*} [Field k] {N : ℕ}
+variable {k : Type} [Field k] {N : ℕ}
 
 /-! ### The genuine core of (K′)
 
@@ -67,7 +67,7 @@ whose weight has a negative coordinate.
 
 Assembled from the simple-constituent extraction (#4922), the `ν_N = 0` Cauchy
 content (#4896 part (a)), and the twist weight-shift. -/
-theorem quotDetTwist_nonzero_subrep_has_neg_weight (k : Type*) [Field k]
+theorem quotDetTwist_nonzero_subrep_has_neg_weight (k : Type) [Field k]
     [IsAlgClosed k] [CharZero k] (N : ℕ) (r : ℕ) (hr : 1 ≤ r)
     (W : Subrepresentation (quotDetTwistRep k N r)) (hW : W ≠ ⊥) :
     ∃ μ : Fin N → ℤ, (∃ i, μ i < 0) ∧
@@ -165,7 +165,7 @@ nonnegative is `⊥`.
 By the core `quotDetTwist_nonzero_subrep_has_neg_weight`, a nonzero such `W` would
 contain a negative-weight vector, contradicting the glue lemma
 `glWeightSpaceℤ_neg_not_mem_nonneg_span`. -/
-theorem kernelLemmaK' (k : Type*) [Field k] [IsAlgClosed k] [CharZero k] (N : ℕ)
+theorem kernelLemmaK' (k : Type) [Field k] [IsAlgClosed k] [CharZero k] (N : ℕ)
     (r : ℕ) (hr : 1 ≤ r) (W : Subrepresentation (quotDetTwistRep k N r))
     (hW : W.toSubmodule ≤ ⨆ (μ : Fin N → ℕ),
       glWeightSpaceℤ k N (quotDetTwistRep k N r) (fun i => (μ i : ℤ))) :
@@ -180,7 +180,7 @@ theorem kernelLemmaK' (k : Type*) [Field k] [IsAlgClosed k] [CharZero k] (N : �
 
 The `GL_N`-invariance hypothesis `hW_inv` is essential — without it the statement
 is false (see the note on `kernelLemmaK'` in `KernelLemmaKPrime.lean`). -/
-theorem kernelLemmaK'_submodule (k : Type*) [Field k] [IsAlgClosed k] [CharZero k]
+theorem kernelLemmaK'_submodule (k : Type) [Field k] [IsAlgClosed k] [CharZero k]
     (N : ℕ) (r : ℕ) (hr : 1 ≤ r)
     {W : Submodule k (MvPolynomial (Fin N × Fin N) k ⧸ detSubmodule k N)}
     (hW_inv : ∀ (g : Matrix.GeneralLinearGroup (Fin N) k),

--- a/EtingofRepresentationTheory/Chapter5/PolynomialGLDecomposition.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialGLDecomposition.lean
@@ -64,9 +64,8 @@ open CategoryTheory
 
 namespace Etingof.PolynomialGLDecomposition
 
-universe u
 
-variable (k : Type u) [Field k] (N : ℕ)
+variable (k : Type) [Field k] (N : ℕ)
 
 /-- Abbreviation for the group algebra of `GL_N(k)`, the ring over which the
 `GL_N`-equivariant decompositions are stated. -/
@@ -98,7 +97,7 @@ that one shared `ρ_i`. -/
 theorem glTensorRep_schurWeyl_decomposition_equivariant_simple
     [IsAlgClosed k] [CharZero k] (n : ℕ) :
     ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
-      (S : ι → Type u)
+      (S : ι → Type)
       (_ : ∀ i, AddCommGroup (S i))
       (_ : ∀ i, Module k (S i))
       (_ : ∀ i, Module.Finite k (S i))
@@ -107,7 +106,7 @@ theorem glTensorRep_schurWeyl_decomposition_equivariant_simple
       (_ : Pairwise (fun i j => ¬ Nonempty ((L i) ≅ (L j))))
       (_ : ∀ i, 0 < Module.finrank k (S i)),
       ∃ (e : TensorPower k (Fin N → k) n ≃ₗ[k]
-          (DirectSum ι (fun i => S i ⊗[k] (L i : Type u)))),
+          (DirectSum ι (fun i => S i ⊗[k] (L i : Type)))),
         ∀ (g : Matrix.GeneralLinearGroup (Fin N) k)
           (v : TensorPower k (Fin N → k) n),
           e (glTensorRep k N n g v) =
@@ -117,7 +116,7 @@ theorem glTensorRep_schurWeyl_decomposition_equivariant_simple
   classical
   -- The combined explicit + simple decomposition supplies, over one shared
   -- `ρ_i`, the simplicity clause AND the explicit equivariance ingredients
-  -- (the iso `e` already typed in the `(L i : Type u)` family, the evaluation
+  -- (the iso `e` already typed in the `(L i : Type)` family, the evaluation
   -- formula `he`, and the action formula `h_act`).
   obtain ⟨ι, hιFin, hιDec, S', hS'_simp, hS'_dist, hSi_fin, L, hL_simple,
       L_carrier, e, he, h_act⟩ :=
@@ -146,7 +145,7 @@ theorem glTensorRep_schurWeyl_decomposition_equivariant_simple
     apply TensorProduct.ext'
     intro s l
     change (glTensorRep k N n g) (e.symm
-        (DirectSum.lof k ι (fun i => ↥(S' i) ⊗[k] (L i : Type u)) i
+        (DirectSum.lof k ι (fun i => ↥(S' i) ⊗[k] (L i : Type)) i
           (s ⊗ₜ[k] l))) =
       e.symm ((Representation.directSum (fun i =>
         (Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
@@ -207,14 +206,14 @@ theorem polynomial_homog_rep_asModule_embeds_directSum_simple
     (h_span : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M (fun i => μ i) = ⊤)
     (h_homog : ∀ μ : Fin N → ℕ, glWeightSpace k N M μ ≠ ⊥ → ∑ i, μ i = n) :
     ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
-      (S : ι → Type u) (_ : ∀ i, AddCommGroup (S i)) (_ : ∀ i, Module k (S i))
+      (S : ι → Type) (_ : ∀ i, AddCommGroup (S i)) (_ : ∀ i, Module k (S i))
       (_ : ∀ i, Module.Finite k (S i))
       (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
       (_ : ∀ i, IsSimpleModule (GLAlg k N) (Representation.asModule (L i).ρ))
       (_ : Pairwise (fun i j => ¬ Nonempty ((L i) ≅ (L j))))
       (_ : ∀ i, 0 < Module.finrank k (S i))
       (e : TensorPower k (Fin N → k) n ≃ₗ[k]
-          (DirectSum ι (fun i => S i ⊗[k] (L i : Type u))))
+          (DirectSum ι (fun i => S i ⊗[k] (L i : Type))))
       (_ : ∀ (g : Matrix.GeneralLinearGroup (Fin N) k)
             (v : TensorPower k (Fin N → k) n),
             e (glTensorRep k N n g v) =
@@ -222,7 +221,7 @@ theorem polynomial_homog_rep_asModule_embeds_directSum_simple
                 (Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
                   (S i)).tprod (L i).ρ) g (e v))
       (κ : Type) (_ : Finite κ) (gκ : κ → ι)
-      (W : Type u) (_ : AddCommGroup W) (_ : Module (GLAlg k N) W)
+      (W : Type) (_ : AddCommGroup W) (_ : Module (GLAlg k N) W)
       (_ : W ≃ₗ[GLAlg k N]
         DirectSum κ (fun c => Representation.asModule (L (gκ c)).ρ))
       (M' : Submodule (GLAlg k N) W),
@@ -245,14 +244,14 @@ theorem polynomial_homog_rep_asModule_embeds_directSum_simple
   -- (3) view `φ` as a `k`-linear map into the `DirectSum` over the finite index `Fin m`.
   set piToDS := (DirectSum.linearEquivFunOnFintype k (Fin m)
     (fun _ : Fin m => TensorPower k (Fin N → k) n)).symm with hpiToDS
-  set φ' : (M : Type u) →ₗ[k]
+  set φ' : (M : Type) →ₗ[k]
       DirectSum (Fin m) (fun _ : Fin m => TensorPower k (Fin N → k) n) :=
     piToDS.toLinearMap ∘ₗ φ with hφ'
   have hφ'inj : Function.Injective φ' := piToDS.injective.comp hφinj
   have hcoe : ∀ (w : Fin m → TensorPower k (Fin N → k) n) (a : Fin m),
       (piToDS w) a = w a := by intro w a; rw [hpiToDS]; rfl
   -- equivariance of `φ'` for the `Fin m`-fold `directSum` of `glTensorRep`.
-  have hφ'eq : ∀ (g : Matrix.GeneralLinearGroup (Fin N) k) (x : (M : Type u)),
+  have hφ'eq : ∀ (g : Matrix.GeneralLinearGroup (Fin N) k) (x : (M : Type)),
       φ' (M.ρ g x) =
         Representation.directSum (fun _ : Fin m => glTensorRep k N n) g (φ' x) := by
     intro g x
@@ -323,14 +322,14 @@ theorem decompose_polynomial_gl_rep
     (h_span : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M (fun i => μ i) = ⊤)
     (h_homog : ∀ μ : Fin N → ℕ, glWeightSpace k N M μ ≠ ⊥ → ∑ i, μ i = n) :
     ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
-      (S : ι → Type u) (_ : ∀ i, AddCommGroup (S i)) (_ : ∀ i, Module k (S i))
+      (S : ι → Type) (_ : ∀ i, AddCommGroup (S i)) (_ : ∀ i, Module k (S i))
       (_ : ∀ i, Module.Finite k (S i))
       (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
       (_ : ∀ i, IsSimpleModule (GLAlg k N) (Representation.asModule (L i).ρ))
       (_ : Pairwise (fun i j => ¬ Nonempty ((L i) ≅ (L j))))
       (_ : ∀ i, 0 < Module.finrank k (S i))
       (e : TensorPower k (Fin N → k) n ≃ₗ[k]
-          (DirectSum ι (fun i => S i ⊗[k] (L i : Type u))))
+          (DirectSum ι (fun i => S i ⊗[k] (L i : Type))))
       (_ : ∀ (g : Matrix.GeneralLinearGroup (Fin N) k)
             (v : TensorPower k (Fin N → k) n),
             e (glTensorRep k N n g v) =
@@ -347,7 +346,7 @@ theorem decompose_polynomial_gl_rep
       κ, hκFin, gκ, W, hWacg, hWmod, eW, M', ⟨eM⟩⟩ :=
     polynomial_homog_rep_asModule_embeds_directSum_simple k N n M halg h_span h_homog
   -- The ambient summand family, indexed by `κ`.
-  set Lsum : κ → Type u := fun c => Representation.asModule (L (gκ c)).ρ with hLsum
+  set Lsum : κ → Type := fun c => Representation.asModule (L (gκ c)).ρ with hLsum
   haveI : ∀ c, IsSimpleModule (GLAlg k N) (Lsum c) := fun c => hLsimp (gκ c)
   -- Apply the generic isotypic-extraction engine (#4600) to the submodule `M'`.
   obtain ⟨p, h, ⟨eM'⟩⟩ :=

--- a/EtingofRepresentationTheory/Chapter5/PolynomialRepEmbedding.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialRepEmbedding.lean
@@ -44,11 +44,10 @@ namespace Etingof
 
 namespace PolynomialRepEmbedding
 
-universe u
 
 open PolynomialTensorBridge
 
-variable (k : Type u) [Field k] (N n : ℕ)
+variable (k : Type) [Field k] (N n : ℕ)
 
 /-- Splitting the right `(V^*)^⊗n` factor of `V^⊗n ⊗ (V^*)^⊗n` via the
 standard basis: `V^⊗n ⊗ (V^*)^⊗n ≃ₗ[k] (Fin n → Fin N) → V^⊗n`. The
@@ -589,7 +588,7 @@ namespace Etingof.PolynomialRepEmbedding
 
 open PolynomialTensorBridge
 
-variable (k : Type u) [Field k] (N : ℕ)
+variable (k : Type) [Field k] (N : ℕ)
 
 /-- Evaluating `polyRightTransl g p` at `h` coincides with evaluating `p` at
 the product matrix `h * g`. The algebra homs `eval_h ∘ polyRightTransl_g` and

--- a/progress/2026-06-24T00-17-20Z.md
+++ b/progress/2026-06-24T00-17-20Z.md
@@ -1,0 +1,50 @@
+## Accomplished
+
+Closed issue #5113 — the **single remaining `sorry`** in the project, at
+`CauchyDetQuotient.lean` (`quotDetRep_irreducible_constituent_lastWeight_zero`).
+
+The blocker was a universe mismatch: the #5076 assembly's #5075 constituent-character
+extractor `clean_simple_constituent_formalCharacter_eq_schurPoly_mem` is fixed at
+`Type` (universe 0), because its Schur-Weyl / Specht / double-centralizer simplicity
+foundation is small-universe, but the leaf theorem and its kernel-lemma consumer chain
+were `Type*` / `Type u` polymorphic.
+
+Took **Route A** (narrow the consumer chain to `Type`), chosen over Route B
+(generalize the extractor, which would force generalizing the entire §5.12–5.17
+ℂ/`Type 0` Specht/Schur-Weyl foundation — flagged uncertain in the issue). Route A is
+design-faithful: `k` is always a concrete algebraically-closed char-0 field.
+
+Edits (verified via import-closure analysis to be a tightly contained linear chain,
+terminating at the already-`Type 0` `SchurWeylFormalCharacterIso`):
+
+- `CauchyDetQuotient.lean`: added the 4 ingredient imports (no import cycle — verified
+  decoupled from the kernel chain), narrowed the leaf `(k : Type*)` → `(k : Type)`,
+  filled the `sorry` with the #5076 assembly, documented the `Type` specialization.
+- `KernelLemmaKPrimeAssembly.lean`: 3 theorems + section variable → `Type`.
+- `KernelLemmaK.lean`, `DetInvElim.lean`: `variable {k : Type*}` → `{k : Type}`.
+- `PolynomialRepEmbedding.lean`: 2 `variable (k : Type u)` → `(k : Type)`, removed
+  unused `universe u`.
+- `PolynomialGLDecomposition.lean`: `variable (k : Type u)` → `(k : Type)`, all
+  `Type u` → `Type`, removed unused `universe u`.
+- Doc cleanup: `kernelLemmaK'_submodule` / (K′) no longer described as sorry'd.
+
+## Current frontier
+
+Done. Got a second opinion from Codex (no soundness concern; addressed its three
+style/doc suggestions). PR opening.
+
+## Overall project progress
+
+**The project is now sorry-free.** `#print axioms
+quotDetRep_irreducible_constituent_lastWeight_zero` → `[propext, Classical.choice,
+Quot.sound]` (no `sorryAx`). Full `lake build` succeeds (8931 jobs, exit 0). A
+comment-stripping scan confirms zero genuine `sorry` tokens in Chapter5.
+
+## Next step
+
+Land the PR (auto-merge enabled). After merge, the parent issues #5076 / #4896 /
+#4890 are dischargeable as pure consequences.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR makes the project sorry-free by discharging the lone remaining `sorry`, at `quotDetRep_irreducible_constituent_lastWeight_zero` (`Chapter5/CauchyDetQuotient.lean`). It fills that theorem with the #5076 four-ingredient assembly and removes the universe mismatch that blocked it: the #5075 constituent-character extractor `clean_simple_constituent_formalCharacter_eq_schurPoly_mem` is fixed at `Type` (universe 0) because its Schur-Weyl / Specht / double-centralizer simplicity foundation is small-universe, but the leaf theorem and its kernel-lemma consumer chain were `Type*` / `Type u` polymorphic.

It takes Route A from the issue: narrow the consumer chain (`CauchyDetQuotient`, `KernelLemmaKPrimeAssembly`, `KernelLemmaK`, `DetInvElim`, `PolynomialRepEmbedding`, `PolynomialGLDecomposition`) from `Type*` / `Type u` down to `Type`, rather than Route B (generalize the extractor, which would force generalizing the entire §5.12–5.17 small-universe Specht/Schur-Weyl foundation — flagged uncertain). This is design-faithful: `k` is always a concrete algebraically-closed characteristic-0 field, so the polymorphism along this chain is unused. Import-closure analysis confirms the cascade is a contained linear chain terminating at the already-`Type 0` `SchurWeylFormalCharacterIso`, and that the four added ingredient imports introduce no import cycle.

`#print axioms quotDetRep_irreducible_constituent_lastWeight_zero` reports only `[propext, Classical.choice, Quot.sound]` (no `sorryAx`), and a full `lake build` passes (8931 jobs). A second opinion from Codex found no soundness concern; its style/doc suggestions are incorporated.

Closes #5113.

🤖 Prepared with Claude Code