### PR TITLE
doc: decompose Ch9 Morita B_n cluster (#5139) into #5143-#5147

### DIFF
--- a/progress/2026-06-24T03-48-42Z.md
+++ b/progress/2026-06-24T03-48-42Z.md
@@ -1,0 +1,67 @@
+## Accomplished
+
+One-shot dispatch on #5139 (the Ch9 Morita `B_n`-family cluster, filed from the
+claim-coverage / vacuity audit). Triaged scope and **decomposed** the issue — it
+bundles a stale critical-path item with a self-described ~1-2 week effort across a
+clean dependency chain, too large for one session.
+
+**Key finding — the critical-path item is already done (stale).** The issue's
+first deliverable was "Complete `MoritaStructural` (currently carries sorries) —
+dependency bottleneck." It no longer carries sorries:
+
+- PR #2292 ("close Ch9 MoritaStructural") closed them.
+- Built the module (`lake build …Chapter9.MoritaStructural`, exit 0) and ran
+  `#print axioms Etingof.MoritaStructural` → `[propext, Classical.choice,
+  Quot.sound]`, i.e. **no `sorryAx`**.
+- The theorem is non-vacuous: real `AlgEquiv B (CornerRing e)` conclusion;
+  `KLinearMoritaEquivalent` and `IsBasicAlgebra` are genuine predicates, not
+  `True`-stubs.
+- The remaining "sorry" mentions in `MoritaStructural.lean`,
+  `Infrastructure/BasicAlgebraExistence.lean`, and `Corollary9_7_3.lean` are all
+  **stale docstring comments** describing the old state — no real `sorry`/`admit`
+  tokens. Chapter 9 has zero real sorries apart from one unrelated one in
+  `Theorem9_2_1.lean:386`.
+
+**Second finding — the formalized category class is not yet k-linear.**
+`Etingof.IsFiniteAbelianCategory` (`Definition9_6_1.lean`) extends only `Abelian`
++ `EnoughProjectives` with a finite simple-object index. It carries no `Linear k`
+structure and no `End(simple)=k`. So the prose claims "Hom spaces are
+finite-dimensional" and "`c_ij = dim Hom(P_i,P_j)`" cannot even be *stated* over
+`k` until that class is k-linearized — which is why #5143 is foundational.
+
+Created 5 sub-issues with a clean dependency DAG, left a `Decomposed into …`
+breadcrumb on #5139, and `coordination skip`'d the parent to `replan`.
+
+## Current frontier
+
+#5139 routed to `replan`. Sub-issues:
+- #5143 — Introduction_9.6: k-linearize `IsFiniteAbelianCategory` + Hom spaces
+  finite-dimensional [M] (foundational, no project dep)
+- #5144 — Discussion: rep-theoretic Cartan matrix + `dim B_n = Σ c_ij n_i n_j`
+  [M] (depends #5143)
+- #5145 — Discussion: minimal basic algebra (min dim at n_i=1; B/Rad commutative)
+  [M] (depends #5144)
+- #5146 — Introduction_9.7: progenerators = `⊕ n_i P_i`, n_i≥1 [H] — **needs
+  Krull–Schmidt, not in Mathlib** (long-term blocker)
+- #5147 — Introduction_9.7 + Discussion: `B_n` enumerate the Morita class /
+  Morita classes = {B_n(C)} [H] (depends #5146)
+
+## Overall project progress
+
+Phase 3 formalization with the completeness/vacuity audit in progress. This turn
+confirms one more audit-flagged "still-sorry'd" item (MoritaStructural) is in
+fact complete and non-vacuous, and re-scopes the Ch9 §9.7 prose-gap cluster into
+actionable, correctly-ordered pieces. No code changed (decomposition only).
+
+## Next step
+
+A planner should close #5139 (the 5 sub-issues fully cover its residual scope).
+A worker should start with #5143 (foundational, unblocks #5144→#5145). #5146
+(Krull–Schmidt) is the genuine hard blocker for the [H] chain (#5146→#5147) and
+may warrant its own Krull–Schmidt infrastructure issue first.
+
+## Blockers
+
+#5146 (and transitively #5147) is blocked on Krull–Schmidt for finite abelian
+categories, which is not in Mathlib (flagged in the `lean-formalization` skill).
+The [M] chain (#5143→#5144→#5145) has no Mathlib-gap blocker.


### PR DESCRIPTION
This PR records the one-shot triage of #5139 (the Chapter 9 Morita `B_n`-family cluster) and decomposes its residual scope into properly-sized sub-issues.

The issue's critical-path deliverable was "Complete `MoritaStructural` (currently carries sorries)", but that is stale: `MoritaStructural` is already complete and non-vacuous. Building the module and running `#print axioms Etingof.MoritaStructural` shows `[propext, Classical.choice, Quot.sound]` with no `sorryAx`; PR #2292 closed its sorries. The remaining "sorry" mentions in the Ch9 files are stale docstring comments. The formalized `IsFiniteAbelianCategory` class is also not yet k-linear, so the remaining prose claims cannot be stated over `k` until that is addressed — captured as the foundational sub-issue.

The residual ~1-2 week effort is decomposed into #5143 (Hom finite-dim / k-linearization), #5144 (Cartan matrix + dim formula), #5145 (minimal basic algebra), #5146 (progenerator classification, blocked on Krull-Schmidt), and #5147 (`B_n` enumerate the Morita class), with a clean dependency DAG. #5139 has been routed to `replan` for a planner to close.

Adds only the session progress file; no Lean changes.

🤖 Prepared with Claude Code