### PR TITLE
doc(Ch5 Example5.1.3 #5124): de-vacuify Frobenius-Schur type stubs

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Example5_1_3.lean
+++ b/EtingofRepresentationTheory/Chapter5/Example5_1_3.lean
@@ -1,35 +1,109 @@
 import Mathlib
+import EtingofRepresentationTheory.Chapter5.Definition5_1_1
 
 /-!
 # Example 5.1.3: Type Classification for Specific Groups
 
-Examples of the real/complex/quaternionic classification:
+Examples of the real/complex/quaternionic classification (Definition 5.1.1):
 
-1. ℤ/nℤ: representations of complex type come in conjugate pairs {V, V*}
-2. S₃: all irreducible representations are real (characters are integer-valued)
-3. S₄: all irreducible representations are real
-4. A₅: all irreducible representations are real
-5. Q₈: the 2-dimensional irreducible representation is quaternionic
+1. ℤ/nℤ: representations of complex type come in conjugate pairs {V, V*}; the only
+   real-type ones are the trivial representation and (for `n` even) the sign
+   representation `m ↦ (-1)^m`.
+2. S₃: all three irreducible representations `ℂ₊, ℂ₋, ℂ²` are of real type.
+3. S₄: all five irreducible representations are of real type.
+4. A₅: all five irreducible representations are of real type.
+5. Q₈: the 1-dimensional representations are of real type and the 2-dimensional
+   one is of quaternionic type.
 
 ## Mathlib correspondence
 
-Uses `ZMod`, `Equiv.Perm (Fin n)`, and `Quaternion` types from Mathlib.
+Uses `ZMod`, `Equiv.Perm (Fin n)`, `alternatingGroup`, and `QuaternionGroup` from
+Mathlib. Irreducibility is expressed as `IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule`,
+and the type predicates `Etingof.IsRealType` / `Etingof.IsQuaternionicType` come from
+Definition 5.1.1.
 -/
 
-/-- All irreducible representations of S₃ are of real type (all character values are real).
+/-- For `ℤ/nℤ` (written multiplicatively), a 1-dimensional representation `ρ` on `ℂ`
+whose character `g ↦ ρ g 1` takes some value other than `±1` is **not** of real type
+— i.e. it is of complex type. The only real-type characters are those landing in
+`{1, -1}`, namely the trivial representation and (for `n` even) the sign representation.
 (Etingof Example 5.1.3) -/
-theorem Etingof.Example5_1_3_S3 :
-    -- All character values of irreducible representations of S₃ are real
-    True := by
-  trivial
-  -- TODO: Formalize once character table infrastructure is available.
-  -- The key fact is that all character values of S₃ are integers.
+theorem Etingof.Example5_1_3_ZMod
+    {n : ℕ} [NeZero n]
+    (ρ : Representation ℂ (Multiplicative (ZMod n)) ℂ)
+    (h : ∃ g : Multiplicative (ZMod n), ρ g 1 ≠ 1 ∧ ρ g 1 ≠ -1) :
+    ¬ Etingof.IsRealType ρ := by
+  -- A `G`-invariant bilinear form `B` on a 1-dimensional character `χ` satisfies
+  -- `χ(g)² B(v,w) = B(v,w)`, forcing `χ(g)² = 1`, i.e. `χ(g) ∈ {1, -1}`, for all `g`
+  -- where `B` is nondegenerate. The hypothesis `h` exhibits a `g` violating this.
+  rintro ⟨B, _hsym, hnondeg, hinv⟩
+  obtain ⟨g, hg1, hg2⟩ := h
+  set χ : ℂ := ρ g 1 with hχ
+  -- Every bilinear form on the 1-dimensional space `ℂ` is `B a b = a·b·(B 1 1)`.
+  have key : ∀ a b : ℂ, B a b = a * b * B 1 1 := by
+    intro a b
+    have step : (B a) b = a • (b • B 1 1) := by
+      have h1 : (B a) b = (B (a • (1:ℂ))) (b • (1:ℂ)) := by simp
+      rw [h1, show B (a • (1:ℂ)) = a • B 1 from map_smul B a 1,
+        LinearMap.smul_apply, show (B 1) (b • (1:ℂ)) = b • (B 1) 1 from map_smul (B 1) b 1]
+    rw [step, smul_eq_mul, smul_eq_mul, mul_assoc]
+  -- Nondegeneracy forces the single coefficient `B 1 1` to be nonzero.
+  have hc : B 1 1 ≠ 0 := by
+    intro hc0
+    have : (1 : ℂ) = 0 := hnondeg 1 (fun w => by rw [key, hc0, mul_zero])
+    exact one_ne_zero this
+  -- `G`-invariance at `g` (with `v = w = 1`) gives `χ² · (B 1 1) = B 1 1`.
+  have hinvg : χ * χ * B 1 1 = B 1 1 := by
+    have := hinv g 1 1
+    rw [← hχ, key] at this
+    exact this
+  -- Cancelling the nonzero coefficient yields `χ² = 1`, hence `χ = ±1` — contradiction.
+  have hχχ : χ * χ = 1 := by
+    have : χ * χ * B 1 1 = 1 * B 1 1 := by rw [one_mul]; exact hinvg
+    exact mul_right_cancel₀ hc this
+  rcases mul_self_eq_one_iff.mp hχχ with h1 | h1
+  · exact hg1 h1
+  · exact hg2 h1
 
-/-- The 2-dimensional irreducible representation of Q₈ is of quaternionic type.
+/-- All irreducible representations of `S₃` are of real type: any simple
+`ℂ[S₃]`-module carries a nondegenerate `S₃`-invariant symmetric bilinear form.
+(The character values of `S₃` are all integers.) (Etingof Example 5.1.3) -/
+theorem Etingof.Example5_1_3_S3
+    {V : Type*} [AddCommGroup V] [Module ℂ V] [Module.Finite ℂ V]
+    (ρ : Representation ℂ (Equiv.Perm (Fin 3)) V)
+    (hρ : IsSimpleModule (MonoidAlgebra ℂ (Equiv.Perm (Fin 3))) ρ.asModule) :
+    Etingof.IsRealType ρ := by
+  -- All three irreducibles `ℂ₊, ℂ₋, ℂ²` have integer (hence real) character values,
+  -- so their Frobenius–Schur indicator is `1`, i.e. they are of real type.
+  sorry
+
+/-- All irreducible representations of `S₄` are of real type. (Etingof Example 5.1.3) -/
+theorem Etingof.Example5_1_3_S4
+    {V : Type*} [AddCommGroup V] [Module ℂ V] [Module.Finite ℂ V]
+    (ρ : Representation ℂ (Equiv.Perm (Fin 4)) V)
+    (hρ : IsSimpleModule (MonoidAlgebra ℂ (Equiv.Perm (Fin 4))) ρ.asModule) :
+    Etingof.IsRealType ρ := by
+  -- The five irreducibles `ℂ₊, ℂ₋, ℂ², ℂ³₊, ℂ³₋` all have real character values.
+  sorry
+
+/-- All irreducible representations of `A₅` are of real type. (Etingof Example 5.1.3) -/
+theorem Etingof.Example5_1_3_A5
+    {V : Type*} [AddCommGroup V] [Module ℂ V] [Module.Finite ℂ V]
+    (ρ : Representation ℂ (alternatingGroup (Fin 5)) V)
+    (hρ : IsSimpleModule (MonoidAlgebra ℂ (alternatingGroup (Fin 5))) ρ.asModule) :
+    Etingof.IsRealType ρ := by
+  -- The five irreducibles `ℂ, ℂ³₊, ℂ³₋, ℂ⁴, ℂ⁵` all have real character values.
+  sorry
+
+/-- The 2-dimensional irreducible representation of `Q₈ = QuaternionGroup 2` is of
+quaternionic type: there is a simple `ℂ[Q₈]`-module structure on `Fin 2 → ℂ`
+admitting a nondegenerate `Q₈`-invariant skew-symmetric bilinear form.
 (Etingof Example 5.1.3) -/
 theorem Etingof.Example5_1_3_Q8 :
-    -- The 2-dimensional irreducible representation of Q₈ admits an invariant
-    -- skew-symmetric bilinear form
-    True := by
-  trivial
-  -- TODO: Formalize once QuaternionGroup and its representations are set up.
+    ∃ ρ : Representation ℂ (QuaternionGroup 2) (Fin 2 → ℂ),
+      IsSimpleModule (MonoidAlgebra ℂ (QuaternionGroup 2)) ρ.asModule ∧
+      Etingof.IsQuaternionicType ρ := by
+  -- The 2-dimensional irrep uses the Pauli-type matrices `ρ(i) = [[0,1],[-1,0]]`,
+  -- `ρ(j) = [[√-1,0],[0,-√-1]]`, `ρ(k) = [[0,-√-1],[-√-1,0]]`. Its FS indicator is
+  -- `-1`, witnessed by the invariant skew form `[[0,1],[-1,0]]`.
+  sorry

--- a/progress/2026-06-24T04-42-57Z.md
+++ b/progress/2026-06-24T04-42-57Z.md
@@ -1,0 +1,61 @@
+## Accomplished
+
+One-shot dispatch on #5124 (vacuity-audit item: `Chapter5/Example5_1_3.lean`
+stubbed `Example5_1_3_S3` and `Example5_1_3_Q8` as `: True`). Replaced the vacuous
+`True` stubs with genuine Frobenius–Schur type statements built on the real
+predicates from Definition 5.1.1, and added statements for the cases the book's
+Example 5.1.3 covers but the file omitted (S₄, A₅, ℤ/n).
+
+The file now states five honest theorems:
+
+- `Example5_1_3_ZMod` — a 1-dim character of `ℤ/nℤ` (multiplicative) whose value
+  at some `g` is not `±1` is **not** of real type (complex type). **Fully proved,
+  sorry-free** (`#print axioms` → `[propext, Classical.choice, Quot.sound]`). The
+  proof: any bilinear form on the 1-dim space `ℂ` is `B a b = a·b·(B 1 1)`;
+  nondegeneracy forces `B 1 1 ≠ 0`; `G`-invariance forces `χ(g)²·(B 1 1) = B 1 1`,
+  so `χ(g)² = 1`, i.e. `χ(g) ∈ {1,-1}` — contradicting the hypothesis.
+- `Example5_1_3_S3`, `_S4`, `_A5` — every simple `ℂ[G]`-module is of real type,
+  for `G = Equiv.Perm (Fin 3)`, `Equiv.Perm (Fin 4)`, `alternatingGroup (Fin 5)`.
+  Statements only (sorry); full proofs need character-table infrastructure.
+- `Example5_1_3_Q8` — there exists a simple `ℂ[Q₈]`-module on `Fin 2 → ℂ` (a
+  2-dimensional space) of quaternionic type, `Q₈ = QuaternionGroup 2`. Statement
+  only (sorry); needs the explicit Pauli-matrix construction + invariant skew form.
+
+Irreducibility is expressed as `IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule`,
+matching the rest of Chapter 5. The Q₈ statement is an existential over
+`Representation ℂ Q₈ (Fin 2 → ℂ)`, so no `def` body is sorried — the construction
+lives inside the existential.
+
+Module builds clean (`lake build …Chapter5.Example5_1_3`, exit 0); only the four
+expected `sorry` warnings on S₃/S₄/A₅/Q₈. No external code referenced the old
+`True`-typed signatures (only the `Chapter5.lean` aggregator imports the file).
+
+`progress/items.json`: `Chapter5/Example5.1.3` moved `sorry_free → false`,
+`status: statement_formalized` (was a vacuously-`sorry_free` `True` stub).
+
+## Current frontier
+
+#5124 de-vacuified. One of five sub-statements (ℤ/n complex type) is fully proved;
+the four group-specific real/quaternionic-type claims are honest statements with
+sorried proofs.
+
+## Overall project progress
+
+Phase 3 formalization with the completeness/vacuity audit ongoing. This turn
+converts the audit's hardest flagged `True`-stub into genuine specs and closes one
+sub-claim outright.
+
+## Next step
+
+Fill the remaining four sorries. Each needs character/representation infrastructure:
+- S₃/S₄/A₅ real type: the cleanest route is FS(V) = 1 via `frobeniusSchurIndicator`
+  (Definition 5.1.4) once the FS ⇒ real-type equivalence (Theorem 5.1.5 region) is
+  available, plus the fact that these groups' character values are real/rational.
+- Q₈ quaternionic: construct the 2-dim Pauli representation explicitly on
+  `Fin 2 → ℂ`, prove it simple, and exhibit the invariant skew form `[[0,1],[-1,0]]`.
+
+## Blockers
+
+None at the definition level. The four open sorries are proof-level and need
+character-table / explicit-construction work (the issue's stated H difficulty);
+they are not blocking other items (only the aggregator imports this file).

--- a/progress/items.json
+++ b/progress/items.json
@@ -2566,8 +2566,8 @@
     "end_page": "94",
     "start_line": 5,
     "end_line": 6,
-    "status": "sorry_free",
-    "sorry_free": true
+    "status": "statement_formalized",
+    "sorry_free": false
   },
   {
     "id": "Chapter5/Definition5.1.4",


### PR DESCRIPTION
Partial progress on #5124

Session: `204fecaf-1c8c-46dc-99f5-bf8c7697ba7f`

9e5ff132 doc(Ch5 Example5.1.3 #5124): replace vacuous `True` stubs with genuine FS-type statements

🤖 Prepared with Claude Code