### PR TITLE
fix(Ch5 Definition5.8.1): replace vacuous `True` stub — define Ind_H^G V via Mathlib `Rep.ind`

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Definition5_8_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Definition5_8_1.lean
@@ -3,35 +3,40 @@ import Mathlib
 /-!
 # Definition 5.8.1: Induced Representation
 
-Let H be a subgroup of G and V a representation of H. The **induced representation**
-Ind_H^G V is defined as:
-  Ind_H^G V = {f : G → V | f(hx) = ρ_V(h) f(x) for all h ∈ H, x ∈ G}
-with the G-action given by (g · f)(x) = f(xg).
+Let `H` be a subgroup of `G` and `V` a representation of `H`. The **induced representation**
+`Ind_H^G V` is the representation of `G` that Etingof describes by the function-space model
 
-Equivalently, Ind_H^G V ≅ k[G] ⊗_{k[H]} V.
+  `Ind_H^G V = {f : G → V | f(h x) = ρ_V(h) f(x) for all h ∈ H, x ∈ G}`
 
-Properties:
-- dim(Ind_H^G V) = [G : H] · dim(V)
+with the `G`-action `(g · f)(x) = f(x g)`.
 
 ## Mathlib correspondence
 
-Mathlib has building blocks (`MonoidAlgebra`, `TensorProduct`) but may not have a
-dedicated `Representation.induced` construction. The tensor product formulation
-k[G] ⊗_{k[H]} V is the standard algebraic approach.
+Mathlib ships a general induced representation `Representation.ind` (and its packaged form
+`Rep.ind`) built as the tensor model `(k[G] ⊗_k V)_H`, the `H`-coinvariants of `k[G] ⊗_k V`,
+with the `G`-action defined by sending `h : G` and `⟦h₁ ⊗ₜ v⟧` to `⟦h₁ h⁻¹ ⊗ₜ v⟧`. We realize
+`Ind_H^G V` as `Representation.ind H.subtype ρ`, induction along the subgroup inclusion
+`H.subtype : H →* G`.
+
+The tensor model used here is the *left* adjoint of restriction; Etingof's function-space model
+`{f : G → V | f(h x) = ρ(h) f(x)}` is literally the *coinduced* representation `Rep.coind`. For
+finite groups the two agree (`Rep.indCoindIso`), so this is the same `Ind_H^G V`.
+
+Properties (proved downstream): `dim(Ind_H^G V) = [G : H] · dim(V)`.
 -/
 
-/-- The induced representation Ind_H^G V = {f : G → V | f(hx) = ρ(h)f(x)},
-with G-action (g·f)(x) = f(xg). dim(Ind V) = [G:H] · dim(V).
-(Etingof Definition 5.8.1)
+open Representation
 
-TODO: Define as a proper `Representation` once the subtype carries the needed
-`AddCommGroup`/`Module` instances, or use the tensor product formulation
-k[G] ⊗_{k[H]} V. -/
-theorem Etingof.Definition5_8_1
-    {G : Type*} [Group G] [Fintype G] [DecidableEq G]
+/-- The induced representation `Ind_H^G V` of a representation `ρ : Representation ℂ H V` of a
+subgroup `H ≤ G`, realized via Mathlib's general induction `Representation.ind` along the subgroup
+inclusion `H.subtype : H →* G`. Concretely the underlying module is
+`Representation.IndV H.subtype ρ`, the `H`-coinvariants of `ℂ[G] ⊗_ℂ V`, with `G` acting on the
+`ℂ[G]` factor.
+(Etingof Definition 5.8.1) -/
+noncomputable def Etingof.Definition5_8_1
+    {G : Type*} [Group G]
     (H : Subgroup G)
-    {V : Type*} [AddCommGroup V] [Module ℂ V] [Module.Finite ℂ V]
+    {V : Type*} [AddCommGroup V] [Module ℂ V]
     (ρ : Representation ℂ H V) :
-    -- dim(Ind_H^G V) = [G : H] · dim(V)
-    True := by
-  trivial
+    Representation ℂ G (Representation.IndV H.subtype ρ) :=
+  Representation.ind H.subtype ρ

--- a/progress/2026-06-24T06-32-35Z_9e577507.md
+++ b/progress/2026-06-24T06-32-35Z_9e577507.md
@@ -1,0 +1,44 @@
+## Accomplished
+
+Resolved issue #5123: replaced the vacuous `True` stub in
+`EtingofRepresentationTheory/Chapter5/Definition5_8_1.lean` with a genuine construction of
+the induced representation.
+
+`Etingof.Definition5_8_1` is now a `noncomputable def` returning
+`Representation ℂ G (Representation.IndV H.subtype ρ)`, defined as
+`Representation.ind H.subtype ρ` — Mathlib's general induction along the subgroup inclusion
+`H.subtype : ↥H →* G` (tensor model `(ℂ[G] ⊗ V)_H`). The central object of §5.8–5.9 now
+exists project-wide.
+
+Notes / decisions:
+- Used the `Representation`-level `Representation.ind` (universe-polymorphic, `Type*`) rather
+  than the `Rep`-namespace `Rep.ind` (which pins `G, H, V : Type u`). This keeps the original
+  issue signature (`ρ : Representation ℂ H V`, with `G, V : Type*` independent) intact.
+- Dropped the now-unnecessary `[Fintype G] [DecidableEq G] [Module.Finite ℂ V]` hypotheses;
+  the construction is fully general and these only made the def harder to apply downstream.
+- Documented that Etingof's function-space model `{f : G → V | f(hx) = ρ(h)f(x)}` is literally
+  the *coinduced* representation; it agrees with this tensor (induced) model for finite groups
+  via `Rep.indCoindIso`.
+
+Build: `lake build EtingofRepresentationTheory.Chapter5.Definition5_8_1` succeeds, no warnings.
+
+## Current frontier
+
+Definition 5.8.1 is a real object. Downstream items that referenced it as `True` can now be
+stated against the actual representation.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. One more definition-level vacuity finding cleared (highest
+priority per "Definitions Must Be Constructed").
+
+## Next step
+
+Unblocked: Theorem 5.9.1 (Frobenius character formula) and Remark 5.8.2 can now be restated
+in terms of `Etingof.Definition5_8_1` instead of the `True` placeholders. Theorem 5.9.1 in
+particular still carries a `True` stub and is now ready for real formalization (character of
+the induced representation), drawing on the new construction and Mathlib's character API.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5123

Session: `9e577507-718a-46d9-815d-a10e03aa3e45`

857e6921 feat(Ch5 Definition5.8.1 #5123): construct induced representation via Representation.ind

🤖 Prepared with Claude Code