### PR TITLE
fix(Ch5 Theorem5.9.1): replace vacuous `True` stub — Frobenius character formula for Ind

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_9_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_9_1.lean
@@ -1,31 +1,79 @@
 import Mathlib
+import EtingofRepresentationTheory.Chapter5.Definition5_8_1
 
 /-!
 # Theorem 5.9.1: Frobenius Formula for Induced Characters
 
-For H ⊂ G, a representation V of H, and g ∈ G, the character of the
-induced representation is:
-  χ_{Ind_H^G V}(g) = Σ_{σ ∈ H\G : x_σ g x_σ⁻¹ ∈ H} χ_V(x_σ g x_σ⁻¹)
+For `H ⊆ G`, a representation `V` of `H`, and `g ∈ G`, the character of the
+induced representation `Ind_H^G V` is
 
-where {x_σ} is a set of coset representatives for H\G.
+  `χ_{Ind_H^G V}(g) = Σ_{σ ∈ H\G : x_σ g x_σ⁻¹ ∈ H} χ_V(x_σ g x_σ⁻¹)`,
+
+where `{x_σ}` is a set of right-coset representatives for `H \ G`. This is the
+**Frobenius formula** (Etingof Theorem 5.9.1).
+
+## Statement used here: the averaged form
+
+Picking a transversal of `H \ G` is awkward to formalize and the choice is
+immaterial. We use the equivalent *averaged* form, which sums over **all** of
+`G` and divides by `|H|`:
+
+  `χ_{Ind_H^G V}(g) = (1/|H|) · Σ_{x ∈ G : x g x⁻¹ ∈ H} χ_V(x g x⁻¹)`.
+
+This is provably equal to Etingof's coset-representative formula: every right
+coset `H x_σ` contains exactly `|H|` elements `h x_σ` (`h ∈ H`), and for each
+such element
+
+* `(h x_σ) g (h x_σ)⁻¹ = h (x_σ g x_σ⁻¹) h⁻¹ ∈ H ⇔ x_σ g x_σ⁻¹ ∈ H`, and
+* `χ_V(h (x_σ g x_σ⁻¹) h⁻¹) = χ_V(x_σ g x_σ⁻¹)` since `χ_V` is a class function
+  on `H`.
+
+So the sum over `G` counts each coset's contribution `|H|` times; dividing by
+`|H|` recovers the sum over cosets. The averaged form needs no choice of
+representatives and is the standard Lean-friendly phrasing of the Frobenius
+formula.
 
 ## Mathlib correspondence
 
-Uses coset representatives, character theory, and the induced representation.
-Frobenius reciprocity (the adjunction between induction and restriction) is not
-yet in Mathlib.
+The character is `LinearMap.trace ℂ _ (ρ g)`, following the convention used
+throughout Chapter 5. The induced representation is `Etingof.Definition5_8_1`,
+i.e. Mathlib's `Representation.ind H.subtype ρ` on `Representation.IndV`.
+Frobenius reciprocity (the induction/restriction adjunction) is not yet in
+Mathlib, so the block-trace computation underlying this formula is proved
+directly here (currently `sorry`).
 -/
 
-/-- The Frobenius character formula for induced representations:
-χ_{Ind_H^G V}(g) = Σ_{σ : x_σ g x_σ⁻¹ ∈ H} χ_V(x_σ g x_σ⁻¹).
-(Etingof Theorem 5.9.1) -/
+open Representation
+
+/-- **Frobenius formula** (Etingof Theorem 5.9.1, averaged form).
+
+The character of the induced representation `Ind_H^G V` at `g` equals the
+average over `x ∈ G` (with `x g x⁻¹ ∈ H`) of `χ_V(x g x⁻¹)`:
+
+  `χ_{Ind V}(g) = (1/|H|) · Σ_{x : x g x⁻¹ ∈ H} χ_V(x g x⁻¹)`.
+
+See the module docstring for why this averaged form is equivalent to Etingof's
+sum over coset representatives `σ ∈ H \ G`. -/
 theorem Etingof.Theorem5_9_1
-    (G : Type) [Group G] [Fintype G] [DecidableEq G]
+    {G : Type*} [Group G] [Fintype G]
     (H : Subgroup G) [DecidablePred (· ∈ H)]
     {V : Type*} [AddCommGroup V] [Module ℂ V] [Module.Finite ℂ V]
     (ρ : Representation ℂ H V)
     (g : G) :
-    -- χ_{Ind V}(g) = Σ over coset reps σ with σgσ⁻¹ ∈ H of χ_V(σgσ⁻¹)
-    -- TODO: Express precisely once induced representation and character API are available
-    True := by
-  trivial
+    LinearMap.trace ℂ (Representation.IndV H.subtype ρ)
+        (Etingof.Definition5_8_1 H ρ g)
+      = (Fintype.card H : ℂ)⁻¹ *
+          ∑ x : G,
+            if h : x * g * x⁻¹ ∈ H then
+              LinearMap.trace ℂ V (ρ ⟨x * g * x⁻¹, h⟩)
+            else 0 := by
+  -- Proof strategy (Etingof, Discussion proof of Theorem 5.9.1):
+  --   Decompose `Ind_H^G V = ⨁_σ V_σ` over right cosets `σ ∈ H\G`, where
+  --   `V_σ = {f ∈ Ind V | f(g) = 0 ∀ g ∉ σ}`. Then `χ(g) = Σ_σ χ_σ(g)`, the
+  --   sum of diagonal block traces. A coset summand contributes `0` unless
+  --   `σ g = σ`; when `σ g = σ`, writing `x_σ g = h x_σ` with
+  --   `h = x_σ g x_σ⁻¹ ∈ H`, the map `α : V_σ → V`, `α(f) = f(x_σ)` is an
+  --   isomorphism intertwining `g` on `V_σ` with `ρ(h)` on `V`, so
+  --   `χ_σ(g) = χ_V(x_σ g x_σ⁻¹)`. Summing and averaging over the `|H|`
+  --   elements of each coset yields the stated formula.
+  sorry

--- a/progress/2026-06-24T06-53-16Z_7853decb.md
+++ b/progress/2026-06-24T06-53-16Z_7853decb.md
@@ -1,0 +1,36 @@
+## Accomplished
+- Closed the vacuity in `Chapter5/Theorem5_9_1.lean` (issue #5131): replaced the
+  `: True` stub of `Etingof.Theorem5_9_1` with a genuine statement of the
+  Frobenius character formula for induced representations.
+- Stated it in the **averaged form**
+  `χ_{Ind V}(g) = (1/|H|) · Σ_{x∈G : xgx⁻¹∈H} χ_V(xgx⁻¹)`, using the now-real
+  `Etingof.Definition5_8_1` (`Representation.ind H.subtype ρ` on `IndV`) for the
+  LHS and the Chapter-5 character convention `LinearMap.trace ℂ _ (ρ ·)`.
+  The averaged form is provably equal to Etingof's coset-representative sum
+  (each right coset `Hx_σ` has `|H|` elements giving the same class-function
+  value); module docstring records the equivalence.
+- Proof is `sorry` with a full block-trace proof sketch from the book's
+  "Discussion proof of Theorem 5.9.1". Frobenius reciprocity is not in Mathlib,
+  so the computation must be done directly here.
+- File builds (only the expected `sorry` warning); removed an unused
+  `[DecidableEq G]` flagged by the linter.
+- Updated `progress/items.json` status `sorry_free` → `statement_formalized`
+  (it had been incorrectly marked sorry-free while a vacuous stub).
+
+## Current frontier
+Statement formalized and compiling; proof body sorried.
+
+## Overall project progress
+Stage 3 formalization. One more vacuous `True` stub eliminated from the
+completeness audit. Definition 5.8.1 (#5123, dependency) already landed.
+
+## Next step
+Discharge the `sorry`: formalize the coset decomposition
+`Ind_H^G V = ⨁_σ V_σ` and the per-coset block-trace identity
+`χ_σ(g) = χ_V(x_σ g x_σ⁻¹)`. This is difficulty H and likely a multi-session
+effort; consider decomposing into the direct-sum decomposition lemma and the
+block-isomorphism lemma.
+
+## Blockers
+None for the statement. The proof needs the coset block-trace machinery built
+from scratch (no Frobenius reciprocity in Mathlib).

--- a/progress/items.json
+++ b/progress/items.json
@@ -3090,8 +3090,8 @@
     "end_page": "109",
     "start_line": 5,
     "end_line": 10,
-    "status": "sorry_free",
-    "sorry_free": true
+    "status": "statement_formalized",
+    "sorry_free": false
   },
   {
     "id": "Chapter5/Remark5.9.2",


### PR DESCRIPTION
Closes #5131

Session: `7853decb-6ee5-40d4-9a41-23b5a1bdc2f6`

a782ed66 feat(Ch5 Theorem5.9.1 #5131): state Frobenius character formula for Ind

🤖 Prepared with Claude Code