### PR TITLE
feat(Ch3 #5135): formalize prose-claim gaps (isotypic eval map, free-module surjection, JH length, tracial character)

### DIFF
--- a/EtingofRepresentationTheory/Chapter3.lean
+++ b/EtingofRepresentationTheory/Chapter3.lean
@@ -6,6 +6,7 @@ import EtingofRepresentationTheory.Chapter3.Corollary3_2_1
 import EtingofRepresentationTheory.Chapter3.Theorem3_2_2
 import EtingofRepresentationTheory.Chapter3.Definition3_3_2
 import EtingofRepresentationTheory.Chapter3.Theorem3_3_1
+import EtingofRepresentationTheory.Chapter3.Remark3_3_4
 import EtingofRepresentationTheory.Chapter3.Definition3_4_1
 import EtingofRepresentationTheory.Chapter3.Lemma3_4_2
 import EtingofRepresentationTheory.Chapter3.Definition3_5_1
@@ -16,6 +17,7 @@ import EtingofRepresentationTheory.Chapter3.Corollary3_5_5
 import EtingofRepresentationTheory.Chapter3.Example3_5_6
 import EtingofRepresentationTheory.Chapter3.Definition3_5_7
 import EtingofRepresentationTheory.Chapter3.Proposition3_5_8
+import EtingofRepresentationTheory.Chapter3.Introduction3_6
 import EtingofRepresentationTheory.Chapter3.Theorem3_6_2
 import EtingofRepresentationTheory.Chapter3.Theorem3_7_1
 import EtingofRepresentationTheory.Chapter3.Theorem3_8_1

--- a/EtingofRepresentationTheory/Chapter3.lean
+++ b/EtingofRepresentationTheory/Chapter3.lean
@@ -20,6 +20,7 @@ import EtingofRepresentationTheory.Chapter3.Proposition3_5_8
 import EtingofRepresentationTheory.Chapter3.Introduction3_6
 import EtingofRepresentationTheory.Chapter3.Theorem3_6_2
 import EtingofRepresentationTheory.Chapter3.Theorem3_7_1
+import EtingofRepresentationTheory.Chapter3.Discussion_after_Theorem3_7_1
 import EtingofRepresentationTheory.Chapter3.Theorem3_8_1
 import EtingofRepresentationTheory.Chapter3.Lemma3_8_2
 import EtingofRepresentationTheory.Chapter3.Theorem3_10_2

--- a/EtingofRepresentationTheory/Chapter3.lean
+++ b/EtingofRepresentationTheory/Chapter3.lean
@@ -1,6 +1,7 @@
 import EtingofRepresentationTheory.Chapter3.Definition3_1_1
 import EtingofRepresentationTheory.Chapter3.Example3_1_2
 import EtingofRepresentationTheory.Chapter3.Proposition3_1_4
+import EtingofRepresentationTheory.Chapter3.Remark3_1_3
 import EtingofRepresentationTheory.Chapter3.Lemma3_1_6
 import EtingofRepresentationTheory.Chapter3.Corollary3_2_1
 import EtingofRepresentationTheory.Chapter3.Theorem3_2_2

--- a/EtingofRepresentationTheory/Chapter3/Discussion_after_Theorem3_7_1.lean
+++ b/EtingofRepresentationTheory/Chapter3/Discussion_after_Theorem3_7_1.lean
@@ -1,0 +1,58 @@
+import Mathlib.RingTheory.Length
+
+/-!
+# Discussion after Theorem 3.7.1: Length of a representation
+
+The Jordan-Hölder theorem shows that the number `n` of terms in a filtration of `V` with
+irreducible successive quotients does not depend on the choice of filtration; this number
+is the **length** of `V`. The discussion claims:
+
+> It is easy to see that `n` is also the maximal length of a filtration of `V` in which all
+> the inclusions are strict.
+
+We formalize this. A filtration with strict inclusions is an `LTSeries (Submodule A V)` (a
+chain `U₀ < U₁ < ⋯ < U_m`); its "length" is `m` (the number of inclusions). A composition
+series `s` (a chain with each step a covering relation `⋖`, i.e. simple quotients) from `⊥`
+to `⊤` has `s.length = n`. We show `n` is the greatest length attained by any strict
+filtration:
+
+* the composition series itself is a strict filtration of length `n` (since `⋖` implies
+  `<`), so the value `n` is attained;
+* every strict filtration has length `≤ n`, because the supremum of strict-chain lengths is
+  the Krull dimension of the submodule lattice, which equals `Module.length A V = n`.
+
+This uses `Module.length_compositionSeries` (the composition-series length equals the
+module length) and `Order.LTSeries.length_le_krullDim` (`Module.length` is the supremum of
+strict-chain lengths).
+-/
+
+open Order
+
+namespace Etingof
+
+variable (A : Type*) (V : Type*) [Ring A] [AddCommGroup V] [Module A V]
+
+/-- The length `n` of `V` (the common length of any composition series from `⊥` to `⊤`) is
+the maximal length of a strictly increasing filtration of `V`. Etingof, discussion after
+Theorem 3.7.1.
+
+Here a strictly increasing filtration is an `LTSeries (Submodule A V)`, and its length is
+the number of strict inclusions. `IsGreatest` packages the two facts: the value `s.length`
+is attained by some strict filtration, and it is an upper bound for all of them. -/
+theorem jordanHolder_length_isGreatest_strict
+    (s : CompositionSeries (Submodule A V)) (hbot : s.head = ⊥) (htop : s.last = ⊤) :
+    IsGreatest (Set.range fun l : LTSeries (Submodule A V) => (l.length : ℕ∞))
+      (s.length : ℕ∞) := by
+  constructor
+  · -- The composition series is itself a strict filtration of length `s.length`.
+    refine ⟨s.map ⟨id, fun h => h.1⟩, ?_⟩
+    simp only [RelSeries.map_length]
+  · -- Every strict filtration has length ≤ s.length = Module.length A V.
+    rintro _ ⟨l, rfl⟩
+    have hkrull : (l.length : ℕ∞) ≤ Module.length A V := by
+      have h1 := LTSeries.length_le_krullDim l
+      rw [← Module.coe_length] at h1
+      exact_mod_cast h1
+    rwa [Module.length_compositionSeries s hbot htop]
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter3/Introduction3_6.lean
+++ b/EtingofRepresentationTheory/Chapter3/Introduction3_6.lean
@@ -1,0 +1,55 @@
+import EtingofRepresentationTheory.Chapter3.Theorem3_6_2
+
+/-!
+# Introduction to Section 3.6: Characters vanish on commutators
+
+The character of a finite dimensional representation `V` of an algebra `A` is the linear
+function `χ_V : A → k`, `χ_V(a) = Tr|_V(ρ(a))` (defined as `Etingof.character` in
+`Theorem3_6_2`).
+
+This file formalizes the prose claim from the section introduction: if `[A, A]` is the
+span of the commutators `[x, y] = xy - yx`, then `[A, A] ⊆ ker χ_V`, because the trace is
+cyclic (`tr(ρ(x)ρ(y)) = tr(ρ(y)ρ(x))`, `LinearMap.trace_mul_comm`). Consequently the
+character factors through the quotient `A/[A, A]`.
+-/
+
+open Module
+
+variable (k : Type*) (A : Type*) (V : Type*)
+  [CommRing k] [Ring A] [Algebra k A]
+  [AddCommGroup V] [Module k V] [Module A V] [IsScalarTower k A V]
+  [Free k V] [Module.Finite k V]
+
+namespace Etingof
+
+/-- The character is a class function on commutators: `χ_V(xy) = χ_V(yx)`. This is the
+cyclic property of the trace, since `ρ` is an algebra homomorphism. -/
+theorem character_mul_comm (x y : A) :
+    character k A V (x * y) = character k A V (y * x) := by
+  simp only [character, LinearMap.comp_apply, AlgHom.toLinearMap_apply, map_mul]
+  exact LinearMap.trace_mul_comm k _ _
+
+/-- The commutator submodule `[A, A]`: the `k`-span of all commutators `xy - yx`. -/
+def commutatorSubmodule : Submodule k A :=
+  Submodule.span k {z : A | ∃ x y : A, z = x * y - y * x}
+
+/-- Every commutator lies in the kernel of the character: `[A, A] ⊆ ker χ_V`. -/
+theorem commutatorSubmodule_le_ker_character :
+    commutatorSubmodule k A ≤ LinearMap.ker (character k A V) := by
+  rw [commutatorSubmodule, Submodule.span_le]
+  rintro z ⟨x, y, rfl⟩
+  simp only [SetLike.mem_coe, LinearMap.mem_ker, map_sub]
+  rw [character_mul_comm, sub_self]
+
+/-- The character viewed as a map on the quotient `A/[A, A] → k`. This is the factorization
+`χ_V : A/[A, A] → k` asserted in the prose. -/
+noncomputable def characterQuotient : (A ⧸ commutatorSubmodule k A) →ₗ[k] k :=
+  Submodule.liftQ _ (character k A V) (commutatorSubmodule_le_ker_character k A V)
+
+/-- The quotient character recovers the character after composing with the projection:
+`characterQuotient ∘ mkQ = character`. -/
+theorem characterQuotient_mk (a : A) :
+    characterQuotient k A V (Submodule.Quotient.mk a) = character k A V a :=
+  rfl
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter3/Remark3_1_3.lean
+++ b/EtingofRepresentationTheory/Chapter3/Remark3_1_3.lean
@@ -1,0 +1,89 @@
+import Mathlib.LinearAlgebra.TensorProduct.Basic
+import EtingofRepresentationTheory.Chapter2.Corollary2_3_10
+
+/-!
+# Remark 3.1.3: Canonical decomposition of a semisimple representation
+
+By Schur's lemma, a semisimple finite dimensional representation `V` of `A` is canonically
+identified with `⨁_X Hom_A(X, V) ⊗ X`, where `X` runs over the irreducible representations
+of `A`. The identification is the natural map
+
+`f : ⨁_X Hom_A(X, V) ⊗ X → V`, `g ⊗ x ↦ g(x)`.
+
+This file constructs the canonical evaluation map `g ⊗ x ↦ g(x)` (the building block of
+`f`, for each individual irreducible `X`) as genuine data — `Etingof.evalTensor` — and
+proves the heart of the remark: when `V` is irreducible (the case the book reduces to via
+"one may assume that `V` is irreducible"), the evaluation map
+
+`Hom_A(V, V) ⊗_k V → V`
+
+is a `k`-linear isomorphism. Indeed `Hom_A(V, V) = k · id` by Schur over the algebraically
+closed field `k` (Corollary 2.3.10), so the map has the explicit two-sided inverse
+`v ↦ id ⊗ v`.
+
+The assembly of the per-`X` maps into the full direct-sum isomorphism over all irreducibles
+remains; see the surrounding development of the isotypic decomposition.
+-/
+
+open scoped TensorProduct
+
+namespace Etingof
+
+variable (k : Type*) (A : Type*) (X : Type*) (V : Type*)
+  [CommRing k] [Ring A] [Algebra k A]
+  [AddCommGroup X] [Module k X] [Module A X] [IsScalarTower k A X]
+  [AddCommGroup V] [Module k V] [Module A V] [IsScalarTower k A V]
+
+/-- The `k`-bilinear evaluation pairing `Hom_A(X, V) × X → V`, `(g, x) ↦ g(x)`, packaged as
+a `k`-linear map `Hom_A(X, V) →ₗ[k] (X →ₗ[k] V)` sending an `A`-linear `g` to its underlying
+`k`-linear map. -/
+def evalBilinear : (X →ₗ[A] V) →ₗ[k] (X →ₗ[k] V) where
+  toFun g := g.restrictScalars k
+  map_add' g g' := LinearMap.restrictScalars_add g g'
+  map_smul' c g := LinearMap.restrictScalars_smul c g
+
+/-- The canonical evaluation map `Hom_A(X, V) ⊗_k X → V`, `g ⊗ x ↦ g(x)`. This is the
+building block of the natural map `f` of Remark 3.1.3. -/
+noncomputable def evalTensor : (X →ₗ[A] V) ⊗[k] X →ₗ[k] V :=
+  TensorProduct.lift (evalBilinear k A X V)
+
+@[simp]
+theorem evalTensor_tmul (g : X →ₗ[A] V) (x : X) :
+    evalTensor k A X V (g ⊗ₜ[k] x) = g x := rfl
+
+end Etingof
+
+namespace Etingof
+
+variable (k : Type*) (A : Type*) (V : Type*)
+  [Field k] [IsAlgClosed k] [Ring A] [Algebra k A]
+  [AddCommGroup V] [Module k V] [Module A V] [IsScalarTower k A V]
+  [IsSimpleModule A V] [FiniteDimensional k V]
+
+/-- For an irreducible finite dimensional representation `V` over an algebraically closed
+field, the canonical evaluation map `Hom_A(V, V) ⊗_k V → V`, `g ⊗ x ↦ g(x)`, is a `k`-linear
+isomorphism. This is the irreducible base case of Remark 3.1.3 (the case to which the book
+reduces the general statement). The inverse is `v ↦ id ⊗ v`. -/
+noncomputable def evalTensorEquivOfIsSimple :
+    (V →ₗ[A] V) ⊗[k] V ≃ₗ[k] V :=
+  LinearEquiv.ofLinear
+    (evalTensor k A V V)
+    (TensorProduct.mk k (V →ₗ[A] V) V LinearMap.id)
+    (by
+      ext v
+      simp)
+    (by
+      refine TensorProduct.ext' fun g x => ?_
+      -- Goal: id ⊗ₜ (evalTensor (g ⊗ₜ x)) = g ⊗ₜ x
+      obtain ⟨c, hc⟩ := Etingof.Corollary_2_3_10 (k := k) g
+      have hg : g = c • LinearMap.id := by
+        ext v; rw [LinearMap.smul_apply, LinearMap.id_apply]; exact hc v
+      simp only [LinearMap.coe_comp, Function.comp_apply, evalTensor_tmul,
+        TensorProduct.mk_apply, LinearMap.id_coe, id_eq]
+      rw [hc x, ← TensorProduct.smul_tmul, ← hg])
+
+@[simp]
+theorem evalTensorEquivOfIsSimple_tmul (g : V →ₗ[A] V) (x : V) :
+    evalTensorEquivOfIsSimple k A V (g ⊗ₜ[k] x) = g x := rfl
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter3/Remark3_3_4.lean
+++ b/EtingofRepresentationTheory/Chapter3/Remark3_3_4.lean
@@ -1,0 +1,58 @@
+import Mathlib.LinearAlgebra.Basis.Defs
+import Mathlib.LinearAlgebra.Quotient.Basic
+import Mathlib.LinearAlgebra.FiniteDimensional.Defs
+import Mathlib.Algebra.Algebra.Tower
+
+/-!
+# Remark 3.3.4: A finite dimensional representation is a quotient of a free module
+
+Let `X` be an `n`-dimensional representation of `A`, with a `k`-basis `{x₁, …, xₙ}`. Then
+there is a unique `A`-module homomorphism `ψ : Aⁿ → X` with `ψ(a₁, …, aₙ) = ∑ᵢ aᵢ xᵢ`, and
+it is surjective. Hence `X` is a quotient of the free module `Aⁿ`.
+
+We model the free module `Aⁿ` as `ι → A` for a `Fintype` index `ι` (a basis of `X`). The
+map `ψ` is `A`-linear and surjective: any element of `X` is a `k`-linear combination of the
+basis, and `k` acts through `A` via the scalar tower, so the same element is the image of
+the corresponding tuple of scalars from `A`.
+-/
+
+open Module
+
+namespace Etingof
+
+variable {k : Type*} (A : Type*) {X : Type*}
+  [CommRing k] [Ring A] [Algebra k A]
+  [AddCommGroup X] [Module k X] [Module A X] [IsScalarTower k A X]
+  {ι : Type*} [Fintype ι]
+
+/-- The `A`-linear map `ψ : Aⁿ → X` from a `k`-basis `b` of `X`, sending the tuple
+`(aᵢ)` to `∑ᵢ aᵢ • bᵢ`. The free module `Aⁿ` is realized as `ι → A`. -/
+noncomputable def freeCover (b : Basis ι k X) : (ι → A) →ₗ[A] X where
+  toFun a := ∑ i, (a i • b i : X)
+  map_add' a a' := by
+    simp only [Pi.add_apply, add_smul, Finset.sum_add_distrib]
+  map_smul' c a := by
+    simp only [Pi.smul_apply, smul_eq_mul, mul_smul, RingHom.id_apply, Finset.smul_sum]
+
+@[simp]
+theorem freeCover_apply (b : Basis ι k X) (a : ι → A) :
+    freeCover A b a = ∑ i, (a i • b i : X) := rfl
+
+/-- The map `ψ : Aⁿ → X` is surjective. Etingof Remark 3.3.4. -/
+theorem freeCover_surjective (b : Basis ι k X) :
+    Function.Surjective (freeCover A b) := by
+  intro x
+  -- Use the basis coordinates of `x`, mapped into `A` via the algebra map.
+  refine ⟨fun i => algebraMap k A (b.repr x i), ?_⟩
+  rw [freeCover_apply]
+  rw [show (∑ i, (algebraMap k A (b.repr x i) • b i : X)) = ∑ i, ((b.repr x i) • b i : X) from
+    Finset.sum_congr rfl fun i _ => algebraMap_smul A (b.repr x i) (b i)]
+  exact b.sum_repr x
+
+/-- `X` is a quotient of the free module `Aⁿ`: the quotient of `Aⁿ` by the kernel of `ψ`
+is `A`-linearly isomorphic to `X`. -/
+noncomputable def quotientEquivOfFreeCover (b : Basis ι k X) :
+    ((ι → A) ⧸ LinearMap.ker (freeCover A b)) ≃ₗ[A] X :=
+  (freeCover A b).quotKerEquivOfSurjective (freeCover_surjective A b)
+
+end Etingof

--- a/progress/2026-06-24T14-11-01Z_e0f4e3f3.md
+++ b/progress/2026-06-24T14-11-01Z_e0f4e3f3.md
@@ -1,0 +1,48 @@
+## Accomplished
+
+Formalized the four Chapter 3 prose-claim gaps from issue #5135 (claim-coverage /
+vacuity audit). All four were items marked `sorry_free` by the audit but with **no Lean
+file** — the prose made mathematical claims that were nowhere formalized. New, sorry-free
+formalizations:
+
+- **Introduction_to_3.6** (`Introduction3_6.lean`): `character_mul_comm`
+  (`χ_V(xy) = χ_V(yx)` via `LinearMap.trace_mul_comm`); `commutatorSubmodule` (`[A,A]`);
+  `commutatorSubmodule_le_ker_character` (`[A,A] ⊆ ker χ_V`); `characterQuotient` (the
+  factorization `χ_V : A/[A,A] → k`).
+- **Remark3.3.4** (`Remark3_3_4.lean`): `freeCover : (ι → A) →ₗ[A] X`, `(aᵢ) ↦ Σ aᵢ•bᵢ`
+  from a `k`-basis; `freeCover_surjective`; `quotientEquivOfFreeCover`
+  (`(ι → A)/ker ≃ₗ[A] X`), i.e. `X` is a quotient of the free module `Aⁿ`.
+- **Discussion_after_Theorem3.7.1** (`Discussion_after_Theorem3_7_1.lean`):
+  `jordanHolder_length_isGreatest_strict` — the composition-series length `n` is the
+  `IsGreatest` length among strictly-increasing submodule filtrations (`LTSeries`), via
+  `Module.length_compositionSeries` and `Order.LTSeries.length_le_krullDim`.
+- **Remark3.1.3** (`Remark3_1_3.lean`): constructs the canonical evaluation map
+  `evalTensor : (X →ₗ[A] V) ⊗[k] X →ₗ[k] V`, `g ⊗ x ↦ g(x)` (genuine data, no sorry), and
+  proves the irreducible base case `evalTensorEquivOfIsSimple`
+  (`Hom_A(V,V) ⊗_k V ≃ₗ[k] V` via Schur, Corollary 2.3.10, with explicit inverse
+  `v ↦ id ⊗ v`).
+
+All four wired into `Chapter3.lean`; `lake build EtingofRepresentationTheory.Chapter3`
+passes. `#print axioms` shows only `propext, Classical.choice, Quot.sound` (no `sorryAx`)
+for every new declaration. `progress/items.json` updated with `sorry_free: true` and notes.
+
+## Current frontier
+
+Issue #5135 complete for all four listed deliverables.
+
+## Overall project progress
+
+Stage 3 (formalization) — claim-coverage / vacuity audit. This turn removes four
+prose-claim gaps in Chapter 3 that previously had no Lean content despite being audited as
+covered.
+
+## Next step
+
+Optional follow-up (filed as a sub-issue): assemble the per-`X` `evalTensor` maps into the
+full direct-sum isomorphism `⨁_X Hom_A(X,V) ⊗ X ≃ V` over all irreducibles `X` (the general
+form of Remark 3.1.3). The single-irreducible base case and the canonical map are already in
+place; the remaining work is the direct-sum / isotypic assembly.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -1326,7 +1326,9 @@
     "end_page": "43",
     "start_line": 13,
     "end_line": 13,
-    "status": "sorry_free"
+    "status": "sorry_free",
+    "sorry_free": true,
+    "notes": "Remark3_1_3.lean: constructs the canonical evaluation map evalTensor : (X →ₗ[A] V) ⊗[k] X → V, g⊗x ↦ g(x) (genuine data, no sorry), and proves the irreducible base case evalTensorEquivOfIsSimple (Hom_A(V,V) ⊗ V ≃ₗ[k] V via Schur, Corollary 2.3.10). Full ⊕-over-all-irreducibles assembly remains as follow-up."
   },
   {
     "id": "Chapter3/Discussion_before_Proposition3.1.4",
@@ -1493,7 +1495,9 @@
     "end_page": "49",
     "start_line": 15,
     "end_line": 2,
-    "status": "sorry_free"
+    "status": "sorry_free",
+    "sorry_free": true,
+    "notes": "Remark3_3_4.lean: freeCover : (ι → A) →ₗ[A] X, (aᵢ) ↦ Σ aᵢ•bᵢ from a k-basis; freeCover_surjective; quotientEquivOfFreeCover ((ι → A)/ker ≃ₗ[A] X), i.e. X is a quotient of the free module Aⁿ."
   },
   {
     "id": "Chapter3/Introduction_to_3.4",
@@ -1633,7 +1637,9 @@
     "end_page": "52",
     "start_line": 3,
     "end_line": 10,
-    "status": "sorry_free"
+    "status": "sorry_free",
+    "sorry_free": true,
+    "notes": "Introduction3_6.lean: character_mul_comm (\u03c7_V(xy)=\u03c7_V(yx) via LinearMap.trace_mul_comm); commutatorSubmodule [A,A]; commutatorSubmodule_le_ker_character ([A,A] \u2286 ker \u03c7_V); characterQuotient (\u03c7_V factors through A/[A,A])."
   },
   {
     "id": "Chapter3/Exercise3.6.1",
@@ -1686,7 +1692,9 @@
     "end_page": "54",
     "start_line": 5,
     "end_line": 8,
-    "status": "sorry_free"
+    "status": "sorry_free",
+    "sorry_free": true,
+    "notes": "Discussion_after_Theorem3_7_1.lean: jordanHolder_length_isGreatest_strict — the composition-series length n is IsGreatest among lengths of strictly-increasing submodule filtrations (LTSeries), via Module.length_compositionSeries and Order.LTSeries.length_le_krullDim."
   },
   {
     "id": "Chapter3/Introduction_to_3.8",


### PR DESCRIPTION
Closes #5135

Session: `e0f4e3f3-2bc2-40bd-8bee-ed4c22c1ca26`

e6921907 feat(Ch3 #5135): construct canonical evaluation map and prove irreducible base case (Remark 3.1.3)
a14ef0d8 feat(Ch3 #5135): formalize length = max strict filtration (Discussion after Thm 3.7.1)
c3d61c7a feat(Ch3 #5135): formalize char vanishes on commutators (Intro 3.6) and free-module surjection (Remark 3.3.4)

🤖 Prepared with Claude Code