### PR TITLE
fix(Ch4 Theorem4.6.3): replace vacuous `True` stub — unitary ⟹ completely reducible

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Theorem4_6_3.lean
+++ b/EtingofRepresentationTheory/Chapter4/Theorem4_6_3.lean
@@ -18,7 +18,9 @@ Mathlib has `Submodule.IsCompl` and orthogonal complement theory in inner produc
 This combines representation theory with inner product space structure.
 -/
 
-/-- A unitary representation of any group is completely reducible (semisimple).
+/-- A unitary representation of any group is completely reducible (semisimple):
+every `ρ`-invariant subspace `W` has a `ρ`-invariant complement, namely its
+orthogonal complement `Wᗮ` under the `G`-invariant inner product.
 (Etingof Theorem 4.6.3) -/
 theorem Etingof.Theorem4_6_3
     (G : Type*) [Group G]
@@ -26,7 +28,19 @@ theorem Etingof.Theorem4_6_3
     (ρ : Representation ℂ G V)
     (hunit : ∀ g : G, ∀ v w : V,
       @inner ℂ V _ (ρ g v) (ρ g w) = @inner ℂ V _ v w) :
-    -- V is completely reducible (every subrepresentation has an invariant complement)
-    -- TODO: needs MonoidAlgebra module instance derived from Representation
-    True := by
-  trivial
+    ∀ W : Submodule ℂ V, (∀ g : G, ∀ w ∈ W, ρ g w ∈ W) →
+      ∃ W' : Submodule ℂ V, (∀ g : G, ∀ w ∈ W', ρ g w ∈ W') ∧ IsCompl W W' := by
+  intro W hW
+  refine ⟨Wᗮ, ?_, W.isCompl_orthogonal⟩
+  -- Wᗮ is G-invariant: if w ⊥ W then ρ g w ⊥ W, using ⟪u, ρ g w⟫ = ⟪ρ g⁻¹ u, w⟫
+  -- and the fact that ρ g⁻¹ u ∈ W (since W is invariant) so this inner product vanishes.
+  intro g w hw
+  rw [Submodule.mem_orthogonal] at hw ⊢
+  intro u hu
+  have hgu : ρ g⁻¹ u ∈ W := hW g⁻¹ u hu
+  have h1 : ρ g (ρ g⁻¹ u) = u := by
+    rw [← Module.End.mul_apply, ← map_mul, mul_inv_cancel, map_one, Module.End.one_apply]
+  calc @inner ℂ V _ u (ρ g w)
+      = @inner ℂ V _ (ρ g (ρ g⁻¹ u)) (ρ g w) := by rw [h1]
+    _ = @inner ℂ V _ (ρ g⁻¹ u) w := hunit g _ _
+    _ = 0 := hw _ hgu

--- a/progress/2026-06-24T14-30-26Z_b82144d9.md
+++ b/progress/2026-06-24T14-30-26Z_b82144d9.md
@@ -1,0 +1,36 @@
+## Accomplished
+
+Replaced the vacuous `True` stub in `Chapter4/Theorem4_6_3.lean` (issue #5121) with
+a real statement and a complete (sorry-free) proof.
+
+**Statement.** A finite-dimensional unitary representation `ρ : Representation ℂ G V`
+is completely reducible: every `ρ`-invariant subspace `W` has a `ρ`-invariant
+complement. Formalized as: for every `W : Submodule ℂ V` invariant under all `ρ g`,
+there exists `W'` invariant under all `ρ g` with `IsCompl W W'`.
+
+**Proof.** Take `W' = Wᗮ`. Complementarity is `Submodule.isCompl_orthogonal`
+(available in finite dimensions via `HasOrthogonalProjection`). Invariance of `Wᗮ`:
+for `w ∈ Wᗮ` and any `u ∈ W`, `⟪u, ρ g w⟫ = ⟪ρ g (ρ g⁻¹ u), ρ g w⟫ = ⟪ρ g⁻¹ u, w⟫`
+by the unitarity hypothesis, and this is `0` since `ρ g⁻¹ u ∈ W` (W invariant) and
+`w ∈ Wᗮ`. The identity `ρ g (ρ g⁻¹ u) = u` comes from `ρ` being a monoid hom
+(`← Module.End.mul_apply, ← map_mul, mul_inv_cancel, map_one, Module.End.one_apply`).
+
+`#print axioms` shows only `propext, Classical.choice, Quot.sound` — no `sorryAx`.
+
+## Current frontier
+
+Done. `lake build EtingofRepresentationTheory.Chapter4.Theorem4_6_3` passes.
+
+## Overall project progress
+
+Phase 3 formalization. This closes one of the `vacuous-statement` audit items
+(`True` stub → genuine theorem + proof). Chapter 4 remains otherwise sorry-free.
+
+## Next step
+
+Other `vacuous-statement` / `completeness-audit` issues from the coverage audit
+(`progress/coverage-audit/`) can be picked up similarly.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5121

Session: `b82144d9-be4a-4215-95a5-20d5d77f1083`

bf8d2cda fix(Ch4 Theorem4.6.3 #5121): replace vacuous True stub — unitary ⟹ completely reducible

🤖 Prepared with Claude Code