### PR TITLE
docs(once): exempt replan/repair from coordination claim ABORT guard

### DIFF
--- a/.claude/commands/once.md
+++ b/.claude/commands/once.md
@@ -25,10 +25,20 @@ immediately with `ABORT: no issue number provided`.
    `coordination claim <N> --label <type>`. Do **NOT** use
    `coordination list-unclaimed` — you are not picking from the
    queue.
+   - **Exception — `replan` and `repair` types do not use
+     `coordination claim`.** `coordination claim` deliberately
+     rejects a `replan`-labelled issue (`Issue #N needs replan`),
+     and `repair` claims a PR via `coordination claim-pr-repair`.
+     For these types, skip steps 3–4 and follow the matching skill's
+     own lifecycle (`replan` edits issues directly — no claim, no
+     branch, no PR; `repair` follows `pr-repair-flow`). A
+     `coordination claim` rejection for a `replan`/`repair` issue is
+     **not** an ABORT condition.
 4. **If the claim fails** (issue already claimed by another agent,
    issue closed, issue not labelled with the worker type, etc.),
    exit immediately. Print `ABORT: claim failed for #<N>` and do
-   nothing else. No worktree commits, no branches, no PR.
+   nothing else. No worktree commits, no branches, no PR. (Does not
+   apply to the `replan`/`repair` exception above.)
 5. Once the claim succeeds, **execute the issue end-to-end**
    following the standard worker flow for the matched type
    (implementation, build, tests, commit, push, open PR).


### PR DESCRIPTION
This PR exempts `replan` and `repair` worker types from the `coordination claim` ABORT guard in the `/once` one-shot dispatch command. A `pod once <N>` dispatch for a `replan` issue follows steps 3-4 of `/once` and attempts `coordination claim <N> --label replan`, but `coordination claim` deliberately rejects replan-labelled issues (`Issue #N needs replan. You MUST NOT work on this issue`). Read literally, that rejection trips the step-4 ABORT, which would strand a fully-decomposed parent issue permanently (it is also filtered out of `list-replan` once it carries a merged-PR reference, so no future replan session rescues it either). The carve-out points `replan`/`repair` at their own skill lifecycles and clarifies that a claim rejection for them is not an ABORT condition.

Surfaced while triaging #5137 (worker-decomposed into #5169-#5172 with the [E] item merged via #5173); the parent was closed as fully superseded.

🤖 Prepared with Claude Code