### PR TITLE
doc(replan): warn coordination plan has no --help

### DIFF
--- a/.claude/commands/replan.md
+++ b/.claude/commands/replan.md
@@ -64,6 +64,13 @@ the following:
 - **Still valid, body stale**: update the issue body with current
   state, then remove the `replan` label.
 
+When creating a replacement or residual issue, the invocation is
+`coordination plan [--label L] [--critical-path] "title"` with the body
+piped on **stdin**. The command has **no `--help`**: any positional
+argument is taken literally as the issue title, so `coordination plan
+--help` silently creates a junk issue titled `--help`. Never probe it
+that way — pass the real title directly.
+
 Process **every** candidate from `list-replan` before exiting.
 
 ## Step 4: Exit

--- a/progress/2026-06-24T14-37-33Z.md
+++ b/progress/2026-06-24T14-37-33Z.md
@@ -1,0 +1,38 @@
+## Accomplished
+
+Triaged replan issue #5124 (one-shot `pod once` dispatch, WORKER TYPE: replan).
+
+Determined the issue is a **partial-progress** case: PR #5151 (`b7f657d0`, merged)
+already replaced the vacuous `True` stubs in
+`EtingofRepresentationTheory/Chapter5/Example5_1_3.lean` with genuine
+Frobenius–Schur-type statements. PR #5151 was published `--partial`, which applied
+the `replan` label. The file now contains no `True` stub; `Example5_1_3_ZMod` is
+fully proved, and the S₃/S₄/A₅/Q₈ statements are real, non-vacuous `Prop`s.
+
+Actions taken (issue edits only — replan produces no PR):
+- Created residual issue #5186 (`feature`, `critical-path`) for the remaining
+  deliverables: filling the four `sorry` proofs (S₃, S₄, A₅ real-type; Q₈
+  quaternionic-type).
+- Closed #5124 with a forward link to #5186.
+- Closed accidental junk issue #5185 (created by an exploratory
+  `coordination plan --help`, which treats all args as a title).
+
+## Current frontier
+
+Replan candidate #5124 fully disposed of. Vacuity deliverable confirmed merged;
+remaining proof work tracked in #5186.
+
+## Overall project progress
+
+Chapter 5 vacuity-audit cleanup: the `True`-stub elimination for Example 5.1.3 is
+already merged. Remaining is normal H-difficulty formalization (FS-indicator
+infrastructure for specific groups), now a fresh feature item.
+
+## Next step
+
+A worker can claim #5186 to fill the four `sorry`s. Consider per-group
+decomposition (Q₈ is the hardest — explicit Pauli matrices + invariant skew form).
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR documents a footgun in the `replan` skill: `coordination plan` has no `--help` and treats any positional argument as the issue title (reading the body from stdin). A `pod once 5124` replan dispatch probed `coordination plan --help` while learning the syntax and silently created a junk issue titled `--help` (since cleaned up). The added note tells triage agents to pass the real title directly.

Surfaced during replan triage of #5124, which was disposed of as partial progress (vacuity deliverable merged in #5151; residual proof work tracked in #5186).

🤖 Prepared with Claude Code