### PR TITLE
feat(Ch2): formalize the easy prose-claim gaps (quotients, k[t] faithful, commutativity)

### DIFF
--- a/EtingofRepresentationTheory/Chapter2.lean
+++ b/EtingofRepresentationTheory/Chapter2.lean
@@ -11,9 +11,11 @@ import EtingofRepresentationTheory.Chapter2.Definition2_2_5
 import EtingofRepresentationTheory.Chapter2.Definition2_2_6
 import EtingofRepresentationTheory.Chapter2.Proposition2_2_3
 import EtingofRepresentationTheory.Chapter2.Example2_2_4
+import EtingofRepresentationTheory.Chapter2.Discussion_commutativity_examples
 
 -- Section 2.3: Representations
 import EtingofRepresentationTheory.Chapter2.Definition2_3_1
+import EtingofRepresentationTheory.Chapter2.Discussion_2_5_well_defined
 import EtingofRepresentationTheory.Chapter2.Definition2_3_4
 import EtingofRepresentationTheory.Chapter2.Definition2_3_5
 import EtingofRepresentationTheory.Chapter2.Definition2_3_6

--- a/EtingofRepresentationTheory/Chapter2/Discussion_2_5_well_defined.lean
+++ b/EtingofRepresentationTheory/Chapter2/Discussion_2_5_well_defined.lean
@@ -1,0 +1,67 @@
+import Mathlib.RingTheory.TwoSidedIdeal.Basic
+import Mathlib.RingTheory.Congruence.Basic
+import Mathlib.LinearAlgebra.Quotient.Basic
+
+/-!
+# Discussion 2.5: Well-definedness of quotient algebras and quotient representations
+
+The prose following Definition 2.5 checks three facts that the book establishes by hand and
+that Mathlib supplies through its quotient infrastructure:
+
+* If `I ⊆ A` is a (two-sided) ideal, then `A/I` is again an algebra. The book verifies that the
+  product `(a + I)(b + I) := ab + I` is well defined, using that `I` is both a left and a right
+  ideal. In Mathlib this well-definedness is exactly the statement that `I.ringCon` is a ring
+  congruence, and the quotient `A ⧸ I` (modelled by `I.ringCon.Quotient`) then carries a `Ring`
+  and an `Algebra k` structure automatically.
+* If `V` is a representation of `A` and `W ⊆ V` is a subrepresentation, then `V/W` is again a
+  representation, with `ρ_{V/W}(a)(v + W) := ρ_V(a)v + W`. In Mathlib this is the `A`-module
+  structure on `V ⧸ W` for a submodule `W : Submodule A V`.
+* Left ideals of `A` are the subrepresentations of the regular representation, so for a left
+  ideal `I ⊆ A` the quotient `A/I` is a representation of `A`.
+
+Each of these is `inferInstance` once the objects are phrased in Mathlib's language.
+-/
+
+namespace Etingof
+
+section QuotientAlgebra
+
+variable (k A : Type*) [CommRing k] [Ring A] [Algebra k A]
+
+/-- **`A/I` is an algebra.** For a two-sided ideal `I` of an algebra `A`, the quotient `A/I`
+(modelled as `I.ringCon.Quotient`) is again a `k`-algebra. The well-definedness of the
+multiplication `(a + I)(b + I) := ab + I` — checked by hand in the book using that `I` is both a
+left and a right ideal — is precisely the fact that `I.ringCon` is a ring congruence, after which
+the algebra structure is automatic. -/
+example (I : TwoSidedIdeal A) : Algebra k I.ringCon.Quotient := inferInstance
+
+/-- The canonical quotient map `A → A/I` is a homomorphism of `k`-algebras. -/
+noncomputable example (I : TwoSidedIdeal A) : A →ₐ[k] I.ringCon.Quotient :=
+  RingCon.mkₐ k I.ringCon
+
+end QuotientAlgebra
+
+section QuotientRepresentation
+
+variable (A V : Type*) [Ring A] [AddCommGroup V] [Module A V]
+
+/-- **`V/W` is a representation.** If `V` is a representation of `A` (a `Module A V`) and
+`W ⊆ V` is a subrepresentation (a `Submodule A V`), then the quotient `V/W` is again a
+representation of `A`, with action `a • (v + W) := a • v + W`. -/
+example (W : Submodule A V) : Module A (V ⧸ W) := inferInstance
+
+end QuotientRepresentation
+
+section RegularQuotient
+
+variable (A : Type*) [Ring A]
+
+/-- **`A/I` is a representation for a left ideal `I`.** Left ideals of `A` are exactly the
+subrepresentations of the regular representation (the `A`-module `A`), so for a left ideal
+`I ⊆ A`, modelled as a submodule `I : Submodule A A`, the quotient `A/I` is a representation
+of `A`. -/
+example (I : Submodule A A) : Module A (A ⧸ I) := inferInstance
+
+end RegularQuotient
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter2/Discussion_commutativity_examples.lean
+++ b/EtingofRepresentationTheory/Chapter2/Discussion_commutativity_examples.lean
@@ -1,0 +1,87 @@
+import Mathlib.Algebra.MonoidAlgebra.Defs
+import Mathlib.Data.Matrix.Basis
+import Mathlib.LinearAlgebra.Matrix.ToLin
+import Mathlib.Algebra.FreeAlgebra
+
+/-!
+# Discussion (commutativity examples after the five examples of Section 2.2)
+
+The book observes that, among the running examples of algebras, `A` is commutative in cases 1
+and 2, not commutative in cases 3 (`End V` with `dim V > 1`) and 4 (`FreeAlgebra` on `> 1`
+generators), and in case 5 (`A = k[G]`) commutative if and only if `G` is commutative.
+
+This file formalizes the two non-trivial claims:
+
+* **Case 5.** `MonoidAlgebra k G` is commutative if and only if `G` is commutative. The forward
+  direction (`G` commutative `⇒` `k[G]` commutative) is Mathlib's `MonoidAlgebra.commSemiring`;
+  the converse uses that `g ↦ single g 1` is an injective multiplicative map.
+* **Cases 3 and 4.** `End V` is noncommutative for `dim V > 1` (witnessed at `dim V = 2` by two
+  `2 × 2` matrix units), and `FreeAlgebra k (Fin n)` is noncommutative for `n > 1` (witnessed at
+  `n = 2` by the two generators, mapped to the non-commuting matrix units).
+-/
+
+namespace Etingof
+
+open Matrix
+
+/-- **Case 5.** The group algebra `k[G]` is commutative if and only if the monoid `G` is
+commutative. -/
+theorem monoidAlgebra_mul_comm_iff (k : Type*) [CommSemiring k] [Nontrivial k]
+    (G : Type*) [Monoid G] :
+    (∀ x y : MonoidAlgebra k G, x * y = y * x) ↔ (∀ g h : G, g * h = h * g) := by
+  constructor
+  · -- `k[G]` commutative ⇒ `G` commutative: compare `single g 1 * single h 1` with the
+    -- reversed product and use that `g ↦ single g 1` is injective (as `1 ≠ 0`).
+    intro hcomm g h
+    have key := hcomm (MonoidAlgebra.single g 1) (MonoidAlgebra.single h 1)
+    rw [MonoidAlgebra.single_mul_single, MonoidAlgebra.single_mul_single] at key
+    simp only [mul_one] at key
+    exact Finsupp.single_left_injective one_ne_zero key
+  · -- `G` commutative ⇒ `k[G]` commutative: this is Mathlib's `CommSemiring` instance.
+    intro hcomm
+    letI : CommMonoid G := { (inferInstance : Monoid G) with mul_comm := hcomm }
+    intro x y
+    exact mul_comm x y
+
+section Noncommutative
+
+variable (k : Type*) [CommRing k] [Nontrivial k]
+
+/-- The two `2 × 2` matrix units `E₀₁` and `E₁₀` do not commute: `E₀₁E₁₀ = E₀₀` while
+`E₁₀E₀₁ = E₁₁`, and these differ in their `(0,0)` entry. This is the concrete witness for the
+noncommutativity of `End V` (here `dim V = 2`). -/
+private lemma single_not_commute :
+    (Matrix.single 0 1 1 : Matrix (Fin 2) (Fin 2) k) * Matrix.single 1 0 1
+      ≠ Matrix.single 1 0 1 * Matrix.single 0 1 1 := by
+  intro h
+  rw [Matrix.single_mul_single_same, Matrix.single_mul_single_same] at h
+  have h00 := congrFun (congrFun h 0) 0
+  rw [Matrix.single_apply, Matrix.single_apply, if_pos (by decide), if_neg (by decide),
+    mul_one] at h00
+  exact one_ne_zero h00
+
+/-- **Case 3.** `End V` is not commutative when `dim V > 1`: already for `V = k²` there are two
+endomorphisms (the matrix units `E₀₁`, `E₁₀`) that do not commute. -/
+example : ∃ f g : Module.End k (Fin 2 → k), f * g ≠ g * f := by
+  refine ⟨Matrix.toLinAlgEquiv' (Matrix.single 0 1 1),
+    Matrix.toLinAlgEquiv' (Matrix.single 1 0 1), ?_⟩
+  intro h
+  rw [← map_mul, ← map_mul] at h
+  exact single_not_commute k ((Matrix.toLinAlgEquiv' (R := k)).injective h)
+
+/-- **Case 4.** `FreeAlgebra k (Fin n)` is not commutative when `n > 1`: already for `n = 2`
+the two generators `ι 0` and `ι 1` do not commute, since the algebra map sending them to the
+non-commuting matrix units `E₀₁`, `E₁₀` would otherwise force those to commute. -/
+example : ∃ a b : FreeAlgebra k (Fin 2), a * b ≠ b * a := by
+  refine ⟨FreeAlgebra.ι k 0, FreeAlgebra.ι k 1, ?_⟩
+  intro h
+  apply single_not_commute k
+  have := congrArg
+    (FreeAlgebra.lift k ![(Matrix.single 0 1 1 : Matrix (Fin 2) (Fin 2) k),
+      Matrix.single 1 0 1]) h
+  simpa only [map_mul, FreeAlgebra.lift_ι_apply, Matrix.cons_val_zero, Matrix.cons_val_one,
+    Matrix.head_cons] using this
+
+end Noncommutative
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter2/Proposition2_7_1.lean
+++ b/EtingofRepresentationTheory/Chapter2/Proposition2_7_1.lean
@@ -4,6 +4,7 @@ import Mathlib.LinearAlgebra.Basis.VectorSpace
 import Mathlib.Algebra.Algebra.Subalgebra.Lattice
 import Mathlib.Algebra.Polynomial.Derivative
 import Mathlib.Algebra.Polynomial.AlgebraMap
+import Mathlib.LinearAlgebra.Finsupp.LinearCombination
 
 /-!
 # Proposition 2.7.1: Basis for the Weyl Algebra
@@ -253,8 +254,11 @@ private lemma polyRep_rel :
     polyRepGen, Matrix.cons_val_zero, Matrix.cons_val_one]
   exact deriv_mul_polyMulX k
 
-/-- Algebra hom from the Weyl algebra to `End_k(k[X])`. -/
-private noncomputable def polyRep :
+/-- The **polynomial representation** of the Weyl algebra on `k[X]`, sending the generator
+`x` to multiplication by `X` and the generator `y` to the derivative `d/dX`. This is the
+representation `k[t]` of the Weyl algebra discussed in Section 2.7; it is faithful in
+characteristic zero (`WeylAlgebra.polyRep_injective`) but not in characteristic `p`. -/
+noncomputable def polyRep :
     WeylAlgebra k →ₐ[k] Module.End k (Polynomial k) :=
   RingQuot.liftAlgHom k ⟨polyRepFree k, polyRep_rel k⟩
 
@@ -299,16 +303,19 @@ private lemma polyRep_monomial_diag (i j : ℕ) :
 
 -- === Linear independence proof ===
 
-/-- The standard monomials of the Weyl algebra are linearly independent
-over any characteristic-zero integral domain. -/
-private lemma linearIndep [CharZero k] [NoZeroDivisors k] :
-    LinearIndependent k (fun p : ℕ × ℕ => WeylAlgebra.monomial k p.1 p.2) := by
+/-- The images of the basis monomials `xⁱyʲ` under the polynomial representation `polyRep`
+(`x ↦ X·`, `y ↦ d/dX` on `k[X]`) are linearly independent over any characteristic-zero
+integral domain. This is the crux of faithfulness of `k[X]` in characteristic zero: an element
+in the kernel of `polyRep`, expanded in the (spanning) monomial basis, gives a linear relation
+among these images, forcing all coefficients to vanish. -/
+private lemma polyImage_linearIndep [CharZero k] [NoZeroDivisors k] :
+    LinearIndependent k (fun p : ℕ × ℕ => polyRep k (WeylAlgebra.monomial k p.1 p.2)) := by
   rw [linearIndependent_iff']
   intro s g hg
-  -- Applying polyRep and extracting coefficient m from evaluation at X^n gives 0
-  -- polyRep annihilates the linear combination
+  -- The relation among the images means polyRep annihilates the corresponding combination
+  -- of monomials; extracting coefficient m from evaluation at X^n then gives 0.
   have hpoly : polyRep k (∑ r ∈ s, g r • WeylAlgebra.monomial k r.1 r.2) = 0 := by
-    rw [hg, map_zero]
+    rw [map_sum]; simp_rw [map_smul]; exact hg
   -- Extract coefficient m from evaluation at X^n
   have hcoeff : ∀ (n m : ℕ),
       ∑ r ∈ s, g r *
@@ -366,6 +373,49 @@ private lemma linearIndep [CharZero k] [NoZeroDivisors k] :
     rw [polyRep_monomial_diag, Polynomial.coeff_C_mul_X_pow, if_pos rfl] at honly
     exact (mul_eq_zero.mp honly).resolve_right
       (Nat.cast_ne_zero.mpr (Nat.factorial_ne_zero j))
+
+/-- The standard monomials of the Weyl algebra are linearly independent
+over any characteristic-zero integral domain. -/
+private lemma linearIndep [CharZero k] [NoZeroDivisors k] :
+    LinearIndependent k (fun p : ℕ × ℕ => WeylAlgebra.monomial k p.1 p.2) :=
+  (polyImage_linearIndep k).of_comp (polyRep k).toLinearMap
+
+/-- **Faithfulness of `k[X]` in characteristic zero (Discussion after Proposition 2.7.1).**
+The polynomial representation `polyRep` of the Weyl algebra on `k[X]` (`x ↦ X·`, `y ↦ d/dX`)
+is *faithful* — i.e. the algebra homomorphism `polyRep : WeylAlgebra k →ₐ[k] End k k[X]` is
+injective — whenever `k` is a characteristic-zero integral domain.
+
+This is the "check it!" claim of the book: `k[t]` is a faithful representation of the Weyl
+algebra in characteristic zero. It *fails* in characteristic `p`, where `(d/dt)^p Q = 0` for
+every polynomial `Q`; the char-free repair is the module `E = tᵃ k[a][t, t⁻¹]` of
+`FaithfulWeylModule.lean` (`WeylAlgebra.repE_injective`).
+
+The proof mirrors the linear-independence argument: the monomials `xⁱyʲ` span the Weyl algebra
+(`WeylAlgebra.monomials_span`, char-free) and their images under `polyRep` are linearly
+independent (`polyImage_linearIndep`), so `polyRep` is injective. -/
+theorem WeylAlgebra.polyRep_injective [CharZero k] [NoZeroDivisors k] :
+    Function.Injective (polyRep k) := by
+  classical
+  set mono : ℕ × ℕ → WeylAlgebra k := fun p => WeylAlgebra.monomial k p.1 p.2 with hmono
+  -- The monomials span (char-free), so linear combinations of them are surjective onto `A`.
+  have hsurj : Function.Surjective (Finsupp.linearCombination k mono) := by
+    rw [← LinearMap.range_eq_top, Finsupp.range_linearCombination]
+    exact top_le_iff.mp (WeylAlgebra.monomials_span k)
+  -- Their images under `polyRep` are linearly independent.
+  have hli : LinearIndependent k (fun p : ℕ × ℕ => polyRep k (mono p)) :=
+    polyImage_linearIndep k
+  rw [injective_iff_map_eq_zero (polyRep k)]
+  intro w hw
+  obtain ⟨f, rfl⟩ := hsurj w
+  have h0 : Finsupp.linearCombination k (fun p => polyRep k (mono p)) f = 0 := by
+    have hap : polyRep k (Finsupp.linearCombination k mono f)
+        = Finsupp.linearCombination k (fun p => polyRep k (mono p)) f := by
+      rw [Finsupp.linearCombination_apply, Finsupp.linearCombination_apply, map_finsuppSum]
+      simp only [map_smul]
+    rw [← hap]; exact hw
+  have hf : f = 0 :=
+    hli.finsuppLinearCombination_injective (h0.trans (map_zero _).symm)
+  rw [hf, map_zero]
 
 /-- **Proposition 2.7.1 (i)**: The standard monomials `{xⁱyʲ : i, j ≥ 0}` form a basis
 for the Weyl algebra `A` over `k`.

--- a/progress/2026-06-24T14-40-36Z_a330750d.md
+++ b/progress/2026-06-24T14-40-36Z_a330750d.md
@@ -1,0 +1,51 @@
+## Accomplished
+
+Formalized the Chapter 2 prose-claim coverage gaps from issue #5133 (claim-coverage / vacuity
+audit). Four prose claims now have genuine Lean content:
+
+- **Discussion_2.5_well_defined** (`Chapter2/Discussion_2_5_well_defined.lean`, new): three
+  `example`s showing `A/I` is a `k`-algebra for a two-sided ideal `I` (via `TwoSidedIdeal.ringCon`
+  + `RingCon.Quotient`'s `Algebra` instance, with the quotient map as `RingCon.mkₐ`), `V/W` is a
+  representation for a subrepresentation `W : Submodule A V`, and `A/I` is a representation for a
+  left ideal `I : Submodule A A`. All `inferInstance`, matching the book's "well defined because…"
+  paragraph.
+
+- **Discussion_faithful_example (char 0)** (in `Chapter2/Proposition2_7_1.lean`): added
+  `WeylAlgebra.polyRep_injective`, proving the polynomial representation `polyRep` of the Weyl
+  algebra on `k[X]` (`x ↦ X·`, `y ↦ d/dX`) is faithful over any characteristic-zero integral
+  domain. To do this I made `polyRep` public (was `private`) and refactored the existing
+  `linearIndep` proof: its delicate strong-induction core now proves the stronger
+  `polyImage_linearIndep` (linear independence of the *images* `polyRep (xⁱyʲ)`), and `linearIndep`
+  is recovered in one line via `LinearIndependent.of_comp`. Faithfulness then mirrors the existing
+  `FaithfulWeylModule.repE_injective` argument (monomials span + image-lin-indep ⇒ injective).
+
+- **Discussion_commutativity_examples (1) and (2)**
+  (`Chapter2/Discussion_commutativity_examples.lean`, new): `monoidAlgebra_mul_comm_iff` proves
+  `k[G]` commutative ⟺ `G` commutative (forward via `MonoidAlgebra.commSemiring` with a local
+  `CommMonoid G` instance; converse via `single_mul_single` + `Finsupp.single_left_injective`).
+  Two `example`s witness noncommutativity: a private helper `single_not_commute` shows the `2×2`
+  matrix units `E₀₁`, `E₁₀` do not commute, reused to show `End k (Fin 2 → k)` is noncommutative
+  (via `Matrix.toLinAlgEquiv'`) and `FreeAlgebra k (Fin 2)` is noncommutative (mapping the
+  generators to the matrix units via `FreeAlgebra.lift`).
+
+All three new files plus the refactored `Proposition2_7_1.lean` are wired into `Chapter2.lean`.
+`lake build EtingofRepresentationTheory.Chapter2` succeeds (8669 jobs, no errors; only pre-existing
+deprecation warnings inside the moved `linearIndep` body).
+
+## Current frontier
+
+Issue #5133 fully addressed. No sorries introduced; `polyRep` is now a public, reusable definition.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. This turn closes a batch of Chapter 2 prose-claim coverage gaps
+identified by the vacuity audit. Chapter 2 builds clean end-to-end.
+
+## Next step
+
+Pick up the next coverage-audit issue (other chapters have analogous prose-claim gaps; see
+`progress/coverage-audit/`).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5133

Session: `a330750d-79d9-474d-ba60-948c62c45cbb`

a3580982 feat(Ch2 #5133): formalize prose-claim gaps (quotients well-defined, k[X] faithful in char 0, commutativity of examples)

🤖 Prepared with Claude Code