### PR TITLE
feat(Ch2 Discussion_quiver_rep_bijection #5132): orthogonal idempotent foundation

### DIFF
--- a/EtingofRepresentationTheory/Chapter2.lean
+++ b/EtingofRepresentationTheory/Chapter2.lean
@@ -40,6 +40,7 @@ import EtingofRepresentationTheory.Chapter2.Definition2_8_4
 import EtingofRepresentationTheory.Chapter2.Definition2_8_8
 import EtingofRepresentationTheory.Chapter2.Definition2_8_9
 import EtingofRepresentationTheory.Chapter2.Definition2_8_10
+import EtingofRepresentationTheory.Chapter2.Discussion_quiver_rep_bijection
 import EtingofRepresentationTheory.Chapter2.Example2_8_2
 
 -- Section 2.9: Lie Algebras

--- a/EtingofRepresentationTheory/Chapter2/Discussion_quiver_rep_bijection.lean
+++ b/EtingofRepresentationTheory/Chapter2/Discussion_quiver_rep_bijection.lean
@@ -1,0 +1,94 @@
+import EtingofRepresentationTheory.Chapter2.Definition2_8_3
+import EtingofRepresentationTheory.Chapter2.Definition2_8_4
+
+/-!
+# Discussion: quiver representations vs. path-algebra modules
+
+The discussion following Definition 2.8.4 in Etingof asserts that a representation of a
+quiver `Q` is "the same thing" as a representation (module) of its path algebra `P_Q`, with
+mutually inverse assignments `V ↦ (pᵢ V)` and `(Vᵢ) ↦ ⊕ᵢ Vᵢ`, giving a bijection between
+isomorphism classes.
+
+This file develops the algebraic foundation that both directions of that bijection rest on:
+the trivial paths `pᵢ = ofPath ⟨i, i, nil⟩` form a family of **orthogonal idempotents**
+summing (for a finite vertex set) to `1`, and they **absorb** an oriented path on the
+correct side. Concretely, for an oriented path `a : x ⟶* y`,
+
+* `pₓ · a = a` and `pₖ · a = 0` for `k ≠ x` (the source idempotent acts on the left), and
+* `a · p_y = a` and `a · pₖ = 0` for `k ≠ y` (the target idempotent acts on the right).
+
+These are precisely the relations that make `pᵢ V` the `i`-th vertex space and that pin down
+which vertex space a single-arrow path maps out of and into.
+
+## Convention / direction note
+
+`Definition2_8_4` builds `P_Q` with Mathlib's **source-to-target** concatenation
+(`comp x y` is defined when `target x = source y`, giving a path `source x ⟶* target y`).
+This is the *opposite* of Etingof's body-text reading `ab = "first b then a"`; the two
+conventions produce mutually opposite algebras. The absorption laws below are stated for the
+source-to-target algebra actually constructed.
+
+A consequence worth flagging for the full bijection (tracked in the
+`Discussion_quiver_rep_bijection` work item): under this convention, for an arrow
+`e : i ⟶ j` the basis element `aₑ = ofPath ⟨i, j, e.toPath⟩` satisfies `pᵢ · aₑ = aₑ` and
+`aₑ · p_j = aₑ`, so in a *left* `P_Q`-module the operator `v ↦ aₑ • v` carries `p_j V` into
+`pᵢ V`, i.e. it points `Vⱼ → Vᵢ`. Matching this against `Etingof.QuiverRepresentation` (where
+an arrow `i ⟶ j` carries `Vᵢ → Vⱼ`) therefore requires either the opposite algebra, right
+modules, or `Qᵒᵖ`; that modelling choice is left to the bijection construction itself.
+-/
+
+namespace Etingof.PathAlgebra
+
+variable {k : Type*} {Q : Type*} [Field k] [Quiver Q] [DecidableEq Q]
+
+/-- The trivial path idempotent `pᵢ` at a vertex `i`: the basis element of `PathAlgebra k Q`
+indexed by the empty (length-zero) path at `i`. -/
+noncomputable def trivialPath (i : Q) : PathAlgebra k Q :=
+  ofPath ⟨i, i, Quiver.Path.nil⟩
+
+theorem trivialPath_def (i : Q) :
+    (trivialPath i : PathAlgebra k Q) = Finsupp.single ⟨i, i, Quiver.Path.nil⟩ 1 :=
+  rfl
+
+/-- Left absorption: multiplying a basis path `a : x ⟶* y` on the left by the trivial path
+`pᵢ` returns `a` when `i` is its source, and `0` otherwise. -/
+theorem trivialPath_mul_ofPath (i a b : Q) (p : Quiver.Path a b) :
+    (trivialPath i : PathAlgebra k Q) * ofPath ⟨a, b, p⟩
+      = if i = a then ofPath ⟨a, b, p⟩ else 0 := by
+  simp only [trivialPath, ofPath, single_mul_single, one_mul, one_smul, compSingle_nil_left]
+
+/-- Right absorption: multiplying a basis path `a : x ⟶* y` on the right by the trivial path
+`pᵢ` returns `a` when `i` is its target, and `0` otherwise. -/
+theorem ofPath_mul_trivialPath (a b i : Q) (p : Quiver.Path a b) :
+    (ofPath ⟨a, b, p⟩ : PathAlgebra k Q) * trivialPath i
+      = if b = i then ofPath ⟨a, b, p⟩ else 0 := by
+  simp only [trivialPath, ofPath, single_mul_single, mul_one, one_smul, compSingle_nil_right]
+
+/-- The trivial paths are idempotents: `pᵢ · pᵢ = pᵢ`. -/
+theorem trivialPath_mul_self (i : Q) :
+    (trivialPath i : PathAlgebra k Q) * trivialPath i = trivialPath i := by
+  have h := trivialPath_mul_ofPath (k := k) i i i Quiver.Path.nil
+  rw [if_pos rfl] at h
+  exact h
+
+/-- The trivial paths are orthogonal: `pᵢ · pⱼ = 0` when `i ≠ j`. -/
+theorem trivialPath_mul_of_ne {i j : Q} (h : i ≠ j) :
+    (trivialPath i : PathAlgebra k Q) * trivialPath j = 0 := by
+  have h2 := trivialPath_mul_ofPath (k := k) i j j Quiver.Path.nil
+  rw [if_neg h] at h2
+  exact h2
+
+/-- Orthogonal-idempotent product law in one statement: `pᵢ · pⱼ = pᵢ` if `i = j`, else `0`. -/
+theorem trivialPath_mul_trivialPath (i j : Q) :
+    (trivialPath i : PathAlgebra k Q) * trivialPath j = if i = j then trivialPath i else 0 := by
+  by_cases h : i = j
+  · subst h; rw [trivialPath_mul_self, if_pos rfl]
+  · rw [trivialPath_mul_of_ne h, if_neg h]
+
+/-- **Remark 2.8.5, restated.** For a finite vertex set, the trivial-path idempotents sum to the
+unit: `∑ᵢ pᵢ = 1`. (Restatement of `sum_trivialPaths_eq_one` in terms of `trivialPath`.) -/
+theorem sum_trivialPath [Fintype Q] : (∑ i, trivialPath i : PathAlgebra k Q) = 1 := by
+  simp only [trivialPath]
+  exact sum_trivialPaths_eq_one k Q
+
+end Etingof.PathAlgebra

--- a/progress/2026-06-24T16-22-23Z_0334a98b.md
+++ b/progress/2026-06-24T16-22-23Z_0334a98b.md
@@ -1,0 +1,55 @@
+## Accomplished
+
+One-shot dispatch on issue #5132 (Ch2 path-algebra / quiver-rep bijection). Tasks 1 & 2
+of #5132 (path-algebra multiplication + Ring/Algebra/unit structure, Remark 2.8.5) had
+already landed sorry-free in `Definition2_8_4.lean` (PR #5150); the only residual scope was
+Task 3, the `QuiverRepresentation ≃ Module (PathAlgebra)` bijection (split out to #5149,
+difficulty H).
+
+This turn delivered the **reusable orthogonal-idempotent foundation** that the issue itself
+flags as the suggested first step, in a new sorry-free file
+`EtingofRepresentationTheory/Chapter2/Discussion_quiver_rep_bijection.lean`:
+
+- `trivialPath i` (`= pᵢ`), the trivial-path idempotent at a vertex.
+- `trivialPath_mul_ofPath` / `ofPath_mul_trivialPath`: left/right **absorption** laws — `pₓ`
+  acts as identity on a path with source `x` (zero otherwise), `p_y` on the right for target `y`.
+- `trivialPath_mul_self` (idempotency), `trivialPath_mul_of_ne` (orthogonality), and the
+  combined `trivialPath_mul_trivialPath` (`pᵢ pⱼ = δᵢⱼ pᵢ`).
+- `sum_trivialPath` (`∑ᵢ pᵢ = 1`, restating Remark 2.8.5's `sum_trivialPaths_eq_one`).
+
+All six lemmas verified `#print axioms`-clean (no `sorryAx`). File added to the `Chapter2.lean`
+aggregator; full `lake build` of the new module green.
+
+## Convention / direction finding (important for the full bijection)
+
+`Definition2_8_4` builds `P_Q` with Mathlib's **source-to-target** concatenation, the
+*opposite* of Etingof's body-text `ab = "first b then a"`. The absorption laws make this
+precise: for an arrow `e : i ⟶ j`, `pᵢ · aₑ = aₑ` and `aₑ · p_j = aₑ`, so in a *left*
+`P_Q`-module the operator `v ↦ aₑ • v` carries `p_j V → pᵢ V`, i.e. points `Vⱼ → Vᵢ` —
+the reverse of `Etingof.QuiverRepresentation` (arrow `i ⟶ j` carries `Vᵢ → Vⱼ`). The full
+bijection therefore needs a modelling decision: opposite algebra, right modules, or `Qᵒᵖ`.
+This is documented in the new file's module docstring and noted on #5149.
+
+## Current frontier
+
+Foundation lemmas done. The two functors (`V ↦ (pᵢ V)` and `(Vᵢ) ↦ ⊕ Vᵢ`) and their
+mutual-inverse / iso-class bijection are not yet built — they need the restriction-of-scalars
++ submodule + direct-sum plumbing and the convention decision above.
+
+## Overall project progress
+
+Chapter 2 §2.8 path-algebra infrastructure: multiplication, Ring/Algebra/unit, and now the
+orthogonal-idempotent decomposition are all sorry-free. The representation↔module bijection
+(#5149) remains the open H-difficulty piece.
+
+## Next step
+
+Continue #5149 using the new `trivialPath_*` lemmas. First resolve the direction convention
+(recommend constructing the functor from a left `P_Q`-module to a `QuiverRepresentation` of
+`Qᵒᵖ`, or switching to the opposite algebra), then build the two assignments and prove
+mutually inverse.
+
+## Blockers
+
+None. #5132's residual scope is fully tracked by #5149 (already open, `feature`-labelled),
+which now also carries this foundation.


### PR DESCRIPTION
Closes #5132

This PR adds the reusable orthogonal-idempotent foundation for the path-algebra / quiver-representation bijection (Etingof's discussion after Def 2.8.4), in a new sorry-free file `EtingofRepresentationTheory/Chapter2/Discussion_quiver_rep_bijection.lean`. Tasks 1 & 2 of this issue (the path-algebra multiplication and the `Ring`/`Algebra`/unit structure, Remark 2.8.5) already landed via #5150; the remaining Task 3 — the full `QuiverRepresentation k Q ≃ Module (PathAlgebra k Q)` bijection on isomorphism classes — is tracked in #5149, which this foundation directly serves.

The new lemmas, all `#print axioms`-clean (no `sorryAx`):

- `trivialPath i` (the idempotent `pᵢ`), with `trivialPath_mul_ofPath` / `ofPath_mul_trivialPath` left/right absorption laws.
- `trivialPath_mul_self` (idempotency), `trivialPath_mul_of_ne` (orthogonality), `trivialPath_mul_trivialPath` (`pᵢ pⱼ = δᵢⱼ pᵢ`).
- `sum_trivialPath` (`∑ᵢ pᵢ = 1`, restating Remark 2.8.5).

The module docstring also records a convention finding important for the full bijection: `Definition2_8_4` uses Mathlib's source-to-target concatenation, the opposite of Etingof's body-text reading, so in a left `P_Q`-module an arrow `i ⟶ j` acts as `Vⱼ → Vᵢ`. Matching `Etingof.QuiverRepresentation` therefore needs the opposite algebra / right modules / `Qᵒᵖ` — a modelling decision left to the bijection construction in #5149.

🤖 Prepared with Claude Code
