### PR TITLE
fix(Ch4 Theorem4.6.2): replace vacuous `True` stub — unitarizability (existence + uniqueness)

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Theorem4_6_2.lean
+++ b/EtingofRepresentationTheory/Chapter4/Theorem4_6_2.lean
@@ -135,6 +135,106 @@ theorem Theorem4_6_2_existence
     _ = ∑ g : G, c₀.inner (ρ g v) (ρ g w) :=
           Equiv.sum_comp (Equiv.mulRight h) (fun g => c₀.inner (ρ g v) (ρ g w))
 
+/-!
+### Tools for the uniqueness statement
+
+A positive definite Hermitian form `c` is *nondegenerate*: the conjugate-linear map
+`v ↦ c(v, ·)` into the dual `V →ₗ[ℂ] ℂ` is injective, and (in finite dimensions) bijective.
+Composing the inverse of this map for `c₁` with the map for `c₂` yields a genuine
+`ℂ`-linear endomorphism `A` of `V` with `c₁(A v, w) = c₂(v, w)`; this is the intertwiner
+of the book proof.
+-/
+
+namespace Theorem4_6_2
+
+variable {V : Type*} [AddCommGroup V] [Module ℂ V]
+
+open scoped ComplexConjugate
+
+/-- Right additivity of an `InnerProductSpace.Core`, derived from left additivity and
+Hermitian symmetry. -/
+private lemma core_inner_add_right (c : InnerProductSpace.Core ℂ V) (x y z : V) :
+    c.inner x (y + z) = c.inner x y + c.inner x z := by
+  rw [← c.conj_inner_symm x (y + z), c.add_left, map_add, c.conj_inner_symm x y,
+    c.conj_inner_symm x z]
+
+/-- Right `ℂ`-linearity of an `InnerProductSpace.Core`. -/
+private lemma core_inner_smul_right (c : InnerProductSpace.Core ℂ V) (x y : V) (r : ℂ) :
+    c.inner x (r • y) = r * c.inner x y := by
+  rw [← c.conj_inner_symm x (r • y), c.smul_left, map_mul, c.conj_inner_symm x y, Complex.conj_conj]
+
+/-- Left subtractivity of an `InnerProductSpace.Core`. -/
+private lemma core_inner_sub_left (c : InnerProductSpace.Core ℂ V) (x y z : V) :
+    c.inner (x - y) z = c.inner x z - c.inner y z := by
+  rw [sub_eq_add_neg, c.add_left, ← neg_one_smul ℂ y, c.smul_left]
+  simp [sub_eq_add_neg]
+
+/-- The functional `w ↦ c(v, w)` as an element of the dual `V →ₗ[ℂ] ℂ`. -/
+private noncomputable def innerFunctional (c : InnerProductSpace.Core ℂ V) (v : V) :
+    Module.Dual ℂ V where
+  toFun w := c.inner v w
+  map_add' y z := core_inner_add_right c v y z
+  map_smul' r w := by simp only [RingHom.id_apply, smul_eq_mul]; exact core_inner_smul_right c v w r
+
+@[simp] private lemma innerFunctional_apply (c : InnerProductSpace.Core ℂ V) (v w : V) :
+    innerFunctional c v w = c.inner v w := rfl
+
+/-- The conjugate-linear map `v ↦ c(v, ·)` from `V` into its dual. -/
+private noncomputable def innerToDual (c : InnerProductSpace.Core ℂ V) :
+    V →ₛₗ[starRingEnd ℂ] Module.Dual ℂ V where
+  toFun := innerFunctional c
+  map_add' v v' := by
+    ext w; simp only [innerFunctional_apply, LinearMap.add_apply]; exact c.add_left v v' w
+  map_smul' r v := by
+    ext w
+    simp only [innerFunctional_apply, LinearMap.smul_apply, smul_eq_mul]
+    exact c.smul_left v w r
+
+@[simp] private lemma innerToDual_apply (c : InnerProductSpace.Core ℂ V) (v w : V) :
+    innerToDual c v w = c.inner v w := rfl
+
+/-- Nondegeneracy: the conjugate-linear map into the dual is injective. -/
+private lemma innerToDual_injective (c : InnerProductSpace.Core ℂ V) :
+    Function.Injective (innerToDual c) := by
+  intro u u' h
+  have h' : ∀ w, c.inner u w = c.inner u' w := fun w => by
+    have := DFunLike.congr_fun h w; simpa using this
+  have hz : c.inner (u - u') (u - u') = 0 := by
+    rw [core_inner_sub_left, h' (u - u'), sub_self]
+  have := c.definite (u - u') hz
+  exact sub_eq_zero.mp this
+
+/-- In finite dimensions, the conjugate-linear map into the dual is surjective: it is an
+injective conjugate-linear map between two `ℝ`-spaces of equal (real) dimension. -/
+private lemma innerToDual_surjective (c : InnerProductSpace.Core ℂ V) [FiniteDimensional ℂ V] :
+    Function.Surjective (innerToDual c) := by
+  haveI : FiniteDimensional ℝ V := Module.Finite.trans ℂ V
+  haveI : FiniteDimensional ℝ (Module.Dual ℂ V) := Module.Finite.trans ℂ (Module.Dual ℂ V)
+  let fR : V →ₗ[ℝ] Module.Dual ℂ V :=
+    { toFun := innerToDual c
+      map_add' := (innerToDual c).map_add
+      map_smul' := fun r v => by
+        simp only [RingHom.id_apply]
+        rw [RCLike.real_smul_eq_coe_smul (K := ℂ) r v, LinearMap.map_smulₛₗ, RCLike.conj_ofReal,
+          ← RCLike.real_smul_eq_coe_smul (K := ℂ) r (innerToDual c v)] }
+  have hinj : Function.Injective fR := innerToDual_injective c
+  have hfin : Module.finrank ℝ V = Module.finrank ℝ (Module.Dual ℂ V) := by
+    rw [← Module.finrank_mul_finrank ℝ ℂ V, ← Module.finrank_mul_finrank ℝ ℂ (Module.Dual ℂ V),
+      Subspace.dual_finrank_eq]
+  exact (LinearMap.injective_iff_surjective_of_finrank_eq_finrank hfin).mp hinj
+
+/-- The conjugate-linear equivalence `V ≃ V*` induced by a nondegenerate form in finite
+dimensions. -/
+private noncomputable def innerEquivDual (c : InnerProductSpace.Core ℂ V) [FiniteDimensional ℂ V] :
+    V ≃ₛₗ[starRingEnd ℂ] Module.Dual ℂ V :=
+  LinearEquiv.ofBijective (innerToDual c) ⟨innerToDual_injective c, innerToDual_surjective c⟩
+
+@[simp] private lemma innerEquivDual_apply (c : InnerProductSpace.Core ℂ V) [FiniteDimensional ℂ V]
+    (v w : V) : innerEquivDual c v w = c.inner v w := rfl
+
+end Theorem4_6_2
+
+open Theorem4_6_2 in
 set_option linter.unusedFintypeInType false in
 /-- For an irreducible representation, the unitary structure is unique up to scaling
 by a positive real number: any two `G`-invariant positive definite Hermitian forms
@@ -153,11 +253,77 @@ theorem Theorem4_6_2_uniqueness
     (h₁ : ∀ (g : G) (v w : V), c₁.inner (ρ g v) (ρ g w) = c₁.inner v w)
     (h₂ : ∀ (g : G) (v w : V), c₂.inner (ρ g v) (ρ g w) = c₂.inner v w) :
     ∃ lam : ℝ, 0 < lam ∧ ∀ v w : V, c₂.inner v w = (lam : ℂ) * c₁.inner v w := by
-  -- Both forms are nondegenerate, so `c₂(v, w) = c₁(A v, w)` for a unique linear `A`,
-  -- which intertwines `ρ` by `G`-invariance of both forms. Schur's lemma (using `hirr`)
-  -- forces `A = λ • id`, and positivity of both forms forces `λ > 0`.
-  -- Requires building the Riesz/adjoint correspondence at the `InnerProductSpace.Core`
-  -- level plus Schur's lemma for irreducible `ρ`.
-  sorry
+  classical
+  haveI : Nontrivial V := hnontrivial
+  -- The intertwiner `A`, characterised by `c₁(A v, w) = c₂(v, w)`.
+  set A : Module.End ℂ V := ((innerEquivDual c₁).symm.toLinearMap).comp (innerToDual c₂) with hA_def
+  -- Defining property of `A`.
+  have hA : ∀ v w, c₁.inner (A v) w = c₂.inner v w := by
+    intro v w
+    have hval : innerEquivDual c₁ (A v) = innerToDual c₂ v :=
+      (innerEquivDual c₁).apply_symm_apply (innerToDual c₂ v)
+    have hw := DFunLike.congr_fun hval w
+    rwa [innerEquivDual_apply, innerToDual_apply] at hw
+  -- `g · g⁻¹` acts trivially.
+  have hgg : ∀ (g : G) (x : V), ρ g (ρ g⁻¹ x) = x := fun g x => by
+    have : ρ g (ρ g⁻¹ x) = ρ (g * g⁻¹) x := by rw [map_mul]; rfl
+    rw [this, mul_inv_cancel, map_one]; rfl
+  -- `A` intertwines `ρ`: it commutes with every `ρ g`.
+  have hcomm : ∀ (g : G) (v : V), A (ρ g v) = ρ g (A v) := by
+    intro g v
+    apply innerToDual_injective c₁
+    ext w
+    change c₁.inner (A (ρ g v)) w = c₁.inner (ρ g (A v)) w
+    have hR : c₁.inner (ρ g (A v)) w = c₂.inner (ρ g v) w := by
+      calc c₁.inner (ρ g (A v)) w
+          = c₁.inner (ρ g (A v)) (ρ g (ρ g⁻¹ w)) := by rw [hgg g w]
+        _ = c₁.inner (A v) (ρ g⁻¹ w) := h₁ g (A v) (ρ g⁻¹ w)
+        _ = c₂.inner v (ρ g⁻¹ w) := hA v (ρ g⁻¹ w)
+        _ = c₂.inner (ρ g v) (ρ g (ρ g⁻¹ w)) := (h₂ g v (ρ g⁻¹ w)).symm
+        _ = c₂.inner (ρ g v) w := by rw [hgg g w]
+    rw [hA (ρ g v) w, hR]
+  -- Schur: an intertwiner of an irreducible representation over `ℂ` is a scalar.
+  obtain ⟨μ, hμ⟩ := Module.End.exists_eigenvalue A
+  have hWinv : ∀ g : G, ∀ v ∈ Module.End.eigenspace A μ, ρ g v ∈ Module.End.eigenspace A μ := by
+    intro g v hv
+    rw [Module.End.mem_eigenspace_iff] at hv ⊢
+    rw [hcomm g v, hv, map_smul]
+  have hWtop : Module.End.eigenspace A μ = ⊤ := (hirr _ hWinv).resolve_left hμ
+  have hAμ : ∀ v, A v = μ • v := by
+    intro v
+    have : v ∈ Module.End.eigenspace A μ := by rw [hWtop]; exact Submodule.mem_top
+    rwa [Module.End.mem_eigenspace_iff] at this
+  -- Hence `c₂ = conj μ • c₁` as forms.
+  have hform : ∀ v w, c₂.inner v w = (starRingEnd ℂ) μ * c₁.inner v w := by
+    intro v w
+    rw [← hA v w, hAμ v]
+    exact c₁.smul_left v w μ
+  -- Positivity: for `c` positive definite and `v ≠ 0`, `c(v, v)` is a positive real.
+  have hpos : ∀ (c : InnerProductSpace.Core ℂ V) {v : V}, v ≠ 0 →
+      c.inner v v = (RCLike.re (c.inner v v) : ℂ) ∧ 0 < RCLike.re (c.inner v v) := by
+    intro c v hv
+    have him : RCLike.im (c.inner v v) = 0 :=
+      RCLike.conj_eq_iff_im.mp (c.conj_inner_symm v v)
+    have hreal : c.inner v v = (RCLike.re (c.inner v v) : ℂ) := by
+      apply RCLike.ext <;> simp [him]
+    refine ⟨hreal, ?_⟩
+    rcases (c.re_inner_nonneg v).lt_or_eq with h | h
+    · exact h
+    · exact absurd (c.definite v (by rw [hreal, ← h]; simp)) hv
+  obtain ⟨v₀, hv₀⟩ := exists_ne (0 : V)
+  obtain ⟨h1real, h1pos⟩ := hpos c₁ hv₀
+  obtain ⟨h2real, h2pos⟩ := hpos c₂ hv₀
+  set a : ℝ := RCLike.re (c₁.inner v₀ v₀) with ha_def
+  set b : ℝ := RCLike.re (c₂.inner v₀ v₀) with hb_def
+  refine ⟨b / a, div_pos h2pos h1pos, ?_⟩
+  -- It remains to identify `conj μ` with the positive real `b / a`.
+  have hconj : (starRingEnd ℂ) μ = ((b / a : ℝ) : ℂ) := by
+    have hkey : c₂.inner v₀ v₀ = (starRingEnd ℂ) μ * c₁.inner v₀ v₀ := hform v₀ v₀
+    rw [h1real, h2real] at hkey
+    have ha0 : (a : ℂ) ≠ 0 := by exact_mod_cast h1pos.ne'
+    rw [Complex.ofReal_div, eq_div_iff ha0]
+    exact hkey.symm
+  intro v w
+  rw [hform v w, hconj]
 
 end Etingof

--- a/progress/2026-06-24T16-34-59Z_e64ed378.md
+++ b/progress/2026-06-24T16-34-59Z_e64ed378.md
@@ -1,0 +1,35 @@
+## Accomplished
+Proved `Theorem4_6_2_uniqueness` in `EtingofRepresentationTheory/Chapter4/Theorem4_6_2.lean`
+(issue #5120, the "uniqueness" half of the existence+uniqueness deliverable; existence was
+already proved). The `sorry` is gone and the file builds clean with no warnings.
+
+Approach (fully algebraic, no analysis/topology instances on the bare module `V`):
+- Added private helpers in a `Theorem4_6_2` namespace: right-additivity / right-`ℂ`-linearity
+  / left-subtractivity for `InnerProductSpace.Core`, the dual functional `w ↦ c(v,w)`
+  (`innerFunctional`), and the conjugate-linear map `innerToDual : V →ₛₗ[conj] V*`.
+- `innerToDual_injective` from definiteness; `innerToDual_surjective` by restricting the
+  conjugate-linear map to an `ℝ`-linear map between equal-real-dimension spaces
+  (`finrank ℝ V = finrank ℝ ℂ · finrank ℂ V = finrank ℝ V*`) and using
+  `injective_iff_surjective_of_finrank_eq_finrank`. Packaged as `innerEquivDual`.
+- The intertwiner `A := (innerEquivDual c₁).symm ∘ innerToDual c₂` is `ℂ`-linear (conj∘conj=id
+  via `RingHomInvPair`), satisfies `c₁(A v, w) = c₂(v, w)`, and commutes with `ρ` by
+  `G`-invariance of both forms.
+- Schur via `Module.End.exists_eigenvalue` (`ℂ` alg-closed, `V` f.d. nontrivial): the
+  `μ`-eigenspace is `ρ`-invariant and nonzero, so `hirr` forces it to be `⊤`, i.e. `A = μ·id`.
+- Hence `c₂ = conj μ · c₁`; positive-definiteness of both forms at any `v₀ ≠ 0` shows
+  `conj μ = (b/a : ℝ)` with `a,b > 0`, giving `lam = b/a > 0`.
+
+Updated `progress/items.json`: `Chapter4/Theorem4.6.2` → `proof_complete`, `sorry_free: true`.
+
+## Current frontier
+`Theorem4_6_2.lean` is fully proved and sorry-free. Issue #5165 (the standalone tracker for
+this same uniqueness `sorry`) is now also satisfied by this change.
+
+## Overall project progress
+Stage 3 formalization ongoing. This removes one of the remaining `sorry`s in Chapter 4.
+
+## Next step
+Land this PR. A follow-up planner can close #5165 as subsumed (the `sorry` it tracks is gone).
+
+## Blockers
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -2204,8 +2204,8 @@
     "end_page": "71",
     "start_line": 5,
     "end_line": 14,
-    "status": "proof_partial",
-    "sorry_free": false
+    "status": "proof_complete",
+    "sorry_free": true
   },
   {
     "id": "Chapter4/Discussion_after_Theorem4.6.2",


### PR DESCRIPTION
Closes #5120

Session: `e64ed378-4022-4f07-9c03-9999c60a2770`

aa9daf6a feat(Ch4 Theorem4_6_2 #5120): prove uniqueness of unitary structure (Schur + positivity)

🤖 Prepared with Claude Code