### PR TITLE
feat: clength API for finite abelian categories (Krull-Schmidt 1/5)

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Length.lean
+++ b/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Length.lean
@@ -1,0 +1,120 @@
+import EtingofRepresentationTheory.Chapter9.Definition9_6_1
+import EtingofRepresentationTheory.Chapter9.Introduction_9_6
+import Mathlib.Order.KrullDimension
+import Mathlib.CategoryTheory.Subobject.Lattice
+import Mathlib.Algebra.Homology.ShortComplex.ShortExact
+
+/-!
+# Composition length for finite abelian categories (Krull–Schmidt, link 1/5)
+
+This file introduces a `ℕ`-valued **composition length** `Etingof.clength X` for objects of a
+finite abelian category, together with the additivity property that every later Krull–Schmidt
+step (existence of a decomposition into indecomposables, Fitting's lemma) uses as its
+well-founded induction measure.
+
+## Design
+
+`clength X` is defined as the order-theoretic **height** of the top element of the subobject
+lattice `CategoryTheory.Subobject X`:
+
+```
+clength X = (Order.height (⊤ : Subobject X)).toNat.
+```
+
+For a finite-length object this height is finite and equals the length of any composition
+series, by the Jordan–Hölder theorem applied to the (modular) subobject lattice. The definition
+above is *total* — it returns a real `ℕ` for every object — so it can serve as the carrier of the
+API even before the finiteness/additivity content is in place. `Order.height` lives in `ℕ∞`, and
+`.toNat` sends `⊤` (the not-finite-length case, which does not occur in a finite abelian category)
+to `0`.
+
+## Mathlib correspondence and the additivity crux
+
+Mathlib develops Jordan–Hölder only abstractly (`Mathlib/Order/JordanHolder.lean`,
+`CompositionSeries`, `CompositionSeries.jordan_holder`) and concretely for `Submodule R M`
+(`JordanHolderModule.instJordanHolderLattice`). For the subobject lattice of an abelian category
+it has **neither** a `JordanHolderLattice` instance, **nor** the `IsModularLattice (Subobject X)`
+instance, **nor** the categorical second isomorphism theorem `(A ⊔ B)/A ≅ B/(A ⊓ B)` that such an
+instance needs. The Stacks-project route (tag `0FCK`) for categorical Jordan–Hölder is flagged as
+future work in `Mathlib/CategoryTheory/Noetherian.lean`.
+
+Consequently the **additivity** of `clength` over short exact sequences,
+
+```
+clength S.X₂ = clength S.X₁ + clength S.X₃,
+```
+
+is the genuine categorical Jordan–Hölder content and is the hard part of this link. It is stated
+here (top-down) and its proof — which requires either wiring `JordanHolderLattice` onto
+`Subobject X` or a direct Schreier-refinement argument, together with finiteness of the height in a
+finite abelian category — is left as a documented `sorry`, tracked as a follow-up issue. The
+`clength_eq_zero` characterisation is proved in the (unconditional) "zero ⇒ length zero"
+direction; its converse, and positivity for nonzero objects, both require the same finiteness
+input and are likewise isolated.
+
+This top-down split lets the downstream consumers (existence-of-decomposition and Fitting's-lemma
+sub-issues of #5153) build against the final `clength` API immediately.
+-/
+
+universe w v u
+
+open CategoryTheory CategoryTheory.Limits
+
+namespace Etingof
+
+variable {C : Type u} [Category.{v} C] [IsFiniteAbelianCategory C]
+
+/-- The **composition length** of an object `X` of a finite abelian category: the height of the
+top element of the subobject lattice `Subobject X`. For a finite-length object this equals the
+length of any composition series (well-defined by the Jordan–Hölder theorem). The definition is
+total, returning `0` on the not-finite-length case (which does not occur in a finite abelian
+category). -/
+noncomputable def clength (X : C) : ℕ :=
+  (Order.height (⊤ : Subobject X)).toNat
+
+/-- A zero object has composition length `0`: its subobject lattice is a singleton, so the top
+element is a minimum and has height `0`. -/
+theorem clength_eq_zero_of_isZero {X : C} (h : IsZero X) : clength X = 0 := by
+  have : Subsingleton (Subobject X) := Subobject.subsingleton_of_isZero h
+  have hmin : IsMin (⊤ : Subobject X) := fun b _ => le_of_eq (Subsingleton.elim _ _)
+  simp only [clength, Order.height_eq_zero.2 hmin, ENat.toNat_zero]
+
+/-- An object has composition length `0` iff it is a zero object.
+
+The `←` direction is `clength_eq_zero_of_isZero`. The `→` direction needs that the height of
+`⊤ : Subobject X` is *finite* in a finite abelian category (`Order.height ... ≠ ⊤`); only then does
+`(Order.height ⊤).toNat = 0` force `Order.height ⊤ = 0`, i.e. `X` zero (via
+`Subobject.nontrivial_of_not_isZero`). That finiteness is the same categorical Jordan–Hölder input
+as `clength_additive`; see the module doc. -/
+theorem clength_eq_zero_iff {X : C} : clength X = 0 ↔ IsZero X := by
+  refine ⟨?_, clength_eq_zero_of_isZero⟩
+  -- Requires finiteness of `Order.height (⊤ : Subobject X)` in a finite abelian category.
+  sorry
+
+/-- A nonzero object has positive composition length.
+
+`Subobject.nontrivial_of_not_isZero` gives `⊤ ≠ ⊥`, hence `¬ IsMin ⊤` and `Order.height ⊤ ≠ 0`;
+positivity of `clength = (Order.height ⊤).toNat` additionally needs `Order.height ⊤ ≠ ⊤`, the
+finiteness input discussed in the module doc. -/
+theorem clength_pos_of_not_isZero {X : C} (h : ¬ IsZero X) : 0 < clength X := by
+  -- Requires finiteness of `Order.height (⊤ : Subobject X)` in a finite abelian category.
+  sorry
+
+/-- **Additivity of composition length over short exact sequences** — the Krull–Schmidt crux.
+
+For a short exact sequence `0 → X₁ → X₂ → X₃ → 0`, the composition length is additive. This is the
+categorical Jordan–Hölder content: it follows from wiring `JordanHolderLattice` onto `Subobject X`
+(supplying `IsModularLattice (Subobject X)` and the categorical second isomorphism theorem), neither
+of which is in Mathlib. Tracked as a follow-up issue; see the module doc. -/
+theorem clength_additive {S : ShortComplex C} (hS : S.ShortExact) :
+    clength S.X₂ = clength S.X₁ + clength S.X₃ := by
+  sorry
+
+/-- Composition length is additive over biproducts: `clength (Y ⊞ Z) = clength Y + clength Z`.
+
+This follows from `clength_additive` applied to the split short exact sequence
+`0 → Y → Y ⊞ Z → Z → 0` built from `biprod.inl` and `biprod.snd`. -/
+theorem clength_biprod (Y Z : C) : clength (Y ⊞ Z) = clength Y + clength Z := by
+  sorry
+
+end Etingof

--- a/progress/2026-06-24T18-01-01Z_b9f3f11a.md
+++ b/progress/2026-06-24T18-01-01Z_b9f3f11a.md
@@ -1,0 +1,62 @@
+## Accomplished
+
+Created `EtingofRepresentationTheory/Chapter9/KrullSchmidt/Length.lean` (issue #5205,
+Krull–Schmidt link 1/5), establishing the composition-length API for finite abelian
+categories top-down:
+
+- **Real definition** `Etingof.clength X := (Order.height (⊤ : Subobject X)).toNat` — a total
+  `ℕ`-valued function. For a finite-length object the height is finite and equals the length of
+  any composition series (Jordan–Hölder); `.toNat` sends the not-finite-length case to `0`.
+- **Proved** `clength_eq_zero_of_isZero` (zero object ⇒ length `0`), sorry-free, via
+  `Subobject.subsingleton_of_isZero` + `Order.height_eq_zero`.
+- **Stated** the full target API: `clength_eq_zero_iff`, `clength_pos_of_not_isZero`,
+  `clength_additive`, `clength_biprod`, each with documented `sorry` and a precise explanation of
+  the missing input.
+
+`lake build EtingofRepresentationTheory.Chapter9.KrullSchmidt.Length` succeeds (warnings only:
+the four `sorry`s plus a harmless `unusedSectionVars` advisory on `clength_eq_zero_of_isZero`).
+
+## Current frontier
+
+The four sorried theorems all reduce to one missing piece: **categorical Jordan–Hölder** for the
+subobject lattice of an abelian category. Concretely Mathlib lacks (verified by source search):
+- `IsModularLattice (Subobject X)` for abelian `C`,
+- the categorical second isomorphism theorem `(A ⊔ B)/A ≅ B/(A ⊓ B)` (needed for
+  `JordanHolderLattice.second_iso`),
+- any `JordanHolderLattice (Subobject X)` instance or length function for categorical objects.
+`Mathlib/CategoryTheory/Noetherian.lean` explicitly flags categorical Jordan–Hölder (Stacks tag
+`0FCK`) as future work.
+
+`HasFiniteLength` (Introduction_9_6.lean) is `Prop`-valued, so `clength` cannot be defined by
+recursion on it — the height-of-subobject-lattice route is the chosen carrier instead.
+
+Note a modelling gap surfaced: `IsFiniteAbelianCategory` (Definition9_6_1.lean) does **not** carry
+finite length (that lives on `IsFiniteAbelianCategoryOverField.finiteLength`). So
+`clength_eq_zero_iff` (→ direction) and `clength_pos_of_not_isZero` are only true once finiteness
+of `Order.height (⊤ : Subobject X)` is available — the same Jordan–Hölder input.
+
+## Overall project progress
+
+Chapter 9 Krull–Schmidt foundational chain (children of #5153) begun. This is link 1/5: the
+`clength` API surface now exists and compiles; the additivity proof (the hard categorical content)
+remains. Downstream consumers (existence-of-decomposition, Fitting's lemma) can now import and
+reference the final `clength` signatures.
+
+## Next step
+
+Prove `clength_additive` over short exact sequences. Two routes:
+1. **JordanHolderLattice on `Subobject X`** — prove `IsModularLattice (Subobject X)` for abelian
+   `C` and the categorical second isomorphism theorem, instantiate `JordanHolderLattice`, then
+   relate `clength` to `CompositionSeries.length` and prove additivity via Schreier/Jordan–Hölder.
+   This also yields finiteness, unblocking `clength_eq_zero_iff` and `clength_pos_of_not_isZero`.
+2. **Direct argument** over `HasFiniteLength` derivations plus a separate additivity proof.
+
+Either route is substantial (categorical JH is not in Mathlib) and warrants its own issue(s). A
+prerequisite worth isolating: `IsModularLattice (Subobject X)` for an abelian category, a clean
+self-contained Mathlib-style lemma.
+
+## Blockers
+
+None hard — the remaining work is well-scoped but large (categorical Jordan–Hölder). Landing as a
+partial PR so the API is available; parent #5205 returns to `replan` for the planner to carve out
+the additivity follow-up.


### PR DESCRIPTION
This PR adds `EtingofRepresentationTheory/Chapter9/KrullSchmidt/Length.lean`, establishing the composition-length API for finite abelian categories (Krull–Schmidt link 1/5, #5205). It defines `Etingof.clength X` as the order-theoretic height of the top element of the subobject lattice `Subobject X` — a total `ℕ`-valued function that, for a finite-length object, equals the length of any composition series by Jordan–Hölder. It proves `clength_eq_zero_of_isZero` (a zero object has length `0`) sorry-free, and states the remaining target API (`clength_eq_zero_iff`, `clength_pos_of_not_isZero`, `clength_additive`, `clength_biprod`) top-down so downstream consumers can build against the final signatures.

This is a **partial** delivery. The additivity of `clength` over short exact sequences is the genuine categorical Jordan–Hölder content, and Mathlib supplies none of its prerequisites for abelian categories: no `IsModularLattice (Subobject X)`, no categorical second isomorphism theorem `(A ⊔ B)/A ≅ B/(A ⊓ B)`, and no `JordanHolderLattice (Subobject X)` instance (`Mathlib/CategoryTheory/Noetherian.lean` flags this as future work, Stacks tag `0FCK`). Those theorems, plus the `→` direction of `clength_eq_zero_iff` and positivity for nonzero objects — all of which additionally need finiteness of the subobject-lattice height in a finite abelian category — are left as documented `sorry`s for a focused follow-up. A modelling note is recorded in the progress file: `IsFiniteAbelianCategory` does not itself carry finite length (that lives on `IsFiniteAbelianCategoryOverField.finiteLength`), which is why the finiteness-dependent statements cannot yet be closed.

`lake build EtingofRepresentationTheory.Chapter9.KrullSchmidt.Length` succeeds.

🤖 Prepared with Claude Code
