### PR TITLE
feat(Ch3 Remark3.1.3 #5174): assemble full evalDirectSum map + equiv (surjectivity proven, injectivity residual)

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/Remark3_1_3.lean
+++ b/EtingofRepresentationTheory/Chapter3/Remark3_1_3.lean
@@ -153,6 +153,21 @@ theorem evalDirectSum_surjective
     (fun _ _ => (LinearMap.range _).add_mem)
   exact simpleSubmodule_le_range_evalDirectSum k A X V hcomplete m.1 m.2 hy
 
+/-- `evalDirectSum` is injective.
+
+Proof strategy (Schur, using `Etingof.Corollary_2_3_10` that `End_A(X i) = k·id`): if
+`∑ᵢ evalTensor (ξ i) = 0`, each summand `evalTensor (ξ i)` lies in the `X i`-isotypic component
+of `V`. By pairwise non-isomorphism these components are independent (`sSupIndep`), so each
+`evalTensor (ξ i) = 0`. The per-`X` map `evalTensor : Hom_A(X i, V) ⊗_k X i → V` is injective:
+choosing a `k`-basis `gⱼ` of `Hom_A(X i, V)`, a nonzero kernel element would give a simple
+submodule `S ≅ X i` of `(X i)ⁿ` inside `ker (yⱼ ↦ ∑ gⱼ(yⱼ))`; its component maps `X i → X i`
+are scalars `cⱼ` (Corollary 2.3.10), and `∑ cⱼ gⱼ = 0` forces all `cⱼ = 0`, contradicting
+simplicity. Hence `ξ i = 0`. -/
+theorem evalDirectSum_injective
+    (hpair : ∀ i j, i ≠ j → IsEmpty (X i ≃ₗ[A] X j)) :
+    Function.Injective (evalDirectSum k A X V) := by
+  sorry
+
 /-- The Remark 3.1.3 isomorphism: for a semisimple finite dimensional representation `V`, the
 natural map `⨁_i Hom_A(X i, V) ⊗_k X i → V`, `g ⊗ x ↦ g(x)`, is a `k`-linear isomorphism,
 where `{X i}` is a complete set of pairwise non-isomorphic irreducibles.
@@ -164,7 +179,7 @@ noncomputable def evalDirectSumEquiv
     (hpair : ∀ i j, i ≠ j → IsEmpty (X i ≃ₗ[A] X j))
     (hcomplete : ∀ (W : Submodule A V), IsSimpleModule A W → ∃ i, Nonempty (W ≃ₗ[A] X i)) :
     (⨁ i, (X i →ₗ[A] V) ⊗[k] X i) ≃ₗ[k] V :=
-  LinearEquiv.ofBijective (evalDirectSum k A X V) (by
-    sorry)
+  LinearEquiv.ofBijective (evalDirectSum k A X V)
+    ⟨evalDirectSum_injective k A X V hpair, evalDirectSum_surjective k A X V hcomplete⟩
 
 end Etingof

--- a/EtingofRepresentationTheory/Chapter3/Remark3_1_3.lean
+++ b/EtingofRepresentationTheory/Chapter3/Remark3_1_3.lean
@@ -123,6 +123,36 @@ theorem linearMap_eq_zero_of_isEmpty_linearEquiv {Y Z : Type*}
   by_contra hf
   exact h.elim (LinearEquiv.ofBijective f (f.bijective_of_ne_zero hf))
 
+/-- Every simple `A`-submodule of `V` is contained in the range of `evalDirectSum`: if `W ≃ X i`
+then the inclusion `W ↪ V` is `g(e w) = w` for `g = W.subtype ∘ e⁻¹ ∈ Hom_A(X i, V)`, so each
+`w ∈ W` is hit. -/
+theorem simpleSubmodule_le_range_evalDirectSum
+    (hcomplete : ∀ (W : Submodule A V), IsSimpleModule A W → ∃ i, Nonempty (W ≃ₗ[A] X i))
+    (W : Submodule A V) (hW : IsSimpleModule A W) :
+    (W : Set V) ⊆ LinearMap.range (evalDirectSum k A X V) := by
+  obtain ⟨i, ⟨e⟩⟩ := hcomplete W hW
+  intro w hw
+  refine ⟨DirectSum.lof k ι _ i ((W.subtype ∘ₗ e.symm.toLinearMap) ⊗ₜ[k] e ⟨w, hw⟩), ?_⟩
+  rw [evalDirectSum_lof_tmul]
+  simp
+
+/-- `evalDirectSum` is surjective when `{X i}` is complete: `V` is the supremum of its simple
+`A`-submodules (semisimplicity), each of which lies in the range. -/
+theorem evalDirectSum_surjective
+    (hcomplete : ∀ (W : Submodule A V), IsSimpleModule A W → ∃ i, Nonempty (W ≃ₗ[A] X i)) :
+    Function.Surjective (evalDirectSum k A X V) := by
+  rw [← LinearMap.range_eq_top]
+  rw [eq_top_iff]
+  intro v _
+  have htop : v ∈ sSup { m : Submodule A V | IsSimpleModule A m } := by
+    rw [IsSemisimpleModule.sSup_simples_eq_top A V]; trivial
+  rw [sSup_eq_iSup'] at htop
+  refine Submodule.iSup_induction _
+    (motive := fun y => y ∈ LinearMap.range (evalDirectSum k A X V))
+    htop (fun m y hy => ?_) (LinearMap.range _).zero_mem
+    (fun _ _ => (LinearMap.range _).add_mem)
+  exact simpleSubmodule_le_range_evalDirectSum k A X V hcomplete m.1 m.2 hy
+
 /-- The Remark 3.1.3 isomorphism: for a semisimple finite dimensional representation `V`, the
 natural map `⨁_i Hom_A(X i, V) ⊗_k X i → V`, `g ⊗ x ↦ g(x)`, is a `k`-linear isomorphism,
 where `{X i}` is a complete set of pairwise non-isomorphic irreducibles.

--- a/EtingofRepresentationTheory/Chapter3/Remark3_1_3.lean
+++ b/EtingofRepresentationTheory/Chapter3/Remark3_1_3.lean
@@ -1,4 +1,5 @@
 import Mathlib.LinearAlgebra.TensorProduct.Basic
+import Mathlib.RingTheory.SimpleModule.Isotypic
 import EtingofRepresentationTheory.Chapter2.Corollary2_3_10
 
 /-!
@@ -85,5 +86,55 @@ noncomputable def evalTensorEquivOfIsSimple :
 @[simp]
 theorem evalTensorEquivOfIsSimple_tmul (g : V →ₗ[A] V) (x : V) :
     evalTensorEquivOfIsSimple k A V (g ⊗ₜ[k] x) = g x := rfl
+
+end Etingof
+
+namespace Etingof
+
+open scoped DirectSum
+
+variable (k : Type*) (A : Type*) {ι : Type*} (X : ι → Type*) (V : Type*)
+  [Field k] [IsAlgClosed k] [Ring A] [Algebra k A]
+  [Fintype ι] [DecidableEq ι]
+  [∀ i, AddCommGroup (X i)] [∀ i, Module k (X i)] [∀ i, Module A (X i)]
+  [∀ i, IsScalarTower k A (X i)]
+  [∀ i, IsSimpleModule A (X i)] [∀ i, FiniteDimensional k (X i)]
+  [AddCommGroup V] [Module k V] [Module A V] [IsScalarTower k A V]
+  [FiniteDimensional k V] [IsSemisimpleModule A V]
+
+/-- The full natural map `f` of Remark 3.1.3, assembled from the per-irreducible evaluation
+maps `Etingof.evalTensor`. With `{X i}` a finite family of irreducibles, this is the `k`-linear
+map `⨁_i Hom_A(X i, V) ⊗_k X i → V`, `g ⊗ x ↦ g(x)`. -/
+noncomputable def evalDirectSum :
+    (⨁ i, (X i →ₗ[A] V) ⊗[k] X i) →ₗ[k] V :=
+  DirectSum.toModule k ι V (fun i => evalTensor k A (X i) V)
+
+@[simp]
+theorem evalDirectSum_lof_tmul (i : ι) (g : X i →ₗ[A] V) (x : X i) :
+    evalDirectSum k A X V (DirectSum.lof k ι (fun i => (X i →ₗ[A] V) ⊗[k] X i) i (g ⊗ₜ[k] x))
+      = g x := by
+  simp [evalDirectSum]
+
+/-- Schur vanishing: a homomorphism between non-isomorphic simple modules is zero. -/
+theorem linearMap_eq_zero_of_isEmpty_linearEquiv {Y Z : Type*}
+    [AddCommGroup Y] [Module A Y] [AddCommGroup Z] [Module A Z]
+    [IsSimpleModule A Y] [IsSimpleModule A Z]
+    (h : IsEmpty (Y ≃ₗ[A] Z)) (f : Y →ₗ[A] Z) : f = 0 := by
+  by_contra hf
+  exact h.elim (LinearEquiv.ofBijective f (f.bijective_of_ne_zero hf))
+
+/-- The Remark 3.1.3 isomorphism: for a semisimple finite dimensional representation `V`, the
+natural map `⨁_i Hom_A(X i, V) ⊗_k X i → V`, `g ⊗ x ↦ g(x)`, is a `k`-linear isomorphism,
+where `{X i}` is a complete set of pairwise non-isomorphic irreducibles.
+
+Following Etingof's reduction: `V` decomposes as a direct sum of its isotypic components, the
+map restricts on each summand to an isomorphism onto the corresponding component, and Schur's
+lemma kills the cross terms. -/
+noncomputable def evalDirectSumEquiv
+    (hpair : ∀ i j, i ≠ j → IsEmpty (X i ≃ₗ[A] X j))
+    (hcomplete : ∀ (W : Submodule A V), IsSimpleModule A W → ∃ i, Nonempty (W ≃ₗ[A] X i)) :
+    (⨁ i, (X i →ₗ[A] V) ⊗[k] X i) ≃ₗ[k] V :=
+  LinearEquiv.ofBijective (evalDirectSum k A X V) (by
+    sorry)
 
 end Etingof

--- a/progress/2026-06-24T18-28-12Z_8ee419e1.md
+++ b/progress/2026-06-24T18-28-12Z_8ee419e1.md
@@ -1,0 +1,52 @@
+## Accomplished
+
+Worked issue #5174 (Ch3 Remark 3.1.3: assemble the full `⨁_X Hom_A(X,V)⊗X ≃ V`
+isotypic isomorphism). In `EtingofRepresentationTheory/Chapter3/Remark3_1_3.lean`:
+
+- **`evalDirectSum`** (new, genuine data): the full natural map
+  `⨁_i (X i →ₗ[A] V) ⊗_k X i → V`, `g ⊗ x ↦ g(x)`, as
+  `DirectSum.toModule k ι V (fun i => evalTensor k A (X i) V)`, with simp lemma
+  `evalDirectSum_lof_tmul`.
+- **`linearMap_eq_zero_of_isEmpty_linearEquiv`** (sorry-free): Schur vanishing —
+  a hom between non-isomorphic simples is zero (via `LinearMap.bijective_of_ne_zero`).
+- **`simpleSubmodule_le_range_evalDirectSum`** (sorry-free): every simple `A`-submodule
+  `W ≅ X i` lies in the range (`g = W.subtype ∘ e⁻¹`, `g(e w) = w`).
+- **`evalDirectSum_surjective`** (sorry-free): `V` is the sup of its simple `A`-submodules
+  (`IsSemisimpleModule.sSup_simples_eq_top` + `Submodule.iSup_induction`), each in the range.
+- **`evalDirectSumEquiv`** (the deliverable `≃ₗ[k]`): assembled via `LinearEquiv.ofBijective`
+  from `evalDirectSum_injective` and `evalDirectSum_surjective`.
+- **`evalDirectSum_injective`**: the one remaining `sorry`, with the full Schur /
+  Corollary 2.3.10 proof strategy written in its docstring.
+
+File builds: `lake build EtingofRepresentationTheory.Chapter3.Remark3_1_3` succeeds with
+exactly one `sorry` warning (in `evalDirectSum_injective`).
+
+## Current frontier
+
+`evalDirectSum_injective` is the single open `sorry`. Everything else (the map as data,
+surjectivity, Schur vanishing, the equiv structure) is sorry-free.
+
+## Overall project progress
+
+Phase 3 formalization, endgame. This adds the full Remark 3.1.3 assembly on top of the
+previously-landed base case. Item `Chapter3/Remark3.1.3` moved from `sorry_free` to
+`proof_partial` (the file now carries one proof-level sorry).
+
+## Next step
+
+Prove `evalDirectSum_injective`. Recommended decomposition (documented in the file):
+1. Per-`X` lemma `evalTensor` injective for `X i` simple fin-dim over alg-closed `k`:
+   choose a `k`-basis `gⱼ` of `Hom_A(X i, V)`; a nonzero kernel element yields a simple
+   `S ≅ X i` inside `ker (yⱼ ↦ ∑ gⱼ(yⱼ)) ≤ (X i)ⁿ`; its component maps are scalars `cⱼ`
+   (`Etingof.Corollary_2_3_10`), and `∑ cⱼ gⱼ = 0` forces `cⱼ = 0`, contradiction.
+   Useful API: `TensorProduct.finsuppScalarLeft`, `Basis.repr`, `IsSemisimpleModule`.
+2. Global assembly: `evalTensor (ξ i) ∈ isotypicComponent A V (X i)`; pairwise
+   non-isomorphism ⇒ these components are independent (`sSupIndep_isotypicComponents` +
+   injectivity of `i ↦ isotypicComponent A V (X i)`); conclude each `ξ i = 0`.
+Alternative closer: `evalDirectSum` is surjective, so it suffices to show
+`finrank (⨁ Hom_A(X i,V)⊗X i) = finrank V`, then surjective + equal finrank ⇒ injective.
+
+## Blockers
+
+None at the definition level. The remaining work is a single proof-level `sorry`
+(difficulty ~7, ~100+ lines). Tracked by a follow-up issue.

--- a/progress/items.json
+++ b/progress/items.json
@@ -1326,9 +1326,9 @@
     "end_page": "43",
     "start_line": 13,
     "end_line": 13,
-    "status": "sorry_free",
-    "sorry_free": true,
-    "notes": "Remark3_1_3.lean: constructs the canonical evaluation map evalTensor : (X →ₗ[A] V) ⊗[k] X → V, g⊗x ↦ g(x) (genuine data, no sorry), and proves the irreducible base case evalTensorEquivOfIsSimple (Hom_A(V,V) ⊗ V ≃ₗ[k] V via Schur, Corollary 2.3.10). Full ⊕-over-all-irreducibles assembly remains as follow-up."
+    "status": "proof_partial",
+    "sorry_free": false,
+    "notes": "Remark3_1_3.lean: constructs evalTensor (genuine data), the irreducible base case evalTensorEquivOfIsSimple, and the full assembly evalDirectSum : ⨁_i Hom_A(X i,V)⊗X i → V plus evalDirectSumEquiv (≃ₗ via ofBijective). Surjectivity (evalDirectSum_surjective) and Schur vanishing are proven sorry-free; one sorry remains in evalDirectSum_injective (per-X evalTensor injectivity + isotypic independence; strategy documented in the file). Follow-up issue tracks the injectivity."
   },
   {
     "id": "Chapter3/Discussion_before_Proposition3.1.4",


### PR DESCRIPTION
This PR assembles the full Remark 3.1.3 natural map on top of the previously-landed irreducible base case. It adds `Etingof.evalDirectSum`, the map `⨁_i (X i →ₗ[A] V) ⊗_k X i → V`, `g ⊗ x ↦ g(x)`, as genuine data, and packages it as the `k`-linear isomorphism `Etingof.evalDirectSumEquiv` for a complete family `{X i}` of pairwise non-isomorphic irreducibles.

The supporting facts are proven sorry-free: Schur vanishing for non-isomorphic simples (`linearMap_eq_zero_of_isEmpty_linearEquiv`), containment of every simple `A`-submodule in the range (`simpleSubmodule_le_range_evalDirectSum`), and surjectivity (`evalDirectSum_surjective`, via `IsSemisimpleModule.sSup_simples_eq_top`).

This is a partial PR: one `sorry` remains, in `evalDirectSum_injective`, whose docstring records the full Schur / `Corollary_2_3_10` proof strategy. The residual injectivity is tracked by #5216.

🤖 Prepared with Claude Code
