### PR TITLE
Prove §4.4 conjugate-character identities (char_inv_eq_conj + self-dual⟺real reverse)

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Discussion_4_4.lean
+++ b/EtingofRepresentationTheory/Chapter4/Discussion_4_4.lean
@@ -1,4 +1,5 @@
 import Mathlib
+import EtingofRepresentationTheory.Chapter4.Corollary4_2_4
 
 /-!
 # Discussion 4.4: Duals and tensor products of representations
@@ -22,6 +23,7 @@ representations (the roots-of-unity step) is proved here as
 -/
 
 open FDRep CategoryTheory CategoryTheory.MonoidalCategory Representation
+open scoped Matrix ComplexOrder
 
 universe u
 
@@ -59,17 +61,58 @@ finite-dimensional inner product space (`LinearMap.toMatrix_adjoint` together wi
 `Matrix.trace_conjTranspose`). -/
 theorem char_inv_eq_conj (V : FDRep ℂ G) (g : G) :
     V.character g⁻¹ = (starRingEnd ℂ) (V.character g) := by
-  -- Proof strategy: see the docstring. Either route (roots-of-unity eigenvalue sum,
-  -- or unitarization + `trace(adjoint f) = conj(trace f)`) discharges this; both
-  -- require machinery (eigenvalue/charpoly multiset manipulation, or transporting
-  -- the Theorem 4.6.2 `InnerProductSpace.Core` to an `InnerProductSpace ℂ` instance)
-  -- that is tracked as a separate work item.
-  sorry
+  classical
+  haveI : Nonempty G := ⟨1⟩
+  -- Work with the matrix of `ρ_V` in a chosen basis.
+  let b := Module.finBasis ℂ V
+  set M : G → Matrix (Fin (Module.finrank ℂ V)) (Fin (Module.finrank ℂ V)) ℂ :=
+    fun h => LinearMap.toMatrix b b (V.ρ h) with hM
+  have hM_mul : ∀ a c : G, M (a * c) = M a * M c := by
+    intro a c; simp only [hM, map_mul, LinearMap.toMatrix_mul]
+  have hM_one : M 1 = 1 := by simp only [hM, map_one, LinearMap.toMatrix_one]
+  have hchar : ∀ h : G, V.character h = (M h).trace := by
+    intro h; simp only [FDRep.character, hM]; rw [LinearMap.trace_eq_matrix_trace ℂ b]
+  have hunit : ∀ h : G, IsUnit (M h) := fun h =>
+    ⟨⟨M h, M h⁻¹, by rw [← hM_mul, mul_inv_cancel, hM_one],
+      by rw [← hM_mul, inv_mul_cancel, hM_one]⟩, rfl⟩
+  have hdet : ∀ h : G, IsUnit (M h).det :=
+    fun h => (Matrix.isUnit_iff_isUnit_det _).mp (hunit h)
+  have hginv : (M g)⁻¹ = M g⁻¹ :=
+    Matrix.inv_eq_left_inv (by rw [← hM_mul, inv_mul_cancel, hM_one])
+  -- The averaged Hermitian form `H = Σ_h (ρ h)ᴴ (ρ h)` is positive definite (hence invertible)
+  -- and `G`-invariant: `(ρ g)ᴴ H (ρ g) = H`. This is the unitarization of Theorem 4.6.2.
+  set H : Matrix (Fin (Module.finrank ℂ V)) (Fin (Module.finrank ℂ V)) ℂ :=
+    ∑ h : G, (M h)ᴴ * M h with hH
+  have hH_pd : H.PosDef := by
+    rw [hH]
+    refine Matrix.posDef_sum Finset.univ_nonempty (fun h _ => ?_)
+    have := (Matrix.IsUnit.posDef_star_left_conjugate_iff (hunit h)).mpr Matrix.PosDef.one
+    simpa [Matrix.star_eq_conjTranspose] using this
+  have hH_det : IsUnit H.det := (Matrix.isUnit_iff_isUnit_det _).mp hH_pd.isUnit
+  have hinv : (M g)ᴴ * H * M g = H := by
+    have step : ∀ h : G, (M g)ᴴ * ((M h)ᴴ * M h) * M g = (M (h * g))ᴴ * M (h * g) := by
+      intro h; rw [hM_mul, Matrix.conjTranspose_mul]; simp only [mul_assoc]
+    calc (M g)ᴴ * H * M g
+        = ∑ h : G, (M g)ᴴ * ((M h)ᴴ * M h) * M g := by rw [hH, Finset.mul_sum, Finset.sum_mul]
+      _ = ∑ h : G, (M (h * g))ᴴ * M (h * g) := Finset.sum_congr rfl (fun h _ => step h)
+      _ = ∑ h : G, (M h)ᴴ * M h := Equiv.sum_comp (Equiv.mulRight g) fun h => (M h)ᴴ * M h
+      _ = H := rfl
+  -- Solve for `(ρ g)ᴴ`: it is conjugate to `(ρ g)⁻¹` by `H`.
+  have e1 : (M g)ᴴ * H = H * (M g)⁻¹ := by
+    have h2 : (M g)ᴴ * H * M g * (M g)⁻¹ = H * (M g)⁻¹ := by rw [hinv]
+    rwa [mul_assoc ((M g)ᴴ * H) (M g) (M g)⁻¹, Matrix.mul_nonsing_inv _ (hdet g), mul_one] at h2
+  have hconj : (M g)ᴴ = H * (M g)⁻¹ * H⁻¹ := by
+    calc (M g)ᴴ = (M g)ᴴ * H * H⁻¹ := by
+          rw [mul_assoc, Matrix.mul_nonsing_inv _ hH_det, mul_one]
+      _ = H * (M g)⁻¹ * H⁻¹ := by rw [e1]
+  -- Conclude: `conj χ(g) = trace (ρ g)ᴴ = trace (ρ g)⁻¹ = χ(g⁻¹)`.
+  rw [hchar g⁻¹, hchar g, starRingEnd_apply, ← Matrix.trace_conjTranspose, hconj,
+    Matrix.trace_mul_cycle, Matrix.nonsing_inv_mul _ hH_det, one_mul, hginv]
 
 /-- Self-dual ⟺ real character (Etingof §4.4): a finite-dimensional complex
 representation `V` of a finite group is isomorphic to its dual `V*` (as
 representations) if and only if its character is real-valued. -/
-theorem self_dual_iff_char_real (V : FDRep ℂ G) :
+theorem self_dual_iff_char_real {G : Type} [Group G] [Fintype G] (V : FDRep ℂ G) :
     Nonempty (of (dual V.ρ) ≅ V) ↔
       ∀ g : G, (starRingEnd ℂ) (V.character g) = V.character g := by
   constructor
@@ -78,12 +121,16 @@ theorem self_dual_iff_char_real (V : FDRep ℂ G) :
       have h0 := congrFun (FDRep.char_iso e) g
       rwa [FDRep.char_dual] at h0
     rw [← char_inv_eq_conj, h]
-  · intro _hreal
-    -- Reverse direction: a real character forces `χ_V = χ_{V*}`, and over `ℂ` two
-    -- finite-dimensional representations of a finite group with equal characters are
-    -- isomorphic (characters determine the representation). That determination
-    -- theorem is tracked as a separate work item.
-    sorry
+  · intro hreal
+    -- A real character forces `χ_{V*} = χ_V`: indeed `χ_{V*}(g) = χ_V(g⁻¹) = conj χ_V(g) = χ_V(g)`.
+    -- Over `ℂ`, equal characters force an isomorphism of representations
+    -- (`Etingof.Corollary4_2_4`, characters determine the representation).
+    classical
+    have hchar_eq : FDRep.character (of (dual V.ρ)) = FDRep.character V := by
+      funext g
+      rw [Discussion_4_4_char_dual V g, char_inv_eq_conj V g]
+      exact hreal g
+    exact Etingof.Corollary4_2_4 G (of (dual V.ρ)) V hchar_eq
 
 end Complex
 

--- a/progress/2026-06-24T19-22-46Z.md
+++ b/progress/2026-06-24T19-22-46Z.md
@@ -1,0 +1,46 @@
+## Accomplished
+
+Closed both documented sorries in
+`EtingofRepresentationTheory/Chapter4/Discussion_4_4.lean` (issue #5180).
+
+- **`char_inv_eq_conj`** (`χ_V(g⁻¹) = conj χ_V(g)`): proved via the
+  unitarization route (Theorem 4.6.2 made concrete on matrices). In a
+  chosen basis `b`, set `M h := toMatrix b b (V.ρ h)`. The averaged
+  Hermitian form `H = Σ_h (M h)ᴴ (M h)` is positive definite
+  (`Matrix.posDef_sum` + `Matrix.IsUnit.posDef_star_left_conjugate_iff` +
+  `Matrix.PosDef.one`), hence invertible, and `G`-invariant:
+  `(M g)ᴴ H (M g) = H` (reindex `h ↦ h*g`). Solving gives
+  `(M g)ᴴ = H (M g)⁻¹ H⁻¹`, so
+  `conj χ(g) = trace (M g)ᴴ = trace (M g)⁻¹ = χ(g⁻¹)` via
+  `Matrix.trace_conjTranspose` and `trace_mul_cycle`.
+- **Reverse of `self_dual_iff_char_real`**: a real character makes
+  `χ_{V*} = χ_V` (using `char_inv_eq_conj`), and over `ℂ` equal characters
+  force an isomorphism — exactly the already-proved
+  `Etingof.Corollary4_2_4` (characters determine the representation).
+
+`Etingof.Corollary4_2_4` is fixed at `G : Type` (Type 0); generalizing it
+to `Type u` makes the Maschke `Injective` instance search blow up, so
+instead `self_dual_iff_char_real` is now stated with an explicit
+`{G : Type}` binder (it only needs Type 0 to invoke the corollary).
+`char_inv_eq_conj` stays universe-polymorphic.
+
+Added `open scoped Matrix ComplexOrder` (the latter supplies the
+`PartialOrder ℂ` / `StarOrderedRing ℂ` instances used by `Matrix.PosDef`).
+
+## Current frontier
+
+`lake build EtingofRepresentationTheory.Chapter4` completes with no errors
+and no `sorry`. Issue #5180 is fully discharged.
+
+## Overall project progress
+
+Phase 3 formalization ongoing. Chapter 4 §4.4 duals/tensor discussion is
+now sorry-free.
+
+## Next step
+
+Pick up the next unclaimed feature issue.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5180

Session: `38e2ee75-5297-4bd4-bdb6-541e756726b8`

2db88cdc feat(Ch4 Discussion_4_4 #5180): prove char_inv_eq_conj + self-dual⟺real reverse

🤖 Prepared with Claude Code