### PR TITLE
feat(Ch2 #5218): forward arrow maps + Qᵒᵖ functor of the quiver-rep / path-module bijection

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Discussion_quiver_rep_bijection.lean
+++ b/EtingofRepresentationTheory/Chapter2/Discussion_quiver_rep_bijection.lean
@@ -89,6 +89,24 @@ theorem trivialPath_mul_trivialPath (i j : Q) :
   · subst h; rw [trivialPath_mul_self, if_pos rfl]
   · rw [trivialPath_mul_of_ne h, if_neg h]
 
+/-- The path-algebra basis element `aₑ = ofPath ⟨i, j, e.toPath⟩` of a single arrow `e : i ⟶ j`. -/
+noncomputable def ofArrow {i j : Q} (e : i ⟶ j) : PathAlgebra k Q :=
+  ofPath ⟨i, j, e.toPath⟩
+
+/-- The source idempotent absorbs an arrow on the left: `pᵢ · aₑ = aₑ` for `e : i ⟶ j`. -/
+theorem trivialPath_mul_ofArrow {i j : Q} (e : i ⟶ j) :
+    (trivialPath i : PathAlgebra k Q) * ofArrow e = ofArrow e := by
+  have h := trivialPath_mul_ofPath (k := k) i i j e.toPath
+  rw [if_pos rfl] at h
+  exact h
+
+/-- The target idempotent absorbs an arrow on the right: `aₑ · p_j = aₑ` for `e : i ⟶ j`. -/
+theorem ofArrow_mul_trivialPath {i j : Q} (e : i ⟶ j) :
+    (ofArrow e : PathAlgebra k Q) * trivialPath j = ofArrow e := by
+  have h := ofPath_mul_trivialPath (k := k) i j j e.toPath
+  rw [if_pos rfl] at h
+  exact h
+
 /-- **Remark 2.8.5, restated.** For a finite vertex set, the trivial-path idempotents sum to the
 unit: `∑ᵢ pᵢ = 1`. (Restatement of `sum_trivialPaths_eq_one` in terms of `trivialPath`.) -/
 theorem sum_trivialPath [Fintype Q] : (∑ i, trivialPath i : PathAlgebra k Q) = 1 := by
@@ -194,6 +212,53 @@ theorem isInternal_vertexSpace :
     rw [← hsum, LinearMap.sum_apply]
     exact Submodule.sum_mem _ fun i _ =>
       Submodule.mem_iSup_of_mem i (vertexProj_mem_vertexSpace i v)
+
+/-! ## Arrow maps and the forward functor `V ↦ (pᵢ V, aₑ ↾)`
+
+For an arrow `e : i ⟶ j`, left multiplication by `aₑ = ofArrow e` carries `Vⱼ = pⱼ V` into
+`Vᵢ = pᵢ V` (because `pᵢ · aₑ = aₑ`): it points `Vⱼ → Vᵢ`, the *opposite* direction to an arrow
+`i ⟶ j` of `Etingof.QuiverRepresentation k Q` (which carries `Vᵢ → Vⱼ`).
+
+This is the modelling decision flagged in the module docstring. We resolve it by assembling the
+data into a representation of the **opposite quiver** `Qᵒᵖ`: an arrow `op j ⟶ op i` of `Qᵒᵖ`
+(i.e. the opposite of `e : i ⟶ j`) carries `Vⱼ → Vᵢ`, exactly matching `arrowMap e`. So a left
+`P_Q`-module `V` yields the quiver representation `forwardRep : QuiverRepresentation k Qᵒᵖ` with
+vertex spaces `(Vᵢ)` and arrow maps the restricted left-multiplications. (Equivalently one could
+use right modules or `(P_Q)ᵒᵖ`; the opposite quiver keeps everything on the left-module side.)
+-/
+
+/-- Left multiplication by an arrow element lands in the source vertex space:
+`aₑ • x ∈ Vᵢ` for `e : i ⟶ j`, since `pᵢ · aₑ = aₑ`. (Holds for every `x : V`.) -/
+theorem ofArrow_smul_mem {i j : Q} (e : i ⟶ j) (x : V) :
+    (ofArrow e : PathAlgebra k Q) • x ∈ (vertexSpace i : Submodule k V) := by
+  refine ⟨(ofArrow e : PathAlgebra k Q) • x, ?_⟩
+  rw [vertexProj_apply, ← mul_smul, trivialPath_mul_ofArrow]
+
+/-- **Forward arrow map.** For an arrow `e : i ⟶ j`, the restricted left-multiplication by
+`aₑ = ofArrow e`, a `k`-linear map `Vⱼ → Vᵢ` between vertex spaces. Note the source-to-target
+convention makes this point `Vⱼ → Vᵢ` (opposite to an `i ⟶ j` arrow of a `QuiverRepresentation`
+of `Q`); see the opposite-quiver discussion above. -/
+noncomputable def arrowMap {i j : Q} (e : i ⟶ j) :
+    (vertexSpace j : Submodule k V) →ₗ[k] (vertexSpace i : Submodule k V) :=
+  LinearMap.restrict (moduleEnd (ofArrow e)) (fun x _ => ofArrow_smul_mem e x)
+
+@[simp] theorem arrowMap_coe_apply {i j : Q} (e : i ⟶ j) (x : (vertexSpace j : Submodule k V)) :
+    (arrowMap e x : V) = (ofArrow e : PathAlgebra k Q) • (x : V) :=
+  LinearMap.coe_restrict_apply _ _
+
+/-- **Forward direction of the bijection.** A left `P_Q`-module `V` gives a representation of the
+opposite quiver `Qᵒᵖ`: vertex spaces `Vᵢ = pᵢ V`, and for the opposite of an arrow `e : i ⟶ j`
+the restricted left-multiplication `arrowMap e : Vⱼ → Vᵢ`. The opposite quiver is forced by the
+source-to-target convention of `Definition2_8_4` (see the discussion above). -/
+noncomputable def forwardRep : Etingof.QuiverRepresentation k Qᵒᵖ where
+  obj X := (vertexSpace (V := V) X.unop : Submodule k V)
+  mapLinear {_X _Y} f := arrowMap f.unop
+
+@[simp] theorem forwardRep_obj (X : Qᵒᵖ) :
+    (forwardRep (k := k) (Q := Q) (V := V)).obj X = (vertexSpace X.unop : Submodule k V) := rfl
+
+@[simp] theorem forwardRep_mapLinear {X Y : Qᵒᵖ} (f : X ⟶ Y) :
+    (forwardRep (k := k) (Q := Q) (V := V)).mapLinear f = arrowMap f.unop := rfl
 
 end ModuleDecomposition
 

--- a/progress/2026-06-24T19-43-44Z_ae864f73.md
+++ b/progress/2026-06-24T19-43-44Z_ae864f73.md
@@ -1,0 +1,61 @@
+## Accomplished
+
+One-shot feature session `ae864f73` (`/once 5218`) on the forward half of the
+quiver-representation / path-module bijection, built on the module-side decomposition
+`V = ⊕ᵢ pᵢV` (#5149/#5219). In
+`EtingofRepresentationTheory/Chapter2/Discussion_quiver_rep_bijection.lean`:
+
+- `Etingof.PathAlgebra.ofArrow e` — path-algebra basis element of a single arrow
+  `e : i ⟶ j`, with absorption laws `trivialPath_mul_ofArrow` (`pᵢ·aₑ = aₑ`) and
+  `ofArrow_mul_trivialPath` (`aₑ·p_j = aₑ`).
+- `ofArrow_smul_mem` — left-multiplication by `aₑ` lands in the source vertex space `Vᵢ`.
+- `arrowMap e : Vⱼ →ₗ[k] Vᵢ` — restricted left-multiplication between vertex spaces
+  (source-to-target convention points it `Vⱼ → Vᵢ`), plus `arrowMap_coe_apply`.
+- `forwardRep : QuiverRepresentation k Qᵒᵖ` — **deliverable 2, modelling decision.** A
+  left `P_Q`-module gives a representation of the **opposite quiver**: an arrow
+  `op j ⟶ op i` (opposite of `e : i ⟶ j`) carries `Vⱼ → Vᵢ`, matching `arrowMap e`.
+  Keeps everything on the left-module side. With `forwardRep_obj`/`forwardRep_mapLinear`.
+
+Deliverables 1 (arrow maps) and 2 (modelling decision) of #5218, sorry-free.
+`lake build EtingofRepresentationTheory.Chapter2.Discussion_quiver_rep_bijection` succeeds;
+`#print axioms forwardRep`/`arrowMap` → `[propext, Classical.choice, Quot.sound]` (no `sorryAx`).
+
+## Key decisions
+
+- **Opposite quiver, not opposite algebra or right modules.** The source-to-target
+  convention makes the naive path-action an anti-homomorphism w.r.t. `P_Q` (algebra product
+  `single⟨a,b,p⟩·single⟨b,d,q⟩ = single⟨a,d,p.comp q⟩` vs `End` composition order). Using
+  `Qᵒᵖ` for the codomain keeps the input a genuine *left* `P_Q`-module and makes the arrow
+  direction `Vⱼ → Vᵢ` line up with an `op j ⟶ op i` arrow. This is the cleanest of the three
+  options the issue listed, and it makes forward/reverse compose into a bijection between
+  left `P_Q`-modules and `QuiverRepresentation k Qᵒᵖ`.
+- **Decomposed deliverables 3 + 4 into #5222** rather than attempting the heavy reverse
+  direction in a one-shot. The reverse direction is a noncomputable def/instance whose body
+  must be constructed (algebra hom `PathAlgebra k Q →ₐ End k (⊕ᵢ Vᵢ)` with multiplicativity
+  over `Quiver.Path.comp`), plus the mutual-inverse proof — too large to land cleanly here.
+  #5222 documents the anti-homomorphism subtlety so the next worker has the modelling note.
+
+## Verification
+
+- `lake build EtingofRepresentationTheory.Chapter2.Discussion_quiver_rep_bijection` succeeds
+  (1394 jobs, no warnings).
+- File is sorry-free; axiom check clean.
+
+## Current frontier
+
+Issue #5218: deliverables 1 + 2 done and committed (partial PR). Reverse direction (3) and
+iso-class bijection (4) tracked in #5222.
+
+## Overall project progress
+
+Etingof draft 1, Stage 3, Chapter 2 §2.8 quiver/path-algebra discussion. Forward functor of the
+quiver-rep ↔ path-module bijection is in the build on top of the module decomposition.
+
+## Next step
+
+A worker claims #5222 (reverse direction first, then the bijection). The modelling note there
+explains why the input is `QuiverRepresentation k Qᵒᵖ` and the path-action subtlety.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Partial progress on #5218

Session: `ae864f73-7714-4f33-b5a2-e686986f14e3`

8e5d81fd doc: progress entry for #5218 forward arrow maps + Qᵒᵖ functor
511b413d feat(Ch2 Discussion_quiver_rep_bijection #5218): forward arrow maps + Qᵒᵖ functor

🤖 Prepared with Claude Code