### PR TITLE
feat(Ch5): prove even_finrank_of_nondegenerate_alternating (symplectic even-dim)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/FrobeniusSchurRealType.lean
+++ b/EtingofRepresentationTheory/Chapter5/FrobeniusSchurRealType.lean
@@ -400,15 +400,46 @@ Definition 5.1.1: "every quaternionic representation is even-dimensional".)
 -/
 
 /-- A nondegenerate alternating bilinear form on a finite-dimensional space forces
-the dimension to be even (existence of a symplectic basis).
+the dimension to be even.
 
-Isolated pending the symplectic-basis even-rank theorem (not yet in Mathlib). -/
+The slick determinant argument (no symplectic basis needed): an alternating form
+is skew-symmetric, so its Gram matrix `M` in any basis satisfies `Mᵀ = -M`. Hence
+`det M = det Mᵀ = det (-M) = (-1)ⁿ det M`. If `n = finrank` were odd this gives
+`det M = -det M`, so `det M = 0` (characteristic `0`), contradicting the
+nondegeneracy `det M ≠ 0`. -/
 private theorem even_finrank_of_nondegenerate_alternating
     (B : V →ₗ[ℂ] V →ₗ[ℂ] ℂ)
-    (_halt : ∀ v, B v v = 0)
-    (_hnondeg : ∀ v, (∀ w, B v w = 0) → v = 0) :
+    (halt : ∀ v, B v v = 0)
+    (hnondeg : ∀ v, (∀ w, B v w = 0) → v = 0) :
     Even (Module.finrank ℂ V) := by
-  sorry
+  -- Alternating ⟹ skew-symmetric: expand `B (v + w) (v + w) = 0`.
+  have hskew : ∀ v w, B v w = - B w v := by
+    intro v w
+    have h := halt (v + w)
+    simp only [map_add, LinearMap.add_apply, halt] at h
+    linear_combination h
+  by_contra hne
+  rw [Nat.not_even_iff_odd] at hne
+  -- Work with the Gram matrix `M` of `B` in the canonical finite basis.
+  set b := Module.finBasis ℂ V with hb
+  set M := LinearMap.BilinForm.toMatrix b B with hM
+  -- Nondegeneracy is literally the hypothesis, so `det M ≠ 0`.
+  have hnd : LinearMap.BilinForm.Nondegenerate B := by
+    rw [LinearMap.BilinForm.nondegenerate_iff_ker_eq_bot, LinearMap.ker_eq_bot']
+    intro m hm
+    exact hnondeg m (fun w => by rw [hm]; simp)
+  have hdet_ne : M.det ≠ 0 := (LinearMap.BilinForm.nondegenerate_iff_det_ne_zero b).mp hnd
+  -- Skew-symmetry of `B` makes `M` skew-symmetric.
+  have htrans : M.transpose = -M := by
+    ext i j
+    simp only [hM, Matrix.transpose_apply, Matrix.neg_apply, LinearMap.BilinForm.toMatrix_apply]
+    exact hskew (b j) (b i)
+  -- `det M = (-1)ⁿ det M`, and `n` odd forces `det M = 0`.
+  have h1 : M.det = (-1) ^ Module.finrank ℂ V * M.det := by
+    conv_lhs => rw [← Matrix.det_transpose M, htrans, Matrix.det_neg]
+    simp [Fintype.card_fin]
+  rw [hne.neg_one_pow] at h1
+  exact hdet_ne (by linear_combination (1 / 2 : ℂ) * h1)
 
 /-- **L3 — quaternionic ⟹ even-dimensional.** A representation of quaternionic
 type is even-dimensional. So an **odd-dimensional** representation cannot be of

--- a/progress/2026-06-25T00-00-00Z_0e8b7249.md
+++ b/progress/2026-06-25T00-00-00Z_0e8b7249.md
@@ -1,0 +1,45 @@
+## Accomplished
+
+Closed issue #5236: proved `Etingof.even_finrank_of_nondegenerate_alternating`
+in `EtingofRepresentationTheory/Chapter5/FrobeniusSchurRealType.lean`, removing
+the last `sorry` blocking `even_finrank_of_isQuaternionicType` (L3 of the
+Frobenius-Schur structural package).
+
+Rather than the symplectic-basis induction the issue suggested, used the slick
+determinant argument: an alternating form is skew-symmetric, so its Gram matrix
+`M = BilinForm.toMatrix b B` satisfies `Mᵀ = -M`. Then
+`det M = det Mᵀ = det(-M) = (-1)ⁿ det M`; an odd `n` forces `det M = -det M`,
+hence `det M = 0` (characteristic 0), contradicting nondegeneracy `det M ≠ 0`
+(`BilinForm.nondegenerate_iff_det_ne_zero`).
+
+## Current frontier
+
+`FrobeniusSchurRealType.lean` builds clean. One unrelated pre-existing `sorry`
+remains at line 112: `exists_nonzero_invariant_symmetric_of_FS_eq_one` (the
+trace-identity heart of steps 1–3), out of scope for #5236.
+
+## Overall project progress
+
+Phase 3 formalization, Chapter 5 Frobenius-Schur package. L1 (real/rational
+form ⟹ real type), L2 (ambivalent ⟹ real character), and now L3
+(quaternionic ⟹ even-dimensional) are fully proved. The remaining gap in the
+real-type bridge is the FS trace identity.
+
+## Next step
+
+Tackle `exists_nonzero_invariant_symmetric_of_FS_eq_one` (the
+`dim(sym ∩ Bil^G) − dim(skew ∩ Bil^G) = FS(ρ)` trace computation) — that is the
+last `sorry` in this file and the heart of `isRealType_of_frobeniusSchurIndicator_eq_one`.
+
+## Blockers
+
+None.
+
+## Gotcha recorded
+
+`LinearMap.BilinForm.Nondegenerate B` does NOT defeq-unfold to
+`∀ m, (∀ n, B m n = 0) → m = 0` during elaboration (neither `:= hnondeg`, a
+`fun m hm => ...` lambda, `show`, nor `unfold` succeed). Convert via
+`rw [LinearMap.BilinForm.nondegenerate_iff_ker_eq_bot, LinearMap.ker_eq_bot']`
+instead. Also: the `ᵀ` transpose notation needs `open scoped Matrix`; use
+`M.transpose` to avoid the import.


### PR DESCRIPTION
Closes #5236

Session: `0e8b7249-6869-4e3c-bc17-4a21b40aaf4f`

80184959 doc(progress): record #5236 even-rank determinant proof + Nondegenerate defeq gotcha
dbd95d8a feat(Ch5): prove even_finrank_of_nondegenerate_alternating (#5236)

🤖 Prepared with Claude Code