### PR TITLE
feat(Ch5 Example5.1.3): A₅ odd-dim irreps real type + self-dual dichotomy package

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Example5_1_3.lean
+++ b/EtingofRepresentationTheory/Chapter5/Example5_1_3.lean
@@ -532,14 +532,59 @@ theorem Etingof.Example5_1_3_S4
   exact isRealType_of_coordForm_transport ρ hρ ψ hψ c
     (Etingof.youngSymmetrizer_im_eq_zero 4 la) v₀ hv₀ hcne
 
-/-- All irreducible representations of `A₅` are of real type. (Etingof Example 5.1.3) -/
+set_option maxRecDepth 10000 in
+/-- **A₅ is ambivalent:** every element is conjugate to its inverse. A finite
+check over the 60 elements of `A₅` (`decide`). This is the input to L2 / the
+self-dual dichotomy: it makes every `A₅` character self-dual (`χ(g⁻¹) = χ(g)`). -/
+theorem Etingof.alternatingGroup_ambivalent (g : alternatingGroup (Fin 5)) :
+    IsConj g g⁻¹ := by
+  have h : ∀ h : alternatingGroup (Fin 5), ∃ c : alternatingGroup (Fin 5),
+      c * h * c⁻¹ = h⁻¹ := by decide
+  obtain ⟨c, hc⟩ := h g
+  exact isConj_iff.mpr ⟨c, hc⟩
+
+/-- **The 4-dimensional (standard) irreducible of `A₅` is of real type.** Every
+even-dimensional simple `ℂ[A₅]`-module is the 4-dimensional standard representation
+`ℂ⁴` (the permutation representation on `Fin 5` minus the trivial line), which is
+realised by rational permutation matrices, hence of real type by L1
+(`isRealType_of_rational_form`).
+
+Isolated as a `sorry`: identifying an *abstract* even-dimensional simple module with
+the concrete standard representation needs the dimension classification of `A₅`'s
+irreducibles — five conjugacy classes, dims `{1, 3, 3, 4, 5}` via Frobenius
+divisibility (`dim ∣ |G|`) and `∑ dimᵢ² = 60`. That classification (and Frobenius
+divisibility in particular) is not yet available in Mathlib or this project; it is
+the sole remaining gap for Example 5.1.3 (A₅). Tracked separately. -/
+theorem Etingof.isRealType_of_A5_even_standard
+    {V : Type*} [AddCommGroup V] [Module ℂ V] [Module.Finite ℂ V]
+    (ρ : Representation ℂ (alternatingGroup (Fin 5)) V)
+    (hρ : IsSimpleModule (MonoidAlgebra ℂ (alternatingGroup (Fin 5))) ρ.asModule)
+    (hsd : ∀ g, Representation.character ρ g⁻¹ = Representation.character ρ g)
+    (heven : Even (Module.finrank ℂ V)) :
+    Etingof.IsRealType ρ := by
+  sorry
+
+/-- All irreducible representations of `A₅` are of real type. (Etingof Example 5.1.3)
+
+`A₅` is ambivalent (`alternatingGroup_ambivalent`), so every character is self-dual
+(`χ(g⁻¹) = χ(g)`). The odd-dimensional irreducibles `ℂ, ℂ³₊, ℂ³₋, ℂ⁵` are then of
+real type by the self-dual dichotomy plus L3 (quaternionic ⟹ even-dimensional):
+`isRealType_of_self_dual_of_odd_finrank`. The single even-dimensional irreducible —
+the 4-dimensional standard representation — is rational, handled by
+`isRealType_of_A5_even_standard`. -/
 theorem Etingof.Example5_1_3_A5
     {V : Type*} [AddCommGroup V] [Module ℂ V] [Module.Finite ℂ V]
     (ρ : Representation ℂ (alternatingGroup (Fin 5)) V)
     (hρ : IsSimpleModule (MonoidAlgebra ℂ (alternatingGroup (Fin 5))) ρ.asModule) :
     Etingof.IsRealType ρ := by
-  -- The five irreducibles `ℂ, ℂ³₊, ℂ³₋, ℂ⁴, ℂ⁵` all have real character values.
-  sorry
+  -- Ambivalence ⟹ self-dual character.
+  have hsd : ∀ g, Representation.character ρ g⁻¹ = Representation.character ρ g := by
+    intro g
+    obtain ⟨c, hc⟩ := isConj_iff.mp (Etingof.alternatingGroup_ambivalent g)
+    rw [← hc]; exact Representation.char_conj ρ g c
+  rcases Nat.even_or_odd (Module.finrank ℂ V) with heven | hodd
+  · exact Etingof.isRealType_of_A5_even_standard ρ hρ hsd heven
+  · exact Etingof.isRealType_of_self_dual_of_odd_finrank ρ hρ hsd hodd
 
 namespace Etingof.Q8
 

--- a/EtingofRepresentationTheory/Chapter5/FrobeniusSchurRealType.lean
+++ b/EtingofRepresentationTheory/Chapter5/FrobeniusSchurRealType.lean
@@ -455,4 +455,100 @@ theorem even_finrank_of_isQuaternionicType
   have h2 : (2 : ℂ) * B v v = 0 := by linear_combination e
   exact (mul_eq_zero.mp h2).resolve_left (by norm_num)
 
+/-!
+## Self-dual dichotomy — real *or* quaternionic (no trace identity needed)
+
+If a simple representation has a **self-dual** character (`χ(g⁻¹) = χ(g)`, the
+hypothesis supplied by an *ambivalent* group via L2) then it is of real type or
+quaternionic type. The argument bypasses the still-isolated Frobenius-Schur trace
+identity: self-duality gives `⟨χ, χ⟩`-style positivity, so the space of invariant
+bilinear forms is nonzero; symmetrising / antisymmetrising any nonzero invariant
+form yields a nonzero invariant **symmetric** or **skew-symmetric** form, which is
+nondegenerate by simplicity. Combined with L3 this gives the workhorse corollary
+`isRealType_of_self_dual_of_odd_finrank`.
+-/
+
+/-- For a self-dual simple representation (`χ(g⁻¹) = χ(g)`), the space of invariant
+bilinear forms is nontrivial: there is a nonzero `G`-invariant bilinear form.
+
+The dimension of the invariant bilinear forms is
+`finrank (linHom ρ ρ.dual).invariants = (|G|)⁻¹ ∑_g χ(g⁻¹)²`
+(`card_inv_mul_sum_char_eq_finrank` + `char_linHom` + `char_dual`); self-duality
+rewrites this to the character orthonormality sum `(|G|)⁻¹ ∑_g χ(g) χ(g⁻¹) = 1`, so
+the dimension is `1 > 0`. -/
+theorem exists_nonzero_invariant_bilin_of_self_dual
+    (ρ : Representation ℂ G V)
+    (hρ : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule)
+    (hsd : ∀ g, Representation.character ρ g⁻¹ = Representation.character ρ g) :
+    ∃ B : V →ₗ[ℂ] V →ₗ[ℂ] ℂ, B ≠ 0 ∧ (∀ g v w, B (ρ g v) (ρ g w) = B v w) := by
+  haveI : Representation.IsIrreducible ρ :=
+    (Representation.irreducible_iff_isSimpleModule_asModule ρ).mpr hρ
+  haveI : Nonempty G := ⟨1⟩
+  haveI : Invertible (Nat.card G : ℂ) :=
+    invertibleOfNonzero (by simp only [ne_eq, Nat.cast_eq_zero]; exact Nat.card_pos.ne')
+  -- `finrank` of the invariant bilinear forms, cast to `ℂ`, equals `1`.
+  have hkey := Representation.card_inv_mul_sum_char_eq_finrank (Representation.linHom ρ ρ.dual)
+  have hortho := Representation.char_orthonormal ρ ρ
+  rw [if_pos ⟨Representation.Equiv.refl ρ⟩] at hortho
+  have hchar : ∀ g, (Representation.linHom ρ ρ.dual).character g
+      = ρ.character g * ρ.character g⁻¹ := fun g => by
+    rw [Representation.char_linHom, Representation.char_dual, hsd g]
+  rw [Finset.sum_congr rfl (fun g _ => hchar g), hortho] at hkey
+  have hfr : (Module.finrank ℂ ((Representation.linHom ρ ρ.dual).invariants) : ℂ) = 1 :=
+    hkey.symm
+  have hpos : 0 < Module.finrank ℂ ((Representation.linHom ρ ρ.dual).invariants) := by
+    rw [Nat.pos_iff_ne_zero]; intro h0; rw [h0] at hfr; norm_num at hfr
+  -- positive `finrank` ⟹ a nonzero invariant element ⟹ a nonzero invariant bilinear form.
+  haveI : Nontrivial ((Representation.linHom ρ ρ.dual).invariants) :=
+    Module.nontrivial_of_finrank_pos hpos
+  obtain ⟨x, hx0⟩ := exists_ne (0 : (Representation.linHom ρ ρ.dual).invariants)
+  refine ⟨x.1, fun h0 => hx0 (Subtype.ext h0), ?_⟩
+  intro g v w
+  have hmem : (Representation.linHom ρ ρ.dual) g⁻¹ x.1 = x.1 := x.2 g⁻¹
+  have h1 := LinearMap.congr_fun (LinearMap.congr_fun hmem v) w
+  simpa [Representation.linHom_apply, Representation.dual_apply,
+    Module.Dual.transpose_apply] using h1
+
+/-- **Self-dual dichotomy.** A simple complex representation with self-dual
+character (`χ(g⁻¹) = χ(g)`) is of real type or of quaternionic type: take a
+nonzero invariant bilinear form `B`; its symmetric part `B + Bᵀ` and skew part
+`B − Bᵀ` are both invariant and sum to `2B ≠ 0`, so one of them is a nonzero
+invariant symmetric / skew-symmetric form, nondegenerate by simplicity. -/
+theorem isRealType_or_isQuaternionicType_of_self_dual
+    (ρ : Representation ℂ G V)
+    (hρ : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule)
+    (hsd : ∀ g, Representation.character ρ g⁻¹ = Representation.character ρ g) :
+    Etingof.IsRealType ρ ∨ Etingof.IsQuaternionicType ρ := by
+  obtain ⟨B, hBne, hBinv⟩ := exists_nonzero_invariant_bilin_of_self_dual ρ hρ hsd
+  have hflipinv : ∀ g v w, B.flip (ρ g v) (ρ g w) = B.flip v w := fun g v w => by
+    simp only [LinearMap.flip_apply]; exact hBinv g w v
+  by_cases hS : B + B.flip = 0
+  · -- `B` itself is skew-symmetric, nonzero, invariant ⟹ quaternionic type.
+    refine Or.inr ⟨B, ?_, nondegenerate_of_invariant_of_simple ρ hρ B hBne hBinv, hBinv⟩
+    intro v w
+    have h := LinearMap.congr_fun (LinearMap.congr_fun hS v) w
+    simp only [LinearMap.add_apply, LinearMap.zero_apply, LinearMap.flip_apply] at h
+    linear_combination h
+  · -- the symmetric part `B + Bᵀ` is nonzero, invariant ⟹ real type.
+    refine Or.inl ⟨B + B.flip, fun v w => ?_,
+      nondegenerate_of_invariant_of_simple ρ hρ _ hS (fun g v w => ?_), fun g v w => ?_⟩
+    · simp only [LinearMap.add_apply, LinearMap.flip_apply]; ring
+    · simp only [LinearMap.add_apply]; rw [hBinv, hflipinv]
+    · simp only [LinearMap.add_apply]; rw [hBinv, hflipinv]
+
+/-- **Odd-dimensional self-dual simple ⟹ real type.** The workhorse for the
+odd-dimensional irreducibles of an ambivalent group: a simple representation with
+self-dual character and odd dimension is of real type (dichotomy rules out complex
+type, L3 rules out quaternionic type). -/
+theorem isRealType_of_self_dual_of_odd_finrank
+    (ρ : Representation ℂ G V)
+    (hρ : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule)
+    (hsd : ∀ g, Representation.character ρ g⁻¹ = Representation.character ρ g)
+    (hodd : Odd (Module.finrank ℂ V)) :
+    Etingof.IsRealType ρ := by
+  rcases isRealType_or_isQuaternionicType_of_self_dual ρ hρ hsd with h | h
+  · exact h
+  · exact absurd (even_finrank_of_isQuaternionicType ρ h)
+      (by rw [Nat.not_even_iff_odd]; exact hodd)
+
 end Etingof

--- a/progress/2026-06-25T04-52-27Z_edb32a1f.md
+++ b/progress/2026-06-25T04-52-27Z_edb32a1f.md
@@ -1,0 +1,72 @@
+## Accomplished
+
+One-shot session (`/once 5204`) on Example 5.1.3 — all irreducible reps of A₅ are
+of real type. **Partial:** 4 of the 5 irreducibles are now proved real type,
+sorry-free, plus a reusable structural package; the single even-dimensional case is
+isolated behind a documented helper.
+
+New reusable lemmas in `Chapter5/FrobeniusSchurRealType.lean` (all sorry-free,
+axioms = {propext, Classical.choice, Quot.sound}):
+
+- `exists_nonzero_invariant_bilin_of_self_dual` — for a simple rep with self-dual
+  character (`χ(g⁻¹)=χ(g)`), the space of invariant bilinear forms is nonzero.
+  Proof: `card_inv_mul_sum_char_eq_finrank` for `linHom ρ ρ.dual` + `char_linHom` +
+  `char_dual` give `finrank = (|G|)⁻¹∑χ(g⁻¹)²`; self-duality rewrites this to the
+  orthonormality sum `= 1 > 0`. **Crucially this bypasses the still-isolated FS
+  trace identity** (`exists_nonzero_invariant_symmetric_of_FS_eq_one`, line 106).
+- `isRealType_or_isQuaternionicType_of_self_dual` — symmetrise/antisymmetrise a
+  nonzero invariant form; `2B = (B+Bᵀ)+(B−Bᵀ)≠0` so one part is a nonzero invariant
+  symmetric/skew form, nondegenerate by simplicity. (No Schur-uniqueness needed.)
+- `isRealType_of_self_dual_of_odd_finrank` — dichotomy + L3 (quaternionic ⟹ even):
+  self-dual + odd dim ⟹ real type. The odd-dimensional workhorse.
+
+In `Chapter5/Example5_1_3.lean`:
+
+- `Etingof.alternatingGroup_ambivalent` — every `g ∈ A₅` is conjugate to `g⁻¹`
+  (`decide` over the 60 elements, `maxRecDepth 10000`). Sorry-free.
+- `Etingof.Example5_1_3_A5` now: ambivalence ⟹ self-dual character; case-splits on
+  parity of `finrank`. Odd (ℂ, ℂ³₊, ℂ³₋, ℂ⁵) ⟹ `isRealType_of_self_dual_of_odd_finrank`.
+- `Etingof.isRealType_of_A5_even_standard` — even-dim (= 4-dim standard rep) case,
+  **isolated `sorry`** with documentation.
+
+## Key decisions
+
+- The issue's planned route (5 conjugacy classes + Frobenius divisibility ⇒ dims
+  {1,3,3,4,5}) is infeasible: Frobenius divisibility (`dim ∣ |G|`) is not in Mathlib
+  (`grep` of `Mathlib/RepresentationTheory` confirms) and is a major undertaking
+  (character integrality / algebraic integers).
+- Found a cleaner partial route that needs no dimension classification and no FS
+  trace identity for the odd cases: ambivalent ⇒ self-dual character ⇒ (dichotomy)
+  real or quaternionic ⇒ (L3) odd dim forces real. This closes 4 of 5 irreps.
+- The 4-dim case genuinely cannot be closed without identifying an abstract
+  even-dim simple module with the concrete (rational) standard rep, which needs the
+  classification. Isolated, not faked.
+
+## Verification
+
+- `lake build EtingofRepresentationTheory.Chapter5.Example5_1_3` succeeds (8608 jobs).
+- Four new lemmas confirmed sorry-free via `#print axioms`.
+- Remaining sorries: `FrobeniusSchurRealType:106` (pre-existing FS trace identity,
+  #5233) and `Example5_1_3:558` (`isRealType_of_A5_even_standard`, new tracking issue).
+
+## Current frontier
+
+Example 5.1.3 (A₅): odd-dimensional irreps done; even-dim (4-dim standard) remains.
+
+## Overall project progress
+
+Stage 3, Chapter 5. The self-dual dichotomy package is reusable for any ambivalent
+group's odd-dim irreps (e.g. a clean S₃ re-derivation) and is independent of the
+unfinished FS trace identity.
+
+## Next step
+
+A worker fills `isRealType_of_A5_even_standard` once the A₅ dimension classification
+(or just "the unique even irrep is the rational standard rep") is available — see the
+new tracking issue. Alternatively, completing the FS trace identity (#5233) gives a
+uniform route for all five.
+
+## Blockers
+
+Even-dim A₅ case blocked on A₅ irrep dimension classification / Frobenius
+divisibility (not in Mathlib). Tracked in a new issue.


### PR DESCRIPTION
This PR proves that four of the five irreducible representations of A₅ (ℂ, ℂ³₊, ℂ³₋, ℂ⁵) are of real type and adds a reusable self-dual dichotomy package, isolating the single even-dimensional (4-dimensional standard) case behind a documented helper. It is partial progress on #5204; the remaining even-dimensional case is tracked in #5251.

The new structural lemmas in `FrobeniusSchurRealType.lean` are sorry-free and bypass the still-isolated Frobenius-Schur trace identity: `exists_nonzero_invariant_bilin_of_self_dual` derives a nonzero invariant bilinear form from a self-dual character via character orthonormality and the invariant-dimension formula; `isRealType_or_isQuaternionicType_of_self_dual` symmetrises/antisymmetrises it; and `isRealType_of_self_dual_of_odd_finrank` combines this with L3 (quaternionic implies even-dimensional) to close the odd-dimensional case. In `Example5_1_3.lean`, `alternatingGroup_ambivalent` establishes that every element of A₅ is conjugate to its inverse (`decide`), so every A₅ character is self-dual, and `Example5_1_3_A5` case-splits on the parity of the dimension.

The even-dimensional case (`isRealType_of_A5_even_standard`, a documented `sorry`) needs identifying an abstract even-dimensional simple module with the rational standard representation, which requires the A₅ dimension classification / Frobenius divisibility (not in Mathlib). See #5251.

`lake build EtingofRepresentationTheory.Chapter5.Example5_1_3` succeeds; the four new lemmas are confirmed sorry-free via `#print axioms`.

🤖 Prepared with Claude Code