### PR TITLE
feat(Ch5): sum of squared dimensions of complex irreps = |G|

### DIFF
--- a/EtingofRepresentationTheory/Infrastructure/IrreducibleEnumeration.lean
+++ b/EtingofRepresentationTheory/Infrastructure/IrreducibleEnumeration.lean
@@ -755,3 +755,39 @@ theorem IrrepDecomp.d_eq_finrank [NeZero (Nat.card G : k)]
   -- finrank k (V i) = finrank k (columnFDRep (τ i)) = D.d (τ i) = D.d (σ i)
   rw [show (σ : Fin D.n → Fin D.n) i = τ i from rfl, ← D.finrank_columnFDRep (τ i)]
   exact (LinearEquiv.finrank_eq (FDRep.isoToLinearEquiv (hτ i).some)).symm
+
+/-! ### Sum of squared dimensions of the irreducibles -/
+
+/-- **Artin-Wedderburn dimension count, dimension form.** For any complete set `V` of
+pairwise non-isomorphic simple `FDRep k G` objects indexed by `Fin D.n`, the sum of the
+squares of their `Module.finrank` equals `|G|`. This is `IrrepDecomp.sum_sq_eq_card`
+re-expressed in terms of the actual dimensions of chosen representatives rather than the
+Wedderburn block sizes, via the matching permutation from `IrrepDecomp.d_eq_finrank`. -/
+theorem IrrepDecomp.sum_finrank_sq_eq_card [NeZero (Nat.card G : k)]
+    (D : IrrepDecomp k G) (V : Fin D.n → FDRep k G)
+    (hV : ∀ i, Simple (V i))
+    (hinj : ∀ i j, Nonempty ((V i) ≅ (V j)) → i = j) :
+    ∑ i, (Module.finrank k (V i)) ^ 2 = Fintype.card G := by
+  obtain ⟨σ, hσ⟩ := D.d_eq_finrank V hV hinj
+  calc ∑ i, (Module.finrank k (V i)) ^ 2
+      = ∑ i, (D.d (σ i)) ^ 2 := by
+        refine Finset.sum_congr rfl fun i _ => ?_; rw [hσ i]
+    _ = ∑ i, (D.d i) ^ 2 := Equiv.sum_comp σ (fun i => D.d i ^ 2)
+    _ = Fintype.card G := D.sum_sq_eq_card
+
+/-- **Existence form of the Artin-Wedderburn dimension count.** Every finite group `G`
+over an algebraically closed field `k` with `char(k) ∤ |G|` admits a finite family of
+pairwise non-isomorphic simple `FDRep k G` objects, complete (every simple is isomorphic
+to one of them), whose squared dimensions sum to `|G|`. Concretely the family is the set
+of column-vector representations `columnFDRep` of the Wedderburn-Artin decomposition. -/
+theorem exists_simples_sum_finrank_sq_eq_card (k G : Type u) [Field k] [IsAlgClosed k]
+    [Group G] [Fintype G] [NeZero (Nat.card G : k)] :
+    ∃ (n : ℕ) (V : Fin n → FDRep k G),
+      (∀ i, Simple (V i)) ∧
+      (∀ i j, Nonempty ((V i) ≅ (V j)) → i = j) ∧
+      (∀ (W : FDRep k G), Simple W → ∃ i, Nonempty (W ≅ V i)) ∧
+      ∑ i, (Module.finrank k (V i)) ^ 2 = Fintype.card G := by
+  let D : IrrepDecomp k G := IrrepDecomp.mk'
+  refine ⟨D.n, D.columnFDRep, D.columnFDRep_simple, D.columnFDRep_injective,
+    D.columnFDRep_surjective, ?_⟩
+  exact D.sum_finrank_sq_eq_card D.columnFDRep D.columnFDRep_simple D.columnFDRep_injective

--- a/progress/20260625T053615Z_130baf4a.md
+++ b/progress/20260625T053615Z_130baf4a.md
@@ -1,0 +1,58 @@
+## Accomplished
+
+One-shot feature session `130baf4a` (`/once 5255`): the Artin-Wedderburn dimension
+count for a finite group `G` — the sum of the squares of the dimensions of the
+irreducible `ℂ[G]`-modules equals `|G|`.
+
+Discovered that `Infrastructure/IrreducibleEnumeration.lean` (already in the build,
+imported at `EtingofRepresentationTheory.lean:1`, sorry-free) already proves the heavy
+lifting:
+
+- `IrrepDecomp.sum_sq_eq_card`: `∑ i, (D.d i)^2 = Fintype.card G` for the Wedderburn
+  block sizes `D.d`, via `IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed`
+  (Maschke ⇒ `ℂ[G]` semisimple, Wedderburn-Artin over an algebraically closed field,
+  `finrank` transport along the algebra iso).
+- `IrrepDecomp.d_eq_finrank`: the block sizes match the `Module.finrank` of any complete
+  family of non-isomorphic simple representatives, up to a permutation.
+
+The issue's exact deliverable was the *dimension form*, phrased via `Module.finrank ℂ Vᵢ`
+of chosen simple representatives. Added the two capstone theorems that assemble it:
+
+- `IrrepDecomp.sum_finrank_sq_eq_card`: for any complete family `V : Fin D.n → FDRep k G`
+  of pairwise non-isomorphic simples, `∑ i, (Module.finrank k (V i))^2 = Fintype.card G`.
+  Proof: `d_eq_finrank` gives a permutation `σ` with `D.d (σ i) = finrank (V i)`; reindex
+  the sum by `σ` (`Equiv.sum_comp`) and apply `sum_sq_eq_card`.
+- `exists_simples_sum_finrank_sq_eq_card`: existence form — every finite group over an
+  algebraically closed field of good characteristic admits such a complete family (the
+  Wedderburn `columnFDRep` family) whose squared dimensions sum to `|G|`.
+
+## Verification
+
+- `lake build EtingofRepresentationTheory.Infrastructure.IrreducibleEnumeration` succeeds
+  (8580 jobs). The pre-existing style/linter warnings (lines 473, 658, 684, 704, 719) are
+  untouched original code.
+- `#print axioms` on both new theorems: `[propext, Classical.choice, Quot.sound]` only —
+  no `sorryAx`.
+
+## Current frontier
+
+Issue #5255 fully delivered. The general sum-of-squares foundation (over any
+algebraically closed field of good characteristic, specialising to `ℂ` and to `A₅`) is in
+the build.
+
+## Overall project progress
+
+Etingof draft 1, Stage 3. The three missing-from-Mathlib foundations feeding
+`Etingof.A5_frobeniusSchur_all_pos` (`Chapter5/Example5_1_3.lean`): the
+`∑ dᵢ² = |G|` identity is the one this issue covers, and it is now available as
+`IrrepDecomp.sum_finrank_sq_eq_card` / `exists_simples_sum_finrank_sq_eq_card`.
+
+## Next step
+
+A worker wires `IrrepDecomp.sum_finrank_sq_eq_card` (specialised to `A₅`, `k = ℂ`) into
+the `A5_frobeniusSchur_all_pos` consumer in `Chapter5/Example5_1_3.lean`, alongside the
+`#irreps = #conjugacy classes = 5` input and the Frobenius-Schur involution count.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR adds the Artin-Wedderburn dimension count for a finite group `G` in dimension form: for `G` over an algebraically closed field of good characteristic, the sum of the squares of the `Module.finrank` of a complete family of pairwise non-isomorphic simple `FDRep` objects equals `|G|` (`∑ i, (finrank k (V i))^2 = Fintype.card G`). Specialised to `ℂ` and `A₅`, this is one of the three missing-from-Mathlib foundations feeding the verified `Etingof.A5_frobeniusSchur_all_pos` endgame.

The heavy lifting already lived sorry-free in `Infrastructure/IrreducibleEnumeration.lean`: `IrrepDecomp.sum_sq_eq_card` proves `∑ (D.d i)^2 = |G|` for the Wedderburn block sizes (Maschke gives `ℂ[G]` semisimple, then `IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed` plus `finrank` transport along the algebra iso), and `IrrepDecomp.d_eq_finrank` matches those block sizes to the `finrank` of any complete family of simple representatives up to a permutation. This adds the two capstone theorems that combine them into the issue's exact statement: `IrrepDecomp.sum_finrank_sq_eq_card` (for a given family) and `exists_simples_sum_finrank_sq_eq_card` (existence form, via the `columnFDRep` family).

Both new theorems are sorry-free; `#print axioms` reports only `propext, Classical.choice, Quot.sound`. `lake build` of the file succeeds.

Closes #5255

🤖 Prepared with Claude Code