### PR TITLE
feat(Ch5): Frobenius-Schur involution count #{g : g²=1} = ∑ FS(Vᵢ)·dim Vᵢ

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_1_5.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_1_5.lean
@@ -1,6 +1,7 @@
 import Mathlib
 import EtingofRepresentationTheory.Infrastructure.IrreducibleEnumeration
 import EtingofRepresentationTheory.Infrastructure.RegularCharacter
+import EtingofRepresentationTheory.Chapter5.Definition5_1_4
 
 /-!
 # Theorem 5.1.5: Frobenius-Schur Theorem (Involution Count)
@@ -82,3 +83,40 @@ theorem Etingof.Theorem5_1_5
   rw [invOf_eq_inv]
   have hne : (Fintype.card G : k) ≠ 0 := Invertible.ne_zero _
   field_simp [hne]
+
+section ComplexIndicatorForm
+
+-- `IrrepDecomp ℂ G` requires `G` in the same universe as `ℂ`, i.e. `Type 0`.
+variable {G : Type} [Group G] [Fintype G]
+
+/-- The Definition 5.1.4 Frobenius-Schur indicator (`Etingof.frobeniusSchurIndicator`,
+on the underlying `Representation ℂ G ↥V`) agrees with the FDRep-level indicator
+`FDRep.frobeniusSchurIndicator`. Both are `|G|⁻¹ ∑_g χ_V(g²)`. -/
+lemma Etingof.frobeniusSchurIndicator_ρ_eq
+    [DecidableEq G] [Invertible (Fintype.card G : ℂ)]
+    (V : FDRep ℂ G) :
+    Etingof.frobeniusSchurIndicator V.ρ = V.frobeniusSchurIndicator := by
+  simp only [Etingof.frobeniusSchurIndicator, FDRep.frobeniusSchurIndicator,
+    FDRep.character, invOf_eq_inv, smul_eq_mul]
+
+/-- **Frobenius-Schur involution count (Definition 5.1.4 form, over ℂ).** The number of
+involutions `#{g : G | g² = 1}` equals `∑_i FS(Vᵢ) · dim Vᵢ`, where `i` ranges over the
+irreducible `ℂ[G]`-modules and `FS` is the Definition 5.1.4 Frobenius-Schur indicator
+(`Etingof.frobeniusSchurIndicator` of the underlying representation `(Vᵢ).ρ`).
+
+This restates `Etingof.Theorem5_1_5` with the bare-representation indicator, the form the
+A₅ real-type endgame (`Etingof.A5_frobeniusSchur_all_pos`) consumes. -/
+theorem Etingof.frobeniusSchur_involution_count
+    [DecidableEq G] [NeZero (Nat.card G : ℂ)] [Invertible (Fintype.card G : ℂ)]
+    (D : IrrepDecomp ℂ G)
+    (V : Fin D.n → FDRep ℂ G)
+    (hV : ∀ i, Simple (V i))
+    (hinj : ∀ i j, Nonempty ((V i) ≅ (V j)) → i = j) :
+    ((Finset.univ.filter (fun g : G => g * g = 1)).card : ℂ) =
+      ∑ i : Fin D.n,
+        Etingof.frobeniusSchurIndicator (V i).ρ * (Module.finrank ℂ (V i) : ℂ) := by
+  rw [Etingof.Theorem5_1_5 D V hV hinj]
+  refine Finset.sum_congr rfl (fun i _ => ?_)
+  rw [Etingof.frobeniusSchurIndicator_ρ_eq, mul_comm]
+
+end ComplexIndicatorForm

--- a/progress/2026-06-25T05-37-11Z.md
+++ b/progress/2026-06-25T05-37-11Z.md
@@ -1,0 +1,32 @@
+## Accomplished
+Proved the Frobenius-Schur involution-count identity in the Definition 5.1.4 form
+(issue #5256). Added to `Chapter5/Theorem5_1_5.lean`:
+
+- `Etingof.frobeniusSchurIndicator_ρ_eq`: the Definition 5.1.4 indicator
+  `Etingof.frobeniusSchurIndicator V.ρ` (on the underlying `Representation ℂ G ↥V`)
+  equals the FDRep-level `FDRep.frobeniusSchurIndicator V`. Both are `|G|⁻¹ ∑_g χ_V(g²)`;
+  proved by `simp` unfolding both defs through `FDRep.character` (= trace) + `invOf_eq_inv`.
+- `Etingof.frobeniusSchur_involution_count`: `(#{g : G | g²=1} : ℂ) = ∑ᵢ FS(Vᵢ)·dim Vᵢ`
+  over the irreducible ℂ[G]-modules, with `FS = Etingof.frobeniusSchurIndicator (Vᵢ).ρ`.
+  Proved by rewriting with the existing `Etingof.Theorem5_1_5` (the FDRep-indicator form,
+  already sorry-free) then a per-term `sum_congr` using the bridge lemma + `mul_comm`.
+
+Both compile sorry-free; `#print axioms` shows only `propext, Classical.choice, Quot.sound`.
+
+## Current frontier
+The identity is the second of three missing-from-Mathlib foundations feeding
+`Etingof.A5_frobeniusSchur_all_pos` toward the even-dimensional A₅ real-type case
+(#5251). The new theorem provides the `∑ᵢ ε i · d i = #{g : g²=1}` input in the exact
+Definition 5.1.4 form the A₅ endgame expects.
+
+## Overall project progress
+Stage 3 (formalization) endgame. This adds infrastructure for Example 5.1.3 (A₅).
+
+## Next step
+Wire `frobeniusSchur_involution_count` into the A₅ argument: instantiate at
+`G = alternatingGroup (Fin 5)`, evaluate the involution count (16) by `decide`, and
+feed `A5_frobeniusSchur_all_pos`. Still blocked on the dimension classification gap
+(`isRealType_of_A5_even_standard`, #5251) for the full Example 5.1.3 closure.
+
+## Blockers
+None for this item.


### PR DESCRIPTION
Closes #5256

Session: `e8ec7c25-61df-47f8-b291-decd5c3767c0`

b9b5d928 feat(Ch5): Frobenius-Schur involution count in Definition 5.1.4 form (#5256)

🤖 Prepared with Claude Code