### PR TITLE
docs(progress): verify and close #5222 (quiver-rep bijection complete)

### DIFF
--- a/progress/2026-06-26T00-58-57Z.md
+++ b/progress/2026-06-26T00-58-57Z.md
@@ -1,0 +1,43 @@
+## Accomplished
+
+Verified issue #5222 (Ch2 `Discussion_quiver_rep_bijection`: reverse direction +
+iso-class bijection) is **already fully complete** and closed it.
+
+Both deliverables had landed via merged PRs before this one-shot dispatch:
+
+- **Deliverable 3** (reverse-direction left `P_Q`-module): `reverseModule`/`toEnd`/
+  `pathMap`/`pathEnd` — merged in #5225.
+- **Deliverable 4** (mutual-inverse / iso-class bijection): `repEquivAt`/
+  `repRoundTrip` (with `repEquivAt_naturality`) — merged in #5244, via the
+  split-out tracking issue #5224 (now closed).
+
+Verification performed against `origin/main`:
+
+- `EtingofRepresentationTheory/Chapter2/Discussion_quiver_rep_bijection.lean` is
+  byte-identical to `main` and contains no `sorry` (line 377 is a doc comment only).
+- `lake build EtingofRepresentationTheory.Chapter2.Discussion_quiver_rep_bijection`
+  succeeds (1395 jobs).
+- `#print axioms` for `repRoundTrip`, `reverseModule`, `repEquivAt` shows only
+  `[propext, Classical.choice, Quot.sound]` — no `sorryAx`.
+
+This matches the issue's stated verification criteria exactly.
+
+## Current frontier
+
+The quiver-representation / path-module bijection is complete: forward functor
+(`forwardRep`, #5218), reverse module (`reverseModule`, #5225), and the iso-class
+bijection round-trips (`repRoundTrip`, #5244). No open residual.
+
+## Overall project progress
+
+Phase 3 formalization ongoing. Ch2 quiver-representation bijection thread
+(#5149 → #5218 → #5222/#5225 → #5224/#5244) is fully closed out.
+
+## Next step
+
+Pick up other open Phase 3 formalization issues. Nothing further on the
+quiver-representation bijection.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR records the progress note confirming issue #5222 is complete and closes the loop on the quiver-representation / path-module bijection thread.

Both deliverables of #5222 had already landed before this one-shot dispatch: the reverse-direction left `P_Q`-module (#5225) and the iso-class bijection round-trip (#5244, via the split-out #5224). This dispatch verified the merged result against `origin/main`: the file builds (1395 jobs), is sorry-free, and `#print axioms` for `repRoundTrip`, `reverseModule`, and `repEquivAt` shows only `[propext, Classical.choice, Quot.sound]`. Issue #5222 is now closed as completed; this PR adds only the progress handoff file.

🤖 Prepared with Claude Code