### PR TITLE
feat(Ch2 Problem 2.15.1f): uniqueness of the (λ+1)-dim irrep of sl₂ (≅ V_λ)

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Theorem2_1_1.lean
+++ b/EtingofRepresentationTheory/Chapter2/Theorem2_1_1.lean
@@ -434,6 +434,47 @@ theorem Theorem_2_1_1_i (d : ℕ+) :
     subst hneq
     exact ⟨sl2_irrep_equiv hirrV hirrW mV mW nV PV PW⟩
 
+/-- **Problem 2.15.1(f): uniqueness of the irreducible representation in each dimension.**
+Every `(lam + 1)`-dimensional irreducible representation `V` of `sl(2, ℂ)` is isomorphic, as
+a Lie module, to the standard irreducible `V_lam = Fin (lam + 1) → ℂ` constructed in
+`Sl2Irrep`. (The book's existence/irreducibility direction is `Sl2Irrep.irrep_isIrreducible`;
+this is the uniqueness direction.)
+
+The proof follows the book: pick a primitive (highest weight) vector `v` in `V`
+(`exists_primitiveVector`), so that `v, F·v, …, Fᶫᵃᵐ·v` is a basis of `V`
+(`primitiveOrbit_basis`); the same construction in the standard `V_lam` produces a matching
+basis, and the linear map identifying the two f-orbits intertwines the `sl(2)`-action
+(`sl2_irrep_equiv`). The common weight is forced to be `lam` by the dimension count
+(`primitiveVector_dim`). -/
+theorem Problem_2_15_1_f (lam : ℕ)
+    {V : Type*} [AddCommGroup V] [Module ℂ V] [FiniteDimensional ℂ V]
+    [LieRingModule sl2 V] [LieModule ℂ sl2 V]
+    (hdimV : Module.finrank ℂ V = lam + 1)
+    (hirrV : LieModule.IsIrreducible ℂ sl2 V) :
+    Nonempty (V ≃ₗ⁅ℂ, sl2⁆ (Fin (lam + 1) → ℂ)) := by
+  -- The standard `(lam+1)`-dimensional irreducible from `Sl2Irrep`.
+  haveI : NeZero (lam + 1) := ⟨Nat.succ_ne_zero lam⟩
+  have hirrW : LieModule.IsIrreducible ℂ sl2 (Fin (lam + 1) → ℂ) :=
+    Sl2Irrep.irrep_isIrreducible (lam + 1)
+  have hdimW : Module.finrank ℂ (Fin (lam + 1) → ℂ) = lam + 1 :=
+    Sl2Irrep.irrep_finrank (lam + 1)
+  have hntV : Nontrivial V := by
+    rw [← finrank_pos_iff (R := ℂ), hdimV]; omega
+  have hntW : Nontrivial (Fin (lam + 1) → ℂ) := by
+    rw [← finrank_pos_iff (R := ℂ), hdimW]; omega
+  -- Primitive vectors in both modules, with natural-number weights.
+  obtain ⟨mV, μV, PV⟩ := exists_primitiveVector hirrV
+  obtain ⟨mW, μW, PW⟩ := exists_primitiveVector hirrW
+  obtain ⟨nV, hnV⟩ := PV.exists_nat
+  obtain ⟨nW, hnW⟩ := PW.exists_nat
+  rw [hnV] at PV; rw [hnW] at PW
+  -- Each weight is pinned down to `lam` by the dimension.
+  have hdV := primitiveVector_dim hirrV mV nV PV
+  have hdW := primitiveVector_dim hirrW mW nW PW
+  have hnVeq : nV = lam := by omega
+  have hnWeq : nW = lam := by omega
+  exact ⟨sl2_irrep_equiv hirrV hirrW mV mW lam (hnVeq ▸ PV) (hnWeq ▸ PW)⟩
+
 /-! ## Casimir element and complete reducibility
 
 The Casimir element C = h² + 2ef + 2fe of sl(2) commutes with the action of sl(2) on any

--- a/progress/2026-06-26T01-22-53Z_b5fdab12.md
+++ b/progress/2026-06-26T01-22-53Z_b5fdab12.md
@@ -1,0 +1,49 @@
+## Accomplished
+
+Formalized **Problem 2.15.1(f) uniqueness** (issue #5285): every `(lam+1)`-dimensional
+irreducible representation of `sl(2, ℂ)` is isomorphic, as a Lie module, to the standard
+irreducible `V_lam = Fin (lam+1) → ℂ` built in `Chapter2/Sl2Irrep.lean`.
+
+Added theorem `Etingof.Problem_2_15_1_f` in `Chapter2/Theorem2_1_1.lean`:
+
+```
+theorem Problem_2_15_1_f (lam : ℕ) {V : Type*} [...]
+    (hdimV : Module.finrank ℂ V = lam + 1)
+    (hirrV : LieModule.IsIrreducible ℂ sl2 V) :
+    Nonempty (V ≃ₗ⁅ℂ, sl2⁆ (Fin (lam + 1) → ℂ))
+```
+
+It is a direct corollary of the existing primitive-vector machinery already in the file:
+`exists_primitiveVector` (highest-weight vector exists in any nontrivial finite-dim
+irreducible), `primitiveVector_dim` (weight `n` forces dimension `n+1`), and
+`sl2_irrep_equiv` (two irreducibles with primitive vectors of equal weight are Lie-isomorphic
+via the f-orbit bases). Instantiating the target against the concrete standard `V_lam` and
+pinning the common weight to `lam` by the dimension count gives the result.
+
+Key realisation: the abstract uniqueness was already proved as the second clause of
+`Theorem_2_1_1_i` (over universe `Type`); part (f) just specialises it to the concrete
+`Sl2Irrep` module and generalises the source to `Type*` by re-using the private helpers
+directly rather than the `Type`-restricted public theorem.
+
+No new `sorry`. Full `lake build` succeeds (8963 jobs).
+
+## Current frontier
+
+Issue #5285 complete. Diff is +41 lines in `Chapter2/Theorem2_1_1.lean`.
+
+## Overall project progress
+
+Chapter 2 Problem 2.15.1 is `sorry_free` in `progress/items.json`. Existence/irreducibility
+(`Sl2Irrep`), classification + complete reducibility (`Theorem_2_1_1_i`, `Theorem_2_1_1_ii`),
+Casimir eigenvalue (part g, #5284), and now the explicit part-(f) statement against the
+standard `V_lam` are all in place.
+
+## Next step
+
+Remaining sub-parts of Problem 2.15.1 noted in the issue as out of scope: (l) Jacobson–Morozov,
+(m) Clebsch–Gordan, (n) Jordan normal form. Parts (h)–(k) complete reducibility are subsumed by
+`Theorem_2_1_1_ii`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5285

Session: `b5fdab12-a5ca-41ee-958a-4d1140e2fff4`

0c63ac7f feat(Ch2 Problem 2.15.1f): uniqueness of the (λ+1)-dim irrep of sl₂ (≅ V_λ)

🤖 Prepared with Claude Code