### PR TITLE
feat(Ch2 2.15.1m): tensor sl2-action + Clebsch-Gordan highest-weight vectors

### DIFF
--- a/EtingofRepresentationTheory/Chapter2.lean
+++ b/EtingofRepresentationTheory/Chapter2.lean
@@ -2,6 +2,7 @@
 import EtingofRepresentationTheory.Chapter2.Sl2Defs
 import EtingofRepresentationTheory.Chapter2.Sl2Irrep
 import EtingofRepresentationTheory.Chapter2.Problem2_15_1_m
+import EtingofRepresentationTheory.Chapter2.Problem2_15_1_m_Module
 import EtingofRepresentationTheory.Chapter2.Theorem2_1_1
 import EtingofRepresentationTheory.Chapter2.Theorem2_1_2
 

--- a/EtingofRepresentationTheory/Chapter2/Problem2_15_1_m_Module.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_15_1_m_Module.lean
@@ -1,0 +1,77 @@
+import Mathlib.Algebra.Lie.TensorProduct
+import Mathlib.Data.Nat.Choose.Basic
+import EtingofRepresentationTheory.Chapter2.Sl2Irrep
+
+/-!
+# Clebsch–Gordan, module level (Problem 2.15.1(m))
+
+The companion file `Problem2_15_1_m.lean` proves the **character identity** behind the
+Clebsch–Gordan decomposition `V_λ ⊗ V_μ ≅ ⨁_{k=0}^{min(λ,μ)} V_{λ+μ−2k}`. This file
+begins the promotion of that combinatorial statement to a genuine `sl(2)`-module
+isomorphism, following the book's route (highest-weight vectors + dimension count +
+distinct Casimir scalars, avoiding Weyl complete reducibility).
+
+## What is here
+
+* The tensor product `V_λ ⊗[ℂ] V_μ` automatically carries an `sl(2)`-module structure
+  via Mathlib's `TensorProduct.LieModule` instances; the action is the expected
+  derivation `X • (v ⊗ w) = (X•v) ⊗ w + v ⊗ (X•w)` (`TensorProduct.LieModule.lie_tmul_right`).
+* For each `k = 0,…,min(λ,μ)` we write down the explicit **highest-weight vector**
+  `cgHW λ μ k = Σ_{i=0}^k (−1)^i C(k,i) · e_i ⊗ e_{k−i}` of weight `λ+μ−2k`
+  (`cgHW`), and prove it is an `H`-eigenvector of that weight
+  (`lie_sl2_h_cgHW`) annihilated by the raising operator `E` (`lie_sl2_e_cgHW`).
+
+The coefficients `(−1)^i C(k,i)` are forced by the highest-weight condition `E·w = 0`,
+which after grouping by the basis tensor `e_a ⊗ e_b` (`a+b = k−1`) reads
+`(a+1)c_{a+1} + (k−a)c_a = 0`; this is Pascal's absorption identity
+`Nat.choose_succ_right_eq`.
+
+## Remaining work
+
+Assembling the full module isomorphism — showing each `cgHW λ μ k` generates an
+irreducible subrep `≅ V_{λ+μ−2k}` (via `irrep_isIrreducible` and the distinct Casimir
+scalars `casimir_eq_scalar_lambda`), and that these exhaust `V_λ ⊗ V_μ` by the
+dimension count `clebsch_gordan_dim` — is tracked as follow-up work.
+-/
+
+open scoped TensorProduct
+open Etingof Etingof.Sl2Irrep
+
+namespace Etingof.Sl2Irrep
+
+variable (lam mu : ℕ)
+
+/-- The tensor product `V_λ ⊗ V_μ` carries the derivation `sl(2)`-action
+`X • (v ⊗ w) = (X•v) ⊗ w + v ⊗ (X•w)`, recorded here as the bracket on a pure tensor. -/
+theorem lie_tmul (x : sl2) (v : Fin (lam + 1) → ℂ) (w : Fin (mu + 1) → ℂ) :
+    ⁅x, v ⊗ₜ[ℂ] w⁆ = ⁅x, v⁆ ⊗ₜ[ℂ] w + v ⊗ₜ[ℂ] ⁅x, w⁆ :=
+  TensorProduct.LieModule.lie_tmul_right x v w
+
+/-- The Clebsch–Gordan **highest-weight vector** of weight `λ+μ−2k` in `V_λ ⊗ V_μ`:
+`cgHW λ μ k = Σ_{i=0}^{k} (−1)^i C(k,i) · (e_i ⊗ e_{k−i})`.
+
+Defined for `k ≤ min(λ,μ)` so that all the basis indices `i ≤ λ` and `k−i ≤ μ` are in
+range. -/
+noncomputable def cgHW (k : ℕ) (hk : k ≤ min lam mu) :
+    (Fin (lam + 1) → ℂ) ⊗[ℂ] (Fin (mu + 1) → ℂ) :=
+  ∑ i : Fin (k + 1),
+    ((-1) ^ (i : ℕ) * (k.choose (i : ℕ) : ℂ)) •
+      (e_basis (lam + 1) ⟨(i : ℕ), by omega⟩ ⊗ₜ[ℂ]
+        e_basis (mu + 1) ⟨k - (i : ℕ), by omega⟩)
+
+/-- `cgHW λ μ k` is an `H`-eigenvector of weight `λ+μ−2k`: each summand
+`e_i ⊗ e_{k−i}` has weight `(λ−2i) + (μ−2(k−i)) = λ+μ−2k`. -/
+theorem lie_sl2_h_cgHW (k : ℕ) (hk : k ≤ min lam mu) :
+    ⁅sl2_h, cgHW lam mu k hk⁆ = ((lam : ℂ) + mu - 2 * k) • cgHW lam mu k hk := by
+  rw [cgHW, lie_sum, Finset.smul_sum]
+  apply Finset.sum_congr rfl
+  intro i _
+  have hik : (i : ℕ) ≤ k := by omega
+  rw [lie_smul, lie_tmul, lie_sl2_h_e_basis, lie_sl2_h_e_basis,
+    ← TensorProduct.smul_tmul', TensorProduct.tmul_smul, ← add_smul, smul_smul, smul_smul]
+  congr 1
+  simp only [Fin.val_mk]
+  push_cast [Nat.cast_sub hik]
+  ring
+
+end Etingof.Sl2Irrep

--- a/EtingofRepresentationTheory/Chapter2/Problem2_15_1_m_Module.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_15_1_m_Module.lean
@@ -74,4 +74,56 @@ theorem lie_sl2_h_cgHW (k : ℕ) (hk : k ≤ min lam mu) :
   push_cast [Nat.cast_sub hik]
   ring
 
+/-- The `e_{i-1} ⊗ e_{k-i}` summand of `⁅E, cgHW⁆` (the raising operator acting on the
+first tensor factor). -/
+private noncomputable def cgA (k : ℕ) (hk : k ≤ min lam mu) (i : Fin (k + 1)) :
+    (Fin (lam + 1) → ℂ) ⊗[ℂ] (Fin (mu + 1) → ℂ) :=
+  (((-1) ^ (i : ℕ) * (k.choose (i : ℕ) : ℂ)) * (i : ℕ)) •
+    (e_basis (lam + 1) ⟨(i : ℕ) - 1, by omega⟩ ⊗ₜ[ℂ]
+      e_basis (mu + 1) ⟨k - (i : ℕ), by omega⟩)
+
+/-- The `e_i ⊗ e_{k-i-1}` summand of `⁅E, cgHW⁆` (the raising operator acting on the
+second tensor factor). -/
+private noncomputable def cgB (k : ℕ) (hk : k ≤ min lam mu) (i : Fin (k + 1)) :
+    (Fin (lam + 1) → ℂ) ⊗[ℂ] (Fin (mu + 1) → ℂ) :=
+  (((-1) ^ (i : ℕ) * (k.choose (i : ℕ) : ℂ)) * ((k - (i : ℕ) : ℕ) : ℂ)) •
+    (e_basis (lam + 1) ⟨(i : ℕ), by omega⟩ ⊗ₜ[ℂ]
+      e_basis (mu + 1) ⟨k - (i : ℕ) - 1, by omega⟩)
+
+/-- `cgHW λ μ k` is annihilated by the raising operator `E`: it is a highest-weight
+vector. After grouping `⁅E, ·⁆` by basis tensor, the coefficient of `e_i ⊗ e_{k-1-i}`
+is `(i+1)c_{i+1} + (k-i)c_i = 0`, which is Pascal's absorption identity. -/
+theorem lie_sl2_e_cgHW (k : ℕ) (hk : k ≤ min lam mu) :
+    ⁅sl2_e, cgHW lam mu k hk⁆ = 0 := by
+  rw [cgHW, lie_sum]
+  have hterm : ∀ i : Fin (k + 1),
+      ⁅sl2_e, ((-1) ^ (i : ℕ) * (k.choose (i : ℕ) : ℂ)) •
+        (e_basis (lam + 1) ⟨(i : ℕ), by omega⟩ ⊗ₜ[ℂ]
+          e_basis (mu + 1) ⟨k - (i : ℕ), by omega⟩)⁆
+        = cgA lam mu k hk i + cgB lam mu k hk i := by
+    intro i
+    rw [lie_smul, lie_tmul,
+      lie_sl2_e_e_basis (lam + 1) (i : ℕ) (by omega),
+      lie_sl2_e_e_basis (mu + 1) (k - (i : ℕ)) (by omega),
+      ← TensorProduct.smul_tmul', TensorProduct.tmul_smul, smul_add, smul_smul, smul_smul]
+    rfl
+  rw [Finset.sum_congr rfl (fun i _ => hterm i), Finset.sum_add_distrib]
+  conv_lhs =>
+    rw [Fin.sum_univ_succ (cgA lam mu k hk), Fin.sum_univ_castSucc (cgB lam mu k hk)]
+  rw [show cgA lam mu k hk 0 = 0 by simp [cgA],
+    show cgB lam mu k hk (Fin.last k) = 0 by simp [cgB, Fin.val_last],
+    zero_add, add_zero, ← Finset.sum_add_distrib]
+  apply Finset.sum_eq_zero
+  intro i _
+  have hik : (i : ℕ) ≤ k := by omega
+  have key : (k.choose ((i : ℕ) + 1) : ℂ) * (((i : ℕ) + 1 : ℕ) : ℂ)
+      = (k.choose (i : ℕ) : ℂ) * ((k - (i : ℕ) : ℕ) : ℂ) := by
+    exact_mod_cast Nat.choose_succ_right_eq k (i : ℕ)
+  simp only [cgA, cgB, Fin.val_succ, Fin.coe_castSucc,
+    Nat.add_sub_cancel, Nat.sub_sub]
+  rw [← add_smul]
+  convert zero_smul ℂ _ using 2
+  rw [pow_succ]
+  linear_combination (-(-1 : ℂ) ^ (i : ℕ)) * key
+
 end Etingof.Sl2Irrep

--- a/EtingofRepresentationTheory/Chapter2/Sl2Irrep.lean
+++ b/EtingofRepresentationTheory/Chapter2/Sl2Irrep.lean
@@ -311,11 +311,75 @@ private lemma rhoLieHom_sl2_f_eq (d : ℕ) : rhoLieHom d sl2_f = rhoF d := by
   rw [key, h00, h01, h10]; simp
 
 /-- Standard basis vector e_k in Fin d → ℂ. -/
-private def e_basis (d : ℕ) (k : Fin d) : Fin d → ℂ := Pi.single k 1
+def e_basis (d : ℕ) (k : Fin d) : Fin d → ℂ := Pi.single k 1
 
-private theorem e_basis_apply (d : ℕ) (k j : Fin d) :
+theorem e_basis_apply (d : ℕ) (k j : Fin d) :
     e_basis d k j = if j = k then 1 else 0 := by
   simp [e_basis, Pi.single_apply]
+
+/-! ### Action of the standard triple on basis vectors
+
+The Lie module action of `sl(2)` on `V_d` agrees with `rhoLieHom`; on the standard
+basis `e_0, …, e_{d-1}` the triple `h, e, f` acts by the explicit formulas below.
+These are the boundary-free statements used by the Clebsch–Gordan computation. -/
+
+/-- The Lie module action on `V_d` is given by `rhoLieHom`. -/
+theorem lie_eq_rhoLieHom (d : ℕ) (x : sl2) (v : Fin d → ℂ) :
+    ⁅x, v⁆ = rhoLieHom d x v := rfl
+
+/-- `h` acts diagonally on basis vectors: `⁅h, e_i⁆ = (d - 1 - 2i) • e_i`. -/
+theorem lie_sl2_h_e_basis (d : ℕ) (i : Fin d) :
+    ⁅sl2_h, e_basis d i⁆ = ((d : ℂ) - 1 - 2 * (i : ℕ)) • e_basis d i := by
+  rw [lie_eq_rhoLieHom, rhoLieHom_sl2_h_eq]
+  ext k
+  simp only [rhoH, LinearMap.coe_mk, AddHom.coe_mk, Pi.smul_apply, smul_eq_mul,
+    e_basis_apply]
+  by_cases hk : k = i
+  · subst hk; simp
+  · simp [hk]
+
+/-- `e` (raising) on basis vectors: `⁅e, e_i⁆ = i • e_{i-1}` (and `0` at `i = 0`,
+since the scalar `i` vanishes). -/
+theorem lie_sl2_e_e_basis (d : ℕ) (i : ℕ) (hi : i < d) :
+    ⁅sl2_e, e_basis d ⟨i, hi⟩⁆ = (i : ℂ) • e_basis d ⟨i - 1, by omega⟩ := by
+  rw [lie_eq_rhoLieHom, rhoLieHom_sl2_e_eq]
+  ext k
+  have hkd : (k : ℕ) < d := k.isLt
+  simp only [rhoE, LinearMap.coe_mk, AddHom.coe_mk, Pi.smul_apply, smul_eq_mul,
+    e_basis_apply, Fin.ext_iff, Fin.mk.injEq]
+  by_cases hk : (k : ℕ) + 1 < d
+  · simp only [hk, dite_true]
+    rcases Nat.eq_zero_or_pos i with hi0 | hipos
+    · subst hi0
+      rw [if_neg (by omega : ¬ (k : ℕ) + 1 = 0)]; push_cast; ring
+    · by_cases hki : (k : ℕ) + 1 = i
+      · rw [if_pos hki, if_pos (by omega : (k : ℕ) = i - 1), ← hki]; push_cast; ring
+      · rw [if_neg hki, if_neg (by omega : ¬ (k : ℕ) = i - 1)]; ring
+  · simp only [hk, dite_false, mul_zero]
+    rcases Nat.eq_zero_or_pos i with hi0 | hipos
+    · subst hi0; simp
+    · rw [if_neg (by omega : ¬ (k : ℕ) = i - 1)]; ring
+
+/-- `f` (lowering) on basis vectors below the top: `⁅f, e_i⁆ = (d - 1 - i) • e_{i+1}`
+when `i + 1 < d`. -/
+theorem lie_sl2_f_e_basis (d : ℕ) (i : ℕ) (hi : i + 1 < d) :
+    ⁅sl2_f, e_basis d ⟨i, by omega⟩⁆ = ((d : ℂ) - 1 - (i : ℕ)) • e_basis d ⟨i + 1, hi⟩ := by
+  rw [lie_eq_rhoLieHom, rhoLieHom_sl2_f_eq]
+  ext k
+  have hkd : (k : ℕ) < d := k.isLt
+  simp only [rhoF, LinearMap.coe_mk, AddHom.coe_mk, Pi.smul_apply, smul_eq_mul,
+    e_basis_apply, Fin.ext_iff, Fin.mk.injEq]
+  by_cases hk : 0 < (k : ℕ)
+  · simp only [hk, dite_true]
+    by_cases hki : (k : ℕ) - 1 = i
+    · rw [if_pos hki, if_pos (by omega : (k : ℕ) = i + 1)]
+      have hkc : ((k : ℕ) : ℂ) = (i : ℂ) + 1 := by
+        have : (k : ℕ) = i + 1 := by omega
+        rw [this]; push_cast; ring
+      rw [hkc]; push_cast; ring
+    · rw [if_neg hki, if_neg (by omega : ¬ (k : ℕ) = i + 1)]; ring
+  · simp only [dif_neg hk, mul_zero]
+    rw [if_neg (by omega : ¬ (k : ℕ) = i + 1)]; ring
 
 /-- V_d is irreducible as an sl(2)-module (for d ≥ 1). -/
 theorem irrep_isIrreducible (d : ℕ) [NeZero d] :

--- a/progress/20260626T022846Z_4f3a14da.md
+++ b/progress/20260626T022846Z_4f3a14da.md
@@ -1,0 +1,61 @@
+## Accomplished
+
+One-shot feature session `4f3a14da` (`/once 5289`): laid the sorry-free
+foundation for the Clebsch–Gordan **module** isomorphism `V_λ ⊗ V_μ ≅
+⨁_{k=0}^{min(λ,μ)} V_{λ+μ−2k}` of `sl(2)`, promoting the existing character-level
+result. Partial PR (the full isomorphism assembly is decomposed to #5301).
+
+Two pieces landed:
+
+- **`Chapter2/Sl2Irrep.lean`** — exposed public basis-action API previously locked
+  behind `private`: made `e_basis`/`e_basis_apply` public and added boundary-free
+  action lemmas for the standard triple on basis vectors:
+  - `lie_eq_rhoLieHom`: the Lie module action is `rhoLieHom`.
+  - `lie_sl2_h_e_basis`: `⁅h, e_i⁆ = (d−1−2i) • e_i`.
+  - `lie_sl2_e_e_basis`: `⁅e, e_i⁆ = i • e_{i−1}` (and `0` at `i=0`).
+  - `lie_sl2_f_e_basis`: `⁅f, e_i⁆ = (d−1−i) • e_{i+1}` for `i+1 < d`.
+
+- **`Chapter2/Problem2_15_1_m_Module.lean`** (new) —
+  - `lie_tmul`: the derivation action `⁅x, v⊗w⁆ = ⁅x,v⁆⊗w + v⊗⁅x,w⁆`, from
+    Mathlib's `TensorProduct.LieModule` instances (deliverable 1, essentially free).
+  - `cgHW λ μ k = Σ_{i=0}^k (−1)^i C(k,i) · e_i ⊗ e_{k−i}`: the explicit
+    highest-weight vectors (defined for `k ≤ min(λ,μ)`).
+  - `lie_sl2_h_cgHW`: `cgHW` is an `H`-eigenvector of weight `λ+μ−2k` (each summand
+    has constant weight `(λ−2i)+(μ−2(k−i))`).
+  - `lie_sl2_e_cgHW`: `cgHW` is annihilated by `E`. Proof reindexes the `E`-action
+    sum (peel `i=0` from the first-factor sum via `Fin.sum_univ_succ`, peel `i=k`
+    from the second via `Fin.sum_univ_castSucc`), pairs terms over the same basis
+    tensor `e_i ⊗ e_{k−1−i}`, and kills the coefficient `(i+1)c_{i+1} + (k−i)c_i`
+    using Pascal's absorption `Nat.choose_succ_right_eq`.
+
+Registered the new file in `Chapter2.lean`.
+
+## Verification
+
+- `lake build` of `Sl2Irrep`, `Problem2_15_1_m`, `Problem2_15_1_m_Module` all
+  succeed; no `sorry`.
+- `#print axioms` on all five new lemmas: `[propext, Classical.choice, Quot.sound]`
+  only — no `sorryAx`.
+
+## Current frontier
+
+Highest-weight vectors are built and verified (weight + `E`-annihilation). The
+remaining linear-algebra assembly of the full module isomorphism is tracked in
+#5301 (depends-on #5289).
+
+## Overall project progress
+
+Etingof draft 1, Stage 3. Problem 2.15.1(m): character identity + dimension count
+(done previously) and now the highest-weight-vector foundation for the module
+isomorphism. The module iso itself is decomposed to #5301.
+
+## Next step
+
+Pick up #5301: show each `cgHW λ μ k` generates a subrep `≅ V_{λ+μ−2k}` (apply
+`F` repeatedly; `irrep_isIrreducible` + the distinct Casimir scalars
+`casimir_eq_scalar_lambda`), then use `clebsch_gordan_dim` to conclude the
+internal direct sum exhausts `V_λ ⊗ V_μ`.
+
+## Blockers
+
+None. #5301 is the natural continuation.


### PR DESCRIPTION
Partial progress on #5289

Session: `4f3a14da-d1ec-4610-b719-e5e1c90703ad`

2040e086 docs(progress): CG highest-weight foundation for 2.15.1m (#5289 partial, follow-up #5301)
76236980 feat(Ch2 2.15.1m): prove CG highest-weight vectors are E-annihilated
73a30a99 feat(Ch2 2.15.1m): tensor sl2-action + CG highest-weight vectors (H-weight)

🤖 Prepared with Claude Code