### PR TITLE
doc(Ch5 #5082): confirm clean constituent extractor already landed sorry-free via #5101/#5104

### DIFF
--- a/progress/2026-06-26T03-55-36Z_15c87a26.md
+++ b/progress/2026-06-26T03-55-36Z_15c87a26.md
@@ -1,0 +1,45 @@
+## Accomplished
+
+Verified that the deliverable of #5082 — the DetInvElim-clean constituent-character
+extractor `Etingof.clean_simple_constituent_formalCharacter_eq_schurPoly_mem` — is
+**already landed sorry-free on `main`** and closed the parent issue accordingly.
+
+The work reached `main` through #5082's own decomposition:
+- PR #5101 (issue #5082): composition-series character-additivity infrastructure
+- PR #5104 (issue #5100, the extractor tail): filled
+  `clean_simple_constituent_formalCharacter_eq_schurPoly_mem` sorry-free
+
+Verification performed this session (worktree at `main`, post toolchain bump #5109):
+- `lake build EtingofRepresentationTheory.Chapter5.CleanConstituentExtraction` →
+  Build completed successfully (8636 jobs). Only `linter.style.show` style warnings,
+  no errors, no sorries (`grep -c sorry` = 0).
+- `#print axioms Etingof.clean_simple_constituent_formalCharacter_eq_schurPoly_mem` →
+  `[propext, Classical.choice, Quot.sound]` exactly as required.
+- Transitive-import trace (57 project modules in the closure): **no** module with
+  `DetInvElim` in its name. Direct imports: `CleanQuotientHelpers`, `CleanSubSpanning`,
+  `CleanCharacterExtractionBase`, `SimpleSubrepExtraction`, `Theorem5_22_1`.
+
+Note: the landed theorem is cleaner than the issue's draft signature — it drops the
+unused `n : ℕ` parameter and the `h_homog` hypothesis (the issue marked the latter
+"include iff needed"; it was not needed). It remains a drop-in for the #5076 part-(a)
+call site, which can simply omit those arguments.
+
+## Current frontier
+
+#5082 closed. No code changes were needed — the deliverable was already in `main`.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. The clean (DetInvElim-free) constituent-character
+extraction chain for Ch5 is complete: infrastructure (#5101) + tail (#5104) both
+merged and verified sorry-free.
+
+## Next step
+
+Downstream consumer #5076 (part-(a) call site, `M = quotDetDegreeFDRep k N d`) can
+now use `clean_simple_constituent_formalCharacter_eq_schurPoly_mem` directly. If not
+already wired, that is the natural follow-up.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR records that the deliverable of #5082 — the DetInvElim-clean constituent-character extractor `Etingof.clean_simple_constituent_formalCharacter_eq_schurPoly_mem` in `CleanConstituentExtraction.lean` — is already landed sorry-free on `main`, having reached it through #5082's own decomposition: PR #5101 (composition-series character-additivity infrastructure) and PR #5104 (issue #5100, the extractor tail). Verification this session: `lake build` succeeds (0 sorries, style warnings only), axioms are `[propext, Classical.choice, Quot.sound]`, and the 57-module transitive import closure contains no `DetInvElim` file. The landed theorem is cleaner than the issue's draft signature, dropping the unused `n : ℕ` parameter and the `h_homog` hypothesis while remaining a drop-in for the #5076 part-(a) call site. No code change is needed; this adds only the progress file.

Closes #5082

Session: `15c87a26-909a-40e5-b247-b7f2ee9d5c9c`

🤖 Prepared with Claude Code