### PR TITLE
feat(Ch2 2.15.1h-k): sorry-free Casimir eigenvalue toolkit for sl₂ complete reducibility

### DIFF
--- a/EtingofRepresentationTheory/Chapter2.lean
+++ b/EtingofRepresentationTheory/Chapter2.lean
@@ -1,6 +1,7 @@
 -- Section 2.1: Overview and Classification Theorems
 import EtingofRepresentationTheory.Chapter2.Sl2Defs
 import EtingofRepresentationTheory.Chapter2.Sl2Irrep
+import EtingofRepresentationTheory.Chapter2.Problem2_15_1_complete_reducibility
 import EtingofRepresentationTheory.Chapter2.Problem2_15_1_l
 import EtingofRepresentationTheory.Chapter2.Problem2_15_1_m
 import EtingofRepresentationTheory.Chapter2.Problem2_15_1_m_Module

--- a/EtingofRepresentationTheory/Chapter2/Problem2_15_1_complete_reducibility.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_15_1_complete_reducibility.lean
@@ -1,0 +1,149 @@
+import Mathlib.Algebra.Lie.OfAssociative
+import Mathlib.Algebra.Lie.Submodule
+import Mathlib.LinearAlgebra.Dimension.Finite
+import EtingofRepresentationTheory.Chapter2.Sl2Irrep
+
+/-!
+# Complete reducibility of finite-dimensional `sl(2)`-representations (Problem 2.15.1(h)–(k))
+
+Etingof Problem 2.15.1(h)–(k) proves **Weyl's complete-reducibility theorem for
+`sl(2)`**: every finite-dimensional representation of `sl(2)` is a direct sum of
+the irreducibles `V_λ`. The book gives the elementary **Casimir argument** (not the
+general Weyl theorem, which is not in Mathlib):
+
+* **(h)** On an indecomposable `V`, the Casimir `C = EF + FE + H²/2` has a single
+  eigenvalue `λ(λ+2)/2` for some `λ ∈ ℕ` (generalized eigenspaces of the central
+  element `C` are subrepresentations, so an indecomposable `V` lives in one block).
+* **(i)** `V` has a subrep `W ≅ V_λ` with `V/W ≅ n·V_λ` (use (h) + a minimal
+  counterexample).
+* **(j)** the `H`-eigenspace `V(λ)` is `(n+1)`-dimensional, and `{Fʲvᵢ}` is a basis
+  of `V`. The key sub-lemma: if `Fx = 0` and `Hx = μx` with `x ≠ 0`, then
+  `Cx = μ(μ-2)/2 · x`, which forces `μ = -λ` (the lowest weight is `-λ`).
+* **(k)** `Wᵢ = span(vᵢ, Fvᵢ, …, F^λ vᵢ)` are subreps with `V = ⊕Wᵢ`, each `≅ V_λ`,
+  contradicting indecomposability unless `n = 0`, i.e. `V` is irreducible.
+
+## What is in this file
+
+The reusable **Casimir eigenvalue toolkit** at the level of an *arbitrary*
+`sl(2)`-module `M` (operators `E = ⁅sl2_e, ·⁆`, `F = ⁅sl2_f, ·⁆`, `H = ⁅sl2_h, ·⁆`):
+
+* `casimir M : Module.End ℂ M`, the Casimir operator `C = EF + FE + H²/2`, with its
+  unfolding `casimir_apply`.
+* `casimir_highest_weight`: on a highest-weight vector (`Ex = 0`, `Hx = μx`),
+  `Cx = μ(μ+2)/2 · x`. This is the general-module form of `casimir_eq_scalar_lambda`
+  and of `casimir_cgHW`, and is the input to (h)/(i).
+* `casimir_lowest_weight`: on a lowest-weight vector (`Fx = 0`, `Hx = μx`),
+  `Cx = μ(μ-2)/2 · x`. This is **the key sub-lemma of (j)** (the book's
+  "if `Fx = 0` and `Hx = μx` then `Cx = μ(μ-2)/2·x`").
+
+The final complete-reducibility statement `complete_reducibility` is recorded here
+in its cleanest equivalent form — *every `sl(2)`-submodule of a finite-dimensional
+module has an `sl(2)`-complement* — with the proof left as `sorry` pending the
+(h)–(k) assembly, which is being tracked as dependency-ordered follow-up issues.
+
+The Casimir computations rely only on the `sl(2)`-triple bracket relations
+`⁅E,F⁆ = H`, `⁅H,E⁆ = 2E`, `⁅H,F⁆ = -2F` (`Sl2Irrep.lie_e_f` etc.) and the Leibniz
+rule, so they hold for *any* `sl(2)`-module, finite-dimensional or not.
+-/
+
+open Etingof Etingof.Sl2Irrep
+
+namespace Etingof.Sl2Irrep
+
+section Casimir
+
+variable {M : Type*} [AddCommGroup M] [Module ℂ M]
+  [LieRingModule sl2 M] [LieModule ℂ sl2 M]
+
+/-- **The Casimir operator `C = EF + FE + H²/2`** on an arbitrary `sl(2)`-module `M`,
+where `E = ⁅sl2_e, ·⁆`, `F = ⁅sl2_f, ·⁆`, `H = ⁅sl2_h, ·⁆` are the actions of the
+standard `sl(2)`-triple. It is a genuine element of `Module.End ℂ M`, built from the
+Lie-module structure map `LieModule.toEnd`. -/
+noncomputable def casimir (M : Type*) [AddCommGroup M] [Module ℂ M]
+    [LieRingModule sl2 M] [LieModule ℂ sl2 M] : Module.End ℂ M :=
+  LieModule.toEnd ℂ sl2 M sl2_e * LieModule.toEnd ℂ sl2 M sl2_f
+    + LieModule.toEnd ℂ sl2 M sl2_f * LieModule.toEnd ℂ sl2 M sl2_e
+    + (2⁻¹ : ℂ) • (LieModule.toEnd ℂ sl2 M sl2_h * LieModule.toEnd ℂ sl2 M sl2_h)
+
+/-- Unfolding the Casimir operator into iterated brackets:
+`C x = ⁅E, ⁅F, x⁆⁆ + ⁅F, ⁅E, x⁆⁆ + ½ ⁅H, ⁅H, x⁆⁆`. -/
+theorem casimir_apply (x : M) :
+    casimir M x = ⁅sl2_e, ⁅sl2_f, x⁆⁆ + ⁅sl2_f, ⁅sl2_e, x⁆⁆
+      + (2⁻¹ : ℂ) • ⁅sl2_h, ⁅sl2_h, x⁆⁆ := by
+  simp only [casimir, LinearMap.add_apply, Module.End.mul_apply, LinearMap.smul_apply,
+    LieModule.toEnd_apply_apply]
+
+/-- **Casimir scalar on a highest-weight vector (the (g)/(h) input).** If `x` is killed
+by the raising operator `E` and is an `H`-eigenvector of weight `μ`, then the Casimir
+operator acts on `x` by the scalar `μ(μ+2)/2`.
+
+This is the general-`sl(2)`-module form of `casimir_eq_scalar_lambda` (which is the
+special case `M = V_λ`, `μ = λ`) and of `casimir_cgHW`. -/
+theorem casimir_highest_weight (μ : ℂ) (x : M) (hE : ⁅sl2_e, x⁆ = 0)
+    (hH : ⁅sl2_h, x⁆ = μ • x) :
+    casimir M x = ((μ * (μ + 2)) / 2) • x := by
+  -- `EF·x = ⁅⁅E,F⁆, x⁆ + ⁅F, E·x⁆ = ⁅H, x⁆ = μ·x` (Leibniz, `⁅E,F⁆ = H`, `E·x = 0`).
+  have hEF : ⁅sl2_e, ⁅sl2_f, x⁆⁆ = μ • x := by
+    rw [leibniz_lie sl2_e sl2_f x, lie_e_f, hH, hE, lie_zero, add_zero]
+  -- `FE·x = ⁅F, E·x⁆ = 0`.
+  have hFE : ⁅sl2_f, ⁅sl2_e, x⁆⁆ = 0 := by rw [hE, lie_zero]
+  -- `H²·x = μ²·x`.
+  have hHH : ⁅sl2_h, ⁅sl2_h, x⁆⁆ = (μ * μ) • x := by rw [hH, lie_smul, hH, smul_smul]
+  rw [casimir_apply, hEF, hFE, hHH, add_zero, smul_smul, ← add_smul]
+  congr 1
+  ring
+
+/-- **Casimir scalar on a lowest-weight vector — the key sub-lemma of Problem 2.15.1(j).**
+If `x` is killed by the lowering operator `F` and is an `H`-eigenvector of weight `μ`,
+then the Casimir operator acts on `x` by the scalar `μ(μ-2)/2`.
+
+In the book this is "if `Fx = 0` and `Hx = μx` (with `x ≠ 0`) then `Cx = μ(μ-2)/2·x`",
+the identity used to pin the lowest weight of `V_λ` to `μ = -λ`. -/
+theorem casimir_lowest_weight (μ : ℂ) (x : M) (hF : ⁅sl2_f, x⁆ = 0)
+    (hH : ⁅sl2_h, x⁆ = μ • x) :
+    casimir M x = ((μ * (μ - 2)) / 2) • x := by
+  -- `EF·x = ⁅E, F·x⁆ = 0`.
+  have hEF : ⁅sl2_e, ⁅sl2_f, x⁆⁆ = 0 := by rw [hF, lie_zero]
+  -- `FE·x = -μ·x`: from Leibniz, `0 = EF·x = ⁅H, x⁆ + FE·x = μ·x + FE·x`.
+  have hFE : ⁅sl2_f, ⁅sl2_e, x⁆⁆ = -(μ • x) := by
+    have h := leibniz_lie sl2_e sl2_f x
+    rw [lie_e_f, hH, hEF] at h
+    exact eq_neg_of_add_eq_zero_right h.symm
+  -- `H²·x = μ²·x`.
+  have hHH : ⁅sl2_h, ⁅sl2_h, x⁆⁆ = (μ * μ) • x := by rw [hH, lie_smul, hH, smul_smul]
+  rw [casimir_apply, hEF, hFE, hHH, zero_add, smul_smul, ← neg_smul, ← add_smul]
+  congr 1
+  ring
+
+end Casimir
+
+/-! ## The complete-reducibility conclusion
+
+The statement of complete reducibility, recorded in its cleanest equivalent form for a
+finite-dimensional module: every `sl(2)`-submodule has an `sl(2)`-complement (this is
+the meaning of "semisimple"; for finite-dimensional modules it is equivalent to being a
+direct sum of irreducibles, hence of `V_λ`'s by the classification (f)). The proof, by
+the book's Casimir argument (h)–(k), is left as `sorry` and tracked as follow-up. -/
+
+section CompleteReducibility
+
+variable {M : Type*} [AddCommGroup M] [Module ℂ M] [FiniteDimensional ℂ M]
+  [LieRingModule sl2 M] [LieModule ℂ sl2 M]
+
+/-- **Complete reducibility of finite-dimensional `sl(2)`-representations
+(Problem 2.15.1(h)–(k)).** Every `sl(2)`-submodule `N` of a finite-dimensional
+`sl(2)`-module `M` has an `sl(2)`-complement `N'` (`IsCompl N N'`). Equivalently, `M`
+is a direct sum of irreducible subrepresentations, each isomorphic to some `V_λ`.
+
+The intended proof is the book's elementary Casimir argument: reduce to showing an
+indecomposable finite-dimensional `sl(2)`-module is irreducible, using that the
+generalized eigenspaces of the central Casimir operator `casimir M` are
+subrepresentations (parts (h)–(k)), with `casimir_highest_weight` /
+`casimir_lowest_weight` as the eigenvalue inputs. -/
+theorem complete_reducibility (N : LieSubmodule ℂ sl2 M) :
+    ∃ N' : LieSubmodule ℂ sl2 M, IsCompl N N' := by
+  sorry
+
+end CompleteReducibility
+
+end Etingof.Sl2Irrep

--- a/progress/2026-06-26T04-14-19Z_5c67567f.md
+++ b/progress/2026-06-26T04-14-19Z_5c67567f.md
@@ -1,0 +1,47 @@
+## Accomplished
+
+One-shot session on #5311 (Problem 2.15.1(h)–(k): complete reducibility of
+finite-dimensional `sl(2)`-representations).
+
+Created `Chapter2/Problem2_15_1_complete_reducibility.lean` (added to the Chapter2
+aggregator) with the reusable **general-`sl(2)`-module Casimir eigenvalue toolkit** —
+the genuine tools the book's (h)–(k) build on, all sorry-free:
+
+- `casimir M : Module.End ℂ M` (= `EF + FE + H²/2`, via `LieModule.toEnd`), plus its
+  bracket unfolding `casimir_apply`.
+- `casimir_highest_weight`: `Ex = 0`, `Hx = μx` ⟹ `Cx = μ(μ+2)/2·x`. General-module
+  form of the existing `casimir_eq_scalar_lambda` / `casimir_cgHW`. Input to (h)/(i).
+- `casimir_lowest_weight`: `Fx = 0`, `Hx = μx` ⟹ `Cx = μ(μ-2)/2·x`. **The key
+  sub-lemma of (j)** (pins the lowest weight of `V_λ` to `μ = -λ`).
+
+Verified sorry-free via `#print axioms` (only `propext`/`Classical.choice`/`Quot.sound`).
+
+The final `complete_reducibility` theorem is stated in its cleanest equivalent
+semisimple form — *every `sl(2)`-submodule of a finite-dimensional module has an
+`sl(2)`-complement* — and left `sorry` pending the (h)–(k) assembly.
+
+## Current frontier
+
+The (h)–(k) assembly. Decomposed into dependency-ordered sub-issues (see breadcrumb on
+#5311): Casimir centrality → (h) single eigenvalue on an indecomposable → (i)+(j)+(k)
+indecomposable ⟹ irreducible → assemble `complete_reducibility`.
+
+## Overall project progress
+
+Stage 3 (formalization). Ch2 2.15.1 backbone: irreps `V_λ` (Sl2Irrep), classification
+(f) (#5285), Casimir eigenvalue on `V_λ` (g) (#5281), Jacobson–Morozov single Jordan
+block (l) (#5313), Clebsch–Gordan (m) module ladder (#5307). This adds the
+general-module Casimir toolkit for (h)–(k). The full Weyl complete-reducibility
+conclusion remains a multi-session build (one `sorry`).
+
+## Next step
+
+Pick up the sub-issues in order: start with **Casimir centrality** (small, no deps),
+then **(h)**. Centrality + Mathlib's generalized-eigenspace API (`Module.End`
+`maxGenEigenspace`, central-element invariance) gives (h)'s "generalized eigenspaces are
+subreps, indecomposable ⟹ one block".
+
+## Blockers
+
+None for the landed toolkit. The remaining `sorry` is genuine multi-session work, now
+decomposed.


### PR DESCRIPTION
Partial progress on #5311

Session: `5c67567f-8ded-4291-88d1-a6d1cefd32c4`

d6f9f84f progress(5311): Casimir toolkit landed; (h)-(k) decomposed into #5315-#5318
f77acd66 feat(Ch2 2.15.1h-k): Casimir eigenvalue toolkit for sl₂ complete reducibility

🤖 Prepared with Claude Code