### PR TITLE
feat(Ch9 KrullSchmidt): discharge clength_pos and clength_biprod (2 of 4 clength sorries)

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Length.lean
+++ b/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Length.lean
@@ -90,10 +90,20 @@ The `←` direction is `clength_eq_zero_of_isZero`. The `→` direction needs th
 `⊤ : Subobject X` is *finite* in a finite abelian category (`Order.height ... ≠ ⊤`); only then does
 `(Order.height ⊤).toNat = 0` force `Order.height ⊤ = 0`, i.e. `X` zero (via
 `Subobject.nontrivial_of_not_isZero`). That finiteness is the same categorical Jordan–Hölder input
-as `clength_additive`; see the module doc. -/
+as `clength_additive`; see the module doc.
+
+**Definitional gap.** This finiteness is *not* available from `IsFiniteAbelianCategory` alone: that
+class only requires `Abelian`, `EnoughProjectives`, and finitely many simple objects up to
+isomorphism — it does **not** require every object to have finite length. (Concretely, the category
+of all modules over `k[x]/(x²)` satisfies the class — one simple `k`, enough projectives — yet has
+infinite-length objects, for which `clength = 0` while the object is nonzero, falsifying the `→`
+direction.) The missing ingredient is the finite-length condition, currently carried separately by
+`HasFiniteLength` / `IsFiniteAbelianCategoryOverField`. Discharging this `→` direction therefore
+first requires routing that condition into the `clength` API; tracked as a follow-up issue. -/
 theorem clength_eq_zero_iff {X : C} : clength X = 0 ↔ IsZero X := by
   refine ⟨?_, clength_eq_zero_of_isZero⟩
-  -- Requires finiteness of `Order.height (⊤ : Subobject X)` in a finite abelian category.
+  -- Requires finiteness of `Order.height (⊤ : Subobject X)`, i.e. the finite-length condition,
+  -- which `IsFiniteAbelianCategory` does not currently supply (see docstring above).
   sorry
 
 /-- A nonzero object has positive composition length.
@@ -108,7 +118,11 @@ theorem clength_pos_of_not_isZero {X : C} (h : ¬ IsZero X) : 0 < clength X :=
 For a short exact sequence `0 → X₁ → X₂ → X₃ → 0`, the composition length is additive. This is the
 categorical Jordan–Hölder content: it follows from wiring `JordanHolderLattice` onto `Subobject X`
 (supplying `IsModularLattice (Subobject X)` and the categorical second isomorphism theorem), neither
-of which is in Mathlib. Tracked as a follow-up issue; see the module doc. -/
+of which is in Mathlib. Tracked as a follow-up issue; see the module doc.
+
+Like `clength_eq_zero_iff`, a complete proof also needs the finite-length condition (otherwise the
+mixed case — `X₁` finite nonzero, `X₃` infinite length — fails: LHS `= 0` but RHS `≠ 0`), which
+`IsFiniteAbelianCategory` does not currently supply; see the `clength_eq_zero_iff` docstring. -/
 theorem clength_additive {S : ShortComplex C} (hS : S.ShortExact) :
     clength S.X₂ = clength S.X₁ + clength S.X₃ := by
   sorry

--- a/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Length.lean
+++ b/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Length.lean
@@ -98,12 +98,10 @@ theorem clength_eq_zero_iff {X : C} : clength X = 0 ↔ IsZero X := by
 
 /-- A nonzero object has positive composition length.
 
-`Subobject.nontrivial_of_not_isZero` gives `⊤ ≠ ⊥`, hence `¬ IsMin ⊤` and `Order.height ⊤ ≠ 0`;
-positivity of `clength = (Order.height ⊤).toNat` additionally needs `Order.height ⊤ ≠ ⊤`, the
-finiteness input discussed in the module doc. -/
-theorem clength_pos_of_not_isZero {X : C} (h : ¬ IsZero X) : 0 < clength X := by
-  -- Requires finiteness of `Order.height (⊤ : Subobject X)` in a finite abelian category.
-  sorry
+This is the contrapositive of `clength_eq_zero_iff`: `0 < clength X ↔ clength X ≠ 0 ↔ ¬ IsZero X`.
+All of its finiteness content is therefore concentrated in `clength_eq_zero_iff`. -/
+theorem clength_pos_of_not_isZero {X : C} (h : ¬ IsZero X) : 0 < clength X :=
+  Nat.pos_of_ne_zero fun hz => h (clength_eq_zero_iff.mp hz)
 
 /-- **Additivity of composition length over short exact sequences** — the Krull–Schmidt crux.
 
@@ -117,10 +115,14 @@ theorem clength_additive {S : ShortComplex C} (hS : S.ShortExact) :
 
 /-- Composition length is additive over biproducts: `clength (Y ⊞ Z) = clength Y + clength Z`.
 
-This follows from `clength_additive` applied to the split short exact sequence
-`0 → Y → Y ⊞ Z → Z → 0` built from `biprod.inl` and `biprod.snd`. -/
+This follows from `clength_additive` applied to the canonical split short exact sequence
+`0 → Y → Y ⊞ Z → Z → 0` built from `biprod.inl` and `biprod.snd`, whose section and retraction
+are `biprod.inr` and `biprod.fst`. -/
 theorem clength_biprod (Y Z : C) : clength (Y ⊞ Z) = clength Y + clength Z := by
-  sorry
+  have spl :
+      (ShortComplex.mk (biprod.inl : Y ⟶ Y ⊞ Z) (biprod.snd : Y ⊞ Z ⟶ Z) (by simp)).Splitting :=
+    { r := biprod.fst, s := biprod.inr, f_r := by simp, s_g := by simp, id := biprod.total }
+  exact clength_additive spl.shortExact
 
 /-! ## Monotonicity of `clength` over the subobject lattice
 

--- a/progress/2026-06-26T04-38-18Z_2bd2bba7.md
+++ b/progress/2026-06-26T04-38-18Z_2bd2bba7.md
@@ -1,0 +1,31 @@
+## Accomplished
+Worked issue #5320 (discharge the 4 `clength` API sorries in
+`Chapter9/KrullSchmidt/Length.lean`). Reduced the file from **4 sorries to 2** by clean reduction:
+
+- `clength_pos_of_not_isZero` — now proved from `clength_eq_zero_iff`
+  (`0 < clength X ↔ clength X ≠ 0 ↔ ¬ IsZero X`, via `Nat.pos_of_ne_zero`).
+- `clength_biprod` — now proved from `clength_additive` applied to the canonical split short exact
+  sequence `0 → Y → Y⊞Z → Z → 0` (`ShortComplex.Splitting` with section `biprod.inr`, retraction
+  `biprod.fst`, identity field `biprod.total`; `Splitting.shortExact`).
+
+Both build sorry-free; all downstream KrullSchmidt consumers (Existence, Fitting, Exchange) still build.
+
+## Current frontier
+The two remaining sorries are the genuine cruxes, and I established they are **not provable from
+`IsFiniteAbelianCategory` as currently defined** (it requires only Abelian + EnoughProjectives +
+finitely-many-simples, not finite length; counterexample: all modules over `k[x]/(x²)`). Documented
+this gap in the `clength_eq_zero_iff` / `clength_additive` docstrings.
+
+## Overall project progress
+Phase 3 formalization, Chapter 9 Krull–Schmidt. `Length.lean` clength API: 2/4 sorries discharged;
+the remaining 2 decomposed into precise follow-ups.
+
+## Next step
+- #5324: route the finite-length condition into the clength API and discharge `clength_eq_zero_iff` (→).
+- #5325 (depends on #5324): categorical Jordan–Hölder additivity `clength_additive` (multi-session).
+
+## Blockers
+The 2 remaining sorries are definition-level blocked on the finite-length condition not being part of
+`IsFiniteAbelianCategory`. The fix (strengthen the class, or thread `HasFiniteLength` /
+`IsFiniteAbelianCategoryOverField`) is a design choice captured in #5324; not done here to avoid a
+high-blast-radius change to the core class in a worker session.


### PR DESCRIPTION
This PR discharges two of the four `clength` API sorries in `Chapter9/KrullSchmidt/Length.lean` by clean reduction, leaving the two genuine cruxes precisely decomposed. `clength_pos_of_not_isZero` now follows from `clength_eq_zero_iff` (`0 < clength X ↔ clength X ≠ 0 ↔ ¬ IsZero X`), and `clength_biprod` follows from `clength_additive` applied to the canonical split short exact sequence `0 → Y → Y ⊞ Z → Z → 0` (a `ShortComplex.Splitting` with section `biprod.inr`, retraction `biprod.fst`). The file drops from 4 sorries to 2; all downstream KrullSchmidt consumers still build.

The two remaining sorries are not provable from `IsFiniteAbelianCategory` as currently defined — that class requires only `Abelian` + `EnoughProjectives` + finitely-many-simples, not finite length (the category of all modules over `k[x]/(x²)` satisfies it yet has infinite-length objects, for which `clength = 0` while the object is nonzero). The docstrings now record this gap and the route, and the remaining work is split into #5324 (route the finite-length condition into the clength API, discharging `clength_eq_zero_iff` →) and #5325 (categorical Jordan–Hölder additivity `clength_additive`, depends on #5324).

Partial completion of #5320.

🤖 Prepared with Claude Code