### PR TITLE
This PR upgrades Etingof Theorem 3.7.1 (Jordan-Hölder) so the named theorem captures the full book statement instead of only the equal-length half. `Etingof.jordan_holder` previously projected `.length_eq` from `CompositionSeries.jordan_holder`, discarding the composition-factor equivalence that is the substance of the theorem.

It adds `Etingof.compositionFactor` (the i-th successive quotient), `Etingof.jordan_holder_equivalent` (returns the full `s₁.Equivalent s₂`), and `Etingof.jordan_holder_factors` (the explicit `∃ σ : Fin n ≃ Fin m, ∀ i, Nonempty (Wᵢ ≃ₗ[A] W'_{σ i})` matching the book's permutation statement), while retaining `Etingof.jordan_holder` as the `n = m` length half derived from the equivalence. Builds sorry-free; `#print axioms` shows only the standard three. No downstream consumers, so the change is non-breaking.

Closes #5328

🤖 Prepared with Claude Code

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/Theorem3_7_1.lean
+++ b/EtingofRepresentationTheory/Chapter3/Theorem3_7_1.lean
@@ -23,18 +23,56 @@ quotients being simple modules). The theorem `CompositionSeries.jordan_holder` t
 both equal lengths and a permutation of composition factors.
 -/
 
-/-- The Jordan-Hölder theorem for modules: any two composition series of the same module
-(from ⊥ to ⊤) have the same length and isomorphic composition factors up to permutation.
-Etingof Theorem 3.7.1.
+/-- The `i`-th composition factor of a composition series `s` of submodules of `V`:
+the quotient `s(i+1) / s(i)` of two consecutive (covering) terms. This is the module
+`Wᵢ := Vᵢ/Vᵢ₋₁` of Etingof's filtration, realized as a quotient of the submodule
+`s(i+1)` by the image of `s(i)` inside it.
+
+`Mathlib`'s `JordanHolderModule.instJordanHolderLattice` uses exactly this quotient as the
+`Iso` relation on covering pairs, so the Jordan-Hölder equivalence
+(`CompositionSeries.jordan_holder`) is phrased in terms of `Nonempty (factor _ ≃ₗ factor _)`. -/
+noncomputable abbrev Etingof.compositionFactor {A V : Type*}
+    [Ring A] [AddCommGroup V] [Module A V]
+    (s : CompositionSeries (Submodule A V)) (i : Fin s.length) : Type _ :=
+  s i.succ ⧸ (s i.castSucc).comap (s i.succ).subtype
+
+/-- The **Jordan-Hölder theorem** for modules, full statement (Etingof Theorem 3.7.1):
+any two composition series of the same module (from ⊥ to ⊤) are *equivalent* — there is a
+bijection `σ` between their index sets such that the `i`-th composition factor of the
+first is linearly isomorphic to the `σ i`-th composition factor of the second.
 
 A `CompositionSeries (Submodule A V)` is a `RelSeries` where consecutive submodules are
 related by `⋖` (the covering relation), which is equivalent to requiring successive
 quotients to be simple (irreducible) modules. -/
+theorem Etingof.jordan_holder_equivalent (A : Type*) (V : Type*)
+    [Ring A] [AddCommGroup V] [Module A V]
+    (s₁ s₂ : CompositionSeries (Submodule A V))
+    (hs₁_bot : s₁.head = ⊥) (hs₁_top : s₁.last = ⊤)
+    (hs₂_bot : s₂.head = ⊥) (hs₂_top : s₂.last = ⊤) :
+    s₁.Equivalent s₂ :=
+  CompositionSeries.jordan_holder s₁ s₂
+    (by rw [hs₁_bot, hs₂_bot]) (by rw [hs₁_top, hs₂_top])
+
+/-- The factor-isomorphism half of Jordan-Hölder (Etingof Theorem 3.7.1): there exists a
+permutation `σ` of the index set such that the `i`-th composition factor `Wᵢ` of `s₁` is
+isomorphic to the `σ i`-th composition factor `W'_{σ i}` of `s₂`. This is the substance of
+the theorem — "there exists a permutation σ such that `W_{σ(i)}` is isomorphic to `W'ᵢ`". -/
+theorem Etingof.jordan_holder_factors (A : Type*) (V : Type*)
+    [Ring A] [AddCommGroup V] [Module A V]
+    (s₁ s₂ : CompositionSeries (Submodule A V))
+    (hs₁_bot : s₁.head = ⊥) (hs₁_top : s₁.last = ⊤)
+    (hs₂_bot : s₂.head = ⊥) (hs₂_top : s₂.last = ⊤) :
+    ∃ σ : Fin s₁.length ≃ Fin s₂.length, ∀ i : Fin s₁.length,
+      Nonempty (Etingof.compositionFactor s₁ i ≃ₗ[A] Etingof.compositionFactor s₂ (σ i)) :=
+  Etingof.jordan_holder_equivalent A V s₁ s₂ hs₁_bot hs₁_top hs₂_bot hs₂_top
+
+/-- The Jordan-Hölder theorem for modules, length half (Etingof Theorem 3.7.1): any two
+composition series of the same module (from ⊥ to ⊤) have the same length, so `n = m`.
+This follows from the full equivalence `Etingof.jordan_holder_equivalent`. -/
 theorem Etingof.jordan_holder (A : Type*) (V : Type*)
     [Ring A] [AddCommGroup V] [Module A V]
     (s₁ s₂ : CompositionSeries (Submodule A V))
     (hs₁_bot : s₁.head = ⊥) (hs₁_top : s₁.last = ⊤)
     (hs₂_bot : s₂.head = ⊥) (hs₂_top : s₂.last = ⊤) :
     s₁.length = s₂.length :=
-  (CompositionSeries.jordan_holder s₁ s₂
-    (by rw [hs₁_bot, hs₂_bot]) (by rw [hs₁_top, hs₂_top])).length_eq
+  (Etingof.jordan_holder_equivalent A V s₁ s₂ hs₁_bot hs₁_top hs₂_bot hs₂_top).length_eq

--- a/progress/2026-06-26T05-10-00Z_5328.md
+++ b/progress/2026-06-26T05-10-00Z_5328.md
@@ -1,0 +1,37 @@
+## Accomplished
+Worked issue #5328 (Jordan-Hölder Theorem 3.7.1 proved only equal length, dropping the
+composition-factor isomorphism — the mathematical substance of the theorem).
+
+Upgraded `EtingofRepresentationTheory/Chapter3/Theorem3_7_1.lean` so the named theorem now
+captures **both** halves of the book statement ("n = m, and there exists a permutation σ
+such that W_{σ(i)} ≅ W'ᵢ"):
+
+- `Etingof.compositionFactor s i` — abbrev for the `i`-th successive quotient
+  `s(i+1) / s(i)`, matching the quotient that `JordanHolderModule.instJordanHolderLattice`
+  uses for its `Iso` relation.
+- `Etingof.jordan_holder_equivalent` — returns the full `s₁.Equivalent s₂` from
+  `CompositionSeries.jordan_holder` (previously discarded by projecting `.length_eq`).
+- `Etingof.jordan_holder_factors` — the substance: `∃ σ : Fin n ≃ Fin m, ∀ i,
+  Nonempty (compositionFactor s₁ i ≃ₗ[A] compositionFactor s₂ (σ i))`. Term-mode proof,
+  defeq to the `Equivalent` existential.
+- `Etingof.jordan_holder` — retained as the length half (`n = m`), now derived from the
+  full equivalence via `.length_eq`.
+
+Build: `lake build EtingofRepresentationTheory.Chapter3.Theorem3_7_1` succeeds.
+Sorry-free; `#print axioms` on both new theorems shows only `[propext, Classical.choice,
+Quot.sound]`. No downstream consumers of `Etingof.jordan_holder` (only a doc reference in
+Chapter9/KrullSchmidt/Length.lean), so the addition is non-breaking.
+
+## Current frontier
+Theorem 3.7.1 fully formalized (both halves). Issue #5328 resolved.
+
+## Overall project progress
+Phase 3 formalization. Chapter 3 §3.7 Jordan-Hölder now states the complete theorem
+including the factor isomorphism, closing the under-formalization flagged in the red-team pass.
+
+## Next step
+Address the sibling under-formalization tracked in #5326 (same failure class), and continue
+the Chapter 9 KrullSchmidt clength follow-ups (#5324, #5325).
+
+## Blockers
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -1682,7 +1682,8 @@
     "start_line": 7,
     "end_line": 4,
     "status": "sorry_free",
-    "sorry_free": true
+    "sorry_free": true,
+    "notes": "Full theorem now exposed (#5328): jordan_holder_equivalent gives s₁.Equivalent s₂; jordan_holder_factors gives the permutation σ with Wᵢ ≅ W'_{σ i} via Etingof.compositionFactor; jordan_holder retains the n = m length half."
   },
   {
     "id": "Chapter3/Discussion_after_Theorem3.7.1",


### PR DESCRIPTION
Closes #--issue

Session: `8fc5f072-e91c-4fd2-8f48-f7f3ef801106`

cc8d75cd fix(Ch3 Theorem3.7.1): expose Jordan-Hölder composition-factor isomorphism (#5328)

🤖 Prepared with Claude Code