### PR TITLE
fix(Ch5 5.19.2): replace vacuous partition Schur-Weyl with genuine statement

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Corollary5_19_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Corollary5_19_2.lean
@@ -25,16 +25,30 @@ Lλ = Hom_{Sₙ}(Vλ, V⊗ⁿ) are distinct irreducible GL(V)-representations
 (or zero when the partition has more parts than dim V).
 
 This refines Theorem 5.18.4(iii) by identifying the indexing set
-as partitions of n.
+as partitions of n. The existential carries the genuine module-theoretic
+content: each `S p` (= `Vλ`) is a simple `symGroupImage`-module or zero,
+each `L p` (= `Lλ`) is a distinct irreducible `diagonalActionImage`-module
+or zero, and the iso decomposes `V⊗ⁿ` as `⊕_p S p ⊗ L p`. The proof
+delegates to `Theorem5_18_4_partition_decomposition`, whose `sorry` records
+the one open dependency (the Specht labelling of the simple
+`symGroupImage`-modules); see issue #5326.
 (Etingof Corollary 5.19.2) -/
 theorem Etingof.Corollary5_19_2
     {k : Type u} [Field k] [IsAlgClosed k] [CharZero k]
     {V : Type v} [AddCommGroup V] [Module k V] [Module.Finite k V]
     (n : ℕ) (hN : n ≤ Module.finrank k V) :
     ∃ (S : Nat.Partition n → Type (max u v))
-      (L : Nat.Partition n → Type u)
-      (_ : ∀ p, AddCommGroup (S p)) (_ : ∀ p, Module k (S p))
-      (_ : ∀ p, AddCommGroup (L p)) (_ : ∀ p, Module k (L p)),
+      (_ : ∀ p, AddCommGroup (S p))
+      (_ : ∀ p, Module k (S p))
+      (_ : ∀ p, Module (symGroupImage k V n) (S p))
+      (L : Nat.Partition n → Type (max u v))
+      (_ : ∀ p, AddCommGroup (L p))
+      (_ : ∀ p, Module k (L p))
+      (_ : ∀ p, Module (diagonalActionImage k V n) (L p)),
+      (∀ p, IsSimpleModule (symGroupImage k V n) (S p) ∨ Subsingleton (S p)) ∧
+      (∀ p, IsSimpleModule (diagonalActionImage k V n) (L p) ∨ Subsingleton (L p)) ∧
+      (∀ p q, ¬ Subsingleton (L p) →
+        Nonempty (L p ≃ₗ[diagonalActionImage k V n] L q) → p = q) ∧
       Nonempty (TensorPower k V n ≃ₗ[k]
         DirectSum (Nat.Partition n) (fun p => S p ⊗[k] L p)) :=
   Theorem5_18_4_partition_decomposition k V n hN

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_18_4.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_18_4.lean
@@ -330,58 +330,69 @@ theorem Theorem5_18_4_decomposition
     hV'_acg, hV'_mod, hW'_acg, hW'_mod, ⟨e⟩⟩
 
 /-- Schur-Weyl duality: partition-indexed decomposition of V^⊗n.
-This refines `Theorem5_18_4_decomposition` by re-indexing the decomposition
-by `Nat.Partition n`. Each summand `S p ⊗ L p` collects the components
-from the generic decomposition that are assigned to partition `p`.
-(Etingof Theorem 5.18.4, part iii) -/
+
+As an `(A ⊗[k] B)`-module (with `A = symGroupImage k V n` and
+`B = diagonalActionImage k V n`),
+  `V^⊗n ≅ ⨁_{λ ⊢ n} V_λ ⊗[k] L_λ`,
+where the sum ranges over partitions `λ` of `n`, each `V_λ` is the Specht
+module for `λ` (a simple `A`-module, or zero when `λ` does not appear), and
+each `L_λ` is a distinct irreducible `B`-module (an irreducible polynomial
+`GL(V)`-representation), or zero. This is the book's exact statement of
+Theorem 5.18.4(iii) / Corollary 5.19.2, indexed by `Nat.Partition n`.
+
+The existential carries the genuine content the book asserts:
+* each `S p` (= `V_λ`) carries a `Module (symGroupImage k V n)`-structure and
+  is simple or zero (`IsSimpleModule … ∨ Subsingleton`);
+* each `L p` (= `L_λ`) carries a `Module (diagonalActionImage k V n)`-structure
+  and is simple (irreducible) or zero;
+* distinct partitions give non-isomorphic nonzero `L p`;
+* the `k`-linear iso decomposes `V^⊗n` as `⨁_p S p ⊗[k] L p`.
+
+**Why a genuine restatement was needed.** The previous proof here was
+sorry-free but *vacuous*: it re-indexed the abstract decomposition along the
+constant map `fun _ => Classical.arbitrary (Nat.Partition n)` and set
+`L p := k`, collapsing all of `V^⊗n` onto one arbitrary partition with every
+other summand zero. No `Module A`, `Module B`, simplicity, or distinctness
+constraint linked `S p`/`L p` to `p`, so the statement held for *any* nonzero
+`V^⊗n` and said nothing about partitions. See issue #5326.
+
+**Proof strategy (the genuinely missing dependency).** Start from the abstract
+`Theorem5_18_4_bimodule_decomposition`, whose index set `ι` enumerates the
+distinct simple `A = symGroupImage`-modules appearing in `V^⊗n`, each with its
+`B`-module partner. The remaining content is the *Specht labelling*: over an
+algebraically closed field of characteristic 0 the simple `k[Sₙ]`-modules are
+in bijection with `Nat.Partition n` via the Specht modules
+(`Etingof.SpechtModule` / `Etingof.Theorem5_12_2_irreducible`), inducing an
+injection `ι ↪ Nat.Partition n`. Re-index the bimodule decomposition along
+this genuine labelling (zero summands on partitions outside the image) to
+obtain the statement below. Formalizing that bijection between simple
+`symGroupImage`-modules and partitions is the open piece; the proof is `sorry`
+until it lands. -/
 theorem Theorem5_18_4_partition_decomposition
     [IsAlgClosed k] [CharZero k]
     (hN : n ≤ Module.finrank k V) :
     ∃ (S : Nat.Partition n → Type (max u v))
-      (L : Nat.Partition n → Type u)
       (_ : ∀ p, AddCommGroup (S p))
       (_ : ∀ p, Module k (S p))
+      (_ : ∀ p, Module (symGroupImage k V n) (S p))
+      (L : Nat.Partition n → Type (max u v))
       (_ : ∀ p, AddCommGroup (L p))
-      (_ : ∀ p, Module k (L p)),
+      (_ : ∀ p, Module k (L p))
+      (_ : ∀ p, Module (diagonalActionImage k V n) (L p)),
+      -- each Specht summand `S p` is a simple `A`-module or zero
+      (∀ p, IsSimpleModule (symGroupImage k V n) (S p) ∨ Subsingleton (S p)) ∧
+      -- each `L p` is an irreducible `B`-module or zero
+      (∀ p, IsSimpleModule (diagonalActionImage k V n) (L p) ∨ Subsingleton (L p)) ∧
+      -- distinct partitions give non-isomorphic nonzero `L p`
+      (∀ p q, ¬ Subsingleton (L p) →
+        Nonempty (L p ≃ₗ[diagonalActionImage k V n] L q) → p = q) ∧
       Nonempty (TensorPower k V n ≃ₗ[k]
         DirectSum (Nat.Partition n)
           (fun p => S p ⊗[k] L p)) := by
-  -- Use the existing ι-indexed decomposition from Theorem 5.18.4(iii)
-  obtain ⟨ι, hι, hι_dec, S', L', hS'_acg, hS'_mod, hL'_acg, hL'_mod, ⟨e⟩⟩ :=
-    Theorem5_18_4_decomposition k V n hN
-  -- Re-index: choose any function f : ι → Nat.Partition n, then group
-  -- summands by fiber. Empty fibers contribute zero modules.
-  haveI : Nonempty (Nat.Partition n) :=
-    ⟨⟨Multiset.replicate n 1, fun {i} hi => by
-      simp [Multiset.mem_replicate] at hi; omega,
-      by simp⟩⟩
-  let f : ι → Nat.Partition n := fun _ => Classical.arbitrary _
-  -- Define S p as the fiber direct sum: ⊕_{i : f⁻¹(p)} (S' i ⊗ L' i)
-  -- Define L p = k (so S p ⊗ k ≅ S p via TensorProduct.rid)
-  let M : ι → Type (max u v) := fun i => S' i ⊗[k] L' i
-  refine ⟨fun p => DirectSum {i : ι // f i = p} (fun j => M j.val),
-          fun _ => k,
-          inferInstance, inferInstance, inferInstance, inferInstance, ⟨?_⟩⟩
-  -- Build the equivalence chain:
-  -- V⊗ⁿ ≃ ⊕_ι M ≃ ⊕_{Σ p, fiber} M ≃ ⊕_p (⊕_fiber M) ≃ ⊕_p ((⊕_fiber M) ⊗ k)
-  -- Step 2: re-index ⊕_ι M along the fiber equivalence
-  have e₂ := DirectSum.lequivCongrLeft (R := k)
-    (Equiv.sigmaFiberEquiv f).symm (M := M)
-  -- Step 3+4: sigma curry then tensor with k
-  -- sigmaLcurryEquiv : (R) → [Semiring R] → {ι} → {α : ι → Type} → {δ : (i : ι) → α i → Type} →
-  --   [DecidableEq ι] → [AddCommMonoid] → [Module] →
-  --   DirectSum (Σ x, α x) (fun i => δ i.1 i.2) ≃ₗ[R]
-  --     DirectSum ι (fun i => DirectSum (α i) (fun j => δ i j))
-  let e₃ := @DirectSum.sigmaLcurryEquiv k _ (Nat.Partition n)
-    (fun p => {j : ι // f j = p})
-    (fun p (j : {j : ι // f j = p}) => M j.val)
-    _ (fun _ _ => inferInstance) (fun _ _ => inferInstance)
-  -- Step 4: tensor with k via TensorProduct.rid
-  let e₄ := DFinsupp.mapRange.linearEquiv (R := k)
-    (fun p : Nat.Partition n => (TensorProduct.rid k
-      (DirectSum {j : ι // f j = p} (fun j => M j.val))).symm)
-  -- Now compose: V⊗ⁿ →[e] ⊕_ι M →[e₂] ⊕_Σ M →[e₃] ⊕_p(⊕_fiber M) →[e₄] ⊕_p(⊕_fiber M ⊗ k)
-  exact e.trans (e₂.trans (e₃.trans e₄))
+  -- Requires the Specht labelling of the simple `symGroupImage`-modules
+  -- (`ι ↪ Nat.Partition n`) to re-index `Theorem5_18_4_bimodule_decomposition`.
+  -- See the docstring and issue #5326.
+  sorry
 
 -- Heartbeat bumps match `Theorem5_18_1_bimodule_decomposition`: the deep
 -- `Subalgebra → Ring → Module.End` instance chain plus the `h_eq ▸` transport

--- a/progress/2026-06-26T05-10-29Z_98bd4137.md
+++ b/progress/2026-06-26T05-10-29Z_98bd4137.md
@@ -1,0 +1,55 @@
+## Accomplished
+
+Fixed issue #5326 (EGREGIOUS: vacuous partition-indexed Schur-Weyl
+decomposition). The previous `Theorem5_18_4_partition_decomposition` was a
+sorry-free proof of a *vacuous* statement: it re-indexed the abstract
+decomposition along the constant map `fun _ => Classical.arbitrary` and set
+`L p := k`, so the proposition held for any nonzero `V^⊗n` and carried none of
+the book's content (no `Module A`/`Module B` structure, no simplicity, no
+distinctness, no genuine partition labelling). The named `Corollary5_19_2`
+delegated directly to it, so the book's central Schur-Weyl decomposition was
+content-free.
+
+Rewrote both statements to carry the genuine content the book asserts, indexed
+by `Nat.Partition n`:
+* each `S p` carries `Module (symGroupImage k V n)` and is simple or zero;
+* each `L p` carries `Module (diagonalActionImage k V n)` and is irreducible or
+  zero;
+* distinct partitions give non-isomorphic nonzero `L p`;
+* a `k`-linear iso `V^⊗n ≅ ⨁_p S p ⊗[k] L p`.
+
+The proof is now an honest `sorry` (project principle: state the real theorem,
+push the sorry earlier — strictly better than a sorry-free vacuous proof). The
+docstring records the one genuinely-missing dependency: the Specht labelling of
+the simple `symGroupImage`-modules (`ι ↪ Nat.Partition n`), used to re-index
+the already-proven `Theorem5_18_4_bimodule_decomposition`.
+
+Both `Theorem5_18_4` and `Corollary5_19_2` build (the only `sorry`/warning is
+the intended one at `Theorem5_18_4.lean:371`).
+
+## Current frontier
+
+`Theorem5_18_4_partition_decomposition` statement is correct and elaborates;
+the proof is `sorry`.
+
+## Overall project progress
+
+Chapter 5 Schur-Weyl section: the abstract and bimodule decompositions
+(`Theorem5_18_4_decomposition`, `..._bimodule_decomposition`,
+`..._bimodule_decomposition_explicit`, `..._GL_rep_decomposition*`) remain
+sorry-free and carry the real module-theoretic content. Only the
+partition-labelled refinement (`..._partition_decomposition` / `Corollary5_19_2`)
+now carries an honest sorry, replacing the prior fraudulent proof.
+
+## Next step
+
+Formalize the bijection between simple `symGroupImage k V n`-modules and
+`Nat.Partition n` (via `Etingof.SpechtModule` / `Etingof.Theorem5_12_2_irreducible`),
+yielding an injection `ι ↪ Nat.Partition n`. Re-index
+`Theorem5_18_4_bimodule_decomposition` along it (zero summands outside the
+image) to discharge the `sorry` in `Theorem5_18_4_partition_decomposition`.
+
+## Blockers
+
+None. The `sorry` is an honest open dependency (Specht correspondence for the
+`symGroupImage` quotient), not a blocker on this fix.


### PR DESCRIPTION
Closes #5326

This PR replaces the vacuous partition-indexed Schur-Weyl decomposition with the book's genuine statement. The previous `Theorem5_18_4_partition_decomposition` was a sorry-free proof of a vacuous proposition: it re-indexed the abstract decomposition along the constant map `fun _ => Classical.arbitrary` and set `L p := k`, collapsing all of `V^⊗n` onto one arbitrary partition with every other summand zero. No `Module A` / `Module B` structure, simplicity, distinctness, or genuine partition labelling linked the summands to partitions, so the proposition held for any nonzero `V^⊗n` and carried none of the book's content. The named `Corollary5_19_2` delegated directly to it, leaving the central Schur-Weyl decomposition content-free.

Rewrite both `Theorem5_18_4_partition_decomposition` and `Corollary5_19_2` to carry the genuine content indexed by `Nat.Partition n`: each `S p` carries a `symGroupImage`-module structure and is simple-or-zero, each `L p` carries a `diagonalActionImage`-module structure and is irreducible-or-zero, distinct partitions give non-isomorphic nonzero `L p`, and a `k`-linear iso decomposes `V^⊗n` as `⨁_p S p ⊗ L p`. The proof becomes an honest `sorry` recording the one open dependency — the Specht labelling of the simple `symGroupImage`-modules (`ι ↪ Nat.Partition n`) used to re-index the already-proven `Theorem5_18_4_bimodule_decomposition` — per the project's spec-driven "state the theorem, push the sorry earlier" principle. This is strictly better than a sorry-free proof of a vacuous statement.

Session: `98bd4137-3fa2-4edc-a4fa-1fe542e7a614`

🤖 Prepared with Claude Code