### PR TITLE
fix(Ch5 Theorem 5.9.1): prove the Frobenius induced-character formula (replace sorry)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5.lean
+++ b/EtingofRepresentationTheory/Chapter5.lean
@@ -39,6 +39,7 @@ import EtingofRepresentationTheory.Chapter5.Definition5_8_1
 import EtingofRepresentationTheory.Chapter5.Remark5_8_2
 
 -- Section 5.9: Frobenius Formula
+import EtingofRepresentationTheory.Chapter5.TraceCoinvariants
 import EtingofRepresentationTheory.Chapter5.Theorem5_9_1
 
 -- Section 5.10: Frobenius Reciprocity

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_9_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_9_1.lean
@@ -1,5 +1,6 @@
 import Mathlib
 import EtingofRepresentationTheory.Chapter5.Definition5_8_1
+import EtingofRepresentationTheory.Chapter5.TraceCoinvariants
 
 /-!
 # Theorem 5.9.1: Frobenius Formula for Induced Characters
@@ -44,7 +45,11 @@ directly here (currently `sorry`).
 -/
 
 open Representation
+open scoped TensorProduct
 
+set_option maxHeartbeats 800000 in
+-- reason: composing `TensorProduct.map` rewrites and the tensor-trace factorisation over the
+-- large module `(G →₀ ℂ) ⊗ V` exceeds the default heartbeat budget.
 /-- **Frobenius formula** (Etingof Theorem 5.9.1, averaged form).
 
 The character of the induced representation `Ind_H^G V` at `g` equals the
@@ -67,13 +72,61 @@ theorem Etingof.Theorem5_9_1
             if h : x * g * x⁻¹ ∈ H then
               LinearMap.trace ℂ V (ρ ⟨x * g * x⁻¹, h⟩)
             else 0 := by
-  -- Proof strategy (Etingof, Discussion proof of Theorem 5.9.1):
-  --   Decompose `Ind_H^G V = ⨁_σ V_σ` over right cosets `σ ∈ H\G`, where
-  --   `V_σ = {f ∈ Ind V | f(g) = 0 ∀ g ∉ σ}`. Then `χ(g) = Σ_σ χ_σ(g)`, the
-  --   sum of diagonal block traces. A coset summand contributes `0` unless
-  --   `σ g = σ`; when `σ g = σ`, writing `x_σ g = h x_σ` with
-  --   `h = x_σ g x_σ⁻¹ ∈ H`, the map `α : V_σ → V`, `α(f) = f(x_σ)` is an
-  --   isomorphism intertwining `g` on `V_σ` with `ρ(h)` on `V`, so
-  --   `χ_σ(g) = χ_V(x_σ g x_σ⁻¹)`. Summing and averaging over the `|H|`
-  --   elements of each coset yields the stated formula.
-  sorry
+  -- We use the averaged form directly, via the abstract trace-on-coinvariants identity
+  -- `Etingof.trace_coinvariantsMap`. The induced representation is `Coinvariants τ` for
+  -- `τ = (left regular on ℂ[G]) ⊗ ρ` restricted to `H`, and `Ind_H^G ρ g` is the descent of
+  -- the right-shift `Ψ : single x ⊗ v ↦ single (x g⁻¹) ⊗ v` on `ℂ[G] ⊗ V`. The crux lemma gives
+  --   `χ(g) = (1/|H|) Σ_{h∈H} tr_{ℂ[G]⊗V}(τ(h) ∘ Ψ)`.
+  -- Each summand factors as a tensor trace: `τ(h) ∘ Ψ = (single x ↦ single (h x g⁻¹)) ⊗ ρ(h)`,
+  -- whose ℂ[G]-trace counts `{x : h x g⁻¹ = x} = {x : x g x⁻¹ = h}`. Summing over `h ∈ H` and
+  -- swapping the order of summation collapses each `x` to the single eigenvalue `tr_V ρ(x g x⁻¹)`
+  -- (when `x g x⁻¹ ∈ H`), giving the averaged Frobenius formula.
+  classical
+  haveI : Invertible (Fintype.card H : ℂ) :=
+    invertibleOfNonzero (by exact_mod_cast (Fintype.card_pos (α := H)).ne')
+  -- `Ind_H^G ρ g` is the descent of the right-shift `Ψ` to the coinvariants `Coinvariants τ`,
+  -- so the crux lemma applies.
+  rw [show Etingof.Definition5_8_1 H ρ g = Representation.ind H.subtype ρ g from rfl,
+    Representation.ind_apply, Etingof.trace_coinvariantsMap]
+  congr 1
+  set τ : Representation ℂ H ((G →₀ ℂ) ⊗[ℂ] V) :=
+    Representation.tprod ((Representation.leftRegular ℂ G).comp H.subtype) ρ with hτ
+  -- `τ h` as a tensor product of the (left-regular shift, `ρ h`).
+  have hτh : ∀ h : H,
+      τ h = TensorProduct.map (Representation.leftRegular ℂ G (↑h : G)) (ρ h) := by
+    intro h; rw [hτ, Representation.tprod_apply]; rfl
+  -- The shift on `ℂ[G]` commutes with left-translation by `↑h`.
+  have hshift : ∀ h : H,
+      Representation.leftRegular ℂ G (↑h : G) ∘ₗ Finsupp.lmapDomain ℂ ℂ (· * g⁻¹)
+        = Finsupp.lmapDomain ℂ ℂ (fun x => (↑h : G) * x * g⁻¹) := by
+    intro h
+    refine Finsupp.lhom_ext fun y r => ?_
+    simp [Representation.leftRegular, Representation.ofMulAction_single,
+      Finsupp.lmapDomain_apply, Finsupp.mapDomain_single, mul_assoc]
+  -- Compute each twisted trace as a tensor trace.
+  have hper : ∀ h : H,
+      LinearMap.trace ℂ ((G →₀ ℂ) ⊗[ℂ] V)
+          (τ h ∘ₗ (Finsupp.lmapDomain ℂ ℂ (· * g⁻¹)).rTensor V)
+        = (∑ x : G, if (↑h : G) * x * g⁻¹ = x then (1 : ℂ) else 0)
+            * LinearMap.trace ℂ V (ρ h) := by
+    intro h
+    have hmap : τ h ∘ₗ (Finsupp.lmapDomain ℂ ℂ (· * g⁻¹)).rTensor V
+        = TensorProduct.map (Finsupp.lmapDomain ℂ ℂ (fun x => (↑h : G) * x * g⁻¹)) (ρ h) := by
+      rw [hτh h, LinearMap.rTensor_def, ← TensorProduct.map_comp, hshift h, LinearMap.comp_id]
+    rw [hmap, LinearMap.trace_tensorProduct', Etingof.trace_lmapDomain]
+  rw [Finset.sum_congr rfl (fun h _ => hper h)]
+  -- Distribute, swap the order of summation, and collapse each fibre.
+  simp_rw [Finset.sum_mul]
+  rw [Finset.sum_comm]
+  refine Finset.sum_congr rfl fun x _ => ?_
+  have hcollapse : ∀ h : H,
+      (if (↑h : G) * x * g⁻¹ = x then (1 : ℂ) else 0) * LinearMap.trace ℂ V (ρ h)
+        = if (↑h : G) = x * g * x⁻¹ then LinearMap.trace ℂ V (ρ h) else 0 := by
+    intro h
+    have hiff : ((↑h : G) * x * g⁻¹ = x) ↔ ((↑h : G) = x * g * x⁻¹) := by
+      rw [mul_inv_eq_iff_eq_mul, eq_mul_inv_iff_mul_eq]
+    by_cases hc : (↑h : G) = x * g * x⁻¹
+    · rw [if_pos (hiff.mpr hc), if_pos hc, one_mul]
+    · rw [if_neg (fun hh => hc (hiff.mp hh)), if_neg hc, zero_mul]
+  rw [Finset.sum_congr rfl (fun h _ => hcollapse h),
+    Etingof.sum_subtype_ite_coe H (x * g * x⁻¹) (fun h => LinearMap.trace ℂ V (ρ h))]

--- a/EtingofRepresentationTheory/Chapter5/TraceCoinvariants.lean
+++ b/EtingofRepresentationTheory/Chapter5/TraceCoinvariants.lean
@@ -1,0 +1,195 @@
+import Mathlib
+
+/-!
+# Trace of an endomorphism on the coinvariants of a finite-group representation
+
+For a finite group `Γ` acting on a finite-dimensional module `W` over a field of
+characteristic zero, and an intertwining endomorphism `Φ` of the representation `σ`, the
+trace of the induced map on the coinvariants `W_Γ = Coinvariants σ` is the average over
+`h ∈ Γ` of the trace of `σ(h) ∘ Φ`:
+
+  `tr_{W_Γ}(Φ̄) = (1/|Γ|) · Σ_{h ∈ Γ} tr_W(σ(h) ∘ Φ)`.
+
+This is the abstract heart of the Frobenius character formula (Etingof Theorem 5.9.1).
+
+## Proof outline
+
+Let `e = averageMap σ = (1/|Γ|) Σ_h σ(h)`, the averaging projection onto the invariants
+`P = invariants σ`. Its kernel is exactly the coinvariants relation submodule
+`K = Coinvariants.ker σ`, so `P` and `K` are complementary and the quotient map restricts to
+a linear isomorphism `ι : Coinvariants σ ≃ P`.
+
+* Under `ι`, the induced map `Φ̄ = Coinvariants.map σ σ Φ` is conjugate to the restriction
+  `Φ_P : P → P` of `Φ` (which preserves the invariants because it commutes with `σ`); hence
+  `tr(Φ̄) = tr(Φ_P)` by conjugation-invariance of the trace.
+* `tr_P(Φ_P) = tr_W(e ∘ Φ)`: writing `e = j ∘ p` with `j = P.subtype` and `p` the corestriction
+  of `e`, the cyclic property `tr(j ∘ (p∘Φ)) = tr((p∘Φ) ∘ j)` and `p ∘ Φ ∘ j = Φ_P` give it.
+* `tr_W(e ∘ Φ) = (1/|Γ|) Σ_h tr_W(σ(h) ∘ Φ)` by linearity of the trace and `e = (1/|Γ|)Σ σ(h)`.
+-/
+
+open Representation LinearMap
+
+namespace Etingof
+
+variable {k : Type*} [Field k]
+    {Γ : Type*} [Group Γ] [Fintype Γ] [Invertible (Fintype.card Γ : k)]
+    {W : Type*} [AddCommGroup W] [Module k W] [Module.Finite k W]
+    (σ : Representation k Γ W)
+
+omit [Module.Finite k W] in
+/-- The averaging projection as an explicit linear combination of the group action. -/
+lemma averageMap_eq :
+    averageMap σ = (Fintype.card Γ : k)⁻¹ • ∑ h : Γ, σ h := by
+  simp only [averageMap, GroupAlgebra.average, map_smul, map_sum, asAlgebraHom_of, invOf_eq_inv]
+
+omit [Module.Finite k W] in
+lemma averageMap_apply (w : W) :
+    averageMap σ w = (Fintype.card Γ : k)⁻¹ • ∑ h : Γ, σ h w := by
+  rw [averageMap_eq]; simp
+
+omit [Module.Finite k W] in
+/-- The kernel of the averaging projection is exactly the coinvariants relation submodule. -/
+lemma ker_averageMap : LinearMap.ker (averageMap σ) = Coinvariants.ker σ := by
+  apply le_antisymm
+  · intro w hw
+    have hsub : w - averageMap σ w ∈ Coinvariants.ker σ := by
+      have hne : (Fintype.card Γ : k) ≠ 0 := Invertible.ne_zero _
+      have hrw : w - averageMap σ w
+          = (Fintype.card Γ : k)⁻¹ • ∑ h : Γ, (w - σ h w) := by
+        rw [averageMap_apply, Finset.sum_sub_distrib, smul_sub, Finset.sum_const,
+          Finset.card_univ, ← Nat.cast_smul_eq_nsmul k, smul_smul, inv_mul_cancel₀ hne, one_smul]
+      rw [hrw]
+      refine Submodule.smul_mem _ _ (Submodule.sum_mem _ ?_)
+      intro h _
+      have := Coinvariants.sub_mem_ker (ρ := σ) h w
+      simpa [neg_sub] using (Submodule.neg_mem _ this)
+    have : w = w - averageMap σ w := by
+      rw [LinearMap.mem_ker] at hw; rw [hw, sub_zero]
+    rw [this]; exact hsub
+  · rw [Coinvariants.ker, Submodule.span_le]
+    rintro _ ⟨⟨g, x⟩, rfl⟩
+    simp only [SetLike.mem_coe, LinearMap.mem_ker, map_sub]
+    have key : averageMap σ (σ g x) = averageMap σ x := by
+      rw [averageMap_apply, averageMap_apply]
+      congr 1
+      rw [← Equiv.sum_comp (Equiv.mulRight g) (fun h => σ h x)]
+      refine Finset.sum_congr rfl (fun h _ => ?_)
+      simp only [Equiv.coe_mulRight, map_mul, Module.End.mul_apply]
+    rw [key, sub_self]
+
+omit [Invertible (Fintype.card Γ : k)] [Fintype Γ] [Module.Finite k W] in
+/-- `Φ` preserves the invariants, since it commutes with the group action. -/
+lemma intertwiningMap_mapsTo_invariants (Φ : IntertwiningMap σ σ) :
+    ∀ x ∈ invariants σ, Φ.toLinearMap x ∈ invariants σ := by
+  intro x hx
+  rw [mem_invariants] at hx ⊢
+  intro g
+  have h : Φ.toLinearMap (σ g x) = σ g (Φ.toLinearMap x) := congr($(Φ.isIntertwining' g) x)
+  rw [hx g] at h
+  exact h.symm
+
+/-- **Trace on coinvariants is the average of twisted traces.**
+
+For a finite group `Γ` acting on a finite-dimensional char-zero module `W`, and an
+intertwining endomorphism `Φ`, the trace of the induced map on `Coinvariants σ` equals
+`(1/|Γ|) · Σ_{h} tr_W(σ(h) ∘ Φ)`. -/
+theorem trace_coinvariantsMap (Φ : IntertwiningMap σ σ) :
+    LinearMap.trace k (Coinvariants σ) (Coinvariants.map σ σ Φ)
+      = (Fintype.card Γ : k)⁻¹ * ∑ h : Γ, LinearMap.trace k W (σ h ∘ₗ Φ.toLinearMap) := by
+  have hΦP := intertwiningMap_mapsTo_invariants σ Φ
+  -- The corestriction of the averaging projection onto the invariants.
+  set p : W →ₗ[k] invariants σ :=
+    (averageMap σ).codRestrict (invariants σ) (averageMap_invariant σ) with hp
+  have hsubp : (invariants σ).subtype ∘ₗ p = averageMap σ :=
+    LinearMap.subtype_comp_codRestrict _ _ _
+  have hpid : ∀ x : invariants σ, p x = x := by
+    intro x
+    apply Subtype.ext
+    simp only [hp, LinearMap.codRestrict_apply]
+    exact averageMap_id σ x x.2
+  -- `Φ` restricted to the invariants.
+  set Φ_P : invariants σ →ₗ[k] invariants σ := Φ.toLinearMap.restrict hΦP with hΦ_P
+  -- `P` and `K` are complementary; the quotient map restricts to an iso `Coinvariants σ ≃ P`.
+  have hkerp : LinearMap.ker p = Coinvariants.ker σ := by
+    rw [hp, LinearMap.ker_codRestrict, ker_averageMap]
+  have hcompl : IsCompl (Coinvariants.ker σ) (invariants σ) := by
+    have h1 := LinearMap.isCompl_of_proj hpid
+    rw [hkerp] at h1
+    exact h1.symm
+  set ι : Coinvariants σ ≃ₗ[k] invariants σ :=
+    Submodule.quotientEquivOfIsCompl _ _ hcompl with hι
+  -- Step 1 : `tr_C(Φ̄) = tr_P(Φ_P)`.
+  have hsymm : ∀ x : invariants σ, ι.symm x = Coinvariants.mk σ (x : W) := by
+    intro x
+    refine ι.symm_apply_eq.2 ?_
+    rw [hι]
+    exact (Submodule.quotientEquivOfIsCompl_apply_mk_right hcompl x).symm
+  have hconj : ι.conj (Coinvariants.map σ σ Φ) = Φ_P := by
+    refine LinearMap.ext fun x => ?_
+    rw [LinearEquiv.conj_apply_apply, hsymm x, Coinvariants.map_mk,
+      ← IntertwiningMap.toLinearMap_apply]
+    have hcoe : Φ.toLinearMap (x : W) = ((Φ_P x : invariants σ) : W) := by
+      rw [hΦ_P, LinearMap.restrict_apply]
+    rw [hcoe, ← hsymm (Φ_P x), ι.apply_symm_apply]
+  have step1 : LinearMap.trace k (Coinvariants σ) (Coinvariants.map σ σ Φ)
+      = LinearMap.trace k (invariants σ) Φ_P := by
+    rw [← LinearMap.trace_conj' (Coinvariants.map σ σ Φ) ι, hconj]
+  -- Step 2 : `tr_P(Φ_P) = tr_W(e ∘ Φ)`.
+  have hcomp : p ∘ₗ Φ.toLinearMap ∘ₗ (invariants σ).subtype = Φ_P := by
+    refine LinearMap.ext fun x => ?_
+    apply Subtype.ext
+    simp only [LinearMap.comp_apply, Submodule.subtype_apply, hp, LinearMap.codRestrict_apply,
+      hΦ_P, LinearMap.restrict_apply]
+    exact averageMap_id σ _ (hΦP x x.2)
+  have step2 : LinearMap.trace k (invariants σ) Φ_P
+      = LinearMap.trace k W (averageMap σ ∘ₗ Φ.toLinearMap) := by
+    rw [← hcomp, ← LinearMap.comp_assoc,
+      LinearMap.trace_comp_comm' ((invariants σ).subtype) (p ∘ₗ Φ.toLinearMap),
+      ← hsubp, LinearMap.comp_assoc]
+  -- Step 3 : `tr_W(e ∘ Φ) = (1/|Γ|) Σ_h tr_W(σ(h) ∘ Φ)`.
+  have step3 : LinearMap.trace k W (averageMap σ ∘ₗ Φ.toLinearMap)
+      = (Fintype.card Γ : k)⁻¹ * ∑ h : Γ, LinearMap.trace k W (σ h ∘ₗ Φ.toLinearMap) := by
+    have hcomp_sum : (∑ h : Γ, σ h) ∘ₗ Φ.toLinearMap = ∑ h : Γ, (σ h ∘ₗ Φ.toLinearMap) := by
+      ext w; simp [LinearMap.sum_apply]
+    rw [averageMap_eq, LinearMap.smul_comp, hcomp_sum, map_smul, map_sum, smul_eq_mul]
+  rw [step1, step2, step3]
+
+section Helpers
+
+/-- The trace of `Finsupp.lmapDomain k k φ` on the free module `ι →₀ k`, for a self-map `φ`
+of a finite type, counts the fixed points of `φ`. -/
+lemma trace_lmapDomain {k : Type*} [Field k] {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (φ : ι → ι) :
+    LinearMap.trace k (ι →₀ k) (Finsupp.lmapDomain k k φ)
+      = ∑ x : ι, if φ x = x then (1 : k) else 0 := by
+  rw [LinearMap.trace_eq_matrix_trace k Finsupp.basisSingleOne, Matrix.trace]
+  refine Finset.sum_congr rfl fun x _ => ?_
+  rw [Matrix.diag_apply, LinearMap.toMatrix_apply, Finsupp.coe_basisSingleOne]
+  simp [Finsupp.lmapDomain_apply, Finsupp.mapDomain_single, Finsupp.single_apply]
+
+/-- A sum over a subgroup `H` of an indicator on the coercion `↑h = a` picks out the unique
+preimage when `a ∈ H`. -/
+lemma sum_subtype_ite_coe {G : Type*} [Group G] [DecidableEq G] (H : Subgroup G) [Fintype H]
+    [DecidablePred (· ∈ H)] {k : Type*} [AddCommMonoid k] (a : G) (f : H → k) :
+    ∑ h : H, (if (↑h : G) = a then f h else 0) = if ha : a ∈ H then f ⟨a, ha⟩ else 0 := by
+  by_cases ha : a ∈ H
+  · rw [dif_pos ha]
+    have hcongr : ∀ h : H, (if (↑h : G) = a then f h else 0)
+        = (if h = (⟨a, ha⟩ : H) then f h else 0) := by
+      intro h
+      by_cases hh : h = ⟨a, ha⟩
+      · subst hh; simp
+      · have hne : (↑h : G) ≠ a := fun hc => hh (Subtype.ext hc)
+        rw [if_neg hne, if_neg hh]
+    rw [Finset.sum_congr rfl (fun h _ => hcongr h), Finset.sum_ite_eq']
+    simp
+  · rw [dif_neg ha]
+    refine Finset.sum_eq_zero fun h _ => ?_
+    rw [if_neg]
+    intro hc; exact ha (hc ▸ h.2)
+
+end Helpers
+
+end Etingof
+
+

--- a/progress/20260626T051002Z_a4e7017f.md
+++ b/progress/20260626T051002Z_a4e7017f.md
@@ -1,0 +1,55 @@
+## Accomplished
+
+One-shot feature session `a4e7017f` (`/once 5321`): **proved Theorem 5.9.1, the Frobenius
+character formula for an induced representation, sorry-free** — replacing the `sorry` in
+`Chapter5/Theorem5_9_1.lean`.
+
+Rather than the coset-block decomposition Etingof uses (awkward to formalize: needs a
+transversal of `H\G`), the proof goes through the equivalent **averaging idempotent** route,
+which lands the averaged statement directly. Two files:
+
+- **`Chapter5/TraceCoinvariants.lean`** (new, reusable, Mathlib-grade) — the abstract crux:
+  - `trace_coinvariantsMap`: for a finite group `Γ` acting on a finite-dim char-0 module `W`
+    and an intertwining endomorphism `Φ`,
+    `tr_{Coinvariants σ}(Φ̄) = (1/|Γ|) Σ_{h∈Γ} tr_W(σ(h) ∘ Φ)`.
+    Proof: the averaging projection `e = averageMap σ` projects onto `invariants σ` with kernel
+    exactly `Coinvariants.ker σ` (`ker_averageMap`), so `Coinvariants σ ≃ invariants σ`
+    (`quotientEquivOfIsCompl`); under this iso `Φ̄` is conjugate to `Φ|_invariants`
+    (`trace_conj'`); and `tr_P(Φ|_P) = tr_W(e ∘ Φ)` by the cyclic trace property
+    (`trace_comp_comm'`); finally `e = (1/|Γ|)Σσ(h)` gives the average by linearity.
+  - Supporting: `averageMap_eq`, `averageMap_apply`, `ker_averageMap`,
+    `intertwiningMap_mapsTo_invariants`, plus two generic helpers `trace_lmapDomain`
+    (trace of `Finsupp.lmapDomain φ` counts fixed points of `φ`) and `sum_subtype_ite_coe`.
+
+- **`Chapter5/Theorem5_9_1.lean`** — applies the crux to `τ = (leftRegular ℂ G ⊗ ρ)|_H` and the
+  right-shift `Ψ : single x ⊗ v ↦ single (x g⁻¹) ⊗ v` (which is literally how Mathlib's
+  `Representation.ind` acts, via `ind_apply`). Each `tr(τ(h) ∘ Ψ)` factors as a tensor trace
+  `trace_tensorProduct'`: the `ℂ[G]`-factor is `lmapDomain (x ↦ h x g⁻¹)` whose trace counts
+  `{x : h x g⁻¹ = x} = {x : x g x⁻¹ = h}`, times `tr_V ρ(h)`. Swapping the order of summation
+  and collapsing each fibre (`sum_subtype_ite_coe`) yields the averaged Frobenius formula.
+
+## Verification
+
+- `lake build` of `TraceCoinvariants` and `Theorem5_9_1`: success, no warnings.
+- `#print axioms Etingof.Theorem5_9_1` and `Etingof.trace_coinvariantsMap`:
+  `[propext, Classical.choice, Quot.sound]` only — **no `sorryAx`**.
+- Registered `TraceCoinvariants` in `Chapter5.lean`.
+
+## Current frontier
+
+Theorem 5.9.1 is closed. The averaging-trace lemma `Etingof.trace_coinvariantsMap` is a clean,
+reusable building block for any future induced-character / coinvariants-trace computation.
+
+## Overall project progress
+
+Etingof draft 1, Stage 3. §5.9 (Frobenius formula) is now sorry-free; nothing downstream was
+blocked on it (§5.11 had used reciprocity to avoid it), so this completes 5.9.1 itself.
+
+## Next step
+
+Continue the Stage-3 sorry sweep. The new `trace_coinvariantsMap` may simplify other
+character-of-induced computations if they arise.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5321

Session: `a4e7017f-510b-4b42-ad2f-168e91bd11be`

4273697d fix(Ch5 Theorem 5.9.1): prove the Frobenius induced-character formula (replace sorry)

🤖 Prepared with Claude Code