### PR TITLE
Proposition 3.5.2 is vacuously formalized: proves Set.Nonempty, not two-sided ideal

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/Proposition3_5_2.lean
+++ b/EtingofRepresentationTheory/Chapter3/Proposition3_5_2.lean
@@ -3,22 +3,33 @@ import Mathlib.RingTheory.Jacobson.Ideal
 /-!
 # Proposition 3.5.2: Rad(A) is a Two-Sided Ideal
 
-The radical Rad(A) is a two-sided ideal in A.
+Rad(A), the radical of a finite dimensional algebra `A` — the set of elements acting by
+zero in every irreducible representation, equivalently the intersection of the
+annihilators of all simple modules — is a *two-sided* ideal of `A`.
 
-This follows directly from the definition: Rad(A) is the intersection of annihilators of
-all irreducible representations, and each annihilator is a two-sided ideal.
-
-In Mathlib, the Jacobson radical `Ideal.jacobson ⊥` is already a two-sided ideal by
-construction (it is an `Ideal A`, which in Mathlib is a two-sided ideal for commutative
-rings and a left ideal in general).
+In Mathlib the radical is `Ideal.jacobson (⊥ : Ideal A)`. For a general (possibly
+noncommutative) ring, `Ideal A` is a *left* ideal (`Submodule A A`), so the left-ideal
+property (closure under multiplication on the left) holds by construction. The
+mathematical content of Proposition 3.5.2 is the remaining half: closure under
+multiplication on the right. Mathlib supplies this as the instance
+`Ideal.IsTwoSided` for the Jacobson radical of a two-sided ideal (and `⊥` is two-sided).
 -/
 
-/-- The radical of a finite dimensional algebra is a two-sided ideal.
-Etingof Proposition 3.5.2.
+/-- The radical `Rad(A) = Ideal.jacobson ⊥` is a two-sided ideal: it is closed under
+multiplication on both the left and the right. The left-multiplication closure
+(`r * a ∈ Rad(A)`) is the left-ideal structure of `Ideal A`; the right-multiplication
+closure (`a * r ∈ Rad(A)`) is the genuine content of Etingof Proposition 3.5.2.
 
-In the Mathlib formalization, `Ideal.jacobson ⊥` is already an ideal by construction. -/
-theorem Etingof.radical_is_ideal (A : Type*) [Ring A] :
-    -- The Jacobson radical is already an Ideal A in Mathlib,
-    -- so this is immediate from the type system.
-    (Ideal.jacobson (⊥ : Ideal A)).carrier.Nonempty := by
-  exact ⟨0, (Ideal.jacobson ⊥).zero_mem⟩
+Equivalently, `Ideal.jacobson (⊥ : Ideal A)` carries the `Ideal.IsTwoSided` instance,
+see `Etingof.radical_isTwoSided` below. -/
+theorem Etingof.radical_is_ideal (A : Type*) [Ring A]
+    (a r : A) (ha : a ∈ Ideal.jacobson (⊥ : Ideal A)) :
+    r * a ∈ Ideal.jacobson (⊥ : Ideal A) ∧ a * r ∈ Ideal.jacobson (⊥ : Ideal A) :=
+  ⟨Ideal.mul_mem_left _ r ha, Ideal.mul_mem_right r _ ha⟩
+
+/-- Proposition 3.5.2, packaged as the Mathlib `Ideal.IsTwoSided` property: the radical
+`Ideal.jacobson (⊥ : Ideal A)` is two-sided. This records that the underlying left ideal
+is in fact closed under right multiplication. -/
+theorem Etingof.radical_isTwoSided (A : Type*) [Ring A] :
+    (Ideal.jacobson (⊥ : Ideal A)).IsTwoSided :=
+  inferInstance

--- a/progress/2026-06-26T05-27-53Z_12b8bb77.md
+++ b/progress/2026-06-26T05-27-53Z_12b8bb77.md
@@ -1,0 +1,43 @@
+## Accomplished
+
+Fixed issue #5322: `Etingof.radical_is_ideal` in
+`EtingofRepresentationTheory/Chapter3/Proposition3_5_2.lean` was a vacuous
+formalization — it proved only `(Ideal.jacobson ⊥).carrier.Nonempty` (witnessed
+by `0`), which holds for every ideal and asserts nothing about the radical being
+a two-sided ideal.
+
+Replaced it with the genuine content of Etingof Proposition 3.5.2:
+
+- `Etingof.radical_is_ideal`: for `a ∈ Ideal.jacobson (⊥ : Ideal A)` and any
+  `r : A`, both `r * a` and `a * r` lie in `Ideal.jacobson ⊥`. The right-mult
+  half (`a * r ∈ Rad`) is the non-vacuous content — it requires the
+  `Ideal.IsTwoSided` instance and fails for an arbitrary left ideal.
+- `Etingof.radical_isTwoSided`: the same fact packaged as Mathlib's
+  `(Ideal.jacobson (⊥ : Ideal A)).IsTwoSided`.
+
+Mathlib already supplies the two-sidedness (`instance {I : Ideal R} [I.IsTwoSided]
+: I.jacobson.IsTwoSided` in `Mathlib/RingTheory/Jacobson/Ideal.lean`, with
+`(⊥ : Ideal α).IsTwoSided` from `Mathlib/RingTheory/Ideal/Lattice.lean`), so the
+proofs are short and faithful.
+
+Build: `lake build EtingofRepresentationTheory.Chapter3.Proposition3_5_2` passes,
+no errors/sorry/warnings.
+
+## Current frontier
+
+Issue #5322 fully resolved. The theorem now states real mathematical content.
+
+## Overall project progress
+
+Endgame red-team fixes. This was a present-but-unfaithful statement flagged by an
+adversarial pass of `main`. Item `Chapter3/Proposition3.5.2` remains
+`sorry_free` (status unchanged, now genuinely faithful).
+
+## Next step
+
+None for this issue. Other red-team / faithfulness issues may remain in the
+queue.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5322

Session: `12b8bb77-4b5f-44fa-b068-4962bc12bf92`

1a0c5b84 fix(Ch3 Proposition3.5.2): replace vacuous radical_is_ideal with genuine two-sided statement (#5322)

🤖 Prepared with Claude Code