### PR TITLE
fix(Ch5 Theorem5.23.2): make part (i) complete-reducibility statement faithful

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/SimpleSubrepExtraction.lean
+++ b/EtingofRepresentationTheory/Chapter5/SimpleSubrepExtraction.lean
@@ -16,11 +16,12 @@ part-(a) lemma `quotDetRep_irreducible_constituent_lastWeight_zero`
 
 ## Why a minimal invariant submodule, not complete reducibility
 
-`Theorem5_23_2_i` only delivers `IsSemisimpleModule k Y` — semisimplicity as a
-`k`-vector space, which is vacuous and does **not** hand over a simple
-sub-representation over the group algebra `k[GL_N]`. Instead we take a *minimal
-nonzero invariant submodule* (an **atom** of the `k[GL_N]`-submodule lattice),
-which is simple as a representation without any complete-reducibility input.
+`Theorem5_23_2_i` now states genuine complete reducibility
+(`IsSemisimpleModule k[GL_N] ρ.asModule`), but its proof is still open (the GL_N
+complete-reducibility infrastructure is a long-term blocker), so we cannot consume
+it here. Instead we take a *minimal nonzero invariant submodule* (an **atom** of
+the `k[GL_N]`-submodule lattice), which is simple as a representation without any
+complete-reducibility input.
 
 Two ingredients make this work:
 

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_23_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_23_2.lean
@@ -29,21 +29,47 @@ variable {k : Type*} [Field k] [IsAlgClosed k] [CharZero k]
 
 /-- **Theorem 5.23.2 (i)**: Every finite-dimensional algebraic representation of
 `GL_n(k)` is completely reducible. That is, if `ρ` is an algebraic representation
-of `GL_n(k)` on a finite-dimensional `k`-vector space `Y`, then `Y` is a
-semisimple module under the induced action.
+of `GL_n(k)` on a finite-dimensional `k`-vector space `Y`, then `Y` decomposes as
+a direct sum of irreducible subrepresentations.
+
+This is stated faithfully as semisimplicity of `Y` **as a module over the group
+algebra `k[GL_n(k)]`** — i.e. semisimplicity of the representation `ρ`, which is
+the precise meaning of "completely reducible". This is genuine `GL_n`-equivariant
+content: the group algebra `k[GL_n(k)]` is *not* a semisimple ring (`GL_n(k)` is
+infinite), so this is NOT automatic for an arbitrary module; it holds precisely
+because the representation is *algebraic*.
+
+(Contrast the previous formalization, which asserted only `IsSemisimpleModule k Y`
+— semisimplicity of `Y` as a plain `k`-vector space — which is trivially true for
+*any* vector space over a field and carries no representation-theoretic content.)
+
+**Proof (Etingof, §5.23).** There is an equivariant embedding `ξ : Y → Y ⊗ R`,
+`⟨u, ξ(v)⟩(g) = u(g v)` for `u ∈ Y*` (with trivial `GL`-action on the first
+tensor factor), so it suffices to treat a subrepresentation `Y ⊆ Rᵐ`. Every
+element of `R = k[gᵢⱼ][1/det]` is a polynomial in `gᵢⱼ` times a nonpositive power
+of `det(g)`, so `R` is a quotient of a direct sum of representations
+`Sʳ(V ⊗ V*) ⊗ (∧ᴺ V*)^{⊗s}` (trivial `GL`-action on the `V*` factor). Hence `Y`
+embeds into a direct sum of representations `V^{⊗n} ⊗ (∧ᴺ V*)^{⊗s}`, each of which
+is completely reducible by Schur-Weyl duality (Theorem 5.18.4 / 5.22.1); a
+subrepresentation of a semisimple module is semisimple, so `Y` is semisimple.
+
+The finer statement of the book — that the irreducible summands are the `Lλ` and
+are pairwise nonisomorphic — is the highest-weight classification, which requires
+the GL-rep classification infrastructure (cf. `iso_of_formalCharacter_eq_schurPoly`)
+and is tracked separately.
 (Etingof Theorem 5.23.2, part i) -/
 theorem Theorem5_23_2_i
     (n : ℕ)
     {Y : Type*} [AddCommGroup Y] [Module k Y] [Module.Finite k Y]
-    (ρ : Matrix.GeneralLinearGroup (Fin n) k →* (Y →ₗ[k] Y))
-    (halg : Etingof.IsAlgebraicRepresentation n ρ) :
-    IsSemisimpleModule k Y :=
-  -- Every module over a field is semisimple, since fields are semisimple rings
-  -- (DivisionRing.isSimpleRing + IsArtinianRing → IsSemisimpleRing → IsSemisimpleModule).
-  -- The representation-theoretic content (GL_n-equivariant decomposition into
-  -- irreducible summands L_λ) is captured by the formal character theory in
-  -- Theorem 5.22.1 rather than by this type-theoretic statement.
-  inferInstance
+    (ρ : Representation k (Matrix.GeneralLinearGroup (Fin n) k) Y)
+    (halg : Etingof.IsAlgebraicRepresentation n ⇑ρ) :
+    IsSemisimpleModule
+      (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin n) k)) ρ.asModule := by
+  -- The GL_n(k)-reductivity theorem. See the docstring for the book's proof; the
+  -- key ingredient (complete reducibility of `V^{⊗n} ⊗ (∧ᴺ V*)^{⊗s}` via
+  -- Schur-Weyl duality) is the GL_N complete-reducibility infrastructure that is
+  -- still being built (long-term blocker; see project notes).
+  sorry
 
 /-- The coordinate ring of `GL_n(k)`: the polynomial ring `k[Xᵢⱼ, D]` where `D`
 represents `1/det`. This models the algebra `R` of regular (polynomial) functions
@@ -119,9 +145,18 @@ noncomputable instance AlgIrrepGLDual.module (n : ℕ) (lam : DominantWeight n)
 decomposes as `R ≅ ⊕_λ L*_λ ⊗ L_λ`, where the sum ranges over all dominant weights
 `λ = (λ₁ ≥ ⋯ ≥ λ_n)` with `λᵢ ∈ ℤ`, and `L*_λ` is the contragredient of `L_λ`.
 
-Stated as a `k`-linear isomorphism between the coordinate ring and the direct sum.
-The equivariance with respect to the `GL_n × GL_n`-action is part of the proof
-obligation.
+**⚠ Partial formalization.** The statement below asserts only a *bare `k`-linear*
+isomorphism `R ≃ₗ[k] ⊕_λ L*_λ ⊗ L_λ`, proved by matching ranks
+(`nonempty_linearEquiv_of_rank_eq`): both sides are countably-infinite-dimensional
+free `k`-modules for `n ≥ 1`, so this iso holds for *any* two such modules and
+carries **no** `GL_n × GL_n`-equivariant content — the actual mathematical theorem.
+Capturing the full Peter-Weyl decomposition (a `GL_n × GL_n`-equivariant iso)
+requires representation structures that do not yet exist in the project: a
+`GL_n × GL_n`-action on the *localized* coordinate ring `k[gᵢⱼ][1/det]` (including
+the `1/det` variable, on which `(g,h)` acts by `det(g)/det(h)`), the GL-action on
+each `Lλ` / `L*_λ` (the det-twisted `schurModuleRep`), and the matching
+`GL_n × GL_n`-action on the direct sum. This equivariant strengthening is tracked
+as a follow-up issue (the rank iso below is retained only as scaffolding for it).
 (Etingof Theorem 5.23.2, part ii) -/
 -- The rank of the coordinate ring `k[GL_n]` equals the rank of the direct sum
 -- `⊕_λ L*_λ ⊗ L_λ` over all dominant weights. Both sides are free `k`-modules;

--- a/progress/2026-06-26T08-10-00Z_702de645.md
+++ b/progress/2026-06-26T08-10-00Z_702de645.md
@@ -1,0 +1,55 @@
+## Accomplished
+
+One-shot fidelity fix for issue #5384 (`Chapter5/Theorem5.23.2`, anti-vacuity).
+Re-confirmed the gap is genuine (not a false positive): both Lean statements were
+vacuous.
+
+**Part (i) — FIXED.** Replaced the vacuous conclusion `IsSemisimpleModule k Y`
+(semisimplicity of `Y` as a plain `k`-vector space — trivially true for any vector
+space, no representation content) with the faithful, non-vacuous statement
+`IsSemisimpleModule (MonoidAlgebra k GL_n) ρ.asModule` — genuine complete
+reducibility of the representation `ρ`. Retyped `ρ` as a `Representation` so
+`.asModule` applies. Proof is `sorry` with the book's §5.23 proof outline in the
+docstring (the GL_n complete-reducibility / Schur-Weyl reductivity step is the
+documented long-term blocker). Statement is non-vacuous because `k[GL_n]` is not a
+semisimple ring (GL_n infinite), so semisimplicity is real content holding only
+for algebraic reps. File + all importers build clean.
+
+**Part (ii) — honestly documented + decomposed.** `Theorem5_23_2_ii` remains a
+bare `k`-linear rank-matching iso (no GL×GL equivariance). The faithful
+(GL_n×GL_n-equivariant) Peter-Weyl statement needs new infrastructure that does
+not exist: a GL-rep on `AlgIrrepGL` (det-twisted `schurModuleRep`), a GL×GL action
+on the *localized* coordinate ring including the `1/det` variable, and the matching
+action on the direct sum. Rewrote the docstring to flag the limitation honestly
+(removed the misleading "equivariance is part of the proof obligation" wording) and
+filed follow-up issue **#5396** with a precise build plan. Updated the outdated
+comment in `SimpleSubrepExtraction.lean` describing the old vacuous behavior.
+
+Updated `progress/items.json`: status `sorry_free` → `proof_partial`, fidelity
+stays `gap` (part ii), note rewritten, `followup_issue: 5396`. Did NOT set
+`fidelity: verified` — only part (i) is faithfully stated and neither part is
+proved.
+
+## Current frontier
+
+`Theorem5_23_2.lean` builds (1 sorry: part (i) proof). Importers (SimpleSubrepExtraction,
+SchurModuleSpecialBlock, AlgIrrepGLRep, CauchyDetQuotient(Grading)) all build.
+
+## Overall project progress
+
+Stage 3 fidelity sweep (epic #5338). This turn converted one anti-vacuity gap
+(#5384) from "vacuous but proved" to "part (i) faithful (sorried) + part (ii)
+honestly scoped", and created follow-up #5396 for the full equivariant Peter-Weyl.
+
+## Next step
+
+Work #5396: build `algIrrepGLRep` (det-twisted `schurModuleRep`), extend the
+`k[Xᵢⱼ]` bi-action across `1/det`, and state (then prove) the GL×GL-equivariant
+Peter-Weyl iso. Separately, the part (i) `sorry` awaits the GL_n
+complete-reducibility infrastructure.
+
+## Blockers
+
+GL_n complete reducibility (Schur-Weyl reductivity) for arbitrary algebraic reps
+is a long-term infrastructure blocker (part (i) proof). Part (ii) is blocked on the
+representation infrastructure enumerated in #5396.

--- a/progress/items.json
+++ b/progress/items.json
@@ -4193,12 +4193,13 @@
     "end_page": "133",
     "start_line": 13,
     "end_line": 21,
-    "status": "sorry_free",
+    "status": "proof_partial",
     "fidelity": "gap",
     "needs_statement": false,
-    "fidelity_note": "Both parts are VACUOUS / severely weakened. Part (i): the book says every algebraic GL(V)-rep is completely reducible into pairwise-nonisomorphic L_lambda summands; the Lean (Theorem5_23_2_i) only ...",
+    "fidelity_note": "Part (i) FIXED (#5384): Theorem5_23_2_i now states genuine complete reducibility (IsSemisimpleModule k[GL_n] rho.asModule), non-vacuous; proof sorried (GL_n complete-reducibility blocker). Part (ii) still VACUOUS: Theorem5_23_2_ii is a bare k-linear rank-matching iso with no GL x GL-equivariant content; docstring now flags this honestly. Full equivariant Peter-Weyl tracked in #5396. Set fidelity=verified only when BOTH parts assert the full book claim.",
     "fidelity_decl": "Theorem5_23_2_i, Theorem5_23_2_ii",
-    "fidelity_issue": 5384
+    "fidelity_issue": 5384,
+    "followup_issue": 5396
   },
   {
     "id": "Chapter5/Discussion_proof_of_Theorem5.23.2",


### PR DESCRIPTION
This PR partially fixes the anti-vacuity fidelity gap #5384 for
`Chapter5/Theorem5.23.2`. It re-confirms the gap is genuine and makes **part (i)**
faithful: the conclusion `IsSemisimpleModule k Y` (semisimplicity of `Y` as a plain
`k`-vector space, trivially true for any vector space) is replaced by
`IsSemisimpleModule (MonoidAlgebra k GL_n) ρ.asModule`, the genuine complete
reducibility of the representation. This is non-vacuous: `k[GL_n]` is not a
semisimple ring (`GL_n` is infinite), so semisimplicity holds only because `ρ` is
algebraic. `ρ` is retyped as a `Representation`; the proof is `sorry` with the
book's §5.23 outline (the GL_n complete-reducibility step is a long-term blocker).

**Part (ii)** (`Theorem5_23_2_ii`) remains a bare `k`-linear rank-matching iso with
no `GL_n × GL_n`-equivariant content. Its docstring is rewritten to flag this
honestly (the previous wording misleadingly implied equivariance was captured), and
the full equivariant Peter-Weyl formalization is decomposed into follow-up #5396
(it needs a GL-rep on `Lλ`, a bi-action on the localized coordinate ring including
the `1/det` variable, and the matching direct-sum action — none of which exist yet).

The stale comment in `SimpleSubrepExtraction.lean` describing the old vacuous
behavior is updated, and `items.json` is set to `proof_partial` (fidelity stays
`gap`; not `verified`). All importers build clean.

Closes part (i) of #5384; part (ii) tracked in #5396.

🤖 Prepared with Claude Code
