### PR TITLE
fix(Ch9 Definition9.7.2): assert book's faithful 'B/Rad commutative' basic condition

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/Corollary9_7_3.lean
+++ b/EtingofRepresentationTheory/Chapter9/Corollary9_7_3.lean
@@ -136,15 +136,14 @@ private noncomputable def Etingof.cornerRingAlgEquivOfUnit
 closed field k is Morita equivalent to some basic algebra B. That is, there exists
 a basic k-algebra B such that the module categories of A and B are equivalent.
 
-Note: The algebraic closure hypothesis is necessary — over non-algebraically-closed
-fields, division algebras can have dimension > 1, so the "all simples 1-dimensional"
-definition of basic cannot always be achieved.
+Here *basic* is the book's Definition 9.7.2 (`B/Rad(B)` commutative). The algebraic
+closure hypothesis is used in the construction of `B` as a corner ring `eAe`.
 
 (Etingof Corollary 9.7.3(i), algebra version) -/
 theorem Etingof.Corollary_9_7_3_i
     (A : Type u) [Ring A] [Algebra k A] [Module.Finite k A] [IsAlgClosed k] :
     ∃ (B : Type u) (_ : Ring B) (_ : Algebra k B) (_ : Module.Finite k B),
-      Etingof.IsBasicAlgebraSplit k B ∧ Etingof.MoritaEquivalent A B :=
+      Etingof.IsBasicAlgebra k B ∧ Etingof.MoritaEquivalent A B :=
   Etingof.exists_basic_morita_equivalent k A
 
 /-- **Corollary 9.7.3(i), uniqueness**: The basic algebra B from part (i) is unique

--- a/EtingofRepresentationTheory/Chapter9/Corollary9_7_3.lean
+++ b/EtingofRepresentationTheory/Chapter9/Corollary9_7_3.lean
@@ -24,7 +24,7 @@ basic algebra B_A, and dim B_A ≤ dim A.
 Part (i) combines Theorem 9.6.4 (Morita equivalence via progenerator) with the
 theory of basic algebras from §9.7.
 
-Part (ii) uses the `Etingof.MoritaEquivalent` and `Etingof.IsBasicAlgebra`
+Part (ii) uses the `Etingof.MoritaEquivalent` and `Etingof.IsBasicAlgebraSplit`
 definitions from this project.
 
 ## Proof status
@@ -66,10 +66,10 @@ lemma Etingof.MoritaEquivalent.trans {A : Type u} [Ring A] {B : Type u} [Ring B]
   obtain ⟨e₂⟩ := h₂
   exact ⟨e₁.trans e₂⟩
 
-/-! ## Helper lemmas for IsBasicAlgebra -/
+/-! ## Helper lemmas for IsBasicAlgebraSplit -/
 
 /-- A field k is a basic algebra over itself: every simple k-module is 1-dimensional. -/
-lemma Etingof.isBasicAlgebra_field : Etingof.IsBasicAlgebra k k := by
+lemma Etingof.isBasicAlgebra_field : Etingof.IsBasicAlgebraSplit k k := by
   intro M _ hModA hSimp hModK hST
   -- The two Module k M instances (from A = k and from the explicit k-module) must agree
   -- via the IsScalarTower k k M condition
@@ -144,7 +144,7 @@ definition of basic cannot always be achieved.
 theorem Etingof.Corollary_9_7_3_i
     (A : Type u) [Ring A] [Algebra k A] [Module.Finite k A] [IsAlgClosed k] :
     ∃ (B : Type u) (_ : Ring B) (_ : Algebra k B) (_ : Module.Finite k B),
-      Etingof.IsBasicAlgebra k B ∧ Etingof.MoritaEquivalent A B :=
+      Etingof.IsBasicAlgebraSplit k B ∧ Etingof.MoritaEquivalent A B :=
   Etingof.exists_basic_morita_equivalent k A
 
 /-- **Corollary 9.7.3(i), uniqueness**: The basic algebra B from part (i) is unique
@@ -155,7 +155,7 @@ theorem Etingof.Corollary_9_7_3_i_unique [IsAlgClosed k]
     (A : Type u) [Ring A] [Algebra k A] [Module.Finite k A]
     (B₁ : Type u) [Ring B₁] [Algebra k B₁] [Module.Finite k B₁]
     (B₂ : Type u) [Ring B₂] [Algebra k B₂] [Module.Finite k B₂]
-    (_hB₁ : Etingof.IsBasicAlgebra.{u, u, u} k B₁) (_hB₂ : Etingof.IsBasicAlgebra.{u, u, u} k B₂)
+    (_hB₁ : Etingof.IsBasicAlgebraSplit.{u, u, u} k B₁) (_hB₂ : Etingof.IsBasicAlgebraSplit.{u, u, u} k B₂)
     (h₁ : Etingof.KLinearMoritaEquivalent k A B₁)
     (h₂ : Etingof.KLinearMoritaEquivalent k A B₂) :
     Nonempty (B₁ ≃ₐ[k] B₂) := by
@@ -201,7 +201,7 @@ algebra B_A satisfies dim_k B_A ≤ dim_k A.
 theorem Etingof.Corollary_9_7_3_ii [IsAlgClosed k]
     (A : Type u) [Ring A] [Algebra k A] [Module.Finite k A]
     (B : Type u) [Ring B] [Algebra k B] [Module.Finite k B]
-    (_hB : Etingof.IsBasicAlgebra.{u, u, u} k B)
+    (_hB : Etingof.IsBasicAlgebraSplit.{u, u, u} k B)
     (hMor : Etingof.KLinearMoritaEquivalent k A B) :
     Module.finrank k B ≤ Module.finrank k A := by
   -- By the Morita structural theorem, B ≅ eAe for some idempotent e : A.

--- a/EtingofRepresentationTheory/Chapter9/Definition9_7_2.lean
+++ b/EtingofRepresentationTheory/Chapter9/Definition9_7_2.lean
@@ -1,4 +1,5 @@
 import Mathlib.RingTheory.Jacobson.Radical
+import Mathlib.RingTheory.Ideal.Quotient.Defs
 import Mathlib.RingTheory.Artinian.Ring
 import Mathlib.RingTheory.SimpleModule.Basic
 import Mathlib.LinearAlgebra.Dimension.Finrank
@@ -6,22 +7,48 @@ import Mathlib.LinearAlgebra.Dimension.Finrank
 /-!
 # Definition 9.7.2: Basic algebra
 
-A finite dimensional algebra B is called **basic** if B/Rad(B) is a commutative algebra
-(i.e., a direct sum of copies of the ground field k).
+A finite dimensional algebra `B` is called **basic** if `B/Rad(B)` is a commutative
+algebra.
 
-Equivalently, B is basic if and only if all simple B-modules are one-dimensional.
+This file gives the faithful formalization of the book's literal condition as
+`Etingof.IsBasicAlgebra`, together with the stronger "splitting" condition
+`Etingof.IsBasicAlgebraSplit` (every simple module is one-dimensional) that the
+project uses over algebraically closed fields.
 
-## Mathlib correspondence
+## Why two predicates
 
-We use the "all simple modules are one-dimensional" characterization, expressed via
-`Module.finrank`. This is more directly usable in downstream results than the
-Jacobson radical quotient characterization.
+The book's condition is `B/Rad(B)` commutative. Over a field `k`, the semisimple
+quotient `B/Rad(B)` decomposes (Wedderburn–Artin) as a product `∏ᵢ Mat_{nᵢ}(Dᵢ)`
+for division algebras `Dᵢ`; it is commutative exactly when every `nᵢ = 1` and every
+`Dᵢ` is a field. The condition "every simple module is one-dimensional over `k`" is
+*strictly stronger*: it forces `B/Rad(B) ≅ ∏ k` (each `nᵢ = 1` **and** each `Dᵢ = k`).
+The two coincide precisely over an algebraically closed field, where every finite
+division algebra is `k` itself.
+
+`IsBasicAlgebra` (this file's `Etingof.IsBasicAlgebra`) asserts the book's literal
+condition. `IsBasicAlgebraSplit` captures the algebraically-closed reading and is the
+hypothesis used throughout the Morita-theoretic development in
+`Chapter9/MoritaStructural.lean` and `Infrastructure/BasicAlgebraExistence.lean`,
+where the standing assumption is `IsAlgClosed k` (so the two agree).
 -/
 
-/-- A basic algebra in the sense of Etingof Definition 9.7.2.
-A finite dimensional k-algebra A is basic if every simple A-module is one-dimensional
-over k. -/
+/-- A basic algebra in the sense of Etingof Definition 9.7.2: a `k`-algebra `A`
+whose quotient `A / Rad(A)` by the Jacobson radical is commutative. -/
 def Etingof.IsBasicAlgebra (k : Type*) [Field k]
+    (A : Type*) [Ring A] [Algebra k A] : Prop :=
+  ∀ x y : A ⧸ Ring.jacobson A, x * y = y * x
+
+/-- The "split" basic condition: every simple `A`-module is one-dimensional over `k`.
+Over an algebraically closed field this is equivalent to `IsBasicAlgebra` (the book's
+`A / Rad(A)` commutative condition); in general it is strictly stronger. -/
+def Etingof.IsBasicAlgebraSplit (k : Type*) [Field k]
     (A : Type*) [Ring A] [Algebra k A] : Prop :=
   ∀ (M : Type*) [AddCommGroup M] [Module A M] [IsSimpleModule A M] [Module k M]
     [IsScalarTower k A M], Module.finrank k M = 1
+
+/-- Any commutative `k`-algebra is basic: its radical quotient is again commutative,
+so the defining condition holds trivially.  In particular a field is basic over
+itself (Definition 9.7.2). -/
+theorem Etingof.IsBasicAlgebra.of_commutative (k : Type*) [Field k]
+    (A : Type*) [CommRing A] [Algebra k A] : Etingof.IsBasicAlgebra k A :=
+  fun x y => mul_comm x y

--- a/EtingofRepresentationTheory/Chapter9/MoritaStructural.lean
+++ b/EtingofRepresentationTheory/Chapter9/MoritaStructural.lean
@@ -1234,7 +1234,7 @@ theorem MoritaStructural [IsAlgClosed k]
         (CornerRing.instRing he).toSemiring
         _ (@CornerRing.instAlgebra k _ A _ _ e he)) := by
   -- Step 1: Get a full idempotent e whose corner ring eAe is basic
-  obtain ⟨e, he_full, hbasic_corner⟩ := exists_full_idempotent_basic_corner k A
+  obtain ⟨e, he_full, hbasic_corner, _⟩ := exists_full_idempotent_basic_corner k A
   refine ⟨e, he_full.1, ?_⟩
   -- Step 2: Corner ring eAe is k-linearly Morita equivalent to A
   have hKLinCorner := klinear_morita_equiv_of_full_idempotent (k := k) he_full

--- a/EtingofRepresentationTheory/Chapter9/MoritaStructural.lean
+++ b/EtingofRepresentationTheory/Chapter9/MoritaStructural.lean
@@ -820,7 +820,7 @@ private theorem semisimple_iso_of_finrank_hom_eq
 private noncomputable def head_isomorphism [IsAlgClosed k]
     (B₁ : Type u) [Ring B₁] [Algebra k B₁] [Module.Finite k B₁]
     (B₂ : Type u) [Ring B₂] [Algebra k B₂] [Module.Finite k B₂]
-    (_hB₁ : IsBasicAlgebra k B₁) (_hB₂ : IsBasicAlgebra k B₂)
+    (_hB₁ : IsBasicAlgebraSplit k B₁) (_hB₂ : IsBasicAlgebraSplit k B₂)
     (F : ModuleCat.{u} B₁ ≌ ModuleCat.{u} B₂) [F.functor.Linear k] :
     let Pt := (F.functor.obj (ModuleCat.of B₁ B₁) : Type u)
     let J₂ := Ring.jacobson B₂
@@ -938,7 +938,7 @@ private noncomputable def head_isomorphism [IsAlgClosed k]
 private noncomputable def exists_surjection_with_trivial_kernel_head [IsAlgClosed k]
     (B₁ : Type u) [Ring B₁] [Algebra k B₁] [Module.Finite k B₁]
     (B₂ : Type u) [Ring B₂] [Algebra k B₂] [Module.Finite k B₂]
-    (_hB₁ : IsBasicAlgebra k B₁) (_hB₂ : IsBasicAlgebra k B₂)
+    (_hB₁ : IsBasicAlgebraSplit k B₁) (_hB₂ : IsBasicAlgebraSplit k B₂)
     (F : ModuleCat.{u} B₁ ≌ ModuleCat.{u} B₂) [F.functor.Linear k] :
     Σ' (f : (F.functor.obj (ModuleCat.of B₁ B₁)) →ₗ[B₂] B₂),
       Function.Surjective f ∧
@@ -1035,7 +1035,7 @@ projective module with head `≅ k^n` (one copy of each simple). -/
 private noncomputable def basic_morita_regular_module_iso [IsAlgClosed k]
     (B₁ : Type u) [Ring B₁] [Algebra k B₁] [Module.Finite k B₁]
     (B₂ : Type u) [Ring B₂] [Algebra k B₂] [Module.Finite k B₂]
-    (_hB₁ : IsBasicAlgebra k B₁) (_hB₂ : IsBasicAlgebra k B₂)
+    (_hB₁ : IsBasicAlgebraSplit k B₁) (_hB₂ : IsBasicAlgebraSplit k B₂)
     (F : ModuleCat.{u} B₁ ≌ ModuleCat.{u} B₂) [F.functor.Linear k] :
     F.functor.obj (ModuleCat.of B₁ B₁) ≅ ModuleCat.of B₂ B₂ := by
   -- B₂ is Artinian (finite-dim over field)
@@ -1173,8 +1173,8 @@ private noncomputable def equivEndAlgEquiv [IsAlgClosed k]
 private lemma basic_morita_algEquiv [IsAlgClosed k]
     (B₁ : Type u) [Ring B₁] [Algebra k B₁] [Module.Finite k B₁]
     (B₂ : Type u) [Ring B₂] [Algebra k B₂] [Module.Finite k B₂]
-    (_hB₁ : Etingof.IsBasicAlgebra.{u, u, u} k B₁)
-    (_hB₂ : Etingof.IsBasicAlgebra.{u, u, u} k B₂)
+    (_hB₁ : Etingof.IsBasicAlgebraSplit.{u, u, u} k B₁)
+    (_hB₂ : Etingof.IsBasicAlgebraSplit.{u, u, u} k B₂)
     (h : KLinearMoritaEquivalent k B₁ B₂) :
     Nonempty (B₁ ≃ₐ[k] B₂) := by
   obtain ⟨F, hlin⟩ := h
@@ -1201,7 +1201,7 @@ over an algebraically closed field and `B` is a basic finite-dimensional
 `k`-algebra that is Morita equivalent to `A`, then there exists an idempotent
 `e : A` such that `B` is isomorphic (as a `k`-algebra) to the corner ring `eAe`.
 
-The `IsBasicAlgebra k B` hypothesis is essential: without it the statement is
+The `IsBasicAlgebraSplit k B` hypothesis is essential: without it the statement is
 false. For example, `k` and `Mₙ(k)` are Morita equivalent, but `Mₙ(k)` cannot
 be realized as `eke` for any `e ∈ k`. The basic algebra is always the smallest
 representative in a Morita equivalence class, so it embeds as a corner ring of
@@ -1227,7 +1227,7 @@ equivalence proved in Theorem 9.6.4.
 theorem MoritaStructural [IsAlgClosed k]
     (A : Type u) [Ring A] [Algebra k A] [Module.Finite k A]
     (B : Type u) [Ring B] [Algebra k B] [Module.Finite k B]
-    (_hB : Etingof.IsBasicAlgebra.{u, u, u} k B)
+    (_hB : Etingof.IsBasicAlgebraSplit.{u, u, u} k B)
     (h : KLinearMoritaEquivalent k A B) :
     ∃ (e : A) (he : IsIdempotentElem e),
       Nonempty (@AlgEquiv k B (CornerRing (k := k) e) _ _
@@ -1245,7 +1245,7 @@ theorem MoritaStructural [IsAlgClosed k]
   have hKLinBC : KLinearMoritaEquivalent k B (CornerRing (k := k) e) :=
     h.symm'.trans' hKLinCorner
   -- Step 4: Two basic k-linearly Morita equivalent algebras are isomorphic
-  have hbasic_corner' : IsBasicAlgebra.{_, _, u} k (CornerRing (k := k) e) :=
+  have hbasic_corner' : IsBasicAlgebraSplit.{_, _, u} k (CornerRing (k := k) e) :=
     fun M _ _ _ _ _ => hbasic_corner M
   exact basic_morita_algEquiv B (CornerRing (k := k) e) _hB hbasic_corner' hKLinBC
 

--- a/EtingofRepresentationTheory/Infrastructure/BasicAlgebraExistence.lean
+++ b/EtingofRepresentationTheory/Infrastructure/BasicAlgebraExistence.lean
@@ -239,7 +239,7 @@ lemma exists_full_idempotent_basic_corner
     (k : Type u) [Field k] [IsAlgClosed k]
     (A : Type u) [Ring A] [Algebra k A] [Module.Finite k A] :
     ∃ (e : A) (he : IsFullIdempotent e),
-      @IsBasicAlgebra k _ (CornerRing (k := k) e) (CornerRing.instRing he.1)
+      @IsBasicAlgebraSplit k _ (CornerRing (k := k) e) (CornerRing.instRing he.1)
         (CornerRing.instAlgebra he.1) := by
   -- Step 1: A is Artinian (finite-dim over a field)
   haveI : IsArtinianRing A := IsArtinianRing.of_finite k A
@@ -394,7 +394,7 @@ lemma exists_full_idempotent_basic_corner
         exact IsNilpotent.isUnit_one_sub
           (hker_nil j (by rwa [RingHom.mem_ker, Ideal.Quotient.eq_zero_iff_mem]))
       exact Ideal.eq_top_of_isUnit_mem I hxI hx_unit
-  have he_basic : @IsBasicAlgebra k _ (CornerRing (k := k) e)
+  have he_basic : @IsBasicAlgebraSplit k _ (CornerRing (k := k) e)
       (CornerRing.instRing he_full.1) (CornerRing.instAlgebra he_full.1) := by
     letI : Ring (CornerRing (k := k) e) := CornerRing.instRing he_full.1
     letI : Algebra k (CornerRing (k := k) e) := CornerRing.instAlgebra he_full.1
@@ -1298,7 +1298,7 @@ theorem exists_basic_morita_equivalent
     (k : Type u) [Field k] [IsAlgClosed k]
     (A : Type u) [Ring A] [Algebra k A] [Module.Finite k A] :
     ∃ (B : Type u) (_ : Ring B) (_ : Algebra k B) (_ : Module.Finite k B),
-      IsBasicAlgebra k B ∧ MoritaEquivalent A B := by
+      IsBasicAlgebraSplit k B ∧ MoritaEquivalent A B := by
   obtain ⟨e, he, hbasic⟩ := exists_full_idempotent_basic_corner k A
   letI : Ring (CornerRing (k := k) e) := CornerRing.instRing he.1
   letI : Algebra k (CornerRing (k := k) e) := CornerRing.instAlgebra he.1

--- a/EtingofRepresentationTheory/Infrastructure/BasicAlgebraExistence.lean
+++ b/EtingofRepresentationTheory/Infrastructure/BasicAlgebraExistence.lean
@@ -65,6 +65,17 @@ idempotents for which the corner ring `eAe` is Morita equivalent to `A`. -/
 def IsFullIdempotent {A : Type*} [Ring A] (e : A) : Prop :=
   IsIdempotentElem e ∧ Ideal.span {a * e * b | (a : A) (b : A)} = ⊤
 
+/-- If every left multiple `w * c` is nilpotent (e.g. `c` lies in a nil two-sided
+ideal), then `c` lies in the Jacobson radical of `R`. -/
+theorem mem_jacobson_of_forall_isNilpotent_left_mul {R : Type*} [Ring R] {c : R}
+    (h : ∀ w : R, IsNilpotent (w * c)) : c ∈ Ring.jacobson R := by
+  rw [← Ideal.jacobson_bot, Ideal.mem_jacobson_iff]
+  intro y
+  obtain ⟨b, hb⟩ := (h y).isUnit_one_add.exists_left_inv
+  refine ⟨b, ?_⟩
+  rw [mul_add, mul_one, ← mul_assoc] at hb
+  rw [Ideal.mem_bot, add_comm (b * y * c) b, hb, sub_self]
+
 /-! ## Helper: Existence of full idempotent with basic corner ring
 
 For a finite-dimensional algebra `A` over an algebraically closed field `k`,
@@ -239,7 +250,9 @@ lemma exists_full_idempotent_basic_corner
     (k : Type u) [Field k] [IsAlgClosed k]
     (A : Type u) [Ring A] [Algebra k A] [Module.Finite k A] :
     ∃ (e : A) (he : IsFullIdempotent e),
-      @IsBasicAlgebraSplit k _ (CornerRing (k := k) e) (CornerRing.instRing he.1)
+      @IsBasicAlgebraSplit.{u, u, u} k _ (CornerRing (k := k) e) (CornerRing.instRing he.1)
+        (CornerRing.instAlgebra he.1) ∧
+      @IsBasicAlgebra k _ (CornerRing (k := k) e) (CornerRing.instRing he.1)
         (CornerRing.instAlgebra he.1) := by
   -- Step 1: A is Artinian (finite-dim over a field)
   haveI : IsArtinianRing A := IsArtinianRing.of_finite k A
@@ -394,8 +407,10 @@ lemma exists_full_idempotent_basic_corner
         exact IsNilpotent.isUnit_one_sub
           (hker_nil j (by rwa [RingHom.mem_ker, Ideal.Quotient.eq_zero_iff_mem]))
       exact Ideal.eq_top_of_isUnit_mem I hxI hx_unit
-  have he_basic : @IsBasicAlgebraSplit k _ (CornerRing (k := k) e)
-      (CornerRing.instRing he_full.1) (CornerRing.instAlgebra he_full.1) := by
+  have he_basic : (@IsBasicAlgebraSplit.{u, u, u} k _ (CornerRing (k := k) e)
+      (CornerRing.instRing he_full.1) (CornerRing.instAlgebra he_full.1)) ∧
+      (@IsBasicAlgebra k _ (CornerRing (k := k) e)
+      (CornerRing.instRing he_full.1) (CornerRing.instAlgebra he_full.1)) := by
     letI : Ring (CornerRing (k := k) e) := CornerRing.instRing he_full.1
     letI : Algebra k (CornerRing (k := k) e) := CornerRing.instAlgebra he_full.1
     -- === Part A: φ(q(e)) = constant function E₁₁ ===
@@ -473,6 +488,24 @@ lemma exists_full_idempotent_basic_corner
       have hval : (x ^ (n + 1) : CornerRing (k := k) e).val = (0 : A) :=
         (corner_pow n).trans (by rw [pow_succ, hxn, zero_mul])
       exact Subtype.ext hval
+    -- === Faithful basic condition (Definition 9.7.2): eAe/Rad(eAe) commutative ===
+    -- For any x y, the commutator xy - yx maps to 0 under the ring hom π into the
+    -- commutative ring `∏ k`, so it lies in `ker π`, a nil two-sided ideal, hence
+    -- in the Jacobson radical.  Therefore the radical quotient is commutative.
+    have hfaithful : @IsBasicAlgebra k _ (CornerRing (k := k) e)
+        (CornerRing.instRing he_full.1) (CornerRing.instAlgebra he_full.1) := by
+      intro xq yq
+      obtain ⟨x, rfl⟩ := Ideal.Quotient.mk_surjective xq
+      obtain ⟨y, rfl⟩ := Ideal.Quotient.mk_surjective yq
+      rw [← map_mul, ← map_mul, Ideal.Quotient.eq]
+      apply mem_jacobson_of_forall_isNilpotent_left_mul
+      intro w
+      apply hπ_ker_nilpotent_elem
+      rw [RingHom.mem_ker, map_mul]
+      have hc : π (x * y - y * x) = 0 := by
+        rw [map_sub, map_mul, map_mul, mul_comm (π x) (π y), sub_self]
+      rw [hc, mul_zero]
+    refine ⟨?_, hfaithful⟩
     -- === Part F: ker π annihilates simple modules ===
     -- If a ∈ ker π and a•m ≠ 0, then by simplicity m = (ba)•m for some b,
     -- so m = (ba)^N•m = 0 (ba is nilpotent in ker π), contradiction.
@@ -1288,8 +1321,8 @@ lemma klinear_morita_equiv_of_full_idempotent
   exact cornerFunctor_linear_k (k := k) he.1
 
 /-- **Basic algebra existence**: For a finite-dimensional algebra `A` over an
-algebraically closed field `k`, there exists a basic algebra `B` (all simple
-modules 1-dimensional) that is Morita equivalent to `A`.
+algebraically closed field `k`, there exists a basic algebra `B` (Definition 9.7.2:
+`B/Rad(B)` commutative) that is Morita equivalent to `A`.
 
 This is the constructive core of Corollary 9.7.3(i). The witness `B` is
 a corner ring `eAe` where `e` is a sum of lifted primitive idempotents,
@@ -1298,8 +1331,8 @@ theorem exists_basic_morita_equivalent
     (k : Type u) [Field k] [IsAlgClosed k]
     (A : Type u) [Ring A] [Algebra k A] [Module.Finite k A] :
     ∃ (B : Type u) (_ : Ring B) (_ : Algebra k B) (_ : Module.Finite k B),
-      IsBasicAlgebraSplit k B ∧ MoritaEquivalent A B := by
-  obtain ⟨e, he, hbasic⟩ := exists_full_idempotent_basic_corner k A
+      IsBasicAlgebra k B ∧ MoritaEquivalent A B := by
+  obtain ⟨e, he, _, hbasic⟩ := exists_full_idempotent_basic_corner k A
   letI : Ring (CornerRing (k := k) e) := CornerRing.instRing he.1
   letI : Algebra k (CornerRing (k := k) e) := CornerRing.instAlgebra he.1
   exact ⟨CornerRing (k := k) e,

--- a/progress/2026-06-26T09-45-59Z_7c9d0f0f.md
+++ b/progress/2026-06-26T09-45-59Z_7c9d0f0f.md
@@ -1,0 +1,47 @@
+## Accomplished
+
+Fidelity fix for `Chapter9/Definition9.7.2` (issue #5386, decl `Etingof.IsBasicAlgebra`).
+
+The flagged gap was real (re-confirmed): the book defines *basic* as "B/Rad(B)
+commutative", but the Lean `IsBasicAlgebra` asserted the strictly stronger "every
+simple module is one-dimensional over k". These coincide only over algebraically
+closed fields.
+
+Changes:
+- `Chapter9/Definition9_7_2.lean`: `Etingof.IsBasicAlgebra` now faithfully asserts
+  the book's condition — `A ⧸ Ring.jacobson A` is commutative
+  (`∀ x y, x * y = y * x`). The old "all simples 1-dim" predicate is preserved as
+  `Etingof.IsBasicAlgebraSplit` (documented as the algebraically-closed reading).
+  Added `IsBasicAlgebra.of_commutative` (any commutative algebra is basic).
+- Renamed every downstream reference (`MoritaStructural`, `Corollary9_7_3`,
+  `BasicAlgebraExistence`) from the strong predicate to `IsBasicAlgebraSplit`.
+  This is a pure mechanical rename: every Morita-chain hypothesis is unused
+  (`_hB`), so no proof changed. All three modules build sorry-free.
+
+Key finding: the entire Morita development carries `IsBasicAlgebra` only as an
+*unused* hypothesis (`_hB₁`, `_hB₂`, `_hB`); only the *constructors*
+(`isBasicAlgebra_field`, `exists_full_idempotent_basic_corner`) build the
+predicate, and they build the split form.
+
+## Current frontier
+
+Baseline (faithful definition + split rename) builds and is committed. Optionally
+wiring the public Corollary 9.7.3 statements to the faithful `IsBasicAlgebra` via a
+"split ⟹ basic" bridge (over `[IsAlgClosed k] [Module.Finite k A]`) — the corner
+constructor already builds a ring hom `eAe →+* ∏ k` whose nil kernel gives the
+radical-quotient commutativity directly.
+
+## Overall project progress
+
+Phase 3 formalization, endgame. This is a fidelity-sweep wave-1 fix (epic #5338).
+Definition 9.7.2 now matches the book literally.
+
+## Next step
+
+Set `progress/items.json` `Chapter9/Definition9.7.2` fidelity → `verified`.
+Optionally prove the `IsBasicAlgebraSplit → IsBasicAlgebra` bridge and restate the
+9.7.3 corollaries with the faithful predicate.
+
+## Blockers
+
+None.

--- a/progress/2026-06-26T09-45-59Z_7c9d0f0f.md
+++ b/progress/2026-06-26T09-45-59Z_7c9d0f0f.md
@@ -23,13 +23,17 @@ Key finding: the entire Morita development carries `IsBasicAlgebra` only as an
 (`isBasicAlgebra_field`, `exists_full_idempotent_basic_corner`) build the
 predicate, and they build the split form.
 
-## Current frontier
+Second commit wires the public Corollary 9.7.3(i) to the faithful predicate:
+- `exists_full_idempotent_basic_corner` now *also* produces
+  `IsBasicAlgebra (eAe)` (faithful), reusing its existing ring hom
+  `π : eAe →+* ∏ k`: each commutator `xy - yx` maps to `0` (commutative target),
+  so it lies in `ker π`, a nil two-sided ideal, hence in `Ring.jacobson (eAe)`.
+- New reusable helper `mem_jacobson_of_forall_isNilpotent_left_mul`.
+- `exists_basic_morita_equivalent` and `Etingof.Corollary_9_7_3_i` now state the
+  book's faithful `IsBasicAlgebra`. `#print axioms` on both shows no `sorryAx`.
 
-Baseline (faithful definition + split rename) builds and is committed. Optionally
-wiring the public Corollary 9.7.3 statements to the faithful `IsBasicAlgebra` via a
-"split ⟹ basic" bridge (over `[IsAlgClosed k] [Module.Finite k A]`) — the corner
-constructor already builds a ring hom `eAe →+* ∏ k` whose nil kernel gives the
-radical-quotient commutativity directly.
+The unused Morita-chain hypotheses stay typed as `IsBasicAlgebraSplit` (no consumer
+churn).
 
 ## Overall project progress
 

--- a/progress/items.json
+++ b/progress/items.json
@@ -6512,9 +6512,9 @@
   "start_line": 13,
   "end_line": 16,
   "status": "sorry_free",
-  "fidelity": "gap",
+  "fidelity": "verified",
   "sorry_free": true,
-  "fidelity_note": "Book defines basic as 'B/Rad(B) commutative'. The Lean def IsBasicAlgebra k A := ∀ simple A-module M, finrank k M = 1 (all simples 1-dimensional). These coincide only over algebraically closed k: '...",
+  "fidelity_note": "Resolved (#5386): IsBasicAlgebra now faithfully asserts the book's literal condition 'A/Rad(A) commutative' (A ⧸ Ring.jacobson A commutative). The previous 'all simples 1-dimensional' reading is preserved as IsBasicAlgebraSplit and used over algebraically closed fields, where the two coincide.",
   "fidelity_decl": "Etingof.IsBasicAlgebra",
   "fidelity_issue": 5386
  },


### PR DESCRIPTION
Closes #5386

Session: `7c9d0f0f-8049-4a15-9138-0136209f7dff`

6226899d feat(Ch9 Corollary9.7.3): wire existence to faithful basic-algebra predicate (#5386)
f8cb9669 fix(Ch9 Definition9.7.2): assert book's faithful 'B/Rad commutative' basic-algebra condition (#5386)

🤖 Prepared with Claude Code