### PR TITLE
fix(Ch2 Definition2.14.1): attach Leibniz Lie action to tensor product

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Definition2_14_1.lean
+++ b/EtingofRepresentationTheory/Chapter2/Definition2_14_1.lean
@@ -1,5 +1,4 @@
-import Mathlib.Algebra.Lie.Basic
-import Mathlib.LinearAlgebra.TensorProduct.Basic
+import Mathlib.Algebra.Lie.TensorProduct
 
 /-!
 # Definition 2.14.1: Tensor Product of Lie Algebra Representations
@@ -9,18 +8,38 @@ V ⊗ W with ρ_{V⊗W}(x) = ρ_V(x) ⊗ Id + Id ⊗ ρ_W(x).
 
 ## Mathlib correspondence
 
-Mathlib has both `TensorProduct` and `LieModule`. The Lie module structure on tensor
-products uses the Leibniz rule. The instance may exist under
-`Mathlib.Algebra.Lie.TensorProduct`.
+`Mathlib.Algebra.Lie.TensorProduct` equips `V ⊗ W` with the Leibniz Lie action via the
+instances `TensorProduct.LieModule.lieRingModule` and `TensorProduct.LieModule.lieModule`.
+Importing it brings those instances into scope, so `LieTensorProduct` below genuinely
+carries the Lie module structure the book defines (not a plain `k`-module). The defining
+Leibniz identity is recorded as `Etingof.LieTensorProduct.lie_tmul`.
 -/
 
 open scoped TensorProduct
 
 /-- The tensor product of two Lie algebra representations, in the sense of
-Etingof Definition 2.14.1. The Lie action on V ⊗ W is given by the Leibniz rule:
-x · (v ⊗ w) = (x · v) ⊗ w + v ⊗ (x · w). -/
+Etingof Definition 2.14.1. With `Mathlib.Algebra.Lie.TensorProduct` imported, the
+`LieRingModule`/`LieModule` instances on `V ⊗ W` are in scope, so this abbrev carries
+the Lie action `x · (v ⊗ w) = (x · v) ⊗ w + v ⊗ (x · w)` (the Leibniz rule), not merely
+the underlying `k`-module. See `Etingof.LieTensorProduct.lie_tmul`. -/
 abbrev Etingof.LieTensorProduct (k : Type*) (L : Type*) (V : Type*) (W : Type*)
     [CommRing k] [LieRing L] [LieAlgebra k L]
     [AddCommGroup V] [Module k V] [LieRingModule L V] [LieModule k L V]
     [AddCommGroup W] [Module k W] [LieRingModule L W] [LieModule k L W] :=
   TensorProduct k V W
+
+namespace Etingof
+
+variable {k L V W : Type*}
+    [CommRing k] [LieRing L] [LieAlgebra k L]
+    [AddCommGroup V] [Module k V] [LieRingModule L V] [LieModule k L V]
+    [AddCommGroup W] [Module k W] [LieRingModule L W] [LieModule k L W]
+
+/-- The defining content of Definition 2.14.1: the Lie action on the tensor product
+`V ⊗ W` obeys the Leibniz rule `ρ_{V⊗W}(x) = ρ_V(x) ⊗ Id + Id ⊗ ρ_W(x)`, i.e. on simple
+tensors `x · (v ⊗ w) = (x · v) ⊗ w + v ⊗ (x · w)`. -/
+theorem LieTensorProduct.lie_tmul (x : L) (v : V) (w : W) :
+    ⁅x, (v ⊗ₜ[k] w : LieTensorProduct k L V W)⁆ = ⁅x, v⁆ ⊗ₜ[k] w + v ⊗ₜ[k] ⁅x, w⁆ :=
+  TensorProduct.LieModule.lie_tmul_right x v w
+
+end Etingof

--- a/progress/2026-06-26T10-32-27Z.md
+++ b/progress/2026-06-26T10-32-27Z.md
@@ -1,0 +1,33 @@
+## Accomplished
+
+Resolved fidelity gap #5355 for `Chapter2/Definition2.14.1` (tensor product of
+Lie algebra representations).
+
+- The previous `Etingof.LieTensorProduct` abbrev imported only
+  `TensorProduct.Basic`, so no `LieRingModule` instance on `V ⊗ W` was in scope —
+  the alias was a plain `k`-module with no Lie action, the entire defining content.
+- Switched the import to `Mathlib.Algebra.Lie.TensorProduct`, which brings the
+  `TensorProduct.LieModule.lieRingModule` / `lieModule` instances into scope. The
+  abbrev now genuinely carries the Leibniz Lie action.
+- Added `Etingof.LieTensorProduct.lie_tmul`, which asserts and proves the defining
+  identity `⁅x, v ⊗ₜ w⁆ = ⁅x, v⁆ ⊗ₜ w + v ⊗ₜ ⁅x, w⁆`
+  (`ρ_{V⊗W}(x) = ρ_V(x)⊗Id + Id⊗ρ_W(x)`), via `lie_tmul_right`.
+- Build is clean: `lake build EtingofRepresentationTheory.Chapter2.Definition2_14_1`
+  succeeds, sorry-free.
+- Set `fidelity: verified` for the item in `progress/items.json`.
+
+## Current frontier
+
+Fidelity sweep wave-1 (epic #5338). Item 2.14.1 now verified.
+
+## Overall project progress
+
+Stage 3 formalization ongoing; fidelity-sweep re-confirmation work in progress.
+
+## Next step
+
+Continue re-confirming other wave-1 fidelity-gap issues under epic #5338.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -1279,10 +1279,10 @@
   "start_line": 10,
   "end_line": 14,
   "status": "sorry_free",
-  "fidelity": "gap",
+  "fidelity": "verified",
   "sorry_free": true,
-  "fidelity_note": "The defining content is the LIE ACTION rho_{V⊗W}(x) = rho_V(x)⊗Id + Id⊗rho_W(x) (Leibniz rule). The Lean abbrev is merely := TensorProduct k V W, a PLAIN k-module with NO Lie action attached. The f...",
-  "fidelity_decl": "Etingof.LieTensorProduct (abbrev) := TensorProduct k V W",
+  "fidelity_note": "Resolved (#5355): file now imports Mathlib.Algebra.Lie.TensorProduct, so the LieRingModule/LieModule instances on V ⊗ W are in scope and LieTensorProduct carries the Leibniz Lie action. The defining identity rho_{V⊗W}(x) = rho_V(x)⊗Id + Id⊗rho_W(x) is asserted and proven as Etingof.LieTensorProduct.lie_tmul.",
+  "fidelity_decl": "Etingof.LieTensorProduct (abbrev) := TensorProduct k V W; Etingof.LieTensorProduct.lie_tmul",
   "fidelity_issue": 5355
  },
  {


### PR DESCRIPTION
Closes #5355

Session: `896b9419-6dec-40a7-a839-3a6b21fa0e90`

b33477a6 fix(Ch2 Definition2.14.1): attach Leibniz Lie action to tensor product (#5355)

🤖 Prepared with Claude Code