### PR TITLE
fix(Ch4 Example4.1.3): use genuine representation-irreducibility hypothesis

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Example4_1_3.lean
+++ b/EtingofRepresentationTheory/Chapter4/Example4_1_3.lean
@@ -4,28 +4,48 @@ import Mathlib
 # Example 4.1.3: Representations of ℤ/pℤ in Characteristic p
 
 If G = ℤ/pℤ and k has characteristic p, then every irreducible representation of G
-over k is trivial (1-dimensional with trivial action).
+over k is trivial (the generator acts as the identity).
 
-The argument: any irreducible representation is 1-dimensional, and the generator g must
-act by a p-th root of unity. But over a field of characteristic p, xᵖ - 1 = (x - 1)ᵖ,
-so the only p-th root of unity is 1.
+The book's argument runs through the generator acting by a p-th root of unity, and over a
+field of characteristic p one has `xᵖ - 1 = (x - 1)ᵖ`, so the only p-th root of unity is 1.
+We formalize an equivalent route that takes representation-irreducibility as the genuine
+hypothesis: writing `g` for the generator, `ρ g - 1` is nilpotent (since `(ρ g - 1)ᵖ = 0` by
+the same freshman's-dream identity) and, because `ℤ/pℤ` is abelian, it is a self-intertwiner
+of `ρ`. Schur's lemma then forces `ρ g - 1` to be injective or zero; nilpotency on a nonzero
+space rules out injectivity, so `ρ g = id`.
 
 This shows that the hypothesis in Maschke's theorem (char k ∤ |G|) is essential.
 
 ## Mathlib correspondence
 
-Uses `ZMod p` for the cyclic group and `CharP k p` for characteristic p.
+Uses `ZMod p` for the cyclic group and `CharP k p` for characteristic p. Irreducibility is
+`IsSimpleModule (MonoidAlgebra k (Multiplicative (ZMod p))) ρ.asModule`, i.e. Mathlib's
+`Representation.IsIrreducible ρ`; Schur's lemma is
+`Representation.IsIrreducible.injective_or_eq_zero`.
 -/
 
+open scoped MonoidAlgebra in
 /-- In characteristic p, every irreducible representation of ℤ/pℤ is trivial.
+
+The hypothesis `hirr` is genuine representation-irreducibility: `ρ.asModule` is simple as a
+module over the group algebra `k[ℤ/pℤ]`, i.e. the representation has no proper nonzero
+`ρ`-invariant subspace (Mathlib's `Representation.IsIrreducible`). This is the book's notion,
+*not* `IsSimpleModule k V` (which would force `V` to be one-dimensional and assume away the
+content). The conclusion `ρ g = id` says the representation is trivial.
 (Etingof Example 4.1.3) -/
 theorem Etingof.Example4_1_3
     (k : Type*) (p : ℕ) [Field k] [hp : Fact (Nat.Prime p)] [CharP k p]
     (V : Type*) [AddCommGroup V] [Module k V] [Module.Finite k V]
     (ρ : Representation k (Multiplicative (ZMod p)) V)
-    (hirr : IsSimpleModule k V) :
+    (hirr : IsSimpleModule (MonoidAlgebra k (Multiplicative (ZMod p))) ρ.asModule) :
     -- Every irreducible rep is trivial: ρ(g) = id for all g
     ∀ g : Multiplicative (ZMod p), ρ g = LinearMap.id := by
+  -- Repackage `hirr` as Mathlib's irreducibility predicate so Schur's lemma applies.
+  haveI hirr' : Representation.IsIrreducible ρ :=
+    (Representation.irreducible_iff_isSimpleModule_asModule ρ).mpr hirr
+  haveI : Nontrivial ρ.asModule :=
+    IsSimpleModule.nontrivial (MonoidAlgebra k (Multiplicative (ZMod p))) ρ.asModule
+  haveI : Nontrivial V := (ρ.asModuleEquiv).toEquiv.symm.nontrivial
   intro g
   -- Step 1: g^p = 1 since |Multiplicative (ZMod p)| = p
   have hgp : g ^ p = 1 := by
@@ -36,30 +56,31 @@ theorem Etingof.Example4_1_3
     rw [← map_pow, hgp, map_one]
   -- Step 3: (ρ(g) - 1)^p = 0 by freshman's dream in char p
   have hnil : (ρ g - 1) ^ p = 0 := by
-    haveI : Nontrivial V := IsSimpleModule.nontrivial k (M := V)
     haveI : CharP (Module.End k V) p :=
       charP_of_injective_algebraMap' k p
     rw [sub_pow_char_of_commute p (Commute.one_right _)]
     rw [one_pow, hρp, sub_self]
-  -- Step 4: ρ(g) - 1 is nilpotent
-  have hIsNil : IsNilpotent (ρ g - 1) := ⟨p, hnil⟩
-  -- Step 5: nilpotent endomorphism on simple module must be zero
-  -- By Schur: ker(ρ g - 1) is either ⊥ or ⊤. If ⊥, the map is injective hence
-  -- bijective (finite-dim), contradicting nilpotency. So ker = ⊤, meaning ρ g - 1 = 0.
-  haveI : Nontrivial V := IsSimpleModule.nontrivial k (M := V)
-  have hzero : ρ g - 1 = 0 := by
-    rcases IsSimpleOrder.eq_bot_or_eq_top (LinearMap.ker (ρ g - 1)) with hbot | htop
-    · -- ker = ⊥ means injective. f^p is also injective (iterate).
-      -- But f^p = 0 has ker = ⊤, contradiction.
-      exfalso
-      have hinj := LinearMap.ker_eq_bot.mp hbot
-      have hinj_iter : Function.Injective (⇑(ρ g - 1))^[p] := hinj.iterate p
-      rw [← Module.End.coe_pow] at hinj_iter
-      rw [hnil] at hinj_iter
-      -- hinj_iter : Function.Injective ⇑(0 : Module.End k V)
-      obtain ⟨a, b, hab⟩ := exists_pair_ne V
-      exact hab (hinj_iter (by simp))
-    · exact LinearMap.ker_eq_top.mp htop
-  -- ρ g - 1 = 0 implies ρ g = 1 = LinearMap.id
-  rwa [sub_eq_zero] at hzero
+  -- Step 4: `ρ g - 1` intertwines `ρ` with itself, because `ℤ/pℤ` is abelian, so `ρ h`
+  -- commutes with `ρ g`.
+  have key : ∀ (h : Multiplicative (ZMod p)) (v : V), ρ g (ρ h v) = ρ h (ρ g v) := by
+    intro h v
+    rw [← Module.End.mul_apply, ← map_mul, mul_comm, map_mul, Module.End.mul_apply]
+  let f : Representation.IntertwiningMap ρ ρ :=
+    LinearMap.intertwiningMap_of_isIntertwiningMap ρ ρ (ρ g - 1) (by
+      intro h v
+      simp only [LinearMap.sub_apply, Module.End.one_apply, map_sub, key h v])
+  -- Step 5: by Schur, the intertwiner `f = ρ g - 1` is injective or zero. It cannot be
+  -- injective: it is nilpotent (`fᵖ = 0`) and `V` is nontrivial. Hence `f = 0`, i.e. `ρ g = id`.
+  rcases Representation.IsIrreducible.injective_or_eq_zero f with hinj | hf0
+  · exfalso
+    have hinj' : Function.Injective (⇑(ρ g - 1)) := hinj
+    have hinj_iter : Function.Injective (⇑(ρ g - 1))^[p] := hinj'.iterate p
+    rw [← Module.End.coe_pow, hnil] at hinj_iter
+    obtain ⟨a, b, hab⟩ := exists_pair_ne V
+    exact hab (hinj_iter (by simp))
+  · have hzero : ρ g - 1 = 0 := by
+      ext v
+      have hv := DFunLike.congr_fun hf0 v
+      simpa [f] using hv
+    rwa [sub_eq_zero] at hzero
 

--- a/progress/2026-06-26T11-20-27Z_354fab81.md
+++ b/progress/2026-06-26T11-20-27Z_354fab81.md
@@ -1,0 +1,41 @@
+## Accomplished
+
+Fixed the fidelity gap in `Chapter4/Example4.1.3` (issue #5374).
+
+The Lean theorem `Etingof.Example4_1_3` previously took `hirr : IsSimpleModule k V`,
+which forces `V` to be one-dimensional as a `k`-vector space — the *wrong* notion of
+irreducibility. It silently assumed the book's "irreducible ⟹ 1-dimensional" step and so
+did not faithfully state the book's claim.
+
+Changes:
+- Replaced the hypothesis with genuine representation-irreducibility:
+  `hirr : IsSimpleModule (MonoidAlgebra k (Multiplicative (ZMod p))) ρ.asModule`,
+  which is exactly Mathlib's `Representation.IsIrreducible ρ`.
+- Reworked the proof to avoid relying on `k`-module simplicity. `ρ g - 1` is nilpotent
+  (`(ρ g - 1)ᵖ = 0` by the freshman's-dream identity in characteristic `p`) and, because
+  `ℤ/pℤ` is abelian, is a self-intertwiner of `ρ`. Schur's lemma
+  (`Representation.IsIrreducible.injective_or_eq_zero`) forces it to be injective or zero;
+  nilpotency on a nontrivial space rules out injectivity, so `ρ g = id`.
+- Updated module docstring and theorem docstring to describe the faithful hypothesis and
+  the Schur/nilpotency route.
+- Set `fidelity: verified` for `Chapter4/Example4.1.3` in `progress/items.json`.
+
+File builds clean (no `sorry`, no warnings). Only `Chapter4.lean` (an import aggregator)
+references the declaration, so no downstream call sites needed updating.
+
+## Current frontier
+
+Issue #5374 complete; PR opened.
+
+## Overall project progress
+
+Stage 3 formalization, ongoing fidelity-sweep remediation (epic #5338). One more
+wave-1 fidelity gap closed and re-verified.
+
+## Next step
+
+Continue with the next fidelity-sweep issue or other open work items.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -2107,9 +2107,9 @@
   "start_line": 13,
   "end_line": 14,
   "status": "sorry_free",
-  "fidelity": "gap",
+  "fidelity": "verified",
   "sorry_free": true,
-  "fidelity_note": "Hypothesis fidelity problem. The book claims every IRREDUCIBLE REPRESENTATION of ℤ/p in char p is trivial. The Lean hypothesis is `hirr : IsSimpleModule k V`, i.e. V is simple as a k-vector space (...",
+  "fidelity_note": "Fixed (#5374): hypothesis now `IsSimpleModule (MonoidAlgebra k (Multiplicative (ZMod p))) ρ.asModule`, i.e. genuine representation-irreducibility (Representation.IsIrreducible), matching the book's claim. Proof: ρ g - 1 is a nilpotent self-intertwiner (ℤ/p abelian), so by Schur it is injective-or-zero; nilpotency rules out injective, hence ρ g = id.",
   "fidelity_decl": "Etingof.Example4_1_3",
   "fidelity_issue": 5374
  },


### PR DESCRIPTION
This PR fixes the fidelity gap in `Chapter4/Example4.1.3` by stating the theorem with genuine representation-irreducibility instead of `k`-module simplicity. The previous hypothesis `IsSimpleModule k V` forces `V` to be one-dimensional, silently assuming the book's "irreducible representation is 1-dimensional" step; the new hypothesis `IsSimpleModule (MonoidAlgebra k (Multiplicative (ZMod p))) ρ.asModule` is exactly `Representation.IsIrreducible ρ`, the book's notion. The proof is reworked to avoid relying on `k`-module simplicity: `ρ g - 1` is nilpotent (`(ρ g - 1)ᵖ = 0` by the freshman's-dream identity) and a self-intertwiner since `ℤ/pℤ` is abelian, so Schur's lemma (`Representation.IsIrreducible.injective_or_eq_zero`) forces it to be injective or zero, and nilpotency rules out injectivity, giving `ρ g = id`. Sets `fidelity: verified` for the item.

Closes #5374

🤖 Prepared with Claude Code
