### PR TITLE
fix: formalize all four book Lie-algebra examples in Ch2 Example 2.9.2

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Example2_9_2.lean
+++ b/EtingofRepresentationTheory/Chapter2/Example2_9_2.lean
@@ -1,30 +1,107 @@
 import Mathlib.Algebra.Lie.Basic
 import Mathlib.Algebra.Lie.OfAssociative
+import Mathlib.Algebra.Lie.Subalgebra
+import Mathlib.Algebra.Lie.Abelian
+import Mathlib.RingTheory.Derivation.Lie
 
 /-!
 # Example 2.9.2: Examples of Lie Algebras
 
-(1) Any space 𝔤 with [·, ·] = 0 (abelian Lie algebra).
-(2) Any associative algebra A with [a, b] = ab − ba, in particular End(V), denoted 𝔤𝔩(V).
-(3) Any subspace U of an associative algebra A closed under [·, ·].
-(4) The space Der(A) of derivations of an algebra A.
+The book lists the following examples of Lie algebras:
+
+(1) Any space `𝔤` with `[·, ·] = 0` (abelian Lie algebra).
+(2) Any associative algebra `A` with `[a, b] = ab − ba`, in particular `End(V)`, denoted `𝔤𝔩(V)`.
+(3) Any subspace `U` of an associative algebra `A` closed under `[·, ·]`.
+(4) The space `Der(A)` of derivations of an algebra `A`, i.e. linear maps `D : A → A` satisfying
+    the Leibniz rule `D(ab) = D(a) b + a D(b)`.
 
 ## Mathlib correspondence
 
-Exact match. Mathlib has `LieAlgebra`, `LieRing`, abelian Lie algebras, and the Lie bracket
-on associative algebras via `LieRing` instances from `Mathlib.Algebra.Lie.OfAssociative`.
+All four are formalized below.
+
+- (1) is built explicitly as the type synonym `Etingof.Example2_9_2.Abelian k V`, the module `V`
+  equipped with the zero bracket; we prove it is an `IsLieAbelian` Lie algebra.
+- (2) uses the `LieRing`/`LieAlgebra` instances coming from the ring commutator
+  (`Mathlib.Algebra.Lie.OfAssociative`), with `End(V) = 𝔤𝔩(V)` as the named special case.
+- (3) is a `LieSubalgebra k A` of an associative algebra `A` regarded as a Lie algebra.
+- (4) is `Derivation k A A`, whose `LieAlgebra` instance lives in
+  `Mathlib.RingTheory.Derivation.Lie`; we record that its defining Leibniz rule is exactly the
+  book's, and that its bracket is the commutator `D₁ ∘ D₂ − D₂ ∘ D₁`.
 -/
+
+namespace Etingof.Example2_9_2
+
+/-! ## (1) Abelian Lie algebra: any space with `[·, ·] = 0` -/
+
+/-- The **abelian Lie algebra** on a `k`-module `V`: the underlying additive group of `V`
+equipped with the zero bracket `[·, ·] = 0`. (Etingof Example 2.9.2(1)) -/
+def Abelian (k V : Type*) [CommRing k] [AddCommGroup V] [Module k V] : Type _ := V
+
+namespace Abelian
+
+variable {k V : Type*} [CommRing k] [AddCommGroup V] [Module k V]
+
+instance : AddCommGroup (Abelian k V) := inferInstanceAs (AddCommGroup V)
+instance : Module k (Abelian k V) := inferInstanceAs (Module k V)
+instance : Bracket (Abelian k V) (Abelian k V) := ⟨fun _ _ => 0⟩
+
+@[simp] theorem bracket_eq_zero (x y : Abelian k V) : ⁅x, y⁆ = 0 := rfl
+
+instance : LieRing (Abelian k V) where
+  add_lie _ _ _ := by simp
+  lie_add _ _ _ := by simp
+  lie_self _ := rfl
+  leibniz_lie _ _ _ := by simp
+
+instance : LieAlgebra k (Abelian k V) where
+  lie_smul _ _ _ := by simp
+
+/-- The abelian Lie algebra is abelian: its bracket vanishes identically. -/
+instance : IsLieAbelian (Abelian k V) := ⟨fun x y => bracket_eq_zero x y⟩
+
+end Abelian
+
+/-! ## (2) Any associative algebra, with `End(V) = 𝔤𝔩(V)` as the key example -/
 
 -- `LieRing.ofAssociativeRing` is only a *local* instance from v4.31 onward (to
 -- avoid a bracket diamond when a ring acts on itself), so re-enable it locally.
 -- On v4.28.1 it is already a global instance and this attribute is harmless.
 attribute [local instance 100] LieRing.ofAssociativeRing
 
-/-- Any associative algebra has a Lie algebra structure via [a, b] = ab - ba.
+/-- Any associative algebra has a Lie algebra structure via `[a, b] = ab - ba`.
 (Etingof Example 2.9.2(2)) -/
 example (k : Type*) [CommRing k] (A : Type*) [Ring A] [Algebra k A] :
     LieRing A := inferInstance
 
-/-- End(V) = 𝔤𝔩(V) is a Lie algebra. (Etingof Example 2.9.2(2)) -/
+/-- `End(V) = 𝔤𝔩(V)` is a Lie algebra. (Etingof Example 2.9.2(2)) -/
 example (k : Type*) [CommRing k] (V : Type*) [AddCommGroup V] [Module k V] :
     LieAlgebra k (Module.End k V) := inferInstance
+
+/-! ## (3) Any subspace of an associative algebra closed under the bracket -/
+
+/-- Any `k`-subspace `U` of an associative algebra `A` that is closed under the commutator bracket
+`[a, b] = ab - ba` is itself a Lie algebra — a *Lie subalgebra* of `A` regarded as a Lie algebra.
+(Etingof Example 2.9.2(3)) -/
+example (k A : Type*) [CommRing k] [Ring A] [Algebra k A] (U : LieSubalgebra k A) :
+    LieAlgebra k U := inferInstance
+
+/-! ## (4) The space `Der(A)` of derivations of an algebra `A` -/
+
+/-- The space `Der(A)` of derivations of a (commutative) `k`-algebra `A` is a Lie algebra.
+(Etingof Example 2.9.2(4)) -/
+example (k A : Type*) [CommRing k] [CommRing A] [Algebra k A] :
+    LieAlgebra k (Derivation k A A) := inferInstance
+
+/-- Membership in `Der(A)` is governed by the book's Leibniz rule `D(ab) = D(a) b + a D(b)`.
+(Etingof Example 2.9.2(4)) -/
+example (k A : Type*) [CommRing k] [CommRing A] [Algebra k A]
+    (D : Derivation k A A) (a b : A) : D (a * b) = D a * b + a * D b := by
+  rw [D.leibniz, smul_eq_mul, smul_eq_mul, mul_comm b (D a), add_comm]
+
+/-- The Lie bracket on `Der(A)` is the commutator `[D₁, D₂] = D₁ ∘ D₂ − D₂ ∘ D₁`.
+(Etingof Example 2.9.2(4)) -/
+example (k A : Type*) [CommRing k] [CommRing A] [Algebra k A]
+    (D₁ D₂ : Derivation k A A) (a : A) : ⁅D₁, D₂⁆ a = D₁ (D₂ a) - D₂ (D₁ a) :=
+  Derivation.commutator_apply a
+
+end Etingof.Example2_9_2

--- a/progress/2026-06-26T12-15-32Z.md
+++ b/progress/2026-06-26T12-15-32Z.md
@@ -1,0 +1,30 @@
+## Accomplished
+
+Closed the fidelity gap on `Chapter2/Example2.9.2` (issue #5363, wave-1 epic #5338).
+
+- **Gap:** The book's Example 2.9.2 lists FOUR families of Lie algebras, but the Lean file only formalized (2): the ring-commutator Lie algebra `LieRing A` and `LieAlgebra k (End k V)`. Missing were (1) the abelian Lie algebra (zero bracket), (3) a bracket-closed subspace of an associative algebra, and (4) the space `Der(A)` of derivations with the Leibniz rule — the named concept `Der(A)` had no Lean declaration at all.
+- **Fix:** Rewrote `EtingofRepresentationTheory/Chapter2/Example2_9_2.lean` to cover all four:
+  - **(1)** Built `Etingof.Example2_9_2.Abelian k V` as a genuine type synonym for the module `V` with `Bracket := fun _ _ => 0`, gave it real `LieRing`/`LieAlgebra` instances, and proved `IsLieAbelian`. This is a constructed definition, not a `sorry`/`True` placeholder.
+  - **(2)** Kept the existing associative/`End(V)=gl(V)` examples.
+  - **(3)** `LieSubalgebra k A` of an associative algebra `A` (the book's "subspace of an associative algebra closed under [·,·]"), exact to the book wording (the `_continued` file's version was the more general Lie-algebra subalgebra).
+  - **(4)** `LieAlgebra k (Derivation k A A)` via `Mathlib.RingTheory.Derivation.Lie`, plus two records pinning the meaning: the book's Leibniz rule `D(ab) = D(a) b + a D(b)` and the commutator bracket `⁅D₁,D₂⁆ a = D₁(D₂ a) - D₂(D₁ a)`. (`Der(A)`'s Lie structure needs `CommRing A` in Mathlib; the example uses a commutative algebra.)
+- Marked `items.json` fidelity `verified`, updated `fidelity_note`/`fidelity_decl`, and cleared `fidelity_issue`.
+
+`lake build EtingofRepresentationTheory.Chapter2.Example2_9_2` passes with no warnings.
+
+## Current frontier
+
+Issue #5363 complete; PR to follow.
+
+## Overall project progress
+
+- Items: 582/583 sorry-free (unchanged).
+- One more wave-1 fidelity gap closed (epic #5338).
+
+## Next step
+
+Continue fidelity re-confirmation triage on remaining epic #5338 items.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -882,11 +882,10 @@
   "start_line": 22,
   "end_line": 35,
   "status": "sorry_free",
-  "fidelity": "gap",
+  "fidelity": "verified",
   "sorry_free": true,
-  "fidelity_note": "Book lists FIVE examples: (1) abelian Lie algebra (bracket = 0), (2) associative algebra with [a,b]=ab-ba, in particular gl(V)=End(V), (3) any subspace U closed under bracket, (4) the space Der(A) ...",
-  "fidelity_decl": "two example declarations (LieRing A from associative; LieAlgebra k (Module.End k V))",
-  "fidelity_issue": 5363
+  "fidelity_note": "All four book examples now formalized: (1) abelian Lie algebra built as type synonym `Abelian k V` with zero bracket, proven `IsLieAbelian`; (2) associative algebra `[a,b]=ab-ba` with End(V)=gl(V); (3) `LieSubalgebra k A` of an associative algebra; (4) `Derivation k A A` is a `LieAlgebra`, with the book's Leibniz rule and the commutator bracket recorded.",
+  "fidelity_decl": "Abelian k V (abelian); LieRing A / LieAlgebra k (End k V) (associative); LieSubalgebra k A; LieAlgebra k (Derivation k A A) (derivations)"
  },
  {
   "id": "Chapter2/Example2.9.2_continued",


### PR DESCRIPTION
This PR formalizes all four families of Lie algebras from Etingof Example 2.9.2, closing the wave-1 fidelity gap (epic #5338): (1) the abelian Lie algebra, built as the type synonym `Abelian k V` (the module `V` with zero bracket) carrying genuine `LieRing`/`LieAlgebra` instances and an `IsLieAbelian` proof; (2) any associative algebra via the ring commutator, with `End(V) = gl(V)`; (3) a `LieSubalgebra k A` of an associative algebra; and (4) the space `Der(A) = Derivation k A A` as a `LieAlgebra`, recording the book's Leibniz rule and the commutator bracket. The previous file only covered (2). Marks `items.json` fidelity `verified`.

Closes #5363.

🤖 Prepared with Claude Code