### PR TITLE
fix(Ch6): replace native_decide with honest decide in Dynkin/Dn/E6 root counts

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/DynkinTypes.lean
+++ b/EtingofRepresentationTheory/Chapter6/DynkinTypes.lean
@@ -299,7 +299,7 @@ private lemma DnQF_eq_dotProduct : ∀ (m : ℕ) (x : Fin (m + 4) → ℤ),
     simp only [DnQF]
     set C := 2 • (1 : Matrix (Fin 4) (Fin 4) ℤ) - DynkinType.adj (.D 4 (by omega))
     have hC : C = !![2,-1,0,0; -1,2,-1,-1; 0,-1,2,0; 0,-1,0,2] := by
-      ext i j; fin_cases i <;> fin_cases j <;> native_decide
+      ext i j; fin_cases i <;> fin_cases j <;> decide
     rw [hC]
     simp [dotProduct, mulVec, Fin.sum_univ_succ, Fin.sum_univ_zero, Matrix.cons_val_zero,
       Matrix.cons_val_one, Matrix.cons_val, vecHead]
@@ -823,11 +823,11 @@ private def E6_treePath : Fin 6 → Fin 6 → List (Fin 6) := fun i j =>
 private lemma E6_isDynkin : IsDynkinDiagram 6 (DynkinType.adj .E6) := by
   refine ⟨?_, ?_, ?_, ?_, ?_⟩
   · -- Symmetry
-    exact Matrix.IsSymm.ext (fun i j => by fin_cases i <;> fin_cases j <;> native_decide)
+    exact Matrix.IsSymm.ext (fun i j => by fin_cases i <;> fin_cases j <;> decide)
   · -- Zero diagonal
-    intro i; fin_cases i <;> native_decide
+    intro i; fin_cases i <;> decide
   · -- 0-1 entries
-    intro i j; fin_cases i <;> fin_cases j <;> native_decide
+    intro i j; fin_cases i <;> fin_cases j <;> decide
   · -- Connectivity: provide explicit tree paths and verify
     intro i j
     refine ⟨E6_treePath i j, ?_, ?_, ?_⟩
@@ -837,7 +837,7 @@ private lemma E6_isDynkin : IsDynkinDiagram 6 (DynkinType.adj .E6) := by
       fin_cases i <;> fin_cases j <;>
         simp only [E6_treePath, List.length_cons, List.length_nil, Nat.reduceAdd] at hk <;>
         rcases k with _ | (_ | (_ | (_ | _))) <;>
-        (first | omega | (dsimp only [E6_treePath, List.get]; native_decide))
+        (first | omega | (dsimp only [E6_treePath, List.get]; decide))
   · -- Positive definiteness via Cholesky sum-of-squares decomposition.
     -- The LDLᵀ factorization of the Cartan matrix 2I - adj_E6 gives
     -- D = diag(2, 3/2, 4/3, 5/4, 6/5, 1/2), all positive.
@@ -858,7 +858,7 @@ private lemma E6_isDynkin : IsDynkinDiagram 6 (DynkinType.adj .E6) := by
       set C := 2 • (1 : Matrix (Fin 6) (Fin 6) ℤ) - DynkinType.adj .E6
       have hC : C = !![2,-1,0,0,0,0; -1,2,-1,0,0,0; 0,-1,2,-1,0,-1;
                         0,0,-1,2,-1,0; 0,0,0,-1,2,0; 0,0,-1,0,0,2] := by
-        ext i j; fin_cases i <;> fin_cases j <;> native_decide
+        ext i j; fin_cases i <;> fin_cases j <;> decide
       rw [hC]
       simp [dotProduct, mulVec, Fin.sum_univ_succ, Fin.sum_univ_zero, Matrix.cons_val_zero,
         Matrix.cons_val_one, Matrix.cons_val, vecHead]
@@ -935,9 +935,9 @@ set_option maxHeartbeats 400000 in
 /-- E₇ is a Dynkin diagram. -/
 private lemma E7_isDynkin : IsDynkinDiagram 7 (DynkinType.adj .E7) := by
   refine ⟨?_, ?_, ?_, ?_, ?_⟩
-  · exact Matrix.IsSymm.ext (fun i j => by fin_cases i <;> fin_cases j <;> native_decide)
-  · intro i; fin_cases i <;> native_decide
-  · intro i j; fin_cases i <;> fin_cases j <;> native_decide
+  · exact Matrix.IsSymm.ext (fun i j => by fin_cases i <;> fin_cases j <;> decide)
+  · intro i; fin_cases i <;> decide
+  · intro i j; fin_cases i <;> fin_cases j <;> decide
   · -- Connectivity
     intro i j
     refine ⟨E7_treePath i j, ?_, ?_, ?_⟩
@@ -947,7 +947,7 @@ private lemma E7_isDynkin : IsDynkinDiagram 7 (DynkinType.adj .E7) := by
       fin_cases i <;> fin_cases j <;>
         simp only [E7_treePath, List.length_cons, List.length_nil, Nat.reduceAdd] at hk <;>
         rcases k with _ | (_ | (_ | (_ | (_ | _)))) <;>
-        (first | omega | (dsimp only [E7_treePath, List.get]; native_decide))
+        (first | omega | (dsimp only [E7_treePath, List.get]; decide))
   · -- Positive definiteness via Cholesky SOS decomposition
     -- 420·q = 210(2a-b)² + 70(3b-2c)² + 35(4c-3d-3g)² + 21(5d-4e-3g)² +
     --         14(6e-5f-3g)² + 10(7f-3g)² + 120g²
@@ -964,7 +964,7 @@ private lemma E7_isDynkin : IsDynkinDiagram 7 (DynkinType.adj .E7) := by
       have hC : C = !![2,-1,0,0,0,0,0; -1,2,-1,0,0,0,0; 0,-1,2,-1,0,0,-1;
                         0,0,-1,2,-1,0,0; 0,0,0,-1,2,-1,0; 0,0,0,0,-1,2,0;
                         0,0,-1,0,0,0,2] := by
-        ext i j; fin_cases i <;> fin_cases j <;> native_decide
+        ext i j; fin_cases i <;> fin_cases j <;> decide
       rw [hC]
       simp [dotProduct, mulVec, Fin.sum_univ_succ, Fin.sum_univ_zero, Matrix.cons_val_zero,
         Matrix.cons_val_one, Matrix.cons_val]
@@ -1045,9 +1045,9 @@ set_option maxHeartbeats 1600000 in
 /-- E₈ is a Dynkin diagram. -/
 private lemma E8_isDynkin : IsDynkinDiagram 8 (DynkinType.adj .E8) := by
   refine ⟨?_, ?_, ?_, ?_, ?_⟩
-  · exact Matrix.IsSymm.ext (fun i j => by fin_cases i <;> fin_cases j <;> native_decide)
-  · intro i; fin_cases i <;> native_decide
-  · intro i j; fin_cases i <;> fin_cases j <;> native_decide
+  · exact Matrix.IsSymm.ext (fun i j => by fin_cases i <;> fin_cases j <;> decide)
+  · intro i; fin_cases i <;> decide
+  · intro i j; fin_cases i <;> fin_cases j <;> decide
   · -- Connectivity
     intro i j
     refine ⟨E8_treePath i j, ?_, ?_, ?_⟩
@@ -1057,7 +1057,7 @@ private lemma E8_isDynkin : IsDynkinDiagram 8 (DynkinType.adj .E8) := by
       fin_cases i <;> fin_cases j <;>
         simp only [E8_treePath, List.length_cons, List.length_nil, Nat.reduceAdd] at hk <;>
         rcases k with _ | (_ | (_ | (_ | (_ | (_ | _))))) <;>
-        (first | omega | (dsimp only [E8_treePath, List.get]; native_decide))
+        (first | omega | (dsimp only [E8_treePath, List.get]; decide))
   · -- Positive definiteness via Cholesky SOS decomposition
     -- 840·q = 420(2a-b)² + 140(3b-2c)² + 70(4c-3d-3h)² + 42(5d-4e-3h)² +
     --         28(6e-5f-3h)² + 20(7f-6g-3h)² + 15(8g-3h)² + 105h²
@@ -1074,7 +1074,7 @@ private lemma E8_isDynkin : IsDynkinDiagram 8 (DynkinType.adj .E8) := by
       have hC : C = !![2,-1,0,0,0,0,0,0; -1,2,-1,0,0,0,0,0; 0,-1,2,-1,0,0,0,-1;
                         0,0,-1,2,-1,0,0,0; 0,0,0,-1,2,-1,0,0; 0,0,0,0,-1,2,-1,0;
                         0,0,0,0,0,-1,2,0; 0,0,-1,0,0,0,0,2] := by
-        ext i j; fin_cases i <;> fin_cases j <;> native_decide
+        ext i j; fin_cases i <;> fin_cases j <;> decide
       rw [hC]
       simp [dotProduct, mulVec, Fin.sum_univ_succ, Fin.sum_univ_zero, Matrix.cons_val_zero,
         Matrix.cons_val_one, Matrix.cons_val]

--- a/EtingofRepresentationTheory/Chapter6/Example6_4_9_Dn.lean
+++ b/EtingofRepresentationTheory/Chapter6/Example6_4_9_Dn.lean
@@ -425,21 +425,18 @@ private lemma Dn_bound : ∀ (n : ℕ) (hn : 4 ≤ n) (x : Fin n → ℤ),
         have htail0_le : tail ⟨0, by omega⟩ ≤ 2 := by rw [htail0]; exact hx1_bound
         exact Dn_cascade_bound m hm' tail hq_tail htail0_le htail_pos
 
-set_option linter.style.nativeDecide false in
 private lemma D4_count :
     (rootCountFinset 4 (Etingof.DynkinType.D 4 le_rfl).adj 3).card = 12 := by
-  native_decide
+  decide
 
-set_option linter.style.nativeDecide false in
 private lemma D4_nonzero_count :
     ((rootCountFinset 4 (Etingof.DynkinType.D 4 le_rfl).adj 3).filter
       (fun v => v ⟨0, by omega⟩ ≠ 0)).card = 2 * (4 - 1) := by
-  native_decide
+  decide
 
-set_option linter.style.nativeDecide false in
 private lemma D5_count :
     (rootCountFinset 5 (Etingof.DynkinType.D 5 (by omega)).adj 3).card = 20 := by
-  native_decide
+  decide
 
 /-- Filtering rootCountFinset by v₀ = 0 and dropping the first coordinate
     gives a set with the same cardinality as rootCountFinset of D_m. -/
@@ -532,10 +529,9 @@ private def qFourFinset (n : ℕ) (adj : Matrix (Fin n) (Fin n) ℤ) (hn : 0 < n
     decide (dotProduct (fun i => (v i : ℤ))
       ((2 • (1 : Matrix (Fin n) (Fin n) ℤ) - adj).mulVec (fun i => (v i : ℤ))) = 4)
 
-set_option linter.style.nativeDecide false in
 private lemma D4_qfour :
     (qFourFinset 4 (Etingof.DynkinType.D 4 le_rfl).adj).card = 1 := by
-  native_decide
+  decide
 
 /-- The q=4 count satisfies a recurrence: peeling off vertex 0. -/
 private lemma qFourFinset_peel (m : ℕ) (hm : 4 ≤ m) :
@@ -852,7 +848,6 @@ private lemma zero_union_qfour_card (m : ℕ) (hm : 4 ≤ m) :
     rw [hx] at hxqf; simp at hxqf
   rw [Finset.card_union_of_disjoint h_disj, Finset.card_singleton, qFourFinset_card m hm]
 
-set_option linter.style.nativeDecide false in
 /-- The D_n root count equals n*(n-1). -/
 private lemma Dn_count : ∀ (n : ℕ) (hn : 4 ≤ n),
     (rootCountFinset n (Etingof.DynkinType.D n hn).adj 3).card =

--- a/EtingofRepresentationTheory/Chapter6/Example6_4_9_EType.lean
+++ b/EtingofRepresentationTheory/Chapter6/Example6_4_9_EType.lean
@@ -77,10 +77,14 @@ private lemma E6_bound (x : Fin 6 → ℤ)
       sq_nonneg c, sq_nonneg (2*f-c-3)]
   intro i; fin_cases i <;> simp_all <;> omega
 
-set_option linter.style.nativeDecide false in
+-- Honest kernel `decide` over the 4^6 = 4096 candidate vectors (no native code).
+-- The whnf reduction of the filtered Pi-fintype needs raised recursion/heartbeat limits.
+set_option linter.style.maxHeartbeats false in
+set_option maxRecDepth 10000 in
+set_option maxHeartbeats 4000000 in
 private lemma E6_count :
     (rootCountFinset 6 Etingof.DynkinType.E6.adj 4).card = 36 := by
-  native_decide
+  decide
 
 /-- E₆ has 36 positive roots. (Etingof Example 6.4.9) -/
 theorem Etingof.Example_6_4_9_E6 :

--- a/progress/2026-06-26T14-49-15Z_a74478db.md
+++ b/progress/2026-06-26T14-49-15Z_a74478db.md
@@ -1,0 +1,51 @@
+## Accomplished
+
+Worked #5425 (one-shot): remove native_decide from Ch6 Dynkin-type computations.
+Landed honest kernel `decide` for the feasible 21 of 23 tactic sites:
+
+- `Chapter6/DynkinTypes.lean` (16/16): all matrix-entry equalities, symmetry /
+  zero-diagonal / 0-1-entry checks, and tree-path adjacency checks. These are
+  tiny finite goals (post `fin_cases`), so plain `decide` reduces them. No
+  `set_option` was present to remove.
+- `Chapter6/Example6_4_9_Dn.lean` (4/4): `D4_count`, `D4_nonzero_count`,
+  `D5_count`, `D4_qfour` — all enumerate `Fin n → Fin 3` (≤ 3^5 = 243 vectors),
+  feasible with `decide`. Removed all five `set_option linter.style.nativeDecide
+  false` lines (including a leftover one on `Dn_count`, which has no direct
+  native_decide).
+- `Chapter6/Example6_4_9_EType.lean` E6 (1): `E6_count` over 4^6 = 4096 vectors.
+  Kernel `decide` succeeds in ~50s with `maxRecDepth 10000` + `maxHeartbeats
+  4000000`. Removed its nativeDecide suppression.
+
+All three modules build green.
+
+## Current frontier
+
+E7 and E8 root counts in `Example6_4_9_EType.lean` still use `native_decide`.
+Plain `decide` is NOT a viable replacement (measured):
+- E7 (5^7 = 78 125, ~19× E6): `decide` hits 7 GB RAM at 36s and climbs;
+  projected ~16 min — impractical for CI.
+- E8 (7^8 ≈ 5.76M, ~1400× E6): infeasible — the kernel must materialize a
+  5.76M-element `Finset (Fin 8 → Fin 7)` before filtering → OOM.
+
+Filed #5436 with a precise honest plan: branch-decomposition convolution
+(fixing the degree-3 center vertex decouples the diagram into independent path
+components; the count factorizes into small per-component `decide`s of ≤ 2401
+vectors, assembled by a master Fubini/bijection lemma). E6's landed `decide` is
+a template for the per-component pieces.
+
+## Overall project progress
+
+Part of #5423 (forbid + remove all native_decide). Ch6 now native_decide-free
+except E7_count / E8_count (tracked in #5436). Sibling work: #5426 (Ch5 FS-type)
+still open; Ch4 (#5427) already landed.
+
+## Next step
+
+Pick up #5436: implement the branch-decomposition convolution for E7 and E8,
+remove the two remaining `set_option linter.style.nativeDecide false` lines, and
+fix the stale "native_decide" comments (EType lines 9 & ~316; Example6_4_9.lean
+line 18).
+
+## Blockers
+
+None. #5436 is well-specified and independent.


### PR DESCRIPTION
This PR replaces native_decide with honest kernel decide in the Chapter 6 Dynkin-type computations, covering 21 of the 23 tactic sites in #5425. DynkinTypes (16) — matrix-entry equalities, symmetry / zero-diagonal / 0-1-entry checks, and tree-path adjacency checks — reduce as tiny finite goals after fin_cases. Example6_4_9_Dn (4) enumerates Fin n → Fin 3 (at most 3^5 = 243 vectors). Example6_4_9_EType E6 (1) enumerates 4^6 = 4096 vectors, which kernel decide handles in about 50s with raised maxRecDepth and maxHeartbeats. It also drops every now-pointless set_option linter.style.nativeDecide false suppression in those files.

The two largest counts, E7 (5^7 = 78125) and E8 (7^8 ≈ 5.76M), remain on native_decide and are split out to #5436: plain decide reaches 7 GB / ~16 min for E7 and OOMs materializing a 5.76M-element finset for E8, so they need the branch-decomposition convolution described there. Part of #5423.

🤖 Prepared with Claude Code