### PR TITLE
doc(progress): decompose #5431 into #5449 + #5450

### DIFF
--- a/progress/20260626T163037Z_55973cf1.md
+++ b/progress/20260626T163037Z_55973cf1.md
@@ -1,0 +1,31 @@
+## Accomplished
+
+One-shot dispatch on #5431 (Example4.8.1 4/4: A₅ golden-ratio 3-dim reps + final assembly, closing #5376). After deep scoping I **decomposed** it — the work is genuinely multi-session research, two independent hard pieces, each needing infrastructure that is not in Mathlib. Created:
+
+- **#5449** — build the two 3-dimensional icosahedral rotation reps `ℂ³₊`/`ℂ³₋` of `A₅` as genuine `FDRep ℂ (alternatingGroup (Fin 5))` with golden-ratio characters `(1±√5)/2`.
+- **#5450** (depends-on #5449) — final assembly: five-simples completeness certificate for `Q₈`/`S₄`/`A₅`, delete the `A5_orthonormal` `native_decide`, update items.json, close #5376.
+
+Left a `Decomposed into #5449, #5450` breadcrumb on #5431 and `coordination skip`-ed it to `replan`. **No code changes** — `Example4_8_1.lean` is untouched and remains in its working state.
+
+## Key findings (recorded so successors don't re-derive)
+
+- **Explicit-matrix route for the 3-dim reps is blocked.** A `MonoidHom` out of the concrete `alternatingGroup (Fin 5)` cannot prove `map_mul` by `decide` (60×60 with table lookups, even over the `DecidableEq` ring `Q5 = ℚ[√5]`), and the algebraic route would require formalising that the (2,3,5) von Dyck presentation `⟨a,b | a⁵,b²,(ab)³⟩` has order exactly 60 (Todd–Coxeter), i.e. `PresentedGroup … ≃* A₅` — not in Mathlib.
+- **Only feasible rigorous route for the 3-dim reps:** central-element eigenspace of `Λ²(ℂ⁴)`. `Λ²(ℂ⁴) ≅ ℂ³₊ ⊕ ℂ³₋`; the central element `z = Σ_{c∈C} ρ(c)` (C = one 5-cycle class, 12 elts) acts as `4φ`/`4φ'` on the two summands, minimal poly `X²−4X−16` on `Λ²V`; characters via the projector `(z−4φ'·id)/(4√5)` and `LinearMap.trace_eq_sum_trace_restrict`. Heavy but uses existing infra (`FDRep.char_tensor` in `Discussion_4_4.lean`, `Subrepresentation`, `Module.End.eigenspace`, `S4.fixCardM`).
+- **Completeness theorem is also missing infra.** The "five pairwise-non-iso simples + five conjugacy classes ⇒ complete table" certificate needs #(irreducible `FDRep ℂ G`) = #(conjugacy classes); `Mathlib/RepresentationTheory/` has `simple_iff_char_is_norm_one` and `char_orthonormal` but no `ConjClasses`-count bridge. This is exactly what the rejected `native_decide` orthonormality was standing in for. #5450 must either prove that count theorem (reusable, also helps Example 4.9.1) or use a decidable `IsCharacterTable` predicate.
+- The only `native_decide` left in `Example4_8_1.lean` is `A5_orthonormal` (line ~1029). `Q₈` and `S₄` already have genuine five-rep stacks; `A₅` has `repTriv`/`repC4`/`repC5` genuine. `items.json` `fidelity_decl` for `Chapter4/Example4.8.1` still lists `A5_orthonormal` (must be replaced in #5450).
+
+## Current frontier
+
+#5431 decomposed and routed to `replan`. #5449 is the unblocked research item; #5450 is blocked on it.
+
+## Overall project progress
+
+Fidelity epic for `Chapter4/Example4.8.1` (#5376) still open. Genuine reps done: all of `Q₈` (5/5) and `S₄` (5/5), and `A₅` 3/5 (trivial, ℂ⁴, ℂ⁵). Remaining: the two `A₅` 3-dim reps (#5449) and the completeness assembly + native_decide removal (#5450).
+
+## Next step
+
+A worker claims **#5449** and attempts the `Λ²(ℂ⁴)` central-eigenspace construction of `ℂ³₊`/`ℂ³₋` (top-down: build `Λ²V` FDRep and the eigenspace Subrepresentations first, then characters via the projector trace). Then **#5450** for the completeness theorem + cleanup + close #5376. Both are large; further sub-decomposition (e.g. split the count theorem out of #5450) is reasonable.
+
+## Blockers
+
+#5450 is blocked on #5449. Neither sub-issue has a quick win: the 3-dim-rep construction and the #irreducibles=#classes theorem each require new, non-trivial infrastructure not present in Mathlib.


### PR DESCRIPTION
This PR records the handoff for one-shot dispatch on #5431 (Example 4.8.1 4/4, closing #5376), which I decomposed into #5449 (build the two 3-dim A₅ icosahedral reps as genuine FDReps via the Λ²(ℂ⁴) central-eigenspace route) and #5450 (five-simples completeness assembly + delete the `A5_orthonormal` native_decide + close #5376). No code changes: the explicit-matrix route is blocked without a Todd–Coxeter (2,3,5)-presentation isomorphism to A₅ (not in Mathlib), and the completeness certificate needs a #irreducibles = #conjugacy-classes theorem that Mathlib does not package — both genuinely multi-session. The parent #5431 was skipped to replan with a decomposition breadcrumb.

🤖 Prepared with Claude Code