### PR TITLE
Fidelity gap: Chapter2/Example2.3.14_continued

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Example2_3_14_continued.lean
+++ b/EtingofRepresentationTheory/Chapter2/Example2_3_14_continued.lean
@@ -1,4 +1,5 @@
-import Mathlib.Algebra.MonoidAlgebra.Basic
+import Mathlib.RepresentationTheory.Basic
+import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
 
 /-!
 # Example 2.3.14 (continued): Group Algebra Representations
@@ -8,15 +9,77 @@ import Mathlib.Algebra.MonoidAlgebra.Basic
    ρ : G → Aut(V), where Aut(V) = GL(V) denotes the group of invertible linear maps from V
    to itself (the general linear group of V).
 
+## Formalization
+
+The book asserts an equality of *data*: a representation of the algebra `A = k[G]` on `V`
+is "the same thing" as a representation of the group `G` on `V`, i.e. a group homomorphism
+`ρ : G → GL(V)`. We make this content explicit with two bijections (`Equiv`s), bypassing the
+vacuous tautology `Module k[G] V → Module k[G] V` that was here before.
+
+* `repEquivAlgHom` : a representation `ρ : Representation k G V` is the same data as an
+  algebra homomorphism `k[G] →ₐ[k] Module.End k V`. A `k`-compatible `k[G]`-module structure
+  on `V` is exactly such an algebra homomorphism (a module *is* an action map into the
+  endomorphism algebra), so this is precisely "a representation of `A = k[G]`".
+
+* `repEquivGL` : a representation `ρ : Representation k G V` is the same data as a *group*
+  homomorphism `G →* (V ≃ₗ[k] V)`, i.e. `ρ : G → GL(V)` into the general linear group of
+  invertible linear maps. This is the book's "representation of `G`" side. Invertibility is
+  automatic precisely because `G` is a group (`MonoidHom.toHomUnits`).
+
+Chaining the two: a `k[G]`-module ↔ a representation of `G` ↔ `(V, ρ : G → GL(V))`.
+
 ## Mathlib correspondence
 
-Exact match. Mathlib has `MonoidAlgebra k G` for group algebras and `Representation` for
-group representations. The equivalence between k[G]-modules and G-representations is standard.
+`MonoidAlgebra k G` is `k[G]`; `Representation k G V = (G →* (V →ₗ[k] V))`. The first
+bijection is `MonoidAlgebra.lift`; the second composes `MonoidHom.toHomUnitsMulEquiv` (uses
+that `G` is a group) with `LinearMap.GeneralLinearGroup.generalLinearEquiv`.
 -/
 
-/-- A representation of a group G on V is a group homomorphism G → GL(V).
-This is equivalent to a k[G]-module structure on V. (Etingof Example 2.3.14(3)) -/
-example (k : Type*) [CommRing k] (G : Type*) [Group G]
+namespace Etingof.Example_2_3_14_continued
+
+open scoped MonoidAlgebra
+
+variable (k : Type*) [CommRing k] (G : Type*) [Group G]
     (V : Type*) [AddCommGroup V] [Module k V]
-    [Module (MonoidAlgebra k G) V] :
-    Module (MonoidAlgebra k G) V := inferInstance
+
+/-- **A representation of the algebra `A = k[G]` is the same data as a representation of the
+group `G`.** A representation `ρ : G →* (V →ₗ[k] V)` corresponds bijectively to an algebra
+homomorphism `k[G] →ₐ[k] Module.End k V`; the latter is exactly a `k`-compatible `k[G]`-module
+structure on `V` (the action map into the endomorphism algebra). (Etingof Example 2.3.14(3)) -/
+noncomputable def repEquivAlgHom :
+    Representation k G V ≃ (k[G] →ₐ[k] Module.End k V) :=
+  MonoidAlgebra.lift k (Module.End k V) G
+
+@[simp]
+theorem repEquivAlgHom_apply_single (ρ : Representation k G V) (g : G) :
+    repEquivAlgHom k G V ρ (MonoidAlgebra.single g 1) = ρ g := by
+  simp [repEquivAlgHom]
+
+/-- For a group `G`, a monoid homomorphism `G →* M` into any monoid `M` lands automatically in
+the units `Mˣ`; this is the bijection between the two (the inverse just forgets the units). -/
+def homUnitsEquiv (M : Type*) [Monoid M] : (G →* M) ≃ (G →* Mˣ) where
+  toFun ρ := ρ.toHomUnits
+  invFun f := (Units.coeHom M).comp f
+  left_inv ρ := by ext g; rfl
+  right_inv f := by ext g; rfl
+
+/-- **A representation of `G` is the same data as a group homomorphism `ρ : G → GL(V)`.**
+Here `GL(V) = V ≃ₗ[k] V` is the group of invertible `k`-linear maps `V → V`. Invertibility of
+each `ρ g` is forced because `G` is a group. (Etingof Example 2.3.14(3)) -/
+def repEquivGL :
+    Representation k G V ≃ (G →* (V ≃ₗ[k] V)) :=
+  Equiv.trans
+    (homUnitsEquiv G (Module.End k V))
+    (MulEquiv.monoidHomCongrRightEquiv
+      (LinearMap.GeneralLinearGroup.generalLinearEquiv k V))
+
+@[simp]
+theorem repEquivGL_apply (ρ : Representation k G V) (g : G) (v : V) :
+    repEquivGL k G V ρ g v = ρ g v := rfl
+
+/-- The group homomorphism `ρ : G → GL(V)` attached to a representation acts the same way as
+`ρ` itself: the data really is "the same thing", not an arbitrary relabelling. -/
+theorem repEquivGL_symm_apply (f : G →* (V ≃ₗ[k] V)) (g : G) (v : V) :
+    (repEquivGL k G V).symm f g v = f g v := rfl
+
+end Etingof.Example_2_3_14_continued

--- a/progress/2026-06-26T19-19-31Z_668e72ad.md
+++ b/progress/2026-06-26T19-19-31Z_668e72ad.md
@@ -1,0 +1,47 @@
+## Accomplished
+
+One-shot dispatch on #5359 (fidelity gap: Chapter2/Example2.3.14_continued). The book claim
+(Example 2.3.14(3)) is that a representation of the group algebra `A = k[G]` is "the same
+thing" as a representation of the group `G`, i.e. a vector space `V` with a group homomorphism
+`ρ : G → GL(V)`. The previous Lean content was a vacuous tautology
+(`example [Module k[G] V] : Module k[G] V := inferInstance`) carrying no content.
+
+Rewrote `EtingofRepresentationTheory/Chapter2/Example2_3_14_continued.lean` (namespace
+`Etingof.Example_2_3_14_continued`) to assert the actual claim as two genuine bijections:
+
+- `repEquivAlgHom : Representation k G V ≃ (k[G] →ₐ[k] Module.End k V)` — a representation of
+  `G` is the same data as an algebra homomorphism out of `k[G]`, i.e. a `k`-compatible
+  `k[G]`-module structure on `V` (the action map into the endomorphism algebra). This is the
+  "representation of `A = k[G]`" side. Built from `MonoidAlgebra.lift`.
+- `repEquivGL : Representation k G V ≃ (G →* (V ≃ₗ[k] V))` — a representation of `G` is the
+  same data as a group homomorphism `ρ : G → GL(V)` into the general linear group of
+  invertible linear maps. Built by composing a hand-rolled `homUnitsEquiv` (for a group `G`,
+  `(G →* M) ≃ (G →* Mˣ)`; the `CommMonoid`-requiring `MonoidHom.toHomUnitsMulEquiv` does not
+  apply since `Module.End k V` is noncommutative) with
+  `LinearMap.GeneralLinearGroup.generalLinearEquiv`. Invertibility of each `ρ g` is automatic
+  because `G` is a group.
+
+Characterizing lemmas pin down that the bijections are the intended maps (not arbitrary
+relabellings): `repEquivAlgHom_apply_single` (`single g 1 ↦ ρ g`), `repEquivGL_apply` and
+`repEquivGL_symm_apply` (`ρ g` acts as `ρ g`).
+
+Set `progress/items.json` `Chapter2/Example2.3.14_continued` fidelity to `verified`, updated
+`fidelity_decl`/`fidelity_note`.
+
+## Current frontier
+
+`Example2_3_14_continued.lean` builds clean (no sorry; axioms = propext/Classical.choice/
+Quot.sound only).
+
+## Overall project progress
+
+Fidelity-sweep wave-1 item #5359 fixed (epic #5338). Statement now carries the full book
+content of Example 2.3.14(3): k[G]-module ↔ representation of G ↔ (V, ρ : G → GL(V)).
+
+## Next step
+
+Land the PR for #5359. Other wave-1 fidelity issues remain for other workers.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -486,10 +486,10 @@
   "start_line": 1,
   "end_line": 2,
   "status": "sorry_free",
-  "fidelity": "gap",
+  "fidelity": "verified",
   "sorry_free": true,
-  "fidelity_note": "The statement has the k[G]-module hypothesis as its own goal (hypothesis = conclusion), a vacuous tautology. It asserts nothing about the book's claim that a representation of k[G] is the same data...",
-  "fidelity_decl": "(anonymous) example [Module (MonoidAlgebra k G) V] : Module (MonoidAlgebra k G) V := inferInstance",
+  "fidelity_note": "The book claims a representation of the group algebra A = k[G] is \"the same thing\" as a representation of G, i.e. a vector space V with a group homomorphism rho : G -> GL(V). Formalized as two genuine bijections (Equiv), replacing the prior vacuous tautology Module k[G] V -> Module k[G] V. repEquivAlgHom: Representation k G V is equiv to (k[G] -> _a[k] Module.End k V), i.e. a representation of G is the same data as an algebra homomorphism out of k[G] (= a k-compatible k[G]-module structure on V). repEquivGL: Representation k G V is equiv to (G ->* (V ~=_l[k] V)), i.e. the same data as a group homomorphism rho : G -> GL(V) into the general linear group of invertible linear maps; invertibility is automatic because G is a group. Characterizing simp/rfl lemmas (repEquivAlgHom_apply_single, repEquivGL_apply, repEquivGL_symm_apply) pin down that the bijections are the intended maps (rho g acts as rho g), not arbitrary relabellings.",
+  "fidelity_decl": "Etingof.Example_2_3_14_continued.repEquivAlgHom; Etingof.Example_2_3_14_continued.repEquivGL",
   "fidelity_issue": 5359
  },
  {


### PR DESCRIPTION
Closes #5359

Session: `668e72ad-6465-4625-8e70-953369ff1d5d`

67908496 fix(Ch2 Example2.3.14_continued): assert k[G]-rep ↔ G-rep ↔ ρ:G→GL(V), not vacuous tautology (#5359)

🤖 Prepared with Claude Code