### PR TITLE
fix(Ch4 Example4.8.1): retire native_decide in A5_orthonormal via honest Q5 norm_num

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Example4_8_1.lean
+++ b/EtingofRepresentationTheory/Chapter4/Example4_8_1.lean
@@ -77,11 +77,35 @@ instance : Neg Q5 := ⟨fun x => ⟨-x.re, -x.im⟩⟩
 instance : Mul Q5 := ⟨fun x y => ⟨x.re * y.re + 5 * x.im * y.im, x.re * y.im + x.im * y.re⟩⟩
 instance (n : ℕ) : OfNat Q5 n := ⟨⟨(OfNat.ofNat n : ℚ), 0⟩⟩
 
+theorem mk_re (a b : ℚ) : (Q5.mk a b).re = a := rfl
+theorem mk_im (a b : ℚ) : (Q5.mk a b).im = b := rfl
+theorem zero_re : (0 : Q5).re = 0 := rfl
+theorem zero_im : (0 : Q5).im = 0 := rfl
+theorem one_re : (1 : Q5).re = 1 := rfl
+theorem one_im : (1 : Q5).im = 0 := rfl
+theorem add_re (x y : Q5) : (x + y).re = x.re + y.re := rfl
+theorem add_im (x y : Q5) : (x + y).im = x.im + y.im := rfl
+theorem neg_re (x : Q5) : (-x).re = -x.re := rfl
+theorem neg_im (x : Q5) : (-x).im = -x.im := rfl
+theorem mul_re (x y : Q5) : (x * y).re = x.re * y.re + 5 * x.im * y.im := rfl
+theorem mul_im (x y : Q5) : (x * y).im = x.re * y.im + x.im * y.re := rfl
+theorem ofNat_re (n : ℕ) : (no_index (OfNat.ofNat n) : Q5).re = (OfNat.ofNat n : ℚ) :=
+  rfl
+theorem ofNat_im (n : ℕ) : (no_index (OfNat.ofNat n) : Q5).im = 0 := rfl
+
 /-- The embedding `ℚ → ℚ[√5]`. -/
 def ofRat (r : ℚ) : Q5 := ⟨r, 0⟩
 
+theorem ofRat_re (r : ℚ) : (ofRat r).re = r := rfl
+theorem ofRat_im (r : ℚ) : (ofRat r).im = 0 := rfl
+
 /-- A finite sum of `Q5` values, indexed by `Fin n`. -/
 def sumFin {n : ℕ} (f : Fin n → Q5) : Q5 := (List.ofFn f).foldr (· + ·) 0
+
+/-- Expand a 5-term `sumFin` into an explicit nested sum (the foldr over `List.ofFn`). -/
+theorem sumFin_five (f : Fin 5 → Q5) :
+    sumFin f = f 0 + (f 1 + (f 2 + (f 3 + (f 4 + 0)))) := by
+  simp only [sumFin, List.ofFn_succ, List.ofFn_zero, List.foldr_cons, List.foldr_nil]; rfl
 
 /-- The class-size-weighted inner product of two class functions,
 `⟪f, g⟫ = (1/|G|) Σ_c |class c| · f(c) · g(c)`.  All character values here are real, so no
@@ -1017,16 +1041,26 @@ def chiA5 : Fin 5 → Fin 5 → Q5 :=
     ![4,  1,  0, -1,          -1          ],
     ![5, -1,  1,  0,           0          ]]
 
-set_option linter.style.nativeDecide false in
-set_option maxHeartbeats 1000000 in
--- `native_decide` evaluates the full orthonormality computation symbolically over `Q5 = ℚ[√5]`, with the golden-ratio `√5` terms cancelling; the raised limit covers the `5 × 5` table of inner products.
 /-- The tabulated `A₅` characters are orthonormal, with the golden-ratio entries
 contributing genuine `√5` terms that cancel.  Combined with the fact that `A₅` has exactly 5
 conjugacy classes (`A5_conj_classes`), this certifies the five rows are the distinct
-irreducible characters of `A₅`. (Etingof Example 4.8.1) -/
+irreducible characters of `A₅`. (Etingof Example 4.8.1)
+
+Proved honestly (no `native_decide`): each of the 25 inner products is split into its rational
+`re`/`im` components (`Q5.ext`), the 5-term `sumFin` is unfolded (`Q5.sumFin_five`), and the
+resulting rational arithmetic -- in which the golden-ratio `√5` terms cancel -- is discharged
+by `norm_num`.  Kernel `decide` cannot evaluate this directly: the `ℚ`-normalisation of the
+`1/60` factor stalls the kernel. -/
 theorem A5_orthonormal (i j : Fin 5) :
     ip 60 sizesA5 (chiA5 i) (chiA5 j) = if i = j then 1 else 0 := by
-  fin_cases i <;> fin_cases j <;> native_decide
+  fin_cases i <;> fin_cases j <;>
+    (first | rw [if_pos rfl] | rw [if_neg (by decide)]) <;>
+    apply Q5.ext <;>
+    norm_num [ip, Q5.sumFin_five, sizesA5, chiA5, Q5.mk_re, Q5.mk_im, Q5.add_re, Q5.add_im,
+      Q5.mul_re, Q5.mul_im, Q5.neg_re, Q5.neg_im, Q5.zero_re, Q5.zero_im, Q5.one_re, Q5.one_im,
+      Q5.ofNat_re, Q5.ofNat_im, Q5.ofRat_re, Q5.ofRat_im, Matrix.cons_val_zero,
+      Matrix.cons_val_one, Matrix.cons_val_two, Matrix.cons_val_three, Matrix.cons_val_four,
+      Matrix.head_cons, Matrix.tail_cons]
 
 /-! ### Genuine `A₅` representations: trivial `ℂ`, the 4-dim `ℂ⁴`, and the 5-dim `ℂ⁵`
 

--- a/progress/2026-06-26T19-43-50Z_453c5d1b.md
+++ b/progress/2026-06-26T19-43-50Z_453c5d1b.md
@@ -1,0 +1,53 @@
+## Accomplished
+
+One-shot dispatch on #5459 (Example 4.8.1 A₅ Phase C). The full Phase C — golden-ratio
+characters of `ℂ³₊`/`ℂ³₋`, simplicity, the five-row table, and retiring `native_decide` — is
+genuinely multi-session: deliverables 1–3 all hinge on the minimal-polynomial fact
+`Zamb² = 20·Zamb + 400` on `Λ²(ℂ⁴)` (the internal eigenspace splitting), which is research-level
+and circular via the class-algebra/character routes (verified during triage). So I landed the
+one independent, achievable deliverable and decomposed the rest.
+
+**Deliverable 4 — retired the only remaining `native_decide` in the file** (`A5_orthonormal`,
+`Chapter4/Example4_8_1.lean`):
+- Replaced `fin_cases … native_decide` with an honest, kernel-checked proof: split each of the
+  25 weighted inner products into rational `re`/`im` components (`Q5.ext`), unfold the 5-term
+  `sumFin` (new `Q5.sumFin_five`), and discharge the rational arithmetic (golden-ratio `√5` terms
+  cancel) with `norm_num`.
+- Added the `Q5` projection lemmas (`mk`/`zero`/`one`/`add`/`neg`/`mul`/`ofNat`/`ofRat` `_re`/`_im`).
+  The `ofNat` lemmas need `no_index (OfNat.ofNat n)` for `simp` to match `Q5` numeric literals —
+  bare statements make no progress. Kept them non-`@[simp]` (passed explicitly) to keep the diff
+  surgical. Kernel `decide` cannot do this honestly: it stalls on `ℚ`-normalisation of `1/60`.
+- `A5_orthonormal` axioms: `propext`/`Classical.choice`/`Quot.sound` only. File builds clean
+  (the 21 `unusedSimpArgs` warnings are pre-existing, e.g. line ~337 `Matrix.toLin'_apply` in the
+  Q₈ section — not introduced here).
+
+## Current frontier
+
+`Chapter4/Example4_8_1.lean` builds; no `native_decide` anywhere. The A₅ icosahedral reps
+`repC3plus`/`repC3minus` exist (Phase A+B) but their characters/simplicity are not yet proven.
+
+## Overall project progress
+
+Example 4.8.1 Q₈/S₄ are complete genuine character tables. A₅ rows 0/3/4 (`ℂ`/`ℂ⁴`/`ℂ⁵`) are
+genuine; the two 3-dim icosahedral reps are constructed as `Zamb`-eigenspaces of `Λ²(ℂ⁴)` but
+their golden-ratio characters remain. `native_decide` is now fully eliminated from the file.
+
+Decomposition of the remaining Phase C work (a linear dependency chain):
+- **C1 = #5462** (pre-existing "Phase B 2/2", unclaimed): minimal polynomial `z²−20z−400=0` on
+  `Λ²(ℂ⁴)` + complementary 3-dim eigenspaces (internal splitting). The hard linchpin; it carries a
+  detailed worked integer-matrix route. My accidental duplicate #5467 was closed in its favour.
+- **C2 = #5468** (depends on #5462): the golden-ratio characters
+  `χ(ℂ³₊)=(3,0,-1,φ,φ')`, `χ(ℂ³₋)=(3,0,-1,φ',φ)` via the two-eigenspace trace equations, bridged
+  to `Q5toC (chiA5 1/2 ·)`.
+- **C3 = #5469** (depends on #5468): simplicity (norm-one), full `Fin 5` `irrepA5`/`tblA5`/`rowA5`,
+  pairwise non-iso (compare `Q5` vectors for the `√5` entry), `Fin 5` exported wrappers.
+
+## Next step
+
+Claim #5462 (Phase B 2/2) — it is unclaimed and unblocks the whole C2→C3 chain. It is the
+research-level minimal-polynomial proof; budget a full session.
+
+## Blockers
+
+C2/C3 are blocked on #5462 (minimal polynomial / internal eigenspace splitting). #5462 itself is
+unblocked and ready to claim.


### PR DESCRIPTION
This PR retires the last `native_decide` in `Chapter4/Example4_8_1.lean` by reproving `A5_orthonormal` (orthonormality of the tabulated A₅ character table) honestly: each of the 25 class-size-weighted `Q5` inner products is split into its rational `re`/`im` components (`Q5.ext`), the five-term `sumFin` is unfolded (new `Q5.sumFin_five`), and the resulting rational arithmetic — in which the golden-ratio `√5` terms cancel — is discharged by `norm_num`. Add the supporting `Q5` projection lemmas (`mk`/`zero`/`one`/`add`/`neg`/`mul`/`ofNat`/`ofRat` `_re`/`_im`); the `ofNat` lemmas use `no_index` so `simp` matches `Q5` numeric literals. Kernel `decide` cannot evaluate this honestly — it stalls on `ℚ`-normalisation of the `1/60` factor — so this removes a forbidden trust hole rather than swapping one slow check for another. `A5_orthonormal` axioms are `propext`/`Classical.choice`/`Quot.sound` only.

Partial completion of #5459 (Example 4.8.1 A₅ Phase C): this lands deliverable 4. The remaining deliverables — the golden-ratio characters of `ℂ³₊`/`ℂ³₋`, simplicity, and the full five-row table — all depend on the minimal-polynomial / internal eigenspace splitting and are tracked as a chain #5462 → #5468 → #5469.

🤖 Prepared with Claude Code