### PR TITLE
feat(Ch2 2.15.1g): Casimir is central on any sl₂-module

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Problem2_15_1_complete_reducibility.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_15_1_complete_reducibility.lean
@@ -117,6 +117,112 @@ theorem casimir_lowest_weight (μ : ℂ) (x : M) (hF : ⁅sl2_f, x⁆ = 0)
 
 end Casimir
 
+section Central
+
+variable {M : Type*} [AddCommGroup M] [Module ℂ M]
+  [LieRingModule sl2 M] [LieModule ℂ sl2 M]
+
+-- Re-enable the Lie ring structure on the associative ring `Module.End ℂ M` so that
+-- `LieHom.map_lie` (bracket preservation of `LieModule.toEnd`) and the commutator
+-- bracket `⁅a, b⁆ = a * b - b * a` are available. Local to this section.
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+omit [LieRingModule sl2 M] [LieModule ℂ sl2 M] in
+/-- The commutator bracket on `Module.End ℂ M` is a derivation of the associative
+product: `⁅a, b * c⁆ = ⁅a, b⁆ * c + b * ⁅a, c⁆`. -/
+private theorem lie_mul' (a b c : Module.End ℂ M) :
+    ⁅a, b * c⁆ = ⁅a, b⁆ * c + b * ⁅a, c⁆ := by
+  simp only [Ring.lie_def]; noncomm_ring
+
+/-- `C` commutes with `E` (`= ⁅sl2_e, ·⁆`): `⁅E, C⁆ = 0`. The Casimir's commutator
+with the raising operator vanishes via `⁅E,E⁆ = 0`, `⁅E,F⁆ = H`, `⁅E,H⁆ = -2E`. -/
+private theorem lie_e_casimir : ⁅LieModule.toEnd ℂ sl2 M sl2_e, casimir M⁆ = 0 := by
+  rw [casimir]
+  set E := LieModule.toEnd ℂ sl2 M sl2_e with hE
+  set F := LieModule.toEnd ℂ sl2 M sl2_f with hF
+  set H := LieModule.toEnd ℂ sl2 M sl2_h with hH
+  have bEF : ⁅E, F⁆ = H := by rw [hE, hF, hH, ← LieHom.map_lie, lie_e_f]
+  have bHE : ⁅H, E⁆ = 2 • E := by rw [hH, hE, ← LieHom.map_lie, lie_h_e, map_nsmul]
+  have bEH : ⁅E, H⁆ = -(2 • E) := by rw [(lie_skew E H).symm, bHE]
+  rw [lie_add, lie_add, lie_mul', lie_mul', lie_smul, lie_mul']
+  simp only [lie_self, bEF, bEH, zero_mul, mul_zero, add_zero, zero_add,
+    neg_mul, mul_neg, smul_mul_assoc, mul_smul_comm]
+  module
+
+/-- `C` commutes with `F` (`= ⁅sl2_f, ·⁆`): `⁅F, C⁆ = 0`, via `⁅F,E⁆ = -H`,
+`⁅F,H⁆ = 2F`, `⁅F,F⁆ = 0`. -/
+private theorem lie_f_casimir : ⁅LieModule.toEnd ℂ sl2 M sl2_f, casimir M⁆ = 0 := by
+  rw [casimir]
+  set E := LieModule.toEnd ℂ sl2 M sl2_e with hE
+  set F := LieModule.toEnd ℂ sl2 M sl2_f with hF
+  set H := LieModule.toEnd ℂ sl2 M sl2_h with hH
+  have bFE : ⁅F, E⁆ = -H := by
+    rw [(lie_skew F E).symm, hF, hE, hH, ← LieHom.map_lie, lie_e_f]
+  have bHF : ⁅H, F⁆ = -(2 • F) := by
+    rw [hH, hF, ← LieHom.map_lie, lie_h_f, map_neg, map_nsmul]
+  have bFH : ⁅F, H⁆ = 2 • F := by rw [(lie_skew F H).symm, bHF, neg_neg]
+  rw [lie_add, lie_add, lie_mul', lie_mul', lie_smul, lie_mul']
+  simp only [lie_self, bFE, bFH, zero_mul, mul_zero, add_zero, zero_add,
+    neg_mul, mul_neg, smul_mul_assoc, mul_smul_comm]
+  module
+
+/-- `C` commutes with `H` (`= ⁅sl2_h, ·⁆`): `⁅H, C⁆ = 0`, via `⁅H,E⁆ = 2E`,
+`⁅H,F⁆ = -2F`, `⁅H,H⁆ = 0`. -/
+private theorem lie_h_casimir : ⁅LieModule.toEnd ℂ sl2 M sl2_h, casimir M⁆ = 0 := by
+  rw [casimir]
+  set E := LieModule.toEnd ℂ sl2 M sl2_e with hE
+  set F := LieModule.toEnd ℂ sl2 M sl2_f with hF
+  set H := LieModule.toEnd ℂ sl2 M sl2_h with hH
+  have bHE : ⁅H, E⁆ = 2 • E := by rw [hH, hE, ← LieHom.map_lie, lie_h_e, map_nsmul]
+  have bHF : ⁅H, F⁆ = -(2 • F) := by
+    rw [hH, hF, ← LieHom.map_lie, lie_h_f, map_neg, map_nsmul]
+  rw [lie_add, lie_add, lie_mul', lie_mul', lie_smul, lie_mul']
+  simp only [lie_self, bHE, bHF, zero_mul, mul_zero, add_zero,
+    neg_mul, mul_neg, smul_mul_assoc, mul_smul_comm]
+  module
+
+/-- Every element of `sl(2)` is the `ℂ`-combination `X = X₀₁·e + X₁₀·f + X₀₀·h` of the
+standard triple, read off from its matrix entries (the `(1,1)` entry is `-X₀₀` by
+tracelessness). -/
+theorem sl2_decomp (x : sl2) :
+    x = (x.val 0 1) • sl2_e + (x.val 1 0) • sl2_f + (x.val 0 0) • sl2_h := by
+  apply Subtype.ext
+  push_cast
+  simp only [sl2_e, sl2_f, sl2_h,
+    LieAlgebra.SpecialLinear.val_single, LieAlgebra.SpecialLinear.val_singleSubSingle]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.add_apply, Matrix.single, sl2_traceless x]
+
+/-- The Casimir commutes with the action of every `x ∈ sl(2)`: `⁅toEnd x, C⁆ = 0`.
+By `ℂ`-bilinearity of the bracket this reduces to the three generators `e, f, h`. -/
+theorem casimir_lie_toEnd (x : sl2) :
+    ⁅LieModule.toEnd ℂ sl2 M x, casimir M⁆ = 0 := by
+  rw [sl2_decomp x, map_add, map_add, map_smul, map_smul, map_smul,
+    add_lie, add_lie, smul_lie, smul_lie, smul_lie,
+    lie_e_casimir, lie_f_casimir, lie_h_casimir, smul_zero, smul_zero, smul_zero,
+    add_zero, add_zero]
+
+/-- **The Casimir operator is central (Problem 2.15.1(g)).** On any `sl(2)`-module `M`,
+`C = casimir M` commutes with the `sl(2)`-action: `⁅x, C m⁆ = C ⁅x, m⁆` for all
+`x ∈ sl(2)` and `m ∈ M`. This is the book's "`C` commutes with `E`, `F`, `H`" at the
+general-module level, and is the prerequisite for part (h): the generalized eigenspaces
+of the central operator `C` are sub-`sl(2)`-modules. -/
+theorem casimir_central (x : sl2) (m : M) :
+    ⁅x, casimir M m⁆ = casimir M ⁅x, m⁆ := by
+  have hcomm : LieModule.toEnd ℂ sl2 M x * casimir M
+      = casimir M * LieModule.toEnd ℂ sl2 M x := by
+    have h := casimir_lie_toEnd (M := M) x
+    rwa [Ring.lie_def, sub_eq_zero] at h
+  calc ⁅x, casimir M m⁆
+      = LieModule.toEnd ℂ sl2 M x (casimir M m) := (LieModule.toEnd_apply_apply ..).symm
+    _ = (LieModule.toEnd ℂ sl2 M x * casimir M) m := (Module.End.mul_apply ..).symm
+    _ = (casimir M * LieModule.toEnd ℂ sl2 M x) m := by rw [hcomm]
+    _ = casimir M (LieModule.toEnd ℂ sl2 M x m) := Module.End.mul_apply ..
+    _ = casimir M ⁅x, m⁆ := by rw [LieModule.toEnd_apply_apply]
+
+end Central
+
 /-! ## The complete-reducibility conclusion
 
 The statement of complete reducibility, recorded in its cleanest equivalent form for a

--- a/progress/2026-06-26T20-08-00Z_cec6e539.md
+++ b/progress/2026-06-26T20-08-00Z_cec6e539.md
@@ -1,0 +1,53 @@
+## Accomplished
+
+One-shot dispatch (`pod once 5311`). Issue #5311 (full Problem 2.15.1(h)–(k) Weyl
+complete reducibility for `sl₂`) had already been decomposed by an earlier session
+into the dependency chain #5315 → #5316 → #5317 → #5318. The next unblocked piece,
+#5315 (**Casimir operator is central**), was the natural landable chunk this session.
+
+Added a sorry-free `Central` section to
+`Chapter2/Problem2_15_1_complete_reducibility.lean`:
+
+- `lie_mul'`: the commutator bracket on `Module.End ℂ M` is a derivation of the
+  associative product (`⁅a, b*c⁆ = ⁅a,b⁆*c + b*⁅a,c⁆`), proved by `Ring.lie_def`
+  + `noncomm_ring`.
+- `lie_e_casimir`, `lie_f_casimir`, `lie_h_casimir`: `⁅toEnd g, casimir M⁆ = 0` for
+  each generator `g ∈ {e,f,h}`, from the sl₂-triple bracket relations
+  (`lie_e_f`/`lie_h_e`/`lie_h_f`) pushed to `Module.End` via `LieHom.map_lie`, then
+  closed with `module`.
+- `sl2_decomp`: every `x : sl2` is `x.val 0 1 • e + x.val 1 0 • f + x.val 0 0 • h`
+  (matrix-entry read-off using `sl2_traceless`).
+- `casimir_lie_toEnd (x : sl2) : ⁅toEnd x, casimir M⁆ = 0` — reduces an arbitrary `x`
+  to the three generators by `ℂ`-bilinearity.
+- `casimir_central (x : sl2) (m : M) : ⁅x, casimir M m⁆ = casimir M ⁅x, m⁆` — the
+  deliverable of #5315 (part (g)'s "C commutes with E, F, H" at the general-module
+  level).
+
+`#print axioms casimir_central` shows only `propext, Classical.choice, Quot.sound`
+(no `sorryAx`). Key pattern: `attribute [local instance 100] LieRing.ofAssociativeRing`
+is required in-section to expose the `LieRing (Module.End ℂ M)` structure (it is only a
+local instance from Lean v4.31, per the note in `Sl2Defs.lean`).
+
+## Current frontier
+
+`complete_reducibility` in the same file is still `sorry` (the parts (h)–(k) assembly),
+unchanged from before this session.
+
+## Overall project progress
+
+Problem 2.15.1 `sl₂` complete reducibility: parts (a)–(g) + (m) backbone landed in
+earlier PRs; the general-module Casimir toolkit (`casimir`, `casimir_highest_weight`,
+`casimir_lowest_weight`) landed in #5319; **this session adds `casimir_central`
+(part (g) centrality / #5315)**. Remaining: #5316 (h: single eigenvalue), #5317
+(i–k: indecomposable ⟹ irreducible), #5318 (assemble `complete_reducibility`).
+
+## Next step
+
+Claim #5316 (now unblocked by `casimir_central`): on an indecomposable finite-dim
+`sl₂`-rep, the central `casimir M` has a single generalized eigenvalue `λ(λ+2)/2`,
+using that generalized eigenspaces of a central operator are sub-`sl₂`-modules
+(`casimir_central` is the input). Then #5317, then #5318.
+
+## Blockers
+
+None. `casimir_central` is sorry-free and unblocks #5316.


### PR DESCRIPTION
This PR adds a sorry-free `Central` section to `Chapter2/Problem2_15_1_complete_reducibility.lean`, proving that the Casimir operator is central on an arbitrary `sl₂`-module: `casimir_central : ⁅x, casimir M m⁆ = casimir M ⁅x, m⁆` for every `x ∈ sl₂`, the general-module form of Etingof Problem 2.15.1(g)'s "C commutes with E, F, H".

The proof goes through `lie_mul'` (the commutator bracket on `Module.End ℂ M` is a derivation of the product), the three generator commutes `lie_{e,f,h}_casimir` (`⁅toEnd g, casimir M⁆ = 0`, from the sl₂-triple relations pushed to `Module.End` by `LieHom.map_lie` and closed with `module`), and `sl2_decomp` reducing an arbitrary `x` to the `e`/`f`/`h` generators by `ℂ`-bilinearity. `#print axioms casimir_central` shows only `propext, Classical.choice, Quot.sound`.

This is exactly the deliverable of #5311's first decomposed sub-issue #5315, and unblocks part (h) (#5316): the generalized eigenspaces of the central `casimir M` are sub-`sl₂`-modules. The umbrella `complete_reducibility` itself remains `sorry`, with the remaining (h)–(k) assembly tracked in #5316 / #5317 / #5318.

Partial progress on #5311. Also completes the scope of #5315 (a planner may close #5315 as covered by this PR).

🤖 Prepared with Claude Code