### PR TITLE
doc(#5473): decompose Theorem5_23_2_i into #5477 + #5478

### DIFF
--- a/progress/2026-06-26T20-25-01Z_a0581549.md
+++ b/progress/2026-06-26T20-25-01Z_a0581549.md
@@ -1,0 +1,69 @@
+## Accomplished
+
+One-shot dispatch on #5473 (discharge the `sorry` in `Theorem5_23_2_i`,
+`Chapter5/Theorem5_23_2.lean:61` — part (i), complete reducibility of every
+finite-dimensional algebraic `GL_n(k)`-representation).
+
+After a thorough feasibility analysis I determined this is a genuine
+multi-piece, partly research-level blocker and **decomposed** it (worker-flow
+Step 4b) into two well-scoped, self-contained sub-issues rather than attempt a
+failing heroic proof:
+
+- **#5477 (crux):** weight-space saturation for polynomial `GL_N`-reps —
+  `⨆ μ, glWeightSpace k N M μ = ⊤` (diagonal-torus diagonalizability / linear
+  reductivity of `(Gₘ)^N`).
+- **#5478 (assembly, depends on #5477):** reduce a general algebraic rep to the
+  polynomial-homogeneous case via det-twist clearing + total-degree homogeneous
+  splitting, apply `decompose_polynomial_gl_rep`, and transfer
+  `IsSemisimpleModule` back across the character twist.
+
+Parent #5473 marked `replan` with a `Decomposed into #5477, #5478` breadcrumb.
+
+## Key findings
+
+- The hard machinery already exists: `decompose_polynomial_gl_rep`
+  (`Chapter5/PolynomialGLDecomposition.lean:318`) proves `GL_N`-equivariant
+  complete reducibility — hence `IsSemisimpleModule (MonoidAlgebra k GL_N)
+  M.asModule` — for a **polynomial homogeneous** algebraic rep (hypotheses
+  `h_span` + `h_homog`).
+- The genuine gap is the reduction of a **general** algebraic rep to that case.
+  The conceptual crux is weight-space saturation `h_span`: it is treated
+  **everywhere** in the project as a *hypothesis* supplied for specific
+  constructed reps (Schur modules, det-degree quotients) and transferred via
+  equivariant surjections — there is **no** general theorem deriving it.
+  `Chapter5/PolynomialRepEmbedding.lean:762` explicitly notes that without
+  `h_span` the embedding is *false* for algebraic-but-not-polynomial reps
+  (`Sym²V ⊗ det⁻¹`). This is exactly the linear-reductivity-of-the-torus
+  result, absent from the project.
+- Reusable pieces for the assembly: `IsAlgebraicRepresentation.detTwist` /
+  `.restrict` / `.of_linearEquiv` (`GLRepAlgebraic.lean`), `detPolyGL` +
+  `evalAtGL_detPolyGL`, the degree grading in `PolyRightGrading.lean`
+  (`polyRightRep_isHomogeneous`) and `CauchyDetQuotient*`, and Mathlib's
+  closure of `IsSemisimpleModule` under direct sums / submodules.
+- The book's alternative route (embedding `Y ↪ Y ⊗ R`) is blocked on the
+  coordinate-ring `GL`-module infrastructure tracked in the still-open #5396, so
+  the det-twist route (reusing `decompose_polynomial_gl_rep`) is the better path.
+
+## Current frontier
+
+`Theorem5_23_2_i` still carries its `sorry`. No Lean code changed this turn
+(decomposition only). Sub-issues #5477 and #5478 capture the full route.
+
+## Overall project progress
+
+Stage 3.2 (Chapter 5) ongoing. Part (i) of Theorem 5.23.2 now has a precise,
+faithful route on the board (#5477 → #5478); part (ii) equivariant Peter-Weyl
+remains tracked in #5396.
+
+## Next step
+
+A worker should claim **#5477** (the crux). Route: each `diagUnit` generator
+acts as a semisimple operator (squarefree minimal polynomial, cf.
+`Theorem5_4_4.lean` / `Module.End.isSemisimple_of_squarefree_aeval_eq_zero`); the
+`N` commuting semisimple operators are simultaneously diagonalizable, so the
+joint eigenspaces (= `glWeightSpace`s) span. Once #5477 lands, #5478 unblocks.
+
+## Blockers
+
+#5478 is blocked on #5477. #5477 itself is the genuine mathematical crux
+(diagonal-torus diagonalizability) — non-trivial but self-contained.


### PR DESCRIPTION
This PR records the one-shot feasibility analysis of #5473 (discharge the `Theorem5_23_2_i` complete-reducibility `sorry`) and adds the corresponding progress note. The general theorem reuses `decompose_polynomial_gl_rep` for the polynomial-homogeneous case but needs the absent weight-space-saturation crux (#5477, diagonal-torus diagonalizability) plus a det-twist + homogeneous-splitting assembly (#5478, depends on #5477). #5473 is marked `replan` with a decomposition breadcrumb; this PR only adds a `progress/` file (no Lean changes).

🤖 Prepared with Claude Code