### PR TITLE
feat(Ch8): finite-dimensional algebras are semiprimary (Bass-route infra for #5476)

### DIFF
--- a/EtingofRepresentationTheory/Chapter8.lean
+++ b/EtingofRepresentationTheory/Chapter8.lean
@@ -3,6 +3,7 @@ import EtingofRepresentationTheory.Chapter8.Definition8_1_2
 import EtingofRepresentationTheory.Chapter8.Theorem8_1_5
 import EtingofRepresentationTheory.Chapter8.Definition8_1_6
 import EtingofRepresentationTheory.Chapter8.Example8_1_7
+import EtingofRepresentationTheory.Chapter8.SemiprimaryAlgebra
 import EtingofRepresentationTheory.Chapter8.Definition8_1_8
 import EtingofRepresentationTheory.Chapter8.Definition8_2_1
 import EtingofRepresentationTheory.Chapter8.Definition8_2_3

--- a/EtingofRepresentationTheory/Chapter8/SemiprimaryAlgebra.lean
+++ b/EtingofRepresentationTheory/Chapter8/SemiprimaryAlgebra.lean
@@ -1,0 +1,48 @@
+import Mathlib.RingTheory.Artinian.Module
+import Mathlib.RingTheory.Jacobson.Semiprimary
+import Mathlib.LinearAlgebra.FiniteDimensional.Defs
+import Mathlib.Algebra.Algebra.Tower
+
+/-!
+# Finite-dimensional algebras are semiprimary
+
+A finite-dimensional algebra `A` over a field `k` is a left Artinian ring, hence
+**semiprimary**: its Jacobson radical `Ring.jacobson A` is nilpotent and the quotient
+`A ⧸ Ring.jacobson A` is semisimple (`Mathlib.RingTheory.Jacobson.Semiprimary`).
+
+This is the foundational ring-theoretic layer for the Bass route to Example 8.1.7
+(`projective ⟺ injective dual`): over a left perfect — a fortiori semiprimary — ring,
+every flat left module is projective. The flat-⟹-projective theorem itself is the
+substantial remaining piece (Bass's characterization of perfect rings); see issue #5476.
+
+## Main results
+
+* `isArtinianRing_of_finiteDimensional`: a finite-dimensional `k`-algebra is a left
+  Artinian ring.
+* `isSemiprimaryRing_of_finiteDimensional`: a finite-dimensional `k`-algebra is semiprimary.
+
+Both are stated as `theorem`s rather than `instance`s because the field `k` does not appear
+in the conclusion (`IsArtinianRing A` / `IsSemiprimaryRing A`), so type-class search cannot
+recover it; downstream users supply `k` explicitly via `haveI := ... k A`.
+-/
+
+/-- A finite-dimensional algebra over a field is a left Artinian ring.
+
+The left ideals of `A` are in particular `k`-subspaces, and a finite-dimensional vector space
+satisfies the descending chain condition on subspaces; `isArtinian_of_tower` transports the
+Artinian property along the scalar tower `k → A → A`. -/
+theorem isArtinianRing_of_finiteDimensional
+    (k A : Type*) [Field k] [Ring A] [Algebra k A] [FiniteDimensional k A] :
+    IsArtinianRing A :=
+  isArtinian_of_tower k inferInstance
+
+/-- A finite-dimensional algebra over a field is semiprimary: its Jacobson radical is
+nilpotent and the quotient by the Jacobson radical is semisimple.
+
+This is immediate from `isArtinianRing_of_finiteDimensional` together with Mathlib's instance
+that every left Artinian ring is semiprimary. -/
+theorem isSemiprimaryRing_of_finiteDimensional
+    (k A : Type*) [Field k] [Ring A] [Algebra k A] [FiniteDimensional k A] :
+    IsSemiprimaryRing A :=
+  haveI : IsArtinianRing A := isArtinianRing_of_finiteDimensional k A
+  inferInstance

--- a/progress/2026-06-26T21-40-05Z_1cd34896.md
+++ b/progress/2026-06-26T21-40-05Z_1cd34896.md
@@ -1,0 +1,64 @@
+## Accomplished
+
+Worked issue #5476 ("Infra for Example 8.1.7 (part 2): flat ⟹ projective over a
+finite-dimensional algebra / Bass / perfect rings").
+
+**Discovered a planner-level blocker** that affects the whole #5474 / #5475 / #5476 chain:
+the issue's stated deliverable
+
+```
+[Field k] [Ring A] [Algebra k A] [FiniteDimensional k A]
+[AddCommGroup P] [Module A P] → Module.Flat A P → Module.Projective A P
+```
+
+**does not typecheck**. Mathlib's `Module.Flat` is defined only over a `CommSemiring`
+(`Mathlib/RingTheory/Flat/Basic.lean`, the `class Flat` at line 113 sits under a
+`[CommSemiring R]` variable block). A finite-dimensional algebra `A` is noncommutative in
+general (matrix algebras, group algebras), so `Module.Flat A P` fails instance synthesis
+(`failed to synthesize CommSemiring A`). Mathlib also has **no** noncommutative tensor
+product (right-module ⊗ left-module over a noncommutative ring), so noncommutative
+flatness cannot even be *stated* yet. This is the true foundational gap for the chain.
+
+**Landed the one genuinely-completable, sorry-free, reusable piece**: the foundational
+ring-theory layer of the Bass route, in
+`EtingofRepresentationTheory/Chapter8/SemiprimaryAlgebra.lean`:
+
+* `isArtinianRing_of_finiteDimensional`: a finite-dimensional `k`-algebra is left Artinian
+  (`isArtinian_of_tower k inferInstance`).
+* `isSemiprimaryRing_of_finiteDimensional`: hence semiprimary (Jacobson radical nilpotent,
+  semisimple quotient) — via Mathlib's existing `IsArtinianRing → IsSemiprimaryRing` instance
+  (`Mathlib/RingTheory/Artinian/Module.lean:643`).
+
+Mathlib already supplies the rest of the foundational layer that issue #5476 worried was
+missing: `IsSemiprimaryRing` (`Mathlib/RingTheory/Jacobson/Semiprimary.lean`), Jacobson
+nilpotency for Artinian rings, and semisimple quotients. The genuinely-missing, hard piece
+is exactly Bass's flat-⟹-projective theorem over a perfect/semiprimary ring — and that
+cannot be approached until a noncommutative flatness primitive exists.
+
+## Current frontier
+
+`SemiprimaryAlgebra.lean` builds (`lake build` of the target: 1579 jobs, success), is
+sorry-free, and is wired into `Chapter8.lean`. The flat-⟹-projective deliverable is blocked
+on the missing noncommutative-flatness primitive.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. Example 8.1.7 (`Chapter8/Example8_1_7.lean`) statement is
+in place with a single `sorry` for the biconditional; its supporting infra issues
+#5474/#5475/#5476 are now known to require a noncommutative flatness notion first.
+
+## Next step
+
+Replan the #5474/#5475/#5476 chain. Recommended prerequisite issue (for the planner to
+create): **define noncommutative left-module flatness** — i.e. a right-module ⊗ left-module
+tensor product over a (noncommutative) ring landing in `AddCommGroup`, plus a flatness
+predicate (the tensor functor preserves injections). Lambek (#5475) and Bass (#5476) should
+then be restated in terms of that primitive. Alternatively, bypass a standalone flatness
+predicate and prove the two implications of `P projective ⟺ Module.Dual k P injective`
+directly. Either way, `isSemiprimaryRing_of_finiteDimensional` (this PR) is the ring-theory
+input the Bass direction will consume.
+
+## Blockers
+
+Mathlib has no noncommutative flatness / noncommutative tensor product. The literal
+deliverable of #5476 is unformalizable until that primitive is built. #5476 marked `replan`.


### PR DESCRIPTION
This PR lands the foundational ring-theory layer for the Bass route to Example 8.1.7: `isArtinianRing_of_finiteDimensional` (a finite-dimensional `k`-algebra is left Artinian, via `isArtinian_of_tower`) and `isSemiprimaryRing_of_finiteDimensional` (hence semiprimary — Jacobson radical nilpotent, semisimple quotient — through Mathlib's existing `IsArtinianRing → IsSemiprimaryRing` instance). Both are sorry-free, in a new `EtingofRepresentationTheory/Chapter8/SemiprimaryAlgebra.lean` wired into `Chapter8.lean`.

This is partial progress on #5476. The issue's full deliverable (`Module.Flat A P → Module.Projective A P` over a finite-dimensional algebra) cannot be stated in current Mathlib: `Module.Flat` requires `CommSemiring`, finite-dimensional algebras are noncommutative in general, and Mathlib has no noncommutative tensor product, so flatness of a left module over a noncommutative ring is not yet expressible. #5476 is marked `replan` with a full analysis in its comments. The semiprimary infrastructure here is the input the eventual Bass (flat ⟹ projective) direction will consume regardless of how noncommutative flatness is modelled.

🤖 Prepared with Claude Code
