### PR TITLE
feat(Ch2 2.15.1(h)): Casimir generalized-eigenspace decomposition into subreps

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Problem2_15_1_complete_reducibility.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_15_1_complete_reducibility.lean
@@ -1,6 +1,9 @@
 import Mathlib.Algebra.Lie.OfAssociative
 import Mathlib.Algebra.Lie.Submodule
 import Mathlib.LinearAlgebra.Dimension.Finite
+import Mathlib.LinearAlgebra.Eigenspace.Triangularizable
+import Mathlib.Algebra.DirectSum.Module
+import Mathlib.Analysis.Complex.Polynomial.Basic
 import EtingofRepresentationTheory.Chapter2.Sl2Irrep
 
 /-!
@@ -222,6 +225,70 @@ theorem casimir_central (x : sl2) (m : M) :
     _ = casimir M ⁅x, m⁆ := by rw [LieModule.toEnd_apply_apply]
 
 end Central
+
+section GenEigenspaceDecomp
+
+variable {M : Type*} [AddCommGroup M] [Module ℂ M]
+  [LieRingModule sl2 M] [LieModule ℂ sl2 M]
+
+/-- The Casimir operator commutes with the action of every `x ∈ sl(2)` — the
+operator-algebra (`Commute`) form of `casimir_central`. -/
+theorem commute_casimir_toEnd (x : sl2) :
+    Commute (casimir M) (LieModule.toEnd ℂ sl2 M x) := by
+  change casimir M * LieModule.toEnd ℂ sl2 M x = LieModule.toEnd ℂ sl2 M x * casimir M
+  apply LinearMap.ext
+  intro m
+  simp only [Module.End.mul_apply, LieModule.toEnd_apply_apply]
+  exact (casimir_central x m).symm
+
+/-- **The generalized eigenspace of the Casimir operator for eigenvalue `a`, as an
+`sl(2)`-submodule.** Because `casimir M` commutes with the `sl(2)`-action
+(`commute_casimir_toEnd`), each of its generalized eigenspaces is invariant under the
+action, so it is a genuine subrepresentation. This is the precise meaning of the book's
+"the generalized eigenspace decomposition of `C` is a decomposition of representations"
+in part (h). -/
+noncomputable def casimirGenEigenspace (a : ℂ) : LieSubmodule ℂ sl2 M where
+  toSubmodule := (casimir M).maxGenEigenspace a
+  lie_mem := by
+    intro x m hm
+    have hmap := Module.End.mapsTo_maxGenEigenspace_of_comm
+      (commute_casimir_toEnd (M := M) x) a
+    rw [show ⁅x, m⁆ = LieModule.toEnd ℂ sl2 M x m from (LieModule.toEnd_apply_apply ..).symm]
+    exact hmap hm
+
+@[simp] theorem casimirGenEigenspace_toSubmodule (a : ℂ) :
+    (casimirGenEigenspace (M := M) a : Submodule ℂ M) = (casimir M).maxGenEigenspace a :=
+  rfl
+
+/-- The Casimir generalized eigenspaces are independent (as subrepresentations). -/
+theorem casimirGenEigenspace_iSupIndep : iSupIndep (casimirGenEigenspace (M := M)) := by
+  rw [← LieSubmodule.iSupIndep_toSubmodule]
+  simpa only [casimirGenEigenspace_toSubmodule] using
+    Module.End.independent_maxGenEigenspace (casimir M)
+
+variable [FiniteDimensional ℂ M]
+
+/-- In finite dimensions, the Casimir generalized eigenspaces span the whole module
+(`ℂ` is algebraically closed). -/
+theorem casimirGenEigenspace_iSup_eq_top :
+    ⨆ a, casimirGenEigenspace (M := M) a = ⊤ := by
+  rw [← LieSubmodule.iSup_toSubmodule_eq_top]
+  simpa only [casimirGenEigenspace_toSubmodule] using
+    Module.End.iSup_maxGenEigenspace_eq_top (casimir M)
+
+/-- **The generalized-eigenspace decomposition of the Casimir is an internal direct sum of
+subrepresentations — the structural heart of Problem 2.15.1(h).** A finite-dimensional
+`sl(2)`-module is the internal direct sum of the Casimir generalized eigenspaces
+`casimirGenEigenspace a`, each of which is an `sl(2)`-submodule. Consequently an
+*indecomposable* finite-dimensional `sl(2)`-module has a single Casimir eigenvalue: this is
+the input to parts (i)–(k). -/
+theorem casimirGenEigenspace_isInternal :
+    DirectSum.IsInternal (fun a => (casimirGenEigenspace (M := M) a : Submodule ℂ M)) :=
+  DirectSum.isInternal_submodule_of_iSupIndep_of_iSup_eq_top
+    ((LieSubmodule.iSupIndep_toSubmodule).mpr casimirGenEigenspace_iSupIndep)
+    ((LieSubmodule.iSup_toSubmodule_eq_top).mpr casimirGenEigenspace_iSup_eq_top)
+
+end GenEigenspaceDecomp
 
 /-! ## The complete-reducibility conclusion
 

--- a/progress/2026-06-26T22-16-11Z_1916a2d4.md
+++ b/progress/2026-06-26T22-16-11Z_1916a2d4.md
@@ -1,0 +1,53 @@
+## Accomplished
+
+One-shot (`/once`) session on issue #5311 (Ch2 Problem 2.15.1(h)–(k), complete
+reducibility of finite-dimensional `sl₂`-representations).
+
+Landed the **structural heart of part (h)** — the Casimir generalized-eigenspace
+decomposition as a decomposition of *representations* — sorry-free, in
+`EtingofRepresentationTheory/Chapter2/Problem2_15_1_complete_reducibility.lean`:
+
+- `commute_casimir_toEnd` — the `Commute` (operator-algebra) form of the already
+  proven `casimir_central`: `casimir M` commutes with every `toEnd x`, `x ∈ sl(2)`.
+- `casimirGenEigenspace a : LieSubmodule ℂ sl2 M` — the generalized eigenspace
+  `(casimir M).maxGenEigenspace a` packaged as an `sl(2)`-submodule. Invariance comes
+  from `Module.End.mapsTo_maxGenEigenspace_of_comm` applied to `commute_casimir_toEnd`.
+  This is exactly the book's "the generalized eigenspace decomposition of `C` is a
+  decomposition of representations".
+- `casimirGenEigenspace_toSubmodule` (simp), `casimirGenEigenspace_iSupIndep`
+  (independence, via `Module.End.independent_maxGenEigenspace` + the
+  `LieSubmodule.iSupIndep_toSubmodule` transfer), `casimirGenEigenspace_iSup_eq_top`
+  (finite-dim span, via `Module.End.iSup_maxGenEigenspace_eq_top` + ℂ alg-closed), and
+- `casimirGenEigenspace_isInternal` — `DirectSum.IsInternal` of the eigenspaces.
+
+This is precisely the input #5316 (part (h): single Casimir eigenvalue on an
+indecomposable rep) needs: an indecomposable module must live in a single
+`casimirGenEigenspace`.
+
+## Current frontier
+
+The final `complete_reducibility` theorem (every fin-dim `sl₂`-submodule has an
+`sl₂`-complement) still carries its pre-existing `sorry`. Parts (i)–(k) and the
+final assembly are not done.
+
+## Overall project progress
+
+Casimir toolkit for `sl₂` complete reducibility now in `main`:
+- (g) `casimir_central` + eigenvalue lemmas `casimir_highest_weight` /
+  `casimir_lowest_weight` (earlier sessions, #5319/#5472).
+- (h) generalized-eigenspace decomposition into subreps (this session).
+Remaining: (h) single-eigenvalue conclusion on indecomposables (#5316), (i)–(k)
+indecomposable ⟹ irreducible (#5317), final assembly (#5318).
+
+## Next step
+
+Pick up #5316: define "indecomposable" (no nontrivial `IsCompl` LieSubmodule split,
+or `M` nonzero with no proper direct-sum decomposition) and use
+`casimirGenEigenspace_isInternal` + `casimirGenEigenspace_iSupIndep` to show an
+indecomposable fin-dim `sl₂`-module has a single Casimir eigenvalue `a`, then identify
+`a = λ(λ+2)/2` for some `λ ∈ ℕ` via the highest-weight analysis.
+
+## Blockers
+
+None. #5315's deliverable (`casimir_central`) is already in `main` (#5472 merged);
+that issue was stale-open and has been closed.


### PR DESCRIPTION
Partial progress on #5311

Session: `1916a2d4-982f-4077-a686-ce08a81019f7`

606ff014 feat(Ch2 #5311 (h)): Casimir generalized-eigenspace decomposition into subreps

🤖 Prepared with Claude Code