### PR TITLE
doc(skill): note stale-blocked issues from merged-but-unclosed deps

### DIFF
--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -76,6 +76,18 @@ open. `check-blocked` (run by `pod` each loop) removes `blocked` when
 all dependencies close. Blocked issues are excluded from
 `list-unclaimed` and `queue-depth`.
 
+A `blocked` issue can be **stale**: its `depends-on` dependency was
+satisfied by a merged PR but the dependency *issue* stayed open (GitHub
+does not always auto-close a linked issue on squash-merge, e.g. when the
+PR landed on a non-default branch or the squash dropped the `Closes #N`
+line). `check-blocked` only keys off the dependency's open/closed state,
+so it never clears the label in this case and the blocked issue is stuck
+forever. If you find a dependency issue whose deliverable is already in
+`main` (`git grep` the merged symbol; check `gh pr list --search "<dep#>
+in:body" --state merged`), close the stale dependency with a forward link
+to the merging PR, then run `coordination check-blocked` to release the
+downstream issue.
+
 **Branch naming**: `agent/<first-8-chars-of-UUID>`
 **Plan files**: `plans/<UUID-prefix>.md`
 **Progress files**: `progress/<UTC-timestamp>_<UUID-prefix>.md`


### PR DESCRIPTION
This PR records, in the `agent-worker-flow` skill, how to detect and clear a `blocked` issue whose `depends-on` dependency was satisfied by a merged PR but left open. `check-blocked` keys only off the dependency's open/closed state, so such an issue stays blocked forever. Hit while working #5311: #5315's `casimir_central` merged via #5472 but #5315 stayed open, leaving #5316 falsely blocked.

🤖 Prepared with Claude Code