### PR TITLE
Mixed-universe simple-k[Sₙ]-module Specht classification (enabler for #5493)

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Corollary4_2_2.lean
+++ b/EtingofRepresentationTheory/Chapter4/Corollary4_2_2.lean
@@ -19,11 +19,11 @@ We use the center dimension argument:
 
 open FDRep CategoryTheory
 
-universe u
+universe u v
 
 section CenterDimension
 
-variable {k G : Type u} [Field k] [IsAlgClosed k] [Group G] [Fintype G] [DecidableEq G]
+variable {k : Type u} {G : Type v} [Field k] [IsAlgClosed k] [Group G] [Fintype G] [DecidableEq G]
   [NeZero (Nat.card G : k)]
 
 /-! #### Helper: characterize center of MonoidAlgebra -/
@@ -213,7 +213,7 @@ of conjugacy classes: there exist exactly `Fintype.card (ConjClasses G)` pairwis
 non-isomorphic simple representations, and every simple representation is isomorphic
 to one of them. (Etingof Corollary 4.2.2) -/
 theorem Etingof.Corollary4_2_2
-    {G : Type u} [Group G] [Fintype G] [DecidableEq G]
+    {G : Type v} [Group G] [Fintype G] [DecidableEq G]
     {k : Type u} [Field k] [IsAlgClosed k]
     [Invertible (Fintype.card G : k)] :
     ∃ (n : ℕ) (V : Fin n → FDRep k G),

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_12_2_ClassificationGeneral.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_12_2_ClassificationGeneral.lean
@@ -32,9 +32,9 @@ namespace Etingof
 noncomputable section
 open scoped Classical
 
-universe u
+universe u w
 
-variable (k : Type) [Field k] [IsAlgClosed k] [CharZero k]
+variable (k : Type u) [Field k] [IsAlgClosed k] [CharZero k]
 
 private abbrev G' (n : ℕ) := Equiv.Perm (Fin n)
 private abbrev A' (n : ℕ) := MonoidAlgebra k (G' n)
@@ -159,7 +159,7 @@ private lemma centralIdem'_comm (n : ℕ) (D : IrrepDecomp k (G' n))
 
 /-- For a simple `A'(n)`-module, exactly one central idempotent acts as identity. -/
 private lemma exists_unique_block (n : ℕ) (D : IrrepDecomp k (G' n))
-    (L : Type) [AddCommGroup L] [Module (A' k n) L] [IsSimpleModule (A' k n) L] :
+    (L : Type w) [AddCommGroup L] [Module (A' k n) L] [IsSimpleModule (A' k n) L] :
     ∃! j : Fin D.n, ∀ l : L, centralIdem' k n D j • l = l := by
   have hsum : ∀ l : L, l = ∑ j, centralIdem' k n D j • l := by
     intro l; conv_lhs => rw [← one_smul (A' k n) l, ← centralIdem'_sum k n D]; rw [Finset.sum_smul]
@@ -204,17 +204,17 @@ private lemma exists_unique_block (n : ℕ) (D : IrrepDecomp k (G' n))
 
 /-- The block assignment for a simple submodule of `A'(n)`. -/
 private noncomputable def blockOf (n : ℕ) (D : IrrepDecomp k (G' n))
-    (L : Type) [AddCommGroup L] [Module (A' k n) L] [IsSimpleModule (A' k n) L] :
+    (L : Type w) [AddCommGroup L] [Module (A' k n) L] [IsSimpleModule (A' k n) L] :
     Fin D.n :=
   (exists_unique_block k n D L).choose
 
 private lemma blockOf_spec (n : ℕ) (D : IrrepDecomp k (G' n))
-    (L : Type) [AddCommGroup L] [Module (A' k n) L] [IsSimpleModule (A' k n) L] :
+    (L : Type w) [AddCommGroup L] [Module (A' k n) L] [IsSimpleModule (A' k n) L] :
     ∀ l : L, centralIdem' k n D (blockOf k n D L) • l = l :=
   (exists_unique_block k n D L).choose_spec.1
 
 private lemma blockOf_unique (n : ℕ) (D : IrrepDecomp k (G' n))
-    (L : Type) [AddCommGroup L] [Module (A' k n) L] [IsSimpleModule (A' k n) L]
+    (L : Type w) [AddCommGroup L] [Module (A' k n) L] [IsSimpleModule (A' k n) L]
     (j : Fin D.n) (hj : ∀ l : L, centralIdem' k n D j • l = l) :
     j = blockOf k n D L :=
   (exists_unique_block k n D L).choose_spec.2 j hj
@@ -444,7 +444,7 @@ private lemma blockOf_specht_injective_general (n : ℕ) (D : IrrepDecomp k (G' 
 This follows from `#partitions(n) = #conjugacy_classes(S_n) = #Wedderburn_blocks(k[S_n])`,
 ensuring that the Specht modules exhaust all Wedderburn blocks. -/
 private lemma exists_young_symmetrizer_nontrivial_general (n : ℕ)
-    (M : Type) [AddCommGroup M] [Module (A' k n) M]
+    (M : Type w) [AddCommGroup M] [Module (A' k n) M]
     [IsSimpleModule (A' k n) M] :
     ∃ la : Nat.Partition n, ∃ m : M, YoungSymmetrizerK k n la • m ≠ 0 := by
   by_contra h
@@ -501,7 +501,7 @@ private lemma exists_young_symmetrizer_nontrivial_general (n : ℕ)
 /-- The evaluation linear map from a Specht module `V_λ` to `M`, sending `v` to `v • m₀`.
 This is `k[S_n]`-linear since the action on `V_λ ⊆ k[S_n]` is left multiplication. -/
 private noncomputable def spechtEvalMap (n : ℕ) (la : Nat.Partition n)
-    (M : Type) [AddCommGroup M] [Module (A' k n) M] (m₀ : M) :
+    (M : Type w) [AddCommGroup M] [Module (A' k n) M] (m₀ : M) :
     (SpechtModuleK k n la) →ₗ[A' k n] M where
   toFun v := (v : A' k n) • m₀
   map_add' v w := by
@@ -519,7 +519,7 @@ The proof strategy: for a simple `M`, some Young symmetrizer `c_λ` acts nontriv
 The evaluation map `V_λ → M`, `v ↦ v · m₀`, is then a nonzero `k[S_n]`-linear map between
 simple modules. By Schur's lemma, it is an isomorphism. -/
 theorem Theorem5_12_2_classification_general
-    (n : ℕ) (M : Type) [AddCommGroup M] [Module (A' k n) M]
+    (n : ℕ) (M : Type w) [AddCommGroup M] [Module (A' k n) M]
     [IsSimpleModule (A' k n) M] :
     ∃ la : Nat.Partition n,
       Nonempty (M ≃ₗ[A' k n] (SpechtModuleK k n la)) := by
@@ -535,6 +535,25 @@ theorem Theorem5_12_2_classification_general
     SpechtModuleK_isSimpleModule_general k n la
   have hf_bij := LinearMap.bijective_of_ne_zero hf_ne
   exact ⟨la, ⟨(LinearEquiv.ofBijective f hf_bij).symm⟩⟩
+
+/-- **Mixed-universe restatement** of `Theorem5_12_2_classification_general`, with the group
+algebra `k[Sₙ]` spelled out (rather than the private `A'` abbreviation) and the module universe
+`w` explicitly independent of the field universe `u`.
+
+This is the form consumed by `Theorem5_18_4_partition_decomposition` (#5493): the simple
+Schur-Weyl summands `Sᵢ : Type (max u v)` are, restricted along the surjection
+`k[Sₙ] ↠ symGroupImage k V n`, simple `k[Sₙ]`-modules, hence (over an algebraically closed
+field of characteristic `0`) isomorphic to Specht modules `SpechtModuleK k n λᵢ`; the resulting
+map `i ↦ λᵢ` is the injection `ι ↪ Nat.Partition n` needed to re-index the decomposition. The
+file is a leaf with respect to `Theorem5_18_4.lean`, so the discharge can import it without a
+cycle. -/
+theorem classification_general_u
+    (n : ℕ) (M : Type w) [AddCommGroup M]
+    [Module (MonoidAlgebra k (Equiv.Perm (Fin n))) M]
+    [IsSimpleModule (MonoidAlgebra k (Equiv.Perm (Fin n))) M] :
+    ∃ la : Nat.Partition n,
+      Nonempty (M ≃ₗ[MonoidAlgebra k (Equiv.Perm (Fin n))] SpechtModuleK k n la) :=
+  Theorem5_12_2_classification_general k n M
 
 end
 

--- a/EtingofRepresentationTheory/Infrastructure/IrreducibleEnumeration.lean
+++ b/EtingofRepresentationTheory/Infrastructure/IrreducibleEnumeration.lean
@@ -22,9 +22,9 @@ char(k) ∤ |G|, we establish:
 
 open CategoryTheory
 
-universe u
+universe u v
 
-variable {k G : Type u} [Field k] [IsAlgClosed k] [Group G] [Fintype G]
+variable {k : Type u} {G : Type v} [Field k] [IsAlgClosed k] [Group G] [Fintype G]
 
 /-! ### Finite-dimensionality and semisimplicity of k[G] -/
 
@@ -55,7 +55,7 @@ theorem MonoidAlgebra.wedderburnArtin [Finite G] [NeZero (Nat.card G : k)] :
 /-- Bundled Wedderburn-Artin decomposition data for the group algebra `k[G]`.
 Packages the number of irreducible representations `n`, their dimensions `d`,
 and the algebra isomorphism. -/
-structure IrrepDecomp (k G : Type u) [Field k] [IsAlgClosed k] [Group G] [Fintype G]
+structure IrrepDecomp (k : Type u) (G : Type v) [Field k] [IsAlgClosed k] [Group G] [Fintype G]
     [NeZero (Nat.card G : k)] where
   /-- Number of isomorphism classes of irreducible representations -/
   n : ℕ
@@ -780,7 +780,7 @@ over an algebraically closed field `k` with `char(k) ∤ |G|` admits a finite fa
 pairwise non-isomorphic simple `FDRep k G` objects, complete (every simple is isomorphic
 to one of them), whose squared dimensions sum to `|G|`. Concretely the family is the set
 of column-vector representations `columnFDRep` of the Wedderburn-Artin decomposition. -/
-theorem exists_simples_sum_finrank_sq_eq_card (k G : Type u) [Field k] [IsAlgClosed k]
+theorem exists_simples_sum_finrank_sq_eq_card (k : Type u) (G : Type v) [Field k] [IsAlgClosed k]
     [Group G] [Fintype G] [NeZero (Nat.card G : k)] :
     ∃ (n : ℕ) (V : Fin n → FDRep k G),
       (∀ i, Simple (V i)) ∧

--- a/progress/20260627T041151Z_b963c38c.md
+++ b/progress/20260627T041151Z_b963c38c.md
@@ -1,0 +1,63 @@
+## Accomplished
+
+One-shot dispatch on **#5494** (mixed-universe simple-`k[Sₙ]`-module Specht
+classification, enabler for #5493). Implemented via **Option 1 (relax universe
+binders in place)** — the lower-code-volume route the issue recommended — after
+confirming empirically that the FDRep machinery survives mixed universes
+(`Rep (k : Type u) (G : Type v)` and `FDRep (R : Type u) (G : Type v)` are both
+already mixed-universe in Mathlib).
+
+Changes (3 files, ~35 lines, zero blast radius — full project rebuilds clean):
+
+- **`Infrastructure/IrreducibleEnumeration.lean`**: `universe u` → `u v`;
+  `variable {k G : Type u}` → `{k : Type u} {G : Type v}`; structure
+  `IrrepDecomp (k G : Type u)` → `(k : Type u) (G : Type v)`;
+  `exists_simples_sum_finrank_sq_eq_card` binder likewise. The whole FDRep
+  column-rep stack (`columnFDRep`, `columnFDRep_surjective`, `n_eq_card_simples`)
+  ported with no proof edits.
+- **`Chapter4/Corollary4_2_2.lean`**: same `{k : Type u} {G : Type v}` relaxation
+  on the section `variable` and on `Etingof.Corollary4_2_2`. Center-dimension
+  argument unchanged.
+- **`Chapter5/Theorem5_12_2_ClassificationGeneral.lean`**: `variable (k : Type)`
+  → `(k : Type u)`, and the abstract simple module from `Type` → `Type w` in the
+  block machinery (`exists_unique_block`, `blockOf`, `blockOf_spec`,
+  `blockOf_unique`) and in `exists_young_symmetrizer_nontrivial_general`,
+  `spechtEvalMap`, `Theorem5_12_2_classification_general`. Added a public
+  restatement **`Etingof.classification_general_u`** with `k[Sₙ]` spelled out
+  (`MonoidAlgebra k (Equiv.Perm (Fin n))`, not the private `A'`) and module
+  universe `w` explicitly independent of field universe `u` — the exact shape the
+  #5493 discharge consumes.
+
+Verified the deliverable against the consumer's exact signature
+(`k : Type u`, `M : Type (max u v)`, group algebra of `Equiv.Perm (Fin n)`) in a
+throwaway file: `classification_general_u k n M` typechecks directly.
+
+## Current frontier
+
+`Theorem5_12_2_classification_general` / `classification_general_u` now hold for
+`k : Type u` and modules `M : Type w` with `w` independent of `u`. The
+`Theorem5_12_2_ClassificationGeneral.lean` leaf does **not** import
+`Theorem5_18_4.lean`, so #5493 can import it without a cycle.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. This is an infrastructure enabler, not a new
+book item — no `items.json` change. Full `EtingofRepresentationTheory` builds
+clean (8972 jobs, 0 errors). The only remaining sorry in the relevant stack is
+`Theorem5_18_4_partition_decomposition` itself (#5493), which this unblocks.
+
+## Next step
+
+A worker claims **#5493** and discharges the `sorry` in
+`Theorem5_18_4_partition_decomposition`: for each simple Schur-Weyl summand
+`Sᵢ : Type (max u v)`, restrict the `symGroupImage`-action along the surjection
+`k[Sₙ] ↠ symGroupImage` (`symGroupAlgHom_range`) to make `Sᵢ` a simple
+`k[Sₙ]`-module, apply `Etingof.classification_general_u k n Sᵢ` to get
+`Sᵢ ≃ₗ SpechtModuleK k n λᵢ`, and use injectivity of `i ↦ λᵢ` (a `k[Sₙ]`-linear
+equiv between `symGroupImage`-modules is automatically `symGroupImage`-linear,
+since the action factors through the surjection) to build `ι ↪ Nat.Partition n`
+and re-index `Theorem5_18_4_bimodule_decomposition_full`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5494

Session: `b963c38c-66f1-402f-a779-7d805b755c15`

2196e1dc feat(Ch5 #5494): mixed-universe simple-k[Sₙ]-module Specht classification

🤖 Prepared with Claude Code