### PR TITLE
Fidelity: Theorem5.23.2(ii) — state Peter-Weyl GL×GL-equivariantly (build GL-rep on Lλ + bi-action on coordinate ring)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/AlgIrrepGLRep.lean
+++ b/EtingofRepresentationTheory/Chapter5/AlgIrrepGLRep.lean
@@ -248,4 +248,36 @@ theorem algIrrepGLRep_isSimple (n : ℕ) (lam : DominantWeight n)
   exact isSimpleModule_charTwistRep (detChar ℂ n ^ (-(lam.shift : ℤ)))
     (schurModuleRep ℂ n lam.toNatWeight)
 
+/-! ## The dual representation and bare-`Representation` forms
+
+For the Peter-Weyl decomposition we need the underlying `Representation`s with
+carriers *literally* `AlgIrrepGL`/`AlgIrrepGLDual` (so they tensor and sum to the
+right-hand side of Theorem 5.23.2(ii)). `algIrrepGLRepρ` is the det-twisted
+Schur-module representation as a bare `Representation` (its carrier is
+definitionally `AlgIrrepGL n lam k`, matching `(AlgIrrepGLRep n lam k).ρ`). -/
+
+/-- The genuine irreducible algebraic representation `L_λ` as a bare
+`Representation` on the carrier `AlgIrrepGL n lam k`: the Schur module twisted by
+`det^{-λ.shift}`. Equals `(AlgIrrepGLRep n lam k).ρ` up to the carrier coercion. -/
+noncomputable def algIrrepGLRepρ (n : ℕ) (lam : DominantWeight n)
+    (k : Type*) [Field k] [IsAlgClosed k] :
+    Representation k (Matrix.GeneralLinearGroup (Fin n) k) (AlgIrrepGL n lam k) :=
+  charTwistRep (detChar k n ^ (-(lam.shift : ℤ))) (schurModuleRep k n lam.toNatWeight)
+
+/-- The contragredient `L*_λ` as an `FDRep`: by the highest-weight classification
+for `GL_n`, the dual of `L_λ` is `L_{-w₀λ}`, so `AlgIrrepGLRepDual` is just
+`AlgIrrepGLRep` at the `w₀`-twisted weight. Its carrier is definitionally
+`AlgIrrepGLDual n lam k`. -/
+noncomputable def AlgIrrepGLRepDual (n : ℕ) (lam : DominantWeight n)
+    (k : Type*) [Field k] [IsAlgClosed k] :
+    FDRep k (Matrix.GeneralLinearGroup (Fin n) k) :=
+  AlgIrrepGLRep n lam.w0Twist k
+
+/-- The contragredient `L*_λ` as a bare `Representation` on the carrier
+`AlgIrrepGLDual n lam k`. -/
+noncomputable def algIrrepGLRepDualρ (n : ℕ) (lam : DominantWeight n)
+    (k : Type*) [Field k] [IsAlgClosed k] :
+    Representation k (Matrix.GeneralLinearGroup (Fin n) k) (AlgIrrepGLDual n lam k) :=
+  algIrrepGLRepρ n lam.w0Twist k
+
 end Etingof

--- a/EtingofRepresentationTheory/Chapter5/LocalizationGLBiAction.lean
+++ b/EtingofRepresentationTheory/Chapter5/LocalizationGLBiAction.lean
@@ -1,0 +1,240 @@
+import Mathlib
+import EtingofRepresentationTheory.Chapter5.PolynomialGLBiAction
+import EtingofRepresentationTheory.Chapter5.LocalizationGLRightAction
+
+/-!
+# The `GL_N × GL_N` bi-action on the coordinate ring `O = A[det⁻¹]`
+
+`LocalizationGLRightAction.lean` extended the right-translation representation
+`polyRightRep` from `A = k[Xᵢⱼ]` to the determinant localization
+`O = A[det⁻¹] = Localization.Away (detPoly k N)`, giving `localRightRep`. This
+file does the same for the **left** translation `polyLeftRep`
+(`PolynomialGLBiAction.lean`), producing `localLeftRep`, and then combines the two
+commuting one-sided actions into a single genuine **`GL_N × GL_N`-representation**
+`localBiRep` on `O`.
+
+`O` is Etingof's coordinate ring `R` of regular functions on `GL_N(k)`: every
+regular function is a polynomial in the matrix entries `gᵢⱼ` divided by a power of
+`det(g)`. The bi-action is left/right translation, `(g,h)·φ = L_g R_h φ`, the
+`GL_N × GL_N`-structure whose Peter-Weyl decomposition is Theorem 5.23.2(ii).
+
+## Construction
+
+The left translation `lTransAlgHom (g : Matrix)` carries `detPoly` to
+`det g · detPoly` (`lTransAlgHom_det`); since `det g` is a unit, it sends the
+powers of `detPoly` to units of `O`, so `IsLocalization.liftAlgHom` extends it to
+`localLeftAlgHom g : O →ₐ[k] O`. Multiplicativity is inherited from
+`lTransAlgHom_mul`, giving `localLeftRep`. The two one-sided actions commute on
+`O` (`localLeftAlgHom_comm_localRightAlgHom`, lifting
+`lTransAlgHom_comp_rTransAlgHom` across the localization), so
+`Representation.ofCommutingPair` packages them as `localBiRep`.
+-/
+
+namespace Etingof.LocalizationGLAction
+
+open MvPolynomial Etingof.PolynomialGLAction Etingof.DetLocalization
+
+variable {k : Type*} [Field k] {N : ℕ}
+
+/-! ## A representation of a product group from two commuting actions -/
+
+/-- Two commuting representations of `G` and `H` on the **same** module `V`
+assemble into a representation of `G × H`: `(g, h) ↦ ρ g ∘ σ h`. The commutation
+hypothesis is exactly what makes this a monoid homomorphism. -/
+noncomputable def _root_.Representation.ofCommutingPair
+    {k G H V : Type*} [CommSemiring k] [Monoid G] [Monoid H]
+    [AddCommMonoid V] [Module k V]
+    (ρ : Representation k G V) (σ : Representation k H V)
+    (hcomm : ∀ (g : G) (h : H), ρ g * σ h = σ h * ρ g) :
+    Representation k (G × H) V where
+  toFun gh := ρ gh.1 * σ gh.2
+  map_one' := by simp
+  map_mul' x y := by
+    change ρ (x * y).1 * σ (x * y).2 = (ρ x.1 * σ x.2) * (ρ y.1 * σ y.2)
+    -- (ρx₁ ρy₁)(σx₂ σy₂) = (ρx₁ σx₂)(ρy₁ σy₂); swap the middle ρy₁ σx₂.
+    rw [Prod.fst_mul, Prod.snd_mul, map_mul, map_mul,
+      mul_assoc (ρ x.1) (ρ y.1), ← mul_assoc (ρ y.1) (σ x.2) (σ y.2),
+      hcomm y.1 x.2, mul_assoc (σ x.2) (ρ y.1) (σ y.2),
+      ← mul_assoc (ρ x.1) (σ x.2)]
+
+@[simp] theorem _root_.Representation.ofCommutingPair_apply
+    {k G H V : Type*} [CommSemiring k] [Monoid G] [Monoid H]
+    [AddCommMonoid V] [Module k V]
+    (ρ : Representation k G V) (σ : Representation k H V)
+    (hcomm : ∀ (g : G) (h : H), ρ g * σ h = σ h * ρ g) (g : G) (h : H) (v : V) :
+    Representation.ofCommutingPair ρ σ hcomm (g, h) v = ρ g (σ h v) :=
+  rfl
+
+/-! ## The left-translation action on the localization `O = A[det⁻¹]` -/
+
+/-- For a matrix `M`, the `k`-algebra hom `A →ₐ[k] O` obtained by composing the
+left translation `lTransAlgHom M` with the structure map `A → O`. -/
+noncomputable def lTransToAway (M : Matrix (Fin N) (Fin N) k) :
+    MvPolynomial (Fin N × Fin N) k →ₐ[k] Localization.Away (detPoly k N) :=
+  (IsScalarTower.toAlgHom k (MvPolynomial (Fin N × Fin N) k)
+      (Localization.Away (detPoly k N))).comp (lTransAlgHom M)
+
+@[simp] theorem lTransToAway_apply (M : Matrix (Fin N) (Fin N) k)
+    (a : MvPolynomial (Fin N × Fin N) k) :
+    lTransToAway M a = algebraMap _ (Localization.Away (detPoly k N)) (lTransAlgHom M a) :=
+  rfl
+
+/-- Determinant semi-invariance phrased with `detPoly` (a restatement of
+`lTransAlgHom_det`). -/
+theorem lTransAlgHom_detPoly (M : Matrix (Fin N) (Fin N) k) :
+    lTransAlgHom M (detPoly k N) = MvPolynomial.C M.det * detPoly k N :=
+  lTransAlgHom_det M
+
+/-- For `g ∈ GL_N`, the powers of `detPoly` map to units of `O` under
+`lTransToAway (g : Matrix)`. -/
+theorem isUnit_lTransToAway_detPoly_pow (g : Matrix.GeneralLinearGroup (Fin N) k)
+    (y : Submonoid.powers (detPoly k N)) :
+    IsUnit (lTransToAway (g : Matrix (Fin N) (Fin N) k) (y : MvPolynomial (Fin N × Fin N) k)) := by
+  obtain ⟨n, hn⟩ := y.2
+  rw [← hn]
+  change IsUnit (lTransToAway (g : Matrix (Fin N) (Fin N) k) (detPoly k N ^ n))
+  rw [lTransToAway_apply, map_pow, map_pow]
+  refine IsUnit.pow n ?_
+  rw [lTransAlgHom_detPoly, map_mul]
+  refine IsUnit.mul ?_ ?_
+  · have hdet : IsUnit ((g : Matrix (Fin N) (Fin N) k).det) :=
+      (Matrix.isUnit_iff_isUnit_det _).mp (Units.isUnit g)
+    exact (hdet.map (MvPolynomial.C : k →+* MvPolynomial (Fin N × Fin N) k)).map
+      (algebraMap (MvPolynomial (Fin N × Fin N) k) (Localization.Away (detPoly k N)))
+  · exact IsLocalization.Away.algebraMap_isUnit
+      (S := Localization.Away (detPoly k N)) (detPoly k N)
+
+/-- The left-translation `k`-algebra endomorphism of `O = A[det⁻¹]` attached to
+`g ∈ GL_N`: the localization extension of `lTransAlgHom (g : Matrix)`. -/
+noncomputable def localLeftAlgHom (g : Matrix.GeneralLinearGroup (Fin N) k) :
+    Localization.Away (detPoly k N) →ₐ[k] Localization.Away (detPoly k N) :=
+  IsLocalization.liftAlgHom (f := lTransToAway (g : Matrix (Fin N) (Fin N) k))
+    (isUnit_lTransToAway_detPoly_pow g)
+
+/-- `localLeftAlgHom g` extends the left translation on `A`: on the image of
+`a ∈ A` it is `algebraMap (lTransAlgHom (g) a)`. -/
+@[simp] theorem localLeftAlgHom_algebraMap (g : Matrix.GeneralLinearGroup (Fin N) k)
+    (a : MvPolynomial (Fin N × Fin N) k) :
+    localLeftAlgHom g (algebraMap _ (Localization.Away (detPoly k N)) a)
+      = algebraMap _ _ (lTransAlgHom (g : Matrix (Fin N) (Fin N) k) a) := by
+  simp only [localLeftAlgHom, IsLocalization.coe_liftAlgHom, IsLocalization.lift_eq]
+  rfl
+
+/-- `localLeftAlgHom 1 = id`. -/
+theorem localLeftAlgHom_one :
+    localLeftAlgHom (1 : Matrix.GeneralLinearGroup (Fin N) k)
+      = AlgHom.id k (Localization.Away (detPoly k N)) := by
+  apply IsLocalization.algHom_ext (R := k) (A := MvPolynomial (Fin N × Fin N) k)
+    (L := Localization.Away (detPoly k N)) (B := Localization.Away (detPoly k N))
+    (Submonoid.powers (detPoly k N))
+  apply AlgHom.ext
+  intro a
+  rw [AlgHom.comp_apply, AlgHom.comp_apply]
+  change localLeftAlgHom (1 : Matrix.GeneralLinearGroup (Fin N) k)
+      (algebraMap (MvPolynomial (Fin N × Fin N) k) (Localization.Away (detPoly k N)) a)
+    = AlgHom.id k (Localization.Away (detPoly k N))
+      (algebraMap (MvPolynomial (Fin N × Fin N) k) (Localization.Away (detPoly k N)) a)
+  rw [localLeftAlgHom_algebraMap, AlgHom.id_apply, Units.val_one, lTransAlgHom_one,
+    AlgHom.id_apply]
+
+/-- Multiplicativity: `localLeftAlgHom (g₁ g₂) = localLeftAlgHom g₁ ∘ localLeftAlgHom g₂`. -/
+theorem localLeftAlgHom_mul (g₁ g₂ : Matrix.GeneralLinearGroup (Fin N) k) :
+    localLeftAlgHom (g₁ * g₂)
+      = (localLeftAlgHom g₁).comp (localLeftAlgHom g₂) := by
+  apply IsLocalization.algHom_ext (R := k) (A := MvPolynomial (Fin N × Fin N) k)
+    (L := Localization.Away (detPoly k N)) (B := Localization.Away (detPoly k N))
+    (Submonoid.powers (detPoly k N))
+  apply AlgHom.ext
+  intro a
+  rw [AlgHom.comp_apply, AlgHom.comp_apply]
+  change localLeftAlgHom (g₁ * g₂)
+      (algebraMap (MvPolynomial (Fin N × Fin N) k) (Localization.Away (detPoly k N)) a)
+    = (localLeftAlgHom g₁).comp (localLeftAlgHom g₂)
+      (algebraMap (MvPolynomial (Fin N × Fin N) k) (Localization.Away (detPoly k N)) a)
+  rw [localLeftAlgHom_algebraMap, AlgHom.comp_apply, localLeftAlgHom_algebraMap,
+    localLeftAlgHom_algebraMap, Units.val_mul, lTransAlgHom_mul, AlgHom.comp_apply]
+
+/-- The **left-translation representation of `GL_N` on `O = A[det⁻¹]`**:
+`g ↦ localLeftAlgHom g`. -/
+noncomputable def localLeftRep (k : Type*) [Field k] (N : ℕ) :
+    Representation k (Matrix.GeneralLinearGroup (Fin N) k)
+      (Localization.Away (detPoly k N)) where
+  toFun g := (localLeftAlgHom g).toLinearMap
+  map_one' := by
+    change (localLeftAlgHom (1 : Matrix.GeneralLinearGroup (Fin N) k)).toLinearMap = _
+    rw [localLeftAlgHom_one]; rfl
+  map_mul' g₁ g₂ := by
+    change (localLeftAlgHom (g₁ * g₂)).toLinearMap = _
+    rw [localLeftAlgHom_mul]; rfl
+
+@[simp] theorem localLeftRep_apply (g : Matrix.GeneralLinearGroup (Fin N) k)
+    (x : Localization.Away (detPoly k N)) :
+    localLeftRep k N g x = localLeftAlgHom g x :=
+  rfl
+
+/-- **The structure map `A → O` is left-`GL_N`-equivariant.** -/
+theorem localLeftRep_algebraMap (g : Matrix.GeneralLinearGroup (Fin N) k)
+    (a : MvPolynomial (Fin N × Fin N) k) :
+    localLeftRep k N g (algebraMap _ (Localization.Away (detPoly k N)) a)
+      = algebraMap _ _ (polyLeftRep k N g a) :=
+  localLeftAlgHom_algebraMap g a
+
+/-! ## The two one-sided actions commute -/
+
+/-- **Left and right translations commute on `O = A[det⁻¹]`.** The two algebra
+endomorphisms commute on the polynomial subring `A`
+(`lTransAlgHom_comp_rTransAlgHom`); by the universal property of the localization
+the commutation lifts to all of `O`. -/
+theorem localLeftAlgHom_comp_localRightAlgHom
+    (g h : Matrix.GeneralLinearGroup (Fin N) k) :
+    (localLeftAlgHom g).comp (localRightAlgHom h)
+      = (localRightAlgHom h).comp (localLeftAlgHom g) := by
+  apply IsLocalization.algHom_ext (R := k) (A := MvPolynomial (Fin N × Fin N) k)
+    (L := Localization.Away (detPoly k N)) (B := Localization.Away (detPoly k N))
+    (Submonoid.powers (detPoly k N))
+  apply AlgHom.ext
+  intro a
+  rw [AlgHom.comp_apply, AlgHom.comp_apply]
+  change (localLeftAlgHom g).comp (localRightAlgHom h)
+      (algebraMap (MvPolynomial (Fin N × Fin N) k) (Localization.Away (detPoly k N)) a)
+    = (localRightAlgHom h).comp (localLeftAlgHom g)
+      (algebraMap (MvPolynomial (Fin N × Fin N) k) (Localization.Away (detPoly k N)) a)
+  rw [AlgHom.comp_apply, AlgHom.comp_apply, localRightAlgHom_algebraMap,
+    localLeftAlgHom_algebraMap, localLeftAlgHom_algebraMap, localRightAlgHom_algebraMap]
+  -- reduce to commutation on `A` and apply `lTransAlgHom_comp_rTransAlgHom`
+  have hcomm := AlgHom.congr_fun (lTransAlgHom_comp_rTransAlgHom
+    (g : Matrix (Fin N) (Fin N) k) (h : Matrix (Fin N) (Fin N) k)) a
+  rw [AlgHom.comp_apply, AlgHom.comp_apply] at hcomm
+  rw [hcomm]
+
+/-- The left and right `GL_N`-actions on `O` commute as linear endomorphisms. -/
+theorem localLeftRep_commute_localRightRep
+    (g h : Matrix.GeneralLinearGroup (Fin N) k) :
+    localLeftRep k N g * localRightRep k N h
+      = localRightRep k N h * localLeftRep k N g := by
+  apply LinearMap.ext
+  intro x
+  rw [Module.End.mul_apply, Module.End.mul_apply, localLeftRep_apply,
+    localRightRep_apply, localRightRep_apply, localLeftRep_apply]
+  exact AlgHom.congr_fun (localLeftAlgHom_comp_localRightAlgHom g h) x
+
+/-! ## The `GL_N × GL_N` bi-representation -/
+
+/-- **The `GL_N × GL_N` bi-action on the coordinate ring `O = A[det⁻¹]`.** For
+`(g, h) ∈ GL_N × GL_N`, `(g, h)` acts by `L_g R_h` (left translation by `g`
+composed with right translation by `h`). This is the genuine
+`GL_N × GL_N`-representation on Etingof's coordinate ring `R` whose Peter-Weyl
+decomposition is Theorem 5.23.2(ii). -/
+noncomputable def localBiRep (k : Type*) [Field k] (N : ℕ) :
+    Representation k
+      (Matrix.GeneralLinearGroup (Fin N) k × Matrix.GeneralLinearGroup (Fin N) k)
+      (Localization.Away (detPoly k N)) :=
+  Representation.ofCommutingPair (localLeftRep k N) (localRightRep k N)
+    localLeftRep_commute_localRightRep
+
+@[simp] theorem localBiRep_apply (g h : Matrix.GeneralLinearGroup (Fin N) k)
+    (x : Localization.Away (detPoly k N)) :
+    localBiRep k N (g, h) x = localLeftAlgHom g (localRightAlgHom h x) :=
+  rfl
+
+end Etingof.LocalizationGLAction

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_23_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_23_2.lean
@@ -145,6 +145,13 @@ noncomputable instance AlgIrrepGLDual.module (n : ℕ) (lam : DominantWeight n)
 decomposes as `R ≅ ⊕_λ L*_λ ⊗ L_λ`, where the sum ranges over all dominant weights
 `λ = (λ₁ ≥ ⋯ ≥ λ_n)` with `λᵢ ∈ ℤ`, and `L*_λ` is the contragredient of `L_λ`.
 
+**Superseded by the genuine equivariant statement.** The genuine
+`GL_n × GL_n`-equivariant Peter-Weyl isomorphism is now
+`Theorem5_23_2_ii_equivariant` in `Chapter5.Theorem5_23_2_PeterWeyl` (#5396): it
+intertwines the left/right translation bi-action on `R = k[gᵢⱼ][1/det]`
+(`localBiRep`) with the action on `⊕_λ L*_λ ⊗ L_λ` (`peterWeylRHS`). The bare
+rank iso below is retained only as scaffolding.
+
 **⚠ Partial formalization.** The statement below asserts only a *bare `k`-linear*
 isomorphism `R ≃ₗ[k] ⊕_λ L*_λ ⊗ L_λ`, proved by matching ranks
 (`nonempty_linearEquiv_of_rank_eq`): both sides are countably-infinite-dimensional

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_23_2_PeterWeyl.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_23_2_PeterWeyl.lean
@@ -1,0 +1,105 @@
+import Mathlib
+import EtingofRepresentationTheory.Chapter5.AlgIrrepGLRep
+import EtingofRepresentationTheory.Chapter5.LocalizationGLBiAction
+
+/-!
+# Theorem 5.23.2(ii): the genuine `GL_n × GL_n`-equivariant Peter-Weyl decomposition
+
+`Theorem5_23_2.lean` states part (ii) only as a *bare `k`-linear* rank-matching
+isomorphism `R ≃ₗ[k] ⊕_λ L*_λ ⊗ L_λ` — true for any two countably-infinite-dim
+free modules, carrying no representation-theoretic content. This file states the
+genuine theorem: a **`GL_n × GL_n`-equivariant** isomorphism
+
+  `R ≅ ⊕_λ L*_λ ⊗ L_λ`   as representations of `GL_n × GL_n`,
+
+where `R = k[gᵢⱼ][1/det] = Localization.Away (detPoly k n)` is the coordinate ring
+with its left/right translation bi-action (`localBiRep`, `LocalizationGLBiAction.lean`),
+`L_λ = AlgIrrepGL` carries the det-twisted Schur-module action (`algIrrepGLRepρ`,
+`AlgIrrepGLRep.lean`), `L*_λ = AlgIrrepGLDual` its contragredient
+(`algIrrepGLRepDualρ`), and the action on the summand `L*_λ ⊗ L_λ` is the left
+factor on `L*_λ` (via the first `GL_n`) and the right factor on `L_λ` (via the
+second `GL_n`).
+
+The right-hand-side representation `peterWeylRHS` is assembled with
+`Representation.tprod` and `Representation.directSum`. The equivariant
+isomorphism `Theorem5_23_2_ii_equivariant` is the content of Etingof §5.23(ii); its
+proof from part (i) and the Cauchy decomposition machinery
+(`PolynomialGLDecomposition.lean`, `CauchyDetQuotient*`) is out of scope here and
+is left as `sorry` with the book outline recorded in the proof.
+-/
+
+open scoped TensorProduct
+
+noncomputable section
+
+namespace Etingof
+
+open Etingof.LocalizationGLAction Etingof.DetLocalization
+
+variable {k : Type*}
+
+/-- **The right-hand side of Peter-Weyl as a `GL_n × GL_n`-representation.**
+`⊕_λ L*_λ ⊗ L_λ`, where the first `GL_n` acts on the `L*_λ` factor (via
+`MonoidHom.fst`) and the second `GL_n` acts on the `L_λ` factor (via
+`MonoidHom.snd`). Built from `Representation.tprod` over each summand and
+`Representation.directSum` over all dominant weights. -/
+noncomputable def peterWeylRHS (n : ℕ) (k : Type*) [Field k] [IsAlgClosed k] :
+    Representation k
+      (Matrix.GeneralLinearGroup (Fin n) k × Matrix.GeneralLinearGroup (Fin n) k)
+      (DirectSum (DominantWeight n) fun lam =>
+        (AlgIrrepGLDual n lam k ⊗[k] AlgIrrepGL n lam k)) :=
+  Representation.directSum fun lam =>
+    Representation.tprod
+      ((algIrrepGLRepDualρ n lam k).comp (MonoidHom.fst _ _))
+      ((algIrrepGLRepρ n lam k).comp (MonoidHom.snd _ _))
+
+@[simp] theorem peterWeylRHS_apply (n : ℕ) (k : Type*) [Field k] [IsAlgClosed k]
+    (g h : Matrix.GeneralLinearGroup (Fin n) k)
+    (x : DirectSum (DominantWeight n) fun lam =>
+      (AlgIrrepGLDual n lam k ⊗[k] AlgIrrepGL n lam k)) :
+    peterWeylRHS n k (g, h) x =
+      DirectSum.lmap (fun lam =>
+        TensorProduct.map (algIrrepGLRepDualρ n lam k g) (algIrrepGLRepρ n lam k h)) x :=
+  rfl
+
+/-- A `GL_n × GL_n`-equivariant `k`-linear isomorphism between two representations:
+a linear equivalence intertwining the two actions. (The full content of the
+Peter-Weyl statement lives in the equivariance condition; without it the bare
+linear equivalence is vacuous, as the rank iso in `Theorem5_23_2.lean` shows.) -/
+def IsEquivariantEquiv {G W₁ W₂ : Type*} [Monoid G] [Field k]
+    [AddCommGroup W₁] [Module k W₁] [AddCommGroup W₂] [Module k W₂]
+    (ρ₁ : Representation k G W₁) (ρ₂ : Representation k G W₂)
+    (e : W₁ ≃ₗ[k] W₂) : Prop :=
+  ∀ (g : G) (x : W₁), e (ρ₁ g x) = ρ₂ g (e x)
+
+/-- **Theorem 5.23.2(ii) — Peter-Weyl for `GL_n(k)`.** The coordinate ring
+`R = k[gᵢⱼ][1/det]`, as a representation of `GL_n × GL_n` under the left/right
+translation bi-action `(g, h) · φ = L_g R_h φ` (`localBiRep`), is
+**`GL_n × GL_n`-equivariantly isomorphic** to `⊕_λ L*_λ ⊗ L_λ` (`peterWeylRHS`),
+the sum over all dominant integer weights `λ = (λ₁ ≥ ⋯ ≥ λ_n)`.
+
+Unlike the bare rank iso `Theorem5_23_2_ii` in `Theorem5_23_2.lean`, this carries
+genuine representation-theoretic content: the isomorphism intertwines the two
+`GL_n × GL_n`-actions (`IsEquivariantEquiv`).
+
+**Proof (Etingof §5.23(ii)).** By part (i) every algebraic representation is
+completely reducible into the `L_λ`, which are pairwise non-isomorphic. The matrix
+coefficient map `L*_λ ⊗ L_λ → R`, `u ⊗ v ↦ (g ↦ ⟨u, g⁻¹ v⟩)`, is `GL × GL`-equivariant
+(left `GL` on `L*_λ`, right `GL` on `L_λ`); summing over `λ` and using that the
+matrix coefficients of the pairwise-distinct irreducibles `L_λ` are linearly
+independent and span `R` (the Cauchy decomposition,
+`PolynomialGLDecomposition.lean` / `CauchyDetQuotient*`) gives the isomorphism.
+The detailed assembly is out of scope for this file. -/
+theorem Theorem5_23_2_ii_equivariant
+    (n : ℕ) (k : Type*) [Field k] [IsAlgClosed k] [CharZero k] :
+    Nonempty { e : Localization.Away (detPoly k n) ≃ₗ[k]
+        (DirectSum (DominantWeight n) fun lam =>
+          (AlgIrrepGLDual n lam k ⊗[k] AlgIrrepGL n lam k)) //
+      IsEquivariantEquiv (localBiRep k n) (peterWeylRHS n k) e } := by
+  -- The book's proof (matrix coefficients + Cauchy decomposition); see the
+  -- docstring. The supporting decomposition machinery
+  -- (`PolynomialGLDecomposition`, `CauchyDetQuotient*`) is the substantial input
+  -- and is being assembled separately.
+  sorry
+
+end Etingof

--- a/progress/2026-06-27T05-49-03Z_6ee530ca.md
+++ b/progress/2026-06-27T05-49-03Z_6ee530ca.md
@@ -1,0 +1,56 @@
+## Accomplished
+
+Fidelity fix for **Theorem 5.23.2(ii)** (issue #5396): replaced the anti-vacuous
+bare `k`-linear rank iso with a genuine `GL_n × GL_n`-equivariant Peter-Weyl
+statement.
+
+- **`LocalizationGLBiAction.lean`** (new): built `localLeftRep`, the
+  left-translation `GL_n`-action on the determinant localization
+  `O = A[det⁻¹] = Localization.Away (detPoly k N)` (mirroring the existing
+  `localRightRep`), proved the two one-sided actions commute on `O`
+  (`localLeftRep_commute_localRightRep`, lifting `lTransAlgHom_comp_rTransAlgHom`
+  across the localization), and packaged them into a single genuine
+  `GL_n × GL_n`-representation `localBiRep` via the new reusable
+  `Representation.ofCommutingPair`.
+- **`AlgIrrepGLRep.lean`**: added the contragredient `AlgIrrepGLRepDual`
+  (= `AlgIrrepGLRep` at the `w₀`-twisted weight) plus bare-`Representation` forms
+  `algIrrepGLRepρ` / `algIrrepGLRepDualρ` whose carriers are literally
+  `AlgIrrepGL` / `AlgIrrepGLDual`.
+- **`Theorem5_23_2_PeterWeyl.lean`** (new): assembled the RHS rep `peterWeylRHS`
+  (`⊕_λ L*_λ ⊗ L_λ` via `Representation.tprod` + `Representation.directSum`, first
+  `GL` on `L*_λ`, second on `L_λ`) and stated the genuine equivariant iso
+  `Theorem5_23_2_ii_equivariant`: `R` (with `localBiRep`) is
+  `GL_n × GL_n`-equivariantly isomorphic to `peterWeylRHS`, equivariance bundled
+  as `IsEquivariantEquiv`. The book proof (matrix coefficients + Cauchy
+  decomposition) is sorried per the issue.
+- Updated the old `Theorem5_23_2_ii` docstring to point at the genuine version,
+  and set `Chapter5/Theorem5.23.2` `fidelity: verified` in `progress/items.json`
+  (both parts now assert the full book claim; proofs remain partial).
+
+All four target files build; the only `sorry` is the (allowed) book proof of the
+equivariant iso.
+
+## Current frontier
+
+The equivariant iso `Theorem5_23_2_ii_equivariant` is stated but its proof is
+sorried, and `Theorem5_23_2_i` remains sorried (GL_n complete-reducibility
+blocker).
+
+## Overall project progress
+
+Phase 3 formalization ongoing. Theorem 5.23.2 now has faithful statements for
+both parts; two long-standing proof blockers remain (complete reducibility of
+algebraic GL_n-reps; the Cauchy-decomposition assembly of Peter-Weyl).
+
+## Next step
+
+Discharge the `Theorem5_23_2_ii_equivariant` sorry using the matrix-coefficient
+map `L*_λ ⊗ L_λ → R` together with the Cauchy decomposition machinery
+(`PolynomialGLDecomposition.lean`, `CauchyDetQuotient*`). Also continue the
+GL_n complete-reducibility infrastructure feeding `Theorem5_23_2_i`.
+
+## Blockers
+
+None for this item's statement-level deliverable. The two proofs depend on the
+GL_n complete-reducibility and Cauchy-decomposition infrastructure tracked
+elsewhere.

--- a/progress/items.json
+++ b/progress/items.json
@@ -4184,10 +4184,10 @@
   "start_line": 13,
   "end_line": 21,
   "status": "proof_partial",
-  "fidelity": "gap",
+  "fidelity": "verified",
   "needs_statement": false,
-  "fidelity_note": "Part (i) FIXED (#5384): Theorem5_23_2_i now states genuine complete reducibility (IsSemisimpleModule k[GL_n] rho.asModule), non-vacuous; proof sorried (GL_n complete-reducibility blocker). Part (ii) still VACUOUS: Theorem5_23_2_ii is a bare k-linear rank-matching iso with no GL x GL-equivariant content; docstring now flags this honestly. Full equivariant Peter-Weyl tracked in #5396. Set fidelity=verified only when BOTH parts assert the full book claim.",
-  "fidelity_decl": "Theorem5_23_2_i, Theorem5_23_2_ii",
+  "fidelity_note": "Part (i): Theorem5_23_2_i states genuine complete reducibility (IsSemisimpleModule k[GL_n] rho.asModule), non-vacuous; proof sorried (GL_n complete-reducibility blocker). Part (ii) FIXED (#5396): genuine GL_n x GL_n-equivariant Peter-Weyl statement Theorem5_23_2_ii_equivariant (Theorem5_23_2_PeterWeyl.lean) -- R = k[gij][1/det] with the localBiRep left/right translation bi-action is GL x GL-equivariantly isomorphic to peterWeylRHS = sum_lam L*_lam (x) L_lam (built via Representation.tprod / Representation.directSum); IsEquivariantEquiv carries the real content. Book proof (matrix coefficients + Cauchy decomposition) sorried. The old bare rank iso Theorem5_23_2_ii is retained as scaffolding. Both parts now assert the full book claim; statement fidelity verified, proofs remain partial.",
+  "fidelity_decl": "Theorem5_23_2_i, Theorem5_23_2_ii_equivariant",
   "fidelity_issue": 5384,
   "followup_issue": 5396
  },


### PR DESCRIPTION
Closes #5396

Session: `6ee530ca-bd85-42a2-a4c6-d73876ccee62`

1d08446b doc(Ch5 #5396): point Theorem5_23_2_ii at equivariant version; mark fidelity verified
6ea70b3f feat(Ch5 #5396): genuine GL_n × GL_n-equivariant Peter-Weyl statement for R
c232fa5a feat(Ch5 #5396): GL_N × GL_N bi-action on the coordinate ring O = A[det⁻¹]

🤖 Prepared with Claude Code