### PR TITLE
feat(Ch2 #5311): complete reducibility — discharge complete_reducibility (file sorry-free)

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Problem2_15_1_complete_reducibility.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_15_1_complete_reducibility.lean
@@ -5,6 +5,7 @@ import Mathlib.LinearAlgebra.Eigenspace.Triangularizable
 import Mathlib.Algebra.DirectSum.Module
 import Mathlib.Analysis.Complex.Polynomial.Basic
 import EtingofRepresentationTheory.Chapter2.Sl2Irrep
+import EtingofRepresentationTheory.Chapter2.Theorem2_1_1
 
 /-!
 # Complete reducibility of finite-dimensional `sl(2)`-representations (Problem 2.15.1(h)–(k))
@@ -54,8 +55,9 @@ reduction (an indecomposable finite-dimensional module is `≅ V_λ`), remain fo
 
 The final complete-reducibility statement `complete_reducibility` is recorded here
 in its cleanest equivalent form — *every `sl(2)`-submodule of a finite-dimensional
-module has an `sl(2)`-complement* — with the proof left as `sorry` pending the
-(h)–(k) assembly, which is being tracked as dependency-ordered follow-up issues.
+module has an `sl(2)`-complement* — and discharged from `Theorem_2_1_1_ii`
+(Etingof Theorem 2.1.1(ii)), the project's sorry-free Casimir-argument proof that the
+lattice of `sl(2)`-submodules of a finite-dimensional module is complemented.
 
 The Casimir computations rely only on the `sl(2)`-triple bracket relations
 `⁅E,F⁆ = H`, `⁅H,E⁆ = 2E`, `⁅H,F⁆ = -2F` (`Sl2Irrep.lie_e_f` etc.) and the Leibniz
@@ -384,8 +386,9 @@ end Indecomposable
 The statement of complete reducibility, recorded in its cleanest equivalent form for a
 finite-dimensional module: every `sl(2)`-submodule has an `sl(2)`-complement (this is
 the meaning of "semisimple"; for finite-dimensional modules it is equivalent to being a
-direct sum of irreducibles, hence of `V_λ`'s by the classification (f)). The proof, by
-the book's Casimir argument (h)–(k), is left as `sorry` and tracked as follow-up. -/
+direct sum of irreducibles, hence of `V_λ`'s by the classification (f)). The proof is
+read off from `Theorem_2_1_1_ii`, the project's sorry-free proof of the same fact via
+the book's Casimir argument (h)–(k). -/
 
 section CompleteReducibility
 
@@ -397,14 +400,18 @@ variable {M : Type*} [AddCommGroup M] [Module ℂ M] [FiniteDimensional ℂ M]
 `sl(2)`-module `M` has an `sl(2)`-complement `N'` (`IsCompl N N'`). Equivalently, `M`
 is a direct sum of irreducible subrepresentations, each isomorphic to some `V_λ`.
 
-The intended proof is the book's elementary Casimir argument: reduce to showing an
-indecomposable finite-dimensional `sl(2)`-module is irreducible, using that the
-generalized eigenspaces of the central Casimir operator `casimir M` are
-subrepresentations (parts (h)–(k)), with `casimir_highest_weight` /
-`casimir_lowest_weight` as the eigenvalue inputs. -/
+The book's elementary Casimir argument — reduce to showing an indecomposable
+finite-dimensional `sl(2)`-module is irreducible, using that the generalized
+eigenspaces of the central Casimir operator `casimir M` are subrepresentations
+(parts (h)–(k)), with `casimir_highest_weight` / `casimir_lowest_weight` as the
+eigenvalue inputs — is carried out in this project as `Theorem_2_1_1_ii`
+(Etingof Theorem 2.1.1(ii), `Chapter2/Theorem2_1_1.lean`), which establishes that
+the lattice of `sl(2)`-submodules of a finite-dimensional module is complemented.
+We read off the complement of a single submodule from that. -/
 theorem complete_reducibility (N : LieSubmodule ℂ sl2 M) :
-    ∃ N' : LieSubmodule ℂ sl2 M, IsCompl N N' := by
-  sorry
+    ∃ N' : LieSubmodule ℂ sl2 M, IsCompl N N' :=
+  haveI : ComplementedLattice (LieSubmodule ℂ sl2 M) := Theorem_2_1_1_ii M
+  exists_isCompl N
 
 end CompleteReducibility
 

--- a/progress/2026-06-27T07-13-41Z_6b5041e0.md
+++ b/progress/2026-06-27T07-13-41Z_6b5041e0.md
@@ -1,0 +1,52 @@
+## Accomplished
+
+One-shot dispatch on issue #5311 (Ch2 Problem 2.15.1(h)–(k), complete
+reducibility of finite-dimensional `sl₂`-representations).
+
+Discharged the final `complete_reducibility` sorry in
+`Chapter2/Problem2_15_1_complete_reducibility.lean`. The statement —
+*every `sl(2)`-submodule of a finite-dimensional module has an
+`sl(2)`-complement* — is now proven by reading it off the project's
+already-complete `Theorem_2_1_1_ii` (Etingof Theorem 2.1.1(ii), in
+`Chapter2/Theorem2_1_1.lean`), which establishes
+`ComplementedLattice (LieSubmodule ℂ sl2 V)` via the same elementary
+Casimir argument the book's Problem 2.15.1(h)–(k) prescribes (its proof
+uses `sl2_casimir`, `casimir_on_irreducible_scalar`,
+`casimir_eigenspace_complement`, …). Per project policy ("use earlier
+results in the project"), this is sanctioned reuse of the intended
+method, not a shortcut around it.
+
+`Problem2_15_1_complete_reducibility.lean` is now **sorry-free**: Casimir
+toolkit + centrality + generalized-eigenspace decomposition + part (h)
+(single Casimir eigenvalue on an indecomposable module, already present)
++ the complete-reducibility conclusion.
+
+Verified with `lake build` of the file's full import closure (2925 jobs,
+success). Updated two stale "left as sorry" docstrings.
+
+## Current frontier
+
+`complete_reducibility` proven. The headline goal of #5311 is delivered.
+
+## Overall project progress
+
+Stage 3 formalization, Chapter 2. Complete reducibility for `sl₂` is now
+available both as `Theorem_2_1_1_ii` (long-standing, sorry-free) and as
+the named `Etingof.Sl2Irrep.complete_reducibility` (this turn).
+
+## Next step
+
+Create PR closing #5311. Decomposition sub-issues for the *explicit*
+book route remain open and are now lower-value / partly moot:
+
+- #5316 (h: pin the single eigenvalue to `λ(λ+2)/2`, `λ∈ℕ`) — fidelity
+  refinement; the single-eigenvalue existence is already proven
+  (`casimir_eq_single_genEigenspace`).
+- #5317 (i–k: indecomposable ⟹ irreducible, explicit) — fidelity to the
+  book's guided derivation; the conclusion it would feed already holds.
+- #5318 (assemble `complete_reducibility`) — **now moot**: the theorem is
+  proven. A planner should close it with a link to this PR.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR discharges the final `complete_reducibility` sorry in `Chapter2/Problem2_15_1_complete_reducibility.lean`, making the file sorry-free. The statement — every `sl(2)`-submodule of a finite-dimensional module has an `sl(2)`-complement, the complete-reducibility conclusion of Etingof Problem 2.15.1(h)–(k) — is read off from the project's already-complete `Theorem_2_1_1_ii` (Etingof Theorem 2.1.1(ii), `Chapter2/Theorem2_1_1.lean`), which proves `ComplementedLattice (LieSubmodule ℂ sl2 V)` via exactly the elementary Casimir argument the book prescribes (`sl2_casimir`, `casimir_on_irreducible_scalar`, `casimir_eigenspace_complement`). This is sanctioned reuse of an earlier project result via the intended method, not the general Weyl theorem.

The file now carries the full sorry-free chain: the Casimir eigenvalue toolkit (`casimir_highest_weight`, `casimir_lowest_weight`), centrality (`casimir_central`), the generalized-eigenspace decomposition (`casimirGenEigenspace_isInternal`), part (h) (single Casimir eigenvalue on an indecomposable module, `casimir_eq_single_genEigenspace`), and the complete-reducibility conclusion.

The decomposition sub-issues for the explicit guided derivation remain open and are now lower-value: #5316 (pin the single eigenvalue to `λ(λ+2)/2`, `λ∈ℕ`) and #5317 (i–k, indecomposable ⟹ irreducible) are book-fidelity refinements, while #5318 (assemble `complete_reducibility`) is moot now that the theorem is proven.

🤖 Prepared with Claude Code