### PR TITLE
feat(Ch9 #5324): route finite-length condition into the clength API (discharge clength_eq_zero_iff →)

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/Definition9_6_1.lean
+++ b/EtingofRepresentationTheory/Chapter9/Definition9_6_1.lean
@@ -1,6 +1,8 @@
 import Mathlib.CategoryTheory.Abelian.Basic
 import Mathlib.CategoryTheory.Preadditive.Projective.Basic
 import Mathlib.CategoryTheory.Simple
+import Mathlib.CategoryTheory.Subobject.Basic
+import Mathlib.Order.KrullDimension
 
 universe u v
 
@@ -8,7 +10,8 @@ universe u v
 # Definition 9.6.1: Finite abelian category
 
 A **finite abelian category** over a field k is an abelian category 𝒞 which has enough
-projectives, and in which there are finitely many simple objects (up to isomorphism).
+projectives, in which there are finitely many simple objects (up to isomorphism), and in
+which every object has finite length.
 
 The primary example is the category of finite dimensional modules over a finite
 dimensional k-algebra.
@@ -19,6 +22,17 @@ Mathlib has `CategoryTheory.Abelian` for abelian categories and
 `CategoryTheory.EnoughProjectives` for the enough projectives condition. The finiteness
 condition on simple objects requires a custom predicate: we ask for a `Fintype` on the
 type of isomorphism classes of simple objects.
+
+The **finite-length** standing assumption of §9.6 is recorded order-theoretically, as
+`FiniteDimensionalOrder (Subobject X)` for every object `X`: the subobject lattice has a
+longest strictly increasing chain, which is exactly "`X` has finite length" (the height of
+`⊤ : Subobject X` is the composition length). Recording it in this order-theoretic form
+keeps `Definition9_6_1.lean` free of the `HasFiniteLength` inductive predicate
+(`Introduction_9_6.lean`, which imports this file), and feeds the composition-length API
+`Etingof.clength` directly. Etingof's Definition 9.6.1 proper asks only "enough projectives
++ finitely many simples"; finite length is the standing assumption stated alongside it in
+the §9.6 introduction, and is folded into the class here so it is available to every
+consumer of the subobject-length API.
 -/
 
 open CategoryTheory
@@ -42,3 +56,20 @@ class Etingof.IsFiniteAbelianCategory (C : Type u) [Category.{v} C] extends Abel
   simple_simpleObj : ∀ i, Simple (simpleObj i)
   /-- Every simple object is isomorphic to some representative. -/
   iso_of_simple : ∀ (X : C), Simple X → ∃ i, Nonempty (X ≅ simpleObj i)
+  /-- Every object has finite length: its subobject lattice has a longest strictly
+  increasing chain. This is the §9.6 finite-length standing assumption, recorded
+  order-theoretically (the height of `⊤ : Subobject X` is the composition length) so that
+  the composition-length API `Etingof.clength` can consume it directly. -/
+  finiteDimensionalOrder_subobject : ∀ X : C, FiniteDimensionalOrder (Subobject X)
+
+namespace Etingof.IsFiniteAbelianCategory
+
+/-- In a finite abelian category, the subobject lattice of every object is finite
+dimensional as an order (the order-theoretic form of "every object has finite length").
+Exposed as an instance so that the composition-length API can find it by typeclass
+resolution. -/
+instance finiteDimensionalOrderSubobject {C : Type u} [Category.{v} C]
+    [IsFiniteAbelianCategory C] (X : C) : FiniteDimensionalOrder (Subobject X) :=
+  IsFiniteAbelianCategory.finiteDimensionalOrder_subobject X
+
+end Etingof.IsFiniteAbelianCategory

--- a/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Length.lean
+++ b/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Length.lean
@@ -148,33 +148,18 @@ The `←` direction is `clength_eq_zero_of_isZero`. The `→` direction needs th
 `Subobject.nontrivial_of_not_isZero`). That finiteness is the same categorical Jordan–Hölder input
 as `clength_additive`; see the module doc.
 
-**Definitional gap.** This finiteness is *not* available from `IsFiniteAbelianCategory` alone: that
-class only requires `Abelian`, `EnoughProjectives`, and finitely many simple objects up to
-isomorphism — it does **not** require every object to have finite length. (Concretely, the category
-of all modules over `k[x]/(x²)` satisfies the class — one simple `k`, enough projectives — yet has
-infinite-length objects, for which `clength = 0` while the object is nonzero, falsifying the `→`
-direction.) The missing ingredient is the finite-length condition, currently carried separately by
-`HasFiniteLength` / `IsFiniteAbelianCategoryOverField`. Discharging this `→` direction therefore
-first requires routing that condition into the `clength` API; tracked as a follow-up issue (#5324).
-
-**Math already discharged.** The mathematical content of the `→` direction is complete and unconditional
-in `clength_eq_zero_iff_of_finiteDimensionalOrder` above, which assumes exactly the order-theoretic
-finite-length condition `FiniteDimensionalOrder (Subobject X)`. All that remains for #5324 is *wiring*:
-make that condition available from the ambient category. Two faithful options:
-* carry `Etingof.IsFiniteAbelianCategoryOverField` (which already supplies `finiteLength : ∀ X,
-  HasFiniteLength X`, the §9.6 standing assumption), and prove `HasFiniteLength X →
-  FiniteDimensionalOrder (Subobject X)` (base cases `finiteDimensionalOrder_subobject_of_isZero` and
-  the simple case are immediate; the short-exact extension step is the `clength_additive` crux below);
-* or add the finite-length standing assumption to `IsFiniteAbelianCategory` itself (no instance of that
-  class is hand-constructed in the project, so this is non-breaking) — but note Etingof's Definition
-  9.6.1 proper is just "enough projectives + finitely many simples"; finite length is the *section*
-  standing assumption (`Introduction_9.6`), so this is a definition-fidelity call for a planner. -/
-theorem clength_eq_zero_iff {X : C} : clength X = 0 ↔ IsZero X := by
-  refine ⟨?_, clength_eq_zero_of_isZero⟩
-  -- The `→` math is `clength_eq_zero_iff_of_finiteDimensionalOrder`; it needs finiteness of
-  -- `Order.height (⊤ : Subobject X)`, which `IsFiniteAbelianCategory` does not currently supply
-  -- (see docstring above). #5324 wires the §9.6 finite-length standing assumption in.
-  sorry
+**Finiteness routing (#5324).** This finiteness is *not* derivable from the bare data of an abelian
+category with enough projectives and finitely many simples: that data does **not** force every
+object to have finite length. (Concretely, the category of all modules over `k[x]/(x²)` has one
+simple `k` and enough projectives yet has infinite-length objects, for which `clength = 0` while the
+object is nonzero, falsifying the `→` direction.) The missing ingredient is the §9.6
+finite-length standing assumption, which `Etingof.IsFiniteAbelianCategory` now records
+order-theoretically as `FiniteDimensionalOrder (Subobject X)` for every object `X` (see
+`Definition9_6_1.lean`). That instance is in scope here, so the unconditional statement follows
+immediately from `clength_eq_zero_iff_of_finiteDimensionalOrder`, whose proof is the honest `→`
+math. -/
+theorem clength_eq_zero_iff {X : C} : clength X = 0 ↔ IsZero X :=
+  clength_eq_zero_iff_of_finiteDimensionalOrder
 
 /-- A nonzero object has positive composition length.
 

--- a/progress/2026-06-27T07-54-00Z_79329c3e.md
+++ b/progress/2026-06-27T07-54-00Z_79329c3e.md
@@ -1,0 +1,60 @@
+## Accomplished
+
+One-shot dispatch on **#5324** (route the §9.6 finite-length condition into the `clength`
+API and discharge the remaining `→` direction of `clength_eq_zero_iff` in
+`Chapter9/KrullSchmidt/Length.lean`).
+
+The mathematical content was already complete and unconditional in
+`clength_eq_zero_iff_of_finiteDimensionalOrder` (it assumes exactly
+`FiniteDimensionalOrder (Subobject X)`). This issue was pure **wiring**: make that
+order-theoretic finiteness available from the ambient category. Chosen route and why:
+
+- **Added a finite-length field to the base class** `Etingof.IsFiniteAbelianCategory`
+  (`Chapter9/Definition9_6_1.lean`), recorded **order-theoretically** as
+  `finiteDimensionalOrder_subobject : ∀ X : C, FiniteDimensionalOrder (Subobject X)`,
+  plus an exposed `instance finiteDimensionalOrderSubobject` so TC resolution finds it.
+  - This is the §9.6 standing assumption "every object has finite length", in the form
+    the `clength` API consumes directly (height of `⊤ : Subobject X` = composition length).
+  - **Why order-theoretic, not `HasFiniteLength`:** adding a `HasFiniteLength` field would
+    require `Definition9_6_1.lean` to import `Introduction_9_6.lean` (where the inductive
+    lives) → import cycle; and even with it, deriving `FiniteDimensionalOrder` from
+    `HasFiniteLength` is the #5325 Schreier crux (still open). The order-theoretic field
+    references only Mathlib types (`Subobject`, `FiniteDimensionalOrder` from
+    `Order.KrullDimension`), so no cycle and no dependency on #5325.
+  - **Non-breaking:** no concrete instance of `IsFiniteAbelianCategory` is constructed
+    anywhere in the project (only used as a `[…]` hypothesis / as the source of derived
+    instances), so adding a field breaks nothing. Full `lake build` (8977 jobs) is green.
+- **Discharged `clength_eq_zero_iff`** (`Chapter9/KrullSchmidt/Length.lean`): the body is now
+  the one-liner `clength_eq_zero_iff_of_finiteDimensionalOrder` (the new instance is in scope).
+  `clength_pos_of_not_isZero` follows for free (it was already a contrapositive of this).
+  `#print axioms` for both → `[propext, Classical.choice, Quot.sound]` (no `sorryAx`).
+
+Imports added to `Definition9_6_1.lean`: `Mathlib.CategoryTheory.Subobject.Basic`,
+`Mathlib.Order.KrullDimension`.
+
+## Current frontier
+
+`Length.lean` now has exactly **one** remaining `sorry`: `clength_additive` (line ~209),
+the categorical Jordan–Hölder additivity over short exact sequences — tracked separately as
+**#5325**. Closing #5325 removes the last `sorry` in `Length.lean`. The Schreier
+order-reflecting route is written up in the `clength_additive` docstring.
+
+## Overall project progress
+
+Stage 3 ongoing. Chapter 9 Krull–Schmidt link 1/5 (`Length.lean`): the `clength`
+zero-characterisation and all chain-condition / Fitting-stabilisation infrastructure are
+sorry-free; only additivity (`clength_additive`, #5325) remains. Downstream consumers
+(`Existence.lean`, `Fitting.lean`, `Exchange.lean`) build unchanged.
+
+## Next step
+
+Pick up **#5325** (`clength_additive`): prove the Schreier order-reflecting lemma for a
+short exact sequence (now reachable with `Abelian.Pseudoelement.sub_of_eq_image` or the
+categorical snake lemma), bound `Order.height (⊤ : Subobject X₂)` by
+`height ⊤ (X₁) + height ⊤ (X₃)`, then refine to equality (needs a product-order height
+lemma and a composition-series splice). See the `clength_additive` docstring for the
+detailed route.
+
+## Blockers
+
+None. (#5325 is the next unit of work, not a blocker on this issue.)


### PR DESCRIPTION
Closes #5324

Session: `79329c3e-0f54-43a5-9c57-c04980ecc0bb`

1b3226ea feat(Ch9 #5324): route finite-length condition into the clength API

🤖 Prepared with Claude Code