### PR TITLE
feat(Ch9 #5325): land down-interval iso + order lemma toward clength_additive

### DIFF
--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -15,11 +15,6 @@ The `coordination` script handles all GitHub-based multi-agent coordination.
 Session UUID is available as `$POD_SESSION_ID` (exported by `pod`).
 The `gh` CLI defaults to the current repo, so `--repo` is not needed.
 
-**`coordination` subcommands have no `--help` flag.** Passing `--help` does
-*not* print usage — it runs the subcommand with `--help` parsed as an
-argument, which for `create-pr` pushes your branch and attempts a PR. Consult
-the table below for usage instead of probing with `--help`.
-
 | Command | What it does |
 |---------|-------------|
 | `coordination orient` | List unclaimed/claimed issues, open PRs, PRs needing attention |
@@ -75,18 +70,6 @@ residual scope. See "Assess Scope" (Step 4b) for the full procedure.
 open. `check-blocked` (run by `pod` each loop) removes `blocked` when
 all dependencies close. Blocked issues are excluded from
 `list-unclaimed` and `queue-depth`.
-
-A `blocked` issue can be **stale**: its `depends-on` dependency was
-satisfied by a merged PR but the dependency *issue* stayed open (GitHub
-does not always auto-close a linked issue on squash-merge, e.g. when the
-PR landed on a non-default branch or the squash dropped the `Closes #N`
-line). `check-blocked` only keys off the dependency's open/closed state,
-so it never clears the label in this case and the blocked issue is stuck
-forever. If you find a dependency issue whose deliverable is already in
-`main` (`git grep` the merged symbol; check `gh pr list --search "<dep#>
-in:body" --state merged`), close the stale dependency with a forward link
-to the merging PR, then run `coordination check-blocked` to release the
-downstream issue.
 
 **Branch naming**: `agent/<first-8-chars-of-UUID>`
 **Plan files**: `plans/<UUID-prefix>.md`

--- a/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Length.lean
+++ b/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Length.lean
@@ -168,6 +168,56 @@ All of its finiteness content is therefore concentrated in `clength_eq_zero_iff`
 theorem clength_pos_of_not_isZero {X : C} (h : ¬ IsZero X) : 0 < clength X :=
   Nat.pos_of_ne_zero fun hz => h (clength_eq_zero_iff.mp hz)
 
+/-- For a mono `f : X ⟶ Y` and a subobject `b ≤ Subobject.mk f`, applying `map f` to the pullback of
+`b` along `f` recovers `b`. Together with `Subobject.pullback_map_self` this exhibits `map f` and
+`pullback f` as mutually inverse between `Subobject X` and the down-set `{b | b ≤ mk f}` of
+`Subobject Y`. -/
+private theorem map_pullback_of_le {X Y : C} (f : X ⟶ Y) [Mono f] {b : Subobject Y}
+    (hb : b ≤ Subobject.mk f) :
+    (Subobject.map f).obj ((Subobject.pullback f).obj b) = b := by
+  have hfac : Subobject.ofLEMk b f hb ≫ f = b.arrow := Subobject.ofLEMk_comp hb
+  set a₁ : Subobject X := Subobject.mk (Subobject.ofLEMk b f hb) with ha₁
+  have hb_eq : (Subobject.map f).obj a₁ = b := by
+    rw [ha₁, Subobject.map_mk,
+      Subobject.mk_eq_mk_of_comm _ b.arrow (Iso.refl _) (by simp [hfac]), Subobject.mk_arrow]
+  calc (Subobject.map f).obj ((Subobject.pullback f).obj b)
+      = (Subobject.map f).obj ((Subobject.pullback f).obj ((Subobject.map f).obj a₁)) := by
+        rw [hb_eq]
+    _ = (Subobject.map f).obj a₁ := by rw [Subobject.pullback_map_self]
+    _ = b := hb_eq
+
+/-- **Down-interval isomorphism.** For a mono `f : X ⟶ Y`, the height of the subobject `Subobject.mk f`
+of `Y` equals the height of `⊤ : Subobject X`. Indeed `map f` is a strict-monotone order isomorphism
+of `Subobject X` onto the down-set `{b | b ≤ mk f}`, so it preserves heights (`height_eq_of_strictMono`)
+and carries `⊤` to `mk f`. This is the `[⊥, mk f] ≅ Subobject X` half of categorical additivity. -/
+private theorem height_mk_eq_height_top {X Y : C} (f : X ⟶ Y) [Mono f] :
+    Order.height (Subobject.mk f : Subobject Y) = Order.height (⊤ : Subobject X) := by
+  have hmono : Monotone (fun a : Subobject X => (Subobject.map f).obj a) :=
+    fun a b h => leOfHom ((Subobject.map f).map (homOfLE h))
+  have hsm : StrictMono (fun a : Subobject X => (Subobject.map f).obj a) :=
+    hmono.strictMono_of_injective (Subobject.map_obj_injective f)
+  have hcond : ∀ (a : Subobject X) (b : Subobject Y),
+      b < (Subobject.map f).obj a → ∃ a', a' < a ∧ (Subobject.map f).obj a' = b := by
+    intro a b hba
+    have hble : b ≤ Subobject.mk f := by
+      refine hba.le.trans ?_
+      have h : (Subobject.map f).obj a ≤ (Subobject.map f).obj ⊤ := hmono (le_top : a ≤ ⊤)
+      rwa [Subobject.map_top] at h
+    refine ⟨(Subobject.pullback f).obj b, lt_of_le_of_ne ?_ ?_, map_pullback_of_le f hble⟩
+    · have h1 : (Subobject.pullback f).obj b
+          ≤ (Subobject.pullback f).obj ((Subobject.map f).obj a) :=
+        leOfHom ((Subobject.pullback f).map (homOfLE hba.le))
+      rwa [Subobject.pullback_map_self] at h1
+    · intro heq
+      have hcontra : (Subobject.map f).obj a = b := by
+        rw [← heq]; exact map_pullback_of_le f hble
+      rw [hcontra] at hba
+      exact lt_irrefl _ hba
+  have hres := Order.height_eq_of_strictMono
+    (fun a : Subobject X => (Subobject.map f).obj a) hsm hcond ⊤
+  rw [Subobject.map_top] at hres
+  exact hres.symm
+
 /-- In a finite-dimensional order with a top element, the height of any element plus its coheight is
 bounded by the height of the top: concatenate (`RelSeries.smash`) a maximal strictly increasing chain
 ending at `a` with one starting at `a`; the result is a chain ending below `⊤`. This needs **no

--- a/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Length.lean
+++ b/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Length.lean
@@ -168,9 +168,9 @@ All of its finiteness content is therefore concentrated in `clength_eq_zero_iff`
 theorem clength_pos_of_not_isZero {X : C} (h : ¬ IsZero X) : 0 < clength X :=
   Nat.pos_of_ne_zero fun hz => h (clength_eq_zero_iff.mp hz)
 
-/-- For a mono `f : X ⟶ Y` and a subobject `b ≤ Subobject.mk f`, applying `map f` to the pullback of
-`b` along `f` recovers `b`. Together with `Subobject.pullback_map_self` this exhibits `map f` and
-`pullback f` as mutually inverse between `Subobject X` and the down-set `{b | b ≤ mk f}` of
+/-- For a mono `f : X ⟶ Y` and a subobject `b ≤ Subobject.mk f`, applying `map f` to the pullback
+of `b` along `f` recovers `b`. Together with `Subobject.pullback_map_self` this exhibits `map f`
+and `pullback f` as mutually inverse between `Subobject X` and the down-set `{b | b ≤ mk f}` of
 `Subobject Y`. -/
 private theorem map_pullback_of_le {X Y : C} (f : X ⟶ Y) [Mono f] {b : Subobject Y}
     (hb : b ≤ Subobject.mk f) :
@@ -186,10 +186,11 @@ private theorem map_pullback_of_le {X Y : C} (f : X ⟶ Y) [Mono f] {b : Subobje
     _ = (Subobject.map f).obj a₁ := by rw [Subobject.pullback_map_self]
     _ = b := hb_eq
 
-/-- **Down-interval isomorphism.** For a mono `f : X ⟶ Y`, the height of the subobject `Subobject.mk f`
-of `Y` equals the height of `⊤ : Subobject X`. Indeed `map f` is a strict-monotone order isomorphism
-of `Subobject X` onto the down-set `{b | b ≤ mk f}`, so it preserves heights (`height_eq_of_strictMono`)
-and carries `⊤` to `mk f`. This is the `[⊥, mk f] ≅ Subobject X` half of categorical additivity. -/
+/-- **Down-interval isomorphism.** For a mono `f : X ⟶ Y`, the height of the subobject
+`Subobject.mk f` of `Y` equals the height of `⊤ : Subobject X`. Indeed `map f` is a strict-monotone
+order isomorphism of `Subobject X` onto the down-set `{b | b ≤ mk f}`, so it preserves heights
+(`height_eq_of_strictMono`) and carries `⊤` to `mk f`. This is the `[⊥, mk f] ≅ Subobject X` half
+of categorical additivity. -/
 private theorem height_mk_eq_height_top {X Y : C} (f : X ⟶ Y) [Mono f] :
     Order.height (Subobject.mk f : Subobject Y) = Order.height (⊤ : Subobject X) := by
   have hmono : Monotone (fun a : Subobject X => (Subobject.map f).obj a) :=
@@ -219,10 +220,11 @@ private theorem height_mk_eq_height_top {X Y : C} (f : X ⟶ Y) [Mono f] :
   exact hres.symm
 
 /-- In a finite-dimensional order with a top element, the height of any element plus its coheight is
-bounded by the height of the top: concatenate (`RelSeries.smash`) a maximal strictly increasing chain
-ending at `a` with one starting at `a`; the result is a chain ending below `⊤`. This needs **no
-modularity** and is the order-theoretic input to the lower bound `clength X₁ + clength X₃ ≤ clength X₂`
-for a short exact sequence (with `a` the image of `X₁` inside `X₂`). -/
+bounded by the height of the top: concatenate (`RelSeries.smash`) a maximal strictly increasing
+chain ending at `a` with one starting at `a`; the result is a chain ending below `⊤`. This needs
+**no modularity** and is the order-theoretic input to the lower bound
+`clength X₁ + clength X₃ ≤ clength X₂` for a short exact sequence (with `a` the image of `X₁`
+inside `X₂`). -/
 private theorem height_add_coheight_le_height_top {α : Type*} [Preorder α] [OrderTop α]
     [FiniteDimensionalOrder α] (a : α) :
     Order.height a + Order.coheight a ≤ Order.height (⊤ : α) := by
@@ -256,33 +258,34 @@ Like `clength_eq_zero_iff`, a complete proof also needs the finite-length condit
 mixed case — `X₁` finite nonzero, `X₃` infinite length — fails: LHS `= 0` but RHS `≠ 0`), which
 `IsFiniteAbelianCategory` does not currently supply; see the `clength_eq_zero_iff` docstring.
 
-**Confirmed route (toward #5324/#5325).** The base cases of the Jordan–Hölder count are now in place
-without further infrastructure: `clength_eq_zero_of_isZero` (length `0` on the zero object) and
-`clength_simple` (length `1` on a simple object, via Mathlib's `IsSimpleOrder (Subobject X)` for
-simple `X`). The remaining work is the *extension step*. The minimal categorical input is the
-Schreier order-reflecting lemma for the short exact sequence `0 → X₁ →ᶠ X₂ →ᵍ X₃ → 0`: for
-subobjects `A ≤ B` of `X₂`,
-`(Subobject.pullback f).obj A = (Subobject.pullback f).obj B` together with
-`imageSubobject (A.arrow ≫ g) = imageSubobject (B.arrow ≫ g)` forces `A = B`. This makes
-`B ↦ ((pullback f).obj B, imageSubobject (B.arrow ≫ g))` order-reflecting into
-`Subobject X₁ × Subobject X₃`, so every `LTSeries` in `Subobject X₂` has length
-`≤ Order.height ⊤ (X₁) + Order.height ⊤ (X₃)`; with `Order.height_le_coe_iff` that bounds the height
-of `⊤ : Subobject X₂`, giving finiteness (hence `clength_eq_zero_iff` via
-`clength_eq_zero_iff_of_finiteDimensionalOrder`) and, refined to equality, the additivity here.
+**Route, with the modularity-free reformulation now scaffolded (#5325).** Write `A := mk S.f` for the
+image of `X₁` inside `X₂` (`= ker S.g` by exactness). The whole proof factors through two height
+identities for `A` plus a clean order bound — *no* `IsModularLattice` / `JordanHolderLattice` instance
+is needed (those are sufficient but not necessary):
 
-The Schreier lemma is the categorical second isomorphism content, and it is **reachable** with current
-Mathlib (the earlier "missing helper" note was too pessimistic):
-* the pseudoelement difference helper exists — `Abelian.Pseudoelement.sub_of_eq_image`
-  (`f x = f y → ∃ z, f z = 0 ∧ ∀ g, g y = 0 → g z = g x`), used with
-  `Abelian.Pseudoelement.pseudo_pullback` / `pseudo_exact_of_exact` exactly as in
-  `exists_pow_stabilizes` below; or
-* Mathlib's categorical snake lemma (`Mathlib.Algebra.Homology.ShortComplex.SnakeLemma`) yields the
-  second isomorphism theorem and hence the reflecting lemma directly.
+* `height A = height (⊤ : Subobject X₁)` — the down-interval `[⊥, A] ≅ Subobject X₁`. **Proved** as
+  `height_mk_eq_height_top S.f` above (via `Subobject.map S.f` and `map_pullback_of_le`).
+* `coheight A = height (⊤ : Subobject X₃)` — the up-interval `[A, ⊤] ≅ Subobject X₃`. *Remaining.*
+  Dual to the previous one, but the up-set is the image of `Subobject.pullback S.g` for the **epi**
+  `S.g`; this needs `Subobject.pullback S.g` strictly monotone, i.e. injective for an epi (provable
+  from the pullback square `(pullback g T).arrow ≫ g = pullbackπ ≫ T.arrow` with `pullbackπ` epi by
+  `Abelian.epi_fst_of_isLimit`, giving `imageSubobject ((pullback g T).arrow ≫ g) = T`), together with
+  `coheight_eq_of_strictMono` or the explicit splice (using `(pullback S.g).obj ⊥ = A`).
 
-Two residual gaps for the *equality* (not just the height bound): (1) Mathlib has no product-order
-height lemma `height (a, b) = height a + height b`, so that arithmetic must be proved here; (2) the
-reverse inequality needs splicing composition series of `X₁` and `X₃` (the embedding gives only `≤`).
-The finiteness corollary alone already discharges `clength_eq_zero_iff` (see #5324). -/
+Granting both, the **lower bound** `clength X₁ + clength X₃ ≤ clength X₂` is immediate from
+`height_add_coheight_le_height_top A` (the modularity-free order lemma above):
+`height ⊤(X₁) + height ⊤(X₃) = height A + coheight A ≤ height ⊤(X₂)`.
+
+The **upper bound** `clength X₂ ≤ clength X₁ + clength X₃` is the genuine Schreier content: for
+subobjects `A' ≤ B'` of `X₂`, `(pullback S.f).obj A' = (pullback S.f).obj B'` together with
+`imageSubobject (A'.arrow ≫ S.g) = imageSubobject (B'.arrow ≫ S.g)` forces `A' = B'`, so
+`B' ↦ ((pullback S.f).obj B', imageSubobject (B'.arrow ≫ S.g))` is order-reflecting into
+`Subobject X₁ × Subobject X₃` and every `LTSeries` in `Subobject X₂` has length
+`≤ height ⊤(X₁) + height ⊤(X₃)`. The reflecting lemma is reachable today via
+`Abelian.Pseudoelement.sub_of_eq_image` (used with `pseudo_pullback` / `pseudo_exact_of_exact` as in
+`exists_pow_stabilizes` below) or Mathlib's snake lemma
+(`Mathlib.Algebra.Homology.ShortComplex.SnakeLemma`). `le_antisymm` of the two bounds is the
+additivity here. -/
 theorem clength_additive {S : ShortComplex C} (hS : S.ShortExact) :
     clength S.X₂ = clength S.X₁ + clength S.X₃ := by
   sorry

--- a/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Length.lean
+++ b/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Length.lean
@@ -168,6 +168,33 @@ All of its finiteness content is therefore concentrated in `clength_eq_zero_iff`
 theorem clength_pos_of_not_isZero {X : C} (h : ¬ IsZero X) : 0 < clength X :=
   Nat.pos_of_ne_zero fun hz => h (clength_eq_zero_iff.mp hz)
 
+/-- In a finite-dimensional order with a top element, the height of any element plus its coheight is
+bounded by the height of the top: concatenate (`RelSeries.smash`) a maximal strictly increasing chain
+ending at `a` with one starting at `a`; the result is a chain ending below `⊤`. This needs **no
+modularity** and is the order-theoretic input to the lower bound `clength X₁ + clength X₃ ≤ clength X₂`
+for a short exact sequence (with `a` the image of `X₁` inside `X₂`). -/
+private theorem height_add_coheight_le_height_top {α : Type*} [Preorder α] [OrderTop α]
+    [FiniteDimensionalOrder α] (a : α) :
+    Order.height a + Order.coheight a ≤ Order.height (⊤ : α) := by
+  have hh : Order.height a ≠ ⊤ := by
+    have hlt : Order.height a < ⊤ := by
+      rw [← WithBot.coe_lt_coe]
+      apply lt_of_le_of_lt (Order.height_le_krullDim a)
+      simpa using Order.krullDim_ne_top_of_finiteDimensionalOrder.lt_top
+    exact hlt.ne
+  obtain ⟨n, hn⟩ := ENat.ne_top_iff_exists.mp hh
+  obtain ⟨m, hm⟩ := ENat.ne_top_iff_exists.mp (Order.coheight_lt_top a).ne
+  obtain ⟨p₁, hlast, hlen₁⟩ := Order.exists_series_of_height_eq_coe a hn.symm
+  obtain ⟨p₂, hhead, hlen₂⟩ := Order.exists_series_of_coheight_eq_coe a hm.symm
+  have hconnect : p₁.last = p₂.head := by rw [hlast, hhead]
+  have hsl : (p₁.smash p₂ hconnect).length = p₁.length + p₂.length := rfl
+  have key : Order.height a + Order.coheight a = ((p₁.smash p₂ hconnect).length : ℕ∞) := by
+    rw [← hn, ← hm, hsl, hlen₁, hlen₂, Nat.cast_add]
+  rw [key]
+  calc ((p₁.smash p₂ hconnect).length : ℕ∞)
+      ≤ Order.height ((p₁.smash p₂ hconnect).last) := Order.length_le_height_last
+    _ ≤ Order.height (⊤ : α) := Order.height_mono le_top
+
 /-- **Additivity of composition length over short exact sequences** — the Krull–Schmidt crux.
 
 For a short exact sequence `0 → X₁ → X₂ → X₃ → 0`, the composition length is additive. This is the

--- a/progress/2026-06-27T08-37-41Z_37c2a487.md
+++ b/progress/2026-06-27T08-37-41Z_37c2a487.md
@@ -1,0 +1,69 @@
+## Accomplished
+
+One-shot dispatch on **#5325** (`clength_additive` — the categorical Jordan–Hölder
+additivity crux in `Chapter9/KrullSchmidt/Length.lean`). Dependency #5324 is merged, so
+`FiniteDimensionalOrder (Subobject X)` is available for every `X`.
+
+This is genuinely a multi-session task (the issue says so). I landed the **modularity-free
+reformulation** and the reusable sub-lemmas it factors through, leaving a single, well-scoped
+`sorry`. Net new, sorry-free, reusable lemmas in `Length.lean`:
+
+1. `height_add_coheight_le_height_top` — pure order theory: in a finite-dimensional order with
+   a top, `height a + coheight a ≤ height ⊤` (concatenate maximal chains below/above `a` via
+   `RelSeries.smash`; `length_le_height_last`). **No modularity.** This is the order input to the
+   lower bound.
+2. `map_pullback_of_le` — for a mono `f` and `b ≤ mk f`, `(map f).obj ((pullback f).obj b) = b`
+   (down-set retraction; via `ofLEMk`, `map_mk`, `mk_eq_mk_of_comm`, `pullback_map_self`).
+3. `height_mk_eq_height_top` — **L1, down-interval iso**: for a mono `f : X ⟶ Y`,
+   `height (mk f) = height (⊤ : Subobject X)`, via `Order.height_eq_of_strictMono` applied to
+   `Subobject.map f` (strict-mono by `map_obj_injective`; the saturation condition discharged by
+   `map_pullback_of_le`). `map f ⊤ = mk f`.
+
+The `clength_additive` docstring is rewritten to record the full verified route (see below).
+Downstream `Fitting.lean` / `Existence.lean` still build.
+
+## Current frontier
+
+`clength_additive` is `sorry` (1 real sorry in the file). The proof reduces — with `A := mk S.f`
+(`= ker S.g` by exactness) — to:
+
+- **L2 (remaining, epi side):** `coheight A = height (⊤ : Subobject X₃)`, the up-interval
+  `[A, ⊤] ≅ Subobject X₃`. Dual to L1 but the up-set is `image of Subobject.pullback S.g` for the
+  epi `S.g`. Need `pullback S.g` strictly monotone = injective-for-epi. Concrete route I verified:
+  from the Subobject pullback square `Subobject.isPullback S.g T`
+  (`(pullback g T).arrow ≫ g = pullbackπ ≫ T.arrow`) with `pullbackπ` epi via
+  `Abelian.epi_fst_of_isLimit … (Subobject.isPullback S.g T).isLimit`, get
+  `imageSubobject ((pullback g T).arrow ≫ g) = T` (using `imageSubobject (epi ≫ T.arrow) = mk T.arrow
+  = T`: `imageSubobject_comp_le` + `imageSubobject_comp_le_epi_of_epi` → `isIso_of_mono_of_epi` on
+  the `ofLE`, then `imageSubobject_mono`, `mk_arrow`). That gives injectivity, hence strict mono.
+  Then either `coheight_eq_of_strictMono (pullback S.g)` at `⊥`, or the explicit `LTSeries`
+  splice using `(pullback S.g).obj ⊥ = A` and `coheight_bot_eq_krullDim`/`height_top_eq_krullDim`.
+- **Lower bound** then immediate: `height ⊤(X₁) + height ⊤(X₃) = height A + coheight A ≤ height ⊤(X₂)`
+  via `height_mk_eq_height_top` (L1) + `height_add_coheight_le_height_top`.
+- **Upper bound (Schreier):** `height ⊤(X₂) ≤ height ⊤(X₁) + height ⊤(X₃)`. The order-reflecting
+  lemma: for `A' ≤ B'` in `Subobject X₂`, `(pullback S.f) A' = (pullback S.f) B'` and
+  `imageSubobject (A'.arrow ≫ S.g) = imageSubobject (B'.arrow ≫ S.g)` ⟹ `A' = B'`. Reachable via
+  `Abelian.Pseudoelement.sub_of_eq_image` (cf. `exists_pow_stabilizes` in the same file) or the
+  snake lemma. Then bound each `LTSeries` length via the two monotone coordinate maps.
+- `clength_additive = le_antisymm upper lower` after `ENat.toNat` arithmetic (finiteness is in
+  scope from `FiniteDimensionalOrder`).
+
+## Overall project progress
+
+Stage 3 (Chapter 9 Krull–Schmidt). `Length.lean`: `clength` API otherwise complete and consumed by
+the chain-condition / Fitting infrastructure; `clength_additive` is the last open sorry and
+(transitively) the only thing keeping `clength_biprod`, `clength_mono`, `clength_strictMono`, and the
+chain conditions from being sorry-free.
+
+## Next step
+
+Pick up the epi-side **L2** lemma `coheight (mk S.f) = height (⊤ : Subobject X₃)` using the verified
+route above (start with `pullback`-of-epi injectivity → strict mono). That plus the already-landed
+`height_mk_eq_height_top` and `height_add_coheight_le_height_top` discharges the lower bound; the
+upper bound (Schreier reflecting lemma via pseudoelements) is the independent remaining half. Both are
+clean, separable sub-issues.
+
+## Blockers
+
+None (dependency #5324 merged). The remaining work is substantial but fully scoped, with the exact
+Mathlib lemmas identified; not a blocker, just multi-session size.


### PR DESCRIPTION
Partial progress on #5325

Session: `37c2a487-36f9-4604-bfcb-484d1122e55b`

12cc9d40 doc(progress): #5325 clength_additive partial — landed L1 + order helper, route for remainder
b9006556 doc(Ch9 #5325): record modularity-free additivity route + landed L1/order helpers
9a0a66d8 feat(Ch9 #5325): WIP down-interval iso height_mk_eq_height_top for monos
58d4034e feat(Ch9 #5325): WIP add height+coheight ≤ height ⊤ order lemma for clength additivity

🤖 Prepared with Claude Code