### PR TITLE
feat(Ch5): decompose contragredient det-twist sorry into common-Schur-module analytic core

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/ContragredientIdentity.lean
+++ b/EtingofRepresentationTheory/Chapter5/ContragredientIdentity.lean
@@ -85,6 +85,56 @@ end Untwist
 
 variable {k : Type*} [Field k] [IsAlgClosed k] [CharZero k]
 
+/-- **Both `det^s`-twisted contragredient models land on a common Schur module
+(analytic core).** For a large enough determinant twist `det^s`, there is a single
+non-negative weight `ν` such that *both* twisted models are `GL_n`-equivariantly
+isomorphic to the bare Schur module `SchurModuleSubmodule k n ν` (action
+`schurModuleRep k n ν`):
+
+* the Schur-module contragredient `L_{w₀λ}` twisted by `det^s` (carrier
+  `AlgIrrepGLDual n lam k`, action `charTwistRep (det^s) algIrrepGLRepDualρ`), and
+* the linear dual `L_λ^∨` twisted by `det^s` (carrier
+  `Module.Dual k (AlgIrrepGL n lam k)`, action `charTwistRep (det^s) (ρ.dual)`).
+
+This bundles the entire analytic content of the contragredient identity. The
+intended route applies the GL char→iso keystone `iso_of_formalCharacter_eq_schurPoly`
+(`SchurWeylFormalCharacterIso.lean`) to each twisted model: both are polynomial
+(algebraic, with spanning `ℕ`-weight spaces) with formal character `schurPoly N ν`,
+so each is identified with the *same* Schur module `SchurModuleSubmodule k n ν`.
+
+Two facts feed the character computation (each warrants its own sub-issue):
+
+* (a) `formalCharacter (ρ.dual)` is `formalCharacter ρ` read at inverse torus weights
+  (the dual rep negates weights);
+* (b) the inverted-variable Schur identity `s_λ(x⁻¹)·(x₁⋯x_n)^s = s_{w₀λ+s}(x)`, which
+  makes the `det^s`-twisted dual character a genuine Schur polynomial.
+
+The `det^s`-twisted Schur-module side is the easier half: for `s ≥ (lam.w0Twist).shift`
+it is the determinant-shift of a Schur module, identified with a Schur module by
+iterating Proposition 5.22.2 (`schurModule_shift_iso_detTwist`). The hard half is the
+linear-dual side, which needs (a) and (b).
+
+Once this common model is available, the equivariant equivalence
+`AlgIrrepGLDual ≃ₗ Module.Dual` is obtained by composing the two identifications
+(`exists_detTwist_equivariantEquiv_dual`, sorry-free below).
+
+Sorried pending facts (a) and (b); tracked in
+https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/issues/5526. -/
+theorem exists_common_schurModule_model_detTwist_dual (n : ℕ) (lam : DominantWeight n)
+    (k : Type*) [Field k] [IsAlgClosed k] [CharZero k] :
+    ∃ (s : ℕ) (ν : Fin n → ℕ),
+      Nonempty
+        { e : AlgIrrepGLDual n lam k ≃ₗ[k] SchurModuleSubmodule k n ν //
+          ∀ (g : Matrix.GeneralLinearGroup (Fin n) k) (v : AlgIrrepGLDual n lam k),
+            e (charTwistRep (detChar k n ^ s) (algIrrepGLRepDualρ n lam k) g v)
+              = schurModuleRep k n ν g (e v) }
+      ∧ Nonempty
+        { e : Module.Dual k (AlgIrrepGL n lam k) ≃ₗ[k] SchurModuleSubmodule k n ν //
+          ∀ (g : Matrix.GeneralLinearGroup (Fin n) k) (v : Module.Dual k (AlgIrrepGL n lam k)),
+            e (charTwistRep (detChar k n ^ s) ((algIrrepGLRepρ n lam k).dual) g v)
+              = schurModuleRep k n ν g (e v) } := by
+  sorry
+
 /-- **The `det^s`-twisted models of the contragredient agree (character input).**
 For a large enough determinant twist `det^s`, the Schur-module contragredient
 `L_{w₀λ}` (carrier `AlgIrrepGLDual n lam k`, action `algIrrepGLRepDualρ`) and the
@@ -111,7 +161,17 @@ theorem exists_detTwist_equivariantEquiv_dual (n : ℕ) (lam : DominantWeight n)
         ∀ (g : Matrix.GeneralLinearGroup (Fin n) k) (v : AlgIrrepGLDual n lam k),
           e (charTwistRep (detChar k n ^ s) (algIrrepGLRepDualρ n lam k) g v)
             = charTwistRep (detChar k n ^ s) ((algIrrepGLRepρ n lam k).dual) g (e v) } := by
-  sorry
+  -- Both twisted models land on the same bare Schur module `L_ν` (action
+  -- `schurModuleRep k n ν`), via the analytic core. Compose the two identifications:
+  -- `AlgIrrepGLDual --eA--> L_ν --eB.symm--> Module.Dual`.
+  obtain ⟨s, ν, ⟨eA, heA⟩, ⟨eB, heB⟩⟩ :=
+    exists_common_schurModule_model_detTwist_dual n lam k
+  refine ⟨s, ⟨eA.trans eB.symm, ?_⟩⟩
+  intro g v
+  -- `eB` is injective, so it suffices to compare after applying `eB`.
+  apply eB.injective
+  rw [LinearEquiv.trans_apply, LinearEquiv.trans_apply, eB.apply_symm_apply,
+    heA g v, heB g (eB.symm (eA v)), eB.apply_symm_apply]
 
 /-- **The contragredient identity `L*_λ ≅ L_λ^∨` for `GL_n`.** A `GL_n`-equivariant
 `k`-linear isomorphism identifying the Schur-module realization of the

--- a/progress/2026-06-27T10-41-38Z_be501f4b.md
+++ b/progress/2026-06-27T10-41-38Z_be501f4b.md
@@ -1,0 +1,61 @@
+## Accomplished
+
+Worked issue #5526 (discharge the `sorry` in `exists_detTwist_equivariantEquiv_dual`,
+`Chapter5/ContragredientIdentity.lean`). The full discharge requires two pieces of new
+analytic infrastructure (formal character of a dual representation at inverse torus
+weights; the inverted-variable Schur identity `s_λ(x⁻¹)·(x₁⋯x_n)^s = s_{w₀λ+s}(x)`),
+each a substantial multi-step effort — frontier difficulty for one session. Per the
+endgame decomposition guidance, I restructured rather than attempted a monolithic proof:
+
+- Introduced a precisely-stated **bundled analytic-core helper**
+  `exists_common_schurModule_model_detTwist_dual`: for some `s` and non-negative weight
+  `ν`, *both* det^s-twisted contragredient models (the Schur-module realization
+  `AlgIrrepGLDual` and the linear dual `Module.Dual k (AlgIrrepGL ...)`) are
+  `GL_n`-equivariantly isomorphic to the *same bare Schur module*
+  `SchurModuleSubmodule k n ν` with action `schurModuleRep k n ν`. This is the literal
+  "apply `iso_of_formalCharacter_eq_schurPoly` to each twisted model" route, now stated
+  as the goal. Sorried (the one remaining sorry), with a docstring listing the two
+  analytic sub-facts and the available infrastructure.
+- Rewrote `exists_detTwist_equivariantEquiv_dual` as a **sorry-free assembly**: it
+  consumes the helper's two equivariant equivs `eA`, `eB` to a common Schur module and
+  composes `eA.trans eB.symm`, discharging the equivariance by an `eB.injective` +
+  rewrite argument.
+
+Net effect: the composition skeleton is proven; the sorry moved one level deeper into a
+cleaner, more attackable statement (common bare Schur module target, both sub-facts
+documented). `algIrrepGLDual_iso_linearDual` (#5522) and
+`exists_detTwist_equivariantEquiv_dual` are now both sorry-free.
+
+`lake build EtingofRepresentationTheory.Chapter5.ContragredientIdentity` is green
+(8622 jobs), one expected `sorry` warning on the helper. Verified the keystone
+`iso_of_formalCharacter_eq_schurPoly` is itself now sorry-free (the lean-formalization
+skill's "dead-end" note on it is stale).
+
+Filed sub-issue #5529 for the analytic core.
+
+## Current frontier
+
+`exists_common_schurModule_model_detTwist_dual` (#5529) is the sole sorry behind the
+contragredient identity. The det^s-twisted Schur-module half is the easier side
+(iterate Prop 5.22.2 / `schurModule_shift_iso_detTwist` for `s ≥ lam.w0Twist.shift`);
+the linear-dual half needs (a) formal character of a dual rep at inverse weights and
+(b) the inverted-variable Schur identity. The two halves share `s` and `ν`.
+
+## Overall project progress
+
+Phase 3 formalization, endgame. This turn is a structural decomposition of one Ch5
+contragredient-identity sorry (net sorry count unchanged: 1 → 1, but the assembly is
+now proven and the remaining sorry has a cleaner statement). No other stages affected.
+
+## Next step
+
+Discharge #5529. Suggested order: (1) prove the Schur-module (`AlgIrrepGLDual`) side
+→ a common Schur module via the shift iso, fixing `ν` and a lower bound on `s`; (2)
+build the dual-character lemma (fact a) and the inverted-variable Schur identity (fact
+b); (3) apply `iso_of_formalCharacter_eq_schurPoly` to the dual side with the matching
+`ν`. Facts (a) and (b) may each warrant a further sub-issue.
+
+## Blockers
+
+None (the remaining work is the genuine mathematical content of #5529, not a
+dependency block).


### PR DESCRIPTION
This PR decomposes the remaining contragredient-identity sorry in `Chapter5/ContragredientIdentity.lean` (issue #5526). It proves the composition assembly `exists_detTwist_equivariantEquiv_dual` sorry-free and isolates the analytic content into a precisely-stated bundled helper `exists_common_schurModule_model_detTwist_dual`: for some `s` and non-negative weight `ν`, both det^s-twisted contragredient models (the Schur-module realization on `AlgIrrepGLDual` and the linear dual on `Module.Dual k (AlgIrrepGL ...)`) are GL_n-equivariantly isomorphic to the same bare Schur module `SchurModuleSubmodule k n ν`. This is the literal "apply `iso_of_formalCharacter_eq_schurPoly` to each twisted model" route, now stated as the goal.

This is partial: the bundled helper remains sorried (the genuine analytic core — formal character of a dual representation at inverse torus weights, and the inverted-variable Schur identity `s_λ(x⁻¹)·(x₁⋯x_n)^s = s_{w₀λ+s}(x)`), tracked in #5529. Net sorry count is unchanged, but the composition skeleton is now proven and the remaining sorry has a cleaner, more attackable statement. `algIrrepGLDual_iso_linearDual` (#5522) and `exists_detTwist_equivariantEquiv_dual` are both sorry-free. `lake build EtingofRepresentationTheory.Chapter5.ContragredientIdentity` is green with one expected sorry warning.

🤖 Prepared with Claude Code