### PR TITLE
Formalize fact (a): formal character of a dual GL_n representation (inverse weights)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5.lean
+++ b/EtingofRepresentationTheory/Chapter5.lean
@@ -124,6 +124,7 @@ import EtingofRepresentationTheory.Chapter5.KernelLemmaKPrimeAssembly
 import EtingofRepresentationTheory.Chapter5.DetPowerFiltration
 import EtingofRepresentationTheory.Chapter5.KernelLemmaK
 import EtingofRepresentationTheory.Chapter5.DetInvElim
+import EtingofRepresentationTheory.Chapter5.FormalCharacterDual
 
 -- Section 5.19: Schur-Weyl Duality and Schur Functors
 import EtingofRepresentationTheory.Chapter5.Proposition5_19_1

--- a/EtingofRepresentationTheory/Chapter5/FormalCharacterDual.lean
+++ b/EtingofRepresentationTheory/Chapter5/FormalCharacterDual.lean
@@ -1,0 +1,232 @@
+import Mathlib
+import EtingofRepresentationTheory.Chapter5.DetInvElim
+
+/-!
+# Formal character of a dual `GL_N`-representation (analytic fact (a))
+
+Etingof §5.23. For a finite-dimensional `GL_N(k)`-representation `ρ`, the dual
+representation `Representation.dual ρ` (Mathlib: `(dual ρ) g = f ∘ ρ g⁻¹`) records
+`ρ`'s torus character read at *inverse* weights: the dual rep negates weights. This
+is the building block (a) behind the contragredient identity `L*_λ ≅ L_λ^∨`
+(#5526 / #5529).
+
+## Main results
+
+* `dual_diagUnit_dualBasis` (always true) — given a torus weight eigenbasis `b` of
+  `ρ` with weights `wt`, the **dual basis** `b.dualBasis` is again a torus weight
+  eigenbasis of `Representation.dual ρ`, with weights `-wt`. This is the precise
+  sense in which the diagonal torus acts on the dual by inverse weights.
+
+* `finrank_glWeightSpaceℤ_of_eigenbasis` (always true) — from a weight eigenbasis,
+  the dimension of the integer weight space `glWeightSpaceℤ ρ ν` equals the number
+  of basis vectors of weight `ν`.
+
+* `finrank_glWeightSpaceℤ_dual_eq` (the reusable core) — combining the two, for a
+  representation with a weight eigenbasis,
+  `dim (glWeightSpaceℤ (dual ρ) μ) = dim (glWeightSpaceℤ ρ (-μ))`: the weight-`μ`
+  space of the dual is dual to `ρ`'s weight-`(-μ)` space.
+
+* `formalCharacter_dual_coeff_eq` (the consumer-facing form) — for a polynomial
+  `GL_N`-rep `M` (spanning `ℕ`-weight spaces, `h_span`), the coefficient of `x^μ`
+  in `formalCharacter (FDRep.of (dual M.ρ))` is `dim (glWeightSpaceℤ M.ρ (-μ))`:
+  the `ℕ`-weight `formalCharacter (dual M.ρ)` collects exactly `M.ρ`'s non-positive
+  weights, read with the sign flipped. Since `M.ρ`'s weights are `≥ 0`, the only
+  weight surviving the `ℕ`-truncation is `μ = 0`.
+
+The eigenbasis hypothesis is the honest carrier of polynomiality: `formalCharacter`
+is a *truncated* invariant (it sees only `ℕ`-weights), so the statement lives at the
+weight-space level, where a `det^s`-twist later brings the negative dual weights back
+into range.
+-/
+
+noncomputable section
+
+namespace Etingof
+
+open Etingof.KernelLemmaKPrime
+
+variable {k : Type*} [Field k] {N : ℕ}
+
+/-! ### Torus inverse and a `ℤ`-power separation lemma -/
+
+/-- The inverse of a diagonal torus unit is the diagonal unit at the inverse scalar. -/
+theorem diagUnit_inv (k : Type*) [Field k] (N : ℕ) (i : Fin N) (t : kˣ) :
+    (diagUnit k N i t)⁻¹ = diagUnit k N i t⁻¹ := by
+  apply inv_eq_of_mul_eq_one_right
+  apply Units.ext
+  exact (diagUnit k N i t).val_inv
+
+/-- In a characteristic-zero field, distinct integer exponents give distinct power
+functions of some unit: there is `t ∈ kˣ` with `t^a ≠ t^b`. (Witness: `t = 2`.) -/
+theorem exists_unit_zpow_ne (k : Type*) [Field k] [CharZero k] {a b : ℤ} (hab : a ≠ b) :
+    ∃ t : kˣ, ((t ^ a : kˣ) : k) ≠ ((t ^ b : kˣ) : k) := by
+  refine ⟨Units.mk0 (2 : k) (by norm_num), ?_⟩
+  simp only [Units.val_zpow_eq_zpow_val, Units.val_mk0]
+  intro h
+  apply hab
+  have htrans : ∀ n : ℤ, (2 : k) ^ n = algebraMap ℚ k ((2 : ℚ) ^ n) := by
+    intro n; rw [map_zpow₀, map_ofNat]
+  rw [htrans a, htrans b] at h
+  have hQ : (2 : ℚ) ^ a = (2 : ℚ) ^ b := (algebraMap ℚ k).injective h
+  exact zpow_right_injective₀ (by norm_num) (by norm_num) hQ
+
+/-! ### Weight-space dimension from an eigenbasis -/
+
+/-- **Eigenbasis ⟹ weight-space dimension is a basis count.** If `b` is a basis of
+torus weight eigenvectors with weights `wt`, then the integer weight space
+`glWeightSpaceℤ ρ ν` is exactly the span of the eigenvectors of weight `ν`, hence its
+dimension is the number of such eigenvectors. -/
+theorem finrank_glWeightSpaceℤ_of_eigenbasis (k : Type*) [Field k] [CharZero k]
+    (N d : ℕ) {W : Type*} [AddCommGroup W] [Module k W]
+    (σ : Representation k (Matrix.GeneralLinearGroup (Fin N) k) W)
+    (b : Module.Basis (Fin d) k W) (wt : Fin d → Fin N → ℤ)
+    (hb : ∀ (c : Fin d) (i : Fin N) (t : kˣ),
+        σ (diagUnit k N i t) (b c) = ((t ^ wt c i : kˣ) : k) • b c)
+    (ν : Fin N → ℤ) :
+    Module.finrank k (glWeightSpaceℤ k N σ ν)
+      = (Finset.univ.filter (fun c => wt c = ν)).card := by
+  classical
+  have hspan : glWeightSpaceℤ k N σ ν
+      = Submodule.span k (Set.range (fun c : {c : Fin d // wt c = ν} => b c.val)) := by
+    apply le_antisymm
+    · -- `⊆`: any weight-`ν` vector is supported on matching eigenbasis vectors.
+      intro w hw
+      simp only [glWeightSpaceℤ, Submodule.mem_iInf, LinearMap.mem_ker, LinearMap.sub_apply,
+        LinearMap.smul_apply, LinearMap.id_coe, id_eq, sub_eq_zero] at hw
+      set r := b.repr w with hr
+      have hzero : ∀ c, wt c ≠ ν → r c = 0 := by
+        intro c hc
+        obtain ⟨i, hi⟩ : ∃ i, wt c i ≠ ν i := by
+          by_contra h; push_neg at h; exact hc (funext h)
+        obtain ⟨t, ht⟩ := exists_unit_zpow_ne k hi
+        have expand : σ (diagUnit k N i t) w
+            = ∑ dd, (r dd * ((t ^ wt dd i : kˣ) : k)) • b dd := by
+          conv_lhs => rw [show w = ∑ dd, r dd • b dd from (b.sum_repr w).symm]
+          rw [map_sum]
+          refine Finset.sum_congr rfl (fun dd _ => ?_)
+          rw [map_smul, hb dd i t, smul_smul]
+        have e1 : b.repr (σ (diagUnit k N i t) w) c = r c * ((t ^ wt c i : kˣ) : k) := by
+          rw [expand, map_sum, Finsupp.finsetSum_apply]
+          simp only [map_smul, Finsupp.smul_apply, Module.Basis.repr_self, Finsupp.single_apply,
+            smul_eq_mul, mul_ite, mul_one, mul_zero]
+          rw [Finset.sum_ite_eq' Finset.univ c
+            (fun dd => r dd * ((t ^ wt dd i : kˣ) : k))]
+          simp
+        have e2 : b.repr (σ (diagUnit k N i t) w) c = ((t ^ ν i : kˣ) : k) * r c := by
+          rw [hw i t, map_smul, Finsupp.smul_apply, smul_eq_mul]
+        have key : r c * ((t ^ wt c i : kˣ) : k) = ((t ^ ν i : kˣ) : k) * r c := by
+          rw [← e1, e2]
+        have h0 : r c * (((t ^ wt c i : kˣ) : k) - ((t ^ ν i : kˣ) : k)) = 0 := by
+          linear_combination key
+        rcases mul_eq_zero.1 h0 with h | h
+        · exact h
+        · exact absurd (sub_eq_zero.1 h) ht
+      rw [show w = ∑ c, r c • b c from (b.sum_repr w).symm]
+      apply Submodule.sum_mem
+      intro c _
+      by_cases hc : wt c = ν
+      · exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨⟨c, hc⟩, rfl⟩)
+      · rw [hzero c hc, zero_smul]; exact Submodule.zero_mem _
+    · -- `⊇`: each matching eigenbasis vector lies in the weight space.
+      rw [Submodule.span_le]
+      rintro _ ⟨c, rfl⟩
+      simp only [SetLike.mem_coe, glWeightSpaceℤ, Submodule.mem_iInf, LinearMap.mem_ker,
+        LinearMap.sub_apply, LinearMap.smul_apply, LinearMap.id_coe, id_eq, sub_eq_zero]
+      intro i t
+      rw [hb c.val i t, show wt c.val i = ν i from congrFun c.property i]
+  rw [hspan,
+    finrank_span_eq_card
+      (show LinearIndependent k (fun c : {c : Fin d // wt c = ν} => b c.val) from
+        b.linearIndependent.comp Subtype.val Subtype.val_injective),
+    Fintype.card_subtype]
+
+/-! ### The dual basis is a weight eigenbasis with negated weights -/
+
+/-- **The dual basis is a torus weight eigenbasis of the dual representation.** If
+`b` is a basis of torus weight eigenvectors of `σ` with weights `wt`, then each dual
+basis vector `b.dualBasis c` is a weight eigenvector of `Representation.dual σ` with
+weight `-wt c`. -/
+theorem dual_diagUnit_dualBasis (k : Type*) [Field k] (N d : ℕ)
+    {W : Type*} [AddCommGroup W] [Module k W]
+    (σ : Representation k (Matrix.GeneralLinearGroup (Fin N) k) W)
+    (b : Module.Basis (Fin d) k W) (wt : Fin d → Fin N → ℤ)
+    (hb : ∀ (c : Fin d) (i : Fin N) (t : kˣ),
+        σ (diagUnit k N i t) (b c) = ((t ^ wt c i : kˣ) : k) • b c)
+    (c : Fin d) (i : Fin N) (t : kˣ) :
+    (Representation.dual σ) (diagUnit k N i t) (b.dualBasis c)
+      = ((t ^ (- wt c i) : kˣ) : k) • b.dualBasis c := by
+  apply Module.Basis.ext b
+  intro e
+  rw [Representation.dual_apply, Module.Dual.transpose_apply, LinearMap.comp_apply,
+    diagUnit_inv, hb e i t⁻¹, map_smul, LinearMap.smul_apply,
+    Module.Basis.dualBasis_apply_self]
+  by_cases h : e = c
+  · subst h
+    rw [if_pos rfl, smul_eq_mul, smul_eq_mul, mul_one, mul_one]
+    congr 1
+    rw [inv_zpow, zpow_neg]
+  · rw [if_neg h, smul_zero, smul_zero]
+
+/-! ### The dual weight space at `μ` is dual to `ρ`'s weight space at `-μ` -/
+
+/-- **Fact (a), weight-space level.** For a representation with a torus weight
+eigenbasis, the weight-`μ` space of the dual representation has the same dimension as
+`ρ`'s weight-`(-μ)` space: the dual rep negates weights. -/
+theorem finrank_glWeightSpaceℤ_dual_eq (k : Type*) [Field k] [CharZero k]
+    (N d : ℕ) {W : Type*} [AddCommGroup W] [Module k W]
+    (σ : Representation k (Matrix.GeneralLinearGroup (Fin N) k) W)
+    (b : Module.Basis (Fin d) k W) (wt : Fin d → Fin N → ℤ)
+    (hb : ∀ (c : Fin d) (i : Fin N) (t : kˣ),
+        σ (diagUnit k N i t) (b c) = ((t ^ wt c i : kˣ) : k) • b c)
+    (μ : Fin N → ℤ) :
+    Module.finrank k (glWeightSpaceℤ k N (Representation.dual σ) μ)
+      = Module.finrank k (glWeightSpaceℤ k N σ (fun i => - μ i)) := by
+  classical
+  rw [finrank_glWeightSpaceℤ_of_eigenbasis k N d (Representation.dual σ) b.dualBasis
+        (fun c i => - wt c i) (fun c i t => dual_diagUnit_dualBasis k N d σ b wt hb c i t) μ,
+      finrank_glWeightSpaceℤ_of_eigenbasis k N d σ b wt hb (fun i => - μ i)]
+  congr 1
+  ext c
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+  constructor
+  · intro h; funext i; have := congrFun h i; omega
+  · intro h; funext i; have := congrFun h i; omega
+
+/-! ### Bridge to the `ℕ`-weight `formalCharacter` -/
+
+/-- The `ℕ`-weight space of an `FDRep` is the corresponding integer weight space of
+its underlying representation. -/
+theorem glWeightSpace_eq_glWeightSpaceℤ (k : Type*) [Field k] [IsAlgClosed k] (N : ℕ)
+    (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k)) (μ : Fin N → ℕ) :
+    glWeightSpace k N M (fun i => μ i)
+      = glWeightSpaceℤ k N M.ρ (fun i => (μ i : ℤ)) := by
+  simp only [glWeightSpace, glWeightSpaceℤ]
+  refine iInf_congr fun i => iInf_congr fun t => ?_
+  have hs : ((t ^ (μ i : ℤ) : kˣ) : k) = (t : k) ^ μ i := by
+    rw [Units.val_zpow_eq_zpow_val, zpow_natCast]
+  rw [hs]
+
+/-- **Fact (a), `formalCharacter` corollary.** For a polynomial `GL_N`-representation
+`M` (spanning `ℕ`-weight spaces, `h_span`), the coefficient of `x^μ` in the formal
+character of the dual `FDRep.of (dual M.ρ)` is the dimension of `M.ρ`'s integer
+weight space at `-μ`. Since `M.ρ`'s weights are `≥ 0`, this vanishes unless `μ = 0`:
+the `ℕ`-truncated dual character collects exactly `M.ρ`'s non-positive weights, read
+with the sign flipped. -/
+theorem formalCharacter_dual_coeff_eq (k : Type) [Field k] [IsAlgClosed k] [CharZero k]
+    (N : ℕ) (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
+    (h_span : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M (fun i => μ i) = ⊤)
+    (μ : Fin N →₀ ℕ) :
+    (formalCharacter k N (FDRep.of (Representation.dual M.ρ))).coeff μ
+      = (Module.finrank k (glWeightSpaceℤ k N M.ρ (fun i => - (μ i : ℤ))) : ℚ) := by
+  obtain ⟨d, v, wt, hv⟩ := Etingof.DetInvElim.exists_weight_eigenbasis M h_span
+  have hvℤ : ∀ (c : Fin d) (i : Fin N) (t : kˣ),
+      M.ρ (diagUnit k N i t) (v c) = ((t ^ (wt c i : ℤ) : kˣ) : k) • v c := by
+    intro c i t
+    rw [hv c i t, Units.val_zpow_eq_zpow_val, zpow_natCast]
+  have hmain := finrank_glWeightSpaceℤ_dual_eq k N d M.ρ v (fun c i => (wt c i : ℤ)) hvℤ
+    (fun i => (μ i : ℤ))
+  rw [formalCharacter_coeff k N (FDRep.of (Representation.dual M.ρ)) μ,
+    glWeightSpace_eq_glWeightSpaceℤ k N (FDRep.of (Representation.dual M.ρ)) (fun i => μ i),
+    FDRep.of_ρ', hmain]
+
+end Etingof

--- a/progress/2026-06-27T11-33-56Z_2404ae73.md
+++ b/progress/2026-06-27T11-33-56Z_2404ae73.md
@@ -1,0 +1,65 @@
+## Accomplished
+
+Discharged issue #5533 — formalized analytic fact **(a)** behind the contragredient
+identity: the formal character of a *dual* `GL_N`-representation reads `ρ`'s character
+at *inverse* torus weights. New leaf file
+`EtingofRepresentationTheory/Chapter5/FormalCharacterDual.lean`, registered in the
+`Chapter5.lean` aggregator. All deliverables sorry-free and axiom-clean
+(`propext, Classical.choice, Quot.sound`; no `native_decide`).
+
+Reusable lemmas (namespace `Etingof`):
+
+- `dual_diagUnit_dualBasis` (always true) — given a torus weight eigenbasis `b` of a
+  rep `σ` with weights `wt`, the **dual basis** `b.dualBasis` is again a torus weight
+  eigenbasis of `Representation.dual σ`, with weights `-wt`. This is the precise sense
+  in which the diagonal torus acts on the dual by inverse weights.
+- `finrank_glWeightSpaceℤ_of_eigenbasis` (always true) — from a weight eigenbasis,
+  `dim (glWeightSpaceℤ σ ν)` equals the number of basis vectors of weight `ν`
+  (weight space = span of matching eigenvectors; `⊆` by basis-coordinate separation
+  using `exists_unit_zpow_ne`, `⊇` direct).
+- `finrank_glWeightSpaceℤ_dual_eq` (**the reusable core**) — for a rep with a weight
+  eigenbasis, `dim (glWeightSpaceℤ (dual σ) μ) = dim (glWeightSpaceℤ σ (-μ))`. The
+  weight-`μ` space of the dual is dual to `σ`'s weight-`(-μ)` space. Only needs
+  `[Field k] [CharZero k]` (no `IsAlgClosed`).
+- `formalCharacter_dual_coeff_eq` (**consumer-facing form**) — for a polynomial
+  `GL_N`-rep `M` (spanning `ℕ`-weight spaces, `h_span`), the `x^μ`-coefficient of
+  `formalCharacter (FDRep.of (dual M.ρ))` is `dim (glWeightSpaceℤ M.ρ (-μ))`. Since
+  `M.ρ`'s weights are `≥ 0`, this collects exactly `M.ρ`'s non-positive weights read
+  with the sign flipped; in the `ℕ`-truncation only `μ = 0` survives. Built by feeding
+  the eigenbasis from `DetInvElim.exists_weight_eigenbasis M h_span` into the core.
+
+Supporting: `diagUnit_inv` (`(diagUnit i t)⁻¹ = diagUnit i t⁻¹`), `exists_unit_zpow_ne`
+(integer-exponent power separation in char 0), `glWeightSpace_eq_glWeightSpaceℤ`
+(the `ℕ`-weight `glWeightSpace` of an `FDRep` is the integer weight space of its `ρ`).
+
+Design note: polynomiality is a *threaded* hypothesis (the eigenbasis / `h_span`), as
+the skill's counterexample guidance requires — `formalCharacter` is a truncated
+invariant, so the statement lives at the weight-space level. The cleanest correct
+route is the **dual-basis counting** argument (avoids any torus-semisimmplicity
+projector machinery): a weight eigenbasis of `σ` dualizes to one of `dual σ` with
+negated weights, and both weight-space dimensions are read off as basis counts.
+
+## Current frontier
+
+Fact (a) is landed as a reusable building block. It is consumed by the sorried analytic
+core `exists_common_schurModule_model_detTwist_dual` (#5526, in `ContragredientIdentity.lean`),
+which still also needs fact (b) (the inverted-variable Schur identity
+`s_λ(x⁻¹)·(x₁⋯x_n)^s = s_{w₀λ+s}(x)`).
+
+## Overall project progress
+
+Phase 3 formalization. Chapter 5 §5.23 contragredient identity is being assembled from
+bricks. This turn lands fact (a) (dual character = original at inverse weights) as
+`Chapter5/FormalCharacterDual.lean`. The det^s-twisted dual-character computation
+(#5529 sub-issue C) now has its weight-space input.
+
+## Next step
+
+Use `finrank_glWeightSpaceℤ_dual_eq` / `formalCharacter_dual_coeff_eq` together with
+fact (b) (the inverted Schur identity) to compute the `det^s`-twisted dual character as
+a genuine Schur polynomial, discharging part of `exists_common_schurModule_model_detTwist_dual`
+(#5526).
+
+## Blockers
+
+None for this issue.


### PR DESCRIPTION
Closes #5533

Session: `2404ae73-4fb7-439b-9144-d5890654dae7`

f070e367 feat(Ch5 #5533): formal character of a dual GL_n rep reads inverse weights

🤖 Prepared with Claude Code