### PR TITLE
docs(skill): push progress file before create-pr (auto-merge race)

### DIFF
--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -287,6 +287,13 @@ Write a progress entry to `progress/<UTC-timestamp>_<UUID-prefix>.md`:
 - Decisions made, key patterns discovered
 - What remains, quality metric deltas
 
+**Commit AND push the progress file BEFORE `create-pr`.** `create-pr` enables
+auto-merge, which can squash-merge the PR within seconds — before a progress commit
+you push afterwards reaches main, stranding it on the (then-deleted) branch. Order:
+write progress → `git add -A && git commit` → `git push` → `create-pr`. (If you only
+realize after, the handoff still survives in the issue breadcrumb / sub-issue bodies,
+but the per-turn file will be missing from main.)
+
 **Full completion:**
 ```bash
 git push -u origin <branch>


### PR DESCRIPTION
This PR records the auto-merge race in the agent-worker-flow Step 7: `create-pr` enables auto-merge, which can squash-merge within seconds — before a progress-file commit pushed afterwards reaches main, stranding it on the deleted branch. It prescribes the write → commit → push → create-pr ordering. Surfaced while landing the #5535 partial.

🤖 Prepared with Claude Code