### PR TITLE
docs(Ch5 #5544): decompose linear-dual contragredient half into #5552, #5553

### DIFF
--- a/progress/2026-06-27T13-43-02Z_66dfa8b6.md
+++ b/progress/2026-06-27T13-43-02Z_66dfa8b6.md
@@ -1,0 +1,56 @@
+## Accomplished
+
+One-shot dispatch on **#5544** (linear-dual half of the GL_n contragredient identity,
+parent #5535). After deep investigation of the keystone route, found the task is **3-4
+sessions of work** with several missing infrastructure pieces, so **decomposed it** into
+two precise prerequisite sub-issues and narrowed the parent. No code changes this turn —
+the deliverable is an accurate route map.
+
+The full route was worked out (see issue bodies for details):
+
+- `M.ρ = charTwistRep (detChar^s) ((algIrrepGLRepρ n lam k).dual)`. Using
+  `algIrrepGLRepρ = charTwistRep (detChar^{-(lam.shift:ℤ)}) (schurModuleRep lam.toNatWeight)`
+  and the (missing) dual-of-charTwist identity, this collapses to
+  `charTwistRep (detChar^m) (dual (schurModuleRep lam.toNatWeight))` with `m := s + lam.shift`.
+- Coefficient chain: `(formalCharacter M).coeff μ = finrank (glWeightSpaceℤ σ (m·1 - μ))`
+  (det^m twist shifts the integer weight by `m·1`; the dual negates via
+  `finrank_glWeightSpaceℤ_dual_eq`), `= (schurPoly n lam.toNatWeight).coeff (m·1 - μ)` for the
+  Schur module `σ` (via `schurModule_weight_eq_schurPoly_coeff`), under largeness
+  `lam.toNatWeight 0 ≤ m`.
+- Fact (b) `schurPoly_inverseShift` (alternant form) then yields
+  `formalCharacter M = schurPoly n (w0ShiftWeight n lam.toNatWeight m)`.
+
+**Genuine target weight:** `ν_dual = w0ShiftWeight n lam.toNatWeight (s + lam.shift)`, i.e.
+`ν_dual j = (s + lam.shift) - lam.toNatWeight (Fin.rev j)`. Note the extra `lam.shift`
+versus the Schur half's `ν_Schur = lam.w0Twist.toNatWeight + t` (`s = t + lam.w0Twist.shift`)
+— this is exactly the reconciliation crux the issue flagged, and it belongs in #5535.
+
+## Current frontier
+
+#5544 is now `replan`+`blocked` (narrowed to the residual keystone-assembly scope),
+blocked on the two new prerequisites:
+
+- **#5552** — dual-of-charTwist identity (`dual (charTwistRep c ρ) = charTwistRep c⁻¹ (dual ρ)`)
+  + general dual-algebraicity (`IsAlgebraicRepresentation (dual ρ)` via adjugate/Cramer
+  substitution on `GLCoordVars`). Independent, reusable infra.
+- **#5553** — the analytic character identity `formalCharacter M = schurPoly n (w0Shift …)`
+  consuming facts (a) #5533 and (b) #5534. Depends on #5552. The coeff↔alternant bridge in
+  its step 4 is the meatiest part and may need a further split.
+
+## Overall project progress
+
+Stage 3 ongoing (Ch5 §5.23). The contragredient identity `L*_λ ≅ L_λ^∨`
+(`ContragredientIdentity.lean`) is assembled down to the sorried
+`exists_common_schurModule_model_detTwist_dual`. Its Schur-module half landed (#5543);
+its linear-dual half (#5544) is now decomposed into #5552/#5553 with the parent narrowed.
+Facts (a) #5533 and (b) #5534 are already closed and feed #5553.
+
+## Next step
+
+Pick up **#5552** first (unblocked; reusable infra). Then **#5553** (unblocks once #5552
+lands). Then the narrowed **#5544** keystone assembly. Defer the shared-ν reconciliation to
+the **#5535** assembler.
+
+## Blockers
+
+None for the session. #5544 is correctly blocked on #5552/#5553 by design.


### PR DESCRIPTION
This PR records the decomposition of the linear-dual half of the GL_n contragredient identity (#5544) into two precise prerequisite sub-issues — #5552 (dual-of-charTwist identity and dual algebraicity) and #5553 (the det^s-twisted-dual formal-character identity consuming facts (a)/(b)) — after investigation showed the half is genuinely multi-session. It adds only the per-turn progress file; #5544 is narrowed to the residual keystone-assembly scope and blocked on the two prereqs. No Lean changes.

🤖 Prepared with Claude Code