### PR TITLE
feat(Ch5 #5549): reduce peterWeylMap_injective to two blocked Schur-orthogonality sub-lemmas

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_23_2_PeterWeyl.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_23_2_PeterWeyl.lean
@@ -171,25 +171,107 @@ theorem nonempty_equivariantEquiv_of_bijective
     exact peterWeylMap_equivariant n k g h x
   exact ⟨e.symm, he.symm⟩
 
-/-- **Injectivity of the assembled matrix-coefficient map** — distinct-irreducible
-orthogonality (Schur orthogonality across summands). The kernel of `peterWeylMap` is a
-`GL_n × GL_n`-subrepresentation of `⊕_λ L*_λ ⊗ L_λ`; since the `L_λ` are pairwise
-non-isomorphic (`algIrrepGLRep_isSimple` makes each `L_λ` simple, so `L*_λ ⊗ L_λ` is a
-multiplicity-free family of `GL_n × GL_n`-irreducibles via the external tensor), that
-kernel is a sub-sum of the summands, hence trivial once `peterWeylMap` is shown nonzero on
-each summand. Per-summand nontriviality comes from the nondegenerate contragredient pairing
-(`algIrrepDualPairing_nondegenerate`) evaluated through the faithful functions-on-`GL` model
-(`evalGLAway_peterWeylSummandMap`): the matrix coefficients `g ↦ ⟨u, ρ_λ(g) v⟩` of a single
-irreducible `L_λ` are linearly independent.
+/-- **Assembly lemma (pure linear algebra): a direct-sum coproduct is injective when each
+summand map is injective and their ranges are independent.** If `f i : N i →ₗ M` is injective
+for every `i` and the family of ranges `range (f i)` is `iSupIndep`, then the coproduct
+`DirectSum.toModule R ι M f : (⨁ i, N i) →ₗ M` is injective.
 
-This is one of the two genuine Cauchy/Peter-Weyl halves of `peterWeylMap_bijective`. The
-present proof obligation is the cross-summand linear independence; the within-summand and
-across-summand orthogonality currently rest on the simplicity infrastructure
-(`algIrrepGLRep_isSimple`, presently `ℂ`-only and degree-constrained, with the general route
-tracked in `progress/schurModule-isSimple-general-route.md`). Tracked as issue #5549. -/
-theorem peterWeylMap_injective (n : ℕ) (k : Type) [Field k] [IsAlgClosed k] [CharZero k] :
-    Function.Injective (peterWeylMap n k) := by
+Proof: corestrict each `f i` to its range, `f i = (range (f i)).subtype ∘ rangeRestrict (f i)`.
+Then `toModule R ι M f = (lsum (subtype)) ∘ (mapRange rangeRestrict)`. The right factor is
+injective because each `rangeRestrict (f i)` is (injectivity of `f i`); the left factor is
+injective by `iSupIndep.dfinsupp_lsum_injective`. This is the structural skeleton of
+Peter-Weyl injectivity: the two genuinely representation-theoretic facts it consumes are the
+per-summand injectivity and the independence of the ranges. -/
+theorem injective_toModule_of_iSupIndep_range
+    {R : Type*} [Ring R] {ι : Type*} [DecidableEq ι]
+    {N : ι → Type*} [∀ i, AddCommGroup (N i)] [∀ i, Module R (N i)]
+    {M : Type*} [AddCommGroup M] [Module R M]
+    (f : ∀ i, N i →ₗ[R] M) (hf : ∀ i, Function.Injective (f i))
+    (hindep : iSupIndep (fun i => LinearMap.range (f i))) :
+    Function.Injective (DirectSum.toModule R ι M f) := by
+  -- `f i` factors as `subtype ∘ rangeRestrict`.
+  have hfeq : (fun i => ((LinearMap.range (f i)).subtype).comp ((f i).rangeRestrict)) = f := by
+    funext i; exact LinearMap.subtype_comp_codRestrict (f i) _ _
+  -- `toModule f = (lsum subtype) ∘ (mapRange rangeRestrict)` pointwise.
+  have hcomp : ∀ x, DirectSum.toModule R ι M f x
+      = (DFinsupp.lsum ℕ (fun i => (LinearMap.range (f i)).subtype))
+          (DFinsupp.mapRange.linearMap (fun i => (f i).rangeRestrict) x) := by
+    intro x
+    rw [DFinsupp.sum_mapRange_index.linearMap, hfeq]
+    rfl
+  -- Left factor injective: ranges are independent.
+  have h1 : Function.Injective
+      (DFinsupp.lsum ℕ (fun i => (LinearMap.range (f i)).subtype)) :=
+    hindep.dfinsupp_lsum_injective
+  -- Right factor injective: each corestriction is injective.
+  have h2 : Function.Injective
+      (DFinsupp.mapRange.linearMap (fun i => (f i).rangeRestrict)) := by
+    have hcoe : ⇑(DFinsupp.mapRange.linearMap (fun i => (f i).rangeRestrict))
+        = DFinsupp.mapRange (fun i => ⇑((f i).rangeRestrict)) (fun i => map_zero _) := rfl
+    rw [hcoe, DFinsupp.mapRange_injective]
+    refine fun i => LinearMap.ker_eq_bot.mp ?_
+    rw [LinearMap.ker_rangeRestrict]
+    exact LinearMap.ker_eq_bot.mpr (hf i)
+  intro a b hab
+  apply h2
+  apply h1
+  rw [← hcomp, ← hcomp, hab]
+
+/-- **Per-summand injectivity (within-summand Schur orthogonality / Burnside density).**
+The single-irreducible matrix-coefficient map `peterWeylSummandMap n lam k : L*_λ ⊗ L_λ →ₗ R`,
+`u ⊗ v ↦ (g ↦ ⟨u, ρ_λ(g) v⟩)`, is injective: the matrix coefficients of one irreducible are
+linearly independent.
+
+Read through the faithful functions-on-`GL` model `evalGLAway_peterWeylSummandMap`, a nonzero
+`z = ∑ uᵢ ⊗ vᵢ` in the kernel gives a linear functional `T ↦ ∑ ⟨uᵢ, T vᵢ⟩` on `End_k(L_λ)`
+that vanishes on every `ρ_λ(g)`; by Burnside density (the image of the group algebra in
+`End_k(L_λ)` is everything, since `L_λ` is simple and `k` is algebraically closed —
+`Module.Finite.toModuleEnd_moduleEnd_surjective`) the functional vanishes on all of
+`End_k(L_λ)`, and nondegeneracy of the contragredient pairing
+(`algIrrepDualPairing_nondegenerate`) forces `z = 0`.
+
+BLOCKED: the Burnside/nondegeneracy route currently rests on `algIrrepGLRep_isSimple`, which is
+`ℂ`-only and degree-constrained (`∑ lam.toNatWeight ≤ n`); the general-`k`, all-weights
+generalization is tracked in `progress/schurModule-isSimple-general-route.md` (issue #4946). -/
+theorem peterWeylSummandMap_injective (n : ℕ) (k : Type) [Field k] [IsAlgClosed k] [CharZero k]
+    (lam : DominantWeight n) :
+    Function.Injective (peterWeylSummandMap n lam k) := by
   sorry
+
+/-- **Cross-summand independence (distinct-irreducible Schur orthogonality).** The ranges of
+the per-summand maps `peterWeylSummandMap n lam k` (the matrix coefficients of `L_λ` inside `R`)
+form an `iSupIndep` family: matrix coefficients of pairwise non-isomorphic irreducibles are
+linearly independent across distinct weights.
+
+Equivariantly, each range is the `GL_n × GL_n`-isotypic component for the simple external-tensor
+module `L*_λ ⊗ L_λ`; distinct `λ` give non-isomorphic simples (distinguished by formal
+character / highest weight), so the isotypic components are independent. This is the
+across-summand half of Peter-Weyl orthogonality.
+
+BLOCKED: rests on simplicity and non-isomorphism of the `L_λ`, i.e. on `algIrrepGLRep_isSimple`
+(presently `ℂ`-only, `∑ lam.toNatWeight ≤ n`) and the external-tensor simplicity of
+`L*_λ ⊗ L_λ` as a `GL_n × GL_n`-module; general route in
+`progress/schurModule-isSimple-general-route.md` (issue #4946). -/
+theorem peterWeylSummandMap_range_iSupIndep
+    (n : ℕ) (k : Type) [Field k] [IsAlgClosed k] [CharZero k] :
+    iSupIndep (fun lam => LinearMap.range (peterWeylSummandMap n lam k)) := by
+  sorry
+
+/-- **Injectivity of the assembled matrix-coefficient map** — distinct-irreducible
+orthogonality (Schur orthogonality across summands). `peterWeylMap` is the direct-sum coproduct
+`DirectSum.toModule` of the per-summand maps `peterWeylSummandMap`; by the pure-linear-algebra
+assembly `injective_toModule_of_iSupIndep_range` it is injective once each per-summand map is
+injective (`peterWeylSummandMap_injective`, within-summand Burnside density) and the ranges are
+independent (`peterWeylSummandMap_range_iSupIndep`, across-summand orthogonality).
+
+This is one of the two genuine Cauchy/Peter-Weyl halves of `peterWeylMap_bijective`. The two
+representation-theoretic inputs both currently rest on the simplicity infrastructure
+(`algIrrepGLRep_isSimple`, presently `ℂ`-only and degree-constrained, with the general route
+tracked in `progress/schurModule-isSimple-general-route.md`, issue #4946). Tracked as #5549. -/
+theorem peterWeylMap_injective (n : ℕ) (k : Type) [Field k] [IsAlgClosed k] [CharZero k] :
+    Function.Injective (peterWeylMap n k) :=
+  injective_toModule_of_iSupIndep_range _
+    (peterWeylSummandMap_injective n k) (peterWeylSummandMap_range_iSupIndep n k)
 
 /-- **Surjectivity of the assembled matrix-coefficient map** — the Cauchy decomposition of
 `R = k[gᵢⱼ][1/det]`: every regular function on `GL_n` is a finite sum of matrix coefficients.

--- a/progress/2026-06-27T14-13-22Z_2bb83298.md
+++ b/progress/2026-06-27T14-13-22Z_2bb83298.md
@@ -1,0 +1,52 @@
+## Accomplished
+
+One-shot dispatch on **#5549** (`peterWeylMap_injective`, the distinct-irreducible
+matrix-coefficient orthogonality half of `peterWeylMap_bijective`). The full theorem is
+genuinely the Peter-Weyl injectivity and is heavily blocked on general-`k`, all-weights
+simplicity (the `algIrrepGLRep_isSimple` / `algIrrepDualPairing_nondegenerate` infrastructure
+is presently `ℂ`-only and degree-constrained `∑ lam.toNatWeight ≤ n`; prior tracker #4946
+closed as replan, route in `progress/schurModule-isSimple-general-route.md`).
+
+Landed the **top-down structural reduction** (partial), all building green:
+
+- **`injective_toModule_of_iSupIndep_range`** — a new, sorry-free, reusable *pure linear
+  algebra* lemma: `DirectSum.toModule R ι M f` is injective when each `f i` is injective and
+  the ranges `range (f i)` are `iSupIndep`. Proof factors `f i = subtype ∘ rangeRestrict` and
+  composes `iSupIndep.dfinsupp_lsum_injective` with componentwise injectivity of
+  `mapRange.linearMap`. `#print axioms` clean (propext/Classical.choice/Quot.sound only).
+- Restructured **`peterWeylMap_injective`** to be sorry-free *in its own body*: it is now
+  `injective_toModule_of_iSupIndep_range _ peterWeylSummandMap_injective
+  peterWeylSummandMap_range_iSupIndep`.
+- Pushed the two genuinely representation-theoretic obligations into crisp sorried sub-lemmas
+  with precise route docstrings:
+  - **`peterWeylSummandMap_injective`** (within-summand Burnside density) → issue **#5555**
+  - **`peterWeylSummandMap_range_iSupIndep`** (cross-summand Schur orthogonality) → issue **#5556**
+
+## Current frontier
+
+`peterWeylMap_injective`'s assembly is done and verified; the two sorries (#5555, #5556) are the
+remaining content, both blocked on the general-`k`/all-weights simplicity generalization.
+`peterWeylMap_surjective` (#5517 family) is still a separate pre-existing sorry. `lake build
+EtingofRepresentationTheory.Chapter5.Theorem5_23_2_PeterWeyl` green.
+
+## Overall project progress
+
+Stage 3 ongoing (Ch5 §5.23). The genuine `GL_n × GL_n`-equivariant Peter-Weyl capstone
+`Theorem5_23_2_ii_equivariant` is assembled down to `peterWeylMap_bijective = ⟨inj, surj⟩`.
+Injectivity (#5549) is now reduced to two blocked sub-lemmas (#5555/#5556) over a sorry-free
+linear-algebra assembly; surjectivity is the Cauchy-decomposition half (#5517 family).
+
+## Next step
+
+#5555 and #5556 are both gated on general-`k`, all-weights Schur-module simplicity (and, for
+#5556, external-tensor simplicity of `L*_λ ⊗ L_λ` plus the highest-weight distinguishing
+invariant). Either revive the general-`k` simplicity chain from
+`progress/schurModule-isSimple-general-route.md`, or restate the per-summand lemmas with the
+simplicity hypotheses threaded through. The pure assembly (`injective_toModule_of_iSupIndep_range`)
+is reusable as-is.
+
+## Blockers
+
+#5555 and #5556 are blocked on the general-`k`, all-weights simplicity infrastructure
+(currently `ℂ`-only, `∑ lam.toNatWeight ≤ n`). This is the same bottleneck flagged in #5549's
+Context and tracked in `progress/schurModule-isSimple-general-route.md`.


### PR DESCRIPTION
Partial progress on #5549

Session: `2bb83298-8270-42c0-b816-aa8f6560cb69`

7d78b31b feat(Ch5 #5549): reduce peterWeylMap_injective to two blocked Schur-orthogonality sub-lemmas

🤖 Prepared with Claude Code