### PR TITLE
feat(Ch5 #5552): dual algebraicity + dual-of-charTwist identity for GL_n

### DIFF
--- a/EtingofRepresentationTheory/Chapter5.lean
+++ b/EtingofRepresentationTheory/Chapter5.lean
@@ -149,6 +149,7 @@ import EtingofRepresentationTheory.Chapter5.SchurWeylPolynomialIdentity
 -- Section 5.23: Algebraic Representations of GL(V)
 import EtingofRepresentationTheory.Chapter5.Definition5_23_1
 import EtingofRepresentationTheory.Chapter5.GLRepAlgebraic
+import EtingofRepresentationTheory.Chapter5.DualCharTwist
 import EtingofRepresentationTheory.Chapter5.DetTwistAlgebraic
 import EtingofRepresentationTheory.Chapter5.PolynomialWeightSaturation
 import EtingofRepresentationTheory.Chapter5.DetClearing

--- a/EtingofRepresentationTheory/Chapter5/DualCharTwist.lean
+++ b/EtingofRepresentationTheory/Chapter5/DualCharTwist.lean
@@ -1,0 +1,41 @@
+import Mathlib
+import EtingofRepresentationTheory.Chapter5.KernelLemmaKPrime
+
+/-!
+# The dual of a character twist
+
+This file records the reusable representation-theoretic identity relating the linear dual
+`Representation.dual` (Mathlib) to the character twist `charTwistRep`
+(`Chapter5/KernelLemmaKPrime.lean`):
+
+* `dual_charTwistRep` — for a character `c : G →* kˣ` and a representation `ρ`,
+  `Representation.dual (charTwistRep c ρ) = charTwistRep c⁻¹ (Representation.dual ρ)`.
+
+The dual negates the group element (`(dual σ) g = transpose (σ g⁻¹)`), so the twisting
+scalar `c g` of `charTwistRep c ρ` is read at `g⁻¹`, i.e. as `c(g⁻¹) = c⁻¹(g)`. Combined
+with `charTwistRep_charTwistRep` this collapses a stacked `det^s`-twist on a contragredient
+into a single twist by the inverse-power determinant character — the form consumed by the
+linear-dual half of the contragredient identity (#5544).
+-/
+
+noncomputable section
+
+namespace Etingof
+
+open Etingof.KernelLemmaKPrime
+
+variable {k : Type*} [CommRing k] {G V : Type*} [Group G] [AddCommGroup V] [Module k V]
+
+/-- **The dual of a character twist is the dual twisted by the inverse character.** Since the
+dual representation reads the group element at `g⁻¹`
+(`(dual σ) g = transpose (σ g⁻¹)`), the twisting scalar of `charTwistRep c ρ` becomes
+`c(g⁻¹) = c⁻¹(g)`, so `dual (charTwistRep c ρ) = charTwistRep c⁻¹ (dual ρ)`. -/
+theorem dual_charTwistRep (c : G →* kˣ) (ρ : Representation k G V) :
+    Representation.dual (charTwistRep c ρ) = charTwistRep c⁻¹ (Representation.dual ρ) := by
+  ext g f v
+  simp only [Representation.dual_apply, Module.Dual.transpose_apply, LinearMap.comp_apply,
+    charTwistRep_apply, LinearMap.smul_apply, map_smul, smul_eq_mul]
+  congr 1
+  rw [map_inv, MonoidHom.inv_apply]
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter5/GLRepAlgebraic.lean
+++ b/EtingofRepresentationTheory/Chapter5/GLRepAlgebraic.lean
@@ -232,6 +232,111 @@ theorem IsAlgebraicRepresentation.of_linearEquiv {k : Type*} [Field k] {N : ℕ}
   rw [Module.Basis.map_apply, ← hcomm g (b c), hbe (ρ g (b c))]
   exact hP g a c
 
+/-! ### Algebraicity is preserved by the linear dual -/
+
+/-- The point at which `evalAtGL g` evaluates the coordinate ring: the matrix-entry
+variable `Xᵢⱼ ↦ gᵢⱼ` and the extra variable `D ↦ det(g)⁻¹`. -/
+noncomputable def evalAtGLpt {k : Type*} [Field k] {N : ℕ}
+    (g : Matrix.GeneralLinearGroup (Fin N) k) : Etingof.GLCoordVars N → k :=
+  Sum.elim (fun ij : Fin N × Fin N => (g : Matrix (Fin N) (Fin N) k) ij.1 ij.2)
+           (fun _ => ((g : Matrix (Fin N) (Fin N) k).det)⁻¹)
+
+theorem evalAtGL_eq_eval {k : Type*} [Field k] {N : ℕ}
+    (g : Matrix.GeneralLinearGroup (Fin N) k)
+    (p : MvPolynomial (Etingof.GLCoordVars N) k) :
+    Etingof.evalAtGL g p = MvPolynomial.eval (evalAtGLpt g) p := rfl
+
+/-- Evaluation of the extra coordinate variable `D` at `g`: it is `det(g)⁻¹`. -/
+theorem evalAtGL_X_inr {k : Type*} [Field k] {N : ℕ}
+    (g : Matrix.GeneralLinearGroup (Fin N) k) :
+    Etingof.evalAtGL g (MvPolynomial.X (Sum.inr ()))
+      = ((g : Matrix (Fin N) (Fin N) k).det)⁻¹ := by
+  change MvPolynomial.eval _ (MvPolynomial.X (Sum.inr ())) = _
+  rw [MvPolynomial.eval_X]
+  rfl
+
+/-- The adjugate of the generic matrix `(Xᵢⱼ)` evaluates at `g` to the adjugate of `g`:
+`evalAtGL g` is a ring hom carrying `Xᵢⱼ ↦ gᵢⱼ`, and the adjugate commutes with ring homs
+(`RingHom.map_adjugate`). -/
+theorem evalAtGL_adjugate {k : Type*} [Field k] {N : ℕ}
+    (g : Matrix.GeneralLinearGroup (Fin N) k) (a b : Fin N) :
+    Etingof.evalAtGL g
+        ((Matrix.of fun i j : Fin N => MvPolynomial.X (R := k) (Sum.inl (i, j))).adjugate a b)
+      = (g : Matrix (Fin N) (Fin N) k).adjugate a b := by
+  have hmap : (MvPolynomial.eval (evalAtGLpt g)).mapMatrix
+        (Matrix.of fun i j : Fin N => MvPolynomial.X (R := k) (Sum.inl (i, j)))
+      = (g : Matrix (Fin N) (Fin N) k) := by
+    ext a' b'
+    simp only [RingHom.mapMatrix_apply, Matrix.map_apply, Matrix.of_apply]
+    exact evalAtGL_X_inl g a' b'
+  rw [evalAtGL_eq_eval]
+  calc MvPolynomial.eval (evalAtGLpt g)
+          ((Matrix.of fun i j : Fin N => MvPolynomial.X (R := k) (Sum.inl (i, j))).adjugate a b)
+      = ((MvPolynomial.eval (evalAtGLpt g)).mapMatrix
+          ((Matrix.of fun i j : Fin N => MvPolynomial.X (R := k) (Sum.inl (i, j))).adjugate)) a b :=
+        rfl
+    _ = (Matrix.adjugate ((MvPolynomial.eval (evalAtGLpt g)).mapMatrix
+          (Matrix.of fun i j : Fin N => MvPolynomial.X (R := k) (Sum.inl (i, j))))) a b := by
+        rw [RingHom.map_adjugate]
+    _ = (g : Matrix (Fin N) (Fin N) k).adjugate a b := by rw [hmap]
+
+/-- The substitution `σ` on the coordinate ring `k[Xᵢⱼ, D]` that realises evaluation at
+the *inverse* matrix: `Xᵢⱼ ↦ D · adjugate(X)ᵢⱼ` (the `(i,j)` entry of `X⁻¹ = det(X)⁻¹ · adj X`)
+and `D ↦ det(X)` (so `det(g⁻¹)⁻¹ = det g`). -/
+noncomputable def invSubst (k : Type*) [Field k] (N : ℕ) :
+    Etingof.GLCoordVars N → MvPolynomial (Etingof.GLCoordVars N) k :=
+  Sum.elim
+    (fun ij : Fin N × Fin N => MvPolynomial.X (Sum.inr ()) *
+      (Matrix.of fun i j : Fin N => MvPolynomial.X (R := k) (Sum.inl (i, j))).adjugate ij.1 ij.2)
+    (fun _ => detPolyGL k N)
+
+/-- **`invSubst` realises evaluation at the inverse matrix.** For any polynomial `p` in the
+coordinate ring, evaluating `bind₁ invSubst p` at `g` gives the same value as evaluating `p`
+at `g⁻¹`. The entries of `g⁻¹` are `det(g)⁻¹ · adjugate(g)` (a polynomial in the `Xᵢⱼ, D`)
+and `det(g⁻¹)⁻¹ = det g`, so the per-variable substitution matches the inverse evaluation
+point. -/
+theorem evalAtGL_bind₁_invSubst {k : Type*} [Field k] {N : ℕ}
+    (g : Matrix.GeneralLinearGroup (Fin N) k)
+    (p : MvPolynomial (Etingof.GLCoordVars N) k) :
+    Etingof.evalAtGL g (MvPolynomial.bind₁ (invSubst k N) p) = Etingof.evalAtGL g⁻¹ p := by
+  have hvar : (fun i => Etingof.evalAtGL g (invSubst k N i)) = evalAtGLpt g⁻¹ := by
+    funext i
+    cases i with
+    | inl ij =>
+        obtain ⟨a, b⟩ := ij
+        show Etingof.evalAtGL g
+            (MvPolynomial.X (Sum.inr ()) *
+              (Matrix.of fun i j : Fin N => MvPolynomial.X (R := k) (Sum.inl (i, j))).adjugate a b)
+          = ((g⁻¹ : Matrix.GeneralLinearGroup (Fin N) k) : Matrix (Fin N) (Fin N) k) a b
+        rw [evalAtGL_mul, evalAtGL_X_inr, evalAtGL_adjugate,
+          Matrix.GeneralLinearGroup.coe_inv, Matrix.inv_def, Matrix.smul_apply, smul_eq_mul,
+          Ring.inverse_eq_inv]
+    | inr u =>
+        show Etingof.evalAtGL g (detPolyGL k N)
+          = (((g⁻¹ : Matrix.GeneralLinearGroup (Fin N) k) : Matrix (Fin N) (Fin N) k).det)⁻¹
+        rw [evalAtGL_detPolyGL, Matrix.GeneralLinearGroup.val_det_apply,
+          Matrix.GeneralLinearGroup.coe_inv, Matrix.det_nonsing_inv, Ring.inverse_eq_inv, inv_inv]
+  rw [evalAtGL_eq_eval, evalAtGL_eq_eval, ← MvPolynomial.aeval_eq_eval, MvPolynomial.aeval_bind₁,
+    MvPolynomial.aeval_eq_eval]
+  rw [show (fun i => MvPolynomial.aeval (evalAtGLpt g) (invSubst k N i)) = evalAtGLpt g⁻¹ from hvar]
+
+/-- **The linear dual of an algebraic representation is algebraic.** If `ρ` is an algebraic
+`GL_N(k)`-representation on `Y`, the contragredient `Representation.dual ρ` on `Module.Dual k Y`
+is again algebraic. In the dual basis `b.dualBasis`, the `(a,c)`-matrix coefficient of
+`(dual ρ) g` is `b.repr (ρ g⁻¹ (b a)) c`, the `(c,a)`-coefficient of `ρ` read at `g⁻¹`; the
+inverse evaluation is absorbed into the polynomials by the substitution `invSubst`
+(`evalAtGL_bind₁_invSubst`). -/
+theorem IsAlgebraicRepresentation.dual {k : Type*} [Field k] {N : ℕ}
+    {Y : Type*} [AddCommGroup Y] [Module k Y] [Module.Finite k Y]
+    (ρ : Representation k (Matrix.GeneralLinearGroup (Fin N) k) Y)
+    (h : Etingof.IsAlgebraicRepresentation N ρ) :
+    Etingof.IsAlgebraicRepresentation N (Representation.dual ρ) := by
+  obtain ⟨m, b, P, hP⟩ := h
+  refine ⟨m, b.dualBasis, fun a c => MvPolynomial.bind₁ (invSubst k N) (P c a), fun g a c => ?_⟩
+  rw [evalAtGL_bind₁_invSubst, Representation.dual_apply, Module.Dual.transpose_apply,
+    Module.Basis.dualBasis_repr, LinearMap.comp_apply, Module.Basis.dualBasis_apply]
+  exact hP g⁻¹ c a
+
 /-! ### The Schur module is algebraic -/
 
 /-- **The Schur module `L_λ` is algebraic.** `SchurModule k N lam` is the restriction of

--- a/EtingofRepresentationTheory/Chapter5/GLRepAlgebraic.lean
+++ b/EtingofRepresentationTheory/Chapter5/GLRepAlgebraic.lean
@@ -246,12 +246,13 @@ theorem evalAtGL_eq_eval {k : Type*} [Field k] {N : ℕ}
     (p : MvPolynomial (Etingof.GLCoordVars N) k) :
     Etingof.evalAtGL g p = MvPolynomial.eval (evalAtGLpt g) p := rfl
 
-/-- Evaluation of the extra coordinate variable `D` at `g`: it is `det(g)⁻¹`. -/
+/-- Evaluation of the extra coordinate variable `D = X (Sum.inr ())` at `g`: it is
+`det(g)⁻¹`. -/
 theorem evalAtGL_X_inr {k : Type*} [Field k] {N : ℕ}
-    (g : Matrix.GeneralLinearGroup (Fin N) k) :
-    Etingof.evalAtGL g (MvPolynomial.X (Sum.inr ()))
+    (g : Matrix.GeneralLinearGroup (Fin N) k) (u : Unit) :
+    Etingof.evalAtGL g (MvPolynomial.X (Sum.inr u))
       = ((g : Matrix (Fin N) (Fin N) k).det)⁻¹ := by
-  change MvPolynomial.eval _ (MvPolynomial.X (Sum.inr ())) = _
+  change MvPolynomial.eval _ (MvPolynomial.X (Sum.inr u)) = _
   rw [MvPolynomial.eval_X]
   rfl
 

--- a/EtingofRepresentationTheory/Chapter5/PeterWeylMatrixCoeff.lean
+++ b/EtingofRepresentationTheory/Chapter5/PeterWeylMatrixCoeff.lean
@@ -58,15 +58,8 @@ open Etingof.DetLocalization Etingof.LocalizationGLAction Etingof.DetInvElim
 
 /-! ## Two small `evalAtGL` helpers and the `det⁻¹`-twist of an algebraic rep -/
 
-/-- Evaluating the formal inverse variable `D = X (Sum.inr ())` at `g ∈ GL_n`
-gives `det(g)⁻¹`. -/
-theorem evalAtGL_X_inr {k : Type*} [Field k] {N : ℕ}
-    (g : Matrix.GeneralLinearGroup (Fin N) k) (u : Unit) :
-    Etingof.evalAtGL g (MvPolynomial.X (Sum.inr u)) =
-      ((g : Matrix (Fin N) (Fin N) k).det)⁻¹ := by
-  change MvPolynomial.eval _ (MvPolynomial.X (Sum.inr u)) = _
-  rw [MvPolynomial.eval_X]
-  rfl
+-- `evalAtGL_X_inr` (evaluation of the formal inverse variable `D` at `g`) lives upstream
+-- in `GLRepAlgebraic.lean`.
 
 /-- `evalAtGL g` is a ring hom, so it commutes with powers. -/
 theorem evalAtGL_pow {k : Type*} [Field k] {N : ℕ}

--- a/progress/20260627T142129Z_01e7b94b.md
+++ b/progress/20260627T142129Z_01e7b94b.md
@@ -1,0 +1,65 @@
+## Accomplished
+
+One-shot dispatch on **#5552** (Ch5 #5544 prereq: dual & dual-of-charTwist
+representation algebraicity + identities for GL_n). Landed both deliverables
+sorry-free.
+
+**Deliverable 1 — dual-of-charTwist identity** (`Chapter5/DualCharTwist.lean`, new file):
+- `dual_charTwistRep (c : G →* kˣ) (ρ : Representation k G V)` :
+  `Representation.dual (charTwistRep c ρ) = charTwistRep c⁻¹ (Representation.dual ρ)`.
+  Proof: `ext g f v`; `simp` with `dual_apply`/`transpose_apply`/`charTwistRep_apply`
+  reduces both sides to a scalar times `f (ρ g⁻¹ v)`; the scalars `c(g⁻¹)` and `c⁻¹(g)`
+  agree via `map_inv` + `MonoidHom.inv_apply`.
+
+**Deliverable 2 — dual algebraicity** (`Chapter5/GLRepAlgebraic.lean`):
+- `IsAlgebraicRepresentation.dual (ρ : Representation …) (h : IsAlgebraicRepresentation N ρ)`
+  `: IsAlgebraicRepresentation N (Representation.dual ρ)`.
+  In `b.dualBasis`, the `(a,c)` coefficient of `(dual ρ) g` is `b.repr (ρ g⁻¹ (b a)) c`
+  (the `(c,a)` coefficient of `ρ` read at `g⁻¹`), so the coefficient polynomials are
+  `bind₁ invSubst (P c a)`.
+- Supporting infra added to `GLRepAlgebraic.lean`:
+  - `evalAtGLpt` / `evalAtGL_eq_eval` — the evaluation point of `evalAtGL` as a function.
+  - `evalAtGL_X_inr` — `D ↦ det(g)⁻¹`.
+  - `evalAtGL_adjugate` — adjugate of the generic matrix evaluates to `adjugate g`
+    (via `RingHom.map_adjugate`).
+  - `invSubst` — the substitution `Xᵢⱼ ↦ D·adjugate(X)ᵢⱼ`, `D ↦ det(X)` realising
+    evaluation at the inverse matrix.
+  - `evalAtGL_bind₁_invSubst` — `evalAtGL g (bind₁ invSubst p) = evalAtGL g⁻¹ p`,
+    proven by checking the per-variable substitution against `evalAtGLpt g⁻¹`
+    (`Matrix.inv_def`, `det_nonsing_inv`, `Ring.inverse_eq_inv`) then
+    `aeval_bind₁` + `aeval_eq_eval`.
+
+Wired `DualCharTwist` into the `Chapter5.lean` aggregator.
+
+Key gotchas resolved: `rw` does not descend under binders (the inner `aeval` stayed
+unconverted — matched the lambda with `aeval` form in the final `rw [show … from hvar]`);
+dualBasis lemmas live under `Module.Basis`, not `Basis`.
+
+`lake build` green for `GLRepAlgebraic` and `DualCharTwist` (errors=0, no new sorry).
+Full `Chapter5` aggregator build launched.
+
+## Current frontier
+
+Both reusable pieces for the linear-dual half of the contragredient identity are in.
+The downstream consumer (#5544) can now collapse the stacked `det^s ∘ det^{…}` twist on
+`M.ρ` to a single `charTwistRep (detChar^…) (dual (schurModuleRep …))`
+(`dual_charTwistRep` + existing `charTwistRep_charTwistRep`) and obtain algebraicity of
+`charTwistRep (detChar^s) (dual algIrrepGLRepρ)` via `IsAlgebraicRepresentation.dual` +
+`IsAlgebraicRepresentation.detTwist`.
+
+## Overall project progress
+
+Stage 3 ongoing. Contragredient-identity infrastructure: the keystone-free Schur-module
+half (#5543) and the dual reusable infra (#5552, this turn) are in; the keystone-consuming
+linear-dual half (#5544) remains to assemble `exists_common_schurModule_model_detTwist_dual`.
+
+## Next step
+
+Pick up #5544: apply `iso_of_formalCharacter_eq_schurPoly` to the `det^s`-twisted linear
+dual `M`, using `dual_charTwistRep` to normalise the twist and
+`IsAlgebraicRepresentation.dual`/`.detTwist` for the algebraicity hypothesis, plus the
+character facts `formalCharacter_dual_coeff_eq` (#5533) and `schurPoly_inverseShift` (#5534).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5552

Session: `01e7b94b-161f-4573-a6e5-3bc5f32ceee5`

9794f6f2 fix(Ch5 #5552): dedup evalAtGL_X_inr into GLRepAlgebraic (name clash)
7f48764a docs(Ch5 #5552): progress file for dual algebraicity + dual-of-charTwist
e7de13a9 feat(Ch5 #5552): dual-of-charTwist identity + dual algebraicity for GL_n

🤖 Prepared with Claude Code