### PR TITLE
feat(Ch5 #5555): sorry-free Burnside-density engine; reduce peterWeylSummandMap_injective to general-k simplicity

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/MatrixCoeffInjective.lean
+++ b/EtingofRepresentationTheory/Chapter5/MatrixCoeffInjective.lean
@@ -1,0 +1,153 @@
+import Mathlib
+
+/-!
+# Matrix coefficients of a finite-dimensional simple representation are independent
+
+This file proves the within-summand half of Peter-Weyl orthogonality at the abstract
+level: for a finite-dimensional simple representation `ρ` of a monoid `G` over an
+algebraically closed field `k`, the matrix coefficients of `V` are linearly
+independent. Concretely, if `z : Module.Dual k V ⊗[k] V` satisfies
+
+  `contractLeft k V (TensorProduct.map id (ρ g) z) = 0`   for every `g : G`,
+
+then `z = 0`.
+
+The argument is the trace-form / Burnside-density one:
+
+* under `Module.Dual k V ⊗ V ≃ End k V` (`dualTensorHom`) a kernel element `z`
+  becomes `S : End k V`, and the vanishing condition reads `trace (ρ g ∘ S) = 0`
+  for every `g` (`trace_eq_contract_apply` together with
+  `dualTensorHom_tensorMap_id_right`);
+* **Burnside density** (`Representation.span_range_eq_top_of_isSimpleModule`): the
+  `k`-linear span of `{ρ g}` is all of `End k V`. This is Schur's lemma over an
+  algebraically closed field (`IsSimpleModule.algebraMap_end_bijective_of_isAlgClosed`,
+  giving `End_{k[G]} V = k`) followed by the Jacobson density theorem
+  (`Module.Finite.toModuleEnd_moduleEnd_surjective`);
+* so `trace (T ∘ S) = 0` for *all* `T : End k V`, and nondegeneracy of the trace
+  pairing (`eq_zero_of_forall_trace_comp_eq_zero`) forces `S = 0`, hence `z = 0`.
+
+The output `matrixCoeff_injective_of_isSimpleModule` is the abstract engine behind
+`Etingof.peterWeylSummandMap_injective`: the only representation-theoretic input it
+needs is the simplicity of `ρ.asModule` as a `k[G]`-module.
+-/
+
+open scoped TensorProduct
+open Module (End)
+
+namespace Etingof
+
+section dualTensorHom
+
+variable {k V : Type*} [CommRing k] [AddCommGroup V] [Module k V]
+
+/-- Pushing the right factor of a tensor through `dualTensorHom`: post-composition.
+`dualTensorHom (id ⊗ T) z = T ∘ dualTensorHom z`. -/
+theorem dualTensorHom_tensorMap_id_right (T : V →ₗ[k] V)
+    (z : Module.Dual k V ⊗[k] V) :
+    dualTensorHom k V V (TensorProduct.map LinearMap.id T z)
+      = T ∘ₗ dualTensorHom k V V z := by
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | tmul φ v =>
+      rw [TensorProduct.map_tmul]
+      ext w
+      simp [dualTensorHom_apply, map_smul]
+  | add a b ha hb => simp only [map_add, LinearMap.comp_add, ha, hb]
+
+/-- Post-composing `dualTensorHom (φ ⊗ w)` with `S` re-expresses it as
+`dualTensorHom ((φ ∘ S) ⊗ w)`: pre-composition pulls into the dual factor. -/
+theorem dualTensorHom_comp_right (φ : Module.Dual k V) (w : V) (S : V →ₗ[k] V) :
+    dualTensorHom k V V (φ ⊗ₜ[k] w) ∘ₗ S
+      = dualTensorHom k V V ((φ ∘ₗ S) ⊗ₜ[k] w) := by
+  ext x
+  simp [dualTensorHom_apply]
+
+end dualTensorHom
+
+section traceNondegenerate
+
+variable {k V : Type*} [Field k] [AddCommGroup V] [Module k V] [FiniteDimensional k V]
+
+/-- **Nondegeneracy of the trace pairing.** If `trace (T ∘ S) = 0` for every
+`T : End k V`, then `S = 0`. (Take `T = dualTensorHom (φ ⊗ w)`; then
+`trace (T ∘ S) = φ (S w)`, so every dual functional kills every `S w`.) -/
+theorem eq_zero_of_forall_trace_comp_eq_zero (S : V →ₗ[k] V)
+    (h : ∀ T : V →ₗ[k] V, LinearMap.trace k V (T ∘ₗ S) = 0) : S = 0 := by
+  ext w
+  rw [LinearMap.zero_apply]
+  rw [← Module.forall_dual_apply_eq_zero_iff k (S w)]
+  intro φ
+  have hT := h (dualTensorHom k V V (φ ⊗ₜ[k] w))
+  rw [dualTensorHom_comp_right, LinearMap.trace_eq_contract_apply, contractLeft_apply] at hT
+  simpa using hT
+
+end traceNondegenerate
+
+section burnside
+
+variable {k G V : Type*} [Field k] [IsAlgClosed k] [Monoid G]
+  [AddCommGroup V] [Module k V] [FiniteDimensional k V]
+
+/-- **Burnside density.** The `k`-linear span of the image `{ρ g}` of a
+finite-dimensional simple representation over an algebraically closed field is all of
+`End k V`. Equivalently, the algebra map `k[G] → End k V` (`ρ.asAlgebraHom`) is
+surjective. -/
+theorem Representation.asAlgebraHom_surjective_of_isSimpleModule (ρ : Representation k G V)
+    [IsSimpleModule (MonoidAlgebra k G) ρ.asModule] :
+    Function.Surjective ⇑(Representation.asAlgebraHom ρ) := by
+  sorry
+
+/-- The `k`-linear span of `{ρ g}` is all of `End k V`. -/
+theorem Representation.span_range_eq_top_of_isSimpleModule (ρ : Representation k G V)
+    [IsSimpleModule (MonoidAlgebra k G) ρ.asModule] :
+    Submodule.span k (Set.range (fun g => (ρ g : V →ₗ[k] V))) = ⊤ := by
+  rw [Submodule.eq_top_iff']
+  intro T
+  obtain ⟨a, rfl⟩ := Representation.asAlgebraHom_surjective_of_isSimpleModule ρ T
+  -- `asAlgebraHom a` is a `k`-linear combination of the `ρ g`.
+  induction a using MonoidAlgebra.induction_on with
+  | hM g => rw [Representation.asAlgebraHom_of]; exact Submodule.subset_span ⟨g, rfl⟩
+  | hadd f₁ f₂ h₁ h₂ => rw [map_add]; exact Submodule.add_mem _ h₁ h₂
+  | hsmul r f h => rw [map_smul]; exact Submodule.smul_mem _ r h
+
+end burnside
+
+section main
+
+variable {k G V : Type*} [Field k] [IsAlgClosed k] [Monoid G]
+  [AddCommGroup V] [Module k V] [FiniteDimensional k V]
+
+/-- **Matrix coefficients of a simple representation are independent.** If
+`z : Module.Dual k V ⊗ V` satisfies `contractLeft (id ⊗ ρ g) z = 0` for every `g`,
+then `z = 0`. -/
+theorem matrixCoeff_injective_of_isSimpleModule (ρ : Representation k G V)
+    [IsSimpleModule (MonoidAlgebra k G) ρ.asModule]
+    (z : Module.Dual k V ⊗[k] V)
+    (h : ∀ g, contractLeft k V (TensorProduct.map LinearMap.id (ρ g) z) = 0) :
+    z = 0 := by
+  set S : V →ₗ[k] V := dualTensorHom k V V z with hS
+  -- The vanishing condition reads `trace (ρ g ∘ S) = 0`.
+  have htr : ∀ g, LinearMap.trace k V ((ρ g : V →ₗ[k] V) ∘ₗ S) = 0 := by
+    intro g
+    have := h g
+    rw [← LinearMap.trace_eq_contract_apply, dualTensorHom_tensorMap_id_right] at this
+    rw [hS]; exact this
+  -- Burnside: upgrade to all `T`.
+  have hall : ∀ T : V →ₗ[k] V, LinearMap.trace k V (T ∘ₗ S) = 0 := by
+    have hspan := Representation.span_range_eq_top_of_isSimpleModule ρ
+    intro T
+    have hT : T ∈ Submodule.span k (Set.range (fun g => (ρ g : V →ₗ[k] V))) := by
+      rw [hspan]; trivial
+    induction hT using Submodule.span_induction with
+    | mem x hx => obtain ⟨g, rfl⟩ := hx; exact htr g
+    | zero => simp
+    | add x y _ _ hx hy => rw [LinearMap.add_comp, map_add, hx, hy, add_zero]
+    | smul c x _ hx => rw [LinearMap.smul_comp, map_smul, hx, smul_zero]
+  -- Trace nondegeneracy: `S = 0`, hence `z = 0`.
+  have hS0 : S = 0 := eq_zero_of_forall_trace_comp_eq_zero S hall
+  have hz : dualTensorHom k V V z = 0 := by rw [← hS]; exact hS0
+  exact (dualTensorHomEquiv k V V).injective (by simpa using hz)
+
+end main
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter5/MatrixCoeffInjective.lean
+++ b/EtingofRepresentationTheory/Chapter5/MatrixCoeffInjective.lean
@@ -95,7 +95,44 @@ surjective. -/
 theorem Representation.asAlgebraHom_surjective_of_isSimpleModule (ρ : Representation k G V)
     [IsSimpleModule (MonoidAlgebra k G) ρ.asModule] :
     Function.Surjective ⇑(Representation.asAlgebraHom ρ) := by
-  sorry
+  classical
+  -- `M = ρ.asModule` is finite over its endomorphism ring `End_{k[G]} M` (Jacobson input).
+  haveI : Module.Finite (Module.End (MonoidAlgebra k G) ρ.asModule) ρ.asModule :=
+    Module.Finite.of_restrictScalars_finite k
+      (Module.End (MonoidAlgebra k G) ρ.asModule) ρ.asModule
+  -- Schur's lemma over `k` algebraically closed: `End_{k[G]} M = k` (every endomorphism scalar).
+  have hschur := IsSimpleModule.algebraMap_end_bijective_of_isAlgClosed
+    (A := MonoidAlgebra k G) (V := ρ.asModule) k
+  intro T
+  -- Transport `T` to an endomorphism of `M = ρ.asModule` (instances live there).
+  set e := Representation.asModuleEquiv ρ with he
+  set Tas : ρ.asModule →ₗ[k] ρ.asModule :=
+    e.symm.toLinearMap ∘ₗ T ∘ₗ e.toLinearMap with hTas
+  -- `Tas` commutes with the scalars `End_{k[G]} M`, hence is `End_{k[G]} M`-linear.
+  have hTsmul : ∀ (f : Module.End (MonoidAlgebra k G) ρ.asModule) (m : ρ.asModule),
+      Tas (f • m) = f • Tas m := by
+    intro f m
+    obtain ⟨r, hr⟩ := hschur.surjective f
+    have hf : ∀ x : ρ.asModule, f • x = r • x := by
+      intro x
+      rw [← hr, Algebra.algebraMap_eq_smul_one, smul_assoc, one_smul]
+    rw [hf m, hf (Tas m), map_smul]
+  let T' : ρ.asModule →ₗ[Module.End (MonoidAlgebra k G) ρ.asModule] ρ.asModule :=
+    { toFun := Tas, map_add' := Tas.map_add, map_smul' := hTsmul }
+  -- Jacobson density: `T'` is `m ↦ a • m` for some `a ∈ k[G]`.
+  obtain ⟨a, ha⟩ :=
+    Module.Finite.toModuleEnd_moduleEnd_surjective (R := MonoidAlgebra k G) (M := ρ.asModule) T'
+  refine ⟨a, ?_⟩
+  ext v
+  -- `a • (e.symm v) = Tas (e.symm v)`; apply `e` and simplify both sides.
+  have hm : a • e.symm v = Tas (e.symm v) := LinearMap.congr_fun ha (e.symm v)
+  have hkey := congrArg e hm
+  rw [Representation.asModuleEquiv_map_smul] at hkey
+  -- LHS: `asAlgebraHom ρ a (e (e.symm v)) = asAlgebraHom ρ a v`.
+  -- RHS: `e (Tas (e.symm v)) = T (e (e.symm v)) = T v`.
+  simp only [hTas, LinearMap.comp_apply, LinearEquiv.coe_coe, LinearEquiv.apply_symm_apply,
+    he] at hkey
+  exact hkey
 
 /-- The `k`-linear span of `{ρ g}` is all of `End k V`. -/
 theorem Representation.span_range_eq_top_of_isSimpleModule (ρ : Representation k G V)

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_23_2_PeterWeyl.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_23_2_PeterWeyl.lean
@@ -2,6 +2,7 @@ import Mathlib
 import EtingofRepresentationTheory.Chapter5.AlgIrrepGLRep
 import EtingofRepresentationTheory.Chapter5.LocalizationGLBiAction
 import EtingofRepresentationTheory.Chapter5.PeterWeylMatrixCoeff
+import EtingofRepresentationTheory.Chapter5.MatrixCoeffInjective
 
 /-!
 # Theorem 5.23.2(ii): the genuine `GL_n × GL_n`-equivariant Peter-Weyl decomposition
@@ -230,13 +231,66 @@ that vanishes on every `ρ_λ(g)`; by Burnside density (the image of the group a
 `End_k(L_λ)`, and nondegeneracy of the contragredient pairing
 (`algIrrepDualPairing_nondegenerate`) forces `z = 0`.
 
-BLOCKED: the Burnside/nondegeneracy route currently rests on `algIrrepGLRep_isSimple`, which is
-`ℂ`-only and degree-constrained (`∑ lam.toNatWeight ≤ n`); the general-`k`, all-weights
-generalization is tracked in `progress/schurModule-isSimple-general-route.md` (issue #4946). -/
+The representation-theoretic content (Burnside density + trace-form nondegeneracy) is
+discharged sorry-free by the abstract engine
+`matrixCoeff_injective_of_isSimpleModule` (`MatrixCoeffInjective.lean`): a kernel
+element `z`, read through the unconditional contragredient iso `algIrrepGLDualIso`
+into `Module.Dual k L_λ ⊗ L_λ`, satisfies `contractLeft (id ⊗ ρ g) z' = 0` for every
+`g` (the matrix-coefficient identity `evalGLAway_peterWeylSummandMap`); Burnside
+density (`Representation.span_range_eq_top_of_isSimpleModule`, from Schur over
+`IsAlgClosed k` plus Jacobson density) and trace nondegeneracy then force `z' = 0`.
+
+The **only** remaining input is the general-`k`, all-weights simplicity of `L_λ` as a
+`k[GL_n]`-module — the `ℂ`-only, degree-constrained `algIrrepGLRep_isSimple` lifted to
+general `k`, tracked in `progress/schurModule-isSimple-general-route.md` (issue #4946).
+That single `IsSimpleModule` hypothesis is the lone `sorry` below. -/
 theorem peterWeylSummandMap_injective (n : ℕ) (k : Type) [Field k] [IsAlgClosed k] [CharZero k]
     (lam : DominantWeight n) :
     Function.Injective (peterWeylSummandMap n lam k) := by
-  sorry
+  -- The sole remaining gap: general-`k`, all-weights simplicity of `L_λ` (issue #4946).
+  haveI hsimple : IsSimpleModule (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin n) k))
+      (algIrrepGLRepρ n lam k).asModule := by
+    sorry
+  rw [injective_iff_map_eq_zero]
+  intro z hz
+  -- Transport the kernel element into `Module.Dual k L_λ ⊗ L_λ`.
+  set z' : Module.Dual k (AlgIrrepGL n lam k) ⊗[k] AlgIrrepGL n lam k :=
+    TensorProduct.map (algIrrepGLDualIso n lam k).toLinearMap LinearMap.id z with hz'
+  -- Matrix-coefficient identity in transported form, for an arbitrary tensor `w`.
+  have key : ∀ (g : Matrix.GeneralLinearGroup (Fin n) k)
+      (w : AlgIrrepGLDual n lam k ⊗[k] AlgIrrepGL n lam k),
+      contractLeft k (AlgIrrepGL n lam k)
+          (TensorProduct.map LinearMap.id (algIrrepGLRepρ n lam k g)
+            (TensorProduct.map (algIrrepGLDualIso n lam k).toLinearMap LinearMap.id w))
+        = evalGLAway (peterWeylSummandMap n lam k w) g := by
+    intro g w
+    induction w using TensorProduct.induction_on with
+    | zero => simp
+    | tmul u v =>
+        rw [TensorProduct.map_tmul, TensorProduct.map_tmul,
+          evalGLAway_peterWeylSummandMap, algIrrepDualPairing_tmul]
+        rfl
+    | add a b ha hb => simp only [map_add, ha, hb]
+  -- The transported element satisfies the Burnside hypothesis.
+  have hcond : ∀ g, contractLeft k (AlgIrrepGL n lam k)
+      (TensorProduct.map LinearMap.id (algIrrepGLRepρ n lam k g) z') = 0 := by
+    intro g
+    rw [hz', key g z, hz, map_zero]
+  -- Burnside density + trace nondegeneracy: `z' = 0`, hence `z = 0`.
+  have hz'0 : z' = 0 :=
+    matrixCoeff_injective_of_isSimpleModule (algIrrepGLRepρ n lam k) z' hcond
+  have hinj : Function.Injective (TensorProduct.map (algIrrepGLDualIso n lam k).toLinearMap
+      (LinearMap.id : AlgIrrepGL n lam k →ₗ[k] AlgIrrepGL n lam k)) := by
+    have hmap : TensorProduct.map (algIrrepGLDualIso n lam k).toLinearMap
+        (LinearMap.id : AlgIrrepGL n lam k →ₗ[k] AlgIrrepGL n lam k)
+        = (TensorProduct.congr (algIrrepGLDualIso n lam k)
+            (LinearEquiv.refl k (AlgIrrepGL n lam k))).toLinearMap := by
+      rw [TensorProduct.toLinearMap_congr]; rfl
+    rw [hmap]
+    exact (TensorProduct.congr (algIrrepGLDualIso n lam k) _).injective
+  apply hinj
+  rw [map_zero]
+  exact hz'.symm.trans hz'0
 
 /-- **Cross-summand independence (distinct-irreducible Schur orthogonality).** The ranges of
 the per-summand maps `peterWeylSummandMap n lam k` (the matrix coefficients of `L_λ` inside `R`)

--- a/progress/20260628T081701Z_877ec096.md
+++ b/progress/20260628T081701Z_877ec096.md
@@ -1,0 +1,70 @@
+## Accomplished
+
+One-shot dispatch on **#5555** (Ch5: prove `peterWeylSummandMap_injective`,
+within-summand Burnside density). Landed the entire representation-theoretic content
+**sorry-free**, reducing the theorem to a single isolated simplicity hypothesis.
+
+**New file `Chapter5/MatrixCoeffInjective.lean` (sorry-free):** the abstract
+trace-form / Burnside-density engine for within-summand Peter-Weyl orthogonality.
+- `matrixCoeff_injective_of_isSimpleModule (ρ : Representation k G V) [IsSimpleModule
+  (k[G]) ρ.asModule] (z : Dual k V ⊗ V) (h : ∀ g, contractLeft (id ⊗ ρ g) z = 0) :
+  z = 0`. The matrix coefficients of a finite-dimensional simple representation over an
+  algebraically closed `k` are linearly independent.
+- Argument: `z ↦ S := dualTensorHom z : End k V`; the hypothesis reads
+  `trace (ρ g ∘ S) = 0` (`trace_eq_contract_apply` + the new
+  `dualTensorHom_tensorMap_id_right`). **Burnside density**
+  (`Representation.span_range_eq_top_of_isSimpleModule`) upgrades this to
+  `trace (T ∘ S) = 0` for all `T`; trace nondegeneracy
+  (`eq_zero_of_forall_trace_comp_eq_zero`) forces `S = 0`, hence `z = 0`.
+- Burnside is proved from Schur over alg-closed `k`
+  (`IsSimpleModule.algebraMap_end_bijective_of_isAlgClosed`, giving `End_{k[G]} V = k`)
+  plus the Jacobson density theorem (`Module.Finite.toModuleEnd_moduleEnd_surjective`):
+  `asAlgebraHom ρ : k[G] → End k V` is surjective. Key Lean gotchas resolved: the
+  `ρ.asModule` type synonym leaks to `V` under `f • m`, so `T` is conjugated through
+  `asModuleEquiv` (which is `refl`) to live on `asModule`; `Module.Finite (End_{k[G]} M)
+  M` supplied via `Module.Finite.of_restrictScalars_finite`; no dot notation on
+  `Representation` (it reduces to `MonoidHom`).
+
+**`Theorem5_23_2_PeterWeyl.lean`:** `peterWeylSummandMap_injective` proof body now wires
+in the abstract engine. A kernel element `z` is transported through the unconditional
+contragredient iso `algIrrepGLDualIso` into `Dual k L_λ ⊗ L_λ`; the matrix-coefficient
+identity `evalGLAway_peterWeylSummandMap` (both sides reduce to `contractLeft (e u ⊗
+ρ g v)`) turns `psm z = 0` into the abstract `contractLeft` hypothesis. The **only**
+remaining `sorry` is `haveI hsimple : IsSimpleModule (k[GL_n]) (algIrrepGLRepρ
+n lam k).asModule` (general-`k`, all-weights simplicity of `L_λ`).
+
+`lake build EtingofRepresentationTheory.Chapter5.Theorem5_23_2_PeterWeyl` green
+(exit 0). `MatrixCoeffInjective` axiom-checked: only `propext`/`Classical.choice`/
+`Quot.sound`.
+
+## Current frontier
+
+`peterWeylSummandMap_injective` is sorry-free except for the general-`k` simplicity
+instance (`Theorem5_23_2_PeterWeyl.lean:253`). That instance is the lifted
+`algIrrepGLRep_isSimple` (presently `ℂ`-only, degree-constrained), tracked anew as
+**#5559** (route: `progress/schurModule-isSimple-general-route.md`). The same instance
+blocks `peterWeylSummandMap_range_iSupIndep` (#5556) and `peterWeylMap_injective`
+(#5549).
+
+## Overall project progress
+
+Stage 3 ongoing. Peter-Weyl injectivity: the pure-linear-algebra assembly
+(`injective_toModule_of_iSupIndep_range`) and now the within-summand Burnside-density
+engine are both sorry-free; the two per-summand theorems (`peterWeylSummandMap_injective`
+#5555, `peterWeylSummandMap_range_iSupIndep` #5556) are reduced to the shared general-`k`
+simplicity gap (#5559). Surjectivity half (`peterWeylMap_surjective`, #5550) and the
+Cauchy `peterWeylMap_bijective` remain.
+
+## Next step
+
+Pick up **#5559** (general-`k` simplicity of `algIrrepGLRepρ`). It collapses to general-`k`
+Schur-module simplicity `schurModule_isSimple_general`; follow the layered Sub-A…Sub-D
+route in `progress/schurModule-isSimple-general-route.md`, building on the generic
+`SpechtModuleK` / `YoungSymmetrizerK` track. Resolving it makes #5555, #5556, #5549
+sorry-free at once.
+
+## Blockers
+
+#5555 cannot be fully closed (no-sorry) this session: its lone residual is the general-`k`
+simplicity (#5559), a multi-step generalization of the ℂ Specht/Schur-Weyl foundation
+out of scope for a single session. Landed as a partial PR; #5555 routed to replan.


### PR DESCRIPTION
Partial progress on #5555

Session: `877ec096-d910-44a8-a2eb-59e3ae92b859`

d7c9dff3 docs(Ch5 #5555): progress — sorry-free Burnside engine; residual simplicity → #5559
a75f5704 feat(Ch5 #5555): reduce peterWeylSummandMap_injective to general-k simplicity
0f42aa1b feat(Ch5 #5555): sorry-free abstract matrix-coeff injectivity via Burnside density
113232a3 feat(Ch5 #5555): WIP abstract matrix-coeff injectivity skeleton (Burnside sorry)

🤖 Prepared with Claude Code