### PR TITLE
Missing formalization: Chapter2/Remark2.9.3

### DIFF
--- a/EtingofRepresentationTheory/Chapter2.lean
+++ b/EtingofRepresentationTheory/Chapter2.lean
@@ -55,6 +55,7 @@ import EtingofRepresentationTheory.Chapter2.Definition2_9_7
 import EtingofRepresentationTheory.Chapter2.Definition2_9_9
 import EtingofRepresentationTheory.Chapter2.Example2_9_2
 import EtingofRepresentationTheory.Chapter2.Example2_9_2_continued
+import EtingofRepresentationTheory.Chapter2.Remark2_9_3
 import EtingofRepresentationTheory.Chapter2.Example2_9_8
 import EtingofRepresentationTheory.Chapter2.Example2_9_12
 import EtingofRepresentationTheory.Chapter2.Example2_9_13

--- a/EtingofRepresentationTheory/Chapter2/Remark2_9_3.lean
+++ b/EtingofRepresentationTheory/Chapter2/Remark2_9_3.lean
@@ -1,0 +1,51 @@
+import Mathlib.Algebra.Lie.OfAssociative
+import Mathlib.LinearAlgebra.FiniteDimensional.Basic
+import EtingofRepresentationTheory.Chapter2.Definition2_9_1
+
+/-!
+# Remark 2.9.3: Ado's theorem
+
+Etingof states **Ado's theorem**: any finite dimensional Lie algebra is a Lie subalgebra of
+`𝔤𝔩(V)` for a suitable finite dimensional vector space `V`.
+
+Being a Lie subalgebra of `𝔤𝔩(V) = End(V)` means there is an *injective* Lie algebra
+homomorphism `ρ : 𝔤 → End(V)` — a faithful finite-dimensional representation. We record the
+theorem in this form, with `𝔤𝔩(V)` realised as `Module.End k V` carrying its commutator bracket
+(the standard idiom in this development, e.g. the adjoint representation
+`LieAlgebra.ad k L : L →ₗ⁅k⁆ Module.End k L` of Example 2.9.8).
+
+## Scope and proof status
+
+We state Ado's theorem over a field of characteristic zero, the setting in which it was
+originally proved; the extension to fields of positive characteristic is Iwasawa's theorem.
+Etingof states the result without proof, and it is genuinely deep — it is not available in
+Mathlib. We therefore assert the statement faithfully and leave the proof as `sorry`, matching
+the book's own treatment (a remark stating a famous theorem). The mathematical content captured
+here is the existence of a finite-dimensional faithful representation of an arbitrary
+finite-dimensional Lie algebra.
+-/
+
+namespace Etingof
+
+universe u
+
+-- The Lie ring structure on `Module.End k V` (commutator bracket) is a local instance in
+-- Mathlib, just as in Example 2.9.8.
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+variable (k : Type u) [Field k] [CharZero k]
+variable (L : Type u) [LieRing L] [LieAlgebra k L]
+
+/-- **Ado's theorem** (Etingof, Remark 2.9.3): every finite-dimensional Lie algebra `L` over a
+field `k` of characteristic zero embeds into `𝔤𝔩(V) = End(V)` for some finite-dimensional `k`-vector
+space `V`. Equivalently, `L` admits a faithful (injective) finite-dimensional representation
+`ρ : L →ₗ⁅k⁆ End(V)`.
+
+The proof is omitted: Ado's theorem is stated without proof in the book and is not available in
+Mathlib. -/
+theorem ado [FiniteDimensional k L] :
+    ∃ (V : Type u) (_ : AddCommGroup V) (_ : Module k V) (_ : FiniteDimensional k V)
+      (ρ : L →ₗ⁅k⁆ Module.End k V), Function.Injective ρ := by
+  sorry
+
+end Etingof

--- a/progress/20260628T140000Z_6740687f.md
+++ b/progress/20260628T140000Z_6740687f.md
@@ -1,0 +1,52 @@
+## Accomplished
+
+One-shot review dispatch on **#5367** (fidelity-sweep finding, epic #5338): the
+coverage gap for **Chapter2/Remark2.9.3 (Ado's theorem)**.
+
+Re-confirmed the single-judge finding: no Lean declaration for Ado's theorem
+existed anywhere (grep across the whole library found nothing). Genuine coverage
+gap — the book asserts the claim, Lean asserted it nowhere.
+
+Fix: created `EtingofRepresentationTheory/Chapter2/Remark2_9_3.lean` with
+
+```
+theorem Etingof.ado [FiniteDimensional k L] :
+    ∃ (V : Type u) (_ : AddCommGroup V) (_ : Module k V) (_ : FiniteDimensional k V)
+      (ρ : L →ₗ⁅k⁆ Module.End k V), Function.Injective ρ
+```
+
+over a characteristic-zero field `k` and finite-dimensional Lie algebra `L`. This
+faithfully captures the book claim ("any finite dimensional Lie algebra is a Lie
+subalgebra of `𝔤𝔩(V)`"): a Lie subalgebra of `𝔤𝔩(V) = Module.End k V` is exactly
+the image of an injective `LieHom`, i.e. a faithful finite-dimensional
+representation. `𝔤𝔩(V)` is realised as `Module.End k V` with its commutator bracket,
+the established idiom in this development (cf. `LieAlgebra.ad` in Example 2.9.8).
+
+The proof is `sorry`: Ado's theorem is stated without proof in the book and is not
+available in Mathlib (it is genuinely deep). This matches the book's own treatment
+— a remark stating a famous theorem. Statement builds (only the expected `sorry`
+warning).
+
+Registered the file in `EtingofRepresentationTheory/Chapter2.lean` and updated
+`progress/items.json`: `Chapter2/Remark2.9.3` now `status: sorry`,
+`fidelity: verified`, `fidelity_decl: Etingof.ado`.
+
+## Current frontier
+
+#5367 resolved. The coverage gap is closed with a faithful statement; the proof
+remains open (intentionally — Ado is out of scope to prove here).
+
+## Overall project progress
+
+Stage 3 ongoing. Fidelity-sweep gap count drops by one (was 5 `gap` items).
+
+## Next step
+
+Pick up the next open fidelity-sweep / Ch5 issue. If a future effort wants to
+discharge the `sorry`, Ado's theorem would be a substantial standalone
+formalization project (or an upstream-to-Mathlib contribution).
+
+## Blockers
+
+None for #5367. The `Etingof.ado` proof is a deliberate `sorry` (out of scope),
+not a blocker.

--- a/progress/items.json
+++ b/progress/items.json
@@ -906,10 +906,10 @@
   "end_page": "23",
   "start_line": 2,
   "end_line": 3,
-  "status": "sorry_free",
-  "fidelity": "gap",
-  "fidelity_note": "Book states Ado's theorem: any finite-dimensional Lie algebra is a Lie subalgebra of gl(V) for a suitable finite-dimensional V. This is a concrete, formalizable mathematical statement (an existence...",
-  "fidelity_decl": "(none)",
+  "status": "sorry",
+  "fidelity": "verified",
+  "fidelity_note": "Ado's theorem now asserted in Lean as Etingof.ado (Chapter2/Remark2_9_3.lean): for a finite-dimensional Lie algebra L over a characteristic-zero field, there exists a finite-dimensional V and an injective LieHom L →ₗ⁅k⁆ Module.End k V (a faithful finite-dimensional representation). Statement faithful to the book claim. Proof is sorry: the book states Ado's theorem without proof and it is not available in Mathlib.",
+  "fidelity_decl": "Etingof.ado",
   "fidelity_issue": 5367
  },
  {


### PR DESCRIPTION
Closes #5367

Session: `6740687f-c01a-441a-b58a-fadef7db579d`

4dae5c46 feat(Ch2 #5367): assert Ado's theorem statement (Remark 2.9.3)

🤖 Prepared with Claude Code