### PR TITLE
Cauchy step 4: matrix-coefficient correspondence for GL-equivariant L_lam to R

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/PeterWeylMatrixCoeff.lean
+++ b/EtingofRepresentationTheory/Chapter5/PeterWeylMatrixCoeff.lean
@@ -263,4 +263,59 @@ theorem peterWeylSummandMap_equivariant
   -- `g⁻¹ * (y * h)` versus `(g⁻¹ * y) * h`: associativity.
   rw [mul_assoc]
 
+/-! ## Step 4: matrix-coefficient correspondence for equivariant maps `L_λ → R` -/
+
+/-- **Matrix-coefficient correspondence (Step 4 of §5.23(ii)).** Any `GL_n`-equivariant
+`k`-linear map `ι : L_λ → R = A[det⁻¹]` intertwining the Schur-module action
+`algIrrepGLRepρ` with the right-translation representation `localRightRep` realizes each
+`ι v` as a matrix coefficient of the per-summand map: there is a contragredient vector
+`u ∈ L*_λ` with `ι v = peterWeylSummandMap (u ⊗ v)` for every `v`.
+
+Concretely `u = e⁻¹(ε ∘ ι)` where `ε φ = evalGLAway φ 1` is evaluation at the identity
+and `e = algIrrepGLDualIso`. The matrix coefficient of `ι` at `v`,
+`g ↦ ε(localRightRep g (ι v)) = evalGLAway (ι v) g`, equals `⟨u, ρ(g) v⟩` through
+`evalGLAway`, and `evalGLAway`-injectivity (`evalGLAway_injective`, `k` infinite via
+`CharZero`) upgrades the pointwise identity to equality in `R`. -/
+theorem equivariant_eq_peterWeylSummandMap
+    (ι : AlgIrrepGL n lam k →ₗ[k] Localization.Away (detPoly k n))
+    (hι : ∀ (g : Matrix.GeneralLinearGroup (Fin n) k) (v : AlgIrrepGL n lam k),
+      ι (algIrrepGLRepρ n lam k g v) = localRightRep k n g (ι v))
+    (v : AlgIrrepGL n lam k) :
+    ∃ u : AlgIrrepGLDual n lam k,
+      ι v = peterWeylSummandMap n lam k (u ⊗ₜ[k] v) := by
+  -- `ε ∘ ι` as a linear functional `L_λ → k`, `w ↦ evalGLAway (ι w) 1`.
+  let epsIota : AlgIrrepGL n lam k →ₗ[k] k :=
+    { toFun := fun w => evalGLAway (ι w) 1
+      map_add' := fun w w' => by rw [map_add, map_add]; rfl
+      map_smul' := fun c w => by
+        rw [map_smul, RingHom.id_apply, evalGLAway_smul, Pi.smul_apply, smul_eq_mul] }
+  -- Transport this functional back through the contragredient identity to get `u`.
+  refine ⟨(algIrrepGLDualIso n lam k).symm epsIota, ?_⟩
+  -- The chosen `u` pairs against any `w` as `ε(ι w) = evalGLAway (ι w) 1`.
+  have hpair : ∀ w, algIrrepDualPairing n lam k
+      ((algIrrepGLDualIso n lam k).symm epsIota ⊗ₜ[k] w) = evalGLAway (ι w) 1 := by
+    intro w
+    rw [algIrrepDualPairing_tmul, LinearEquiv.apply_symm_apply, contractLeft_apply]
+    rfl
+  -- Compare in the faithful functions-on-`GL` model.
+  apply evalGLAway_injective
+  funext g
+  rw [evalGLAway_peterWeylSummandMap, hpair (algIrrepGLRepρ n lam k g v), hι,
+    evalGLAway_localRightRep, one_mul]
+
+/-- **Image of an equivariant map lands in the per-summand range.** Packaging
+`equivariant_eq_peterWeylSummandMap`: for any `GL_n`-equivariant `ι : L_λ → R`
+intertwining `algIrrepGLRepρ` with right translation `localRightRep`, the image of `ι`
+is contained in `LinearMap.range (peterWeylSummandMap n lam k)`. This is the inclusion
+that, summed over all equivariant copies of `L_λ` inside `R`, drives surjectivity of the
+Peter-Weyl summand map onto the `L_λ`-isotypic part of `R`. -/
+theorem equivariant_range_le_peterWeylSummandMap
+    (ι : AlgIrrepGL n lam k →ₗ[k] Localization.Away (detPoly k n))
+    (hι : ∀ (g : Matrix.GeneralLinearGroup (Fin n) k) (v : AlgIrrepGL n lam k),
+      ι (algIrrepGLRepρ n lam k g v) = localRightRep k n g (ι v)) :
+    LinearMap.range ι ≤ LinearMap.range (peterWeylSummandMap n lam k) := by
+  rintro _ ⟨v, rfl⟩
+  obtain ⟨u, hu⟩ := equivariant_eq_peterWeylSummandMap n lam k ι hι v
+  exact ⟨u ⊗ₜ[k] v, hu.symm⟩
+
 end Etingof

--- a/progress/2026-06-28T12-47-41Z_b4e34424.md
+++ b/progress/2026-06-28T12-47-41Z_b4e34424.md
@@ -1,0 +1,49 @@
+## Accomplished
+
+Issue #5578 (Cauchy step 4: matrix-coefficient correspondence for GL-equivariant
+`L_λ → R`). Added two sorry-free results to
+`Chapter5/PeterWeylMatrixCoeff.lean`:
+
+- `equivariant_eq_peterWeylSummandMap`: for any `GL_n`-equivariant `k`-linear
+  `ι : AlgIrrepGL n λ k → R = Localization.Away (detPoly k n)` intertwining
+  `algIrrepGLRepρ` with the right-translation rep `localRightRep`, there is a
+  contragredient vector `u ∈ AlgIrrepGLDual n λ k` with
+  `ι v = peterWeylSummandMap n λ k (u ⊗ v)` for every `v`.
+- `equivariant_range_le_peterWeylSummandMap`: packaged corollary,
+  `LinearMap.range ι ≤ LinearMap.range (peterWeylSummandMap n λ k)`.
+
+Construction: `u = e⁻¹(ε ∘ ι)` where `ε φ = evalGLAway φ 1` (eval at identity) and
+`e = algIrrepGLDualIso`. The matrix coefficient `evalGLAway (ι v) g` equals
+`⟨u, ρ(g) v⟩` via `evalGLAway_peterWeylSummandMap`, `algIrrepDualPairing_tmul` +
+`contractLeft_apply`, the equivariance hypothesis, and
+`evalGLAway_localRightRep` at eval point `1` (with `one_mul`);
+`evalGLAway_injective` (`k` infinite via `CharZero`) upgrades the pointwise
+identity to equality in `R`.
+
+Both theorems are axiom-clean (`propext, Classical.choice, Quot.sound`; no
+`sorryAx`). `lake build EtingofRepresentationTheory.Chapter5.PeterWeylMatrixCoeff`
+green.
+
+## Current frontier
+
+Step 4 of Etingof §5.23(ii) is complete. The per-summand map
+`peterWeylSummandMap` now has its full API: defining identity
+(`evalGLAway_peterWeylSummandMap`), `GL_n × GL_n`-equivariance
+(`peterWeylSummandMap_equivariant`), and the equivariant-image inclusion
+(this PR).
+
+## Overall project progress
+
+Stage 3 (formalization). Chapter 5 Schur-Weyl / Peter-Weyl cluster toward
+`Theorem5_23_2(ii)` (#5572): steps 1 (`RightTranslationHull`), 3
+(`evalGLAway_localRightRep`), and now 4 (this PR) in place.
+
+## Next step
+
+Assemble surjectivity of `peterWeylSummandMap_iSup_range_eq_top` (#5572) by
+summing `equivariant_range_le_peterWeylSummandMap` over the equivariant copies of
+`L_λ` inside `R` (the finite-dimensional right-translation hulls from step 1).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5578

Session: `b4e34424-6f52-4c1e-bcde-a5cf9fec562e`

1bc5c59f feat(Ch5 #5578): matrix-coefficient correspondence for equivariant L_lam to R

🤖 Prepared with Claude Code