### PR TITLE
Fidelity gap: Chapter7/Example7.1.5

### DIFF
--- a/EtingofRepresentationTheory/Chapter7/Example7_1_5.lean
+++ b/EtingofRepresentationTheory/Chapter7/Example7_1_5.lean
@@ -8,12 +8,20 @@ The category **AbelianGroups** is a full subcategory of the category **Groups**.
 ## Mathlib correspondence
 
 Mathlib has `CommGrpCat` (= abelian groups) and `GrpCat`. The forgetful functor
-from `CommGrpCat` to `GrpCat` realizes the full subcategory relationship.
+`forget₂ CommGrpCat GrpCat` realizes the full subcategory relationship: it is
+fully faithful (`Functor.Full` + `Functor.Faithful`), which is exactly the
+statement that abelian groups form a full subcategory of groups.
 -/
 
 open CategoryTheory
 
-/-- CommGrpCat (abelian groups) is a category. (Etingof Example 7.1.5)
-The forgetful functor to GrpCat is fully faithful, realizing abelian groups
-as a full subcategory of groups. -/
-example : Category CommGrpCat := inferInstance
+/-- The forgetful functor from abelian groups to groups is full. (Etingof Example 7.1.5) -/
+example : (forget₂ CommGrpCat GrpCat).Full := inferInstance
+
+/-- The forgetful functor from abelian groups to groups is faithful. (Etingof Example 7.1.5) -/
+example : (forget₂ CommGrpCat GrpCat).Faithful := inferInstance
+
+/-- AbelianGroups is a full subcategory of Groups: the forgetful functor
+`forget₂ CommGrpCat GrpCat` is fully faithful. (Etingof Example 7.1.5) -/
+noncomputable example : (forget₂ CommGrpCat GrpCat).FullyFaithful :=
+  Functor.FullyFaithful.ofFullyFaithful _

--- a/progress/2026-06-29T00-00-00Z_b8082f14.md
+++ b/progress/2026-06-29T00-00-00Z_b8082f14.md
@@ -1,0 +1,33 @@
+## Accomplished
+
+Resolved fidelity gap #5594 for `Chapter7/Example7.1.5` (AbelianGroups as a
+full subcategory of Groups).
+
+- The old Lean only asserted `Category CommGrpCat` (abelian groups form a
+  category) — strictly weaker than Etingof's claim that AbelianGroups is a
+  **full subcategory** of Groups.
+- Replaced with statements of the actual content: `(forget₂ CommGrpCat GrpCat)`
+  is `Full`, `Faithful`, and `FullyFaithful` (the last via
+  `Functor.FullyFaithful.ofFullyFaithful`). Mathlib supplies the `Full`/
+  `Faithful` instances; fully-faithful forgetful functor = full subcategory.
+- Updated `progress/items.json`: `fidelity: gap` → `verified`, refreshed note,
+  `fidelity_decl`, and `last_updated`.
+
+Builds clean: `lake build EtingofRepresentationTheory.Chapter7.Example7_1_5`.
+
+## Current frontier
+
+Single-issue one-shot dispatch complete.
+
+## Overall project progress
+
+Stage 3+ fidelity adjudication ongoing (epic #5338). One more wave-1 `unsure`
+→ resolved this turn.
+
+## Next step
+
+Continue remaining fidelity-adjudication issues under epic #5338 / parent #5387.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -5301,12 +5301,12 @@
   "start_line": 5,
   "end_line": 6,
   "status": "sorry_free",
-  "fidelity": "gap",
+  "fidelity": "verified",
   "sorry_free": true,
-  "fidelity_note": "Wave-2 adjudication (unsure->gap). Strictly weaker: asserts only that abelian groups form a category, not the book's 'full subcategory of Groups' (forget2 CommGrpCat GrpCat full+faithful). See #5594.",
-  "fidelity_decl": "example : Category CommGrpCat := inferInstance",
+  "fidelity_note": "Resolved #5594: now states the full-subcategory content directly. (forget2 CommGrpCat GrpCat) is Full, Faithful, and FullyFaithful, exactly Etingof's claim that abelian groups form a full subcategory of groups.",
+  "fidelity_decl": "example : (forget₂ CommGrpCat GrpCat).FullyFaithful",
   "fidelity_issue": 5594,
-  "last_updated": "2026-06-28"
+  "last_updated": "2026-06-29"
  },
  {
   "id": "Chapter7/Discussion_after_Example7.1.5",


### PR DESCRIPTION
Closes #5594

Session: `b8082f14-aa4f-4976-9e10-741c5407cb44`

916557f4 fix(Ch7 #5594): state AbelianGroups as full subcategory of Groups

🤖 Prepared with Claude Code