### PR TITLE
doc(Ch5 5.14.3/5.15.1): clarify book's H_m is the power sum, not a typo

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_14_3.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_14_3.lean
@@ -22,11 +22,17 @@ of the partition λ (under the relabeling given by g). This "monochromatic"
 condition is captured exactly by the power sum polynomial p_m = Σᵢ xᵢᵐ,
 where each term xᵢᵐ represents placing an entire m-cycle into row i.
 
-**Note**: An earlier version of this file incorrectly used `MvPolynomial.hsymm`
-(complete homogeneous symmetric polynomials). The hsymm polynomial
-H_m = Σ_{|α|=m} x^α allows distributing m elements across multiple rows,
-but cycles must go to a single row. The power sum p_m = Σᵢ xᵢᵐ correctly
-enforces this constraint.
+**Book notation (important)**: Etingof (p. 116) writes this formula with `H_m(x)`,
+but *defines* `H_m(x) := Σⱼ xⱼᵐ` — the **power sum** (a non-standard use of the letter
+`H`, which conventionally denotes the complete homogeneous symmetric polynomial). So the
+book's `H_m` is exactly our `p_m`; the formalization agrees with the book and there is
+no typo in the book.
+
+**Note**: An earlier version of this file used Mathlib's `MvPolynomial.hsymm` — the
+*complete homogeneous* polynomial `Σ_{|α|=m} x^α`, which is NOT the book's `H_m`. That
+allows distributing m elements across multiple rows, but each cycle must go to a single
+row, so it gives the wrong characters. The power sum `p_m = Σᵢ xᵢᵐ` (= the book's `H_m`)
+correctly enforces this constraint.
 
 ## Mathlib correspondence
 
@@ -56,8 +62,10 @@ in σ (including fixed points as 1-cycles). The power sum polynomial p_m = Σᵢ
 each cycle is assigned to a single row, which is the correct generating function for
 permutation module characters.
 
-**Previous version used hsymm (H_m), which is incorrect**: H_m allows distributing m
-elements across rows, but each cycle must go entirely to one row. -/
+**Previous version used Mathlib's `hsymm` (complete homogeneous), which is incorrect**:
+it allows distributing m elements across rows, but each cycle must go entirely to one
+row. (The book's `H_m`, p. 116, is *defined* as the power sum `Σⱼ xⱼᵐ` = our `p_m`, not
+the complete homogeneous polynomial — so power sums match the book.) -/
 noncomputable def cycleTypePsumProduct (n : ℕ) (σ : Equiv.Perm (Fin n)) :
     MvPolynomial (Fin n) ℂ :=
   (σ.cycleType.map (MvPolynomial.psum (Fin n) ℂ)).prod *

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_15_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_15_1.lean
@@ -13,6 +13,12 @@ The character of the Specht module V_λ evaluated at conjugacy class C_i is:
 where ρ = (n-1, n-2, ..., 1, 0), Δ(x) = ∏_{i<j} (xⱼ - xᵢ) is the
 Vandermonde determinant, and p_m are power sum symmetric polynomials.
 
+The book (Etingof, Theorem 5.15.1) writes this with `H_m(x)`, but `H_m` is *defined*
+on p. 116 as `Σⱼ xⱼᵐ` — the power sum (a non-standard use of `H`, which usually means
+the complete homogeneous symmetric polynomial). So the book's `H_m` is our `p_m`; the
+formalization is faithful to the book. (Reading `H_m` as complete-homogeneous would give
+the wrong characters — e.g. the sign character of S₂ on a transposition.)
+
 ## Formalization approach
 
 The character of the Specht module V_λ is defined as the trace of left

--- a/progress/coverage-audit/fidelity-wave-2.md
+++ b/progress/coverage-audit/fidelity-wave-2.md
@@ -65,7 +65,7 @@ Wave 2 is depth but still single-judge per item (Sonnet) and strict about multi-
 
 
 ## Codex cross-vendor tiebreak — outcomes
-- **5.14.3 / 5.15.1** (H_m vs power-sum): `lean-correct` — power sums are right; the book's H_m would be wrong (S₂ counterexample). Marked verified.
+- **5.14.3 / 5.15.1** (H_m vs power-sum): `lean-correct`, and **no book typo**. The book (Etingof p.116) *defines* `H_m(x) := Σⱼ xⱼᵐ` — the power sum (a non-standard use of the letter `H`) — so the book's `H_m` is exactly the Lean's `p_m`. Power sums are required (reading `H_m` as complete-homogeneous fails the S₂ sign-character check); the Lean is faithful. The earlier "book typo" framing (here and in the Lean docstrings) was wrong and has been corrected. Marked verified.
 - **8.1.8** (projective object: lifting vs Hom-exactness): `faithful` — equivalent in abelian categories. Marked verified.
 - **5.10.1** (Frobenius reciprocity direction): `gap` — Lean proves Ind⊣Res form, book states the other; bridge not formalized. Filed.
 


### PR DESCRIPTION
Etingof p.116 *defines* `H_m(x) := Σⱼ xⱼᵐ` (the power sum — a non-standard use of the letter `H`), so the book's `H_m` is exactly the Lean's `p_m`: the formalization is faithful and there is no book typo. The docstrings of Theorem5_14_3 / Theorem5_15_1 previously called `H_m` 'incorrect' without that context (the actual earlier error was Mathlib's `hsymm` = complete homogeneous, which is *not* the book's `H_m`), and the wave-2 certificate repeated a 'book typo' framing — both corrected.

🤖 Prepared with Claude Code