### PR TITLE
audit: Stage 3.7 wave 4 (cross-vendor verified-bucket probe)

### DIFF
--- a/progress/coverage-audit/fidelity-wave-4.md
+++ b/progress/coverage-audit/fidelity-wave-4.md
@@ -1,0 +1,14 @@
+# Stage 3.7 Fidelity Sweep — Wave 4 (cross-vendor verified-bucket probe, Codex)
+
+Cross-vendor (Codex, OpenAI — no Claude quota) spot-check of 5 headline `verified` theorems to bound residual false-negatives in the verified bucket.
+
+## Results (5 probed)
+- **Faithful (cross-vendor confirmed): 2** — Theorem 4.5.1 (orthogonality), Lemma 7.5.1 (Yoneda).
+- **Real gap caught: 1** — **Theorem 9.2.1(i)**: book says "**unique** indecomposable projective P_i"; Lean omits the uniqueness conjunct. Two prior passes missed it. → issue #5669.
+- **Minor/tightening: 1** — Theorem 6.5.2: combined Gabriel decl only re-exports finiteness; part (b) standalone assumes B(d,d)=2 (discharged elsewhere). Parts a/b/c exist and are faithful. → issue #5670.
+- **False alarm (methodology): 1** — Theorem 5.18.1: flagged only because I pointed Codex at one sub-declaration; the double-centralizer + semisimplicity are in sibling declarations. Stays verified.
+
+## Takeaways
+- The `verified` bucket is broadly sound but **not perfect even for headliners**: a third vendor found 1 genuine dropped-conjunct (uniqueness) + 1 worth tightening, out of 5. A full verified re-audit would likely surface a handful more uniqueness/explicit-conjunct omissions — lower severity than the wave-2 downgrades.
+- **Methodology fix for any verified re-audit:** give the auditor the whole theorem's *declaration family*, not a single sub-declaration, or you get 5.18.1-style false gaps.
+- Cross-vendor (Codex) is cheap (OpenAI billing) and complementary — worth using as the tiebreak/third-opinion layer.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3937,7 +3937,8 @@
     "fidelity": "verified",
     "needs_statement": false,
     "notes": "Part (i) proved via Jacobson density theorem. Parts (ii) and (iii) still sorry.",
-    "sorry_free": true
+    "sorry_free": true,
+    "fidelity_note": "verified; wave-4 Codex false-alarm was a narrow-pointer artifact (double-centralizer/semisimplicity are sibling decls)"
   },
   {
     "id": "Chapter5/Discussion_before_Theorem5.18.2",
@@ -4958,7 +4959,8 @@
     "status": "sorry_free",
     "fidelity": "verified",
     "needs_statement": true,
-    "notes": "Part (a) finiteness sorry-free. Part (b) sorry-free. Part (c) still sorry (needs reflection functors)."
+    "notes": "Part (a) finiteness sorry-free. Part (b) sorry-free. Part (c) still sorry (needs reflection functors).",
+    "fidelity_note": "verified (parts a/b/c distributed); combined decl weak — tightening tracked in #5670"
   },
   {
     "id": "Chapter6/Section6.6_heading",
@@ -6287,9 +6289,11 @@
     "start_line": 17,
     "end_line": 10,
     "status": "sorry_free",
-    "fidelity": "verified",
+    "fidelity": "gap",
     "needs_statement": false,
-    "notes": "All sorries proved. PR #1692 proved hσ_surj (last sorry)."
+    "notes": "All sorries proved. PR #1692 proved hσ_surj (last sorry).",
+    "fidelity_issue": 5669,
+    "fidelity_note": "[fidelity] wave-4 Codex: book says \"unique\" P_i; Lean omits uniqueness conjunct"
   },
   {
     "id": "Chapter9/Definition9.2.2",


### PR DESCRIPTION
Codex cross-vendor spot-check of 5 headline `verified` theorems (no Claude quota): 2 confirmed faithful (4.5.1, 7.5.1), 1 real dropped-conjunct caught (Thm 9.2.1 omits the book's 'unique' P_i — issue filed), 1 tightening (Thm 6.5.2 combined decl only re-exports finiteness), 1 false alarm from a narrow declaration pointer (Thm 5.18.1, stays verified). The verified bucket is broadly sound but not perfect for headliners; certificate records the methodology fix (audit whole declaration families).

🤖 Prepared with Claude Code