### PR TITLE
fix(Ch2 Def2.2.1/2.2.2): faithful non-unital associative algebra + genuine unit

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Definition2_2_1.lean
+++ b/EtingofRepresentationTheory/Chapter2/Definition2_2_1.lean
@@ -3,16 +3,50 @@ import Mathlib.Algebra.Algebra.Basic
 /-!
 # Definition 2.2.1: Associative Algebra
 
-An **associative algebra** over k is a vector space A over k together with a bilinear map
-A × A → A, (a, b) ↦ ab, such that (ab)c = a(bc).
+An **associative algebra** over `k` is a vector space `A` over `k` together with a bilinear map
+`A × A → A`, `(a, b) ↦ ab`, such that `(ab)c = a(bc)`.
 
-## Mathlib correspondence
+## Faithfulness note
 
-This is exactly `Algebra k A` with `Ring A`. Mathlib algebras are associative and unital
-by default.
+The book's Definition 2.2.1 is **non-unital**: it asks only for a `k`-vector space with an
+associative bilinear multiplication. The multiplicative unit is *not* part of this definition —
+it is introduced separately in Definition 2.2.2. We therefore encode the definition directly as a
+mixin class carrying the bilinear associative multiplication on a `k`-vector space, rather than
+aliasing Mathlib's `Algebra k A` (which is unital, i.e. strictly stronger than the book asks).
+
+Every unital algebra is in particular such an algebra: the instance
+`Algebra k A → Etingof.AssociativeAlgebra k A` below witnesses that `Algebra k A` is a special
+case, so all unital examples still fit.
 -/
 
-/-- An associative algebra over a field k, in the sense of Etingof Definition 2.2.1.
-This is `Algebra k A` in Mathlib. -/
-abbrev Etingof.AssociativeAlgebra (k : Type*) (A : Type*) [Field k] [Ring A] :=
-  Algebra k A
+/-- **Definition 2.2.1** (Etingof). A (non-unital) associative algebra over a field `k` is a
+`k`-vector space `A` equipped with a bilinear multiplication `A × A → A`, `(a, b) ↦ mul a b`,
+that is associative. The unit is deliberately omitted (see Definition 2.2.2). -/
+class Etingof.AssociativeAlgebra (k A : Type*) [Field k] [AddCommGroup A] [Module k A] where
+  /-- The multiplication `A × A → A`, `(a, b) ↦ ab`. -/
+  mul : A → A → A
+  /-- Associativity: `(ab)c = a(bc)`. -/
+  mul_assoc' : ∀ a b c : A, mul (mul a b) c = mul a (mul b c)
+  /-- Additivity in the left argument (one half of bilinearity). -/
+  add_mul' : ∀ a b c : A, mul (a + b) c = mul a c + mul b c
+  /-- Additivity in the right argument (other half of bilinearity). -/
+  mul_add' : ∀ a b c : A, mul a (b + c) = mul a b + mul a c
+  /-- Scalar compatibility on the left: `(r • a)b = r • (ab)`. -/
+  smul_mul' : ∀ (r : k) (a b : A), mul (r • a) b = r • mul a b
+  /-- Scalar compatibility on the right: `a(r • b) = r • (ab)`. -/
+  mul_smul' : ∀ (r : k) (a b : A), mul a (r • b) = r • mul a b
+
+namespace Etingof.AssociativeAlgebra
+
+/-- Every unital `k`-algebra (in the Mathlib sense) is in particular an associative algebra in the
+sense of Definition 2.2.1: take the ring multiplication, which is associative and bilinear. This
+shows the book's (non-unital) notion is a faithful generalization of Mathlib's unital one. -/
+instance (k A : Type*) [Field k] [Ring A] [Algebra k A] : Etingof.AssociativeAlgebra k A where
+  mul := (· * ·)
+  mul_assoc' := mul_assoc
+  add_mul' := add_mul
+  mul_add' := mul_add
+  smul_mul' r a b := smul_mul_assoc r a b
+  mul_smul' r a b := mul_smul_comm r a b
+
+end Etingof.AssociativeAlgebra

--- a/EtingofRepresentationTheory/Chapter2/Definition2_2_2.lean
+++ b/EtingofRepresentationTheory/Chapter2/Definition2_2_2.lean
@@ -1,24 +1,38 @@
-import Mathlib.Algebra.Algebra.Basic
+import EtingofRepresentationTheory.Chapter2.Definition2_2_1
 
 /-!
 # Definition 2.2.2: Unit in an Associative Algebra
 
-A **unit** in an associative algebra A is an element 1 ∈ A such that 1a = a1 = a.
+A **unit** in an associative algebra `A` is an element `e ∈ A` such that `ea = ae = a` for all `a`.
 
-## Mathlib correspondence
+## Faithfulness note
 
-Mathlib algebras are unital by default — `Ring A` includes `One A` and the unit laws.
-The unit element is `(1 : A)`, and its defining property is captured by the two-sided
-identity laws `one_mul` and `mul_one`.
+Definition 2.2.1 is non-unital (see `Definition2_2_1.lean`), so a unit is genuinely *extra*
+structure introduced here. We define it as the predicate "`e` is a two-sided identity for the
+multiplication of `A`", and record that such a unit is unique when it exists — so this is a real
+defining property, not a fact that holds automatically for any ring.
+
+(The base field `k` is an explicit argument because, for a non-unital algebra mixin, the carrier
+`A` does not determine `k`.)
 -/
 
-namespace EtingofRepresentationTheory.Chapter2
+namespace Etingof.AssociativeAlgebra
 
-/-- **Definition 2.2.2.** The element `(1 : A)` is a *unit* in the associative algebra `A`:
-it satisfies the two-sided identity property `1 * a = a` and `a * 1 = a` for every `a ∈ A`.
-This is the defining content of Etingof Definition 2.2.2; in Mathlib it is provided by
-`Ring A` (more precisely by `MulOneClass A`) through `one_mul` and `mul_one`. -/
-theorem one_isUnit (A : Type*) [Ring A] (a : A) : 1 * a = a ∧ a * 1 = a :=
-  ⟨one_mul a, mul_one a⟩
+variable (k : Type*) {A : Type*} [Field k] [AddCommGroup A] [Module k A]
+  [inst : AssociativeAlgebra k A]
 
-end EtingofRepresentationTheory.Chapter2
+/-- **Definition 2.2.2** (Etingof). An element `e : A` is a *unit* (two-sided identity) of the
+associative algebra `A` over `k` when `e * a = a` and `a * e = a` for every `a : A`, where `*` is
+the multiplication of Definition 2.2.1. Unlike a bare `Ring`, an algebra in the sense of
+Definition 2.2.1 need not have such an element. -/
+def IsUnit (e : A) : Prop :=
+  ∀ a : A, inst.mul e a = a ∧ inst.mul a e = a
+
+/-- A unit, if it exists, is unique: if `e` and `e'` are both two-sided identities then
+`e = e * e' = e'`. This is the content that makes "unit" a genuine defining property. -/
+theorem isUnit_unique {e e' : A} (he : IsUnit k e) (he' : IsUnit k e') : e = e' := by
+  have h1 := (he' e).2   -- `e * e' = e`
+  have h2 := (he e').1   -- `e * e' = e'`
+  exact h1.symm.trans h2
+
+end Etingof.AssociativeAlgebra


### PR DESCRIPTION
fix(Ch2 Def2.2.1/2.2.2): faithful non-unital associative algebra + genuine unit

Wave-2 fidelity audit. Etingof Definition 2.2.1 defines a NON-UNITAL associative
algebra (a k-vector space with an associative bilinear multiplication); the unit is
deferred to Definition 2.2.2. The previous Lean aliased Algebra k A over [Ring A],
silently adding a unit not in the book. Replace with a mixin class
Etingof.AssociativeAlgebra carrying the bilinear associative multiplication directly,
with an instance Algebra k A -> AssociativeAlgebra k A so unital algebras remain a
special case (the non-unital notion is a faithful generalization).

Definition 2.2.2 previously stated the vacuous theorem one_isUnit (1*a = a and a*1 = a,
true for any Ring, defining nothing). Replace with a genuine predicate IsUnit (two-sided
identity for the Def 2.2.1 multiplication) plus a uniqueness theorem, so it is a real
defining property. k is explicit since a non-unital mixin carrier does not determine the
base field. No downstream uses; both modules build clean, no sorry/native_decide.

Closes #5616, #5617.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
