### PR TITLE
fix(Ch5 Def5.7.1): restrict virtual representation support to irreducibles

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Definition5_7_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Definition5_7_1.lean
@@ -16,8 +16,13 @@ R(G) would be constructed as the Grothendieck group of the semiring of isomorphi
 classes of finite-dimensional representations.
 -/
 
-/-- A virtual representation is a formal integer linear combination of irreducible
-representations. We model it as a function from irreducible indices to ℤ.
+open CategoryTheory in
+/-- A virtual representation is a formal integer linear combination of **irreducible**
+representations `V = Σ nᵢ Vᵢ`, `nᵢ ∈ ℤ`. We model it as an integer-valued coefficient
+function on objects of `FDRep ℂ G`, subject to two conditions: the support is finite,
+and every representation carrying a nonzero coefficient is irreducible (a `Simple`
+object of the category). The latter condition is what makes this a combination of
+irreducibles rather than of arbitrary representations.
 (Etingof Definition 5.7.1) -/
 structure Etingof.VirtualRepresentation
     (G : Type) [Group G] [Fintype G] where
@@ -25,6 +30,10 @@ structure Etingof.VirtualRepresentation
   coeffs : FDRep ℂ G → ℤ
   /-- Only finitely many coefficients are nonzero. -/
   finite_support : Set.Finite { V | coeffs V ≠ 0 }
+  /-- Coefficients are supported on irreducible representations: any `V` with a nonzero
+  coefficient is a simple (irreducible) object. This restricts the combination to one of
+  irreducibles, as required by the book. -/
+  support_simple : ∀ V, coeffs V ≠ 0 → Simple V
 
 namespace Etingof.VirtualRepresentation
 
@@ -40,8 +49,9 @@ noncomputable def character (V : VirtualRepresentation G) (g : G) : ℂ :=
 /-- The character of the zero virtual representation (all coefficients zero) is zero. -/
 @[simp]
 theorem character_zero (g : G)
-    (h : Set.Finite { V : FDRep ℂ G | (0 : FDRep ℂ G → ℤ) V ≠ 0 }) :
-    character ⟨0, h⟩ g = 0 := by
+    (h : Set.Finite { V : FDRep ℂ G | (0 : FDRep ℂ G → ℤ) V ≠ 0 })
+    (hs : ∀ V, (0 : FDRep ℂ G → ℤ) V ≠ 0 → CategoryTheory.Simple V) :
+    character ⟨0, h, hs⟩ g = 0 := by
   simp [character]
 
 end Etingof.VirtualRepresentation

--- a/progress/2026-06-29T04-19-10Z_80809a6c.md
+++ b/progress/2026-06-29T04-19-10Z_80809a6c.md
@@ -1,0 +1,21 @@
+## Accomplished
+Closed the fidelity gap for `Chapter5/Definition5.7.1` (`Etingof.VirtualRepresentation`,
+issue #5382). The structure previously let `coeffs : FDRep ℂ G → ℤ` range over **all**
+representations, whereas the book defines a virtual representation as an integer linear
+combination of **irreducible** ones. Added a `support_simple` field requiring every
+representation carrying a nonzero coefficient to be a `CategoryTheory.Simple` (irreducible)
+object. Updated `character_zero` to supply the new field (vacuously true for the zero
+combination) and set `fidelity: verified` in `progress/items.json`.
+
+## Current frontier
+File builds clean (`lake build EtingofRepresentationTheory.Chapter5.Definition5_7_1`).
+No other Lean file references `VirtualRepresentation`, so no downstream breakage.
+
+## Overall project progress
+Stage 3 fidelity sweep follow-ups. One more wave-1/wave-3 fidelity gap resolved.
+
+## Next step
+Continue with remaining fidelity-gap issues from epic #5338.
+
+## Blockers
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3645,9 +3645,9 @@
     "start_line": 9,
     "end_line": 10,
     "status": "sorry_free",
-    "fidelity": "gap",
+    "fidelity": "verified",
     "sorry_free": true,
-    "fidelity_note": "[fidelity] The 'coeffs' field has type 'FDRep ℂ G → ℤ', a function on ALL FDReps, not restricted to irreducible (simple) ones. The book defines a virtual representation as an 'integer linear combinati",
+    "fidelity_note": "[fidelity] Resolved (#5382): added the 'support_simple' field requiring every representation with a nonzero coefficient to be a Simple (irreducible) object, so the structure now models an integer combination of irreducibles as the book demands. The virtual character is defined in 'character'.",
     "fidelity_decl": "Etingof.VirtualRepresentation",
     "fidelity_issue": 5382
   },


### PR DESCRIPTION
Closes #5382

Session: `80809a6c-386d-4300-899c-7af2586dc08c`

5c848eba fix(Ch5 Def5.7.1): restrict virtual representation support to irreducibles (#5382)

🤖 Prepared with Claude Code