### PR TITLE
fix(Ch8 Def8.1.2): projective module over a general ring, not CommRing

### DIFF
--- a/EtingofRepresentationTheory/Chapter8/Definition8_1_2.lean
+++ b/EtingofRepresentationTheory/Chapter8/Definition8_1_2.lean
@@ -10,10 +10,15 @@ A module satisfying any of the conditions (i)–(iv) of Theorem 8.1.1 is said to
 
 This is exactly `Module.Projective R M` in Mathlib, which asserts that M is a projective
 R-module via the lifting property.
+
+The book works over a general (possibly non-commutative) ring/algebra, so we require only
+`[Ring R]` — matching Theorem 8.1.1's `[Ring R]` setting and the book's module theory over an
+arbitrary algebra `A`. (Narrowing to `CommRing` would silently exclude the non-commutative rings
+that are central to the chapter; `Module.Projective` itself needs only a semiring.)
 -/
 
 /-- A projective module, in the sense of Etingof Definition 8.1.2.
-This is `Module.Projective R M` in Mathlib. -/
-abbrev Etingof.ProjectiveModule (R : Type*) (M : Type*) [CommRing R] [AddCommGroup M]
+This is `Module.Projective R M` in Mathlib, over a general ring `R`. -/
+abbrev Etingof.ProjectiveModule (R : Type*) (M : Type*) [Ring R] [AddCommGroup M]
     [Module R M] :=
   Module.Projective R M


### PR DESCRIPTION
fix(Ch8 Def8.1.2): projective module over a general ring, not CommRing

Wave-2 fidelity audit (#5627). Etingof Definition 8.1.2 / Theorem 8.1.1 work over a
general (possibly non-commutative) ring/algebra A. The Lean abbrev Etingof.ProjectiveModule
required [CommRing R], silently excluding the non-commutative rings central to the chapter's
module theory; Mathlib's Module.Projective itself needs only a semiring. Relax [CommRing R]
to [Ring R], matching Theorem 8.1.1's setting. No downstream uses; builds clean.

Closes #5627.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
