### PR TITLE
doc(skill): commit Lean changes when the targeted build passes, not after a full build

### DIFF
--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -256,6 +256,14 @@ Pushed-but-not-PR'd work is effectively lost — nobody will find it.
 - If 20+ minutes have passed without a commit, stop and commit now.
 - Use `coordination create-pr N --partial` as soon as you have useful
   progress, even if incomplete. This saves the work as a visible PR.
+- **Lean: commit + create-pr the moment the targeted `lake build <module>`
+  passes — do NOT hold the commit waiting on a full-library build.** The
+  whole-project build is CI's job, and a one-shot session frequently ends
+  (time or quota) while a background full build is still running, losing
+  100% of the work even though the real change already compiled. If you
+  want extra assurance, push the PR first (CI runs the full build) and
+  only then start any local full build. Never let an uncommitted change
+  sit behind a `lake build` that compiles all of Mathlib.
 
 **Failure handling:**
 - Build fails on pre-existing issue → log and work around


### PR DESCRIPTION
This PR adds a Lean-specific commit-timing rule to the agent-worker-flow skill: commit and create-pr as soon as the targeted `lake build <module>` passes, rather than holding the commit until a background full-library build finishes. A one-shot agent on #5625 produced the correct fix and passed the targeted build, then exited while the full-library build was still running — losing 100% of the work, which pod then logged as a failed 'skip'. The whole-project build is CI's job.

🤖 Prepared with Claude Code