### PR TITLE
This PR closes the fidelity gap in `Chapter9/Definition9.2.2` (#5664) by adding the missing essential-epimorphism (minimality) condition to the `Etingof.ProjectiveCover` structure.

The structure previously bundled a projective, indecomposable module `P` with a bare surjection `π : P ↠ M`. As flagged, any projective surjecting onto `M` would then qualify, dropping the defining minimality of a projective cover. We add a `surjection_essential` field requiring `ker π` to be a superfluous (small) submodule:

  `∀ N : Submodule R P, N ⊔ LinearMap.ker surjection = ⊤ → N = ⊤`

This is the standard characterization of an essential epimorphism (equivalently `ker π ⊆ Rad P` in the finite-dimensional setting, recovering the `dim Hom(Pᵢ, Mⱼ) = δᵢⱼ` description of Theorem 9.2.1). The module and structure docstrings are updated to explain the condition. No downstream construction sites exist, so nothing breaks; `Theorem9_2_1.lean` still builds.

🤖 Prepared with Claude Code

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/Definition9_2_2.lean
+++ b/EtingofRepresentationTheory/Chapter9/Definition9_2_2.lean
@@ -16,13 +16,26 @@ Projective covers are not yet formalized in Mathlib. The concept would bundle a 
 module P together with a surjection P ↠ M that is essential (minimal).
 
 Indecomposability uses `Etingof.IsIndecomposable` from Definition 2.3.8.
+
+## The essential (minimal) condition
+
+A bare projective surjection `P ↠ M` is *not* a projective cover: any projective module
+surjecting onto `M` would qualify, so the notion would not be minimal. The defining feature of
+the projective cover `Pᵢ ↠ Mᵢ` of Theorem 9.2.1 is that the surjection is *essential*, i.e. its
+kernel is a *superfluous* (small) submodule of `P`: no proper submodule of `P` already surjects
+onto `M`. We encode this as
+
+  `∀ N, N ⊔ ker π = ⊤ → N = ⊤`,
+
+which is the standard characterization of an essential epimorphism (equivalently, `ker π ⊆ Rad P`
+for finite-dimensional modules, recovering the `dim Hom(Pᵢ, Mⱼ) = δᵢⱼ` description).
 -/
 
 /-- The projective cover of a module M, in the sense of Etingof Definition 9.2.2.
 
 A projective cover consists of:
 - A module `P` that is projective and indecomposable
-- A surjective `R`-linear map `π : P →ₗ[R] M`
+- a surjective `R`-linear map `π : P →ₗ[R] M` whose kernel is superfluous (essential epimorphism)
 
 This bundles the data of the projective cover together with the surjection.
 Uniqueness (up to isomorphism) is a separate theorem (part of Theorem 9.2.1). -/
@@ -37,6 +50,11 @@ structure Etingof.ProjectiveCover (R : Type*) [Ring R]
   /-- The surjection from the projective cover onto the module -/
   surjection : P →ₗ[R] M
   surjection_surjective : Function.Surjective surjection
+  /-- The surjection is *essential*: its kernel is a superfluous (small) submodule of `P`, i.e.
+  no proper submodule of `P` surjects onto `M`. This is the minimality condition distinguishing a
+  projective cover from an arbitrary projective surjecting onto `M`. -/
+  surjection_essential :
+    ∀ N : Submodule R P, N ⊔ LinearMap.ker surjection = ⊤ → N = ⊤
 
 attribute [instance] Etingof.ProjectiveCover.addCommGroup
   Etingof.ProjectiveCover.module

--- a/progress/20260630T000000Z_fe6e4d1a.md
+++ b/progress/20260630T000000Z_fe6e4d1a.md
@@ -1,0 +1,25 @@
+## Accomplished
+Closed the fidelity gap in `Chapter9/Definition9.2.2` (issue #5664). The
+`Etingof.ProjectiveCover` structure previously bundled projective +
+indecomposable + a bare surjection, but dropped the essential-epimorphism
+(minimality) condition. Added the field
+
+  `surjection_essential : ∀ N : Submodule R P, N ⊔ LinearMap.ker surjection = ⊤ → N = ⊤`
+
+encoding that `ker π` is a superfluous (small) submodule, the standard
+characterization of an essential epimorphism. Updated the module docstring and
+structure docstring to explain why the bare surjection is insufficient.
+
+## Current frontier
+`EtingofRepresentationTheory/Chapter9/Definition9_2_2.lean` rebuilt cleanly;
+downstream `Theorem9_2_1.lean` still builds (no construction sites of
+`ProjectiveCover` exist downstream, so no breakage).
+
+## Overall project progress
+Stage 3 formalization; Wave-3 fidelity adjudication (epic #5338) ongoing.
+
+## Next step
+Continue Wave-3 fidelity items.
+
+## Blockers
+None.


### PR DESCRIPTION
Closes #--issue

Session: `fe6e4d1a-f4f3-4352-a6f1-ee0ffcc239cb`

80a60419 fix(Ch9 Def9.2.2): add essential-epimorphism condition to ProjectiveCover (#5664)

🤖 Prepared with Claude Code