### PR TITLE
feat: prove representation-level trivial/sign claims for Example5.12.3

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Example5_12_3.lean
+++ b/EtingofRepresentationTheory/Chapter5/Example5_12_3.lean
@@ -1,5 +1,6 @@
 import EtingofRepresentationTheory.Chapter5.CharValueHookFormula
 import EtingofRepresentationTheory.Chapter5.FRTHelpers
+import EtingofRepresentationTheory.Chapter5.Lemma5_13_1
 
 /-!
 # Example 5.12.3: Concrete Examples of Specht Modules
@@ -20,6 +21,14 @@ and `card_standardYoungTableau_eq`), specialised to each shape. The book's `(n)`
 and `(1ⁿ)` cases are the trivial- and sign-representation extremes, both of
 dimension `1`; the four explicit small partitions exhibit the remaining
 nontrivial dimensions.
+
+For the two extreme partitions the book asserts a representation isomorphism,
+not merely a dimension. We capture this directly at the `ℂ[Sₙ]`-module level:
+`Example5_12_3_trivial_rep` shows every group element acts as the identity on
+`V_{(n)}` (trivial representation), and `Example5_12_3_sign_rep` shows every
+group element `σ` acts as `sign σ` on `V_{(1ⁿ)}` (sign representation). These
+distinguish the two one-dimensional representations, which a dimension count
+alone cannot.
 
 ## Mathlib correspondence
 
@@ -248,6 +257,185 @@ theorem Example5_12_3_dim_211 :
       hookLengthProduct_eq_of p_211 [2, 1, 1] 8 (sortedParts_eq_of _ [2, 1, 1] rfl (by decide))
         (by decide)]
   rfl
+
+/-! ## Representation-level structure: the trivial and sign characters
+
+The book's claim is stronger than a dimension count: `V_{(n)}` is the *trivial*
+representation and `V_{(1ⁿ)}` is the *sign* representation. A dimension of `1`
+is necessary but not sufficient — `Sₙ` has exactly two one-dimensional
+representations, and the book asserts a specific one in each case. We pin this
+down as genuine `ℂ[Sₙ]`-module statements: every group element `σ` acts on
+`V_{(n)}` as the identity (`Example5_12_3_trivial_rep`), and on `V_{(1ⁿ)}` as
+multiplication by `sign σ` (`Example5_12_3_sign_rep`).
+
+The arguments are the classical ones. For `(n)` the column group `Q_λ` is
+trivial, so `c_λ = a_λ = ∑_{g} g` and `g · a_λ = a_λ`; for `(1ⁿ)` the row group
+`P_λ` is trivial, so `c_λ = b_λ = ∑_g sign(g)·g` and `g · b_λ = sign(g)·b_λ`.
+Combined with `dim V_λ = 1`, the action on the whole one-dimensional module is
+determined by its action on the generator `c_λ`. -/
+
+/-- For the one-column partition `(1ⁿ)` every cell lies in column `0`. -/
+theorem colOfPos_replicate_one (n k : ℕ) : colOfPos (List.replicate n 1) k = 0 := by
+  induction n generalizing k with
+  | zero => simp [colOfPos]
+  | succ m ih =>
+    rw [List.replicate_succ]
+    simp only [colOfPos]
+    split_ifs with h
+    · omega
+    · exact ih (k - 1)
+
+/-- For the one-column partition `(1ⁿ)` the row of cell `k` is `k` itself. -/
+theorem rowOfPos_replicate_one (n : ℕ) :
+    ∀ k, k < n → rowOfPos (List.replicate n 1) k = k := by
+  induction n with
+  | zero => intro k hk; omega
+  | succ m ih =>
+    intro k hk
+    rw [List.replicate_succ]
+    simp only [rowOfPos]
+    split_ifs with h
+    · omega
+    · rw [ih (k - 1) (by omega)]; omega
+
+/-! ### The one-row partition `(n)`: trivial action -/
+
+/-- For the one-row partition `(n)`, every permutation preserves rows
+(there is only one row), so `P_λ = Sₙ`. -/
+theorem mem_rowSubgroup_rowPartition (n : ℕ) (hn : 0 < n) (σ : Equiv.Perm (Fin n)) :
+    σ ∈ RowSubgroup n (rowPartition n hn) := by
+  have hrow : ∀ j : Fin n, rowOfPos [n] j.val = 0 := fun j => by
+    simp only [rowOfPos]; exact if_pos j.isLt
+  intro k
+  rw [sortedParts_rowPartition n hn, hrow (σ k), hrow k]
+
+/-- For the one-row partition `(n)`, the column group `Q_λ` is trivial: every
+cell is in its own column, so a column-preserving permutation is the identity. -/
+theorem columnSubgroup_rowPartition_eq_one (n : ℕ) (hn : 0 < n) (σ : Equiv.Perm (Fin n))
+    (hσ : σ ∈ ColumnSubgroup n (rowPartition n hn)) : σ = 1 := by
+  have hcol : ∀ j : Fin n, colOfPos [n] j.val = j.val := fun j => by
+    simp only [colOfPos]; exact if_pos j.isLt
+  apply Equiv.Perm.ext
+  intro k
+  have h := hσ k
+  rw [sortedParts_rowPartition n hn, hcol (σ k), hcol k] at h
+  rw [Equiv.Perm.one_apply]
+  exact Fin.ext h
+
+/-- For the one-row partition `(n)`, the column antisymmetrizer `b_λ` is `1`. -/
+theorem columnAntisymmetrizer_rowPartition (n : ℕ) (hn : 0 < n) :
+    ColumnAntisymmetrizer n (rowPartition n hn) = 1 := by
+  classical
+  have htriv : ∀ g : ↥(ColumnSubgroup n (rowPartition n hn)), (g : Equiv.Perm (Fin n)) = 1 :=
+    fun g => columnSubgroup_rowPartition_eq_one n hn g.val g.prop
+  haveI : Unique ↥(ColumnSubgroup n (rowPartition n hn)) :=
+    ⟨⟨⟨1, (ColumnSubgroup n (rowPartition n hn)).one_mem⟩⟩, fun g => Subtype.ext (htriv g)⟩
+  simp only [ColumnAntisymmetrizer, htriv, Units.val_one, Int.cast_one,
+    one_smul, map_one, Finset.sum_const, Finset.card_univ, Fintype.card_unique]
+
+/-- `c_λ` for the one-row partition equals the full symmetrizer `a_λ = ∑_g g`,
+and every group element absorbs into it: `of(σ) · c_λ = c_λ`. -/
+theorem of_mul_youngSymmetrizer_rowPartition (n : ℕ) (hn : 0 < n) (σ : Equiv.Perm (Fin n)) :
+    MonoidAlgebra.of ℂ (Equiv.Perm (Fin n)) σ * YoungSymmetrizer n (rowPartition n hn)
+      = YoungSymmetrizer n (rowPartition n hn) := by
+  rw [YoungSymmetrizer, columnAntisymmetrizer_rowPartition n hn, one_mul]
+  exact of_row_mul_RowSymmetrizer σ (mem_rowSubgroup_rowPartition n hn σ)
+
+/-! ### The one-column partition `(1ⁿ)`: sign action -/
+
+/-- For the one-column partition `(1ⁿ)`, every permutation preserves columns
+(there is only one column), so `Q_λ = Sₙ`. -/
+theorem mem_columnSubgroup_columnPartition (n : ℕ) (hn : 0 < n) (σ : Equiv.Perm (Fin n)) :
+    σ ∈ ColumnSubgroup n (columnPartition n hn) := by
+  intro k
+  rw [sortedParts_columnPartition n hn, colOfPos_replicate_one, colOfPos_replicate_one]
+
+/-- For the one-column partition `(1ⁿ)`, the row group `P_λ` is trivial: every
+cell is in its own row, so a row-preserving permutation is the identity. -/
+theorem rowSubgroup_columnPartition_eq_one (n : ℕ) (hn : 0 < n) (σ : Equiv.Perm (Fin n))
+    (hσ : σ ∈ RowSubgroup n (columnPartition n hn)) : σ = 1 := by
+  apply Equiv.Perm.ext
+  intro k
+  have h := hσ k
+  rw [sortedParts_columnPartition n hn,
+    rowOfPos_replicate_one n (σ k).val (σ k).isLt,
+    rowOfPos_replicate_one n k.val k.isLt] at h
+  rw [Equiv.Perm.one_apply]
+  exact Fin.ext h
+
+/-- For the one-column partition `(1ⁿ)`, the row symmetrizer `a_λ` is `1`. -/
+theorem rowSymmetrizer_columnPartition (n : ℕ) (hn : 0 < n) :
+    RowSymmetrizer n (columnPartition n hn) = 1 := by
+  classical
+  have htriv : ∀ g : ↥(RowSubgroup n (columnPartition n hn)), (g : Equiv.Perm (Fin n)) = 1 :=
+    fun g => rowSubgroup_columnPartition_eq_one n hn g.val g.prop
+  haveI : Unique ↥(RowSubgroup n (columnPartition n hn)) :=
+    ⟨⟨⟨1, (RowSubgroup n (columnPartition n hn)).one_mem⟩⟩, fun g => Subtype.ext (htriv g)⟩
+  simp only [RowSymmetrizer, htriv, map_one, Finset.sum_const, Finset.card_univ,
+    Fintype.card_unique, one_nsmul]
+
+/-- `c_λ` for the one-column partition equals the full antisymmetrizer
+`b_λ = ∑_g sign(g)·g`, and `of(σ) · c_λ = sign(σ) · c_λ`. -/
+theorem of_mul_youngSymmetrizer_columnPartition (n : ℕ) (hn : 0 < n) (σ : Equiv.Perm (Fin n)) :
+    MonoidAlgebra.of ℂ (Equiv.Perm (Fin n)) σ * YoungSymmetrizer n (columnPartition n hn)
+      = ((↑(↑(Equiv.Perm.sign σ) : ℤ) : ℂ)) • YoungSymmetrizer n (columnPartition n hn) := by
+  rw [YoungSymmetrizer, rowSymmetrizer_columnPartition n hn, mul_one]
+  exact of_col_mul_ColumnAntisymmetrizer σ (mem_columnSubgroup_columnPartition n hn σ)
+
+/-! ### From the generator to the whole module -/
+
+/-- If `V_λ` is one-dimensional and the group element `σ` scales the generator
+`c_λ` by `χ`, then `σ` acts on every vector of `V_λ` by `χ`. (Since `V_λ` is
+one-dimensional over `ℂ`, it equals `ℂ · c_λ`, so the `ℂ[Sₙ]`-action is
+determined by its value on `c_λ`.) -/
+theorem spechtModule_smul_eq (n : ℕ) (la : Nat.Partition n) (σ : Equiv.Perm (Fin n)) (χ : ℂ)
+    (hdim : Module.finrank ℂ (SpechtModule n la) = 1)
+    (hgen : (MonoidAlgebra.of ℂ (Equiv.Perm (Fin n)) σ : SymGroupAlgebra n)
+        * YoungSymmetrizer n la = χ • YoungSymmetrizer n la)
+    (v : SpechtModule n la) :
+    (MonoidAlgebra.of ℂ (Equiv.Perm (Fin n)) σ : SymGroupAlgebra n) • v = χ • v := by
+  classical
+  have hcne : YoungSymmetrizer n la ≠ 0 := by
+    intro h0
+    have hbot : SpechtModule n la = ⊥ := by
+      rw [SpechtModule, h0]; exact Submodule.span_singleton_eq_bot.mpr rfl
+    rw [hbot, Module.finrank_zero_of_subsingleton] at hdim
+    exact one_ne_zero hdim.symm
+  have hmem_c : YoungSymmetrizer n la ∈ SpechtModule n la := Submodule.subset_span rfl
+  have hspan_le : Submodule.span ℂ {YoungSymmetrizer n la}
+      ≤ (SpechtModule n la).restrictScalars ℂ := by
+    rw [Submodule.span_singleton_le_iff_mem]; exact hmem_c
+  have hfin : Module.finrank ℂ ((SpechtModule n la).restrictScalars ℂ) = 1 := hdim
+  have hspaneq : Submodule.span ℂ {YoungSymmetrizer n la}
+      = (SpechtModule n la).restrictScalars ℂ :=
+    Submodule.eq_of_le_of_finrank_le hspan_le (by rw [hfin, finrank_span_singleton hcne])
+  have hv_mem : (v : SymGroupAlgebra n) ∈ Submodule.span ℂ {YoungSymmetrizer n la} := by
+    rw [hspaneq]; exact v.2
+  obtain ⟨z, hz⟩ := Submodule.mem_span_singleton.mp hv_mem
+  apply Subtype.ext
+  rw [Submodule.coe_smul, Submodule.coe_smul_of_tower, smul_eq_mul, ← hz,
+    Algebra.mul_smul_comm, hgen, smul_comm]
+
+/-- **Etingof Example 5.12.3 (trivial representation).** For the one-row
+partition `λ = (n)`, every group element acts as the identity on the Specht
+module `V_{(n)}`: it is the trivial representation of `Sₙ`. -/
+theorem Example5_12_3_trivial_rep (n : ℕ) (hn : 0 < n) (σ : Equiv.Perm (Fin n))
+    (v : SpechtModule n (rowPartition n hn)) :
+    (MonoidAlgebra.of ℂ (Equiv.Perm (Fin n)) σ : SymGroupAlgebra n) • v = v := by
+  have h := spechtModule_smul_eq n (rowPartition n hn) σ 1 (Example5_12_3_trivial n hn)
+    (by rw [one_smul]; exact of_mul_youngSymmetrizer_rowPartition n hn σ) v
+  rwa [one_smul] at h
+
+/-- **Etingof Example 5.12.3 (sign representation).** For the one-column
+partition `λ = (1,…,1)`, every group element `σ` acts as multiplication by
+`sign σ` on the Specht module `V_{(1ⁿ)}`: it is the sign representation of
+`Sₙ`. -/
+theorem Example5_12_3_sign_rep (n : ℕ) (hn : 0 < n) (σ : Equiv.Perm (Fin n))
+    (v : SpechtModule n (columnPartition n hn)) :
+    (MonoidAlgebra.of ℂ (Equiv.Perm (Fin n)) σ : SymGroupAlgebra n) • v
+      = ((↑(↑(Equiv.Perm.sign σ) : ℤ) : ℂ)) • v :=
+  spechtModule_smul_eq n (columnPartition n hn) σ _ (Example5_12_3_sign n hn)
+    (of_mul_youngSymmetrizer_columnPartition n hn σ) v
 
 end Example5_12_3
 

--- a/progress/2026-06-30T10-41-54Z_79c8b805.md
+++ b/progress/2026-06-30T10-41-54Z_79c8b805.md
@@ -1,0 +1,53 @@
+## Accomplished
+
+Review issue #5637 (Wave-2 fidelity sweep, `Chapter5/Example5.12.3`). Re-confirmed
+the finding and closed its primary, precise part.
+
+The book asserts `V_{(n)}` is the *trivial* representation and `V_{(1ⁿ)}` is the
+*sign* representation — isomorphisms of `ℂ[Sₙ]`-modules, strictly stronger than the
+dimension-`1` count that was previously formalized (`Sₙ` has two one-dimensional
+representations; a dimension cannot distinguish them).
+
+Added to `EtingofRepresentationTheory/Chapter5/Example5_12_3.lean` (no sorries, no
+new axioms):
+
+- `Example5_12_3_trivial_rep`: every `σ ∈ Sₙ` acts as the identity on `V_{(n)}`.
+- `Example5_12_3_sign_rep`: every `σ ∈ Sₙ` acts as `sign σ` on `V_{(1ⁿ)}`.
+
+Supporting lemmas: `colOfPos_replicate_one`, `rowOfPos_replicate_one`,
+the subgroup characterizations (`P_λ = Sₙ`, `Q_λ = 1` for the row partition and
+dually for the column partition), `columnAntisymmetrizer_rowPartition = 1`,
+`rowSymmetrizer_columnPartition = 1`, the generator-transformation lemmas
+`of_mul_youngSymmetrizer_rowPartition` / `..._columnPartition`, and a reusable
+bridge `spechtModule_smul_eq` (a one-dimensional Specht module's `ℂ[Sₙ]`-action is
+determined by its action on the generator `c_λ`).
+
+Key levers used: existing `of_row_mul_RowSymmetrizer` and
+`of_col_mul_ColumnAntisymmetrizer` (Lemma5_13_1) for the generator transformation;
+`Submodule.eq_of_le_of_finrank_le` + `finrank_span_singleton` + the already-proved
+`Example5_12_3_trivial` / `_sign` (dim `= 1`) to collapse the module to `ℂ · c_λ`.
+
+## Current frontier
+
+`Chapter5/Example5_12_3.lean` builds cleanly (`lake build
+EtingofRepresentationTheory.Chapter5` succeeds, no warnings in this file).
+
+## Overall project progress
+
+Stage 3 formalization. This is a fidelity-review item; the formalization remains
+sorry-free and now matches the book's representation-level claims for the two
+extreme partitions.
+
+## Next step
+
+Residual fidelity (smaller, optional follow-up): the `n = 3, 4` cases
+(`V_{(2,1)} = ℂ²`, `V_{(3,1)} = ℂ³₋`, `V_{(2,1,1)} = ℂ³₊`) are still identified only
+by dimension, not by an explicit equivariant isomorphism to the named irreps.
+Pinning these down needs the standard representation `ℂ²`/`ℂ³±` defined and an
+intertwiner (or a uniqueness-of-irrep-by-dimension argument leveraging the existing
+`SpechtModule` simplicity result). The book states these as bare named examples, so
+this is lower priority than the trivial/sign gap that is now closed.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3965,7 +3965,7 @@
     "status": "sorry_free",
     "fidelity": "gap",
     "sorry_free": true,
-    "fidelity_note": "[partial-example] The book says 'V_{(n)} is the trivial representation' and 'V_{(1,...,1)} is the sign representation'. The Lean theorems only prove 'Module.finrank ℂ (SpechtModule n (rowPartition n h",
+    "fidelity_note": "Trivial/sign claims now proved at the representation level: Example5_12_3_trivial_rep (every σ acts as identity on V_{(n)}) and Example5_12_3_sign_rep (every σ acts as sign σ on V_{(1ⁿ)}). Residual: the n=3,4 cases (ℂ², ℂ³₋, ℂ³₊) are still identified only by dimension, not by an explicit equivariant isomorphism to the named irreps.",
     "fidelity_issue": 5637
   },
   {


### PR DESCRIPTION
Closes #5637

Session: `79c8b805-1680-4ce4-8406-01c9b18ed259`

6d3331bc feat: prove representation-level trivial/sign claims for Example5.12.3 (#5637)

🤖 Prepared with Claude Code