### PR TITLE
feat(Ch7 #5646): additive/k-linear fidelity for Example 7.9.2 Rep functors

### DIFF
--- a/EtingofRepresentationTheory/Chapter7/Example7_9_2.lean
+++ b/EtingofRepresentationTheory/Chapter7/Example7_9_2.lean
@@ -1,34 +1,119 @@
+import Mathlib.RepresentationTheory.Induced
+import Mathlib.RepresentationTheory.Rep.Res
+import Mathlib.CategoryTheory.Linear.Yoneda
+import Mathlib.CategoryTheory.Adjunction.Additive
 import Mathlib.Algebra.Category.ModuleCat.ChangeOfRings
 import Mathlib.CategoryTheory.Linear.LinearFunctor
 
 /-!
 # Example 7.9.2: Additive and k-linear Functors in Representation Theory
 
-The functors Ind_K^G, Res_K^G, Hom_G(V, ?) in the theory of group representations
-over a field k are additive and k-linear.
+> The functors `Ind_K^G`, `Res_K^G`, `Hom_G(V, ?)` in the theory of group
+> representations over a field `k` are additive and `k`-linear.
 
-## Mathlib correspondence
+This file records the three statements of the example against the *actual*
+group-representation functors on `Rep k G`, not merely the underlying
+change-of-rings functor on `ModuleCat`:
 
-The restriction of scalars functor `ModuleCat.restrictScalars` is shown to be
-additive and linear in Mathlib's `ChangeOfRings.lean`. These instances apply to
-the representation-theoretic restriction functor since `Rep k G` is built on
-`ModuleCat k`.
+* **Restriction** `Res_K^G` is `Rep.resFunctor φ : Rep k G ⥤ Rep k H` for a group
+  homomorphism `φ : G →* H` (`Res_K^G` is the case of the inclusion `K ↪ G`).
+  Additivity and `k`-linearity are already `Mathlib` instances; we name them here.
+* **Induction** `Ind_K^G` is `Rep.indFunctor k φ : Rep k G ⥤ Rep k H`. It is the
+  left adjoint of restriction (`Rep.indResAdjunction`), and additivity/linearity
+  transfer along the adjunction from restriction. The transfer of additivity is
+  `Mathlib`'s `Adjunction.left_adjoint_additive`; the linear companion
+  `left_adjoint_linear` is proved below.
+* **`Hom_G(V, ?)`** is the covariant hom-functor `Rep k G ⥤ ModuleCat k`,
+  i.e. `(linearCoyoneda k (Rep k G)).obj (op V)`. Additivity is a `Mathlib`
+  instance; `k`-linearity is proved below.
+
+The `ModuleCat.restrictScalars` instances at the end record the underlying
+algebraic change-of-rings statement that the representation-theoretic
+restriction is built on.
 -/
 
-open CategoryTheory
+open CategoryTheory Opposite
+
+namespace Etingof
+
+/-! ## A linear companion to `Adjunction.left_adjoint_additive` -/
+
+/-- If `adj : F ⊣ G` is an adjunction between `R`-linear categories and the right
+adjoint `G` is additive and `R`-linear, then the left adjoint `F` is `R`-linear.
+This is the `Functor.Linear` companion of
+`CategoryTheory.Adjunction.left_adjoint_additive`. -/
+lemma left_adjoint_linear {C D : Type*} [Category C] [Category D] [Preadditive C]
+    [Preadditive D] (R : Type*) [Semiring R] [Linear R C] [Linear R D]
+    {F : C ⥤ D} {G : D ⥤ C} (adj : F ⊣ G) [G.Additive] [G.Linear R] : F.Linear R where
+  map_smul {X Y} f r := (adj.homEquiv X (F.obj Y)).injective <| by
+    simp only [Adjunction.homEquiv_unit, Functor.map_smul, Linear.comp_smul,
+      ← Functor.comp_map, ← adj.unit.naturality, Functor.id_map, Linear.smul_comp]
+
+/-! ## The three functors of Example 7.9.2 -/
+
+section GroupRepresentations
+
+universe u
+
+variable {k G H : Type u} [Field k] [Group G] [Group H] (φ : G →* H)
+
+/-- `Res_K^G` is additive (Etingof Example 7.9.2): the restriction functor
+`Rep.resFunctor φ : Rep k H ⥤ Rep k G` along a group homomorphism is additive. -/
+theorem resFunctor_additive : (Rep.resFunctor (k := k) φ).Additive := inferInstance
+
+/-- `Res_K^G` is `k`-linear (Etingof Example 7.9.2): the restriction functor
+`Rep.resFunctor φ : Rep k H ⥤ Rep k G` along a group homomorphism is `k`-linear. -/
+theorem resFunctor_linear : (Rep.resFunctor (k := k) φ).Linear k := inferInstance
+
+/-- `Ind_K^G` is additive (Etingof Example 7.9.2): the induction functor
+`Rep.indFunctor k φ : Rep k G ⥤ Rep k H` is additive, since it is left adjoint to
+the (additive) restriction functor. -/
+theorem indFunctor_additive : (Rep.indFunctor.{u} k φ).Additive :=
+  (Rep.indResAdjunction k φ).left_adjoint_additive
+
+/-- `Ind_K^G` is `k`-linear (Etingof Example 7.9.2): the induction functor
+`Rep.indFunctor k φ : Rep k G ⥤ Rep k H` is `k`-linear, since it is left adjoint
+to the (`k`-linear) restriction functor. -/
+theorem indFunctor_linear : (Rep.indFunctor.{u} k φ).Linear k :=
+  Etingof.left_adjoint_linear k (Rep.indResAdjunction k φ)
+
+variable (V : Rep k G)
+
+/-- `Hom_G(V, ?)` is additive (Etingof Example 7.9.2): the covariant hom-functor
+`(linearCoyoneda k (Rep k G)).obj (op V) : Rep k G ⥤ ModuleCat k` is additive. -/
+theorem homGFunctor_additive : ((linearCoyoneda k (Rep k G)).obj (op V)).Additive :=
+  inferInstance
+
+/-- `Hom_G(V, ?)` is `k`-linear (Etingof Example 7.9.2): the covariant hom-functor
+`(linearCoyoneda k (Rep k G)).obj (op V) : Rep k G ⥤ ModuleCat k` is `k`-linear. -/
+theorem homGFunctor_linear : ((linearCoyoneda k (Rep k G)).obj (op V)).Linear k where
+  map_smul {X Y} f r := by
+    ext g
+    exact Linear.comp_smul V X Y g r f
+
+end GroupRepresentations
+
+/-! ## Underlying change-of-rings statement
+
+The representation-theoretic restriction `Rep.resFunctor` is built on the algebraic
+restriction of scalars `ModuleCat.restrictScalars`. These instances record that the
+underlying change-of-rings functor is additive and linear. -/
+
 open scoped ModuleCat.Algebra
 
 /-- The restriction of scalars functor along a ring homomorphism is additive.
-This underlies the fact that Res_K^G is additive (Etingof Example 7.9.2). -/
-instance Etingof.restrictScalars_additive
+This underlies the fact that `Res_K^G` is additive (Etingof Example 7.9.2). -/
+instance restrictScalars_additive
     {R S : Type*} [Ring R] [Ring S] (f : R →+* S) :
     Functor.Additive (ModuleCat.restrictScalars f) :=
   inferInstance
 
 /-- The restriction of scalars functor along an algebra homomorphism is linear.
-This underlies the fact that Res_K^G is k-linear (Etingof Example 7.9.2). -/
-instance Etingof.restrictScalars_linear
+This underlies the fact that `Res_K^G` is `k`-linear (Etingof Example 7.9.2). -/
+instance restrictScalars_linear
     {R₀ R S : Type*} [CommSemiring R₀] [Ring R] [Ring S]
     [Algebra R₀ R] [Algebra R₀ S] (f : R →ₐ[R₀] S) :
     Functor.Linear R₀ (ModuleCat.restrictScalars f.toRingHom) :=
   inferInstance
+
+end Etingof

--- a/progress/2026-06-30T11-27-14Z_5ac7b5f5.md
+++ b/progress/2026-06-30T11-27-14Z_5ac7b5f5.md
@@ -1,0 +1,44 @@
+## Accomplished
+Adjudicated and **fixed** the Wave-2 fidelity finding on `Chapter7/Example7.9.2`
+(issue #5646). The book claims the functors `Ind_K^G`, `Res_K^G`, `Hom_G(V, ?)` in
+group representation theory are additive and `k`-linear. The previous Lean file only
+asserted these for the *underlying* algebraic `ModuleCat.restrictScalars` functor, never
+mentioning `Rep k G`. Re-confirmed the finding (the formal statements genuinely did not
+touch group representations) and rewrote the file to record the claims against the actual
+group-representation functors:
+
+- `Etingof.resFunctor_additive` / `resFunctor_linear` — `Res` is `Rep.resFunctor φ`;
+  additivity and `k`-linearity are already `Mathlib` instances, now named for fidelity.
+- `Etingof.indFunctor_additive` / `indFunctor_linear` — `Ind` is `Rep.indFunctor k φ`,
+  left adjoint to restriction via `Rep.indResAdjunction`. Additivity transfers along the
+  adjunction by `Mathlib`'s `Adjunction.left_adjoint_additive`. Linearity needed a new
+  general lemma `Etingof.left_adjoint_linear` (the `Functor.Linear` companion of
+  `left_adjoint_additive`), proved here via the unit/`homEquiv` computation — upstreamable.
+- `Etingof.homGFunctor_additive` / `homGFunctor_linear` — `Hom_G(V, ?)` is the covariant
+  hom-functor `(linearCoyoneda k (Rep k G)).obj (op V) : Rep k G ⥤ ModuleCat k`. Additivity
+  is a `Mathlib` instance; `k`-linearity proved directly (`Linear.comp_smul`).
+- The original `restrictScalars_additive` / `restrictScalars_linear` instances are kept,
+  reframed as the underlying change-of-rings statement that representation-theoretic
+  restriction is built on.
+
+`lake build EtingofRepresentationTheory.Chapter7.Example7_9_2` succeeds (1967 jobs, no
+sorries, no warnings). `[Field k]` matches the book's "over a field `k`".
+
+## Current frontier
+Issue #5646 is fully addressed: all three functors of Example 7.9.2 now have additivity
+and `k`-linearity recorded against the genuine `Rep k G` functors.
+
+## Overall project progress
+Stage 3 formalization; Wave-2 fidelity sweep (epic #5338) ongoing. #5646 resolved.
+
+## Next step
+Continue the Wave-2 fidelity sweep (`progress/coverage-audit/fidelity-wave-2.md`).
+
+## Blockers
+None for this item. **Pre-existing, unrelated:** the `Chapter7` aggregate
+(`EtingofRepresentationTheory/Chapter7.lean`) fails to build because
+`Chapter7/Example7_6_3.lean` imports `Mathlib.RepresentationTheory.FdRep` (wrong case;
+canonical is `FDRep`). This collides with the canonical `FDRep` pulled in by `import
+Mathlib`. Confirmed this failure pre-dates this change (it fails at base commit
+`cd828317` with my file stashed), so it is out of scope for #5646. Worth a separate
+one-character fix to line 3 of `Example7_6_3.lean`.


### PR DESCRIPTION
Closes #5646

Session: `5ac7b5f5-f1b7-4ca2-a4b7-374aaa5ff1ef`

fb363d85 feat(Ch7 #5646): record additive/k-linear fidelity for the actual Rep functors of Example 7.9.2

🤖 Prepared with Claude Code