### PR TITLE
feat(Ch9): cover all modules in a semisimple block (Example 9.5.2 part i)

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/Example9_5_2.lean
+++ b/EtingofRepresentationTheory/Chapter9/Example9_5_2.lean
@@ -16,40 +16,71 @@ sum of copies of one simple).
 is only one simple module — the residue field).
 
 (iii) The algebra from Problem 9.3.2 has one block.
+
+## Scope of this file
+
+Part (i) is captured at the level the project's `Etingof.AreLinked` definition supports.
+That definition (Definition 9.5.1) links *all* modules — not only the simple ones — by
+`Ext¹`-adjacency, so over a semisimple ring, where `Ext¹` vanishes identically, the linking
+relation collapses to isomorphism. We therefore prove the sharp statement
+`Etingof.semisimple_areLinked_iff_iso`: over a semisimple ring **every** block is a single
+isomorphism class, covering all modules in a block, not just the simple ones. The original
+`Etingof.semisimple_blocks_singleton` (linked simples are isomorphic, hence each block has a
+unique simple object) is an immediate corollary.
+
+Note the relationship to the book's phrasing "each block is equivalent to the category of
+vector spaces". Etingof's block attached to a simple `S` is the full subcategory of modules
+whose Jordan–Hölder factors are all `≅ S`; over a semisimple ring that subcategory is the
+isotypic component `{S^{⊕n}}`, equivalent to vector spaces with `n` the dimension. The
+project's `AreLinked` relation partitions *more finely* — because `Ext¹ = 0` forbids any
+nonsplit extension, `S` and `S^{⊕2}` end up in different `AreLinked`-blocks. Both viewpoints
+agree on the load-bearing consequence formalized here, "one simple object per block"; the
+finer `AreLinked` statement records that no larger module is linked to a simple. Promoting
+the Etingof "≃ Vec" subcategory equivalence would require an isotypic-subcategory definition
+not present in Definition 9.5.1.
+
+Part (iii) — "the algebra of Problem 9.3.2 has one block" — requires first *constructing*
+that generators-and-relations algebra `A = ℂ⟨g, x⟩ / (gx + xg, x², g² - 1)` and then proving
+`Ext¹` between its two one-dimensional simples is nonzero (the linking is via a genuine
+nonsplit extension, not an isomorphism). That construction is tracked as its own work item
+(Problem 9.3.2) and is not formalized here.
 -/
 
 universe v u
 
 open CategoryTheory
 
-/-- For a semisimple ring, any two non-isomorphic simple modules have
-`Ext¹ = 0` in both directions, so each simple module forms its own block.
-(Etingof Example 9.5.2 (i)) -/
-theorem Etingof.semisimple_blocks_singleton
+/-- Over a semisimple ring no two objects of `ModuleCat R` are `Ext¹`-adjacent: every module
+is projective, so `Ext¹(A, B)` is subsingleton in both directions and therefore not
+nontrivial. -/
+theorem Etingof.semisimple_not_extAdjacent
     (R : Type u) [Ring R] [Small.{v} R] [IsSemisimpleRing R]
-    (X Y : ModuleCat.{v} R)
-    (_hX : IsSimpleModule R X) (_hY : IsSimpleModule R Y)
-    (hlinked : Etingof.AreLinked R X Y) :
-    Nonempty (X ≅ Y) := by
-  -- For semisimple R, all modules are projective, so Ext¹ is subsingleton
-  -- (hence not nontrivial). This makes ExtAdjacent vacuously false.
-  -- The only way modules can be linked is via isomorphism.
-  have not_adj : ∀ (A B : ModuleCat.{v} R), ¬ Etingof.ExtAdjacent R A B := by
-    intro A B h
-    rcases h with h | h
-    · haveI : Module.Projective R A := Module.projective_of_isSemisimpleRing R A
-      haveI := Abelian.Ext.subsingleton_of_projective A B 0
-      exact not_nontrivial _ h
-    · haveI : Module.Projective R B := Module.projective_of_isSemisimpleRing R B
-      haveI := Abelian.Ext.subsingleton_of_projective B A 0
-      exact not_nontrivial _ h
-  -- With ExtAdjacent empty, the only base relation is isomorphism.
-  -- Induct on EqvGen to extract the isomorphism.
-  clear _hX _hY
+    (A B : ModuleCat.{v} R) : ¬ Etingof.ExtAdjacent R A B := by
+  intro h
+  rcases h with h | h
+  · haveI : Module.Projective R A := Module.projective_of_isSemisimpleRing R A
+    haveI := Abelian.Ext.subsingleton_of_projective A B 0
+    exact not_nontrivial _ h
+  · haveI : Module.Projective R B := Module.projective_of_isSemisimpleRing R B
+    haveI := Abelian.Ext.subsingleton_of_projective B A 0
+    exact not_nontrivial _ h
+
+/-- For a semisimple ring, the linking relation collapses to isomorphism for **all** modules
+(not just simple ones): two modules are linked iff they are isomorphic. Equivalently, each
+block is a single isomorphism class. This is the "covering all modules in a block" content of
+Etingof Example 9.5.2 (i) ("each block is equivalent to the category of vector spaces"): since
+`Ext¹` vanishes over a semisimple ring, there are no nonsplit extensions to enlarge a block
+beyond one isomorphism class. -/
+theorem Etingof.semisimple_areLinked_iff_iso
+    (R : Type u) [Ring R] [Small.{v} R] [IsSemisimpleRing R]
+    (X Y : ModuleCat.{v} R) :
+    Etingof.AreLinked R X Y ↔ Nonempty (X ≅ Y) := by
+  refine ⟨fun hlinked => ?_, fun e => Etingof.areLinked_of_iso R e.some⟩
+  -- With `ExtAdjacent` empty, the only base relation is isomorphism; induct on `EqvGen`.
   induction hlinked with
   | rel _ _ h =>
     rcases h with h | h
-    · exact absurd h (not_adj _ _)
+    · exact absurd h (Etingof.semisimple_not_extAdjacent R _ _)
     · exact h
   | refl => exact ⟨Iso.refl _⟩
   | symm _ _ _ ih =>
@@ -59,6 +90,17 @@ theorem Etingof.semisimple_blocks_singleton
     obtain ⟨e₁⟩ := ih₁
     obtain ⟨e₂⟩ := ih₂
     exact ⟨e₁ ≪≫ e₂⟩
+
+/-- For a semisimple ring, any two non-isomorphic simple modules have
+`Ext¹ = 0` in both directions, so each simple module forms its own block.
+(Etingof Example 9.5.2 (i)) -/
+theorem Etingof.semisimple_blocks_singleton
+    (R : Type u) [Ring R] [Small.{v} R] [IsSemisimpleRing R]
+    (X Y : ModuleCat.{v} R)
+    (_hX : IsSimpleModule R X) (_hY : IsSimpleModule R Y)
+    (hlinked : Etingof.AreLinked R X Y) :
+    Nonempty (X ≅ Y) :=
+  (Etingof.semisimple_areLinked_iff_iso R X Y).mp hlinked
 
 /-- For a commutative local artinian ring, there is only one simple module (up to
 isomorphism), so all modules belong to a single block.

--- a/progress/2026-06-30T11-37-12Z_ccbb36b9.md
+++ b/progress/2026-06-30T11-37-12Z_ccbb36b9.md
@@ -1,0 +1,54 @@
+## Accomplished
+
+Worked issue #5648 (fidelity audit of `Chapter9/Example9.5.2`, label `review`,
+one-shot dispatch). Re-confirmed the three findings against the book blob, the
+Lean file, and Definition 9.5.1, then closed the two tractable gaps:
+
+- **Gap (1) + (3): part (i) only covered simples.** The old
+  `Etingof.semisimple_blocks_singleton` proved `Nonempty (X ≅ Y)` for *linked
+  simple* modules only. Added `Etingof.semisimple_areLinked_iff_iso`, which
+  upgrades this to **all** modules: over a semisimple ring,
+  `AreLinked R X Y ↔ Nonempty (X ≅ Y)`. This covers "all modules in a block,
+  not just simples" — each semisimple block is exactly one isomorphism class.
+  Factored out `Etingof.semisimple_not_extAdjacent` (no `Ext¹`-adjacency over a
+  semisimple ring) and re-derived `semisimple_blocks_singleton` as a one-line
+  corollary (signature preserved, so downstream references are unaffected).
+- Documented honestly the definitional relationship to Etingof's "each block ≃
+  category of vector spaces": the project's `AreLinked` (all-modules
+  `Ext¹`-linking from Definition 9.5.1) partitions *more finely* than Etingof's
+  composition-factor blocks (`S` and `S^{⊕2}` land in different
+  `AreLinked`-blocks because `Ext¹ = 0`). Both agree on "one simple object per
+  block". A true "≃ Vec" subcategory equivalence would need an
+  isotypic-subcategory definition absent from Definition 9.5.1.
+
+Build green: `lake build EtingofRepresentationTheory.Chapter9.Example9_5_2`.
+
+## Current frontier
+
+Part (iii) — "the algebra of Problem 9.3.2 has one block" — is **not**
+formalized. This is gap (2) of #5648 and the entire scope of the dedicated open
+issue #5722.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. Example 9.5.2 parts (i) and (ii) are formalized;
+part (i) now covers all modules in a block (was simples-only). Part (iii)
+remains.
+
+## Next step
+
+Formalize Problem 9.3.2 (issue #5722): construct the 4-dimensional algebra
+`A = ℂ⟨g, x⟩ / (gx + xg, x², g² - 1)` (no generators-and-relations/`RingQuot`
+algebra pattern exists in the project yet — this is new infrastructure),
+identify its two one-dimensional simples `χ₊` (g ↦ 1), `χ₋` (g ↦ −1), and prove
+`Ext¹(χ₊, χ₋)` is nontrivial via the genuine nonsplit 2-dimensional extension
+(g = diag(1,−1), x nilpotent). That `Ext¹ ≠ 0` then gives `ExtAdjacent`, hence
+`AreLinked`, hence a single block — surfaced as Example 9.5.2(iii). No project
+proof of `Nontrivial (Abelian.Ext _ _ 1)` exists yet, so this is multi-session,
+new-infrastructure work; it was correctly out of reach for this single session.
+
+## Blockers
+
+None for the landed work. Part (iii)/#5722 is large new-infrastructure work
+(generators-relations algebra + first `Ext¹`-nonvanishing in the project),
+deliberately deferred to its dedicated issue rather than stubbed.


### PR DESCRIPTION
This PR strengthens Example 9.5.2 part (i) so that it covers every module in a semisimple block, not only the simple ones. Over a semisimple ring `Ext¹` vanishes, so the linking relation of Definition 9.5.1 collapses to isomorphism for all modules: `Etingof.semisimple_areLinked_iff_iso` proves `AreLinked R X Y ↔ Nonempty (X ≅ Y)`, i.e. each block is a single isomorphism class. The factored helper `Etingof.semisimple_not_extAdjacent` records that no two objects are `Ext¹`-adjacent over a semisimple ring, and the original `Etingof.semisimple_blocks_singleton` is re-derived as a corollary with its signature unchanged. The file docstring now records honestly how the project's all-modules `AreLinked` partition relates to the book's "each block is equivalent to the category of vector spaces".

This closes findings (1) and (3) of issue #5648 (part (i) covered only simples). Finding (2) — part (iii), "the algebra of Problem 9.3.2 has one block" — is not included: it requires constructing the generators-and-relations algebra `A = ℂ⟨g, x⟩ / (gx + xg, x², g² - 1)` and the project's first `Ext¹`-nonvanishing proof, and is tracked by issue #5722. The parent issue #5648 is therefore marked `replan` for the residual scope.

🤖 Prepared with Claude Code