### PR TITLE
feat(Ch5 #5638): prove exterior half of Problem 4.12.3 irreducibility

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/DiagonalCoordinate.lean
+++ b/EtingofRepresentationTheory/Chapter5/DiagonalCoordinate.lean
@@ -1,0 +1,150 @@
+import Mathlib
+
+/-!
+# Coordinate submodules of a diagonal operator, and an irreducibility criterion
+
+This file isolates the *linear-algebra* heart of Problem 4.12.3 from Etingof's book (the
+irreducibility of `SⁿV` and `∧ⁿV` as `GL(V)`-representations, cited in Example 5.19.3).
+
+The argument there has two reusable, representation-free ingredients:
+
+* **Diagonal ⟹ coordinate submodule.** If a linear operator `T` acts diagonally on a basis
+  `b` with *pairwise distinct* eigenvalues (`w` injective), then every `T`-invariant submodule
+  `W` is a *coordinate submodule*: a basis vector's coordinate of an element of `W` can only be
+  nonzero on basis vectors that themselves lie in `W` (`mem_of_repr_ne_zero`). This is the
+  "distinct eigenvalues ⟹ a subrepresentation is spanned by a subset of the eigenbasis" step of
+  the Hint. We prove it directly with a Lagrange-style product `∏ (T - wₛ)`, so it needs no
+  finite-dimensionality and no eigenspace machinery.
+
+* **Connectivity ⟹ irreducible.** If, on top of that, the basis indices are connected by a
+  relation `Adj` that is *realised inside* `W` (whenever `b s ∈ W` and `Adj s t` then `b t ∈ W`),
+  then `W` is `⊥` or the whole space. This is the "use the transvections `ρ(1 + Eᵢⱼ)` to show the
+  spanning subset is everything once it is nonempty" step of the Hint.
+
+Both are stated for an arbitrary basis over a field; the case-specific work (exhibiting the
+diagonal element with distinct eigenvalues, and realising `Adj` via transvections) is done by the
+caller.
+-/
+
+open scoped BigOperators
+open Module
+
+namespace Etingof.DiagonalCoordinate
+
+variable {k : Type*} [Field k]
+  {M : Type*} [AddCommGroup M] [Module k M]
+  {B : Type*} (b : Basis B k M)
+
+section CoordinateSubmodule
+
+variable {T : Module.End k M} {w : B → k}
+
+open Polynomial
+
+/-- A polynomial in a `W`-invariant operator preserves `W`. -/
+private lemma aeval_mem {W : Submodule k M} (hW : ∀ x ∈ W, T x ∈ W) (q : k[X]) :
+    ∀ z ∈ W, aeval T q z ∈ W := by
+  induction q using Polynomial.induction_on with
+  | C a => intro z hz; rw [aeval_C, Module.algebraMap_end_apply]; exact W.smul_mem a hz
+  | add p q hp hq =>
+    intro z hz; rw [map_add, LinearMap.add_apply]; exact W.add_mem (hp z hz) (hq z hz)
+  | monomial n a ih =>
+    intro z hz
+    rw [show C a * X ^ (n + 1) = (C a * X ^ n) * X by ring, map_mul, Module.End.mul_apply, aeval_X]
+    exact ih (T z) (hW z hz)
+
+/-- **Diagonal operator ⟹ coordinate submodule.** If `T` acts diagonally on the basis `b` with
+pairwise distinct eigenvalues `w`, then any `T`-invariant submodule `W` contains every basis
+vector `b t` whose coordinate appears in some element of `W`. Equivalently, `W` is spanned by a
+subset of the eigenbasis.
+
+The proof is the Lagrange-interpolation argument: the polynomial `p = ∏_{s ≠ t} (X - w s)`
+evaluated at `T` annihilates every eigencomponent of `y` except the `t`-component, which it
+scales by the nonzero `∏_{s ≠ t} (w t - w s)`; since `aeval T p` preserves `W`, the surviving
+component `b t` lies in `W`. -/
+theorem mem_of_repr_ne_zero (hT : ∀ s, T (b s) = w s • b s) (hw : Function.Injective w)
+    {W : Submodule k M} (hW : ∀ x ∈ W, T x ∈ W)
+    {y : M} (hy : y ∈ W) {t : B} (ht : b.repr y t ≠ 0) : b t ∈ W := by
+  classical
+  set σ := (b.repr y).support with hσ
+  have htσ : t ∈ σ := Finsupp.mem_support_iff.mpr ht
+  -- The interpolating polynomial killing every eigenvalue except `w t`.
+  set p : k[X] := ∏ s ∈ σ.erase t, (X - C (w s)) with hp
+  -- Scalar that survives at `t`.
+  set c := ∏ s ∈ σ.erase t, (w t - w s) with hc
+  have hcne : c ≠ 0 := by
+    rw [hc, Finset.prod_ne_zero_iff]
+    intro s hs
+    exact sub_ne_zero.mpr (fun h => (Finset.ne_of_mem_erase hs) (hw h).symm)
+  -- `aeval T p` acts on each basis vector `b u` as the scalar `p.eval (w u)`.
+  have heval : ∀ u, aeval T p (b u) = (∏ s ∈ σ.erase t, (w u - w s)) • b u := by
+    intro u
+    rw [Module.End.aeval_apply_of_mem_apply_eq_smul (hT u)]
+    congr 1
+    rw [hp, eval_prod]
+    exact Finset.prod_congr rfl (fun s _ => by rw [eval_sub, eval_X, eval_C])
+  -- Expand `y` along the basis and push `aeval T p` through.
+  have hyexp : y = (b.repr y).sum (fun i a => a • b i) := by
+    conv_lhs => rw [← b.linearCombination_repr y]
+    rw [Finsupp.linearCombination_apply]
+  have hPy : aeval T p y = (b.repr y t * c) • b t := by
+    conv_lhs => rw [hyexp]
+    rw [map_finsuppSum, Finsupp.sum, Finset.sum_eq_single t]
+    · rw [map_smul, heval t, smul_smul]
+    · intro u hu hut
+      rw [map_smul, heval u]
+      have : (∏ s ∈ σ.erase t, (w u - w s)) = 0 :=
+        Finset.prod_eq_zero (Finset.mem_erase.mpr ⟨hut, hu⟩) (by simp)
+      rw [this, zero_smul, smul_zero]
+    · intro h; exact absurd htσ h
+  -- `aeval T p y ∈ W`, and the surviving scalar is nonzero, so `b t ∈ W`.
+  have hPyW : aeval T p y ∈ W := aeval_mem hW p y hy
+  rw [hPy] at hPyW
+  have hscale : b.repr y t * c ≠ 0 := mul_ne_zero ht hcne
+  have := W.smul_mem (b.repr y t * c)⁻¹ hPyW
+  rwa [smul_smul, inv_mul_cancel₀ hscale, one_smul] at this
+
+end CoordinateSubmodule
+
+section Irreducible
+
+variable {T : Module.End k M} {w : B → k}
+
+/-- **Connectivity ⟹ irreducible.** Suppose `T` acts diagonally on the basis `b` with pairwise
+distinct eigenvalues, and `Adj` is a relation on the index set `B` such that:
+
+* any two indices are connected by `Adj` (`hconn`), and
+* `Adj` is *realised inside* `W`: whenever `b s ∈ W` and `Adj s t`, also `b t ∈ W` (`hstep`).
+
+Then a `T`-invariant submodule `W` is `⊥` or `⊤`. This packages Problem 4.12.3: the diagonal
+element supplies the distinct eigenvalues, and the transvections supply `Adj`. -/
+theorem eq_bot_or_eq_top_of_connected
+    (hT : ∀ s, T (b s) = w s • b s) (hw : Function.Injective w)
+    {W : Submodule k M} (hW : ∀ x ∈ W, T x ∈ W)
+    (Adj : B → B → Prop)
+    (hconn : ∀ s t, Relation.ReflTransGen Adj s t)
+    (hstep : ∀ s t, b s ∈ W → Adj s t → b t ∈ W) :
+    W = ⊥ ∨ W = ⊤ := by
+  classical
+  rcases eq_or_ne W ⊥ with hbot | hbot
+  · exact Or.inl hbot
+  -- `W ≠ ⊥`, so some basis vector lies in `W`.
+  right
+  obtain ⟨y, hyW, hy0⟩ := (Submodule.ne_bot_iff W).mp hbot
+  obtain ⟨s, hs⟩ : ∃ s, b.repr y s ≠ 0 := by
+    have hry : b.repr y ≠ 0 := fun h => hy0 (by simpa using congrArg b.repr.symm h)
+    simpa using Finsupp.ne_iff.mp hry
+  have hsW : b s ∈ W := mem_of_repr_ne_zero b hT hw hW hyW hs
+  -- Propagate membership along the connected `Adj`-graph to every basis vector.
+  have hall : ∀ t, b t ∈ W := by
+    intro t
+    have : Relation.ReflTransGen Adj s t := hconn s t
+    induction this with
+    | refl => exact hsW
+    | tail _ hadj ih => exact hstep _ _ ih hadj
+  rw [eq_top_iff, ← b.span_eq]
+  exact Submodule.span_le.mpr (Set.range_subset_iff.mpr hall)
+
+end Irreducible
+
+end Etingof.DiagonalCoordinate

--- a/EtingofRepresentationTheory/Chapter5/Example5_19_3.lean
+++ b/EtingofRepresentationTheory/Chapter5/Example5_19_3.lean
@@ -1,4 +1,5 @@
 import EtingofRepresentationTheory.Chapter5.Theorem5_18_4
+import EtingofRepresentationTheory.Chapter5.ExteriorIrreducible
 
 /-!
 # Example 5.19.3: Schur Functors for Special Partitions
@@ -545,30 +546,30 @@ The book closes Example 5.19.3 by asserting that `L_{(n)} = SⁿV` and `L_{(1ⁿ
 *irreducible* `GL(V)`-representations, "except that `∧ⁿV` is zero if `n > dim V`", citing
 Problem 4.12.3 for the irreducibility.
 
-Two pieces of that final sentence:
+Three pieces of that final sentence:
 
 * The parenthetical vanishing `∧ⁿV = 0` for `n > dim V` is proved below
   (`Example5_19_3_exterior_subsingleton_of_dim_lt`): a genuine, complete result.
 
-* The irreducibility itself is the content of **Problem 4.12.3**, whose proof is the
-  distinct-eigenvalue / transvection argument:
-  pick a diagonal `H ∈ GL(V)` whose action on the representation has pairwise distinct
-  eigenvalues, so any subrepresentation `W` is spanned by a subset `S` of the eigenbasis;
-  then use invariance under the transvections `ρ(1 + E_{ij})` (`i ≠ j`) to force `S` to be
-  the whole basis once it is nonempty. Formalizing it is a standalone multi-step
-  development (it needs the symmetric-power monomial basis — *absent* from Mathlib, which
-  only has `Module.Basis.exteriorPower` for the exterior side — a generic diagonal with
-  distinct weights, the spectral-spanning lemma "an invariant subspace of a diagonalizable
-  operator with distinct eigenvalues is spanned by eigenvectors", and the transvection
-  orbit-connectivity argument). It is tracked as its own issue and is **not** proved here.
+* **The exterior half is now fully proved** (`Example5_19_3_exterior_irreducible`, via
+  `Etingof.exteriorPower_eq_bot_or_top` in `Chapter5.ExteriorIrreducible`). The reusable heart of
+  Problem 4.12.3 — "an invariant subspace of a diagonal operator with pairwise distinct eigenvalues
+  is spanned by a subset of the eigenbasis", and "connectivity of the eigenbasis under the group
+  forces irreducibility" — is packaged abstractly in `Chapter5.DiagonalCoordinate`. For `∧ⁿV` the
+  diagonal element `diag(2^(2⁰), …, 2^(2^{d-1}))` has distinct eigenvalues on `Module.Basis.exteriorPower`,
+  and the permutation matrices (transitive on `n`-subsets) supply the connectivity.
 
-To record the irreducibility claim precisely — rather than dropping it silently — the
-exact propositions are pinned below as `Prop`-valued definitions referencing the actual
-`GL(V)`-actions already constructed in this file (`symmetricPowerMap` on `SⁿV` and
-`exteriorPower.map n` on `∧ⁿV`). A subrepresentation is a submodule stable under the action
-of every `g ∈ GL(V)` (`g : V ≃ₗ[k] V`); irreducibility says the only such submodules are
-`⊥` and `⊤`. Proving `Example5_19_3_symmetric_irreducible` / `Example5_19_3_exterior_irreducible`
-is exactly the remaining Problem 4.12.3 work. -/
+* **The symmetric half (`Example5_19_3_symmetric_irreducible`) remains open.** The same
+  `DiagonalCoordinate` criterion applies, but it requires a *monomial basis of `SⁿV`* indexed by
+  degree-`n` monomials — which is **absent from Mathlib** (only the exterior basis
+  `Module.Basis.exteriorPower` exists; the symmetric-power universal property is a Mathlib TODO).
+  Permutations are *not* transitive on monomials, so the connectivity genuinely needs the
+  transvections `ρ(1 + E_{ij})` of the book's Hint. Building that basis and the transvection
+  connectivity is the remaining work; the criterion is ready to consume them.
+
+The symmetric claim is pinned below as a `Prop`-valued definition referencing the actual
+`GL(V)`-action (`symmetricPowerMap` on `SⁿV`): a subrepresentation is a submodule stable under
+every `g ∈ GL(V)` (`g : V ≃ₗ[k] V`); irreducibility says the only such submodules are `⊥` and `⊤`. -/
 
 /-- Book fidelity (Example 5.19.3, parenthetical): `∧ⁿV` is the zero representation when
 `n > dim V`. Over a field, `finrank (⋀ⁿV) = C(dim V, n) = 0` for `n > dim V`, so `∧ⁿV` is a
@@ -587,10 +588,13 @@ the irreducibility assertion in Example 5.19.3): every `GL(V)`-subrepresentation
 symmetric power — i.e. every submodule stable under `symmetricPowerMap g` for all
 `g ∈ GL(V)` — is either `⊥` or `⊤`.
 
-This records the statement faithfully against the `GL(V)`-action already constructed here.
-Its proof is the distinct-eigenvalue / transvection argument of Problem 4.12.3 and is
-deferred (see the section docstring above); it is **not** asserted to hold by this
-definition, which merely names the proposition. -/
+This records the statement faithfully against the `GL(V)`-action already constructed here. Its
+proof reduces, via `Etingof.DiagonalCoordinate.eq_bot_or_eq_top_of_connected`, to (i) a monomial
+basis of `SⁿV` with the diagonal element acting by distinct eigenvalues, and (ii) the transvection
+connectivity of that basis. Step (i) needs the symmetric-power monomial basis, currently absent
+from Mathlib (see the section docstring above), so the proof is deferred; it is **not** asserted to
+hold by this definition, which merely names the proposition. The exterior analogue
+`Example5_19_3_exterior_irreducible` *is* fully proved. -/
 def Example5_19_3_symmetric_irreducible
     {k : Type} [Field k] {V : Type} [AddCommGroup V] [Module k V] [Module.Finite k V]
     (n : ℕ) : Prop :=
@@ -598,19 +602,26 @@ def Example5_19_3_symmetric_irreducible
     (∀ g : V ≃ₗ[k] V, ∀ w ∈ W, symmetricPowerMap (g : V →ₗ[k] V) w ∈ W) →
       W = ⊥ ∨ W = ⊤
 
-/-- The precise irreducibility claim for `L_{(1ⁿ)} = ∧ⁿV` (Problem 4.12.3, the second half
-of the irreducibility assertion in Example 5.19.3, valid for `n ≤ dim V`; for `n > dim V`
-the space is zero, see `Example5_19_3_exterior_subsingleton_of_dim_lt`): every
-`GL(V)`-subrepresentation of the exterior power — i.e. every submodule stable under
-`exteriorPower.map n g` for all `g ∈ GL(V)` — is either `⊥` or `⊤`.
+/-- **Irreducibility of `L_{(1ⁿ)} = ∧ⁿV`** (Problem 4.12.3, the second half of the irreducibility
+assertion in Example 5.19.3; for `n > dim V` the space is zero, see
+`Example5_19_3_exterior_subsingleton_of_dim_lt`): every `GL(V)`-subrepresentation of the exterior
+power — i.e. every submodule stable under `exteriorPower.map n g` for all `g ∈ GL(V)` — is either
+`⊥` or `⊤`.
 
-As with the symmetric case, this names the proposition faithfully against the action built
-in this file; its proof (Problem 4.12.3) is deferred and is not asserted here. -/
-def Example5_19_3_exterior_irreducible
-    {k : Type} [Field k] {V : Type} [AddCommGroup V] [Module k V] [Module.Finite k V]
-    (n : ℕ) : Prop :=
-  ∀ W : Submodule k (⋀[k]^n V),
+This is a genuine, complete proof of Problem 4.12.3 for the exterior power, following the book's
+Hint: the diagonal element `diag(2^(2⁰), …, 2^(2^{d-1}))` has pairwise distinct eigenvalues on the
+monomial basis `e_{i₁} ∧ ⋯ ∧ e_{iₙ}` of `∧ⁿV` (the eigenvalues are `2^(∑ 2^{iⱼ})`, distinct by
+binary uniqueness), so any subrepresentation is spanned by a subset of that basis; and the
+permutation matrices, acting transitively on the `n`-subsets, then force a nonzero subrepresentation
+to be everything. See `Etingof.exteriorPower_eq_bot_or_top` for the proof. The hypothesis
+`[CharZero k]` (the book works over `ℂ`) is essential: over small finite fields the diagonal element
+with distinct eigenvalues need not exist. -/
+theorem Example5_19_3_exterior_irreducible
+    {k : Type} [Field k] [CharZero k] {V : Type} [AddCommGroup V] [Module k V] [Module.Finite k V]
+    (n : ℕ) :
+    ∀ W : Submodule k (⋀[k]^n V),
     (∀ g : V ≃ₗ[k] V, ∀ w ∈ W, exteriorPower.map n (g : V →ₗ[k] V) w ∈ W) →
-      W = ⊥ ∨ W = ⊤
+      W = ⊥ ∨ W = ⊤ :=
+  fun W hW => Etingof.exteriorPower_eq_bot_or_top W hW
 
 end Etingof

--- a/EtingofRepresentationTheory/Chapter5/ExteriorIrreducible.lean
+++ b/EtingofRepresentationTheory/Chapter5/ExteriorIrreducible.lean
@@ -1,0 +1,189 @@
+import Mathlib
+import EtingofRepresentationTheory.Chapter5.DiagonalCoordinate
+
+/-!
+# Irreducibility of `∧ⁿV` as a `GL(V)`-representation (Problem 4.12.3, exterior half)
+
+This file proves that the exterior power `⋀[k]^n V` of a finite-dimensional vector space over a
+characteristic-zero field is an *irreducible* `GL(V)`-representation: the only subspaces stable
+under every `exteriorPower.map n g` (`g : V ≃ₗ[k] V`) are `⊥` and `⊤`.
+
+This is the exterior half of Problem 4.12.3 from Etingof's book, cited in Example 5.19.3. The
+proof follows the book's Hint, packaged through `Etingof.DiagonalCoordinate`:
+
+* **Distinct eigenvalues.** Pick a basis `bV` of `V` and the diagonal element
+  `H = diag(t₀, …, t_{d-1})` with `tᵢ = 2 ^ (2 ^ i)`. On the monomial basis `b_S = ⋀_{i ∈ S} eᵢ`
+  of `⋀ⁿV` it acts with eigenvalue `∏_{i ∈ S} tᵢ = 2 ^ (∑_{i ∈ S} 2 ^ i)`. Because subsets have
+  distinct sums of powers of two, these eigenvalues are pairwise distinct, so by
+  `DiagonalCoordinate.mem_of_repr_ne_zero` any subrepresentation `W` is spanned by a subset of the
+  `b_S`.
+
+* **Connectivity by permutations.** Where the book uses transvections (needed for the symmetric
+  case), for the exterior power it suffices that `GL(V)` contains the permutation matrices, which
+  act *transitively* on the `n`-subsets `S`: an order-matching permutation `σ` sends `b_S` exactly
+  to `b_T`. Hence once some `b_S ∈ W`, every `b_T ∈ W`, so `W = ⊤`.
+-/
+
+open scoped TensorProduct BigOperators
+open Module
+
+namespace Etingof
+
+variable {k : Type*} [Field k]
+  {V : Type*} [AddCommGroup V] [Module k V]
+
+section Reindex
+
+/-- Reindex a product over the sorted enumeration of a finset back to the finset. -/
+private lemma prod_over_orderEmb {α : Type*} [LinearOrder α] {s : Finset α} {m : ℕ}
+    (h : s.card = m) (f : α → k) :
+    ∏ i : Fin m, f (s.orderEmbOfFin h i) = ∏ j ∈ s, f j := by
+  rw [← Finset.prod_coe_sort s f, ← Equiv.prod_comp (s.orderIsoOfFin h).toEquiv (fun x : s => f x)]
+  refine Finset.prod_congr rfl (fun i _ => ?_)
+  simp [Finset.coe_orderIsoOfFin_apply]
+
+end Reindex
+
+section ExteriorBasis
+
+variable {d n : ℕ}
+
+/-- A linear endomorphism `g` acts on a monomial basis vector `b_S = ⋀_{i ∈ S} eᵢ` of `⋀ⁿV` by
+applying `g` to each factor. -/
+private lemma map_exteriorBasis (bV : Basis (Fin d) k V) (g : V →ₗ[k] V)
+    (S : Set.powersetCard (Fin d) n) :
+    exteriorPower.map n g (bV.exteriorPower n S) =
+      exteriorPower.ιMulti k n (fun i => g (bV (S.val.orderEmbOfFin S.prop i))) := by
+  rw [exteriorPower.basis_apply, exteriorPower.ιMulti_family, exteriorPower.map_apply_ιMulti]
+  refine congrArg _ (funext (fun i => ?_))
+  simp only [Function.comp_apply, Set.powersetCard.ofFinEmbEquiv_symm_apply]
+
+end ExteriorBasis
+
+section DiagonalWeights
+
+variable {d n : ℕ}
+
+/-- The diagonal weights `tᵢ = 2 ^ (2 ^ i)`, nonzero in characteristic zero. -/
+private noncomputable def diagWeight [CharZero k] (i : Fin d) : k := (2 : k) ^ (2 ^ (i : ℕ))
+
+private lemma diagWeight_ne_zero [CharZero k] (i : Fin d) : diagWeight (k := k) i ≠ 0 :=
+  pow_ne_zero _ (by norm_num)
+
+/-- The diagonal units used to build the diagonal element `H ∈ GL(V)`. -/
+private noncomputable def diagUnit [CharZero k] (i : Fin d) : kˣ :=
+  Units.mk0 (diagWeight i) (diagWeight_ne_zero i)
+
+/-- The eigenvalue of `b_S` under the diagonal element: `∏_{i ∈ S} tᵢ`. -/
+private noncomputable def diagEig [CharZero k] (S : Set.powersetCard (Fin d) n) : k :=
+  ∏ j ∈ S.val, diagWeight (k := k) j
+
+/-- The eigenvalues `∏_{i ∈ S} tᵢ = 2 ^ (∑_{i ∈ S} 2 ^ i)` are pairwise distinct, because subsets
+have distinct sums of powers of two. -/
+private lemma diagEig_injective [CharZero k] :
+    Function.Injective (diagEig (k := k) (d := d) (n := n)) := by
+  intro S T h
+  -- Rewrite each eigenvalue as `(2 : k) ^ (exponent S)`.
+  have hexp : ∀ U : Set.powersetCard (Fin d) n,
+      diagEig (k := k) U = (2 : k) ^ (∑ j ∈ U.val, 2 ^ (j : ℕ)) := by
+    intro U
+    rw [diagEig, ← Finset.prod_pow_eq_pow_sum]
+    rfl
+  rw [hexp, hexp] at h
+  -- Cancel the base `2` to get equal exponents.
+  have hnat : (((2 : ℕ) ^ (∑ j ∈ S.val, 2 ^ (j : ℕ)) : ℕ) : k)
+      = (((2 : ℕ) ^ (∑ j ∈ T.val, 2 ^ (j : ℕ)) : ℕ) : k) := by push_cast; exact h
+  have hpow : (2 : ℕ) ^ (∑ j ∈ S.val, 2 ^ (j : ℕ)) = (2 : ℕ) ^ (∑ j ∈ T.val, 2 ^ (j : ℕ)) :=
+    Nat.cast_injective hnat
+  have hsum : (∑ j ∈ S.val, 2 ^ (j : ℕ)) = ∑ j ∈ T.val, 2 ^ (j : ℕ) :=
+    Nat.pow_right_injective (le_refl 2) hpow
+  -- Distinct subsets give distinct sums of powers of two (binary representation).
+  have hmap : (S.val.map Fin.valEmbedding) = (T.val.map Fin.valEmbedding) := by
+    apply Finset.equivBitIndices.symm.injective
+    change (∑ i ∈ S.val.map Fin.valEmbedding, 2 ^ i) = ∑ i ∈ T.val.map Fin.valEmbedding, 2 ^ i
+    rw [Finset.sum_map, Finset.sum_map]
+    exact hsum
+  exact Subtype.ext (Finset.map_injective Fin.valEmbedding hmap)
+
+end DiagonalWeights
+
+section Permutation
+
+variable {d n : ℕ}
+
+/-- For any two `n`-subsets `S`, `T` of `Fin d`, there is a permutation of `Fin d` carrying the
+sorted enumeration of `S` to that of `T`. (Permutations act transitively on `n`-subsets.) -/
+private lemma exists_perm_orderEmb (S T : Set.powersetCard (Fin d) n) :
+    ∃ σ : Equiv.Perm (Fin d), ∀ i : Fin n,
+      σ (S.val.orderEmbOfFin S.prop i) = T.val.orderEmbOfFin T.prop i := by
+  classical
+  -- An order-matching bijection between the elements of `S` and of `T`.
+  let φ : {x // x ∈ S.val} ≃ {x // x ∈ T.val} :=
+    (S.val.orderIsoOfFin S.prop).symm.toEquiv.trans (T.val.orderIsoOfFin T.prop).toEquiv
+  refine ⟨φ.extendSubtype, fun i => ?_⟩
+  have hmem : S.val.orderEmbOfFin S.prop i ∈ S.val := S.val.orderEmbOfFin_mem S.prop i
+  rw [Equiv.extendSubtype_apply_of_mem φ _ hmem]
+  -- Evaluate `φ` on the `i`-th sorted element of `S`.
+  change ((T.val.orderIsoOfFin T.prop)
+      ((S.val.orderIsoOfFin S.prop).symm ⟨_, hmem⟩) : Fin d) = T.val.orderEmbOfFin T.prop i
+  have hSi : ((S.val.orderIsoOfFin S.prop).symm ⟨S.val.orderEmbOfFin S.prop i, hmem⟩) = i := by
+    rw [OrderIso.symm_apply_eq]
+    exact Subtype.ext (Finset.coe_orderIsoOfFin_apply S.val S.prop i)
+  rw [hSi, Finset.coe_orderIsoOfFin_apply]
+
+end Permutation
+
+/-- **Irreducibility of `∧ⁿV` (Problem 4.12.3, exterior half).** Over a characteristic-zero field,
+every subspace of `⋀[k]^n V` stable under the `GL(V)`-action `g ↦ exteriorPower.map n g` is `⊥` or
+`⊤`. -/
+theorem exteriorPower_eq_bot_or_top [CharZero k] [Module.Finite k V] {n : ℕ}
+    (W : Submodule k (⋀[k]^n V))
+    (hW : ∀ g : V ≃ₗ[k] V, ∀ w ∈ W, exteriorPower.map n (g : V →ₗ[k] V) w ∈ W) :
+    W = ⊥ ∨ W = ⊤ := by
+  classical
+  set d := finrank k V with hd
+  -- A basis of `V` and the induced monomial basis of `⋀ⁿV`.
+  let bV : Basis (Fin d) k V := finBasis k V
+  let b : Basis (Set.powersetCard (Fin d) n) k (⋀[k]^n V) := bV.exteriorPower n
+  -- The diagonal element `H ∈ GL(V)` and the operator it induces on `⋀ⁿV`.
+  let H : V ≃ₗ[k] V := bV.equiv (bV.unitsSMul diagUnit) (Equiv.refl _)
+  set T : Module.End k (⋀[k]^n V) := exteriorPower.map n (H : V →ₗ[k] V) with hT_def
+  -- `H` acts diagonally on `bV`.
+  have hH : ∀ j : Fin d, H (bV j) = diagWeight (k := k) j • bV j := by
+    intro j
+    simp only [H, Basis.equiv_apply, Equiv.refl_apply, Basis.unitsSMul_apply, Units.smul_def]
+    rfl
+  -- `b S` written via the sorted enumeration of `S`.
+  have hbS : ∀ S : Set.powersetCard (Fin d) n,
+      b S = exteriorPower.ιMulti k n (fun i => bV (S.val.orderEmbOfFin S.prop i)) := by
+    intro S
+    rw [exteriorPower.basis_apply, exteriorPower.ιMulti_family]
+    exact congrArg _ (funext (fun i => by
+      rw [Function.comp_apply, Set.powersetCard.ofFinEmbEquiv_symm_apply]))
+  -- `T = exteriorPower.map n H` acts diagonally on the monomial basis `b`.
+  have hTdiag : ∀ S, T (b S) = diagEig (k := k) S • b S := by
+    intro S
+    rw [hT_def, map_exteriorBasis bV (H : V →ₗ[k] V) S]
+    rw [show (fun i => (H : V →ₗ[k] V) (bV (S.val.orderEmbOfFin S.prop i))) =
+        (fun i => diagWeight (k := k) (S.val.orderEmbOfFin S.prop i) •
+          bV (S.val.orderEmbOfFin S.prop i)) from funext (fun i => hH _)]
+    rw [AlternatingMap.map_smul_univ, prod_over_orderEmb, hbS S]
+    rfl
+  -- Distinct eigenvalues.
+  have hinj : Function.Injective (diagEig (k := k) (d := d) (n := n)) := diagEig_injective
+  -- `W` is `T`-invariant (apply the hypothesis to `g = H`).
+  have hWT : ∀ x ∈ W, T x ∈ W := fun x hx => hW H x hx
+  -- Connectivity: the total relation, realised by permutation matrices.
+  refine DiagonalCoordinate.eq_bot_or_eq_top_of_connected b hTdiag hinj hWT
+    (fun _ _ => True) (fun s t => Relation.ReflTransGen.tail Relation.ReflTransGen.refl trivial)
+    (fun S U hS _ => ?_)
+  -- From `b S ∈ W`, an order-matching permutation `σ` sends `b S` to `b U`.
+  obtain ⟨σ, hσ⟩ := exists_perm_orderEmb S U
+  have hmap : exteriorPower.map n (bV.equiv bV σ : V →ₗ[k] V) (b S) = b U := by
+    rw [map_exteriorBasis bV (bV.equiv bV σ : V →ₗ[k] V) S, hbS U]
+    refine congrArg _ (funext (fun i => ?_))
+    rw [LinearEquiv.coe_coe, Basis.equiv_apply, hσ i]
+  rw [← hmap]
+  exact hW (bV.equiv bV σ) (b S) hS
+
+end Etingof

--- a/progress/2026-06-30T12-10-40Z.md
+++ b/progress/2026-06-30T12-10-40Z.md
@@ -1,0 +1,49 @@
+## Accomplished
+Proved the **exterior half** of Problem 4.12.3 (issue #5638), turning the unproven
+`Example5_19_3_exterior_irreducible` `Prop`-def into a real theorem: every `GL(V)`-stable
+subspace of `∧ⁿV` is `⊥` or `⊤`.
+
+Two new files:
+
+* `Chapter5/DiagonalCoordinate.lean` — the reusable, representation-free heart of Problem
+  4.12.3, proved with no finite-dimensionality assumption:
+  - `mem_of_repr_ne_zero`: if `T` acts diagonally on a basis `b` with **pairwise distinct**
+    eigenvalues, any `T`-invariant submodule `W` contains every basis vector whose coordinate
+    is nonzero on some element of `W` (i.e. `W` is a *coordinate submodule*). Proved by the
+    Lagrange-product `∏_{s≠t}(T - wₛ)` via `aeval`, isolating one eigencomponent.
+  - `eq_bot_or_eq_top_of_connected`: distinct-eigenvalue diagonal + a connectivity relation
+    `Adj` realised inside `W` ⟹ `W = ⊥ ∨ W = ⊤`.
+
+* `Chapter5/ExteriorIrreducible.lean` — applies the criterion to `∧ⁿV`:
+  - Diagonal `diag(2^(2⁰),…,2^(2^{d-1}))` has distinct eigenvalues on `Module.Basis.exteriorPower`
+    (eigenvalue of `b_S` is `2^(∑_{i∈S} 2^i)`, distinct by binary uniqueness via
+    `Finset.equivBitIndices`).
+  - Connectivity is supplied by permutation matrices: an order-matching permutation sends `b_S`
+    to `b_T` exactly, and permutations act transitively on `n`-subsets (`Equiv.extendSubtype`).
+  - Main result `Etingof.exteriorPower_eq_bot_or_top` (needs `[CharZero k]`).
+
+`Example5_19_3.lean` updated: exterior def → proven theorem; section/symmetric docstrings rewritten
+to record the new status and the precise remaining work.
+
+## Current frontier
+`Example5_19_3_symmetric_irreducible` is still an unproven `Prop`-def. The same
+`DiagonalCoordinate` criterion applies, but it needs a **monomial basis of `SⁿV`**. Concrete
+in-project path identified (no Mathlib-TODO blocker required): build the basis as the
+**symmetrized-orbit sums** of the tensor-product basis of `V^⊗n` — these have *disjoint supports*
+for distinct monomials, hence are linearly independent, and span `symInvariants ≅ SⁿV`. Then the
+diagonal eigenvalue is `∏ tᵢ^{aᵢ}` (distinct for generic `t`) and connectivity needs the
+**transvections** `ρ(1+E_{ij})` of the book's Hint (permutations are *not* transitive on monomials).
+Estimated ~400–600 lines; deferred for budget.
+
+## Overall project progress
+Stage 3 formalization; Wave-3 fidelity (epic #5338). Exterior irreducibility of Example 5.19.3 now
+genuinely proved (was an unproven Prop-def); symmetric half remains.
+
+## Next step
+Formalize the symmetric monomial basis via orbit-sums + transvection connectivity, then apply
+`DiagonalCoordinate.eq_bot_or_eq_top_of_connected` exactly as in `ExteriorIrreducible.lean`.
+
+## Blockers
+None for the exterior half (done). Symmetric half is a sizeable but unblocked development (see
+frontier). Note: `Chapter7.lean` has a **pre-existing** `FdRep`/`FDRep` import collision unrelated
+to this work (only Chapter5 was touched).


### PR DESCRIPTION
This PR proves the exterior half of Problem 4.12.3, cited in Example 5.19.3: every `GL(V)`-stable subspace of `∧ⁿV` over a characteristic-zero field is `⊥` or `⊤`. It converts the previously unproven `Example5_19_3_exterior_irreducible` `Prop`-def into a real theorem.

It adds `Chapter5/DiagonalCoordinate.lean`, the reusable representation-free heart of the argument, proved with no finite-dimensionality assumption. `mem_of_repr_ne_zero` shows that a diagonal operator with pairwise distinct eigenvalues makes every invariant submodule a coordinate submodule (Lagrange-product `∏_{s≠t}(T - wₛ)` via `aeval`, isolating one eigencomponent), and `eq_bot_or_eq_top_of_connected` turns distinct eigenvalues plus a connectivity relation into irreducibility.

It adds `Chapter5/ExteriorIrreducible.lean` applying the criterion to `∧ⁿV`: the diagonal `diag(2^(2⁰), …, 2^(2^{d-1}))` acts on `Module.Basis.exteriorPower` with eigenvalues `2^(∑_{i∈S} 2^i)`, pairwise distinct by binary uniqueness, and the permutation matrices (transitive on `n`-subsets, via an order-matching `Equiv.extendSubtype`) supply the connectivity. The `[CharZero k]` hypothesis (the book works over `ℂ`) is essential, since over small finite fields a diagonal element with distinct eigenvalues need not exist.

The symmetric half (`Example5_19_3_symmetric_irreducible`) remains an unproven `Prop`-def and is the reason this is a partial PR. The same criterion applies but needs a monomial basis of `SⁿV` (achievable in-project via symmetrized-orbit sums of the tensor basis, which have disjoint supports) plus the transvection connectivity of the book's Hint, since permutations are not transitive on monomials. The rewritten docstrings record this precise remaining path.

🤖 Prepared with Claude Code