### PR TITLE
feat(Ch4 #5635): A₅ Phase C — golden-ratio character numerator S=(60,0,-20,60,-40) and tr(z²)=3600

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Example4_8_1.lean
+++ b/EtingofRepresentationTheory/Chapter4/Example4_8_1.lean
@@ -1735,6 +1735,43 @@ lemma zEnd_comp_char_val (j : Fin 5) :
   rw [Finset.sum_congr rfl (fun h _ => hchar _), ← Finset.mul_sum, ← Int.cast_sum, key j]
   fin_cases j <;> norm_num
 
+/-- **`tr(z²) = 3600` on `Λ²(ℂ⁴)`.**  Since `z` is central (`zEnd_central`), each summand of
+`z² = ∑_g z·ρ(g·r·g⁻¹)` has the same trace as `z·ρ(r)` (conjugation invariance of the trace):
+`tr(z·ρ(g·r·g⁻¹)) = tr(ρ(g)·z·ρ(r)·ρ(g)⁻¹) = tr(z·ρ(r))`.  Summing the constant over the 60
+elements of `A₅` gives `60·tr(z·ρ(r)) = 60·60 = 3600` (using `zEnd_comp_char_val 3`, as
+`r = classRepA5 3`).  With `tr(z) = 60` (`zEnd_trace`) and `dim_ℂ End_G(Λ²) = 2`
+(`lam2_hom_finrank`), this is the second trace identity: writing `z² = a·1 + b·z` in the
+2-dimensional endomorphism algebra, `tr(z²) = 6a + 60b = 3600` and `tr(z) = 60` combine (with
+`dim ℂ³₊ = dim ℂ³₋ = 3`, so `b = μ⁺ + μ⁻ = 20`) to give `a = 400`, i.e. the minimal polynomial
+`z² − 20·z − 400 = 0` with roots `μ± = 10 ± 10√5`. -/
+lemma zEnd_sq_trace : LinearMap.trace ℂ (↥lam2Sub.toSubmodule) (zEnd * zEnd) = 3600 := by
+  have hconj : ∀ g : G,
+      LinearMap.trace ℂ (↥lam2Sub.toSubmodule) (zEnd * lam2Sub.toRepresentation (g * r5 * g⁻¹))
+        = LinearMap.trace ℂ (↥lam2Sub.toSubmodule) (zEnd * lam2Sub.toRepresentation r5) := by
+    intro g
+    have hc : lam2Sub.toRepresentation g * zEnd = zEnd * lam2Sub.toRepresentation g :=
+      (zEnd_central g).eq
+    have hrw : zEnd * lam2Sub.toRepresentation (g * r5 * g⁻¹)
+        = lam2Sub.toRepresentation g * (zEnd * lam2Sub.toRepresentation r5)
+            * lam2Sub.toRepresentation g⁻¹ := by
+      rw [map_mul, map_mul]
+      simp only [← mul_assoc]
+      rw [hc]
+    rw [hrw, LinearMap.trace_mul_comm, ← mul_assoc, ← map_mul, inv_mul_cancel, map_one, one_mul]
+  have hz2 : zEnd * zEnd = ∑ g : G, zEnd * lam2Sub.toRepresentation (g * r5 * g⁻¹) := by
+    rw [← Finset.mul_sum]; rfl
+  rw [hz2, map_sum, Finset.sum_congr rfl (fun g _ => hconj g), Finset.sum_const, Finset.card_univ,
+    nsmul_eq_mul]
+  have hr5 : LinearMap.trace ℂ (↥lam2Sub.toSubmodule) (zEnd * lam2Sub.toRepresentation r5) = 60 := by
+    have h := zEnd_comp_char_val 3
+    rw [show classRepA5 3 = r5 from rfl] at h
+    rw [h]
+    norm_num [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+      Matrix.cons_val_three, Matrix.cons_val_four, Matrix.head_cons, Matrix.tail_cons]
+  have hcard : (Fintype.card G : ℂ) = 60 := by
+    rw [← Nat.card_eq_fintype_card, card_G]; norm_num
+  rw [hr5, hcard]; norm_num
+
 end
 
 end A5

--- a/EtingofRepresentationTheory/Chapter4/Example4_8_1.lean
+++ b/EtingofRepresentationTheory/Chapter4/Example4_8_1.lean
@@ -1689,6 +1689,52 @@ def repC3plus : FDRep ℂ G := FDRep.of repC3plusSub.toRepresentation
 /-- `ℂ³₋`, the second genuine 3-dimensional icosahedral representation of `A₅`. -/
 def repC3minus : FDRep ℂ G := FDRep.of repC3minusSub.toRepresentation
 
+/-! #### The eigenspace character numerator `S(g) = tr(z ∘ ρ(g))`
+
+The two 3-dimensional icosahedral characters are recovered from `Λ²(ℂ⁴)` by the linear system
+`χ₊ + χ₋ = χ_{Λ²}` and `μ⁺·χ₊ + μ⁻·χ₋ = S`, where `S(g) := tr(z·ρ(g))` and `z` acts as the
+scalar `μ⁺` on `ℂ³₊` and `μ⁻` on `ℂ³₋`.  Solving gives the golden-ratio entries
+`χ₊(g) = (S(g) − μ⁻·χ_{Λ²}(g))/(μ⁺ − μ⁻)`.  Here we compute the honest 60-term group sum
+`S = (60, 0, −20, 60, −40)` at the five class representatives. -/
+
+/-- `tr(z·ρ(g))` written as the honest character sum `∑_{h∈A₅} χ_{Λ²}(h·r·h⁻¹·g)`, using that
+`z = ∑_h ρ(h·r·h⁻¹)` and that `ρ` is a monoid homomorphism. -/
+lemma zEnd_comp_char (g : G) :
+    LinearMap.trace ℂ (↥lam2Sub.toSubmodule) (zEnd * lam2Sub.toRepresentation g)
+      = ∑ h : G, lam2.character (h * r5 * h⁻¹ * g) := by
+  have hchar : ∀ x : G, LinearMap.trace ℂ (↥lam2Sub.toSubmodule) (lam2Sub.toRepresentation x)
+      = lam2.character x := fun _ => rfl
+  rw [zEnd, Finset.sum_mul, map_sum]
+  refine Finset.sum_congr rfl fun h _ => ?_
+  rw [← map_mul, hchar]
+
+-- honest `decide` of the character sum over 5×60 group elements; no `native_decide`
+set_option maxRecDepth 8000 in
+set_option maxHeartbeats 4000000 in
+/-- **The eigenspace character numerator `S(g) = tr(z·ρ(g))` at the five class representatives is
+`(60, 0, −20, 60, −40)`.**  Each value is the honest 60-term sum `∑_h χ_{Λ²}(h·r·h⁻¹·g)`, with
+`χ_{Λ²}(y) = ½·((fix₅(y) − 1)² − (fix₅(y²) − 1))` evaluated by `decide` over the 60 elements of
+`A₅` (no `native_decide`).  Together with `χ_{Λ²} = (6, 0, −2, 1, 1)` and `z = μ⁺` on `ℂ³₊`,
+`z = μ⁻` on `ℂ³₋`, this pins the golden-ratio characters `χ₊ = (3, 0, −1, φ, φ')`,
+`χ₋ = (3, 0, −1, φ', φ)`. -/
+lemma zEnd_comp_char_val (j : Fin 5) :
+    LinearMap.trace ℂ (↥lam2Sub.toSubmodule) (zEnd * lam2Sub.toRepresentation (classRepA5 j))
+      = (![60, 0, -20, 60, -40] j : ℂ) := by
+  rw [zEnd_comp_char]
+  have hchar : ∀ y : G, lam2.character y
+      = (2⁻¹ : ℂ) * ((((S4.fixCardM (G := G) (α := Fin 5) y : ℤ) - 1) ^ 2
+          - ((S4.fixCardM (G := G) (α := Fin 5) (y * y) : ℤ) - 1) : ℤ) : ℂ) := by
+    intro y
+    rw [lam2_char_formula, repC4_char, repC4_char]
+    push_cast; ring
+  have key : ∀ i : Fin 5,
+      (∑ h : G, (((S4.fixCardM (G := G) (α := Fin 5) (h * r5 * h⁻¹ * classRepA5 i) : ℤ) - 1) ^ 2
+        - ((S4.fixCardM (G := G) (α := Fin 5) ((h * r5 * h⁻¹ * classRepA5 i)
+            * (h * r5 * h⁻¹ * classRepA5 i)) : ℤ) - 1)))
+      = ![120, 0, -40, 120, -80] i := by decide
+  rw [Finset.sum_congr rfl (fun h _ => hchar _), ← Finset.mul_sum, ← Int.cast_sum, key j]
+  fin_cases j <;> norm_num
+
 end
 
 end A5

--- a/progress/2026-07-01T01-30-21Z_900d88dc.md
+++ b/progress/2026-07-01T01-30-21Z_900d88dc.md
@@ -1,0 +1,72 @@
+## Accomplished
+
+One-shot session on issue #5635 (reopened review: the A₅ public API covers only 3 of 5 irreps;
+the two golden-ratio icosahedral reps `repC3plus`/`repC3minus` exist as genuine `FDRep` objects
+but are not in `irrepA5`, not proved 3-dim/`Simple`/character-correct). This is the full
+**Phase C** (#5459), inherently multi-session.
+
+Landed the two **honest computations that actually produce the golden ratio** — the pieces that
+"see" √5 — both sorry-free and `native_decide`-free, in `Example4_8_1.lean`:
+
+1. **`zEnd_comp_char` / `zEnd_comp_char_val`** — the eigenspace character numerator
+   `S(g) := tr(z·ρ(g)) = ∑_{h∈A₅} χ_{Λ²}(h·r·h⁻¹·g)`, evaluated at the five class reps to
+   `S = (60, 0, −20, 60, −40)`. Honest 60-term-per-class `decide` using
+   `χ_{Λ²}(y) = ½·((fix₅(y)−1)² − (fix₅(y²)−1))`. This is the right-hand side of the linear
+   system that yields the golden-ratio characters (see math note below).
+
+2. **`zEnd_sq_trace`** — `tr(z²) = 3600` on `Λ²(ℂ⁴)`, via the conjugation-invariance reduction
+   `tr(z·ρ(g·r·g⁻¹)) = tr(z·ρ(r))` (z central) so `tr(z²) = 60·tr(z·ρ(r)) = 60·60`. This avoids
+   the infeasible 3600-term double `decide`; it reduces to `zEnd_comp_char_val 3`.
+
+### The math, fully worked out (for the successor)
+
+`z` acts as the scalar `μ⁺` on `ℂ³₊` and `μ⁻` on `ℂ³₋`, `μ± = 10 ± 10√5`, `μ⁺−μ⁻ = 20√5`.
+Two linear identities in the class functions:
+- `χ₊ + χ₋ = χ_{Λ²}` (`lam2_character` = `(6,0,−2,1,1)`),
+- `μ⁺·χ₊ + μ⁻·χ₋ = S` (`zEnd_comp_char_val` = `(60,0,−20,60,−40)`).
+
+Solving: `χ₊(g) = (S(g) − μ⁻·χ_{Λ²}(g))/(μ⁺−μ⁻)`. Checked by hand at every class:
+`χ₊ = (3,0,−1,φ,φ')`, `χ₋ = (3,0,−1,φ',φ)` with `φ=(1+√5)/2`. These are exactly the two book
+rows (rows 1,2 of `chiA5`).
+
+Minimal polynomial: in the 2-dimensional `End_G(Λ²)` (`lam2_hom_finrank = 2`), `{1,z,z²}` are
+dependent, so `z² = a·1 + b·z`. Trace pins it: `tr(z)=60` (`zEnd_trace`), `tr(z²)=3600`
+(`zEnd_sq_trace`), and `dim ℂ³₊ = dim ℂ³₋ = 3` give `b = μ⁺+μ⁻ = 20`, then `6a+60·20=3600` ⟹
+`a = 400`. So `z² − 20z − 400 = 0`.
+
+## Current frontier
+
+Two cornerstone lemmas committed on `agent/900d88dc` (green build, 8580 jobs, sorry-free,
+native_decide-free). The public API `Etingof.Example4_8_1_A5_irrep : Fin 3 → …` is still `Fin 3`.
+
+## Overall project progress
+
+Ch.4 Example 4.8.1: Q₈ and S₄ complete (5/5 each). A₅ has 3/5 rows in the public API
+(ℂ, ℂ⁴, ℂ⁵). This session adds the honest √5-producing computations (`S` numerator, `tr z²`),
+building on prior `lam2_hom_finrank=2` (#5741) and `zEnd_trace=60`. The Fin-5 API is not yet
+extended, so #5635 stays open (PR is `Refs`, not `Closes`; marked `replan`).
+
+## Next step (concrete, for #5459 Phase C)
+
+Remaining chain, in order (each step now has its numeric target fixed by this session):
+
+1. **Package `z` as a categorical endo `zHom : lam2 ⟶ lam2`** (equivariance = `zEnd_central`).
+   Relate its underlying `Module.End` to `zEnd`, and `1,zHom,zHom²` to `1,zEnd,zEnd²`.
+2. **Minimal polynomial `zEnd² = 20·zEnd + 400·1`**: `{1,zEnd,zEnd²}` dependent (3 vectors in the
+   dim-2 `lam2 ⟶ lam2`); pin coefficients with `zEnd_trace`, `zEnd_sq_trace`, and the two
+   eigenspace-dimension facts (`dim=3` each, from the isotypic argument: `⟨χ_{Λ²},χ_triv⟩ =
+   ⟨χ_{Λ²},χ_C4⟩ = ⟨χ_{Λ²},χ_C5⟩ = 0` and `⟨χ_{Λ²},χ_{Λ²}⟩ = 2` force constituents `{3,3}`).
+3. **Eigenspace dims / `IsCompl`**: projector `P⁺ = (zEnd − μ⁻)/(20√5)`, idempotent from the min
+   poly, `range = repC3plusSub`, `tr P⁺ = 3` ⟹ `finrank repC3plus = 3` (and `repC3minus`);
+   `lam2 = repC3plus ⊕ repC3minus`.
+4. **Characters**: apply `χ₊(g) = (S(g) − μ⁻·χ_{Λ²}(g))/(μ⁺−μ⁻)` (all inputs now landed) to get
+   `(3,0,−1,φ,φ')`, `(3,0,−1,φ',φ)`; bridge to `Q5toC (chiA5 1/2 ·)`.
+5. **Simplicity** via `⟨χ₊,χ₊⟩ = 1`; extend `irrepA5`/`tblA5`/`rowA5` to `Fin 5`; pairwise
+   non-iso over `Q5` (√5 entry distinguishes ℂ³₊ from ℂ³₋); update the
+   `Etingof.Example4_8_1_A5_*` wrappers to `Fin 5`. Optionally retire `A5_orthonormal`.
+
+## Blockers
+
+None new. Full Phase C is inherently multi-session; #5459 tracks the remainder. The
+√5-producing computations (the genuinely hard, potentially-infeasible-by-brute-force part) are
+now landed and verified, which de-risks steps 2–4.


### PR DESCRIPTION
This PR advances A₅ Phase C (#5459) of Example 4.8.1 by landing the two honest computations that actually produce the golden ratio for the icosahedral characters ℂ³₊/ℂ³₋ — the parts that "see" √5 — both sorry-free and native_decide-free. It does not extend the public API to Fin 5, so it uses `Refs #5635`, not `Closes`.

`zEnd_comp_char` / `zEnd_comp_char_val` compute the eigenspace character numerator S(g) = tr(z·ρ(g)) = ∑_{h∈A₅} χ_Λ²(h·r·h⁻¹·g) at the five class representatives, giving S = (60, 0, −20, 60, −40), by an honest 60-term-per-class `decide` using χ_Λ²(y) = ½·((fix₅(y)−1)² − (fix₅(y²)−1)). `zEnd_sq_trace` proves tr(z²) = 3600 on Λ²(ℂ⁴) via the conjugation-invariance reduction tr(z·ρ(g·r·g⁻¹)) = tr(z·ρ(r)) (z central), so tr(z²) = 60·tr(z·ρ(r)) = 60·60, avoiding the infeasible 3600-term double `decide`.

Together with the existing lam2_hom_finrank = 2 (#5741) and zEnd_trace = 60, these fix every numeric input to the remaining Phase C chain: the character solve χ₊(g) = (S(g) − μ⁻·χ_Λ²(g))/(μ⁺−μ⁻) yields (3,0,−1,φ,φ') and (3,0,−1,φ',φ), and the minimal polynomial z² − 20z − 400 = 0 (μ± = 10 ± 10√5) follows from tr(z), tr(z²), and the eigenspace dimensions. The residual (categorical zHom packaging, minimal polynomial, eigenspace finrank/IsCompl, character bridge, Fin-5 API extension, pairwise non-iso) is tracked by #5459 and laid out step-by-step in the progress file.

🤖 Prepared with Claude Code