### PR TITLE
fix(Ch7): correct case-mismatched import FdRep → FDRep in Example7_6_3

### DIFF
--- a/EtingofRepresentationTheory/Chapter7/Example7_6_3.lean
+++ b/EtingofRepresentationTheory/Chapter7/Example7_6_3.lean
@@ -1,6 +1,6 @@
 import Mathlib.RepresentationTheory.Induced
 import Mathlib.RepresentationTheory.FiniteIndex
-import Mathlib.RepresentationTheory.FdRep
+import Mathlib.RepresentationTheory.FDRep
 import Mathlib.Algebra.Lie.UniversalEnveloping
 import Mathlib.Algebra.MonoidAlgebra.Basic
 import Mathlib.LinearAlgebra.TensorAlgebra.Basic


### PR DESCRIPTION
This PR corrects a case-mismatched import in Example7_6_3.lean: the module is `Mathlib.RepresentationTheory.FDRep` (capital D, and the file body already uses `FDRep`), but the import read `FdRep`. macOS resolves it case-insensitively so local builds pass, but CI on Linux fails with a bad import, breaking the full-library build for every PR. This is why recent PR CI has been red.

🤖 Prepared with Claude Code