### PR TITLE
feat(Ch4 #5635): A₅ Phase C eigenvalue arithmetic μ± and χ_Λ²=χ₊+χ₋

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Example4_8_1.lean
+++ b/EtingofRepresentationTheory/Chapter4/Example4_8_1.lean
@@ -1772,6 +1772,52 @@ lemma zEnd_sq_trace : LinearMap.trace ℂ (↥lam2Sub.toSubmodule) (zEnd * zEnd)
     rw [← Nat.card_eq_fintype_card, card_G]; norm_num
   rw [hr5, hcard]; norm_num
 
+/-! #### The two eigenvalues `μ± = 10 ± 10√5` and the minimal polynomial `X² − 20X − 400`
+
+The eigenvalues of `z` on the two 3-dimensional eigenspaces are `μ± = 10 ± 10√5 = 20φ, 20φ'`.
+These are exactly the two roots of `X² − 20X − 400`: their sum is `20` and their product is
+`−400`, and their difference is `20√5` (the `√5` that produces the golden-ratio characters).
+These identities are the algebraic content of the minimal polynomial `z² − 20z − 400 = 0`. -/
+
+/-- `μ⁺ + μ⁻ = 20` — the trace of the companion `X² − 20X − 400`, i.e. `z² = 20z + 400·1`. -/
+lemma muPlus_add_muMinus : muPlus + muMinus = 20 := by
+  simp only [muPlus, muMinus]; ring
+
+/-- `√5² = 5` in `ℂ`, the single irrational identity feeding the eigenvalue arithmetic. -/
+lemma sqrt5_sq : (Real.sqrt 5 : ℂ) ^ 2 = 5 := by
+  rw [← Complex.ofReal_pow, Real.sq_sqrt (by norm_num : (0 : ℝ) ≤ 5)]; norm_num
+
+/-- `μ⁺ · μ⁻ = −400` — the constant term of the companion `X² − 20X − 400`. -/
+lemma muPlus_mul_muMinus : muPlus * muMinus = -400 := by
+  simp only [muPlus, muMinus]; ring_nf; rw [sqrt5_sq]; norm_num
+
+/-- `μ⁺ − μ⁻ = 20√5` — the golden-ratio-producing gap between the two eigenvalues, the
+denominator in `χ₊(g) = (S(g) − μ⁻·χ_{Λ²}(g))/(μ⁺ − μ⁻)`. -/
+lemma muPlus_sub_muMinus : muPlus - muMinus = 20 * (Real.sqrt 5 : ℂ) := by
+  simp only [muPlus, muMinus]; ring
+
+/-! #### `χ_{Λ²} = χ₊ + χ₋`: the honest character of `Λ²(ℂ⁴)` is the sum of the two book rows -/
+
+/-- `Q5toC` is additive. -/
+lemma Q5toC_add (a b : Q5) : Q5toC (a + b) = Q5toC a + Q5toC b := by
+  simp only [Q5toC, Q5.add_re, Q5.add_im]; push_cast; ring
+
+/-- **The character of `Λ²(ℂ⁴)` is the sum of the two golden-ratio rows `χ₊ + χ₋`.**  The honest
+trace `χ_{Λ²} = (6, 0, −2, 1, 1)` (`lam2_character`) equals `chiA5 1 + chiA5 2` at every class:
+row 1 is `(3, 0, −1, φ, φ')`, row 2 is `(3, 0, −1, φ', φ)`, and `φ + φ' = 1` makes the two
+`√5` contributions cancel on the 5-cycle classes.  Combined with `A5_orthonormal` (rows 1 and 2
+are orthonormal, and orthogonal to rows 0/3/4), this exhibits `Λ²(ℂ⁴)` as the multiplicity-free
+sum of the two 3-dimensional icosahedral constituents `ℂ³₊ ⊕ ℂ³₋` — the character-level
+statement underlying the eigenspace split of the central `z`. -/
+lemma lam2_character_eq_sum (j : Fin 5) :
+    lam2.character (classRepA5 j) = Q5toC (chiA5 1 j) + Q5toC (chiA5 2 j) := by
+  rw [lam2_character, ← Q5toC_add, Q5toC]
+  fin_cases j <;>
+    simp only [chiA5, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+      Matrix.head_cons, Matrix.tail_cons] <;>
+    norm_num [Q5.add_re, Q5.add_im, Q5.mk_re, Q5.mk_im, Q5.ofNat_re, Q5.ofNat_im, Q5.neg_re,
+      Q5.neg_im, Q5.one_re, Q5.one_im, Q5.zero_re, Q5.zero_im]
+
 end
 
 end A5

--- a/progress/2026-07-01T03-30-00Z_11121f63.md
+++ b/progress/2026-07-01T03-30-00Z_11121f63.md
@@ -1,0 +1,62 @@
+## Accomplished
+
+One-shot (`/once`) session on **review issue #5635** (reopened: the A₅ public API
+`Etingof.Example4_8_1_A5_irrep : Fin 3 → …` covers only 3 of the 5 rows of the book's
+A₅ character table; the two golden-ratio icosahedral reps `repC3plus`/`repC3minus` exist
+as genuine `FDRep` objects but are not in `irrepA5`, nor proved 3-dim/`Simple`/character-
+correct). This is the full **Phase C** (tracked by #5459), inherently multi-session.
+
+Re-confirmed the finding is real and outstanding, then landed the next coherent increment
+in `EtingofRepresentationTheory/Chapter4/Example4_8_1.lean` (sorry-free, native_decide-free,
+green build):
+
+- **`muPlus_add_muMinus` (= 20)**, **`muPlus_mul_muMinus` (= −400)**, **`muPlus_sub_muMinus`
+  (= 20√5)** — the two eigenvalues `μ± = 10 ± 10√5` realised as the roots of the minimal
+  polynomial `X² − 20X − 400`, together with the `√5`-gap that produces the golden ratio.
+- **`sqrt5_sq`** — `(√5)² = 5` in `ℂ` (the one irrational identity feeding the arithmetic).
+- **`Q5toC_add`** — additivity of the `Q5 → ℂ` map.
+- **`lam2_character_eq_sum`** — the honest character of `Λ²(ℂ⁴)` equals `chiA5 1 + chiA5 2`
+  (`= χ₊ + χ₋`) at every class rep. Row 1 = `(3,0,−1,φ,φ')`, row 2 = `(3,0,−1,φ',φ)`,
+  `φ+φ' = 1` so the `√5` terms cancel to give `lam2_character = (6,0,−2,1,1)`. Combined with
+  `A5_orthonormal` this is the character-level statement that `Λ²(ℂ⁴)` is the multiplicity-free
+  sum `ℂ³₊ ⊕ ℂ³₋`.
+
+## Current frontier
+
+Five new lemmas committed on `agent/11121f63`. The public API is still `Fin 3`; #5635 stays
+open (PR uses `Refs`, not `Closes`; marked `replan`). The genuinely √5-producing computations
+(`zEnd_comp_char_val` = `S` numerator, `zEnd_sq_trace` = 3600) and now the eigenvalue algebra +
+character-sum are all in place, de-risking the remaining linear-algebra chain.
+
+## Overall project progress
+
+Ch.4 Example 4.8.1: Q₈ and S₄ complete (5/5 rows each, faithful). A₅ has 3/5 rows in the
+public API (`ℂ`, `ℂ⁴`, `ℂ⁵`). Phase C infrastructure landed to date: `lam2_hom_finrank = 2`
+(#5741), `zEnd_trace = 60`, `zEnd_comp_char_val = (60,0,−20,60,−40)`, `zEnd_sq_trace = 3600`
+(#5745), and this session's eigenvalue arithmetic + `χ_Λ² = χ₊ + χ₋`.
+
+## Next step (concrete, for #5459 Phase C)
+
+Remaining chain, in order (numeric targets all fixed):
+
+1. **Minimal polynomial `zEnd² = 20·zEnd + 400·1`** in `End_ℂ ↥lam2Sub.toSubmodule`.
+   `{1, zEnd, zEnd²}` are three G-equivariant endos in the 2-dim `lam2 ⟶ lam2`
+   (`lam2_hom_finrank`), hence dependent; the coefficients are pinned by `zEnd_trace = 60`,
+   `zEnd_sq_trace = 3600`, and the two eigenspace dims (= 3 each). The eigenspace dims come
+   from the isotypic argument: `lam2_character_eq_sum` + `A5_orthonormal` give
+   `⟨χ_Λ², χ_row⟩ = 0` for rows 0/3/4 and `⟨χ_Λ², χ_Λ²⟩ = 2`, so the two constituents are the
+   two 3-dim irreps.
+2. **Eigenspace `finrank = 3`** for `repC3plus`/`repC3minus`: projector
+   `P⁺ = (zEnd − μ⁻)/(μ⁺−μ⁻)` idempotent (from step 1), `tr P⁺ = (60 − 6·μ⁻)/(20√5) = 3`,
+   `lam2 = repC3plus ⊕ repC3minus` (`IsCompl`).
+3. **Characters**: `χ₊(g) = (S(g) − μ⁻·χ_Λ²(g))/(μ⁺−μ⁻)` (all inputs landed) gives
+   `(3,0,−1,φ,φ')`, `(3,0,−1,φ',φ)`; bridge to `Q5toC (chiA5 1/2 ·)`.
+4. **Simplicity** via `⟨χ₊,χ₊⟩ = 1`; extend `irrepA5`/`tblA5`/`rowA5` to `Fin 5`; pairwise
+   non-iso over `Q5` (the `√5` entry distinguishes `ℂ³₊` from `ℂ³₋`); update the public
+   `Etingof.Example4_8_1_A5_*` wrappers to `Fin 5`.
+
+## Blockers
+
+None new. Full Phase C is inherently multi-session; #5459 tracks the remainder. Step 1
+(the minimal polynomial via the isotypic/eigenspace-dimension argument) is the next linchpin
+and now has all of its numeric inputs in the file.


### PR DESCRIPTION
Partial progress on #5635

Session: `11121f63-cb87-4b93-83d0-3025da364765`

3cb3d8ce doc(progress #5635): A₅ Phase C eigenvalue arithmetic + χ_Λ²=χ₊+χ₋ increment
98019ad4 feat(Ch4 #5635): A₅ Phase C — eigenvalue arithmetic μ±, and χ_Λ²=χ₊+χ₋ character-sum

🤖 Prepared with Claude Code