### PR TITLE
feat(Ch4 #5635): A₅ Phase C — z↔Z eigenspace bridge, reduce dim ℂ³± to intrinsic z

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Example4_8_1.lean
+++ b/EtingofRepresentationTheory/Chapter4/Example4_8_1.lean
@@ -1655,6 +1655,25 @@ lemma Zamb_mapsTo : ∀ v ∈ lam2Sub.toSubmodule, Zamb v ∈ lam2Sub.toSubmodul
   rw [Zamb, LinearMap.sum_apply]
   exact Submodule.sum_mem _ fun g _ => lam2Sub.apply_mem_toSubmodule (g * r5 * g⁻¹) hv
 
+/-- **`z` is the restriction of the ambient `Z` to `Λ²(ℂ⁴)`.**  Both are the same 60-term group
+sum `Σ_g ρ(g·r·g⁻¹)`: `zEnd` restricts each summand to `lam2Sub` (Phase B, where the traces are
+computed), while `Zamb` keeps it ambient on `W4 ⊗ W4` (Phase C, where the eigenspaces defining
+`ℂ³₊`, `ℂ³₋` live).  Coercing `zEnd v` back to `W4 ⊗ W4` recovers `Z` applied to the coercion —
+the identity transporting the trace / minimal-polynomial data of `z` onto the `Z`-eigenspaces. -/
+lemma zEnd_coe (v : ↥lam2Sub.toSubmodule) :
+    ((zEnd v : ↥lam2Sub.toSubmodule) : W4 ⊗[ℂ] W4) = Zamb (v : W4 ⊗[ℂ] W4) := by
+  simp only [zEnd, Zamb, LinearMap.sum_apply, Submodule.coe_sum]
+  rfl
+
+/-- **The `μ`-eigenspaces of `z` and of `Z` correspond under `Λ²(ℂ⁴) ↪ W4 ⊗ W4`.**  A vector of
+`Λ²(ℂ⁴)` is a `μ`-eigenvector of the intrinsic `zEnd` iff its ambient image is a `μ`-eigenvector
+of `Zamb`.  Immediate from `zEnd_coe`. -/
+lemma zEnd_eigenspace_iff (μ : ℂ) (v : ↥lam2Sub.toSubmodule) :
+    v ∈ Module.End.eigenspace zEnd μ
+      ↔ (v : W4 ⊗[ℂ] W4) ∈ Module.End.eigenspace Zamb μ := by
+  rw [Module.End.mem_eigenspace_iff, Module.End.mem_eigenspace_iff, Subtype.ext_iff, zEnd_coe,
+    Submodule.coe_smul]
+
 /-! #### The two eigenvalues and the genuine eigenspace subrepresentations -/
 
 /-- The eigenvalue `μ⁺ = 10 + 10√5 = 20·φ` of `z` on `ℂ³₊`. -/
@@ -1688,6 +1707,51 @@ def repC3plus : FDRep ℂ G := FDRep.of repC3plusSub.toRepresentation
 
 /-- `ℂ³₋`, the second genuine 3-dimensional icosahedral representation of `A₅`. -/
 def repC3minus : FDRep ℂ G := FDRep.of repC3minusSub.toRepresentation
+
+/-- **The carrier of `ℂ³₊` is the image of the `μ⁺`-eigenspace of the intrinsic `z`.**  The
+subrepresentation `ℂ³₊ = Λ²(ℂ⁴) ⊓ ker(Z − μ⁺)` is exactly the `μ⁺`-eigenspace of `zEnd` inside
+`Λ²(ℂ⁴)`, pushed forward along the inclusion `Λ²(ℂ⁴) ↪ W4 ⊗ W4` (`zEnd_eigenspace_iff`). -/
+lemma repC3plusSub_toSubmodule_eq :
+    repC3plusSub.toSubmodule
+      = (Module.End.eigenspace zEnd muPlus).map lam2Sub.toSubmodule.subtype := by
+  ext x
+  rw [show repC3plusSub.toSubmodule
+      = lam2Sub.toSubmodule ⊓ Module.End.eigenspace Zamb muPlus from rfl,
+    Submodule.mem_inf, Submodule.mem_map]
+  constructor
+  · rintro ⟨hx, hxe⟩
+    exact ⟨⟨x, hx⟩, (zEnd_eigenspace_iff muPlus ⟨x, hx⟩).mpr hxe, rfl⟩
+  · rintro ⟨⟨y, hy⟩, hye, rfl⟩
+    exact ⟨hy, (zEnd_eigenspace_iff muPlus ⟨y, hy⟩).mp hye⟩
+
+/-- **The carrier of `ℂ³₋` is the image of the `μ⁻`-eigenspace of the intrinsic `z`.** -/
+lemma repC3minusSub_toSubmodule_eq :
+    repC3minusSub.toSubmodule
+      = (Module.End.eigenspace zEnd muMinus).map lam2Sub.toSubmodule.subtype := by
+  ext x
+  rw [show repC3minusSub.toSubmodule
+      = lam2Sub.toSubmodule ⊓ Module.End.eigenspace Zamb muMinus from rfl,
+    Submodule.mem_inf, Submodule.mem_map]
+  constructor
+  · rintro ⟨hx, hxe⟩
+    exact ⟨⟨x, hx⟩, (zEnd_eigenspace_iff muMinus ⟨x, hx⟩).mpr hxe, rfl⟩
+  · rintro ⟨⟨y, hy⟩, hye, rfl⟩
+    exact ⟨hy, (zEnd_eigenspace_iff muMinus ⟨y, hy⟩).mp hye⟩
+
+/-- **`dim ℂ³₊ = dim(μ⁺-eigenspace of `z`)`.**  Reduces the dimension of the icosahedral
+representation `ℂ³₊` to the eigenspace dimension of the single 6-dimensional operator `z` on
+`Λ²(ℂ⁴)` — the last combinatorial input still needed (`= 3`, via the minimal polynomial
+`z² = 20z + 400` and `tr z = 60`) to prove `ℂ³₊` genuinely 3-dimensional. -/
+lemma repC3plusSub_finrank_eq :
+    Module.finrank ℂ repC3plusSub.toSubmodule
+      = Module.finrank ℂ (Module.End.eigenspace zEnd muPlus) := by
+  rw [repC3plusSub_toSubmodule_eq, Submodule.finrank_map_subtype_eq]
+
+/-- **`dim ℂ³₋ = dim(μ⁻-eigenspace of `z`)`.** -/
+lemma repC3minusSub_finrank_eq :
+    Module.finrank ℂ repC3minusSub.toSubmodule
+      = Module.finrank ℂ (Module.End.eigenspace zEnd muMinus) := by
+  rw [repC3minusSub_toSubmodule_eq, Submodule.finrank_map_subtype_eq]
 
 /-! #### The eigenspace character numerator `S(g) = tr(z ∘ ρ(g))`
 

--- a/progress/2026-07-01T04-06-33Z_7d0fe4ab.md
+++ b/progress/2026-07-01T04-06-33Z_7d0fe4ab.md
@@ -1,0 +1,84 @@
+## Accomplished
+
+One-shot (`/once`) session on **review issue #5635** (reopened: the A₅ public API
+`Etingof.Example4_8_1_A5_irrep : Fin 3 → …` covers only 3 of the 5 rows of the book's A₅
+character table; the two golden-ratio icosahedral reps `repC3plus`/`repC3minus` exist as genuine
+`FDRep` objects but are not in `irrepA5`, nor proved 3-dim/`Simple`/character-correct). This is
+the full **Phase C** (tracked by #5459), inherently multi-session.
+
+Re-confirmed the finding is real and outstanding, then landed the next coherent increment in
+`EtingofRepresentationTheory/Chapter4/Example4_8_1.lean` (sorry-free, native_decide-free, green
+`lake build`). The increment **bridges Phase B and Phase C**: it connects the intrinsic operator
+`zEnd` (on `↥lam2Sub.toSubmodule`, carrier of all the trace data — `zEnd_trace = 60`,
+`zEnd_sq_trace = 3600`, `zEnd_comp_char_val`) with the ambient operator `Zamb` (on `W4 ⊗ W4`,
+which *defines* the eigenspace subrepresentations `ℂ³₊ = Λ²(ℂ⁴) ⊓ ker(Z − μ⁺)`,
+`ℂ³₋ = Λ²(ℂ⁴) ⊓ ker(Z − μ⁻)`). Until now these two operators were unrelated in the file, so none
+of the trace/eigenvalue algebra could touch the objects `repC3plusSub`/`repC3minusSub`.
+
+New lemmas:
+
+- **`zEnd_coe`** — `↑(zEnd v) = Zamb ↑v` for `v : ↥lam2Sub.toSubmodule`: `z` is literally the
+  restriction of `Z` to `Λ²(ℂ⁴)` (same 60-term group sum `Σ_g ρ(g·r·g⁻¹)`, one restricting each
+  summand and the other keeping it ambient). Proved by `Submodule.coe_sum` + `restrict_coe_apply`.
+- **`zEnd_eigenspace_iff`** — `v ∈ eigenspace zEnd μ ↔ ↑v ∈ eigenspace Zamb μ`. Immediate from
+  `zEnd_coe` + `Subtype.ext_iff` + `Submodule.coe_smul`.
+- **`repC3plusSub_toSubmodule_eq` / `repC3minusSub_toSubmodule_eq`** — the carrier of `ℂ³₊`
+  (resp. `ℂ³₋`) equals `(eigenspace zEnd μ⁺).map lam2Sub.toSubmodule.subtype` (resp. `μ⁻`): the
+  ambient eigenspace-intersection carrier is exactly the intrinsic `z`-eigenspace pushed forward
+  along `Λ²(ℂ⁴) ↪ W4 ⊗ W4`.
+- **`repC3plusSub_finrank_eq` / `repC3minusSub_finrank_eq`** — `dim ℂ³₊ = dim(μ⁺-eigenspace of z)`
+  (resp. `μ⁻`), via `Submodule.finrank_map_subtype_eq`. **This reduces the remaining
+  dimension obligation (`dim ℂ³₊ = dim ℂ³₋ = 3`) to a statement about a single 6-dimensional
+  operator `z` on `Λ²(ℂ⁴)`** — no more subtype-of-subtype ambient bookkeeping downstream.
+
+## Current frontier
+
+Six new lemmas committed on `agent/7d0fe4ab`. The public API is still `Fin 3`; #5635 stays open
+(PR uses `Refs`, not `Closes`; marked `replan` via `--partial`). All numeric inputs
+(`zEnd_trace = 60`, `zEnd_sq_trace = 3600`, `zEnd_comp_char_val = (60,0,−20,60,−40)`, the
+eigenvalue arithmetic `μ⁺+μ⁻=20`, `μ⁺μ⁻=−400`, `μ⁺−μ⁻=20√5`, and `χ_Λ² = χ₊+χ₋`) and now the
+`z`↔`Z` eigenspace bridge are in the file.
+
+## Overall project progress
+
+Ch.4 Example 4.8.1: Q₈ and S₄ complete (5/5 rows each, faithful). A₅ has 3/5 rows in the public
+API (`ℂ`, `ℂ⁴`, `ℂ⁵`). Phase C infrastructure landed to date: `lam2_hom_finrank = 2` (#5741),
+`zEnd_trace = 60`, `zEnd_comp_char_val`, `zEnd_sq_trace = 3600` (#5745), eigenvalue arithmetic +
+`χ_Λ² = χ₊+χ₋` (#5751), and this session's `zEnd_coe` / `zEnd_eigenspace_iff` /
+`repC3±Sub_finrank_eq` bridge.
+
+## Next step (concrete, for #5459 Phase C)
+
+Remaining chain, in order (numeric targets all fixed; carrier now reduced to `↥lam2Sub`):
+
+1. **Minimal polynomial `zEnd² = 20·zEnd + 400·1`** in `Module.End ℂ ↥lam2Sub.toSubmodule`.
+   `{1, zEnd, zEnd²}` are three `G`-equivariant endos in the 2-dim `lam2 ⟶ lam2`
+   (`lam2_hom_finrank`), hence dependent; `zEnd` non-scalar (else `tr z = 60 ⇒ z = 10`, but then
+   `tr z² = 600 ≠ 3600`), so `zEnd² = a·1 + b·zEnd`. `tr z² = 6a + 60b = 3600` gives one equation;
+   the second needs either `tr z³ = 96000` (a further honest group-sum decide, `= 60·400+3600·20`)
+   OR the eigenspace dims `= 3` (from `χ_Λ² = χ₊+χ₋` + `A5_orthonormal` isotypic argument, giving
+   `b = μ⁺+μ⁻ = 20`, `a = −μ⁺μ⁻ = 400`). NOTE the packaging hurdle: the finrank-2 fact lives on
+   the categorical `lam2 ⟶ lam2`; must transport `zEnd` (a `Module.End` of the submodule) into
+   that Hom space (build the `FDRep` morphism from `zEnd` + `zEnd_central`), or reprove finrank on
+   `End_G(↥lam2Sub)`.
+2. **Eigenspace `finrank = 3`**: from step 1, `zEnd` is diagonalizable with the two eigenvalues
+   `μ±`; `tr(P⁺) = (tr z − μ⁻·6)/(μ⁺−μ⁻) = 3` gives `dim(eigenspace zEnd μ⁺) = 3`, hence
+   `dim ℂ³₊ = 3` by **this session's `repC3plusSub_finrank_eq`** (and likewise `ℂ³₋`).
+3. **Characters** `χ₊(g) = (S(g) − μ⁻·χ_Λ²(g))/(μ⁺−μ⁻) = (3,0,−1,φ,φ')`, `χ₋ = (3,0,−1,φ',φ)`;
+   all inputs (`zEnd_comp_char_val` = `S`, `lam2_character`) landed. On each eigenspace `z` acts as
+   the scalar `μ±`, so the eigenspace character is `(S − μ∓·χ_Λ²)/(μ±−μ∓)`.
+4. **Simplicity** via `⟨χ₊,χ₊⟩ = 1`; extend `irrepA5`/`tblA5`/`rowA5` to `Fin 5`; pairwise
+   non-iso over `Q5` (the `√5` entry distinguishes `ℂ³₊`/`ℂ³₋`); update the public
+   `Etingof.Example4_8_1_A5_*` wrappers to `Fin 5`.
+
+## Blockers
+
+None new. Full Phase C is inherently multi-session; #5459 tracks the remainder. Step 1 (the
+minimal polynomial) remains the next linchpin; its main *formalization* hurdle is packaging `zEnd`
+as a morphism in `FDRep ℂ G` so the `lam2_hom_finrank = 2` fact applies, not the arithmetic
+(every numeric target is fixed and every eigenspace-dimension consequence is now reduced to
+`↥lam2Sub` by this session's finrank bridge).
+
+Note: the worktree carried two pre-existing uncommitted `.claude/` edits (`commands/review.md`,
+`skills/agent-worker-flow/SKILL.md`) that predate this session; left untouched and NOT included in
+this PR to keep scope clean.


### PR DESCRIPTION
Partial progress on #5635

Session: `7d0fe4ab-d4a7-4319-a786-331a45a580c4`

c51d0e62 feat(Ch4 #5635): A₅ Phase C — z↔Z eigenspace bridge, reduce dim ℂ³± to intrinsic z

🤖 Prepared with Claude Code