### PR TITLE
doc(Ch7 #5640): add homotopy category of spaces to Example 7.1.3

### DIFF
--- a/EtingofRepresentationTheory/Chapter7/Example7_1_3.lean
+++ b/EtingofRepresentationTheory/Chapter7/Example7_1_3.lean
@@ -1,9 +1,11 @@
 import Mathlib.CategoryTheory.Category.Basic
 import Mathlib.CategoryTheory.Types.Basic
+import Mathlib.CategoryTheory.Quotient
 import Mathlib.Algebra.Category.Grp.Basic
 import Mathlib.Algebra.Category.Ring.Basic
 import Mathlib.Algebra.Category.ModuleCat.Basic
 import Mathlib.Topology.Category.TopCat.Basic
+import Mathlib.Topology.Homotopy.Basic
 
 /-!
 # Example 7.1.3: Examples of Categories
@@ -13,10 +15,22 @@ import Mathlib.Topology.Category.TopCat.Basic
 3. The category Vect_k of vector spaces over a field k (morphisms are linear maps).
 4. The category Rep(A) of representations of an algebra A (= A-mod).
 5. The category of topological spaces (morphisms are continuous maps).
+6. The homotopy category of topological spaces (morphisms are homotopy classes of
+   continuous maps).
 
 ## Mathlib correspondence
 
-All of these categories exist in Mathlib as bundled categories.
+Items 1–5 exist in Mathlib as bundled categories (`Type*`, `GrpCat`, `RingCat`,
+`ModuleCat k`, `ModuleCat A`, `TopCat`).
+
+Item 6, the homotopy category of topological spaces, is **not** a bundled category
+in Mathlib. (Mathlib's `HomotopyCategory` is the homotopy category of chain
+complexes, unrelated to spaces.) We construct it here as the categorical quotient
+`CategoryTheory.Quotient` of `TopCat` by the homotopy relation on morphisms:
+Mathlib provides the homotopy relation `ContinuousMap.Homotopic`, proven to be an
+equivalence (`Homotopic.equivalence`) compatible with composition (`Homotopic.comp`).
+Those two facts make it a `CategoryTheory.Congruence`, so the quotient's morphisms
+`X ⟶ Y` are exactly homotopy classes of continuous maps.
 -/
 
 open CategoryTheory
@@ -38,3 +52,30 @@ example (A : Type*) [Ring A] : Category (ModuleCat A) := inferInstance
 
 /-- The category of topological spaces. (Etingof Example 7.1.3(5)) -/
 example : Category TopCat := inferInstance
+
+/-- The homotopy relation on morphisms of `TopCat`: two continuous maps are related
+iff they are homotopic. -/
+def homotopyRel : HomRel TopCat := fun _ _ f g => ContinuousMap.Homotopic f.hom g.hom
+
+/-- Homotopy is a congruence on `TopCat`: it is an equivalence on every hom-set and
+compatible with composition on both sides. This guarantees that the morphisms of the
+quotient category below are exactly homotopy classes of continuous maps. -/
+instance : Congruence homotopyRel where
+  equivalence :=
+    { refl := fun f => ContinuousMap.Homotopic.refl f.hom
+      symm := fun h => ContinuousMap.Homotopic.symm h
+      trans := fun h₁ h₂ => ContinuousMap.Homotopic.trans h₁ h₂ }
+  comp_left := by
+    intro X Y Z f g g' h
+    exact ContinuousMap.Homotopic.comp h (ContinuousMap.Homotopic.refl f.hom)
+  comp_right := by
+    intro X Y Z f f' g h
+    exact ContinuousMap.Homotopic.comp (ContinuousMap.Homotopic.refl g.hom) h
+
+/-- The homotopy category of topological spaces: the quotient of `TopCat` by the
+homotopy relation. Objects are topological spaces; morphisms `X ⟶ Y` are homotopy
+classes of continuous maps. (Etingof Example 7.1.3(6)) -/
+abbrev HomotopyTopCat := CategoryTheory.Quotient homotopyRel
+
+/-- The homotopy category of topological spaces is a category. (Etingof Example 7.1.3(6)) -/
+example : Category HomotopyTopCat := inferInstance

--- a/progress/2026-07-02T04-06-32Z_6a967798.md
+++ b/progress/2026-07-02T04-06-32Z_6a967798.md
@@ -1,0 +1,41 @@
+## Accomplished
+
+Closed the fidelity gap in `Chapter7/Example7.1.3` (issue #5640). The book lists
+six categories; the Lean file previously covered only items 1–5 and silently
+dropped item 6, the **homotopy category of topological spaces**.
+
+- Re-confirmed the finding, and corrected its Mathlib pointer: Mathlib's
+  `HomotopyCategory` is the homotopy category of *chain complexes*
+  (`Mathlib/Algebra/Homology/HomotopyCategory.lean`), and there is no
+  `Mathlib.AlgebraicTopology.Homotopy.Basic`. Mathlib does **not** ship the
+  homotopy category of spaces as a bundled `Category`.
+- Constructed item 6 honestly as `CategoryTheory.Quotient` of `TopCat` by the
+  homotopy relation `homotopyRel : HomRel TopCat := fun _ _ f g => Homotopic f.hom g.hom`.
+- Proved `Congruence homotopyRel` (equivalence via `ContinuousMap.Homotopic.equivalence`
+  data; `comp_left`/`comp_right` via `ContinuousMap.Homotopic.comp`), so the
+  quotient's morphisms `X ⟶ Y` are exactly homotopy classes of continuous maps.
+- Added `abbrev HomotopyTopCat := CategoryTheory.Quotient homotopyRel` and an
+  `example : Category HomotopyTopCat := inferInstance`, matching the file's style.
+- Updated the module docstring to include item 6 and explain the construction.
+
+`lake build EtingofRepresentationTheory.Chapter7.Example7_1_3` passes with no
+sorries and no warnings.
+
+## Current frontier
+
+Item 6 of Example 7.1.3 is now formalized. The file covers all six categories
+from the book.
+
+## Overall project progress
+
+Wave-2 fidelity sweep (epic #5338) item for Chapter7/Example7.1.3 complete.
+
+## Next step
+
+None for this item. A future enhancement could build the quotient functor
+`TopCat ⥤ HomotopyTopCat` (`CategoryTheory.Quotient.functor homotopyRel`) if a
+downstream item needs it, but the book only asks for the category itself.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5640

Session: `6a967798-1969-4566-959b-56c5761f5534`

17fc7916 doc(Ch7 #5640): add homotopy category of spaces to Example 7.1.3

🤖 Prepared with Claude Code