### PR TITLE
Complete example: Chapter7/Example7.3.2

### DIFF
--- a/EtingofRepresentationTheory/Chapter7/Example7_3_2.lean
+++ b/EtingofRepresentationTheory/Chapter7/Example7_3_2.lean
@@ -2,6 +2,7 @@ import Mathlib.LinearAlgebra.Dual.Lemmas
 import Mathlib.LinearAlgebra.Dual.Defs
 import Mathlib.LinearAlgebra.Span.Basic
 import Mathlib.Algebra.Algebra.Tower
+import Mathlib.Algebra.Category.FGModuleCat.Basic
 
 /-!
 # Example 7.3.2: Examples of Natural Transformations
@@ -69,6 +70,74 @@ theorem Etingof.linearEquiv_dualDual_iff_finiteDimensional (k V : Type u)
     exact absurd heq (lt_trans h₁ h₂).ne
   · haveI := h
     exact ⟨Module.evalEquiv k V⟩
+
+/-!
+## Example 7.3.2(1), categorical form: the natural isomorphism `𝟭 ≅ (·)**`
+
+The pointwise iso (`double_dual_iso`) and its naturality square (`double_dual_naturality`)
+together say that the identity and double-dual *functors* on the category of
+finite-dimensional vector spaces are naturally isomorphic. We package this as an
+actual `CategoryTheory.NatIso` on `FGModuleCat k`, the category Etingof calls
+`FVect_k`. The double-dual functor sends `V ↦ V**` and `f ↦ f.dualMap.dualMap`; the
+natural isomorphism to the identity has components the evaluation equivalences
+`a_V : V ≃ V**`, `a_V(u)(g) = g(u)` (Mathlib's `Module.evalEquiv`), whose naturality is
+`Module.Dual.eval_naturality`.
+-/
+
+open CategoryTheory in
+/-- The double-dual endofunctor `V ↦ V**` on the category `FGModuleCat k` of
+finite-dimensional `k`-vector spaces (`FVect_k`). It acts on a morphism `f` by
+`f ↦ f.dualMap.dualMap`; functoriality is definitional
+(`LinearMap.dualMap_comp_dualMap`). (Etingof Example 7.3.2(1)) -/
+noncomputable def Etingof.doubleDualFunctor (k : Type u) [Field k] :
+    FGModuleCat.{u} k ⥤ FGModuleCat.{u} k where
+  obj V := FGModuleCat.of k (Module.Dual k (Module.Dual k V))
+  map {V W} f := FGModuleCat.ofHom f.hom.hom.dualMap.dualMap
+  map_id V := by ext x; rfl
+  map_comp f g := by ext x; rfl
+
+open CategoryTheory in
+/-- **Example 7.3.2(1), categorical form.** On the category `FGModuleCat k` of
+finite-dimensional vector spaces (Etingof's `FVect_k`), the identity functor is
+naturally isomorphic to the double-dual functor `(·)**`. The isomorphism has
+components the standard evaluation maps `a_V : V → V**`, `a_V(u)(g) = g(u)`; naturality
+is `Module.Dual.eval_naturality`. Contrast `linearEquiv_dualDual_iff_finiteDimensional`:
+on all of `Vect_k` no such isomorphism exists. -/
+noncomputable def Etingof.doubleDualNatIso (k : Type u) [Field k] :
+    𝟭 (FGModuleCat.{u} k) ≅ Etingof.doubleDualFunctor k :=
+  NatIso.ofComponents
+    (fun V => (Module.evalEquiv k (V : Type u)).toFGModuleCatIso)
+    (fun {V W} f => by
+      ext x
+      exact (LinearMap.congr_fun (Module.Dual.eval_naturality f.hom.hom) x).symm)
+
+/-!
+## Example 7.3.2(2): the functor `V ↦ V*` on `FVect'_k`
+
+Let `FVect'_k` be the groupoid of finite-dimensional `k`-vector spaces with *isomorphisms*
+as morphisms, and `F : FVect'_k → FVect'_k` the functor `V ↦ V*`, `a ↦ (a*)⁻¹`. Etingof's
+point is that `F` is *pointwise* isomorphic to the identity (`V ≅ V*` for every `V`) yet is
+*not naturally isomorphic* to it: a natural iso would give, for every `V`, an isomorphism
+`V ≅ V*` compatible with the `GL(V)`-action, which is impossible because `V` and `V*` are
+inequivalent as `GL(V)`-representations.
+
+We record the positive half — `V` is isomorphic to `V*` exactly when it is finite-dimensional
+(Mathlib's `Basis.linearEquiv_dual_iff_finiteDimensional`, an Erdős–Kaplansky consequence, the
+same dichotomy `linearEquiv_dualDual_iff_finiteDimensional` gives for the double dual). The
+*non-naturality* is the deeper content of the example; formalizing it requires building the
+groupoid `FVect'_k`, the functor `F`, and the `GL(V)`-representation obstruction, and is left
+to dedicated future work.
+-/
+
+/-- **Example 7.3.2(2), positive part.** A vector space `V` over a field `k` is linearly
+isomorphic to its dual `V*` if and only if it is finite-dimensional. This is why the functor
+`F : V ↦ V*` of Etingof's Example 7.3.2(2) is pointwise isomorphic to the identity on the
+category `FVect'_k` of finite-dimensional spaces. (The deeper claim — that `F` is nonetheless
+*not naturally* isomorphic to the identity — is discussed above but not formalized here.) -/
+theorem Etingof.linearEquiv_dual_iff_finiteDimensional (k V : Type u)
+    [Field k] [AddCommGroup V] [Module k V] :
+    Nonempty (V ≃ₗ[k] Module.Dual k V) ↔ FiniteDimensional k V :=
+  Basis.linearEquiv_dual_iff_finiteDimensional
 
 /-!
 ## Example 7.3.2(3): `End(F) = A` for the forgetful functor `F : A-mod → Vect_k`

--- a/progress/2026-07-02T04-36-54Z_bfc6c247.md
+++ b/progress/2026-07-02T04-36-54Z_bfc6c247.md
@@ -1,0 +1,49 @@
+## Accomplished
+
+Fidelity review of issue #5643 (`Chapter7/Example7.3.2`, Wave-2 fidelity sweep).
+
+**Re-confirmation.** Of the four lettered findings in the issue, (b) infinite-dim
+`V` not iso to `V**`, (c) `End(forgetful F) = A`, and (d) `End(Id_{A-mod}) = Z(A)`
+had already been formalized by commit e0d183e6 (#5790) after the review was written
+(`linearEquiv_dualDual_iff_finiteDimensional`, `forgetful_natEnd_eq_smul` /
+`forgetful_smul_comp`, `idFunctor_natEnd_eq_smul` / `idFunctor_natEnd_central`). The
+only outstanding lettered finding was (a): an actual categorical `NatIso`.
+
+**Fixes this turn**, in `EtingofRepresentationTheory/Chapter7/Example7_3_2.lean`:
+
+- Finding (a): added `Etingof.doubleDualFunctor` (the `V ↦ V**` endofunctor on
+  `FGModuleCat k`, Etingof's `FVect_k`) and `Etingof.doubleDualNatIso`, the actual
+  `CategoryTheory` natural isomorphism `𝟭 (FGModuleCat k) ≅ (·)**`, with components
+  `Module.evalEquiv` and naturality from `Module.Dual.eval_naturality`. Functoriality
+  is definitional (`LinearMap.dualMap_comp_dualMap` is `rfl`).
+- Book sub-item (2) positive part: added `Etingof.linearEquiv_dual_iff_finiteDimensional`
+  (`V ≃ₗ V*` iff finite-dimensional), reusing Mathlib's
+  `Basis.linearEquiv_dual_iff_finiteDimensional`. The file header had advertised
+  sub-item (2) with no theorem; it now has one, with a docstring honestly flagging that
+  the *non-naturality* claim (the deeper content) is not yet formalized.
+
+No `sorry`/`axiom` introduced. `lake build EtingofRepresentationTheory.Chapter7.Example7_3_2`
+succeeds (1803 jobs). Updated `progress/items.json` fidelity note.
+
+## Current frontier
+
+`Chapter7/Example7.3.2` is now near-complete: all four sub-items have Lean content and
+the categorical NatIso is packaged.
+
+## Overall project progress
+
+Stage 3.2 formalization; Wave-2 fidelity sweep in progress. This item moves from
+`fidelity: gap` (one letter finding open) to essentially complete.
+
+## Next step
+
+Only residual gap for this item: sub-item (2)'s *non-naturality* — that the functor
+`F : V ↦ V*` on the groupoid `FVect'_k` is not naturally isomorphic to the identity,
+via the `GL(V)`-representation obstruction. This needs the groupoid `FVect'_k`, the
+functor `F`, and the representation-theoretic argument built as `CategoryTheory`
+objects — a substantial dedicated work item, not a review fix. Recommend a fresh
+`feature` issue if full fidelity on (2) is desired.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -6191,7 +6191,7 @@
     "fidelity": "gap",
     "needs_statement": false,
     "sorry_free": true,
-    "fidelity_note": "[partial-example] Sub-items (1) and (3)-(4) now formalized: `double_dual_iso`/`double_dual_naturality` (finite-dim V ≃ₗ V** + naturality); `linearEquiv_dualDual_iff_finiteDimensional` (infinite-dim V not iso to V**, sub-item 1 second half); `forgetful_natEnd_eq_smul`/`forgetful_smul_comp` (End(forgetful F)=A, sub-item 3); `idFunctor_natEnd_eq_smul`/`idFunctor_natEnd_central` (End(Id_{A-mod})=Z(A), sub-item 4). Remaining: (a) an actual CategoryTheory NatIso id ≅ ** on FVect_k, and (b) sub-item (2), the FVect_k' functor F(V)=V* with V≅F(V) but F not iso to id (needs GL(V)-representation argument).",
+    "fidelity_note": "[near-complete] All four sub-items formalized. Sub-item (1): `double_dual_iso`/`double_dual_naturality` (finite-dim V ≃ₗ V** + naturality), plus `doubleDualFunctor`/`doubleDualNatIso` giving the actual CategoryTheory NatIso `𝟭 ≅ (·)**` on `FGModuleCat k` (Etingof's FVect_k), and `linearEquiv_dualDual_iff_finiteDimensional` (infinite-dim V not iso to V**, second half). Sub-item (2): `linearEquiv_dual_iff_finiteDimensional` (V ≅ V* iff finite-dim, the positive half of the FVect'_k functor F(V)=V*). Sub-item (3): `forgetful_natEnd_eq_smul`/`forgetful_smul_comp` (End(forgetful F)=A). Sub-item (4): `idFunctor_natEnd_eq_smul`/`idFunctor_natEnd_central` (End(Id_{A-mod})=Z(A)). Only remaining gap: sub-item (2)'s *non-naturality* claim (F not naturally iso to id via the GL(V)-representation obstruction), which needs the groupoid FVect'_k + functor F built as CategoryTheory objects; deferred to dedicated future work.",
     "fidelity_issue": 5643
   },
   {


### PR DESCRIPTION
Closes #5643

Session: `bfc6c247-12e1-4924-9b3a-d2accc4fe59c`

41419dce feat(Ch7 #5643): add categorical NatIso 𝟭 ≅ (·)** and sub-item (2) for Example 7.3.2

🤖 Prepared with Claude Code