### PR TITLE
feat: classify L_λ by highest weight (iso ↔ equal weight)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/AlgIrrepGLNonIso.lean
+++ b/EtingofRepresentationTheory/Chapter5/AlgIrrepGLNonIso.lean
@@ -203,4 +203,24 @@ theorem algIrrepGLRepρ_noniso (n : ℕ) (k : Type) [Field k] [IsAlgClosed k] [C
     exact_mod_cast congrArg (Nat.cast : ℕ → ℤ) hi
   omega
 
+/-- **Uniqueness of the highest weight (the complete-invariant classification).**
+The dominant integer weight `λ` is a complete invariant of the irreducible algebraic
+representation `L_λ = algIrrepGLRepρ n λ k`: two of these irreducibles are isomorphic
+as `k[GL_n]`-modules **iff** their highest weights coincide. This is the faithful
+Lean rendering of the book's assertion (Discussion after Definition 5.23.1) that to
+every weakly-decreasing integer sequence `λ₁ ≥ ⋯ ≥ λ_N` there is attached a *unique*
+irreducible algebraic representation `L_λ`, whose highest weight is `λ`. The forward
+direction is `algIrrepGLRepρ_noniso`; the reverse is the identity isomorphism. -/
+theorem algIrrepGLRepρ_iso_iff_eq (n : ℕ) (k : Type) [Field k] [IsAlgClosed k]
+    [CharZero k] {lam mu : DominantWeight n} :
+    Nonempty ((algIrrepGLRepρ n lam k).asModule ≃ₗ[MonoidAlgebra k
+        (Matrix.GeneralLinearGroup (Fin n) k)] (algIrrepGLRepρ n mu k).asModule) ↔
+      lam = mu := by
+  constructor
+  · intro h
+    by_contra hne
+    exact algIrrepGLRepρ_noniso n k hne h
+  · rintro rfl
+    exact ⟨LinearEquiv.refl _ _⟩
+
 end Etingof

--- a/progress/2026-07-02T05-03-24Z_561dee22.md
+++ b/progress/2026-07-02T05-03-24Z_561dee22.md
@@ -1,0 +1,44 @@
+## Accomplished
+
+Closed the Stage 3.7 COVERAGE issue #5680 (blob
+`Chapter5/Discussion_after_Definition5.23.1`). Re-confirmed the prose claim against
+the existing formalization before adding anything:
+
+- **Construction** of `L_λ` for integer weights (det-twisted Schur module): already
+  done as `AlgIrrepGLRep` / `algIrrepGLRepρ`.
+- **Irreducibility** of each `L_λ`: already done as `algIrrepGLRep_isSimple`.
+- **Injectivity** (distinct dominant weights → non-isomorphic `L_λ`): already done as
+  `algIrrepGLRepρ_noniso`.
+- **Surjectivity** ("every irreducible algebraic rep is of this form"): this is
+  *not* stated in this blob — it belongs to Theorem 5.23.2(i), whose Lean version
+  (`Theorem5_23_2_i`) currently proves only semisimplicity, not the `L_λ`
+  identification. Out of scope for this coverage item; the issue body's paraphrase
+  over-reached by importing that clause.
+
+The one genuinely blob-local claim lacking a packaged Lean declaration was the
+book's assertion that to each weakly-decreasing integer sequence `λ` a **unique**
+irreducible `L_λ` is attached (its highest weight). Added
+`algIrrepGLRepρ_iso_iff_eq` in `AlgIrrepGLNonIso.lean`: the complete-invariant
+statement `Nonempty (L_λ ≃ₗ[k[GL_n]] L_μ) ↔ λ = μ`. Forward direction reuses
+`algIrrepGLRepρ_noniso`; reverse is the identity isomorphism.
+
+## Current frontier
+
+`EtingofRepresentationTheory/Chapter5/AlgIrrepGLNonIso.lean` builds cleanly
+(`lake build` on that module: 8669 jobs, success). No new warnings from the added
+declaration (the two pre-existing `show`-linter warnings are at lines 136/142).
+
+## Overall project progress
+
+Stage 3.7 COVERAGE arm (epic #5338): one more prose-blob coverage gap packaged.
+
+## Next step
+
+The real surjectivity direction (every irreducible algebraic `GL_N`-rep ≅ some
+`L_λ`, i.e. the highest-weight theorem) remains absent and is a large standalone
+item under Theorem 5.23.2(i). If a planner wants it covered, it should be a fresh
+feature issue scoped to `Theorem5_23_2.lean`, not this discussion blob.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5680

Session: `561dee22-bec7-41bc-a7a1-4d6eecbf0d4b`

d4ddcfa2 feat(Ch5 #5680): package highest-weight complete-invariant iso ↔ eq for L_λ

🤖 Prepared with Claude Code