### PR TITLE
feat(Ch7 #5683): additive functor preserves binary biproduct F(X⊞Y) ≅ FX⊞FY

### DIFF
--- a/EtingofRepresentationTheory/Chapter7/Definition7_9_1.lean
+++ b/EtingofRepresentationTheory/Chapter7/Definition7_9_1.lean
@@ -1,6 +1,7 @@
 import Mathlib.CategoryTheory.Linear.Basic
 import Mathlib.CategoryTheory.Linear.LinearFunctor
 import Mathlib.CategoryTheory.Preadditive.AdditiveFunctor
+import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Biproducts
 
 /-!
 # Definition 7.9.1: Additive and k-linear Functor
@@ -16,6 +17,16 @@ between Hom spaces.
 Exact match:
 - `CategoryTheory.Functor.Additive` for additive functors
 - `CategoryTheory.Functor.Linear` for k-linear functors
+
+## Discussion after Definition 7.9.1
+
+The book remarks that "it is easy to show that if `F` is an additive functor,
+then `F(X ⊕ Y)` is canonically isomorphic to `F(X) ⊕ F(Y)`". We record this as
+`Etingof.AdditiveFunctor.mapBiprod`: for an additive functor `F` between
+preadditive categories where the source has binary biproducts, there is a
+canonical isomorphism `F(X ⊞ Y) ≅ F(X) ⊞ F(Y)`. This delegates to Mathlib's
+`CategoryTheory.Functor.mapBiprod`, available because an additive functor
+preserves zero morphisms and finite biproducts.
 -/
 
 /-- An additive functor between preadditive categories, in the sense of
@@ -34,3 +45,31 @@ abbrev Etingof.LinearFunctor (k : Type*) [Semiring k] {C : Type*} {D : Type*}
     [CategoryTheory.Linear k C] [CategoryTheory.Linear k D]
     (F : CategoryTheory.Functor C D) :=
   CategoryTheory.Functor.Linear k F
+namespace Etingof.AdditiveFunctor
+
+open CategoryTheory CategoryTheory.Limits
+
+variable {C D : Type*} [Category C] [Category D] [Preadditive C] [Preadditive D]
+  [HasBinaryBiproducts C] (F : C ⥤ D) [F.Additive] (X Y : C)
+
+/-- An additive functor preserves binary biproducts: this is the finite-biproduct
+preservation of an additive functor specialised to a pair. It provides the
+`HasBinaryBiproduct (F X) (F Y)` needed to state the comparison isomorphism below. -/
+instance preservesBinaryBiproduct : PreservesBinaryBiproduct X Y F :=
+  preservesBinaryBiproduct_of_preservesBiproduct F X Y
+
+/-- **Discussion after Definition 7.9.1.** An additive functor `F` between
+preadditive categories (with binary biproducts in the source) sends the biproduct
+`X ⊞ Y` to a canonically isomorphic copy of `F X ⊞ F Y`. This is the canonical
+comparison isomorphism `CategoryTheory.Functor.mapBiprod`, which exists because an
+additive functor preserves zero morphisms and finite biproducts. -/
+noncomputable def mapBiprod : F.obj (X ⊞ Y) ≅ F.obj X ⊞ F.obj Y :=
+  F.mapBiprod X Y
+
+/-- The canonical isomorphism of `mapBiprod` has the expected forward map: it is the
+lift of the two functor-images of the biproduct projections. -/
+theorem mapBiprod_hom :
+    (mapBiprod F X Y).hom = biprod.lift (F.map biprod.fst) (F.map biprod.snd) :=
+  F.mapBiprod_hom X Y
+
+end Etingof.AdditiveFunctor

--- a/progress/2026-07-02T05-13-43Z_4dd6f0f8.md
+++ b/progress/2026-07-02T05-13-43Z_4dd6f0f8.md
@@ -1,0 +1,51 @@
+## Accomplished
+
+Session type: **review** (one-shot dispatch, issue #5683 — Stage 3.7 COVERAGE arm, epic #5338).
+
+Formalized the prose claim in `blobs/Chapter7/Discussion_after_Definition7.9.1.md`:
+"if F is an additive functor, then F(X ⊕ Y) is canonically isomorphic to F(X) ⊕ F(Y)".
+
+- Re-confirmed the claim was un-formalized: `Definition7_9_1.lean` only had the
+  `Etingof.AdditiveFunctor` abbrev; biproduct preservation was never stated.
+- Added to `EtingofRepresentationTheory/Chapter7/Definition7_9_1.lean`:
+  - `Etingof.AdditiveFunctor.preservesBinaryBiproduct` — instance deriving
+    `PreservesBinaryBiproduct X Y F` from an additive functor's finite-biproduct
+    preservation (via Mathlib `preservesBinaryBiproduct_of_preservesBiproduct`).
+    Needed so the `⊞` in the target type `F X ⊞ F Y` typechecks.
+  - `Etingof.AdditiveFunctor.mapBiprod` — the canonical comparison isomorphism
+    `F.obj (X ⊞ Y) ≅ F.obj X ⊞ F.obj Y`, delegating to Mathlib
+    `CategoryTheory.Functor.mapBiprod`.
+  - `Etingof.AdditiveFunctor.mapBiprod_hom` — records the forward map is
+    `biprod.lift (F.map biprod.fst) (F.map biprod.snd)` (holds by `rfl`).
+- Updated `progress/items.json`: the derived coverage item for #5683 is now
+  `status: formalized` with `lean_ref` to the new declaration.
+
+File builds clean (`lake build EtingofRepresentationTheory.Chapter7.Definition7_9_1`),
+0 sorries.
+
+## Current frontier
+
+Issue #5683 complete. Ready to open PR.
+
+## Overall project progress
+
+Stage 3.7 COVERAGE arm continues to close prose-embedded formalizable claims.
+This closes the Ch7 additive-functor / biproduct claim.
+
+## Next step
+
+Open PR closing #5683 and enable auto-merge.
+
+## Blockers
+
+None.
+
+## Key pattern
+
+Mathlib's `Functor.mapBiprod F X Y` presupposes `[PreservesBinaryBiproduct X Y F]`
+(the target uses `⊞` in the codomain, requiring `HasBinaryBiproduct (F X) (F Y)`).
+For an additive functor this instance is not synthesized automatically — the
+finite-biproduct chain stops at `PreservesBiproduct`, and
+`preservesBinaryBiproduct_of_preservesBiproduct` is a lemma, not an instance.
+Declare it as a local `instance` before stating any result whose type mentions
+`F X ⊞ F Y`.

--- a/progress/items.json
+++ b/progress/items.json
@@ -7655,7 +7655,8 @@
     "derived_from": "Chapter7/Discussion_after_Definition7.9.1",
     "source_span": "It is easy to show that if F is an additive functor, then F(X ⊕ Y) is canonically isomorphic to F(X) ⊕ F(Y).",
     "claim": "An additive functor F between preadditive categories with biproducts satisfies F(X ⊞ Y) ≅ F(X) ⊞ F(Y) canonically.",
-    "status": "accepted",
+    "status": "formalized",
+    "lean_ref": "Chapter7/Definition7_9_1.lean (Etingof.AdditiveFunctor.mapBiprod)",
     "coverage_issue": 5683
   },
   {


### PR DESCRIPTION
Closes #5683

Session: `4dd6f0f8-bed0-4473-b01e-5175d48e09d2`

5a21b99a feat(Ch7 #5683): formalize additive functor preserves binary biproduct F(X⊞Y) ≅ FX⊞FY

🤖 Prepared with Claude Code