### PR TITLE
feat(Ch5 #5654): β is an algebraic integer for Remark 5.2.8

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Remark5_2_8.lean
+++ b/EtingofRepresentationTheory/Chapter5/Remark5_2_8.lean
@@ -1,5 +1,6 @@
 import Mathlib
 import EtingofRepresentationTheory.Chapter5.Proposition5_2_5
+import EtingofRepresentationTheory.Chapter5.Theorem5_3_1
 
 /-!
 # Remark 5.2.8: A modification of the vanishing-of-characters argument
@@ -113,5 +114,51 @@ theorem not_isIntegral_rat_mem_Ioo {q : ℚ}
   have hn0 : (0 : ℤ) < n := by exact_mod_cast h0
   have hn1 : n < 1 := by exact_mod_cast h1
   omega
+
+/-!
+## The algebraic-integer half of Steps 3-5
+
+The final contradiction needs two facts about `β := ∏_{g ≠ 1} |χ_V(g)|²`:
+
+* `β` is **rational** — this is the content of Steps 3-4 (Galois invariance in
+  `ℚ(ζ_N)`), which requires cyclotomic / Galois infrastructure and is tracked in
+  the foundation sub-issue;
+* `β` is an **algebraic integer** — established here, `sorry`-free, from the fact
+  that character values are algebraic integers (`FDRep.character_isIntegral`).
+
+Given both, `not_isIntegral_rat_mem_Ioo` closes the argument once `0 < β < 1`.
+The integrality half below needs none of the blocked infrastructure.
+-/
+
+open scoped ComplexConjugate
+
+/-- The complex conjugate of an algebraic integer in `ℂ` is again an algebraic
+integer: conjugation `z ↦ conj z` is a `ℤ`-algebra automorphism of `ℂ`, so it
+preserves integrality over `ℤ`. -/
+theorem isIntegral_conj {z : ℂ} (hz : IsIntegral ℤ z) : IsIntegral ℤ (conj z) :=
+  hz.map (Complex.conjAe.restrictScalars ℤ).toAlgHom
+
+set_option linter.unusedFintypeInType false in
+/-- The squared modulus `|χ_V(g)|²` of a character value is an algebraic integer:
+`|χ_V(g)|² = χ_V(g) · conj(χ_V(g))` is a product of algebraic integers
+(`FDRep.character_isIntegral`), and the algebraic integers form a ring. -/
+theorem isIntegral_normSq_character {G : Type} [Group G] [Fintype G]
+    (V : FDRep ℂ G) (g : G) :
+    IsIntegral ℤ ((Complex.normSq (V.character g) : ℂ)) := by
+  rw [← Complex.mul_conj]
+  exact (FDRep.character_isIntegral V g).mul (isIntegral_conj (FDRep.character_isIntegral V g))
+
+set_option linter.unusedFintypeInType false in
+/-- **The algebraic-integer half of Remark 5.2.8.** For any finite set `s` of group
+elements, `∏_{g ∈ s} |χ_V(g)|²` is an algebraic integer. Taking
+`s = G ∖ {1}` this is exactly "`β` is a product of algebraic integers, hence an
+algebraic integer" — the input to `not_isIntegral_rat_mem_Ioo` that does not depend
+on the cyclotomic Galois argument (Steps 3-4). -/
+theorem isIntegral_prod_normSq_character {G : Type} [Group G] [Fintype G]
+    (V : FDRep ℂ G) (s : Finset G) :
+    IsIntegral ℤ (∏ g ∈ s, (Complex.normSq (V.character g) : ℂ)) := by
+  have h : (∏ g ∈ s, (Complex.normSq (V.character g) : ℂ)) ∈ integralClosure ℤ ℂ :=
+    prod_mem (fun g _ => isIntegral_normSq_character V g)
+  exact h
 
 end Etingof.Remark5_2_8

--- a/progress/2026-07-02T05-39-15Z_ebe76841.md
+++ b/progress/2026-07-02T05-39-15Z_ebe76841.md
@@ -1,0 +1,59 @@
+## Accomplished
+
+One-shot session (`pod once 5654`) on review issue #5654
+(`Chapter5/Remark5.2.8`).
+
+**Re-confirmed the fidelity finding.** Steps 1, 2, and 5 of Remark 5.2.8
+were already landed sorry-free by PR #5774
+(`pow_coprime_bijective`, `prod_ne_one_pow`, `not_isIntegral_rat_mem_Ioo`).
+Steps 3-4 (β ∈ ℚ(ζ_N) and its Galois invariance under ζ ↦ ζʲ, forcing
+β ∈ ℚ) require cyclotomic-field / Galois / `σ_j(χ_V(g)) = χ_V(gʲ)`
+infrastructure and are correctly tracked in the still-open foundation
+sub-issue #5772. An Explore feasibility pass confirmed the crux lemma
+`σ_j(χ_V(g)) = χ_V(gʲ)` does not exist in the project or Mathlib and is a
+multi-hour build; the no-sorry policy forbids stubbing it here.
+
+**Landed the algebraic-integer half, sorry-free** (PR from this session),
+in `EtingofRepresentationTheory/Chapter5/Remark5_2_8.lean`:
+
+- `isIntegral_conj` — complex conjugation preserves integrality over ℤ
+  (conjugation is a ℤ-algebra automorphism of ℂ).
+- `isIntegral_normSq_character` — `|χ_V(g)|²` is an algebraic integer, via
+  `|χ_V(g)|² = χ_V(g)·conj(χ_V(g))` and `FDRep.character_isIntegral`.
+- `isIntegral_prod_normSq_character` — `β = ∏_{g∈s} |χ_V(g)|²` is an
+  algebraic integer for any finite `s` (in particular `s = G∖{1}`).
+
+This is the "β is a product of algebraic integers, hence an algebraic
+integer" ingredient feeding `not_isIntegral_rat_mem_Ioo`. It needs none
+of the blocked cyclotomic infrastructure. `lake build` clean, no
+`sorry`/`native_decide`.
+
+## Current frontier
+
+`Remark5_2_8.lean` now has both the elementary steps (1,2,5) and the
+algebraic-integer half of the closing contradiction. The only missing
+piece is the **rational-ness of β** (Steps 3-4), i.e. the cyclotomic
+Galois argument.
+
+## Overall project progress
+
+Phase 3 formalization, Chapter 5. Remark 5.2.8: 4 of 5 conceptual pieces
+now formalized sorry-free (Steps 1, 2, 5, and the algebraic-integer
+input). Remaining: Steps 3-4 (β rational) tracked in #5772, which itself
+also depends on the yet-unformalized `0 < β < 1` main argument of
+Problem 5.2.7(b).
+
+## Next step
+
+A worker with cyclotomic Galois bandwidth should take #5772: build
+`σ_j(χ_V(g)) = χ_V(gʲ)` on `IsCyclotomicExtension`/`CyclotomicField` +
+the `(ZMod N)ˣ` Galois action, then combine with `prod_ne_one_pow` and
+the integrality lemmas landed here to conclude β ∈ ℤ and derive the
+contradiction. A planner should triage the `replan` on #5654: the
+residual scope is exactly #5772.
+
+## Blockers
+
+Steps 3-4 of Remark 5.2.8 remain blocked on foundation sub-issue #5772
+(cyclotomic Galois infrastructure), which is open and multi-hour. Not a
+blocker for the integrality work landed this session.


### PR DESCRIPTION
This PR adds the sorry-free algebraic-integer half of Remark 5.2.8's closing contradiction to `Remark5_2_8.lean`: `isIntegral_conj` (complex conjugation preserves integrality over ℤ), `isIntegral_normSq_character` (`|χ_V(g)|²` is an algebraic integer via `|χ_V(g)|² = χ_V(g)·conj(χ_V(g))` and `FDRep.character_isIntegral`), and `isIntegral_prod_normSq_character` (`β = ∏_{g∈s} |χ_V(g)|²` is an algebraic integer for any finite `s`). This is the 'β is a product of algebraic integers, hence an algebraic integer' ingredient feeding `not_isIntegral_rat_mem_Ioo`, and it needs none of the cyclotomic Galois infrastructure.

Partial progress on #5654: Steps 1, 2, 5 were landed earlier (PR #5774) and this adds the integrality input. The remaining rational-ness of β (Steps 3-4: β ∈ ℚ(ζ_N) and Galois invariance under ζ ↦ ζʲ) stays tracked in the open foundation sub-issue #5772. `lake build` clean, no `sorry`/`native_decide`.

Refs #5654

🤖 Prepared with Claude Code