### PR TITLE
chore(once): carve triage worker types out of claim-or-abort path

### DIFF
--- a/.claude/commands/once.md
+++ b/.claude/commands/once.md
@@ -25,13 +25,23 @@ immediately with `ABORT: no issue number provided`.
    `coordination claim <N> --label <type>`. Do **NOT** use
    `coordination list-unclaimed` — you are not picking from the
    queue.
+   - **Exception — triage worker types (`replan`, `plan`).** These
+     skills never claim: `replan` edits issues directly and produces
+     no PR, and `coordination claim` deliberately **refuses**
+     `replan`-labelled issues (`CLAIM FAILED: … needs replan`).
+     Do **not** treat that refusal as an abort. Instead confirm the
+     issue is a valid candidate for your type (`coordination
+     list-replan` for replan) and follow that skill's own lifecycle.
 4. **If the claim fails** (issue already claimed by another agent,
    issue closed, issue not labelled with the worker type, etc.),
    exit immediately. Print `ABORT: claim failed for #<N>` and do
-   nothing else. No worktree commits, no branches, no PR.
+   nothing else. No worktree commits, no branches, no PR. (Does not
+   apply to the triage exception in step 3 — a `needs replan` refusal
+   there is expected, not a failure.)
 5. Once the claim succeeds, **execute the issue end-to-end**
    following the standard worker flow for the matched type
-   (implementation, build, tests, commit, push, open PR).
+   (implementation, build, tests, commit, push, open PR). For triage
+   types, execute the skill's direct-edit lifecycle instead (no PR).
 6. Run `/reflect` before finishing.
 
 ## Hard constraints


### PR DESCRIPTION
This PR fixes a contradiction in the `/once` one-shot dispatch command surfaced while triaging replan issue #5287. The template mandated "claim with `coordination claim <N>`, and ABORT if the claim fails", but `coordination claim` deliberately refuses `replan`-labelled issues (`CLAIM FAILED: … needs replan`). A `pod once <N>` dispatch on a replan issue would therefore abort under a literal reading and leave a valid `list-replan` candidate un-triaged. The fix adds an explicit exception so triage worker types (`replan`, `plan`) follow their skill's own direct-edit lifecycle instead of the claim-or-abort path.

Surfaced by `/reflect` during the #5287 replan session, which itself completed correctly (parent closed with a forward link to its completed sub-issue #5289).

🤖 Prepared with Claude Code