### PR TITLE
review(Ch5 #5342): close Chapter 5 fidelity sweep

### DIFF
--- a/progress/2026-07-02T11-45-39Z_e2fd8bc9.md
+++ b/progress/2026-07-02T11-45-39Z_e2fd8bc9.md
@@ -1,0 +1,43 @@
+## Accomplished
+Closed out the Chapter 5 fidelity sweep (issue #5342, Stage 3.7). Waves 1–4 had
+already verified most of the 68 Chapter 5 claim-bearing done items; this one-shot
+session judged the 8 residual items whose `fidelity` field was missing or used a
+non-conforming value (`ok`/`faithful`/`partial`). Judged with Opus 4.8 (distinct
+from the Sonnet/earlier authors), applying PLAN.md Stage 3.2 steps 6–7
+(anti-vacuity + conjunct-by-conjunct fidelity) against each blob and the current
+Lean.
+
+Verdicts (see `progress/coverage-audit/fidelity-wave-5.md` for the full record):
+- **verified** (7): Example5.1.3, Remark5.8.3, Theorem5.9.1, Remark5.9.2,
+  Proposition5.21.1, Proposition5.22.2, Remark5.23.3.
+- **gap** (1): Remark5.2.8 → `fidelity_issue: 5654` (open; final Galois/capstone
+  assembly not yet landed; status already `proof_partial`).
+
+The four previously-flagged items (#5615, #5652, #5653, #5729) were re-audited
+against the *current* Lean, confirmed fixed, and marked `verified` with their now-closed
+`fidelity_issue` dropped. Notable: `Theorem5_9_1` is formalized in the averaged
+form (= book's Remark 5.9.2), an equivalent, docstring-transparent reformulation
+of the coset-representative Theorem 5.9.1 — accepted as verified, caveat recorded.
+
+## Current frontier
+Chapter 5 fidelity worklist: 68/68 items now `verified` (62) or `gap` (6); every
+gap carries a `fidelity_issue`. Only `progress/items.json` and the wave-5 markdown
+were touched — no Lean changes.
+
+## Overall project progress
+Stage 3.7 fidelity sweep: Chapter 5 arm complete (this issue). Epic #5338 tracks
+the remaining chapters. The single open Chapter 5 fidelity gap is #5654
+(Remark5.2.8), itself `depends-on: #5772` (now merged) — the residual is the
+cyclotomic-Galois assembly and the `β∈ℤ ⇒ contradiction` capstone.
+
+## Next step
+- A planner/worker can drive #5654 to completion now that #5772 (Step-4 core) has
+  merged: add the `Gal(ℚ(ζ_N)/ℚ)≅(ℤ/Nℤ)ˣ ⇒ β∈ℚ` step and the final capstone,
+  then re-audit Remark5.2.8 to `verified`.
+- Optional housekeeping (out of scope here): five Chapter 5 `gap` items
+  (Theorem5.6.1/5.10.1/5.27.1, Example5.12.3/5.19.3) still show `status:
+  sorry_free` despite a fidelity gap; PLAN says a gap reverts `sorry_free`. Their
+  repair issues (#5621–5623, #5637, #5638) are the tracking mechanism.
+
+## Blockers
+None.

--- a/progress/coverage-audit/fidelity-wave-5.md
+++ b/progress/coverage-audit/fidelity-wave-5.md
@@ -1,0 +1,110 @@
+# Fidelity sweep — Wave 5 (Chapter 5 residual, issue #5342)
+
+Judge: Opus 4.8 (distinct from the Sonnet/earlier authors of the items below).
+Scope: the Chapter 5 claim-bearing worklist items whose `fidelity` field was
+still missing or non-conforming (`ok` / `faithful` / `partial`) after waves 1–4.
+Method: PLAN.md Stage 3.2 steps 6–7 — anti-vacuity decision test, then
+conjunct-by-conjunct fidelity of the Lean statement against the book blob.
+
+After this wave every Chapter 5 claim-bearing done item (68 total) is
+`verified` (62) or `gap` (6). All six gaps carry a `fidelity_issue`.
+
+## Verdicts
+
+### Chapter5/Example5.1.3 — VERIFIED
+Book: real/complex/quaternionic type classification for ℤ/nℤ, S₃, S₄, A₅, Q₈.
+Lean (`Example5_1_3.lean`, code sorry-free; the one "sorry" token is docstring prose):
+- `Example5_1_3_ZMod`: a 1-dim ℤ/nℤ character with a value ∉ {±1} is **not** real
+  type (the "complex type" direction).
+- `Example5_1_3_S3`, `_S4`, `_A5`: **every** simple ℂ[G]-module is of real type
+  (universally quantified over simple modules — strong, faithful).
+- `Example5_1_3_Q8`: **exhibits** a concrete 2-dimensional simple representation of
+  quaternionic type (named `Q8.rho`, FS indicator −1 witnessed by the invariant
+  skew form). Not an unconstrained existential — a concrete witness with the exact
+  book property.
+Anti-vacuity: passes (S-group statements are ∀ over simple modules; the Q₈
+existential names a concrete rep with a concrete non-trivial property).
+Note (not a gap): the ℤ/nℤ item captures only the complex-type direction (it does
+not separately assert the trivial and sign reps are real type), and the Q₈ item
+does not separately assert the 1-dim reps are real type. These are sub-claim
+coverage matters already handled by the coverage arm; the formalized statements
+are faithful, non-vacuous renderings of the example's substance. → **verified**.
+
+### Chapter5/Remark5.2.8 — GAP (fidelity_issue #5654, open)
+Book: the modified vanishing argument — for `0<j<N=|G|` coprime to `N`,
+`g↦gʲ` is a bijection ⇒ `∏_{g≠1}|χ_V(gʲ)|²=β`; then `β∈K:=ℚ(ζ)`, invariant under
+`ζ↦ζʲ`, hence an integer, giving a contradiction.
+Lean (`Remark5_2_8.lean`, code sorry-free): Steps 1, 2, 5 and the
+algebraic-integer / root-of-unity content are real theorems; Step 4's
+representation-theoretic core (`character_ringHom_pow`, via `trace_pow_eq_sum_eigenvalues`)
+landed under #5772. **Not yet assembled**: the field-theoretic half of Step 4
+(`σ_j` from `Gal(ℚ(ζ_N)/ℚ)≅(ℤ/Nℤ)ˣ`, deducing `β∈ℚ`) and the final
+`β∈ℤ ⇒ contradiction` capstone. Tracked by the **open** issue #5654
+(`depends-on: #5772`). Status is honestly `proof_partial`. → **gap** (`fidelity_issue: 5654`).
+Prior non-standard value `partial` normalized to `gap`.
+
+### Chapter5/Remark5.8.3 — VERIFIED (was `ok`; #5652 resolved & closed)
+Book: `dim(Ind_H^G V) = dim V · (G:H)`.
+Lean `Remark5_8_3`: `finrank ℂ (IndV H.subtype ρ) = finrank ℂ V * H.index`
+(finite index `H`, finite-dimensional `V`) — exact, non-vacuous equality. The
+"determined by `{f(x_σ)}`" observation is `coindVEquivPi`. Missing-formalization
+issue #5652 is closed; file is present and sorry-free. → **verified**.
+
+### Chapter5/Theorem5.9.1 — VERIFIED (fidelity was unset)
+Book Thm 5.9.1 (coset-representative form, no normalization):
+`χ(g)=∑_{σ∈H\G : x_σ g x_σ⁻¹∈H} χ_V(x_σ g x_σ⁻¹)`.
+Lean `Theorem5_9_1`: the **averaged** form
+`χ(g)=(1/|H|)∑_{x∈G : xgx⁻¹∈H} χ_V(xgx⁻¹)` (code sorry-free; the module
+docstring's "currently sorry" is stale). This is the book's own Remark 5.9.2
+reformulation, mathematically **equivalent** to the coset form over ℂ (each right
+coset contributes `|H|` equal terms, cancelled by `1/|H|`), and the file's
+docstring is transparent about the substitution and its justification.
+Anti-vacuity/fidelity: not vacuous, not *weaker* — an equivalent, documented
+reformulation whose statement matches its own docstring. → **verified**.
+Recorded caveat: Theorem 5.9.1 and Remark 5.9.2 collapse to the same Lean
+statement, so the literal coset-representative equation of Thm 5.9.1 is not
+separately formalized; the induced-character content is nonetheless faithful.
+
+### Chapter5/Remark5.9.2 — VERIFIED (was `faithful`; #5653 resolved & closed)
+Book: the averaged Frobenius formula
+`χ(g)=(1/|H|)∑_{x∈G : xgx⁻¹∈H} χ_V(xgx⁻¹)` when `char k` coprime to `|H|`.
+Lean `Remark_5_9_2`: exactly this over `ℂ` (characteristic 0, so the hypothesis
+holds and `(|H|:ℂ)⁻¹` is a genuine inverse), defeq to `Theorem5_9_1`. Exact match.
+→ **verified**.
+
+### Chapter5/Proposition5.21.1 — VERIFIED (was `faithful`; #5615 resolved & closed)
+Book: `∏_m (x₁^m+⋯+x_N^m)^{i_m} = ∑_{λ: ℓ(λ)≤N} χ_λ(C_i) S_λ(x)`, summing over
+**all** partitions of `n` with `≤N` parts.
+Lean `Proposition5_21_1`: `psumPart = ∑ lam : BoundedPartition N n, charValue • schurPoly`
+— the index is `Finset.univ` over **all** bounded partitions, not an unconstrained
+existential over "some finset". This is exactly the #5615 fix (canonical decl is
+now the `univ` sum, not the weaker `∃ lams` form). Code sorry-free. → **verified**.
+
+### Chapter5/Proposition5.22.2 — VERIFIED (fidelity was unset)
+Book: `L_{λ+1^N} ≅ L_λ ⊗ ∧^N V`.
+Lean `Proposition5_22_2`:
+`Nonempty (SchurModule k N (λ+1) ≅ SchurModule k N λ ⊗ detRep k N)` (code sorry-free).
+`detRep` is the 1-dim determinant representation `= ∧^N V` (top exterior power of
+the standard N-dim rep), so the interpretation is faithful. `Nonempty (A ≅ B)` here
+is a genuine isomorphism assertion between two specific Schur modules — false in
+general for mismatched weights, hence non-vacuous. → **verified**.
+
+### Chapter5/Remark5.23.3 — VERIFIED (was `ok`; #5729 resolved & closed)
+Book: `𝔤𝔩(V)` results extend to `𝔰𝔩(V)`/`SL(V)`; on `SL` `L_λ≅L_{λ+1^m}`, so
+irreps are parametrized by `λ₁≥⋯≥λ_N` up to a simultaneous constant shift;
+(book-disavowed) every fin-dim `𝔰𝔩(V)`-rep is completely reducible and every
+irreducible is some `L_λ`; `dim V=2` recovers `𝔰𝔩(2)`.
+Lean (`Remark5_23_3.lean`, code sorry-free): `constShift` / `ShiftEquiv` /
+`SLWeightParam` (= dominant weights modulo constant shift) capture the
+parametrization-up-to-shift claim; `algIrrepGL_finrank_constShift` (`proof_wanted`)
+records the dimension-level `L_λ≅L_{λ+c·1^N}`; `sl_finiteDimensional_completely_reducible`
+(`proof_wanted`) records the **book-disavowed** complete-reducibility claim as
+`proof_wanted` (no sorry, no axiom) — the correct rendering of "we will not do
+this here". → **verified**.
+
+## Outcome
+- Chapter 5 fidelity worklist: 68/68 items now `verified` (62) or `gap` (6).
+- New/normalized this wave: 7 → `verified`, 1 (`Remark5.2.8`) → `gap` (#5654).
+- No new repair issues opened: the sole gap already has an open tracking issue
+  (#5654); the four previously-flagged items (#5615, #5652, #5653, #5729) were
+  re-audited against the *current* Lean, confirmed fixed, and closed.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3200,7 +3200,8 @@
     "start_line": 5,
     "end_line": 6,
     "status": "statement_formalized",
-    "sorry_free": false
+    "sorry_free": false,
+    "fidelity": "verified"
   },
   {
     "id": "Chapter5/Definition5.1.4",
@@ -3388,8 +3389,9 @@
     "start_line": 11,
     "end_line": 12,
     "status": "proof_partial",
-    "fidelity": "partial",
-    "note": "Partially formalized (issue #5654, epic #5338) in Chapter5/Remark5_2_8.lean, replacing the earlier doc-only false closure. The remark is an alternative proof of the vanishing statement of Problem 5.2.7(b), decomposing into five steps. Three are formalized as real sorry-free theorems: Step 1 (pow_coprime_bijective) g ↦ gʲ is a bijection G → G for gcd(|G|,j)=1; Step 2 (prod_ne_one_pow) reindexing the product over G∖{1} along that bijection gives ∏_{g≠1} f(gʲ) = ∏_{g≠1} f(g), i.e. ∏_{g≠1}|χ_V(gʲ)|² = β; Step 5 + contradiction (not_isIntegral_rat_mem_Ioo) no rational algebraic integer lies in (0,1), built on Etingof.Proposition5_2_5. Also formalized sorry-free: the algebraic-integer half (isIntegral_prod_normSq_character, β is a product of algebraic integers) and the root-of-unity content of Step 3 (character_eq_sum_rootsOfUnity: each χ_V(g) is a sum of N-th roots of unity, N=|G|, since the eigenvalues of ρ(g) are roots of its charpoly and ρ(g) has order dividing N — placing β in ℚ(ζ_N)). Step 4 (representation-theoretic core) is now formalized sorry-free (#5772): character_ringHom_pow proves σ(χ_V(g)) = χ_V(gʲ) for any ring endomorphism σ of ℂ raising every N-th root of unity to its j-th power, via the trace-power-sum trace_pow_eq_sum_eigenvalues (ρ(g) is semisimple as its minpoly divides squarefree X^N-1, so V splits into eigenspaces and trace(ρ(g)ᵏ)=∑_μ (dim Eμ)·μᵏ); combined with Step 2, ringHom_prod_char_inv gives σ(β)=β for β=∏_{g≠1} χ_V(g)·χ_V(g⁻¹). The remaining field-theoretic half of Step 4 (producing σ_j from Gal(ℚ(ζ_N)/ℚ)≅(ℤ/Nℤ)ˣ and deducing β∈ℚ from fixed-by-all-σ_j), plus the unformalized 0<β<1 bound of Problem 5.2.7(b), remain tracked as foundation sub-issue #5772."
+    "fidelity": "gap",
+    "note": "Partially formalized (issue #5654, epic #5338) in Chapter5/Remark5_2_8.lean, replacing the earlier doc-only false closure. The remark is an alternative proof of the vanishing statement of Problem 5.2.7(b), decomposing into five steps. Three are formalized as real sorry-free theorems: Step 1 (pow_coprime_bijective) g ↦ gʲ is a bijection G → G for gcd(|G|,j)=1; Step 2 (prod_ne_one_pow) reindexing the product over G∖{1} along that bijection gives ∏_{g≠1} f(gʲ) = ∏_{g≠1} f(g), i.e. ∏_{g≠1}|χ_V(gʲ)|² = β; Step 5 + contradiction (not_isIntegral_rat_mem_Ioo) no rational algebraic integer lies in (0,1), built on Etingof.Proposition5_2_5. Also formalized sorry-free: the algebraic-integer half (isIntegral_prod_normSq_character, β is a product of algebraic integers) and the root-of-unity content of Step 3 (character_eq_sum_rootsOfUnity: each χ_V(g) is a sum of N-th roots of unity, N=|G|, since the eigenvalues of ρ(g) are roots of its charpoly and ρ(g) has order dividing N — placing β in ℚ(ζ_N)). Step 4 (representation-theoretic core) is now formalized sorry-free (#5772): character_ringHom_pow proves σ(χ_V(g)) = χ_V(gʲ) for any ring endomorphism σ of ℂ raising every N-th root of unity to its j-th power, via the trace-power-sum trace_pow_eq_sum_eigenvalues (ρ(g) is semisimple as its minpoly divides squarefree X^N-1, so V splits into eigenspaces and trace(ρ(g)ᵏ)=∑_μ (dim Eμ)·μᵏ); combined with Step 2, ringHom_prod_char_inv gives σ(β)=β for β=∏_{g≠1} χ_V(g)·χ_V(g⁻¹). The remaining field-theoretic half of Step 4 (producing σ_j from Gal(ℚ(ζ_N)/ℚ)≅(ℤ/Nℤ)ˣ and deducing β∈ℚ from fixed-by-all-σ_j), plus the unformalized 0<β<1 bound of Problem 5.2.7(b), remain tracked as foundation sub-issue #5772.",
+    "fidelity_issue": 5654
   },
   {
     "id": "Chapter5/Introduction_5.3",
@@ -3794,10 +3796,9 @@
     "start_line": 19,
     "end_line": 26,
     "status": "sorry_free",
-    "fidelity": "ok",
+    "fidelity": "verified",
     "sorry_free": true,
-    "fidelity_note": "Fixed in #5652: added EtingofRepresentationTheory/Chapter5/Remark5_8_3.lean. `Etingof.Remark5_8_3` proves `finrank ℂ (IndV H.subtype ρ) = finrank ℂ V * H.index` for a finite index subgroup and finite-dimensional V. The proof follows the book: `Etingof.coindVEquivPi` is the ℂ-linear equivalence coindV ≅ (right cosets → V) given by evaluation at chosen coset representatives (Etingof's observation that f is determined by {f(x_σ)}), and `Etingof.indVLinearEquivCoindV` transfers this to the tensor model IndV via Mathlib's finite-index Ind ≅ Coind isomorphism.",
-    "fidelity_issue": 5652
+    "fidelity_note": "Fixed in #5652: added EtingofRepresentationTheory/Chapter5/Remark5_8_3.lean. `Etingof.Remark5_8_3` proves `finrank ℂ (IndV H.subtype ρ) = finrank ℂ V * H.index` for a finite index subgroup and finite-dimensional V. The proof follows the book: `Etingof.coindVEquivPi` is the ℂ-linear equivalence coindV ≅ (right cosets → V) given by evaluation at chosen coset representatives (Etingof's observation that f is determined by {f(x_σ)}), and `Etingof.indVLinearEquivCoindV` transfers this to the tensor model IndV via Mathlib's finite-index Ind ≅ Coind isomorphism."
   },
   {
     "id": "Chapter5/Problem5.8.4",
@@ -3844,7 +3845,8 @@
     "start_line": 5,
     "end_line": 10,
     "status": "statement_formalized",
-    "sorry_free": false
+    "sorry_free": false,
+    "fidelity": "verified"
   },
   {
     "id": "Chapter5/Remark5.9.2",
@@ -3855,9 +3857,8 @@
     "start_line": 11,
     "end_line": 14,
     "status": "sorry_free",
-    "fidelity": "faithful",
-    "fidelity_note": "[resolved #5653] Coverage gap closed by PR for #5653: EtingofRepresentationTheory/Chapter5/Remark5_9_2.lean now provides Etingof.Remark_5_9_2, stating the averaged Frobenius character formula χ(g) = (1/|H|) · Σ_{x∈G : xgx⁻¹∈H} χ_V(xgx⁻¹). The wave-2 finding was correct that no declaration named Remark5_9_2 existed, but the remark's mathematical content was already fully formalized: Etingof.Theorem5_9_1 was proved directly in the averaged form (choosing a transversal of H\\G is awkward to formalize, so the averaged phrasing is the primary statement — see Theorem5_9_1.lean's module docstring). Remark_5_9_2 records that averaged formula under the book item's name, deriving it from Theorem5_9_1 over k = ℂ (characteristic 0, so the 'char coprime to |H|' hypothesis holds automatically). sorry-free; axioms [propext, Classical.choice, Quot.sound]; imported into Chapter5.lean.",
-    "fidelity_issue": 5653
+    "fidelity": "verified",
+    "fidelity_note": "[resolved #5653] Coverage gap closed by PR for #5653: EtingofRepresentationTheory/Chapter5/Remark5_9_2.lean now provides Etingof.Remark_5_9_2, stating the averaged Frobenius character formula χ(g) = (1/|H|) · Σ_{x∈G : xgx⁻¹∈H} χ_V(xgx⁻¹). The wave-2 finding was correct that no declaration named Remark5_9_2 existed, but the remark's mathematical content was already fully formalized: Etingof.Theorem5_9_1 was proved directly in the averaged form (choosing a transversal of H\\G is awkward to formalize, so the averaged phrasing is the primary statement — see Theorem5_9_1.lean's module docstring). Remark_5_9_2 records that averaged formula under the book item's name, deriving it from Theorem5_9_1 over k = ℂ (characteristic 0, so the 'char coprime to |H|' hypothesis holds automatically). sorry-free; axioms [propext, Classical.choice, Quot.sound]; imported into Chapter5.lean."
   },
   {
     "id": "Chapter5/Discussion_proof_of_Theorem5.9.1",
@@ -4723,10 +4724,9 @@
     "start_line": 17,
     "end_line": 32,
     "status": "sorry_free",
-    "fidelity": "faithful",
+    "fidelity": "verified",
     "sorry_free": true,
-    "notes": "Proved in PR #1808 (antisymmetric basis decomposition). Fidelity gap (#5615) resolved: canonical `Proposition5_21_1` is now the faithful `Finset.univ` sum over ALL bounded partitions (was a weaker existential); `Proposition5_21_1_univ` retained as an alias.",
-    "fidelity_issue": 5615
+    "notes": "Proved in PR #1808 (antisymmetric basis decomposition). Fidelity gap (#5615) resolved: canonical `Proposition5_21_1` is now the faithful `Finset.univ` sum over ALL bounded partitions (was a weaker existential); `Proposition5_21_1_univ` retained as an alias."
   },
   {
     "id": "Chapter5/Discussion_before_Proposition5.21.2",
@@ -4820,7 +4820,8 @@
     "end_line": 6,
     "status": "statement_formalized",
     "attention_note": "Statement and proof structure complete, but the proof delegates to the Schur-Weyl character-classification chain, which still has sorries.",
-    "notes": "Triage 2026-06-22: Theorem5_22_1 (SchurModule) is now sorry_free, so the 2026-03-18 blocker is resolved. Proposition5_22_2 itself compiles, but its proof routes through iso_of_formalCharacter_eq_schurPoly (SchurWeylFormalCharacterIso.lean), whose cone carries the Cluster A sorries: schurWeyl_simples_formalCharacter_classification_core and glTensorRep_schurWeyl_simples_pairwise_distinct (SchurWeylSimplesClassification.lean), detInv_elim_of_polynomial (PolynomialRepEmbedding.lean), and kernelLemmaK' (KernelLemmaKPrime.lean). Tracked transitively-honest as statement_formalized until those land."
+    "notes": "Triage 2026-06-22: Theorem5_22_1 (SchurModule) is now sorry_free, so the 2026-03-18 blocker is resolved. Proposition5_22_2 itself compiles, but its proof routes through iso_of_formalCharacter_eq_schurPoly (SchurWeylFormalCharacterIso.lean), whose cone carries the Cluster A sorries: schurWeyl_simples_formalCharacter_classification_core and glTensorRep_schurWeyl_simples_pairwise_distinct (SchurWeylSimplesClassification.lean), detInv_elim_of_polynomial (PolynomialRepEmbedding.lean), and kernelLemmaK' (KernelLemmaKPrime.lean). Tracked transitively-honest as statement_formalized until those land.",
+    "fidelity": "verified"
   },
   {
     "id": "Chapter5/Introduction_5.23",
@@ -4902,10 +4903,9 @@
     "start_line": 5,
     "end_line": 7,
     "status": "sorry_free",
-    "fidelity": "ok",
+    "fidelity": "verified",
     "sorry_free": true,
-    "fidelity_note": "Added in #5729: EtingofRepresentationTheory/Chapter5/Remark5_23_3.lean. Genuinely proves the load-bearing content: the simultaneous constant shift Etingof.DominantWeight.constShift (lam -> lam + c*1^N), the shift-equivalence setoid shiftSetoid, and the parameter type Etingof.SLWeightParam n := Quotient (shiftSetoid n) -- Etingof's parametrization of SL(V)-irreducibles by dominant weights up to a simultaneous constant shift -- plus Etingof.specialLinear_det_eq_one (det = 1 on SL_N, the source of the identification). The two book-disavowed / infrastructure-heavy assertions are recorded via proof_wanted (no sorry, no axiom): Etingof.algIrrepGL_finrank_constShift (dim L_lam = dim L_{lam+c*1^N}, the statable dimension-level shadow of the SL(V) isomorphism) and Etingof.sl_finiteDimensional_completely_reducible (complete reducibility of finite-dimensional sl_N-modules, stated as every LieSubmodule having a complement, mirroring the sl(2) case Etingof.Sl2Irrep.complete_reducibility of Problem 2.15.1, which the book omits: 'we will not do this here').",
-    "fidelity_issue": 5729
+    "fidelity_note": "Added in #5729: EtingofRepresentationTheory/Chapter5/Remark5_23_3.lean. Genuinely proves the load-bearing content: the simultaneous constant shift Etingof.DominantWeight.constShift (lam -> lam + c*1^N), the shift-equivalence setoid shiftSetoid, and the parameter type Etingof.SLWeightParam n := Quotient (shiftSetoid n) -- Etingof's parametrization of SL(V)-irreducibles by dominant weights up to a simultaneous constant shift -- plus Etingof.specialLinear_det_eq_one (det = 1 on SL_N, the source of the identification). The two book-disavowed / infrastructure-heavy assertions are recorded via proof_wanted (no sorry, no axiom): Etingof.algIrrepGL_finrank_constShift (dim L_lam = dim L_{lam+c*1^N}, the statable dimension-level shadow of the SL(V) isomorphism) and Etingof.sl_finiteDimensional_completely_reducible (complete reducibility of finite-dimensional sl_N-modules, stated as every LieSubmodule having a complement, mirroring the sl(2) case Etingof.Sl2Irrep.complete_reducibility of Problem 2.15.1, which the book omits: 'we will not do this here')."
   },
   {
     "id": "Chapter5/Introduction_5.24",


### PR DESCRIPTION
This PR closes the Chapter 5 arm of the Stage 3.7 fidelity sweep by judging the 8 residual claim-bearing items whose `fidelity` field was missing or non-conforming (`ok`/`faithful`/`partial`), applying PLAN Stage 3.2 steps 6–7 with a distinct model (Opus 4.8). Seven are marked `verified` (Example5.1.3, Remark5.8.3, Theorem5.9.1, Remark5.9.2, Proposition5.21.1, Proposition5.22.2, Remark5.23.3) and one `gap` (Remark5.2.8, `fidelity_issue` #5654, still open). All 68 Chapter 5 worklist items are now `verified` (62) or `gap` (6), and every gap carries a `fidelity_issue`. Only `progress/items.json` and the wave record change; no Lean is touched. Findings: `progress/coverage-audit/fidelity-wave-5.md`.

Closes #5342

Session: `e2fd8bc9-5ddb-4f5f-b4bb-3bcb9a3052b5`

🤖 Prepared with Claude Code