### PR TITLE
review(Ch3 #5340): fidelity audit closeout — 27/27 verified

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -39,6 +39,26 @@ Rotate through these areas across sessions:
 **Security**:
 - Check for new issues in recent code, verify past fixes
 
+## Fidelity audits (Stage 3.7)
+
+If your issue is a per-chapter fidelity audit (epic #5338), two things recur:
+
+- **Editing `progress/items.json`:** change `fidelity`/`status` fields **surgically**
+  — `grep -n` the item id, Read those ~15 lines, and `Edit` just the value. Never
+  `json.load`+`json.dump` the whole file: the reserializer reflows indentation
+  (the file is `indent=2`), key order, and unicode, producing a multi-thousand-line
+  diff against the shared file. If you must script a bulk update, match the exact
+  serialization (`indent=2, ensure_ascii=False`, no trailing newline) and check
+  `git diff --stat` before committing.
+- **Residual non-canonical verdicts:** a chapter's items may already be labeled by
+  prior waves with non-canonical values (`faithful`/`partial`/`covered`) or a stale
+  `gap` whose repair issue is already CLOSED. Don't re-audit from scratch — query
+  items.json for non-canonical `fidelity` values, confirm each linked repair issue
+  is CLOSED and the current Lean genuinely matches the book, then normalize to
+  `verified`/`gap`. Reserve `gap` for a *present* statement that is vacuous or
+  silently weaker; honestly-named partial coverage (e.g. an "existence half" with
+  no masquerading full-theorem decl) is a coverage follow-up, not a fidelity gap.
+
 ## Updating Skills
 
 When you discover a recurring pattern or encounter a situation not covered by

--- a/progress/2026-07-02T12-00-00Z_d97fc9d7.md
+++ b/progress/2026-07-02T12-00-00Z_d97fc9d7.md
@@ -1,0 +1,51 @@
+## Accomplished
+
+Closed out issue #5340 — the Chapter 3 fidelity audit (child of epic #5338,
+Stage 3.7 fidelity arm). Prior waves (1–2) had already audited Chapter 3 and
+repaired every gap they found; on entry 22 of the 27 worklist items were
+`verified`, 1 was a stale `gap`, and 5 carried non-canonical fidelity values
+(`faithful`/`partial`/`covered`) left over from the repair cycle.
+
+Re-read those 5 items against their blobs and current Lean statements with a
+different-family judge model (Opus) and normalized every one to canonical
+`verified` after fresh verification:
+
+- Definition3.3.2 (stale `gap` → verified) — #5618 added param A + contragredient
+  Aᵐᵒᵖ-action + defining-equation theorem.
+- Definition3.4.1 (`faithful` → verified) — #5619 structure with both boundary
+  conditions.
+- Theorem3.10.2 (`faithful` → verified) — #5614 uniqueness companion theorem restored.
+- Remark3.10.3 (`covered` → verified) — #5663 counterexample formalized.
+- Remark3.8.6 (`partial` → verified) — formalized decls faithful/non-vacuous;
+  missing finite-length uniqueness is a coverage follow-up (#5662), not a fidelity
+  gap (nothing masquerades as full Krull-Schmidt). Judgment recorded explicitly in
+  the wave file.
+
+Spot-checked 3 inherited `verified` headliners (Thm 3.5.4, 3.7.1, 3.8.1) — all
+faithful, no new gaps. Recorded findings in
+`progress/coverage-audit/fidelity-wave-5.md` and updated `progress/items.json`.
+
+## Current frontier
+
+Chapter 3 fidelity arm complete: **27 verified, 0 gap**. Diff is minimal
+(items.json: 5 items touched; new wave-5.md). No Lean changes, so no build needed.
+
+## Overall project progress
+
+Stage 3.7 fidelity arm (epic #5338). Per-chapter children remaining:
+Ch2 #5339, Ch4 #5341, Ch5 #5342, Ch6 #5343, Ch7 #5344, Ch8 #5345, Ch9 #5346.
+Chapter 3 (#5340) now done.
+
+## Next step
+
+A planner/worker should pick up the next unfinished chapter child (#5339, #5341, …).
+Note for those waves: several chapters likely have the same residual state as
+Ch3 — items already repaired via issues but left under non-canonical fidelity
+labels (`faithful`/`partial`/`covered`/stale `gap`). The efficient move is to
+first query items.json for non-canonical fidelity values in the target chapter,
+confirm the linked repair issues are CLOSED and the Lean genuinely matches the
+book, then normalize to `verified`/`gap` — rather than re-auditing from scratch.
+
+## Blockers
+
+None.

--- a/progress/coverage-audit/fidelity-wave-5.md
+++ b/progress/coverage-audit/fidelity-wave-5.md
@@ -1,0 +1,78 @@
+# Stage 3.7 Fidelity Sweep — Wave 5 (Chapter 3 closeout, issue #5340)
+
+Judge model: Opus (different family than the original formalizers and than the
+wave-1/wave-2 Chapter-3 auditors). Scope: the **27** claim-bearing done items of
+Chapter 3 (`fidelity-worklist.tsv`), applying PLAN.md §3.2 steps 6–7 (anti-vacuity
+decision test + conjunct-by-conjunct fidelity), calibrated on #5322/#5323/#5326 and
+the wave-4 dropped-uniqueness gap (#5669).
+
+## Entry state
+
+Prior waves had already audited Chapter 3 and driven every wave-2 gap through a
+repair issue. On entry, 22 items were `verified`, 1 was `gap` (Definition3.3.2),
+and **5 items carried non-canonical fidelity values** left over from the repair
+cycle (`faithful`, `partial`, `covered`) or a stale `gap`. This wave re-read each
+of those 5 against its blob and current Lean statement and normalized it to the
+canonical `verified`/`gap` vocabulary. The other 22 `verified` items were accepted
+from waves 1–2; three headliners were spot-checked (below) to bound residual risk.
+
+## Normalizations (5 items, all → `verified` after fresh verification)
+
+- **Definition3.3.2** (`gap` → `verified`). Stale gap. Repair #5618 (CLOSED) added
+  the algebra parameter `A`: `DualRepresentation k A V := Module.Dual k V` now
+  carries the contragredient `Aᵐᵒᵖ`-action via `instance instModuleMulOppositeDual`,
+  and the defining-equation theorem `dualRepresentation_smul_apply` proves
+  `(a • f) v = f (a.unop • v)` — exactly the book's `(f·a)(v) = f(av)`. The A^op
+  representation is genuinely constructed; no vacuous/weakened statement remains.
+
+- **Definition3.4.1** (`faithful` → `verified`). Repair #5619 (CLOSED) replaced the
+  bare `RelSeries` abbrev with a `structure` bundling the strictly-ascending chain
+  and both boundary conditions `head_eq_bot` (V₀ = ⊥) and `last_eq_top` (Vₙ = ⊤),
+  matching `0 = V₀ ⊂ ⋯ ⊂ Vₙ = V`. No dropped conjunct.
+
+- **Theorem3.10.2** (`faithful` → `verified`). Part (i) `tensor_product_irreducible`
+  and part (ii) existence `tensor_product_irreducible_classification` are faithful;
+  repair #5614 (CLOSED) restored the dropped uniqueness conjunct as companion
+  theorem `tensor_product_irreducible_classification_unique` (any two A-B-equivariant
+  factorizations give `V ≃ₗ[A] V'` and `W ≃ₗ[B] W'` — the book's "unique V and W"
+  up to isomorphism). No dropped conjunct.
+
+- **Remark3.10.3** (`covered` → `verified`). Repair #5663 (CLOSED) formalized the
+  remark's concrete counterexample: `ratFunc_tensor_ratFunc_not_isField` proves
+  `¬ IsField (RatFunc ℂ ⊗[ℂ] RatFunc ℂ)`, witnessing the failure of Theorem
+  3.10.2(i) for A=B=V=W=ℂ(x). Faithful and non-vacuous (explicit nonzero non-unit
+  witness).
+
+- **Remark3.8.6** (`partial` → `verified`). Judgment call, recorded explicitly.
+  The remark asserts Krull-Schmidt holds for finite-length modules. The formalized
+  declarations (`isNilpotent_or_isUnit_of_finiteLength_indecomposable` = Fitting's
+  lemma, `isLocalRing_end_of_finiteLength_indecomposable`,
+  `exists_indecomposable_decomposition`) are each faithful and non-vacuous, and
+  crucially **none is presented as full Krull-Schmidt while being silently weaker** —
+  the existence half is honestly named "existence half". The missing uniqueness
+  half (Krull-Schmidt-Azumaya) in the finite-length setting is a *coverage*
+  follow-up already tracked and closed as an acceptable resting state (repair
+  #5662, CLOSED, with uniqueness noted as follow-up), not a *fidelity* gap: no
+  vacuous/weakened statement masquerades under this item's name. Full uniqueness
+  for the finite-dimensional case is faithfully proved separately in Theorem 3.8.1
+  (`krull_schmidt_uniqueness`). Verdict `verified` for the fidelity arm; the
+  uniqueness coverage item remains for the coverage arm to schedule if desired.
+
+## Spot-checks of the inherited `verified` bucket (3 headliners, all faithful)
+
+- **Theorem3.5.4** `structure_mod_radical` — proves `A/Rad(A) ≃ₐ[k] ∏ᵢ End(Vᵢ)`
+  over a finite complete family of nonisomorphic simples (Fintype ι + completeness
+  hypothesis). Isomorphism conjunct present; product = direct sum for finite index.
+- **Theorem3.7.1** `jordan_holder` + `jordan_holder_factors` — both conjuncts
+  present: length equality `n = m` and `∃ σ` permutation with `Wᵢ ≃ₗ[A] W'_{σ i}`.
+- **Theorem3.8.1** `krull_schmidt_existence` + `krull_schmidt_uniqueness` — both
+  halves present; uniqueness is `n = m ∧ ∃ σ, ∀ i, Wᵢ ≃ₗ[A] W'_{σ i}`.
+
+No new gaps found in the spot-check.
+
+## Result
+
+All 27 Chapter 3 worklist items are now `verified` (canonical). Chapter-3 fidelity
+verdict counts: **verified 27, gap 0**. Issue #5340 done. No repair issues opened
+(the two dropped-conjunct gaps from wave-2 were already repaired and closed;
+this wave only confirmed and re-labeled them).

--- a/progress/items.json
+++ b/progress/items.json
@@ -1826,12 +1826,12 @@
     "start_line": 9,
     "end_line": 12,
     "status": "sorry_free",
-    "fidelity": "gap",
+    "fidelity": "verified",
     "sorry_free": true,
-    "fidelity_note": "[partial-example] The definition is 'abbrev Etingof.DualRepresentation (k : Type*) (V : Type*) [CommSemiring k] [AddCommMonoid V] [Module k V] := Module.Dual k V'. The parameter A is absent — there is",
+    "fidelity_note": "[fidelity verified, wave-5] Repair #5618 (CLOSED) added the algebra parameter A: DualRepresentation k A V := Module.Dual k V now carries the contragredient Aᵐᵒᵖ-action via instance instModuleMulOppositeDual, with defining-equation theorem dualRepresentation_smul_apply proving (a • f) v = f (a.unop • v) — matching the book's (f·a)(v) = f(av). The A^op-representation is genuinely constructed. No vacuous/weakened statement remains.",
     "fidelity_decl": "Etingof.DualRepresentation (k A V) := Module.Dual k V, with Module A^mop instance (op a . f)(v) = f(a.v)",
     "fidelity_issue": 5618,
-    "last_updated": "2026-06-29"
+    "last_updated": "2026-07-02"
   },
   {
     "id": "Chapter3/Discussion_proof_of_Theorem3.3.1",
@@ -1894,10 +1894,11 @@
     "start_line": 7,
     "end_line": 8,
     "status": "sorry_free",
-    "fidelity": "faithful",
+    "fidelity": "verified",
     "sorry_free": true,
-    "fidelity_note": "[fidelity, resolved #5619] Etingof.Filtration is now a structure bundling the ascending chain (RelSeries) with the two boundary conditions head_eq_bot (V₀ = ⊥) and last_eq_top (Vₙ = ⊤), matching the book's 0 = V₀ ⊂ ⋯ ⊂ Vₙ = V.",
-    "fidelity_issue": 5619
+    "fidelity_note": "[fidelity verified, wave-5] Repair #5619 (CLOSED) replaced the bare RelSeries abbrev with a structure bundling the strictly-ascending chain and both boundary conditions head_eq_bot (V₀ = ⊥) and last_eq_top (Vₙ = ⊤), matching the book's 0 = V₀ ⊂ ⋯ ⊂ Vₙ = V. No dropped conjunct.",
+    "fidelity_issue": 5619,
+    "last_updated": "2026-07-02"
   },
   {
     "id": "Chapter3/Lemma3.4.2",
@@ -2204,8 +2205,8 @@
     "start_line": 11,
     "end_line": 12,
     "status": "sorry_free",
-    "fidelity": "partial",
-    "fidelity_note": "[coverage/needs_completion] wave-3; #5662: existence + Fitting's lemma (nilpotent-or-unit) + local endomorphism ring formalized in Chapter3/Remark3_8_6.lean over an arbitrary ring (no algebraically closed field); uniqueness (Krull-Schmidt-Azumaya exchange) remains as follow-up",
+    "fidelity": "verified",
+    "fidelity_note": "[fidelity verified, wave-5] The formalized declarations (isNilpotent_or_isUnit_of_finiteLength_indecomposable = Fitting's lemma, isLocalRing_end_of_finiteLength_indecomposable, exists_indecomposable_decomposition) are each faithful and non-vacuous; none is presented as full Krull-Schmidt while silently weaker. The uniqueness half (Krull-Schmidt-Azumaya) for the finite-length setting is a coverage follow-up (repair #5662, CLOSED, uniqueness explicitly noted as follow-up), not a fidelity gap: no vacuous/weakened statement masquerades under this item. Full uniqueness for the finite-dimensional case is faithfully proved in Theorem 3.8.1 (krull_schmidt_uniqueness).",
     "fidelity_decl": "Etingof.isNilpotent_or_isUnit_of_finiteLength_indecomposable, Etingof.isLocalRing_end_of_finiteLength_indecomposable, Etingof.exists_indecomposable_decomposition",
     "last_updated": "2026-07-02",
     "fidelity_issue": 5662
@@ -2327,11 +2328,12 @@
     "start_line": 13,
     "end_line": 16,
     "status": "sorry_free",
-    "fidelity": "faithful",
+    "fidelity": "verified",
     "notes": "All sorries resolved. Uniqueness of V, W (Theorem 3.10.2(ii)'s '**unique** V and W') added as companion theorem Etingof.tensor_product_irreducible_classification_unique (#5614).",
     "sorry_free": true,
-    "fidelity_note": "[resolved #5614] Existence is tensor_product_irreducible_classification; uniqueness up to isomorphism is the companion tensor_product_irreducible_classification_unique (V ≅ V' as A-modules, W ≅ W' as B-modules for any two A-B-equivariant factorizations), via Schur's lemma.",
-    "fidelity_issue": 5614
+    "fidelity_note": "[fidelity verified, wave-5] Part (i) tensor_product_irreducible (V⊗W irreducible) and part (ii) existence tensor_product_irreducible_classification are faithful. Repair #5614 (CLOSED) restored the dropped uniqueness conjunct as companion theorem tensor_product_irreducible_classification_unique: any two A-B-equivariant factorizations give V ≃ₗ[A] V' and W ≃ₗ[B] W', i.e. the book's 'unique V and W' (up to iso). No dropped conjunct.",
+    "fidelity_issue": 5614,
+    "last_updated": "2026-07-02"
   },
   {
     "id": "Chapter3/Remark3.10.3",
@@ -2342,8 +2344,8 @@
     "start_line": 17,
     "end_line": 18,
     "status": "sorry_free",
-    "fidelity": "covered",
-    "fidelity_note": "[resolved #5663] Formalized the core obstruction: ratFunc_tensor_ratFunc_not_isField proves ¬ IsField (RatFunc ℂ ⊗[ℂ] RatFunc ℂ), witnessing the failure of Theorem 3.10.2(i) for infinite dimensional representations (A=B=V=W=ℂ(x)). Witness element X⊗1-1⊗X is nonzero (via shift alg hom X↦X+1) but not a unit (multiplication map lmul' sends it to 0).",
+    "fidelity": "verified",
+    "fidelity_note": "[fidelity verified, wave-5] Repair #5663 (CLOSED) formalized the concrete counterexample of the remark: ratFunc_tensor_ratFunc_not_isField proves ¬ IsField (RatFunc ℂ ⊗[ℂ] RatFunc ℂ), witnessing the failure of Theorem 3.10.2(i) for A=B=V=W=ℂ(x). Faithful, non-vacuous (explicit nonzero non-unit witness).",
     "fidelity_decl": "EtingofRepresentationTheory.Chapter3.Remark3_10_3.ratFunc_tensor_ratFunc_not_isField",
     "last_updated": "2026-07-02",
     "fidelity_issue": 5663


### PR DESCRIPTION
This PR closes out the Chapter 3 fidelity audit (issue #5340, child of Stage 3.7 epic #5338) by normalizing the five residual non-canonical fidelity verdicts to canonical `verified`. Prior waves had already found and repaired every Chapter 3 gap; five items were left under stopgap labels (`faithful`/`partial`/`covered` and one stale `gap`). A fresh, different-model re-read of each item's blob against its current Lean statement confirms the repairs (#5618, #5619, #5614, #5663, #5662, all CLOSED) are faithful and non-vacuous, so each is re-labeled `verified`. Three inherited `verified` headliners (Theorems 3.5.4, 3.7.1, 3.8.1) were spot-checked and found faithful, with no new gaps. Findings are recorded in `progress/coverage-audit/fidelity-wave-5.md`; no Lean changed. Chapter 3 fidelity arm is now 27 verified, 0 gap.

Closes #5340

🤖 Prepared with Claude Code