### PR TITLE
chore(skill): surgical items.json edits + gap reconciliation note for review sessions

### DIFF
--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -137,6 +137,16 @@ master: `git checkout agent/<id> && git reset --hard origin/master`.
 Record any project-specific quality metrics (e.g. sorry count, test coverage)
 as described in the project's CLAUDE.md.
 
+**Editing `progress/items.json` (any session, especially review/fidelity
+audits that bulk-update `fidelity`/`status` fields):** edit surgically —
+`grep -n` the item id, Read those ~15 lines, `Edit` just the field value, and
+drop any now-stale `fidelity_note`. Never `json.load`+`json.dump` the whole
+file: the reserializer reflows indentation/key-order/unicode into a
+multi-thousand-line diff against the shared 13k-line file (it only stays clean
+by luck if your dump params happen to match). When flipping a `gap` back to
+`verified`, also remove its `fidelity_issue` and confirm the linked repair
+issue actually merged. (Full rationale in the `lean-formalization` skill.)
+
 ## Step 3: Codebase Orientation
 
 Read the specific files mentioned in the plan/issue. Understand the current state


### PR DESCRIPTION
This PR surfaces, in the agent-worker-flow skill that all worker sessions read, the rule to edit progress/items.json surgically (never json.load+json.dump the whole shared file) and to reconcile gap→verified items whose repair issue has merged. Review and fidelity-audit sessions bulk-edit items.json fidelity fields but are directed to agent-worker-flow rather than lean-formalization where the rule previously lived only. Split out from the #5343 Chapter 6 fidelity-audit /reflect step (that PR already merged).

🤖 Prepared with Claude Code