### PR TITLE
fix: exclude Chapter4 A₅ table modules that OOM the CI runner

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -57,7 +57,14 @@ jobs:
           # - Chapter/root aggregation files (mindepth 2 skips these)
           # - Modules that import full Mathlib + large chapter environments,
           #   which require >15GB to compile (exceeds runner capacity)
-          EXCLUDE="SpechtModuleSimple|SpechtCharacterGeneral|YoungSymTraceKronecker|FrobeniusCharacterBridge|Proposition5_22_2|Example6_4_9_EType|Example6_4_9\.lean"
+          # - Chapter4 A₅ tensor/character-table modules (Example4_8_1,
+          #   Example4_9_1): ~100 `decide`s and a 125-way fin_cases split
+          #   under maxHeartbeats 2-4M. Since #5845/#5846 these two hang the
+          #   runner at 9017/9019 jobs until SIGTERM (exit 143) kills the job
+          #   at ~53 min — every main build since 2026-07-03 died this way.
+          #   Verified locally instead; re-inclusion tracked in a follow-up
+          #   issue.
+          EXCLUDE="SpechtModuleSimple|SpechtCharacterGeneral|YoungSymTraceKronecker|FrobeniusCharacterBridge|Proposition5_22_2|Example6_4_9_EType|Example6_4_9\.lean|Example4_8_1|Example4_9_1"
           find EtingofRepresentationTheory -mindepth 2 -name '*.lean' \
             | grep -vE "$EXCLUDE" \
             | sed 's|/|.|g; s|\.lean$||' \


### PR DESCRIPTION
This PR restore green CI by adding `Chapter4/Example4_8_1` and `Chapter4/Example4_9_1` to the workflow's existing memory-based `EXCLUDE` list. Since the A₅ tensor/character-table merges landed on 2026-07-03, every build on `main` (and on unrelated PRs, including the metadata-only https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/pull/5851) has died at 9017/9019 jobs with SIGTERM (exit 143) at ~53 minutes; log diffing shows these two modules are the only ones that never finish. A local rebuild of `Example4_8_1` alone exceeds 11.9 GB RSS (~100 `decide` calls under `maxHeartbeats 4000000`), which together with concurrent module builds exhausts the 16 GB + 8 GB swap runner. Both modules remain verified by local builds; re-inclusion after optimization is tracked in https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/issues/5852 ("CI: re-include Chapter4 Example4_8_1 / Example4_9_1 after optimizing their kernel computations").

🤖 Prepared with Claude Code