### PR TITLE
Fidelity gap: Chapter9/Definition9.5.1 — AreLinked defined on all modules is coarser than the book's linking; Block drops the JH-factor subcategory

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/Definition9_5_1.lean
+++ b/EtingofRepresentationTheory/Chapter9/Definition9_5_1.lean
@@ -4,14 +4,24 @@ import Mathlib.RingTheory.SimpleModule.Basic
 /-!
 # Definition 9.5.1: Linked simple modules and blocks
 
-Two simple modules X, Y are **linked** if there exists a chain of simple modules
-X = X₀, X₁, …, Xₙ = Y such that for each consecutive pair (Xᵢ, Xᵢ₊₁), either
-Ext¹(Xᵢ, Xᵢ₊₁) ≠ 0 or Ext¹(Xᵢ₊₁, Xᵢ) ≠ 0. This is an equivalence relation on
+Two **simple** finite dimensional modules `X, Y` are **linked** if there is a chain of
+*simple* modules `X = M₀, M₁, …, Mₙ = Y` such that for each consecutive pair `(Mᵢ, Mᵢ₊₁)`,
+either `Ext¹(Mᵢ, Mᵢ₊₁) ≠ 0` or `Ext¹(Mᵢ₊₁, Mᵢ) ≠ 0`. This is an equivalence relation on
+simple modules; its equivalence classes `S₁, …, Sₗ` partition the isomorphism classes of
 simple modules.
 
-The equivalence classes are S₁, …, Sₗ. The k-th **block** 𝒞ₖ of the category of
-finite dimensional A-modules consists of objects whose Jordan–Hölder composition
-factors all belong to Sₖ.
+The k-th **block** `𝒞ₖ` of the category of finite dimensional `A`-modules consists of the
+objects `M` all of whose Jordan–Hölder composition factors lie in `Sₖ`.
+
+## Fidelity note
+
+The chain in the book runs through **simple** modules only. This is essential: over a product
+`A = A₁ × A₂`, taking simples `X` (block 1), `Y` (block 2) and a non-simple `N = N₁ ⊕ N₂` with
+`Ext¹(X, N) ≠ 0` and `Ext¹(N, Y) ≠ 0` would link `X` and `Y` if the chain were allowed to pass
+through `N`, even though `X` and `Y` lie in different blocks. The base relation
+`Etingof.ExtOrIsoSimple` therefore carries `IsSimpleModule` side conditions on both endpoints,
+so every chain step connects two simple modules. Likewise the blocks are the Jordan–Hölder
+subcategories `Etingof.InBlock`, not a quotient of all modules.
 
 ## Mathlib correspondence
 
@@ -38,40 +48,77 @@ in either direction: `Ext¹(X, Y) ≠ 0` or `Ext¹(Y, X) ≠ 0`. -/
 def Etingof.ExtAdjacent (X Y : ModuleCat.{v} R) : Prop :=
   Etingof.DirectlyExtLinked R X Y ∨ Etingof.DirectlyExtLinked R Y X
 
-/-- The base relation for module linking: two modules are related if they are
-Ext¹-adjacent or categorically isomorphic. The isomorphism clause is needed because
-`EqvGen.refl` only provides propositional equality, but the mathematical linking
-relation (Etingof Definition 9.5.1) is defined on isomorphism classes of simple modules. -/
-def Etingof.ExtOrIso (X Y : ModuleCat.{v} R) : Prop :=
-  Etingof.ExtAdjacent R X Y ∨ Nonempty (X ≅ Y)
+/-- The base relation for the **linking of simple modules** (Etingof Definition 9.5.1): two
+modules are related if they are **both simple** and either Ext¹-adjacent or categorically
+isomorphic. The `IsSimpleModule` side conditions are essential — the book's chain runs through
+simple modules only — and the isomorphism clause supplies reflexivity up to isomorphism (the
+linking relation is defined on isomorphism classes of simple modules). -/
+def Etingof.ExtOrIsoSimple (X Y : ModuleCat.{v} R) : Prop :=
+  IsSimpleModule R X ∧ IsSimpleModule R Y ∧
+    (Etingof.ExtAdjacent R X Y ∨ Nonempty (X ≅ Y))
 
-/-- Two modules are **linked** (in the sense of Etingof Definition 9.5.1) if they are
-related by the equivalence closure of Ext¹-adjacency (up to isomorphism): there exists
-a chain `X = X₀, X₁, …, Xₙ = Y` such that each consecutive pair `(Xᵢ, Xᵢ₊₁)` satisfies
-`Ext¹(Xᵢ, Xᵢ₊₁) ≠ 0`, `Ext¹(Xᵢ₊₁, Xᵢ) ≠ 0`, or `Xᵢ ≅ Xᵢ₊₁`. -/
+/-- Two simple modules are **linked** (in the sense of Etingof Definition 9.5.1) if they are
+related by the equivalence closure of the simplicity-gated Ext¹-adjacency relation: there
+exists a chain `X = X₀, X₁, …, Xₙ = Y` of **simple** modules such that each consecutive pair
+`(Xᵢ, Xᵢ₊₁)` satisfies `Ext¹(Xᵢ, Xᵢ₊₁) ≠ 0`, `Ext¹(Xᵢ₊₁, Xᵢ) ≠ 0`, or `Xᵢ ≅ Xᵢ₊₁`. -/
 def Etingof.AreLinked (X Y : ModuleCat.{v} R) : Prop :=
-  Relation.EqvGen (Etingof.ExtOrIso R) X Y
+  Relation.EqvGen (Etingof.ExtOrIsoSimple R) X Y
 
-/-- Isomorphic modules are linked. -/
-theorem Etingof.areLinked_of_iso {X Y : ModuleCat.{v} R} (e : X ≅ Y) :
+/-- Isomorphic simple modules are linked. -/
+theorem Etingof.areLinked_of_iso {X Y : ModuleCat.{v} R}
+    (hX : IsSimpleModule R X) (hY : IsSimpleModule R Y) (e : X ≅ Y) :
     Etingof.AreLinked R X Y :=
-  Relation.EqvGen.rel _ _ (Or.inr ⟨e⟩)
+  Relation.EqvGen.rel _ _ ⟨hX, hY, Or.inr ⟨e⟩⟩
+
+/-- A single Ext¹-adjacency between simple modules is a linking of length one. -/
+theorem Etingof.areLinked_of_extAdjacent {X Y : ModuleCat.{v} R}
+    (hX : IsSimpleModule R X) (hY : IsSimpleModule R Y) (h : Etingof.ExtAdjacent R X Y) :
+    Etingof.AreLinked R X Y :=
+  Relation.EqvGen.rel _ _ ⟨hX, hY, Or.inl h⟩
 
 /-- The linking relation is an equivalence relation. -/
 theorem Etingof.areLinked_equivalence :
     @Equivalence (ModuleCat.{v} R) (Etingof.AreLinked R) :=
   Relation.EqvGen.is_equivalence _
 
-/-- The setoid on `ModuleCat R` induced by the linking relation.
-The equivalence classes of this setoid are the **blocks** of the algebra `R`,
-in the sense of Etingof Definition 9.5.1. -/
-def Etingof.blockSetoid : Setoid (ModuleCat.{v} R) :=
-  ⟨Etingof.AreLinked R, Etingof.areLinked_equivalence R⟩
-
-/-- The **blocks** of a ring `R`, in the sense of Etingof Definition 9.5.1.
-A block is an equivalence class of modules under the linking relation: two modules
-are in the same block iff they are connected by a chain of Ext¹-adjacencies. -/
-def Etingof.Block : Type _ :=
-  Quotient (Etingof.blockSetoid R)
-
 end
+
+section Blocks
+
+variable (R : Type u) [Ring R] [Small.{v} R]
+
+/-- A simple module `S` is a **Jordan–Hölder composition factor** of `M` if it occurs as a
+simple subquotient of `M`: there are submodules `N₁ ≤ N₂` of `M` with `N₂ / N₁ ≅ S`. For a
+finite-length module this recovers exactly the multiset of Jordan–Hölder factors. -/
+def Etingof.IsCompositionFactor (M S : ModuleCat.{v} R) : Prop :=
+  IsSimpleModule R S ∧ ∃ (N₁ N₂ : Submodule R M) (_ : N₁ ≤ N₂),
+    Nonempty ((↥N₂ ⧸ N₁.comap N₂.subtype) ≃ₗ[R] S)
+
+/-- Membership of `M` in the **block** of a simple module `S` (Etingof Definition 9.5.1): every
+Jordan–Hölder composition factor of `M` is linked to `S`. The k-th block `𝒞ₖ` is the full
+subcategory `{ M | Etingof.InBlock R S M }` for any `S ∈ Sₖ`; because linking is iso-invariant
+on simples, this is independent of the chosen representative `S`. -/
+def Etingof.InBlock (S M : ModuleCat.{v} R) : Prop :=
+  ∀ T : ModuleCat.{v} R, Etingof.IsCompositionFactor R M T → Etingof.AreLinked R T S
+
+/-- The type of simple objects of `ModuleCat R`. Its quotient by the linking relation is the
+indexing set `B` of blocks in Etingof Definition 9.5.1. -/
+def Etingof.SimpleObj : Type (max u (v + 1)) :=
+  { X : ModuleCat.{v} R // IsSimpleModule R X }
+
+/-- Linking as a setoid on the simple objects of `ModuleCat R`. The equivalence classes are the
+blocks `Sₖ` partitioning the isomorphism classes of simple modules. -/
+def Etingof.blockSetoid : Setoid (Etingof.SimpleObj.{v} R) where
+  r X Y := Etingof.AreLinked R X.1 Y.1
+  iseqv :=
+    ⟨fun X => (Etingof.areLinked_equivalence R).refl X.1,
+      fun h => (Etingof.areLinked_equivalence R).symm h,
+      fun h₁ h₂ => (Etingof.areLinked_equivalence R).trans h₁ h₂⟩
+
+/-- The set of **blocks** of `R`, in the sense of Etingof Definition 9.5.1: linking equivalence
+classes of simple modules (the index set `B`). Each block `Sₖ` determines the full subcategory
+`{ M | Etingof.InBlock R S M }` of objects whose Jordan–Hölder factors all lie in `Sₖ`. -/
+def Etingof.Block : Type _ :=
+  Quotient (Etingof.blockSetoid.{v} R)
+
+end Blocks

--- a/EtingofRepresentationTheory/Chapter9/Example9_5_2.lean
+++ b/EtingofRepresentationTheory/Chapter9/Example9_5_2.lean
@@ -20,25 +20,20 @@ is only one simple module — the residue field).
 
 ## Scope of this file
 
-Part (i) is captured at the level the project's `Etingof.AreLinked` definition supports.
-That definition (Definition 9.5.1) links *all* modules — not only the simple ones — by
-`Ext¹`-adjacency, so over a semisimple ring, where `Ext¹` vanishes identically, the linking
-relation collapses to isomorphism. We therefore prove the sharp statement
-`Etingof.semisimple_areLinked_iff_iso`: over a semisimple ring **every** block is a single
-isomorphism class, covering all modules in a block, not just the simple ones. The original
-`Etingof.semisimple_blocks_singleton` (linked simples are isomorphic, hence each block has a
-unique simple object) is an immediate corollary.
+Part (i) is captured through the project's `Etingof.AreLinked` relation, which — faithful to
+Definition 9.5.1 — links **simple** modules via chains of *simple* modules connected by
+`Ext¹`-adjacency. Over a semisimple ring `Ext¹` vanishes identically, so the linking relation
+on simples collapses to isomorphism. We prove `Etingof.semisimple_areLinked_iff_iso`: for
+simple `X, Y`, `AreLinked X Y ↔ X ≅ Y`, i.e. each block contains a single isomorphism class of
+simple objects. `Etingof.semisimple_blocks_singleton` is the forward direction.
 
 Note the relationship to the book's phrasing "each block is equivalent to the category of
 vector spaces". Etingof's block attached to a simple `S` is the full subcategory of modules
-whose Jordan–Hölder factors are all `≅ S`; over a semisimple ring that subcategory is the
-isotypic component `{S^{⊕n}}`, equivalent to vector spaces with `n` the dimension. The
-project's `AreLinked` relation partitions *more finely* — because `Ext¹ = 0` forbids any
-nonsplit extension, `S` and `S^{⊕2}` end up in different `AreLinked`-blocks. Both viewpoints
-agree on the load-bearing consequence formalized here, "one simple object per block"; the
-finer `AreLinked` statement records that no larger module is linked to a simple. Promoting
-the Etingof "≃ Vec" subcategory equivalence would require an isotypic-subcategory definition
-not present in Definition 9.5.1.
+whose Jordan–Hölder factors are all in `S`'s linking class (the predicate `Etingof.InBlock`);
+over a semisimple ring that subcategory is the isotypic component `{S^{⊕n}}`, equivalent to
+vector spaces. The statement formalized here is the load-bearing consequence "one simple object
+per block". Promoting the Etingof "≃ Vec" subcategory equivalence would require an
+isotypic-subcategory equivalence beyond the scope of Definition 9.5.1.
 
 Part (iii) — "the algebra of Problem 9.3.2 has one block" — is now formalized. The
 generators-and-relations algebra `A = ℂ⟨g, x⟩ / (gx + xg, x², g² - 1)` is constructed in
@@ -68,20 +63,22 @@ theorem Etingof.semisimple_not_extAdjacent
     haveI := Abelian.Ext.subsingleton_of_projective B A 0
     exact not_nontrivial _ h
 
-/-- For a semisimple ring, the linking relation collapses to isomorphism for **all** modules
-(not just simple ones): two modules are linked iff they are isomorphic. Equivalently, each
-block is a single isomorphism class. This is the "covering all modules in a block" content of
-Etingof Example 9.5.2 (i) ("each block is equivalent to the category of vector spaces"): since
-`Ext¹` vanishes over a semisimple ring, there are no nonsplit extensions to enlarge a block
-beyond one isomorphism class. -/
+/-- For a semisimple ring, the linking relation on **simple** modules collapses to isomorphism:
+two simple modules are linked iff they are isomorphic. Equivalently, each block contains a
+single isomorphism class of simples. This is Etingof Example 9.5.2 (i) ("each block is
+equivalent to the category of vector spaces, and thus has only one simple object"): since
+`Ext¹` vanishes over a semisimple ring, the only chains between simples are isomorphisms. -/
 theorem Etingof.semisimple_areLinked_iff_iso
     (R : Type u) [Ring R] [Small.{v} R] [IsSemisimpleRing R]
-    (X Y : ModuleCat.{v} R) :
+    (X Y : ModuleCat.{v} R) (hX : IsSimpleModule R X) (hY : IsSimpleModule R Y) :
     Etingof.AreLinked R X Y ↔ Nonempty (X ≅ Y) := by
-  refine ⟨fun hlinked => ?_, fun e => Etingof.areLinked_of_iso R e.some⟩
+  refine ⟨fun hlinked => ?_, fun e => Etingof.areLinked_of_iso R hX hY e.some⟩
   -- With `ExtAdjacent` empty, the only base relation is isomorphism; induct on `EqvGen`.
+  -- The simplicity hypotheses are not needed here, and would be reverted by the induction.
+  clear hX hY
   induction hlinked with
   | rel _ _ h =>
+    obtain ⟨_, _, h⟩ := h
     rcases h with h | h
     · exact absurd h (Etingof.semisimple_not_extAdjacent R _ _)
     · exact h
@@ -94,16 +91,15 @@ theorem Etingof.semisimple_areLinked_iff_iso
     obtain ⟨e₂⟩ := ih₂
     exact ⟨e₁ ≪≫ e₂⟩
 
-/-- For a semisimple ring, any two non-isomorphic simple modules have
-`Ext¹ = 0` in both directions, so each simple module forms its own block.
-(Etingof Example 9.5.2 (i)) -/
+/-- For a semisimple ring, any two linked simple modules are isomorphic, so each simple module
+forms its own block. (Etingof Example 9.5.2 (i)) -/
 theorem Etingof.semisimple_blocks_singleton
     (R : Type u) [Ring R] [Small.{v} R] [IsSemisimpleRing R]
     (X Y : ModuleCat.{v} R)
-    (_hX : IsSimpleModule R X) (_hY : IsSimpleModule R Y)
+    (hX : IsSimpleModule R X) (hY : IsSimpleModule R Y)
     (hlinked : Etingof.AreLinked R X Y) :
     Nonempty (X ≅ Y) :=
-  (Etingof.semisimple_areLinked_iff_iso R X Y).mp hlinked
+  (Etingof.semisimple_areLinked_iff_iso R X Y hX hY).mp hlinked
 
 /-- For a commutative local artinian ring, there is only one simple module (up to
 isomorphism), so all modules belong to a single block.
@@ -122,7 +118,7 @@ theorem Etingof.local_artinian_single_block
   subst hIm; subst hJm
   -- Now eX : X ≃ₗ[R] R ⧸ m and eY : Y ≃ₗ[R] R ⧸ m, so X ≅ Y
   have e : X ≃ₗ[R] Y := eX.trans eY.symm
-  exact Etingof.areLinked_of_iso R
+  exact Etingof.areLinked_of_iso R hX hY
     { hom := ModuleCat.ofHom e.toLinearMap
       inv := ModuleCat.ofHom e.symm.toLinearMap
       hom_inv_id := by ext x; exact e.symm_apply_apply x

--- a/EtingofRepresentationTheory/Chapter9/Problem9_3_2.lean
+++ b/EtingofRepresentationTheory/Chapter9/Problem9_3_2.lean
@@ -428,6 +428,8 @@ theorem directlyExtLinked :
 This is Etingof Example 9.5.2 (iii). -/
 theorem areLinked :
     Etingof.AreLinked A (ModuleCat.of A Splus) (ModuleCat.of A Sminus) :=
-  Relation.EqvGen.rel _ _ (Or.inl (Or.inl directlyExtLinked))
+  Relation.EqvGen.rel _ _
+    ⟨(inferInstance : IsSimpleModule A Splus), (inferInstance : IsSimpleModule A Sminus),
+      Or.inl (Or.inl directlyExtLinked)⟩
 
 end Etingof.Problem932

--- a/progress/2026-07-06T04-13-54Z_d1058b42.md
+++ b/progress/2026-07-06T04-13-54Z_d1058b42.md
@@ -1,0 +1,26 @@
+## Accomplished
+
+Fixed the Chapter 9 Definition 9.5.1 fidelity gap (issue #5850, one-shot dispatch).
+
+- **Linking gated on simple modules.** Replaced the base relation `Etingof.ExtOrIso` (Ext¹-adjacency-or-iso on *all* of `ModuleCat R`) with `Etingof.ExtOrIsoSimple`, which carries `IsSimpleModule R X ∧ IsSimpleModule R Y` side conditions on both endpoints. `Etingof.AreLinked` is now the equivalence closure of that gated relation, so every chain step connects two simple modules — matching the book's "chain of simple modules". The coarser all-modules chain that could link simples across a product `A₁ × A₂` (via a non-simple `N = N₁ ⊕ N₂`) no longer exists.
+- **Block subcategory via JH factors.** Added `Etingof.IsCompositionFactor R M S` (S is a simple subquotient of M) and `Etingof.InBlock R S M` (every JH composition factor of M is linked to S) — the book's block subcategory 𝒞ₖ. Redefined `Etingof.blockSetoid`/`Etingof.Block` on the subtype `Etingof.SimpleObj` of simple objects, so `Block` is now the linking-class quotient of the *simples* (the index set B), not a quotient of all modules.
+- **Consumers updated.** `Etingof.areLinked_of_iso` now takes simplicity hypotheses; `Problem9_3_2.areLinked` supplies the two `IsSimpleModule A` instances; `Example9_5_2.{semisimple_areLinked_iff_iso, semisimple_blocks_singleton, local_artinian_single_block}` were re-stated over simple modules (the (i) content survives, now faithful; the former "all modules" iff was a non-book strengthening under the coarse relation). Scope docstrings rewritten.
+- items.json fidelity flipped `gap` → `faithful` with an updated note.
+
+All three files build; axiom-clean (`propext, Classical.choice, Quot.sound`), no `sorry`/`admit`/`native_decide`.
+
+## Current frontier
+
+Fix complete and building. PR pending.
+
+## Overall project progress
+
+Stage 3.7 fidelity sweep. This closes one wave-9 gap (#5850). The JH-factor block subcategory is now defined; a possible future enhancement is proving sanity lemmas about it (e.g. a simple module lies in its own block), but that is not required by the issue.
+
+## Next step
+
+Merge the PR. No follow-up work required for this item.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -7355,10 +7355,10 @@
     "start_line": 19,
     "end_line": 4,
     "status": "sorry_free",
-    "fidelity": "gap",
+    "fidelity": "faithful",
     "needs_statement": true,
     "sorry_free": true,
-    "fidelity_note": "[fidelity wave 9] Book defines linking on SIMPLE modules via chains of simples with Ext¹ ≠ 0, and the k-th block as the subcategory of objects whose JH factors lie in one class S_k. Lean AreLinked is EqvGen on ALL of ModuleCat (chains through arbitrary modules), strictly coarser on simples (concrete: over A = k[ε]/ε² × k[ε]/ε² with X, Y the simples of the two factors, N = X ⊕ Y gives Ext¹(X,N) ≠ 0 and Ext¹(N,Y) ≠ 0 since Ext¹(k,k) ≠ 0 over k[ε]/ε², so AreLinked X Y — yet X, Y lie in different book blocks, as Ext between simples of different factors vanishes); Etingof.Block quotients all modules and drops the JH-factor condition entirely. Silent divergence, not an adjudicated scope note.",
+    "fidelity_note": "[fidelity wave 9 → fixed #5850] Linking now gated on simple modules: the base relation Etingof.ExtOrIsoSimple carries IsSimpleModule side conditions on both endpoints, so every chain step connects two simples (the coarser all-modules chain that linked X, Y across a product A₁ × A₂ via N = N₁ ⊕ N₂ no longer exists). Blocks are the JH-factor subcategories: Etingof.IsCompositionFactor (simple subquotient), Etingof.InBlock S M (all JH factors of M linked to S), and Etingof.Block = quotient of the simple objects by linking (the index set B).",
     "fidelity_issue": 5850
   },
   {


### PR DESCRIPTION
Closes #5850

Session: `d1058b42-4333-4007-b701-2e44ab235d6b`

784d3ff6 fix(Ch9 #5850): gate Definition 9.5.1 linking on simple modules + JH-factor blocks

🤖 Prepared with Claude Code