### PR TITLE
fix: declare cohomology + exactness for Definition 7.8.1

### DIFF
--- a/EtingofRepresentationTheory/Chapter7/Definition7_8_1.lean
+++ b/EtingofRepresentationTheory/Chapter7/Definition7_8_1.lean
@@ -1,5 +1,7 @@
 import Mathlib.Algebra.Homology.HomologicalComplex
 import Mathlib.Algebra.Homology.ShortComplex.Exact
+import Mathlib.Algebra.Homology.ShortComplex.HomologicalComplex
+import Mathlib.Algebra.Homology.ShortComplex.Abelian
 
 /-!
 # Definition 7.8.1: Complex, Differentials, Cohomology, Exact Sequence
@@ -14,9 +16,11 @@ i-th term if H^i = 0, and is an **exact sequence** if exact in all terms.
 ## Mathlib correspondence
 
 Exact match:
-- `HomologicalComplex` for complexes
+- `CochainComplex` for complexes
+- `HomologicalComplex.d` for differentials
 - `HomologicalComplex.homology` for cohomology
-- `CategoryTheory.Exact` for exactness
+- `HomologicalComplex.ExactAt` for exactness in one term
+- `HomologicalComplex.Acyclic` for exactness in all terms (an exact sequence)
 -/
 
 open CategoryTheory
@@ -25,3 +29,25 @@ open CategoryTheory
 This is `CochainComplex` (= `HomologicalComplex` with `ComplexShape.up ℤ`) in Mathlib. -/
 abbrev Etingof.CochainComplex' (C : Type*) [Category C]
     [Limits.HasZeroMorphisms C] := _root_.CochainComplex C ℤ
+
+/-- The differential `d_i : C_i → C_{i+1}` of a cochain complex, in the sense of
+Etingof Definition 7.8.1. This is `HomologicalComplex.d` in Mathlib. -/
+abbrev Etingof.differential {C : Type*} [Category C] [Limits.HasZeroMorphisms C]
+    (K : Etingof.CochainComplex' C) (i : ℤ) : K.X i ⟶ K.X (i + 1) := K.d i (i + 1)
+
+/-- The cohomology `H^i = Ker(d_i)/Im(d_{i-1})` of a cochain complex, in the sense of
+Etingof Definition 7.8.1. This is `HomologicalComplex.homology` in Mathlib. -/
+noncomputable abbrev Etingof.cohomology {C : Type*} [Category C] [Abelian C]
+    (K : Etingof.CochainComplex' C) (i : ℤ) := K.homology i
+
+/-- A cochain complex is **exact in the i-th term** if its cohomology `H^i` vanishes,
+in the sense of Etingof Definition 7.8.1. This is `HomologicalComplex.ExactAt` in
+Mathlib; `HomologicalComplex.exactAt_iff_isZero_homology` shows it is equivalent to
+`H^i = 0`. -/
+abbrev Etingof.ExactAt {C : Type*} [Category C] [Limits.HasZeroMorphisms C]
+    (K : Etingof.CochainComplex' C) (i : ℤ) : Prop := K.ExactAt i
+
+/-- A cochain complex is **an exact sequence** if it is exact in every term, in the
+sense of Etingof Definition 7.8.1. This is `HomologicalComplex.Acyclic` in Mathlib. -/
+abbrev Etingof.IsExactSequence {C : Type*} [Category C] [Limits.HasZeroMorphisms C]
+    (K : Etingof.CochainComplex' C) : Prop := K.Acyclic

--- a/progress/2026-07-06T04-30-48Z_b0ec16a8.md
+++ b/progress/2026-07-06T04-30-48Z_b0ec16a8.md
@@ -1,0 +1,40 @@
+## Accomplished
+
+Closed fidelity gap #5839 for `Chapter7/Definition7.8.1`. Definition 7.8.1
+names four notions (complex, differentials, cohomology, exactness/exact
+sequence), but the Lean file only declared the complex object
+(`Etingof.CochainComplex'`). Cohomology and exactness were mentioned only in
+the docstring's Mathlib-correspondence section with no machine-checked
+declaration.
+
+Added four `abbrev`s so every named notion now has a declaration:
+- `Etingof.differential` — the differential `d_i : C_i → C_{i+1}`
+  (`HomologicalComplex.d`)
+- `Etingof.cohomology` — `H^i = Ker(d_i)/Im(d_{i-1})`
+  (`HomologicalComplex.homology`, `noncomputable`)
+- `Etingof.ExactAt` — exact in the i-th term (`HomologicalComplex.ExactAt`;
+  equivalent to `H^i = 0` via `exactAt_iff_isZero_homology`)
+- `Etingof.IsExactSequence` — exact in all terms, i.e. an exact sequence
+  (`HomologicalComplex.Acyclic`)
+
+Cohomology uses `[Abelian C]` so `CategoryWithHomology`/`HasHomology` resolve
+automatically; the other abbrevs need only `[HasZeroMorphisms C]`. Updated the
+docstring's Mathlib-correspondence list to match. `lake build` of the module
+passes (1143 jobs).
+
+## Current frontier
+
+Fidelity sweep wave 7 (Chapter 7, epic #5338). This item is complete.
+
+## Overall project progress
+
+Stage 3 formalization with ongoing fidelity review sweeps. One review item
+resolved this turn.
+
+## Next step
+
+Continue the Chapter 7 fidelity sweep (issue #5344 / epic #5338).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5839

Session: `b0ec16a8-9461-48bf-a41b-9f3bc23f0023`

a509aff6 fix(Ch7 #5839): declare cohomology + exactness for Definition 7.8.1

🤖 Prepared with Claude Code