### PR TITLE
Fidelity gap: Chapter7/Definition7.8.2 (aliases ShortComplex, drops ShortExact)

### DIFF
--- a/EtingofRepresentationTheory/Chapter7/Definition7_8_2.lean
+++ b/EtingofRepresentationTheory/Chapter7/Definition7_8_2.lean
@@ -12,11 +12,18 @@ Y/X → Z is an isomorphism. Short exact sequences correspond to extensions of Z
 
 ## Mathlib correspondence
 
-Exact match: `CategoryTheory.ShortComplex` and `CategoryTheory.ShortComplex.ShortExact`.
+Exact match: `CategoryTheory.ShortComplex` bundled with the defining predicate
+`CategoryTheory.ShortComplex.ShortExact`. The latter records that `S.f` is a
+mono (injectivity of `X → Y`), `S.g` is an epi (surjectivity of `Y → Z`), and
+`S` is exact at `Y` (equivalently the induced `Y/X → Z` is an isomorphism).
 -/
 
-/-- A short complex in an abelian category, in the sense of Etingof Definition 7.8.2.
-A short exact sequence is a `ShortComplex` satisfying `ShortExact`.
-This is `CategoryTheory.ShortComplex` in Mathlib. -/
-abbrev Etingof.ShortComplex (C : Type*) [CategoryTheory.Category C]
-    [CategoryTheory.Limits.HasZeroMorphisms C] := CategoryTheory.ShortComplex C
+/-- A short exact sequence `0 → X → Y → Z → 0` in an abelian category, in the
+sense of Etingof Definition 7.8.2. It is a `CategoryTheory.ShortComplex`
+together with a proof that it is `ShortComplex.ShortExact`: `X → Y` injective,
+`Y → Z` surjective, and exact at `Y`. Bundling the `ShortExact` predicate is
+what distinguishes a short *exact* sequence from a bare short complex (which the
+zero complex would also satisfy). -/
+def Etingof.ShortExactSequence (C : Type*) [CategoryTheory.Category C]
+    [CategoryTheory.Limits.HasZeroMorphisms C] :=
+  {S : CategoryTheory.ShortComplex C // S.ShortExact}

--- a/progress/2026-07-06T00-00-00Z_eea5e136.md
+++ b/progress/2026-07-06T00-00-00Z_eea5e136.md
@@ -1,0 +1,39 @@
+## Accomplished
+
+Fixed the fidelity gap in `Chapter7/Definition7.8.2` (issue #5840). The Lean
+declaration aliased `Etingof.ShortComplex C := CategoryTheory.ShortComplex C`, a
+bare short *complex* that the zero complex satisfies and that carries no
+exactness — silently dropping the defining `ShortExact` predicate (mono/epi/
+exact-at-Y). Replaced it with
+
+```
+def Etingof.ShortExactSequence (C : Type*) [Category C] [HasZeroMorphisms C] :=
+  {S : CategoryTheory.ShortComplex C // S.ShortExact}
+```
+
+which bundles the `CategoryTheory.ShortComplex.ShortExact` predicate (`X → Y`
+mono, `Y → Z` epi, exact at `Y`), matching Definition 7.8.2. Updated the
+docstring to explain why bundling the predicate is what distinguishes a short
+exact sequence from a bare short complex.
+
+`ShortComplex.ShortExact` only requires `[HasZeroMorphisms C]`, so the existing
+type binders were sufficient. No downstream file referenced the old
+`Etingof.ShortComplex` name (grep-confirmed), so the rename breaks nothing.
+
+## Current frontier
+
+Definition 7.8.2 now faithfully captures short exact sequences. `lake build
+EtingofRepresentationTheory.Chapter7.Definition7_8_2` succeeds.
+
+## Overall project progress
+
+Chapter 7 fidelity sweep (wave 7, epic #5338) — one more finding resolved.
+
+## Next step
+
+None for this item. Continue the Chapter 7 fidelity sweep with remaining wave-7
+findings.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5840

Session: `eea5e136-ec5e-490d-b1f9-e0173c07e8ca`

1bf541d0 fix(Ch7 #5840): bundle ShortExact predicate in Definition 7.8.2

🤖 Prepared with Claude Code