### PR TITLE
review(Ch5 #5094): soundness audit of A/det grading reduction (#4961) + clean SES additivity (#5078) — PASS

### DIFF
--- a/progress/2026-07-06T06-14-37Z_9090e96c.md
+++ b/progress/2026-07-06T06-14-37Z_9090e96c.md
@@ -1,0 +1,88 @@
+# Review (Ch5 #5094): soundness audit — A/det single-degree grading reduction (#4961) + clean SES character-additivity engine (#5078)
+
+**Session type:** review (one-shot dispatch via `pod once 5094`)
+**UTC:** 2026-07-06T06:14:37Z
+**Verdict: PASS.** No defects found; no code changes; no follow-up issue filed.
+
+## Scope
+
+Audited the two merged, sorry-free foundations that the in-flight #5082 extractor
+and the #5076 part-(a) C assembly consume, and which prior review #5068 (PASS, #5088)
+did **not** cover:
+
+- `EtingofRepresentationTheory/Chapter5/CauchyDetQuotientGrading.lean` — the
+  right-`GL_N` grading of `A/det` and the single-degree reduction (#4961).
+- `EtingofRepresentationTheory/Chapter5/CleanFormalCharacterAdditivity.lean` — the
+  DetInvElim-clean SES character-additivity engine (#5078 B0/B1 foundation).
+
+## Deliverable-by-deliverable findings
+
+### 1. No vacuous / mis-stated hypotheses — PASS
+`formalCharacter_add_of_shortExact` (`CleanFormalCharacterAdditivity.lean:96`)
+genuinely encodes a short exact sequence: `hexact : LinearMap.range ι = LinearMap.ker π`
+together with `hι_inj : Function.Injective ι` and `hπ_surj : Function.Surjective π`.
+The weight-spanning hypotheses `hUtop`/`hVtop` are the real
+`⨆ μ : Fin N →₀ ℕ, glWeightSpace k N _ (fun i => μ i) = ⊤`, where `glWeightSpace`
+(`Theorem5_22_1.lean:349`) is the honest `⨅ i t, ker (M.ρ (diagUnit i t) − t^μᵢ • id)`
+torus-eigenspace intersection — not always `⊤`, so not trivially satisfiable.
+`hWtop` (spanning for the quotient `W`) is *derived*, not assumed, from `hVtop` +
+surjectivity. The proof is a genuine per-weight rank–nullity split
+(`dim V_μ = dim (π V_μ) + dim U_μ`) upgraded to equality via the global count.
+
+### 2. Equivariance w.r.t. the correct representations — PASS
+`quotDetProj_equivariant` (`CauchyDetQuotientGrading.lean:134`) is stated against the
+actual `quotDetRep k N` (`KernelLemmaKPrime.lean:88`, `polyRightRep` descended through
+`mapQ`). `homogeneousComponent_polyRightRep` (:60) establishes the degree projection
+commutes with the right `GL_N` action. The output equivariance of
+`exists_degree_embedding_of_simple` is `ψ (L.ρ g v) = (quotDetDegreeFDRep k N d).ρ g (ψ v)`
+against the real `ρ` of `quotDetDegreeFDRep k N d = FDRep.of (quotDetDegreeSubrep k N d).toRepresentation`
+(`CauchyDetQuotientDegree.lean:302`), i.e. the restriction of `quotDetRep`; the proof
+discharges it via `Subtype.val_injective` reducing to `quotDetProj_equivariant`.
+
+### 3. Genuine internal direct sum — PASS
+`quotDetDegreeSubrep_iSup_eq_top` (:161, span) and `quotDetDegreeSubrep_iSupIndep`
+(:177, independence) give `A/det = ⊕_d (A/det)_d`. The per-degree projection laws are
+index-correct with no off-by-one: `quotDetProj_id_on_degree` (:142) uses
+`homogeneousComponent_of_mem` at `if d = d` (`if_pos rfl`), `quotDetProj_zero_on_degree`
+(:150) at `if d = e` with `if_neg (d ≠ e)`. Independence applies `proj_d` to a relation,
+using `id_on_degree` (proj = x) on the `d` term and `zero_on_degree d e (Ne.symm hed)`
+(proj = 0) on every `e ≠ d` term, forcing `x = 0`. Consistent; the reduction cannot pick
+a spurious degree.
+
+### 4. `exists_degree_embedding_of_simple` injectivity is real — PASS
+Each `ψ d = codRestrict (quotDetProj d ∘ φ)` is turned into a genuine
+`MonoidAlgebra`-module hom `Ψ` via `Representation.asModuleHomOfIntertwiner`
+(`RepresentationAsModuleHom.lean`, `toFun = ψ d`). Schur is applied as
+`eq_bot_or_eq_top (LinearMap.ker Ψ)` on the simple domain `Representation.asModule L.ρ`
+(`hLsimp`): each `ψ d` is injective (`ker = ⊥`) or zero (`ker = ⊤`). Non-degeneracy:
+picking `v ≠ 0` (from `IsSimpleModule.nontrivial`), `φ v = ∑_d quotDetProj d (φ v)` is a
+finite homogeneous decomposition; if every `ψ d = 0` then every term is 0, so `φ v = 0`,
+contradicting `hφ_inj`. Hence some `ψ d` is injective. Not a degenerate argument.
+
+### 5. No hidden axioms / `sorry` — PASS
+```
+#print axioms exists_degree_embedding_of_simple
+  → [propext, Classical.choice, Quot.sound]
+#print axioms formalCharacter_add_of_shortExact
+  → [propext, Classical.choice, Quot.sound]
+```
+No `sorryAx`, no custom axioms.
+
+## Verification run
+`lake build EtingofRepresentationTheory.Chapter5.CauchyDetQuotientGrading
+EtingofRepresentationTheory.Chapter5.CleanFormalCharacterAdditivity` — green
+(8626 jobs, only pre-existing style-linter warnings: `push_neg` deprecation at
+`CauchyDetQuotientGrading.lean:254`, `maxHeartbeats` comment at
+`CauchyDetQuotientDegree.lean:503`; neither affects soundness). Fresh
+`lake exe cache get`.
+
+## Impact on downstream #5082 / #5076
+Both audited foundations are sound. The in-flight composition-series extractor (#5082)
+and the part-(a) C assembly (#5076) may build on them without risk from these files.
+No blocker uncovered; no follow-up feature issue needed.
+
+## Next step
+None from this audit. Downstream #5082 / #5076 unblocked with respect to these inputs.
+
+## Blockers
+None.


### PR DESCRIPTION
This PR records the soundness audit of issue #5094: the single-degree A/det grading reduction (#4961) in `EtingofRepresentationTheory/Chapter5/CauchyDetQuotientGrading.lean` and the DetInvElim-clean SES character-additivity engine (#5078) in `EtingofRepresentationTheory/Chapter5/CleanFormalCharacterAdditivity.lean`. It changes no Lean source; it adds only the verdict progress note. Prior review #5068 (PASS, #5088) covered the character foundation only and did not overlap.

**Verdict: PASS** on all five deliverables.

- **Hypotheses not vacuous.** `formalCharacter_add_of_shortExact` genuinely encodes the short exact sequence (`hexact: range ι = ker π`, `hι_inj`, `hπ_surj`); the weight-spanning hypotheses are the honest `⨆ μ, glWeightSpace = ⊤` torus-eigenspace-intersection condition, and quotient spanning is derived from `hVtop`+surjectivity rather than assumed. Proof is a real per-weight rank–nullity split upgraded to equality by the global count.
- **Equivariance vs the correct reps.** `quotDetProj_equivariant` against actual `quotDetRep`; `homogeneousComponent_polyRightRep` supplies the projection/`GL_N`-action commutation; `exists_degree_embedding_of_simple`'s output equivariance is against the real `(quotDetDegreeFDRep k N d).ρ` (the restriction of `quotDetRep`).
- **Genuine internal direct sum.** `_iSup_eq_top` (span) + `_iSupIndep` (independence). Projection laws are index-correct (`_id_on_degree` at `if d=d`, `_zero_on_degree` at `if d=e` with `d≠e`) — no off-by-one that would let the reduction pick a spurious degree.
- **Injectivity is real.** `ψ d` lifted to a `MonoidAlgebra`-module hom via `asModuleHomOfIntertwiner`; Schur (`eq_bot_or_eq_top (ker Ψ)`) on the simple domain gives zero-or-injective, with non-degeneracy from the finite homogeneous decomposition `φ v = ∑_d quotDetProj d (φ v)` and `hφ_inj`.
- **Axiom hygiene.** `#print axioms` on both `exists_degree_embedding_of_simple` and `formalCharacter_add_of_shortExact` → `[propext, Classical.choice, Quot.sound]` only; no `sorryAx`, no custom axioms. `lake build …CauchyDetQuotientGrading …CleanFormalCharacterAdditivity` green on a fresh `lake exe cache get` (8626 jobs; only pre-existing style-linter warnings).

No defects found; no follow-up issue filed. Downstream #5082 / #5076 are unblocked with respect to these inputs. Full audit detail in the progress note and in the audit comment on #5094.

Closes #5094.

🤖 Prepared with Claude Code