### PR TITLE
feat(Ch2 #5892): statement pass for 8 Chapter 2 exercises

### DIFF
--- a/EtingofRepresentationTheory/Chapter2.lean
+++ b/EtingofRepresentationTheory/Chapter2.lean
@@ -45,6 +45,13 @@ import EtingofRepresentationTheory.Chapter2.Corollary2_3_12
 import EtingofRepresentationTheory.Chapter2.Example2_3_14
 import EtingofRepresentationTheory.Chapter2.Example2_3_14_continued
 
+-- Section 2.4: Ideals
+import EtingofRepresentationTheory.Chapter2.Problem2_4_1
+
+-- Section 2.5: Cyclic representations
+import EtingofRepresentationTheory.Chapter2.Problem2_5_1
+import EtingofRepresentationTheory.Chapter2.Problem2_5_2
+
 -- Section 2.7: Characters and the Weyl Algebra
 import EtingofRepresentationTheory.Chapter2.Definition2_7_3
 import EtingofRepresentationTheory.Chapter2.Proposition2_7_1
@@ -74,15 +81,20 @@ import EtingofRepresentationTheory.Chapter2.Remark2_9_4
 import EtingofRepresentationTheory.Chapter2.Example2_9_8
 import EtingofRepresentationTheory.Chapter2.Example2_9_12
 import EtingofRepresentationTheory.Chapter2.Example2_9_13
+import EtingofRepresentationTheory.Chapter2.Exercise2_9_11
 
 -- Section 2.11-2.12: Tensor Products, Symmetric/Exterior Algebras
 import EtingofRepresentationTheory.Chapter2.Definition2_11_1
 import EtingofRepresentationTheory.Chapter2.Remark2_11_4
+import EtingofRepresentationTheory.Chapter2.Problem2_11_3
 import EtingofRepresentationTheory.Chapter2.Problem2_11_6
 import EtingofRepresentationTheory.Chapter2.Definition2_12_1
 
 -- Section 2.14: Tensor/Dual Representations of Lie Algebras
 import EtingofRepresentationTheory.Chapter2.Definition2_14_1
 import EtingofRepresentationTheory.Chapter2.Definition2_14_2
+
+-- Section 2.16: Lie's theorem and related classification problems
+import EtingofRepresentationTheory.Chapter2.Problem2_16_1
 
 /-! # Chapter 2: General Results of Representation Theory -/

--- a/EtingofRepresentationTheory/Chapter2.lean
+++ b/EtingofRepresentationTheory/Chapter2.lean
@@ -90,9 +90,13 @@ import EtingofRepresentationTheory.Chapter2.Problem2_11_3
 import EtingofRepresentationTheory.Chapter2.Problem2_11_6
 import EtingofRepresentationTheory.Chapter2.Definition2_12_1
 
+-- Section 2.13: The Dehn invariant
+import EtingofRepresentationTheory.Chapter2.Problem2_13_1
+
 -- Section 2.14: Tensor/Dual Representations of Lie Algebras
 import EtingofRepresentationTheory.Chapter2.Definition2_14_1
 import EtingofRepresentationTheory.Chapter2.Definition2_14_2
+import EtingofRepresentationTheory.Chapter2.Problem2_14_3
 
 -- Section 2.16: Lie's theorem and related classification problems
 import EtingofRepresentationTheory.Chapter2.Problem2_16_1

--- a/EtingofRepresentationTheory/Chapter2/Exercise2_9_11.lean
+++ b/EtingofRepresentationTheory/Chapter2/Exercise2_9_11.lean
@@ -1,0 +1,37 @@
+import Mathlib
+
+/-!
+# Exercise 2.9.11: Lie algebra representations vs. enveloping algebra representations
+
+The exercise asks to explain why a representation of a Lie algebra `𝔤` is the same thing as a
+representation of its universal enveloping algebra `U(𝔤)`.
+
+## Formalization
+
+A representation of `𝔤` on `V` is a Lie algebra homomorphism `𝔤 →ₗ⁅k⁆ End_k(V)` (Definition
+2.9.7), where the associative algebra `End_k(V)` is viewed as a Lie algebra via its commutator. A
+representation of `U(𝔤)` on `V` is an associative algebra homomorphism `U(𝔤) →ₐ[k] End_k(V)`.
+
+The universal property of the universal enveloping algebra (Mathlib's
+`UniversalEnvelopingAlgebra.lift`) gives a natural bijection between these two sets, which is
+exactly the content of the exercise. Being an equivalence backed by Mathlib, this is recorded as a
+genuine definition rather than a `sorry`.
+-/
+
+namespace Etingof.Exercise2_9_11
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+variable (k : Type*) [Field k]
+variable (L : Type*) [LieRing L] [LieAlgebra k L]
+variable (V : Type*) [AddCommGroup V] [Module k V]
+
+/-- **Exercise 2.9.11.** A representation of the Lie algebra `L` on `V` (a Lie homomorphism
+`L →ₗ⁅k⁆ End_k(V)`) is the same thing as a representation of its universal enveloping algebra
+(an algebra homomorphism `U(L) →ₐ[k] End_k(V)`). The bijection is the universal property of
+`U(L)`. -/
+noncomputable def repEquiv :
+    (L →ₗ⁅k⁆ Module.End k V) ≃ (UniversalEnvelopingAlgebra k L →ₐ[k] Module.End k V) :=
+  UniversalEnvelopingAlgebra.lift k
+
+end Etingof.Exercise2_9_11

--- a/EtingofRepresentationTheory/Chapter2/Problem2_11_3.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_11_3.lean
@@ -1,0 +1,59 @@
+import Mathlib
+
+/-!
+# Problem 2.11.3: The universal property of the tensor product and its consequences
+
+The problem collects several standard facts about tensor products of vector spaces:
+
+* **(a)** a natural bijection between bilinear maps `V × W → U` and linear maps `V ⊗ W → U`;
+* **(b)** if `{vᵢ}` is a basis of `V` and `{wⱼ}` a basis of `W`, then `{vᵢ ⊗ wⱼ}` is a basis of
+  `V ⊗ W`;
+* **(c)** a natural isomorphism `V* ⊗ W → Hom(V, W)` when `V` is finite dimensional;
+* **(d)–(e)** symmetric and exterior powers and their bases / identifications;
+* **(f)–(g)** symmetric/exterior powers of an operator, their traces, and `∧ᴺ A = det(A)·Id`,
+  giving a one-line proof of `det(AB) = det(A) det(B)`.
+
+## Formalization
+
+This file records the cleanly-statable parts (a), (b), (c) and (g). Parts (d)–(f) concern
+symmetric/exterior powers and traces and are deferred to a dedicated follow-up item.
+
+Bilinear maps `V × W → U` are modelled by `V →ₗ[k] W →ₗ[k] U`. All statements are recorded with
+`sorry` proofs (**statement pass**).
+-/
+
+namespace Etingof.Problem2_11_3
+
+variable {k : Type*} [Field k]
+variable {V W U : Type*}
+  [AddCommGroup V] [Module k V] [AddCommGroup W] [Module k W] [AddCommGroup U] [Module k U]
+
+/-- **Problem 2.11.3(a).** There is a natural bijection between bilinear maps `V × W → U`
+(here `V →ₗ[k] W →ₗ[k] U`) and linear maps `V ⊗ W → U`, characterised by sending a bilinear map
+`f` to the linear map with `v ⊗ w ↦ f v w`. -/
+theorem exists_bilinear_equiv_linear :
+    ∃ e : (V →ₗ[k] W →ₗ[k] U) ≃ (TensorProduct k V W →ₗ[k] U),
+      ∀ (f : V →ₗ[k] W →ₗ[k] U) (v : V) (w : W),
+        e f (TensorProduct.tmul k v w) = f v w := by
+  sorry
+
+/-- **Problem 2.11.3(b).** If `{vᵢ}` is a basis of `V` and `{wⱼ}` a basis of `W`, then
+`{vᵢ ⊗ wⱼ}` is a basis of `V ⊗ W`. -/
+theorem exists_basis_tensorProduct {ι κ : Type*} (b : Module.Basis ι k V)
+    (c : Module.Basis κ k W) :
+    Nonempty (Module.Basis (ι × κ) k (TensorProduct k V W)) := by
+  sorry
+
+/-- **Problem 2.11.3(c).** When `V` is finite dimensional there is a natural isomorphism
+`V* ⊗ W ≃ Hom(V, W)`. -/
+theorem exists_dualTensor_equiv_hom [FiniteDimensional k V] :
+    Nonempty (TensorProduct k (Module.Dual k V) W ≃ₗ[k] (V →ₗ[k] W)) := by
+  sorry
+
+/-- **Problem 2.11.3(g).** `∧ᴺ A = det(A)·Id` yields multiplicativity of the determinant:
+`det(A ∘ B) = det(A) · det(B)` for operators on a vector space. -/
+theorem det_comp (A B : V →ₗ[k] V) :
+    LinearMap.det (A ∘ₗ B) = LinearMap.det A * LinearMap.det B := by
+  sorry
+
+end Etingof.Problem2_11_3

--- a/EtingofRepresentationTheory/Chapter2/Problem2_13_1.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_13_1.lean
@@ -1,0 +1,32 @@
+import Mathlib
+
+/-!
+# Problem 2.13.1: The Dehn invariant and Hilbert's third problem
+
+To any polyhedron `A` one attaches its **Dehn invariant** `D(A) ∈ ℝ ⊗ (ℝ/ℚ)` (a tensor product of
+`ℚ`-vector spaces), `D(A) = Σₐ l(a) ⊗ β(a)/π`, summing over edges `a` with length `l(a)` and
+dihedral angle `β(a)`. The problem has three parts:
+
+* **(a)** cutting `A` into `B` and `C` gives `D(A) = D(B) + D(C)`;
+* **(b)** `α = arccos(1/3)/π` is irrational;
+* **(c)** the regular tetrahedron and cube of equal volume have different Dehn invariants, so they
+  are not scissors-congruent (a negative answer to Hilbert's third problem).
+
+## Formalization
+
+The cleanly-statable core is part **(b)**: the irrationality of `arccos(1/3)/π`. Parts (a) and (c)
+require the Dehn-invariant construction on polyhedra (the tensor product `ℝ ⊗_ℚ (ℝ/ℚ)` and a model
+of polyhedra with edges/dihedral angles) and are deferred to a dedicated follow-up item.
+
+This is the **statement pass**: part (b) is recorded with a `sorry` proof.
+-/
+
+namespace Etingof.Problem2_13_1
+
+open Real
+
+/-- **Problem 2.13.1(b).** The number `α = arccos(1/3)/π` is irrational. -/
+theorem irrational_arccos_third_div_pi : Irrational (arccos (1 / 3) / π) := by
+  sorry
+
+end Etingof.Problem2_13_1

--- a/EtingofRepresentationTheory/Chapter2/Problem2_14_3.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_14_3.lean
@@ -1,0 +1,37 @@
+import Mathlib
+
+/-!
+# Problem 2.14.3: The tensor-Hom adjunction for Lie algebra representations
+
+Let `V, W, U` be finite dimensional representations of a Lie algebra `𝔤`. The problem asks to show
+that `Hom_𝔤(V ⊗ W, U)` is isomorphic to `Hom_𝔤(V, U ⊗ W*)`.
+
+## Formalization
+
+Representations of `𝔤` are Lie modules; `Hom_𝔤(A, B)` is the space of Lie-module homomorphisms
+`A →ₗ⁅k,L⁆ B`. The tensor product `V ⊗ W` carries its Lie-module structure from
+`Mathlib.Algebra.Lie.TensorProduct`, and `W* = Module.Dual k W` carries the contragredient
+Lie-module structure from `Module.Dual.instLieModule`. The isomorphism is `k`-linear.
+
+This is the **statement pass**: recorded as the existence of a `k`-linear equivalence with a
+`sorry` proof.
+-/
+
+namespace Etingof.Problem2_14_3
+
+variable {k : Type*} [Field k]
+variable {L : Type*} [LieRing L] [LieAlgebra k L]
+variable {V W U : Type*}
+  [AddCommGroup V] [Module k V] [LieRingModule L V] [LieModule k L V]
+  [AddCommGroup W] [Module k W] [LieRingModule L W] [LieModule k L W]
+  [AddCommGroup U] [Module k U] [LieRingModule L U] [LieModule k L U]
+  [FiniteDimensional k V] [FiniteDimensional k W] [FiniteDimensional k U]
+
+/-- **Problem 2.14.3.** For finite dimensional representations `V, W, U` of a Lie algebra `𝔤`,
+`Hom_𝔤(V ⊗ W, U) ≅ Hom_𝔤(V, U ⊗ W*)`. -/
+theorem exists_tensorHom_adjunction :
+    Nonempty ((TensorProduct k V W →ₗ⁅k,L⁆ U) ≃ₗ[k]
+      (V →ₗ⁅k,L⁆ TensorProduct k U (Module.Dual k W))) := by
+  sorry
+
+end Etingof.Problem2_14_3

--- a/EtingofRepresentationTheory/Chapter2/Problem2_16_1.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_16_1.lean
@@ -1,0 +1,35 @@
+import Mathlib
+
+/-!
+# Problem 2.16.1: Lie's theorem
+
+The **commutant** `K(𝔤)` of a Lie algebra `𝔤` is the linear span of the elements `[x, y]`; it is
+an ideal in `𝔤`. A finite dimensional Lie algebra `𝔤` is **solvable** if `Kⁿ(𝔤) = 0` for some `n`.
+**Lie's theorem:** if `k = ℂ` and `V` is a finite dimensional irreducible representation of a
+solvable Lie algebra `𝔤`, then `V` is 1-dimensional.
+
+## Formalization
+
+Solvability is Mathlib's `LieAlgebra.IsSolvable` (defined via the derived series, matching the
+`Kⁿ(𝔤) = 0` condition). A representation of `𝔤` is a `LieModule`; irreducibility ("the only
+subrepresentations are `0` and `V`") is `IsSimpleOrder (LieSubmodule ℂ 𝔤 V)`. The conclusion
+"`V` is 1-dimensional" is `Module.finrank ℂ V = 1`.
+
+This is the **statement pass**: the statement is recorded with a `sorry` proof.
+-/
+
+namespace Etingof.Problem2_16_1
+
+open Module (finrank)
+
+variable {L : Type*} [LieRing L] [LieAlgebra ℂ L]
+variable {V : Type*} [AddCommGroup V] [Module ℂ V] [LieRingModule L V] [LieModule ℂ L V]
+
+/-- **Problem 2.16.1 (Lie's theorem).** A finite dimensional irreducible representation `V` of a
+solvable complex Lie algebra `L` is one-dimensional. -/
+theorem finrank_eq_one_of_isSolvable [LieAlgebra.IsSolvable L]
+    [FiniteDimensional ℂ V] [Nontrivial V] (hirr : IsSimpleOrder (LieSubmodule ℂ L V)) :
+    finrank ℂ V = 1 := by
+  sorry
+
+end Etingof.Problem2_16_1

--- a/EtingofRepresentationTheory/Chapter2/Problem2_4_1.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_4_1.lean
@@ -1,0 +1,44 @@
+import Mathlib
+
+/-!
+# Problem 2.4.1: Existence of maximal ideals
+
+A **maximal** ideal in a ring `A` is an ideal `I ≠ A` such that any strictly larger ideal
+coincides with `A`. (The definition is made for left, right, or two-sided ideals.) The problem
+asks to show that any unital ring has a maximal left, right, and two-sided ideal, using Zorn's
+lemma.
+
+## Formalization
+
+"Maximal ideal" in Etingof's sense (proper, and any strictly larger ideal is the whole ring) is
+exactly `IsCoatom` in the corresponding lattice of ideals:
+
+* **left ideals** of `A` are `Submodule A A` (the left `A`-module structure on `A`);
+* **right ideals** of `A` are `Submodule Aᵐᵒᵖ Aᵐᵒᵖ` — a submodule for the left action of the
+  opposite ring is precisely a subset closed under right multiplication by `A`;
+* **two-sided ideals** are `TwoSidedIdeal A`.
+
+`IsCoatom I` says `I ≠ ⊤` and any ideal strictly containing `I` equals `⊤`, i.e. `I` is maximal.
+
+This is the **statement pass**: the three existence statements are recorded with `sorry` proofs
+(each is proved by Zorn's lemma in the proof phase).
+-/
+
+namespace Etingof.Problem2_4_1
+
+variable (A : Type*) [Ring A] [Nontrivial A]
+
+/-- Every nontrivial unital ring has a maximal **left** ideal. (Etingof Problem 2.4.1) -/
+theorem exists_maximal_left_ideal : ∃ I : Submodule A A, IsCoatom I := by
+  sorry
+
+/-- Every nontrivial unital ring has a maximal **right** ideal, modelled as a maximal left ideal
+of the opposite ring `Aᵐᵒᵖ`. (Etingof Problem 2.4.1) -/
+theorem exists_maximal_right_ideal : ∃ I : Submodule Aᵐᵒᵖ Aᵐᵒᵖ, IsCoatom I := by
+  sorry
+
+/-- Every nontrivial unital ring has a maximal **two-sided** ideal. (Etingof Problem 2.4.1) -/
+theorem exists_maximal_twoSided_ideal : ∃ I : TwoSidedIdeal A, IsCoatom I := by
+  sorry
+
+end Etingof.Problem2_4_1

--- a/EtingofRepresentationTheory/Chapter2/Problem2_5_1.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_5_1.lean
@@ -1,0 +1,33 @@
+import Mathlib
+import EtingofRepresentationTheory.Chapter2.Definition2_3_8
+
+/-!
+# Problem 2.5.1: A quotient of a polynomial ring is indecomposable
+
+Let `A = k[x₁, …, xₙ]` and let `I ≠ A` be any ideal in `A` containing all homogeneous polynomials
+of degree `≥ N`. The problem asks to show that `A/I` is an indecomposable representation of `A`.
+
+## Formalization
+
+`A = MvPolynomial (Fin n) k`, `I : Ideal A`, and `A/I` carries its natural `A`-module structure.
+"Indecomposable representation" is `Etingof.IsIndecomposable` (Definition 2.3.8). The hypothesis
+that `I` contains every homogeneous polynomial of degree `≥ N` is `MvPolynomial.IsHomogeneous`.
+
+This is the **statement pass**: the statement is recorded with a `sorry` proof.
+-/
+
+namespace Etingof.Problem2_5_1
+
+open MvPolynomial
+
+variable {k : Type*} [Field k] {n : ℕ}
+
+/-- **Problem 2.5.1.** If `I ≠ A = k[x₁, …, xₙ]` is an ideal containing every homogeneous
+polynomial of degree `≥ N`, then `A/I` is an indecomposable representation of `A`. -/
+theorem quotient_isIndecomposable (N : ℕ) (I : Ideal (MvPolynomial (Fin n) k))
+    (hIne : I ≠ ⊤)
+    (hI : ∀ (d : ℕ) (p : MvPolynomial (Fin n) k), N ≤ d → p.IsHomogeneous d → p ∈ I) :
+    Etingof.IsIndecomposable (MvPolynomial (Fin n) k) (MvPolynomial (Fin n) k ⧸ I) := by
+  sorry
+
+end Etingof.Problem2_5_1

--- a/EtingofRepresentationTheory/Chapter2/Problem2_5_2.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_5_2.lean
@@ -1,0 +1,44 @@
+import Mathlib
+import EtingofRepresentationTheory.Chapter2.Definition2_3_8
+
+/-!
+# Problem 2.5.2: Cyclic vectors and cyclic representations
+
+Let `V ≠ 0` be a representation of `A`. A vector `v ∈ V` is **cyclic** if it generates `V`, i.e.
+`Av = V`. A representation admitting a cyclic vector is **cyclic**. The problem asks to show:
+
+* **(a)** `V` is irreducible if and only if all nonzero vectors of `V` are cyclic.
+* **(b)** `V` is cyclic if and only if it is isomorphic to `A/I`, where `I` is a left ideal in `A`.
+* **(c)** Give an example of an indecomposable representation which is not cyclic.
+
+## Formalization
+
+A vector `v` is cyclic when `Submodule.span A {v} = ⊤` (the `A`-submodule it generates is all of
+`V`). Irreducibility is `IsSimpleModule A V`. Left ideals of `A` are `Submodule A A`, and `A/I` is
+the quotient module.
+
+Parts (a) and (b) are recorded here as `sorry` statements. Part (c) — the explicit example
+`A = ℂ[x, y]/I₂` acting on `V = A^*` by `(ρ(a)f)(b) = f(ba)` — requires constructing the coregular
+module structure and is deferred to a dedicated follow-up item.
+
+This is the **statement pass**.
+-/
+
+namespace Etingof.Problem2_5_2
+
+variable {A : Type*} [Ring A]
+
+/-- **Problem 2.5.2(a).** A nonzero representation `V` is irreducible if and only if every nonzero
+vector of `V` is cyclic (generates `V`). -/
+theorem irreducible_iff_forall_cyclic (V : Type*) [AddCommGroup V] [Module A V] [Nontrivial V] :
+    IsSimpleModule A V ↔ ∀ v : V, v ≠ 0 → Submodule.span A {v} = ⊤ := by
+  sorry
+
+/-- **Problem 2.5.2(b).** A nonzero representation `V` is cyclic (admits a cyclic vector) if and
+only if it is isomorphic to `A/I` for some left ideal `I` of `A`. -/
+theorem cyclic_iff_isoQuotient (V : Type*) [AddCommGroup V] [Module A V] [Nontrivial V] :
+    (∃ v : V, Submodule.span A {v} = ⊤) ↔
+      ∃ I : Submodule A A, Nonempty (V ≃ₗ[A] (A ⧸ I)) := by
+  sorry
+
+end Etingof.Problem2_5_2

--- a/progress/2026-07-06T07-47-12Z_54b9b9f4.md
+++ b/progress/2026-07-06T07-47-12Z_54b9b9f4.md
@@ -1,0 +1,50 @@
+## Accomplished
+
+Statement pass for Chapter 2 exercises (issue #5892). Wrote faithful Lean 4 statements
+(sorry proofs / real defs) for 8 of the 20 listed exercises, each in its own file under
+`EtingofRepresentationTheory/Chapter2/`, all added to the `Chapter2.lean` aggregator and
+building cleanly (only expected `sorry` warnings):
+
+- **Problem 2.4.1** (`Problem2_4_1.lean`) — existence of maximal left / right / two-sided ideals,
+  modelled as `IsCoatom` in `Submodule A A`, `Submodule Aᵐᵒᵖ Aᵐᵒᵖ`, `TwoSidedIdeal A`.
+- **Problem 2.5.1** (`Problem2_5_1.lean`) — `A/I` indecomposable for `A = k[x₁..xₙ]`, `I` containing
+  all homogeneous polynomials of degree ≥ N (uses `Etingof.IsIndecomposable`).
+- **Problem 2.5.2** (`Problem2_5_2.lean`) — parts (a) irreducible ⇔ all nonzero vectors cyclic,
+  (b) cyclic ⇔ `V ≅ A/I`. Part (c) (explicit `A*` coregular example) deferred.
+- **Exercise 2.9.11** (`Exercise2_9_11.lean`) — Lie rep = `U(𝔤)` rep, as a genuine `def` = Mathlib's
+  `UniversalEnvelopingAlgebra.lift` (no sorry needed).
+- **Problem 2.11.3** (`Problem2_11_3.lean`) — parts (a) bilinear ⇔ linear on `V ⊗ W`, (b) tensor
+  basis, (c) `V* ⊗ W ≅ Hom(V,W)` (fin dim), (g) `det(A∘B)=det A · det B`. Parts (d)–(f) deferred.
+- **Problem 2.13.1(b)** (`Problem2_13_1.lean`) — `arccos(1/3)/π` is irrational. Parts (a),(c) (Dehn
+  invariant construction) deferred.
+- **Problem 2.14.3** (`Problem2_14_3.lean`) — tensor-Hom adjunction `Hom_𝔤(V⊗W,U) ≅ Hom_𝔤(V,U⊗W*)`
+  for finite-dim Lie modules (uses Mathlib Lie tensor and contragredient-dual instances).
+- **Problem 2.16.1** (`Problem2_16_1.lean`) — Lie's theorem: fin-dim irreducible rep of a solvable
+  complex Lie algebra is 1-dimensional.
+
+Set `progress/items.json` status to `statement_formalized` for these 8 ids.
+
+Created follow-up issue **#5894** for the remaining 12 open-ended exercises.
+
+## Current frontier
+
+8 of 20 Chapter 2 exercises from #5892 have faithful statements. The remaining 12 are the
+open-ended "classify / find / what are" problems handed to #5894.
+
+## Overall project progress
+
+Phase 3 (formalization) statement pass ongoing for Chapter 2. Chapter 2 aggregator builds with
+8701 jobs. This turn added 8 new statement files.
+
+## Next step
+
+A future worker claims #5894 and formalizes the remaining exercises: Problems 2.7.4, 2.7.5, 2.8.6,
+2.8.11, 2.16.2, 2.16.3, 2.16.4, 2.16.5 and Exercises 2.9.5, 2.11.2, 2.11.5, 2.11.7. Several ask for
+an explicit answer (center, classification, Hilbert series) — render the book's *answer* as the
+theorem rather than a placeholder. Note the deferred sub-parts here (2.5.2(c), 2.11.3(d–f),
+2.13.1(a,c)) may warrant their own items.
+
+## Blockers
+
+None. Exercise 2.11.7's blob is truncated in the book extract; #5894 notes to recover the full
+statement from §2.11.

--- a/progress/items.json
+++ b/progress/items.json
@@ -1447,7 +1447,7 @@
     "end_page": "37",
     "start_line": 18,
     "end_line": 8,
-    "status": "not_formalized",
+    "status": "statement_formalized",
     "coverage_note": "No Lean formalization on origin/main (re-derived 2026-07-02; prior 'sorry_free' was vacuous)."
   },
   {
@@ -1502,7 +1502,7 @@
     "end_page": "37",
     "start_line": 18,
     "end_line": 20,
-    "status": "not_formalized",
+    "status": "statement_formalized",
     "coverage_note": "No Lean formalization on origin/main (re-derived 2026-07-02; prior 'sorry_free' was vacuous)."
   },
   {

--- a/progress/items.json
+++ b/progress/items.json
@@ -639,7 +639,7 @@
     "end_page": "15",
     "start_line": 15,
     "end_line": 15,
-    "status": "not_formalized",
+    "status": "statement_formalized",
     "coverage_note": "No Lean formalization on origin/main (re-derived 2026-07-02; prior 'sorry_free' was vacuous)."
   },
   {
@@ -678,7 +678,7 @@
     "end_page": "16",
     "start_line": 19,
     "end_line": 19,
-    "status": "not_formalized",
+    "status": "statement_formalized",
     "coverage_note": "No Lean formalization on origin/main (re-derived 2026-07-02; prior 'sorry_free' was vacuous)."
   },
   {
@@ -689,7 +689,7 @@
     "end_page": "16",
     "start_line": 20,
     "end_line": 29,
-    "status": "not_formalized",
+    "status": "statement_formalized",
     "coverage_note": "No Lean formalization on origin/main (re-derived 2026-07-02; prior 'sorry_free' was vacuous)."
   },
   {
@@ -1174,7 +1174,7 @@
     "end_page": "25",
     "start_line": 1,
     "end_line": 2,
-    "status": "not_formalized",
+    "status": "statement_formalized",
     "coverage_note": "No Lean formalization on origin/main (re-derived 2026-07-02; prior 'sorry_free' was vacuous)."
   },
   {
@@ -1348,7 +1348,7 @@
     "end_page": "33",
     "start_line": 2,
     "end_line": 15,
-    "status": "not_formalized",
+    "status": "statement_formalized",
     "coverage_note": "No Lean formalization on origin/main (re-derived 2026-07-02; prior 'sorry_free' was vacuous)."
   },
   {
@@ -1551,7 +1551,7 @@
     "end_page": "40",
     "start_line": 18,
     "end_line": 4,
-    "status": "not_formalized",
+    "status": "statement_formalized",
     "coverage_note": "No Lean formalization on origin/main (re-derived 2026-07-02; prior 'sorry_free' was vacuous)."
   },
   {


### PR DESCRIPTION
This PR formalizes faithful Lean 4 statements (with `sorry` proofs, per the statement-pass phase) for 8 of the 20 Chapter 2 exercises listed in #5892: Problems 2.4.1 (maximal ideals exist), 2.5.1 (`A/I` indecomposable), 2.5.2 (cyclic vectors, parts a,b), 2.11.3 (tensor product universal property, parts a,b,c,g), 2.13.1(b) (`arccos(1/3)/π` irrational), 2.14.3 (tensor-Hom adjunction for Lie modules), 2.16.1 (Lie's theorem), and Exercise 2.9.11 (Lie rep = enveloping-algebra rep, a real def via `UniversalEnvelopingAlgebra.lift`). Each new file is added to the `Chapter2.lean` aggregator and builds cleanly with only the expected `sorry` warnings, and `progress/items.json` records the 8 exercises as `statement_formalized`.

The remaining 12 exercises are the open-ended "classify / find / what are" problems (Weyl and q-Weyl algebra representation theory, quiver path-algebra presentation, Hilbert series, quantum-group classification, base change, and several `sl(2)` / Lie-algebra classifications). These need careful faithful-statement design — rendering the book's explicit *answer* as the theorem — and are handed to follow-up issue #5894. A few sub-parts deferred here (2.5.2(c), 2.11.3(d–f), 2.13.1(a,c)) are noted in the progress file.

Closes #5892.

🤖 Prepared with Claude Code
