### PR TITLE
Statement pass: Chapter 3 exercises 3.8.4, 3.8.5, 3.9.2–3.9.5

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -384,6 +384,37 @@ as an `S_n`-rep iso (`Chapter5/SpechtBaseChangeComplex.lean`), the working recip
   `↥(p.restrictScalars ℂ)` is defeq to `↥p`, so the equiv lands in `↥(SpechtModuleK ℂ)` directly and
   `(Φ t : ℂ[S_n]) = Ψ t` is `rfl`.
 
+### Base-change module `L ⊗[K] V` over `L ⊗[K] A` — build it, `TensorProduct.Algebra.module` fails (#5896/#5923, Problem 3.8.4)
+
+To state anything about "`V ⊗_K L` as an `A ⊗_K L`-module" (scalar extension of a
+representation to a field extension `L/K`), you need `Module (L ⊗[K] A) (L ⊗[K] V)` — and
+**Mathlib has no such instance**. Two traps that cost real time:
+- **Use Mathlib's scalar-on-left `L ⊗[K] V`, not the book's `V ⊗_K L`.** The `L`-on-right
+  factor of `V ⊗[K] L` has no `Module L` instance; `TensorProduct.leftModule` only acts on the
+  left factor. `L ⊗[K] V ≅ V ⊗_K L` canonically — note the swap in a docstring and move on.
+- **`TensorProduct.Algebra.module` does not elaborate here** (it is a deliberate non-instance;
+  the planner's suggestion to use it is a dead end). Even after supplying `Module A (L⊗V)` on
+  the right factor + `SMulCommClass`/`IsScalarTower` by hand, `TensorProduct.Algebra.module`
+  still fails to find `IsScalarTower K L (L⊗V)` *inside* its own elaboration (the same goal
+  resolves standalone — a fragile diamond on the two scalar actions).
+
+**Working recipe** (all real `def`s, no data-sorry; `Chapter3/Problem3_8_4.lean`,
+`rep`/`repTensor`/`bcMod`): base-change the representation through `End`, then use the
+universal property of the tensor algebra, then `compHom`:
+```
+rep       : A →ₐ[K] Module.End L (L ⊗[K] V) := (Module.End.baseChangeHom K L V).comp (Algebra.lsmul K K V)
+repTensor : (L ⊗[K] A) →ₐ[L] Module.End L (L ⊗[K] V) := AlgHom.liftEquiv K L A (Module.End L (L ⊗[K] V)) rep
+bcMod     : Module (L ⊗[K] A) (L ⊗[K] V) := Module.compHom (L ⊗[K] V) (R := Module.End L (L ⊗[K] V)) repTensor.toRingHom
+```
+Key lemmas: `Algebra.lsmul K K V : A →ₐ[K] End K V` (the `A`-action, needs `IsScalarTower K A V`);
+`Module.End.baseChangeHom K L V : End K V →ₐ[K] End L (L ⊗[K] V)` (base change of endos, from
+`LinearMap.baseChange`); `AlgHom.liftEquiv R S A B : (A →ₐ[R] B) ≃ (S ⊗[R] A →ₐ[S] B)` (needs
+`IsScalarTower R S B`). Pin `R := Module.End …` explicitly in `compHom` or `V` stays a metavar.
+Once `bcMod` is a (file-scoped) instance, `Module L (L⊗A)`, `Algebra L (L⊗A)` and
+`FiniteDimensional L (L ⊗[K] V)` all resolve, and `≃ₗ[L ⊗[K] A]` statements typecheck.
+Encode "`X` is a direct summand of `Y`" as a split injection `∃ i p, p ∘ₗ i = id` (avoids
+quantifying over a complement type/universe).
+
 ### Upgrading `dim V_λ = 1` to the book's representation-iso claim (trivial/sign, #5637)
 
 A recurring Chapter 5 fidelity-gap shape: the book says "`V_{(n)}` is the *trivial*

--- a/EtingofRepresentationTheory/Chapter3.lean
+++ b/EtingofRepresentationTheory/Chapter3.lean
@@ -28,6 +28,7 @@ import EtingofRepresentationTheory.Chapter3.Discussion_after_Theorem3_7_1
 import EtingofRepresentationTheory.Chapter3.Theorem3_8_1
 import EtingofRepresentationTheory.Chapter3.Lemma3_8_2
 import EtingofRepresentationTheory.Chapter3.Problem3_8_3
+import EtingofRepresentationTheory.Chapter3.Problem3_8_4
 import EtingofRepresentationTheory.Chapter3.Problem3_8_5
 import EtingofRepresentationTheory.Chapter3.Remark3_8_6
 import EtingofRepresentationTheory.Chapter3.Problem3_9_1

--- a/EtingofRepresentationTheory/Chapter3/Problem3_8_4.lean
+++ b/EtingofRepresentationTheory/Chapter3/Problem3_8_4.lean
@@ -1,0 +1,83 @@
+import Mathlib
+import EtingofRepresentationTheory.Chapter3.Problem3_8_3
+
+/-!
+# Problem 3.8.4: scalar extension and the Noether-Deuring theorem
+
+> **(i)** Let `V, W` be finite dimensional representations of an algebra `A` over a (not
+> necessarily algebraically closed) field `K`. Let `L` be a field extension of `K`. Suppose
+> that `V ⊗_K L` is isomorphic to `W ⊗_K L` as a module over the `L`-algebra `A ⊗_K L`. Show
+> that `V` and `W` are isomorphic as `A`-modules.
+>
+> **(ii)** (The Noether-Deuring theorem) In the setting of (i), suppose that `V ⊗_K L` is a
+> direct summand in `W ⊗_K L`. Show that `V` is a direct summand in `W`.
+
+The book's hint reduces to a finite extension of degree `n`, identifies `V ⊗_K L` and
+`W ⊗_K L` with `Vⁿ` and `Wⁿ` as `A`-modules, and applies the Krull-Schmidt theorem — valid
+over an arbitrary field by Problem 3.8.3, recorded here as
+`Etingof.Problem3_8_3.krull_schmidt_uniqueness`.
+
+## Base change
+
+Mathlib registers the base-changed scalar `L ⊗[K] V` (scalar factor on the **left**) rather
+than `V ⊗_K L`; the two are canonically isomorphic and we use `L ⊗[K] V` throughout, so the
+book's `A ⊗_K L`-module `V ⊗_K L` is modelled by the `L ⊗[K] A`-module `L ⊗[K] V`.
+
+The `L ⊗[K] A`-action on `L ⊗[K] V` is not a Mathlib instance (the general
+`TensorProduct.Algebra.module` is deliberately not global, to avoid a scalar-action diamond
+on `A ⊗[R] A`). We build it here directly: base change the representation `A →ₐ[K] End K V`
+along `L`, then use the universal property `AlgHom.liftEquiv` of `L ⊗[K] A` to obtain an
+`L`-algebra map `L ⊗[K] A →ₐ[L] End L (L ⊗[K] V)`, and turn it into a module structure with
+`Module.compHom`.
+-/
+
+open scoped TensorProduct
+
+namespace Etingof.Problem3_8_4
+
+variable {K A V W L : Type*}
+  [Field K] [Ring A] [Algebra K A]
+  [AddCommGroup V] [Module K V] [Module A V] [IsScalarTower K A V]
+  [AddCommGroup W] [Module K W] [Module A W] [IsScalarTower K A W]
+  [Field L] [Algebra K L]
+
+/-- The representation of `A` on the base change `L ⊗[K] V`, acting `L`-linearly on the right
+factor. It is the composite of the representation `A →ₐ[K] End K V` with the base-change
+algebra map `End K V →ₐ[K] End L (L ⊗[K] V)`. -/
+noncomputable def rep : A →ₐ[K] Module.End L (L ⊗[K] V) :=
+  (Module.End.baseChangeHom K L V).comp (Algebra.lsmul K K V)
+
+/-- The `L ⊗[K] A`-representation on `L ⊗[K] V`, from the universal property of base change. -/
+noncomputable def repTensor : (L ⊗[K] A) →ₐ[L] Module.End L (L ⊗[K] V) :=
+  AlgHom.liftEquiv K L A (Module.End L (L ⊗[K] V)) (rep (A := A) (V := V) (L := L))
+
+/-- The base change `L ⊗[K] V` as a module over the base-changed algebra `L ⊗[K] A`. This is
+the Lean model of the book's `A ⊗_K L`-module `V ⊗_K L`. -/
+noncomputable instance bcMod : Module (L ⊗[K] A) (L ⊗[K] V) :=
+  Module.compHom (L ⊗[K] V) (R := Module.End L (L ⊗[K] V))
+    (repTensor (A := A) (V := V) (L := L)).toRingHom
+
+/-- **Problem 3.8.4(i).** If the base changes `L ⊗[K] V` and `L ⊗[K] W` are isomorphic as
+`L ⊗[K] A`-modules, then `V` and `W` are already isomorphic as `A`-modules.
+
+Proof (book): reduce to a finite extension `L/K` of degree `n`; then `L ⊗[K] V ≅ Vⁿ` and
+`L ⊗[K] W ≅ Wⁿ` as `A`-modules, so `Vⁿ ≅ Wⁿ`, and Krull-Schmidt over the arbitrary field `K`
+(`Etingof.Problem3_8_3.krull_schmidt_uniqueness`) gives `V ≅ W`. -/
+theorem iso_of_baseChange_iso [FiniteDimensional K V] [FiniteDimensional K W]
+    (h : Nonempty ((L ⊗[K] V) ≃ₗ[L ⊗[K] A] (L ⊗[K] W))) :
+    Nonempty (V ≃ₗ[A] W) := by
+  sorry
+
+/-- **Problem 3.8.4(ii), the Noether-Deuring theorem.** If `L ⊗[K] V` is a direct summand of
+`L ⊗[K] W` as `L ⊗[K] A`-modules, then `V` is a direct summand of `W` as `A`-modules.
+
+A direct summand (up to isomorphism) is encoded as a split injection: a pair `(i, p)` with
+`p ∘ i = id`, whose image is a complemented submodule isomorphic to the smaller module. -/
+theorem directSummand_of_baseChange_directSummand
+    [FiniteDimensional K V] [FiniteDimensional K W]
+    (h : ∃ (i : (L ⊗[K] V) →ₗ[L ⊗[K] A] (L ⊗[K] W))
+           (p : (L ⊗[K] W) →ₗ[L ⊗[K] A] (L ⊗[K] V)), p.comp i = LinearMap.id) :
+    ∃ (i : V →ₗ[A] W) (p : W →ₗ[A] V), p.comp i = LinearMap.id := by
+  sorry
+
+end Etingof.Problem3_8_4

--- a/progress/2026-07-06T09-54-08Z_1730275f.md
+++ b/progress/2026-07-06T09-54-08Z_1730275f.md
@@ -1,0 +1,53 @@
+## Accomplished
+
+One-shot session (`pod once 5896`) landing the final remaining exercise of issue #5896:
+**Problem 3.8.4 (scalar extension and the Noether-Deuring theorem)**, which had been
+decomposed into #5923. Statement pass with `sorry` proofs.
+
+New file `EtingofRepresentationTheory/Chapter3/Problem3_8_4.lean`:
+
+- **Base-change module infrastructure** (all real definitions, no `sorry` on data):
+  - `rep : A →ₐ[K] Module.End L (L ⊗[K] V)` — base change of the `A`-representation, via
+    `Module.End.baseChangeHom K L V ∘ Algebra.lsmul K K V`.
+  - `repTensor : (L ⊗[K] A) →ₐ[L] Module.End L (L ⊗[K] V)` — via `AlgHom.liftEquiv`, the
+    universal property of `L ⊗[K] A`.
+  - `bcMod : Module (L ⊗[K] A) (L ⊗[K] V)` — via `Module.compHom` on `repTensor.toRingHom`.
+    This is the Lean model of the book's `A ⊗_K L`-module `V ⊗_K L`.
+- **Part (i)** `iso_of_baseChange_iso`: `L ⊗ V ≅ L ⊗ W` over `L ⊗ A` ⟹ `V ≅ W` over `A`.
+- **Part (ii)** `directSummand_of_baseChange_directSummand` (Noether-Deuring): direct-summand
+  version, encoding "direct summand" as a split injection `(i, p)` with `p ∘ i = id`.
+
+Import added to `Chapter3.lean`; `progress/items.json` set to `statement_formalized`
+(`sorry_free: false`, `fidelity: verified`). Full `Chapter3` builds cleanly (8670 jobs).
+
+## Key decisions / patterns
+
+- Mathlib does **not** provide `Module (L ⊗[K] A) (L ⊗[K] V)` as an instance — the general
+  `TensorProduct.Algebra.module` is deliberately non-global (scalar-action diamond on
+  `A ⊗[R] A`), and I confirmed it fails to elaborate here (`IsScalarTower K L` resolves
+  standalone but not inside `TensorProduct.Algebra.module`). The robust route that works is
+  `Module.End.baseChangeHom` + `AlgHom.liftEquiv` + `Module.compHom`, avoiding the diamond
+  entirely. **This is a reusable recipe for base-changing any `A`-module to `L ⊗[K] A`.**
+- Used Mathlib's scalar-on-left convention `L ⊗[K] V` for the book's `V ⊗_K L` (canonically
+  isomorphic); `L`-on-right factor has no module instance in Mathlib.
+
+## Current frontier
+
+Problem 3.8.4 statements in place with `sorry` proofs. Issue #5896 is now fully covered
+(5/6 landed earlier in #5925, 3.8.4 here).
+
+## Overall project progress
+
+Statement-pass phase for Chapter 3 exercises is complete: 3.8.4, 3.8.5, 3.9.2–3.9.5 all
+`statement_formalized`. The base-change infrastructure in `Problem3_8_4.lean` is new and
+reusable for any later scalar-extension work.
+
+## Next step
+
+- Close #5923 (fully satisfied by this PR) once merged.
+- Proof pass for Problem 3.8.4: (i) via the book's `Vⁿ`/`Wⁿ` identification and
+  `Etingof.Problem3_8_3.krull_schmidt_uniqueness`; (ii) Noether-Deuring from (i).
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -2178,8 +2178,11 @@
     "end_page": "56",
     "start_line": 15,
     "end_line": 4,
-    "status": "not_formalized",
-    "coverage_note": "Decomposed out of #5896 into #5923 (statement pass): needs base-change module infrastructure (TensorProduct.Algebra.module, a deliberate non-instance) distinct from the other five 3.8/3.9 exercises."
+    "status": "statement_formalized",
+    "sorry_free": false,
+    "fidelity": "verified",
+    "lean_file": "EtingofRepresentationTheory/Chapter3/Problem3_8_4.lean",
+    "coverage_note": "Statement pass (#5896/#5923). Base-change module infrastructure built directly (rep/repTensor/bcMod: L ⊗[K] V as an L ⊗[K] A-module, via Module.End.baseChangeHom + AlgHom.liftEquiv + Module.compHom, since TensorProduct.Algebra.module is not a global instance). Parts (i) iso_of_baseChange_iso and (ii) directSummand_of_baseChange_directSummand (Noether-Deuring) stated with sorry proofs; (ii) encodes direct summand as a split injection. Uses L ⊗[K] V for the book's V ⊗_K L (Mathlib scalar-on-left convention)."
   },
   {
     "id": "Chapter3/Problem3.8.5",


### PR DESCRIPTION
This PR adds a statement pass for Problem 3.8.4 (scalar extension and the Noether-Deuring theorem), the last remaining exercise of #5896 (decomposed into #5923). It builds the base-change module structure of `L ⊗[K] V` over `L ⊗[K] A` directly, since Mathlib's `TensorProduct.Algebra.module` is deliberately not a global instance: base change the representation `A →ₐ[K] End K V` with `Module.End.baseChangeHom`, transport it to `L ⊗[K] A →ₐ[L] End L (L ⊗[K] V)` with `AlgHom.liftEquiv`, and turn it into a module with `Module.compHom`. Parts (i) `iso_of_baseChange_iso` and (ii) `directSummand_of_baseChange_directSummand` are stated with `sorry` proofs; part (ii) encodes a direct summand as a split injection. Full Chapter 3 builds cleanly.

Closes #5896. Also fully covers #5923.

🤖 Prepared with Claude Code