### PR TITLE
feat: statement pass for Chapter 4 Exercise 4.3.1, Problems 4.12.1, 4.12.11

### DIFF
--- a/EtingofRepresentationTheory/Chapter4.lean
+++ b/EtingofRepresentationTheory/Chapter4.lean
@@ -47,8 +47,11 @@ import EtingofRepresentationTheory.Chapter4.Lemma4_10_3
 import EtingofRepresentationTheory.Chapter4.Exercise4_2_3
 import EtingofRepresentationTheory.Chapter4.Problem4_5_2
 import EtingofRepresentationTheory.Chapter4.Problem4_1_4
+import EtingofRepresentationTheory.Chapter4.Exercise4_3_1
+import EtingofRepresentationTheory.Chapter4.Problem4_12_1
 import EtingofRepresentationTheory.Chapter4.Problem4_12_4
 import EtingofRepresentationTheory.Chapter4.Problem4_12_7
 import EtingofRepresentationTheory.Chapter4.Problem4_12_10
+import EtingofRepresentationTheory.Chapter4.Problem4_12_11
 
 /-! # Chapter 4: Representations of Finite Groups: Further Results -/

--- a/EtingofRepresentationTheory/Chapter4/Exercise4_3_1.lean
+++ b/EtingofRepresentationTheory/Chapter4/Exercise4_3_1.lean
@@ -1,0 +1,99 @@
+import Mathlib
+import EtingofRepresentationTheory.Chapter4.Example4_3_Q8
+
+/-!
+# Exercise 4.3.1: the 2-dimensional irreducible representation of `Q₈` on a function space
+
+**Exercise 4.3.1.** Show that the 2-dimensional irreducible representation of `Q₈` can be
+realized in the space of functions `f : Q₈ → ℂ` such that `f(g·i) = √(-1)·f(g)` (the action
+of `G` is by right multiplication, `g ∘ f(x) = f(x·g)`).
+
+## Formalization
+
+We model `Q₈` by Mathlib's `QuaternionGroup 2` (order `8`), with the element `i` taken to be
+`QuaternionGroup.a 1` (an element of order `4`, matching the matrix `rhoI` in
+`Example4_3_Q8`), and `√(-1)` by `Complex.I`.
+
+The action of `Q₈` on functions `Q₈ → ℂ` by right translation, `(g ∘ f)(x) = f(x·g)`, is the
+**right regular representation** `rightRegular`. The book writes the covariance condition as
+`f(g·i) = √(-1)·f(g)`; the subspace invariant under the *right*-translation action is the one
+cut out by the *left* covariance `f(i·g) = √(-1)·f(g)` (the two are the standard equivalent
+conventions for the induced representation `Ind_{⟨i⟩}^{Q₈} χ`, where `χ(i) = √(-1)`). We call
+this invariant subspace `covariantSubspace`.
+
+This is a statement pass. We give faithful signatures with `sorry` proofs for:
+* `covariantSubspace_invariant` — the subspace is a subrepresentation of the right regular
+  representation;
+* `covariantSubspace_finrank` — it is `2`-dimensional;
+* `covariantSubspace_irreducible` — it is irreducible (every invariant subspace of it is `⊥`
+  or the whole space).
+
+The identification with the concrete 2-dimensional irreducible `Example4_3_Q8.repLin` is
+recorded in the docstring and left for a later pass.
+-/
+
+open QuaternionGroup
+
+namespace Etingof.Exercise4_3_1
+
+/-- The right regular representation of `Q₈ = QuaternionGroup 2` on functions `Q₈ → ℂ`:
+`(rightRegular g) f = fun x => f (x * g)`. This is the action `g ∘ f(x) = f(x·g)` from the
+book. -/
+noncomputable def rightRegular :
+    Representation ℂ (QuaternionGroup 2) (QuaternionGroup 2 → ℂ) where
+  toFun g := LinearMap.funLeft ℂ ℂ (· * g)
+  map_one' := by
+    ext f x
+    simp
+  map_mul' g h := by
+    ext f x
+    simp [LinearMap.funLeft_apply, mul_assoc]
+
+@[simp]
+theorem rightRegular_apply (g : QuaternionGroup 2) (f : QuaternionGroup 2 → ℂ)
+    (x : QuaternionGroup 2) : rightRegular g f x = f (x * g) := rfl
+
+/-- The subspace of functions `f : Q₈ → ℂ` satisfying the covariance condition
+`f(i·g) = √(-1)·f(g)` for all `g`, where `i = a 1` and `√(-1) = Complex.I`. This is the space
+in which the 2-dimensional irreducible representation of `Q₈` is realized. -/
+def covariantSubspace : Submodule ℂ (QuaternionGroup 2 → ℂ) where
+  carrier := {f | ∀ g : QuaternionGroup 2, f (a 1 * g) = Complex.I * f g}
+  add_mem' {f₁ f₂} hf₁ hf₂ := by
+    intro g
+    simp only [Pi.add_apply, hf₁ g, hf₂ g]
+    ring
+  zero_mem' := by
+    intro g
+    simp
+  smul_mem' c f hf := by
+    intro g
+    simp only [Pi.smul_apply, smul_eq_mul, hf g]
+    ring
+
+@[simp]
+theorem mem_covariantSubspace {f : QuaternionGroup 2 → ℂ} :
+    f ∈ covariantSubspace ↔ ∀ g : QuaternionGroup 2, f (a 1 * g) = Complex.I * f g :=
+  Iff.rfl
+
+/-- `covariantSubspace` is a subrepresentation of the right regular representation: it is
+invariant under `rightRegular g` for every `g`. -/
+theorem covariantSubspace_invariant (g : QuaternionGroup 2)
+    (f : QuaternionGroup 2 → ℂ) (hf : f ∈ covariantSubspace) :
+    rightRegular g f ∈ covariantSubspace := by
+  sorry
+
+/-- The space `covariantSubspace` is `2`-dimensional. -/
+theorem covariantSubspace_finrank :
+    Module.finrank ℂ covariantSubspace = 2 := by
+  sorry
+
+/-- The realized representation is irreducible: every `Q₈`-invariant subspace `U` contained in
+`covariantSubspace` is either `⊥` or all of `covariantSubspace`. -/
+theorem covariantSubspace_irreducible
+    (U : Submodule ℂ (QuaternionGroup 2 → ℂ))
+    (hUle : U ≤ covariantSubspace)
+    (hUinv : ∀ g : QuaternionGroup 2, ∀ f ∈ U, rightRegular g f ∈ U) :
+    U = ⊥ ∨ U = covariantSubspace := by
+  sorry
+
+end Etingof.Exercise4_3_1

--- a/EtingofRepresentationTheory/Chapter4/Problem4_12_1.lean
+++ b/EtingofRepresentationTheory/Chapter4/Problem4_12_1.lean
@@ -1,0 +1,83 @@
+import Mathlib
+
+/-!
+# Problem 4.12.1: representations of the dihedral group (symmetries of a regular `N`-gon)
+
+**Problem 4.12.1.** Let `G` be the group of symmetries of a regular `N`-gon (it has `2N`
+elements).
+
+(a) Describe all irreducible complex representations of this group (consider the cases of odd
+and even `N`).
+
+(b) Let `V` be the 2-dimensional complex representation of `G` obtained by complexification of
+the standard representation on the real plane (the plane of the polygon). Find the
+decomposition of `V ⊗ V` in a direct sum of irreducible representations.
+
+## Formalization
+
+We model the symmetry group of the regular `N`-gon by Mathlib's `DihedralGroup N` (order `2N`;
+generators `r k` = rotations, `sr k` = reflections).
+
+* **(a)** The faithful content of "describe all irreducibles" is the dimension dichotomy:
+  *every* irreducible complex representation of `DihedralGroup N` is `1`- or `2`-dimensional.
+  (The precise counts — `2` one-dimensional and `(N-1)/2` two-dimensional for odd `N`; `4`
+  one-dimensional and `(N-2)/2` two-dimensional for even `N` — are recorded here in the
+  docstring.)
+
+* **(b)** Over `ℂ` the complexified standard representation `V` diagonalizes on rotations with
+  eigenvalues `ζ^k, ζ^{-k}` (`ζ = exp(2πi/N)` a primitive `N`-th root of unity), and `V ⊗ V`
+  decomposes as `𝟙 ⊕ ε ⊕ V₂`, where `𝟙` is trivial, `ε` is the sign (rotations act by `1`,
+  reflections by `-1`), and `V₂` is the `2`-dimensional representation with rotation by
+  `4π/N`. We state this at the level of **characters**: with `χ_V`, `χ_ε`, `χ_{V₂}` the
+  class functions defined below, `χ_V(g)² = 1 + χ_ε(g) + χ_{V₂}(g)` for all `g`, which is
+  exactly `V ⊗ V ≅ 𝟙 ⊕ ε ⊕ V₂` since the character of a tensor product is the product of
+  characters.
+
+This is a statement pass: faithful signatures with `sorry` proofs.
+-/
+
+open Real
+
+noncomputable section
+
+namespace Etingof.Problem4_12_1
+
+variable {N : ℕ}
+
+/-- A primitive `N`-th root of unity `ζ = exp(2πi/N)`. -/
+noncomputable def zeta (N : ℕ) : ℂ := Complex.exp (2 * π * Complex.I / N)
+
+/-- **Part (a).** Every irreducible complex representation of the dihedral group
+`DihedralGroup N` (for `N ≥ 1`) is either `1`- or `2`-dimensional. -/
+theorem irreducible_dim [NeZero N]
+    {W : Type*} [AddCommGroup W] [Module ℂ W] [FiniteDimensional ℂ W]
+    (ρ : Representation ℂ (DihedralGroup N) W)
+    (hρ : IsSimpleModule (MonoidAlgebra ℂ (DihedralGroup N)) ρ.asModule) :
+    Module.finrank ℂ W = 1 ∨ Module.finrank ℂ W = 2 := by
+  sorry
+
+/-- Character of the complexified standard `2`-dimensional representation `V`:
+`χ_V(r k) = ζ^k + ζ^{-k}` on rotations and `0` on reflections. -/
+noncomputable def chiStd (N : ℕ) : DihedralGroup N → ℂ
+  | .r k => zeta N ^ k.val + (zeta N)⁻¹ ^ k.val
+  | .sr _ => 0
+
+/-- Character of the sign representation `ε`: rotations act by `1`, reflections by `-1`. -/
+def chiSign (N : ℕ) : DihedralGroup N → ℂ
+  | .r _ => 1
+  | .sr _ => -1
+
+/-- Character of the `2`-dimensional representation `V₂` (rotation by `4π/N`):
+`χ_{V₂}(r k) = ζ^{2k} + ζ^{-2k}` on rotations and `0` on reflections. -/
+noncomputable def chiRot2 (N : ℕ) : DihedralGroup N → ℂ
+  | .r k => zeta N ^ (2 * k.val) + (zeta N)⁻¹ ^ (2 * k.val)
+  | .sr _ => 0
+
+/-- **Part (b).** The decomposition `V ⊗ V ≅ 𝟙 ⊕ ε ⊕ V₂`, expressed as the character identity
+`χ_V(g)² = 1 + χ_ε(g) + χ_{V₂}(g)` (the constant `1` is the character of the trivial
+representation). -/
+theorem tensor_square_character (N : ℕ) (g : DihedralGroup N) :
+    chiStd N g ^ 2 = 1 + chiSign N g + chiRot2 N g := by
+  sorry
+
+end Etingof.Problem4_12_1

--- a/EtingofRepresentationTheory/Chapter4/Problem4_12_11.lean
+++ b/EtingofRepresentationTheory/Chapter4/Problem4_12_11.lean
@@ -1,0 +1,170 @@
+import Mathlib
+
+/-!
+# Problem 4.12.11: elasticity theory and representations of `SO(3)`
+
+**Problem 4.12.11.** (Elasticity theory.) Let `V = ℝ³` with its standard inner product, on
+which `SO(3)` acts. The deformation tensor lives in `S²V` and the stress tensor in
+`End(V)`, and Hooke's law is a linear `SO(3)`-equivariant map `f : S²V → End(V)`.
+
+(a) Show that `End(V)` admits a decomposition `ℝ ⊕ V ⊕ W`, where `ℝ` is the trivial
+representation, `V` is the standard `3`-dimensional representation, and `W` is a
+`5`-dimensional representation of `SO(3)`. Show that `S²V = ℝ ⊕ W`.
+
+(b) Show that `V` and `W` are irreducible, even after complexification. Deduce using Schur's
+lemma that `S_P` is always symmetric, and for `x ∈ ℝ`, `y ∈ W` one has `f(x + y) = Kx + μy`
+for some real numbers `K, μ` (the compression modulus `K` and shearing modulus `μ`).
+
+## Formalization
+
+We take `V = Fin 3 → ℝ` and `End(V) = Matrix (Fin 3) (Fin 3) ℝ`, with `SO(3)` modelled by
+`Matrix.specialOrthogonalGroup (Fin 3) ℝ` acting on `End(V)` by conjugation
+`M ↦ A · M · Aᵀ` (`conjRep`; for orthogonal `A`, `Aᵀ = A⁻¹`). Inside `End(V)`:
+
+* `scalarSub` = scalar matrices `ℝ·1` (the trivial summand `ℝ`);
+* `skewSub` = skew-symmetric matrices `Mᵀ = -M` (`3`-dimensional, isomorphic to the standard
+  representation `V`);
+* `symSub` = symmetric matrices `Mᵀ = M` (this is `S²V`, `6`-dimensional);
+* `tracelessSymSub` = traceless symmetric matrices (the `5`-dimensional representation `W`).
+
+Statements (faithful signatures, `sorry` proofs — a statement pass):
+
+* **(a)** each subspace is `SO(3)`-invariant; `End(V) = scalarSub ⊕ skewSub ⊕ tracelessSymSub`
+  and `symSub = scalarSub ⊕ tracelessSymSub`; the dimensions are `1, 3, 5`.
+* **(b)** `skewSub` (`≅ V`) and `tracelessSymSub` (`= W`) are irreducible (stated over `ℝ`;
+  the irreducibility survives complexification, recorded in this docstring). Hooke's law:
+  any `SO(3)`-equivariant `f : End(V) → End(V)` acts as a scalar `K` on `scalarSub` and a
+  scalar `μ` on `tracelessSymSub`, and maps symmetric matrices to symmetric matrices (so the
+  stress tensor `S_P` is symmetric).
+-/
+
+open Matrix
+
+noncomputable section
+
+namespace Etingof.Problem4_12_11
+
+/-- `SO(3)`, modelled as the special orthogonal group of `3 × 3` real matrices. -/
+abbrev SO3 : Submonoid (Matrix (Fin 3) (Fin 3) ℝ) := specialOrthogonalGroup (Fin 3) ℝ
+
+/-- `End(V) = Matrix (Fin 3) (Fin 3) ℝ`, on which `SO(3)` acts by conjugation. -/
+abbrev EndV : Type := Matrix (Fin 3) (Fin 3) ℝ
+
+/-- The conjugation action of `SO(3)` on `End(V)`: `conjRep A M = A · M · Aᵀ`. Since `A` is
+orthogonal, `Aᵀ = A⁻¹`, so this is genuine conjugation. -/
+def conjRep : Representation ℝ SO3 EndV where
+  toFun A := (LinearMap.mulLeft ℝ (A : EndV)).comp
+    (LinearMap.mulRight ℝ (star (A : EndV)))
+  map_one' := by
+    ext M
+    simp
+  map_mul' A B := by
+    ext M
+    simp only [Submonoid.coe_mul, star_mul, LinearMap.comp_apply, LinearMap.mulLeft_apply,
+      LinearMap.mulRight_apply, Module.End.mul_apply]
+    simp [mul_assoc]
+
+@[simp]
+theorem conjRep_apply (A : SO3) (M : EndV) :
+    conjRep A M = (A : EndV) * M * star (A : EndV) := by
+  simp [conjRep, mul_assoc]
+
+/-- The trivial summand `ℝ ⊆ End(V)`: the scalar matrices `ℝ·1`. -/
+def scalarSub : Submodule ℝ EndV := Submodule.span ℝ {(1 : EndV)}
+
+/-- The skew-symmetric matrices `{M | Mᵀ = -M}` — a `3`-dimensional subrepresentation
+isomorphic to the standard representation `V`. -/
+def skewSub : Submodule ℝ EndV where
+  carrier := {M | Mᵀ = -M}
+  add_mem' {a b} ha hb := by
+    simp only [Set.mem_setOf_eq] at ha hb ⊢; rw [transpose_add, ha, hb]; abel
+  zero_mem' := by simp
+  smul_mem' c a ha := by
+    simp only [Set.mem_setOf_eq] at ha ⊢; rw [transpose_smul, ha, smul_neg]
+
+/-- The symmetric matrices `{M | Mᵀ = M}` — this is `S²V ⊆ End(V)`. -/
+def symSub : Submodule ℝ EndV where
+  carrier := {M | Mᵀ = M}
+  add_mem' {a b} ha hb := by
+    simp only [Set.mem_setOf_eq] at ha hb ⊢; rw [transpose_add, ha, hb]
+  zero_mem' := by simp
+  smul_mem' c a ha := by
+    simp only [Set.mem_setOf_eq] at ha ⊢; rw [transpose_smul, ha]
+
+/-- The traceless symmetric matrices `{M | Mᵀ = M ∧ trace M = 0}` — the `5`-dimensional
+representation `W`. -/
+def tracelessSymSub : Submodule ℝ EndV where
+  carrier := {M | Mᵀ = M ∧ M.trace = 0}
+  add_mem' {a b} ha hb := by
+    simp only [Set.mem_setOf_eq] at ha hb ⊢
+    exact ⟨by rw [transpose_add, ha.1, hb.1], by rw [trace_add, ha.2, hb.2, add_zero]⟩
+  zero_mem' := by simp only [Set.mem_setOf_eq]; exact ⟨by simp, by simp⟩
+  smul_mem' c a ha := by
+    simp only [Set.mem_setOf_eq] at ha ⊢
+    exact ⟨by rw [transpose_smul, ha.1], by rw [trace_smul, ha.2, smul_zero]⟩
+
+theorem scalar_le_sym : scalarSub ≤ symSub := by
+  intro M hM
+  rw [scalarSub, Submodule.mem_span_singleton] at hM
+  obtain ⟨c, rfl⟩ := hM
+  change (c • (1 : EndV))ᵀ = c • 1
+  rw [transpose_smul, transpose_one]
+
+theorem tracelessSym_le_sym : tracelessSymSub ≤ symSub := fun _ hM => hM.1
+
+/-! ### Part (a): the decomposition -/
+
+/-- **(a)** Each of the three subspaces is `SO(3)`-invariant. -/
+theorem conjRep_invariant (S : Submodule ℝ EndV)
+    (hS : S = scalarSub ∨ S = skewSub ∨ S = tracelessSymSub)
+    (A : SO3) (M : EndV) (hM : M ∈ S) : conjRep A M ∈ S := by
+  sorry
+
+/-- **(a)** `End(V) = ℝ ⊕ V ⊕ W`: the three subspaces form an internal direct sum of
+`End(V)`. -/
+theorem endV_isInternal :
+    DirectSum.IsInternal ![scalarSub, skewSub, tracelessSymSub] := by
+  sorry
+
+/-- **(a)** `S²V = ℝ ⊕ W`: the symmetric matrices are the internal direct sum of the scalars
+and the traceless symmetric matrices. -/
+theorem symSub_eq_scalar_sup_tracelessSym :
+    scalarSub ⊔ tracelessSymSub = symSub ∧ scalarSub ⊓ tracelessSymSub = ⊥ := by
+  sorry
+
+theorem scalarSub_finrank : Module.finrank ℝ scalarSub = 1 := by sorry
+theorem skewSub_finrank : Module.finrank ℝ skewSub = 3 := by sorry
+theorem tracelessSymSub_finrank : Module.finrank ℝ tracelessSymSub = 5 := by sorry
+
+/-! ### Part (b): irreducibility and Hooke's law -/
+
+/-- **(b)** The standard representation `V ≅ skewSub` is irreducible: every `SO(3)`-invariant
+subspace contained in `skewSub` is `⊥` or all of `skewSub`. (Irreducibility survives
+complexification.) -/
+theorem skewSub_irreducible (U : Submodule ℝ EndV) (hUle : U ≤ skewSub)
+    (hUinv : ∀ (A : SO3), ∀ M ∈ U, conjRep A M ∈ U) :
+    U = ⊥ ∨ U = skewSub := by
+  sorry
+
+/-- **(b)** The representation `W = tracelessSymSub` is irreducible: every `SO(3)`-invariant
+subspace contained in `tracelessSymSub` is `⊥` or all of `tracelessSymSub`. (Irreducibility
+survives complexification.) -/
+theorem tracelessSymSub_irreducible (U : Submodule ℝ EndV) (hUle : U ≤ tracelessSymSub)
+    (hUinv : ∀ (A : SO3), ∀ M ∈ U, conjRep A M ∈ U) :
+    U = ⊥ ∨ U = tracelessSymSub := by
+  sorry
+
+/-- **(b), Hooke's law.** Any `SO(3)`-equivariant linear map `f : End(V) → End(V)` acts as a
+scalar `K` (the compression modulus) on the trivial component `scalarSub` and a scalar `μ`
+(the shearing modulus) on the `W`-component `tracelessSymSub`, and it maps symmetric matrices
+to symmetric matrices (so the stress tensor `S_P = f(d_P)` is always symmetric). Thus for
+`x ∈ ℝ`, `y ∈ W`, `f(x + y) = Kx + μy`. -/
+theorem hooke_law (f : EndV →ₗ[ℝ] EndV)
+    (hf : ∀ A : SO3, f.comp (conjRep A) = (conjRep A).comp f) :
+    ∃ K μ : ℝ,
+      (∀ x ∈ scalarSub, f x = K • x) ∧
+      (∀ y ∈ tracelessSymSub, f y = μ • y) ∧
+      (∀ x ∈ symSub, f x ∈ symSub) := by
+  sorry
+
+end Etingof.Problem4_12_11

--- a/progress/2026-07-06T10-01-35Z_1ce81e46.md
+++ b/progress/2026-07-06T10-01-35Z_1ce81e46.md
@@ -1,0 +1,45 @@
+## Accomplished
+
+One-shot dispatch on issue #5898 (Chapter 4 statement pass). Landed faithful Lean 4
+statement passes (all `sorry` proofs, definitions genuinely constructed) for 3 of the
+remaining exercises:
+
+- **Exercise 4.3.1** (`Chapter4/Exercise4_3_1.lean`) — the 2-dim irreducible representation
+  of `Q₈ = QuaternionGroup 2` realized in a function space. Constructed the right-regular
+  representation `rightRegular` and the covariance subspace `covariantSubspace`; stated its
+  invariance, `finrank = 2`, and irreducibility.
+- **Problem 4.12.1** (`Chapter4/Problem4_12_1.lean`) — dihedral group `DihedralGroup N`:
+  (a) every irreducible complex rep is 1- or 2-dimensional; (b) the `V ⊗ V` decomposition as
+  the character identity `χ_V(g)² = 1 + χ_sign(g) + χ_{V₂}(g)`.
+- **Problem 4.12.11** (`Chapter4/Problem4_12_11.lean`) — elasticity / `SO(3)`: conjugation
+  action on `End(ℝ³)`, the `scalarSub ⊕ skewSub ⊕ tracelessSymSub` decomposition,
+  `S²V = ℝ ⊕ W`, dimension facts (1,3,5), irreducibility of `V` and `W`, and Hooke's law
+  `f(x+y) = Kx + μy` with `S_P` symmetric.
+
+All three added to `Chapter4.lean` aggregator; `progress/items.json` statuses set to
+`statement_formalized` (surgical edits, JSON validated). Each file builds with only the
+expected `sorry` warnings.
+
+## Current frontier
+
+Chapter 4 statement pass. The remaining 5 exercises from #5898 (Problems 4.12.2, 4.12.5,
+4.12.6, 4.12.8, 4.12.9) are tracked by the pre-existing follow-up issue #5904 (I commented
+there with the updated status and closed my accidental duplicate #5942). Note Problem 4.12.7
+is already formalized on `main`.
+
+## Overall project progress
+
+Phase 3 (formalization) statement-pass work for Chapter 4 exercise backlog. Of #5898's 14
+listed exercises: ~6 were already formalized on `main` before this session (Exercise 4.2.3,
+Problems 4.1.4, 4.5.2, 4.12.4, 4.12.7, 4.12.10), 3 landed this session, 5 remain (→ #5904).
+
+## Next step
+
+Work #5904: the 5 remaining Chapter 4 problems, each needing a group/geometry construction:
+Heisenberg group (4.12.2 + its character companion 4.12.9), A₅ icosahedron reusing
+`Example4_8_1.A5` (4.12.5), the ax+b group via `SemidirectProduct` (4.12.6), and finite
+subgroups of SO(3)/SU(2) (4.12.8, reuse `Problem4_12_7`'s SU(2)/SO(3) modelling).
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -2582,8 +2582,8 @@
     "end_page": "66",
     "start_line": 9,
     "end_line": 10,
-    "status": "not_formalized",
-    "coverage_note": "No Lean formalization on origin/main (re-derived 2026-07-02; prior 'sorry_free' was vacuous)."
+    "status": "statement_formalized",
+    "coverage_note": "Statement in EtingofRepresentationTheory/Chapter4/Exercise4_3_1.lean (right-regular rep of QuaternionGroup 2; covariant subspace invariant + finrank 2 + irreducible; sorry proofs, statement pass)."
   },
   {
     "id": "Chapter4/Example4.3_S4",
@@ -3020,8 +3020,8 @@
     "end_page": "83",
     "start_line": 9,
     "end_line": 14,
-    "status": "not_formalized",
-    "coverage_note": "No Lean formalization on origin/main (re-derived 2026-07-02; prior 'sorry_free' was vacuous)."
+    "status": "statement_formalized",
+    "coverage_note": "Statement in EtingofRepresentationTheory/Chapter4/Problem4_12_1.lean (DihedralGroup N: (a) every irreducible is 1- or 2-dim; (b) V⊗V decomposition as character identity χ_V²=1+χ_sign+χ_V2; sorry proofs, statement pass)."
   },
   {
     "id": "Chapter4/Problem4.12.2",
@@ -3129,8 +3129,8 @@
     "end_page": "88",
     "start_line": 9,
     "end_line": 12,
-    "status": "not_formalized",
-    "coverage_note": "No Lean formalization on origin/main (re-derived 2026-07-02; prior 'sorry_free' was vacuous)."
+    "status": "statement_formalized",
+    "coverage_note": "Statement in EtingofRepresentationTheory/Chapter4/Problem4_12_11.lean (SO(3) conjugation on End(ℝ³): scalar/skew/traceless-symmetric decomposition, S²V=ℝ⊕W, irreducibility of V,W, Hooke's law f(x+y)=Kx+μy; sorry proofs, statement pass)."
   },
   {
     "id": "Chapter4/Discussion_4.13",


### PR DESCRIPTION
This PR add faithful Lean statement passes (with `sorry` proofs) for three Chapter 4 exercises: Exercise 4.3.1 realizes the 2-dimensional irreducible representation of `Q₈` inside the covariant function space (right-regular representation, with the subspace shown invariant, 2-dimensional, and irreducible); Problem 4.12.1 covers the dihedral group `DihedralGroup N` — every irreducible complex representation is 1- or 2-dimensional, and `V ⊗ V` decomposes via the character identity `χ_V² = 1 + χ_sign + χ_{V₂}`; and Problem 4.12.11 formalizes the elasticity-theory decomposition of `End(ℝ³)` under `SO(3)` (scalar + skew + traceless-symmetric, `S²V = ℝ ⊕ W`, dimensions 1/3/5, irreducibility of `V` and `W`, and Hooke's law `f(x+y) = Kx + μy` with symmetric stress tensor).

All supporting definitions are genuinely constructed; `sorry` appears only in theorem bodies, as expected for a statement pass. The remaining 5 Chapter 4 problems (4.12.2, 4.12.5, 4.12.6, 4.12.8, 4.12.9) are tracked by #5904.

Closes #5898

🤖 Prepared with Claude Code