### PR TITLE
feat: statement pass for Exercise 5.27.2 (dihedral + Heisenberg)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5.lean
+++ b/EtingofRepresentationTheory/Chapter5.lean
@@ -224,6 +224,8 @@ import EtingofRepresentationTheory.Chapter5.Problem5_16_3
 import EtingofRepresentationTheory.Chapter5.Problem5_24_1
 import EtingofRepresentationTheory.Chapter5.Problem5_24_2
 import EtingofRepresentationTheory.Chapter5.Exercise5_27_2_Affine
+import EtingofRepresentationTheory.Chapter5.Exercise5_27_2_Dihedral
+import EtingofRepresentationTheory.Chapter5.Exercise5_27_2_Heisenberg
 import EtingofRepresentationTheory.Chapter5.Exercise5_27_3
 
 /-! # Chapter 5: Representations of the Symmetric Group -/

--- a/EtingofRepresentationTheory/Chapter5/Exercise5_27_2_Dihedral.lean
+++ b/EtingofRepresentationTheory/Chapter5/Exercise5_27_2_Dihedral.lean
@@ -1,0 +1,76 @@
+import Mathlib
+import EtingofRepresentationTheory.Chapter5.Theorem5_27_1
+
+/-!
+# Exercise 5.27.2 (dihedral group): redo Problem 4.12.1(a) using Theorem 5.27.1
+
+**Exercise 5.27.2.** Redo Problems 4.12.1(a), 4.12.2, and 4.12.6 using Theorem 5.27.1.
+
+This file handles the **Problem 4.12.1(a)** part: describe all irreducible complex
+representations of the dihedral group `D_N`, the symmetry group of a regular `N`-gon (order
+`2N`), distinguishing the cases of odd and even `N`.
+
+## The dihedral group as a semidirect product
+
+`D_N = ⟨r, s | rᴺ = s² = 1, s r s⁻¹ = r⁻¹⟩` is the semidirect product of the cyclic rotation
+group `A = ⟨r⟩ ≅ ℤ/N` (abelian, normal) by the order-two reflection group `G = ⟨s⟩ ≅ ℤ/2`,
+where `s` acts on `A` by inversion `r ↦ r⁻¹`. So `Theorem 5.27.1` (the orbit method for
+`A ⋊ G` with `A` abelian) applies with `A = Multiplicative (ZMod N)`, `G = Multiplicative
+(ZMod 2)`, and `φ` sending the reflection to the inversion automorphism.
+
+We state the classification for Mathlib's `DihedralGroup N` (the concrete group of `N`-gon
+symmetries); the docstrings record how Theorem 5.27.1 produces it. The dual `G`-action on
+`Â = A →* ℂˣ ≅ ℤ/N` is again inversion `χ ↦ χ⁻¹`, so the orbits are:
+
+* the fixed characters (`χ = χ⁻¹`), whose stabilizer is all of `G`; each contributes two
+  `1`-dimensional irreducibles (one per character of `G ≅ ℤ/2`);
+* the free orbit-pairs `{χ, χ⁻¹}` with `χ ≠ χ⁻¹`, whose stabilizer is trivial; each
+  contributes one `2`-dimensional irreducible `V(χ, U)` of dimension `[G : G_χ] = 2`.
+
+The number of fixed characters is `gcd(2, N)`: for `N` odd only `χ = 1` is fixed (one
+character, two `1`-dim irreps), and for `N` even both `χ = 1` and the order-two character
+are fixed (two characters, four `1`-dim irreps). The remaining `N - gcd(2,N)` nontrivial
+characters split into `(N - gcd(2,N))/2` free orbit-pairs, giving that many `2`-dimensional
+irreducibles.
+
+## The classification (Problem 4.12.1(a))
+
+* `N` odd: `2` irreducibles of dimension `1` and `(N-1)/2` of dimension `2`
+  (`∑ dim² = 2 + 4·(N-1)/2 = 2N`);
+* `N` even: `4` irreducibles of dimension `1` and `(N-2)/2` of dimension `2`
+  (`∑ dim² = 4 + 4·(N-2)/2 = 2N`).
+
+Statement pass: the classification is stated; the proof is left as `sorry`.
+-/
+
+noncomputable section
+
+open CategoryTheory Module
+
+namespace Etingof.Exercise5_27_2
+
+variable (N : ℕ) [NeZero N]
+
+open Classical in
+/-- **Exercise 5.27.2 for Problem 4.12.1(a).** The complete classification of the irreducible
+complex representations of the dihedral group `D_N` (symmetries of a regular `N`-gon, order
+`2N`), obtained from Theorem 5.27.1 via the semidirect-product structure `⟨r⟩ ⋊ ⟨s⟩` with `s`
+acting by inversion. Every irreducible has dimension `1` or `2`, and the number of each kind
+depends on the parity of `N`: for `N` odd there are `2` of dimension `1` and `(N-1)/2` of
+dimension `2`; for `N` even there are `4` of dimension `1` and `(N-2)/2` of dimension `2`.
+In both cases `∑ dim² = 2N = |D_N|`. -/
+theorem dihedral_classification :
+    ∃ (n : ℕ) (W : Fin n → FDRep ℂ (DihedralGroup N)),
+      (∀ i, Simple (W i)) ∧
+      (∀ i j, Nonempty (W i ≅ W j) → i = j) ∧
+      (∀ S : FDRep ℂ (DihedralGroup N), Simple S → ∃ i, Nonempty (S ≅ W i)) ∧
+      (∀ i, finrank ℂ (W i : Type) = 1 ∨ finrank ℂ (W i : Type) = 2) ∧
+      (Odd N →
+        (Finset.univ.filter (fun i => finrank ℂ (W i : Type) = 1)).card = 2 ∧
+        (Finset.univ.filter (fun i => finrank ℂ (W i : Type) = 2)).card = (N - 1) / 2) ∧
+      (Even N →
+        (Finset.univ.filter (fun i => finrank ℂ (W i : Type) = 1)).card = 4 ∧
+        (Finset.univ.filter (fun i => finrank ℂ (W i : Type) = 2)).card = (N - 2) / 2) := by
+  sorry
+
+end Etingof.Exercise5_27_2

--- a/EtingofRepresentationTheory/Chapter5/Exercise5_27_2_Heisenberg.lean
+++ b/EtingofRepresentationTheory/Chapter5/Exercise5_27_2_Heisenberg.lean
@@ -1,0 +1,144 @@
+import Mathlib
+import EtingofRepresentationTheory.Chapter5.Theorem5_27_1
+
+/-!
+# Exercise 5.27.2 (Heisenberg group): redo Problem 4.12.2 using Theorem 5.27.1
+
+**Exercise 5.27.2.** Redo Problems 4.12.1(a), 4.12.2, and 4.12.6 using Theorem 5.27.1.
+
+This file handles the **Problem 4.12.2** part: classify all irreducible complex
+representations of the Heisenberg group `H_p` — the group of `3 × 3` upper unitriangular
+matrices over `𝔽_p` (order `p³`).
+
+## The Heisenberg group as a semidirect product
+
+Writing a unitriangular matrix by its strict-upper entries `(a, b, c)` (positions `(1,2)`,
+`(2,3)`, `(1,3)`), the product is `(a,b,c)·(a',b',c') = (a+a', b+b', c+c'+a·b')`. The
+subgroup `A = {(0, b, c)}` is abelian and normal (order `p²`), with complement
+`G = {(a, 0, 0)}` (order `p`); conjugation by `(a,0,0)` sends `(0,b,c) ↦ (0, b, c + a·b)`.
+Thus
+
+`H_p = A ⋊[φ] G`, with `A = Multiplicative (ZMod p × ZMod p)`, `G = Multiplicative (ZMod p)`,
+
+and `φ a` the shear automorphism `(b, c) ↦ (b, c + a·b)` of `A`. Because `A` is abelian,
+**Theorem 5.27.1** (the orbit method) applies directly.
+
+## The classification (orbit method, Theorem 5.27.1)
+
+The dual `G`-action on `Â = A →* ℂˣ ≅ (ℤ/p)²` sends the character indexed by `(β, γ)` to
+the one indexed by `(β - a·γ, γ)`. Hence:
+
+* **Fixed characters** are those with `γ = 0` (there are `p` of them), each with stabilizer
+  all of `G`; over each, Theorem 5.27.1 gives one irreducible `V(χ, U)` per irreducible `U`
+  of `G ≅ ℤ/p`, i.e. `p` one-dimensional characters. This yields `p · p = p²`
+  one-dimensional irreducibles — exactly the characters of `H_p`, which factor through the
+  abelianization `H_p / Z(H_p) ≅ (ℤ/p)²`.
+* **Free orbits** are indexed by `γ ≠ 0` (there are `p - 1`), each of size `p` with trivial
+  stabilizer; over each, Theorem 5.27.1 gives a single irreducible `V(χ, U)` of dimension
+  `[G : G_χ] = p`. These are the `p - 1` representations `R_z` (`z ≠ 1`) of Problem 4.12.2.
+
+So there are exactly `p² + (p - 1)` irreducibles: `p²` of dimension `1` and `p - 1` of
+dimension `p`, consistent with `∑ dim² = p²·1 + (p-1)·p² = p³ = |H_p|`.
+
+Statement pass: the group and its semidirect structure are constructed; the classification
+is stated with the proof left as `sorry`.
+-/
+
+noncomputable section
+
+open CategoryTheory Module
+
+namespace Etingof.Exercise5_27_2
+
+variable (p : ℕ) [Fact p.Prime]
+
+/-- The shear automorphism `(b, c) ↦ (b, c + a·b)` of the abelian translation group
+`Multiplicative (ZMod p × ZMod p)`, realized directly as a multiplicative automorphism. -/
+def heisenbergShear (a : ZMod p) : MulAut (Multiplicative (ZMod p × ZMod p)) where
+  toFun x := Multiplicative.ofAdd
+    ((Multiplicative.toAdd x).1, (Multiplicative.toAdd x).2 + a * (Multiplicative.toAdd x).1)
+  invFun x := Multiplicative.ofAdd
+    ((Multiplicative.toAdd x).1, (Multiplicative.toAdd x).2 - a * (Multiplicative.toAdd x).1)
+  left_inv x := by
+    apply Multiplicative.toAdd.injective; apply Prod.ext
+    · rfl
+    · show (Multiplicative.toAdd x).2 + a * (Multiplicative.toAdd x).1
+        - a * (Multiplicative.toAdd x).1 = (Multiplicative.toAdd x).2
+      ring
+  right_inv x := by
+    apply Multiplicative.toAdd.injective; apply Prod.ext
+    · rfl
+    · show (Multiplicative.toAdd x).2 - a * (Multiplicative.toAdd x).1
+        + a * (Multiplicative.toAdd x).1 = (Multiplicative.toAdd x).2
+      ring
+  map_mul' x y := by
+    apply Multiplicative.toAdd.injective; apply Prod.ext
+    · rfl
+    · show ((Multiplicative.toAdd x).2 + (Multiplicative.toAdd y).2)
+          + a * ((Multiplicative.toAdd x).1 + (Multiplicative.toAdd y).1)
+        = ((Multiplicative.toAdd x).2 + a * (Multiplicative.toAdd x).1)
+          + ((Multiplicative.toAdd y).2 + a * (Multiplicative.toAdd y).1)
+      ring
+
+@[simp] lemma heisenbergShear_zero : heisenbergShear p 0 = 1 := by
+  refine MulEquiv.ext fun x => ?_
+  rw [MulAut.one_apply]
+  apply Multiplicative.toAdd.injective
+  show ((Multiplicative.toAdd x).1, (Multiplicative.toAdd x).2 + 0 * (Multiplicative.toAdd x).1)
+      = Multiplicative.toAdd x
+  apply Prod.ext
+  · rfl
+  · show (Multiplicative.toAdd x).2 + 0 * (Multiplicative.toAdd x).1 = (Multiplicative.toAdd x).2
+    ring
+
+lemma heisenbergShear_add (a a' : ZMod p) :
+    heisenbergShear p (a + a') = heisenbergShear p a * heisenbergShear p a' := by
+  refine MulEquiv.ext fun x => ?_
+  rw [MulAut.mul_apply]
+  apply Multiplicative.toAdd.injective
+  show ((Multiplicative.toAdd x).1, (Multiplicative.toAdd x).2 + (a + a') * (Multiplicative.toAdd x).1)
+      = ((Multiplicative.toAdd x).1,
+          (Multiplicative.toAdd x).2 + a' * (Multiplicative.toAdd x).1 + a * (Multiplicative.toAdd x).1)
+  apply Prod.ext
+  · rfl
+  · show (Multiplicative.toAdd x).2 + (a + a') * (Multiplicative.toAdd x).1
+        = (Multiplicative.toAdd x).2 + a' * (Multiplicative.toAdd x).1
+          + a * ((Multiplicative.toAdd x).1)
+    ring
+
+/-- The `G`-action on the abelian normal subgroup `A` of the Heisenberg group: the
+multiplicative element `a ∈ G = Multiplicative (ZMod p)` acts by the shear `φ a`. -/
+def heisenbergφ : Multiplicative (ZMod p) →* MulAut (Multiplicative (ZMod p × ZMod p)) where
+  toFun a := heisenbergShear p (Multiplicative.toAdd a)
+  map_one' := by
+    show heisenbergShear p (0 : ZMod p) = 1
+    exact heisenbergShear_zero p
+  map_mul' a a' := by
+    show heisenbergShear p (Multiplicative.toAdd a + Multiplicative.toAdd a')
+      = heisenbergShear p (Multiplicative.toAdd a) * heisenbergShear p (Multiplicative.toAdd a')
+    exact heisenbergShear_add p _ _
+
+/-- The **Heisenberg group** `H_p` over `𝔽_p`, realized as the semidirect product of its
+abelian normal subgroup `A = (ℤ/p)²` by `G = ℤ/p` acting by the shear `φ`. -/
+abbrev HeisenbergGroup : Type := Multiplicative (ZMod p × ZMod p) ⋊[heisenbergφ p] Multiplicative (ZMod p)
+
+open Classical in
+/-- **Exercise 5.27.2 for Problem 4.12.2.** The complete classification of the irreducible
+complex representations of the Heisenberg group `H_p` (order `p³`), obtained from Theorem
+5.27.1 via the semidirect-product structure `(ℤ/p)² ⋊ ℤ/p`: there are exactly `p² + (p-1)`
+pairwise non-isomorphic irreducibles forming a complete set, of which `p²` have dimension `1`
+(the characters factoring through the abelianization `(ℤ/p)²`) and `p - 1` have dimension `p`
+(the representations `R_z`, `z ≠ 1`, over the free orbits). Every irreducible has dimension
+`1` or `p`, and `∑ dim² = p²·1 + (p-1)·p² = p³ = |H_p|`. -/
+theorem heisenberg_classification :
+    ∃ (n : ℕ) (W : Fin n → FDRep ℂ (HeisenbergGroup p)),
+      (∀ i, Simple (W i)) ∧
+      (∀ i j, Nonempty (W i ≅ W j) → i = j) ∧
+      (∀ S : FDRep ℂ (HeisenbergGroup p), Simple S → ∃ i, Nonempty (S ≅ W i)) ∧
+      (∀ i, finrank ℂ (W i : Type) = 1 ∨ finrank ℂ (W i : Type) = p) ∧
+      n = p ^ 2 + (p - 1) ∧
+      (Finset.univ.filter (fun i => finrank ℂ (W i : Type) = 1)).card = p ^ 2 ∧
+      (Finset.univ.filter (fun i => finrank ℂ (W i : Type) = p)).card = p - 1 := by
+  sorry
+
+end Etingof.Exercise5_27_2

--- a/progress/2026-07-06T13-07-56Z_a485c215.md
+++ b/progress/2026-07-06T13-07-56Z_a485c215.md
@@ -1,0 +1,50 @@
+## Accomplished
+
+Statement pass for **Exercise 5.27.2** (issue #5920, one-shot dispatch), completing the two
+sub-cases that were still `not_formalized` (the affine case 4.12.6 already landed in #5949):
+
+- **`Chapter5/Exercise5_27_2_Dihedral.lean`** (Problem 4.12.1(a)): irreducible
+  classification of the dihedral group `D_N`, stated for Mathlib's `DihedralGroup N`. Records
+  the semidirect structure `⟨r⟩ ⋊ ⟨s⟩` (`s` acting by inversion) that makes Theorem 5.27.1
+  apply, and states the parity-split count (N odd: two dim-1 and `(N-1)/2` dim-2; N even: four
+  dim-1 and `(N-2)/2` dim-2), plus that every irreducible has dimension 1 or 2. `sorry` proof.
+- **`Chapter5/Exercise5_27_2_Heisenberg.lean`** (Problem 4.12.2): constructs the Heisenberg
+  group over `𝔽_p` as the semidirect product `(ℤ/p)² ⋊[φ] ℤ/p`, where `φ` is the shear
+  automorphism `(b,c) ↦ (b, c+a·b)` — fully constructed (`heisenbergShear`, `heisenbergφ`),
+  no sorried definitions. States the orbit-method classification: `p²` irreducibles of
+  dimension 1 and `p−1` of dimension `p`, `n = p² + (p−1)`, every irreducible of dim 1 or `p`.
+  `sorry` proof of the classification theorem only.
+
+Both files build (`sorry` warnings only). Added both to the `Chapter5.lean` aggregator and
+set `progress/items.json` `Chapter5/Exercise5.27.2` → `statement_formalized`.
+
+## Current frontier
+
+`Chapter5/Problem5.11.1` (A₅ induction catalogue) remains `not_formalized`. This is the last
+item of #5920's original scope and is genuinely a larger, separate piece.
+
+Key discovery for the next agent: the **A₅ irreducible catalogue already exists** in
+`EtingofRepresentationTheory/Chapter4/Example4_8_1/A5Golden.lean`:
+`Etingof.Example4_8_1.A5.irrepA5 : Fin 5 → FDRep ℂ (alternatingGroup (Fin 5))`
+`= ![repTriv, repC3plus, repC3minus, repC4, repC5]` (dims 1,3,3,4,5), with `irrepA5_simple`,
+`irrepA5_character_book`, `irrepA5_pairwise`, plus `Example4_8_1_A5_conj_classes = 5` and
+`Example4_8_1_A5_card = 60`. A faithful Problem 5.11.1 statement can build directly on these:
+realize `Z₂, Z₃, Z₅, A₄, V₄` as subgroups of `A₅`, form the induced reps, and state the
+decomposition multiplicities into `irrepA5` (via Frobenius reciprocity character scalar
+products, exactly as `Discussion5_11_S4S3.lean` does for the S₄/S₃ case).
+
+## Overall project progress
+
+Phase 3 statement pass, Chapter 5 exercise backlog. Exercise 5.27.2 now fully
+statement-formalized across three files. Only Problem 5.11.1 remains open in the Chapter 5
+exercise-backlog for #5920.
+
+## Next step
+
+Formalize `Chapter5/Problem5.11.1` as its own file `Chapter5/Problem5_11_1.lean`, reusing the
+existing `irrepA5` catalogue and the S₄/S₃ Frobenius-reciprocity pattern in
+`Discussion5_11_S4S3.lean`. Tracked by #5929 (whose remaining scope is now just 5.11.1).
+
+## Blockers
+
+None. Problem 5.11.1 is deferred as a separate work item, not blocked.

--- a/progress/items.json
+++ b/progress/items.json
@@ -5219,8 +5219,8 @@
     "end_page": "147",
     "start_line": 15,
     "end_line": 16,
-    "status": "not_formalized",
-    "coverage_note": "No Lean formalization on origin/main (re-derived 2026-07-02; prior 'sorry_free' was vacuous)."
+    "status": "statement_formalized",
+    "coverage_note": "Statement pass across three files, each redoing one Problem via Theorem 5.27.1. (4.12.6) Exercise5_27_2_Affine.lean: affine ax+b group over a finite field as Multiplicative K rtimes Kˣ, q irreducibles (q-1 of dim 1, one of dim q-1). (4.12.1(a)) Exercise5_27_2_Dihedral.lean: dihedral D_N (Mathlib DihedralGroup) as ZMod N rtimes ZMod 2 via inversion; classification by parity (N odd: two dim-1, (N-1)/2 dim-2; N even: four dim-1, (N-2)/2 dim-2). (4.12.2) Exercise5_27_2_Heisenberg.lean: Heisenberg group over F_p constructed as (ZMod p x ZMod p) rtimes ZMod p via the shear automorphism; p^2 irreducibles of dim 1 and p-1 of dim p. All sorry proofs."
   },
   {
     "id": "Chapter5/Exercise5.27.3",


### PR DESCRIPTION
This PR completes the statement pass for Exercise 5.27.2 (redo Problems 4.12.1(a), 4.12.2, 4.12.6 using Theorem 5.27.1) by adding the two sub-cases that were still unformalized; the affine case (4.12.6) already landed in #5949.

- `Exercise5_27_2_Dihedral.lean` (Problem 4.12.1(a)): irreducible classification of the dihedral group `D_N`, stated for Mathlib's `DihedralGroup N`, with the parity-split counts (N odd: two dim-1 and (N-1)/2 dim-2; N even: four dim-1 and (N-2)/2 dim-2) and the constraint that every irreducible has dimension 1 or 2. The docstring records the semidirect structure that makes Theorem 5.27.1 apply.
- `Exercise5_27_2_Heisenberg.lean` (Problem 4.12.2): constructs the Heisenberg group over `F_p` as the semidirect product `(ZMod p × ZMod p) ⋊ ZMod p` via the shear automorphism (fully constructed, no sorried definitions), and states the orbit-method classification: p² irreducibles of dimension 1 and p-1 of dimension p.

Both build with `sorry` proofs only (statement pass). Sets `Chapter5/Exercise5.27.2` to `statement_formalized`.

Partial for #5920: Problem 5.11.1 (A₅ induction catalogue) remains and is tracked by #5929; the progress file points the next agent at the existing `irrepA5` A₅ catalogue in `Chapter4/Example4_8_1/A5Golden.lean`.

🤖 Prepared with Claude Code