### PR TITLE
doc(skill): guard reset --hard against uncommitted worktree edits

### DIFF
--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -134,6 +134,15 @@ open PR on it first (`gh pr list --head agent/<id>`). If a PR exists, create
 a new branch with a suffix (`agent/<id>-v2`). If no PR exists, reset it to
 master: `git checkout agent/<id> && git reset --hard origin/master`.
 
+**Before that `reset --hard`, run `git status --short` first.** A reused
+worktree may carry uncommitted working-tree edits left by a prior session
+(e.g. half-finished skill/command tweaks) — `reset --hard` discards these
+unrecoverably. If you see any, `git diff` them: they are almost always
+disposable cruft the reset is meant to clear, but confirm they are not
+unpushed work before discarding. If they look worth keeping, commit them to
+a throwaway branch (`git stash` is banned in the home repo but fine here) so
+the next session can recover them.
+
 Record any project-specific quality metrics (e.g. sorry count, test coverage)
 as described in the project's CLAUDE.md.
 

--- a/progress/2026-07-07T21-20-56Z_f26d8ae2.md
+++ b/progress/2026-07-07T21-20-56Z_f26d8ae2.md
@@ -1,0 +1,36 @@
+## Accomplished
+Claimed issue #5923 (Statement pass: Chapter 3 Problem 3.8.4, Noether-Deuring / scalar
+extension). On orientation, found the issue's deliverables were **already fully landed** by
+merged PR #5940 (commit `33c2d60c`, in `origin/main`):
+
+- `EtingofRepresentationTheory/Chapter3/Problem3_8_4.lean` exists with faithful statements for
+  both parts: `iso_of_baseChange_iso` (part i) and `directSummand_of_baseChange_directSummand`
+  (part ii, Noether-Deuring), each with a `sorry` proof body (statement pass, as required).
+- Base-change module infrastructure is genuinely constructed (`rep`/`repTensor`/`bcMod`:
+  `L ⊗[K] V` as an `L ⊗[K] A`-module via `Module.End.baseChangeHom` + `AlgHom.liftEquiv` +
+  `Module.compHom` — no sorry'd def bodies).
+- The file is already in the `Chapter3.lean` aggregator.
+- `progress/items.json` status for `Chapter3/Problem3.8.4` is already `statement_formalized`,
+  `fidelity: verified`.
+
+Verified `lake build EtingofRepresentationTheory.Chapter3.Problem3_8_4` succeeds with only the
+two expected `sorry` warnings (lines 66, 76). A prior session had already left a comment on
+#5923: "Fully covered by #5940 ... Safe to close once #5940 merges." #5940 is now MERGED.
+
+Closed #5923 as completed with a link to #5940. No code changes were needed.
+
+## Current frontier
+Chapter 3 statement pass is complete. Remaining open statement-pass issues are for other
+chapters (#5894 Ch2, #5902/#5907/#5924 Ch8, #5904 Ch4, #5910 Ch5, #5914/#5932 Ch9).
+
+## Overall project progress
+Stage 3 (formalization) statement-pass phase, in progress across chapters. Chapter 3 exercises
+(incl. 3.8.4) are all `statement_formalized`.
+
+## Next step
+Pick another unclaimed statement-pass issue (e.g. #5894 Chapter 2 remaining exercises, or a
+Chapter 8/9 homological item). No follow-up needed for 3.8.4 beyond a future proof phase, which
+is explicitly out of scope for these statement-pass issues.
+
+## Blockers
+None.


### PR DESCRIPTION
This PR adds a safety check to the `agent-worker-flow` skill's Step 2 branch-reset instruction so agents inspect uncommitted working-tree changes with `git status --short` / `git diff` before running `git reset --hard origin/master` on a reused worktree.

Reused pod worktrees can carry uncommitted edits left by a prior session (for example, half-finished skill or command tweaks). The existing instruction discarded them unrecoverably. The added guidance has the agent inspect and, if the changes look like unpushed work, preserve them on a throwaway branch before discarding.

Also records the progress handoff for the #5923 turn: that issue's deliverables (statement pass for Problem 3.8.4, Noether-Deuring) were already fully landed by merged PR #5940, so #5923 was verified and closed as complete with no code change.

🤖 Prepared with Claude Code