### PR TITLE
chore: close stale Ch2 issue #5894 + skill guidance for already-complete issues

### DIFF
--- a/progress/2026-07-07T21-24-42Z_13a3d53b.md
+++ b/progress/2026-07-07T21-24-42Z_13a3d53b.md
@@ -1,0 +1,22 @@
+## Accomplished
+Claimed feature issue #5894 (statement pass for the remaining open-ended Chapter 2 exercises). During assumption-verification (Step 4), found the issue was **stale**: all 12 listed exercises were already formalized on `main` with faithful `sorry`-proof statements, imported in the `Chapter2.lean` aggregator, and marked `statement_formalized`/`sorry_free` in `progress/items.json`.
+
+Verified:
+- All 12 `EtingofRepresentationTheory/Chapter2/*.lean` files exist and are tracked/committed on `main`.
+- `lake build EtingofRepresentationTheory.Chapter2` succeeds (only pre-existing copyright/header linter warnings in the aggregator).
+- No `True` / vacuous placeholders in any of the 12 files.
+- The work landed under sibling issues/PRs: #5917 (2.7.4, 2.8.11, 2.11.2, 2.11.5, 2.16.2, 2.16.3, 2.16.4), #5938 (2.7.5, 2.8.6, 2.16.5), #5947 (2.9.5, 2.11.7). #5894 was never auto-closed because those PRs did not carry `Closes #5894`.
+
+Closed #5894 as already-complete with a per-exercise verification table, and removed its stale `claimed` label. No code changes required.
+
+## Current frontier
+Chapter 2 statement pass is complete. No new Lean written this turn.
+
+## Overall project progress
+Stage 3 (statement pass) ongoing across chapters. Chapter 2 open-ended exercises now fully accounted for (all `statement_formalized` or better). Remaining unclaimed statement-pass work: Chapters 4, 5, 7, 8, 9 (issues #5902, #5904, #5907, #5910, #5914, #5924, #5932).
+
+## Next step
+Pick up the next oldest unclaimed feature issue. #5904 (Chapter 4, 9 deep exercises) or #5910 (Chapter 5, 8 exercises) are the largest; #5902/#5907/#5914 are smaller and infrastructure-scoped. A worker should re-verify each issue's `not_formalized` assumption against `items.json` first — this turn showed the queue can contain already-satisfied issues.
+
+## Blockers
+None.


### PR DESCRIPTION
This PR records that issue #5894's deliverables were already satisfied on `main` and adds worker-flow guidance to prevent the same wasted claim recurring.

All 12 open-ended Chapter 2 exercises listed in #5894 were already formalized with faithful `sorry`-proof statements via sibling PRs #5917, #5938, and #5947. Verified: files present under `EtingofRepresentationTheory/Chapter2/`, wired into the `Chapter2.lean` aggregator, `lake build EtingofRepresentationTheory.Chapter2` succeeds, and no `True` placeholders. #5894 was closed as already-complete.

The `agent-worker-flow` skill's Step 4 previously only covered "stale -> `skip` (replan)", which would wrongly re-queue finished work. This adds an "already complete != stale" note: verify `items.json`/target files first and close such issues directly rather than replanning them.

🤖 Prepared with Claude Code