### PR TITLE
doc(command): teach /feature to detect already-landed statement-pass work

### DIFF
--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -12,6 +12,22 @@ to implementation sessions.
 Use `coordination list-unclaimed --label feature` to find work for this session type.
 The priority order in the worker skill still applies — check for PR-fix issues first.
 
+## Check for Already-Landed Work First
+
+Statement-pass and formalization issues frequently go **stale**: their exact
+deliverables land via *other* PRs between issue creation and your claim. Before
+writing any code, cheaply confirm the work is still needed:
+
+- Check `progress/items.json` status for each item id the issue lists.
+- Check whether the target `.lean` files already exist and are wired into the
+  chapter aggregator (`grep` the item's file in `Chapter<N>.lean`).
+- If already present, confirm with `git log origin/main -- <file>` and a chapter build.
+
+If every deliverable is already `statement_formalized`/present on `main`, the
+issue is **complete, not skippable**. Close it with `gh issue close <N> --comment`
+pointing at the merged PRs (per the worker skill's "no code changes" path) — do
+**not** `coordination skip` (that routes to replan for work that no longer exists).
+
 ## Executing Implementation Work
 
 Follow the plan's deliverables. For new implementations, follow the development

--- a/progress/2026-07-07T21-29-03Z_bb8eaf1c.md
+++ b/progress/2026-07-07T21-29-03Z_bb8eaf1c.md
@@ -1,0 +1,44 @@
+## Accomplished
+
+Claimed feature issue **#5904** (statement pass: remaining 9 Chapter 4 exercises)
+and found it **already fully satisfied** — no code changes required.
+
+All nine listed exercises are `statement_formalized` in `progress/items.json`, have
+substantial files under `EtingofRepresentationTheory/Chapter4/`, are wired into the
+`Chapter4.lean` aggregator, and were landed on `main` by other agents across four
+merged PRs since #5904 was authored:
+
+- `Chapter4/Exercise4.3.1`, `Problem4.12.1`, `Problem4.12.11` → PR #5943 (ddac0127)
+- `Chapter4/Problem4.12.2`, `4.12.6`, `4.12.8`, `4.12.9` → PR #5950 (07eecb43)
+- `Chapter4/Problem4.12.5` → PR #5954 (bb312aca)
+- `Chapter4/Problem4.12.7` → PR #5937 (da007b28)
+
+Verified `lake build EtingofRepresentationTheory.Chapter4` succeeds with **0 errors**
+(only expected `sorry` + style-lint warnings).
+
+Closed #5904 as already-complete with a comment pointing to the four PRs.
+
+## Current frontier
+
+Chapter 4 exercise statement pass is complete. No Chapter 4 statement-pass work remains
+in the queue.
+
+## Overall project progress
+
+Stage 3 / statement-pass backlog. Chapter 4 exercises fully statement-formalized.
+Remaining unclaimed statement-pass issues at claim time: #5902 (Ch7, Künneth +
+reflection-functor categorification), #5907 (Ch8 Tor/Ext), #5910 (Ch5 heavy infra),
+#5914 (Ch9 — 9.4.6 already landed, 9.6.5 definition-blocked), #5932 (Ch9 9.6.5,
+copower/tensoring-over-B infrastructure blocked).
+
+## Next step
+
+A worker should pick up #5907 (Ch8) or #5910 (Ch5). Note #5914 is stale: its 9.4.6
+part already landed and 9.6.5 is duplicated by #5932 — a planner should narrow or
+close #5914.
+
+## Blockers
+
+None for this issue (it was already complete). The remaining Ch9 issues (#5914, #5932)
+are blocked on copower/tensoring-over-B infrastructure that must be constructed before
+Problem 9.6.5's functor `G` can be defined.


### PR DESCRIPTION
This PR adds a cheap up-front staleness check to the `/feature` command so a worker recognizes when a statement-pass issue's deliverables have already landed via other PRs.

The gap surfaced while working issue #5904 (statement pass for nine Chapter 4 exercises): all nine were already `statement_formalized` on `main`, landed across #5943, #5950, #5954, and #5937 between the issue's creation and its claim. The worker skill's Step 4 frames file-existence checks as detecting restructuring, not already-complete deliverables, so the pattern is easy to miss. The added note directs a worker to check `progress/items.json` status and target-file existence first, and to close an already-complete issue (rather than `coordination skip`, which mis-routes to replan for work that no longer exists).

Also includes the progress handoff recording the #5904 no-op close.

🤖 Prepared with Claude Code