### PR TITLE
feat(Ch8): state Tor long exact sequences and balancing for Problem 8.2.6

### DIFF
--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_6.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_6.lean
@@ -105,4 +105,23 @@ theorem Problem_8_2_6_v_ext
     (Abelian.Ext.contravariantSequence hS N n₀ n₁ h).Exact := by
   sorry
 
+/-- **Problem 8.2.6(v), `Tor`.** A short exact sequence `S : 0 → M₁ → M₂ → M₃ → 0` of right
+`A`-modules (objects of `ModuleCat Aᵐᵒᵖ`) induces, for each left `A`-module `N` and each
+`n₀ + 1 = n₁`, a connecting homomorphism `δ : Torₙ₁(M₃, N) → Torₙ₀(M₁, N)` making the six-term
+homology window
+`Torₙ₁(M₁,N) → Torₙ₁(M₂,N) → Torₙ₁(M₃,N) →[δ] Torₙ₀(M₁,N) → Torₙ₀(M₂,N) → Torₙ₀(M₃,N)`
+exact. The horizontal maps are the first-argument functoriality of `Etingof.TorFunctor`
+(the `n`-th left derived functor of `- ⊗_A N`); splicing these windows over all `n` gives the
+book's long exact `Tor` sequence in the first argument. Existence of `δ` is part of the claim. -/
+theorem Problem_8_2_6_v_tor
+    (A : Type u) [Ring A] (N : Type u) [AddCommGroup N] [Module A N]
+    {S : ShortComplex (ModuleCat.{u} Aᵐᵒᵖ)} (hS : S.ShortExact)
+    (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+    ∃ δ : (Etingof.TorFunctor A N n₁).obj S.X₃ ⟶ (Etingof.TorFunctor A N n₀).obj S.X₁,
+      (ComposableArrows.mk₅
+        ((Etingof.TorFunctor A N n₁).map S.f) ((Etingof.TorFunctor A N n₁).map S.g)
+        δ
+        ((Etingof.TorFunctor A N n₀).map S.f) ((Etingof.TorFunctor A N n₀).map S.g)).Exact := by
+  sorry
+
 end Etingof

--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_6.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_6.lean
@@ -18,9 +18,7 @@ import Mathlib.Algebra.Category.ModuleCat.Ext.HasExt
 
 ## What is formalized here
 
-Parts **(i)**, **(ii)**, the **`Ext` long exact sequence of (iii)** (covariant, second
-argument) and the **`Ext` long exact sequence of (v)** (contravariant, first argument) are
-stated below.
+All parts (i)–(v) are stated below, for both the `Ext` and `Tor` sides.
 
 * (i) uses `Etingof.Tor` / `Etingof.tensorOver` (Definition 8.2.3) for the `Tor₀` half and
   `Etingof.Ext` (Definition 8.2.4) with `Abelian.Ext.addEquiv₀` for the `Ext⁰` half.
@@ -29,12 +27,20 @@ stated below.
 * The `Ext` long exact sequences of (iii) and (v) are `Abelian.Ext.covariantSequence` and
   `Abelian.Ext.contravariantSequence` from Mathlib, whose objects are exactly the
   `Etingof.Ext` groups.
+* The `Tor` long exact sequences of (iii) and (v) are stated as six-term homology windows
+  (`ComposableArrows _ 5`) with an existentially quantified connecting homomorphism `δ`,
+  mirroring the shape of the `Ext` sequences. The horizontal maps are the first-argument
+  functoriality of `Etingof.TorFunctor` (for (v)) and the second-argument functoriality
+  `torSndMap` built below (for (iii)).
+* The balancing theorem (iv) is stated as a canonical isomorphism between `Etingof.Tor` (left
+  derived of `- ⊗_A N` in `M`) and the left derived functor of `M ⊗_A -` in `N`
+  (`tensorLeftFunctor A M`).
 
-The **`Tor` long exact sequences** of (iii) and (v), together with the **balancing theorem
-(iv)**, are deferred to a follow-up statement pass: the `Tor` construction of Definition 8.2.3
-is currently left-derived only in its *first* argument (`Etingof.TorFunctor A N` is a functor of
-`M`), so it lacks the second-argument functoriality and the balancing API needed to phrase the
-`Tor` connecting maps faithfully. See the follow-up issue linked from #5921.
+To phrase (iii) and (iv) we build genuine second-argument infrastructure: `tensorSndMap`,
+`tensorRightNatTrans`, `torSndMap`, and `tensorLeftFunctor` (all real constructions, no sorried
+`def` bodies). Definition 8.2.3 originally left-derives `- ⊗_A N` only in its first argument
+`M`; a left `A`-module map `g : N → N'` induces a natural transformation of the tensor functors,
+and `NatTrans.leftDerived` supplies the missing second-argument functoriality of `Tor`.
 
 These are statement-level formalizations (spec-first): the proofs are deferred (`sorry`).
 -/
@@ -111,6 +117,46 @@ noncomputable def torSndMap
     Etingof.Tor A N M n ⟶ Etingof.Tor A N' M n :=
   (NatTrans.leftDerived (tensorRightNatTrans A g) n).app M
 
+/-- The functor `N ↦ M ⊗_A N` from left `A`-modules to abelian groups, with the right `A`-module
+`M` held fixed. This is the functor whose left derived functors compute `Tor` "the other way"
+(from a projective resolution of `N` tensored with `M`), used to state the balancing theorem
+Problem 8.2.6(iv). Its action on morphisms is `tensorSndMap`. -/
+noncomputable def tensorLeftFunctor (A : Type u) [Ring A] (M : ModuleCat.{u} Aᵐᵒᵖ) :
+    ModuleCat.{u} A ⥤ AddCommGrpCat.{u} where
+  obj N := AddCommGrpCat.of (Etingof.tensorOver A N M)
+  map {N N'} g := AddCommGrpCat.ofHom (tensorSndMap A g.hom M)
+  map_id N := by
+    ext x
+    induction x with
+    | zero => simp
+    | tmul m n => rfl
+    | add a b ha hb => simp only [map_add, ha, hb]
+  map_comp {N N' N''} g g' := by
+    ext x
+    induction x with
+    | zero => simp
+    | tmul m n => rfl
+    | add a b ha hb => simp only [map_add, ha, hb]
+
+/-- The functor `N ↦ M ⊗_A N` is additive in `N`, so it can be left-derived (Problem 8.2.6(iv)). -/
+instance (A : Type u) [Ring A] (M : ModuleCat.{u} Aᵐᵒᵖ) :
+    (tensorLeftFunctor A M).Additive where
+  map_add {N N' f g} := by
+    ext x
+    obtain ⟨y, rfl⟩ := QuotientAddGroup.mk_surjective x
+    induction y with
+    | zero => simp
+    | tmul m n =>
+      simp only [tensorLeftFunctor, AddCommGrpCat.hom_ofHom, AddCommGrpCat.hom_add,
+        AddMonoidHom.add_apply, tensorSndMap_mk, ModuleCat.hom_add, LinearMap.add_apply,
+        tmul_add]
+      exact map_add (QuotientAddGroup.mk' (Etingof.balancedSubgroup A N' M)) _ _
+    | add a b ha hb =>
+      rw [show ((a + b : TensorProduct ℤ M N) : Etingof.tensorOver A N M)
+            = (a : Etingof.tensorOver A N M) + b from
+          map_add (QuotientAddGroup.mk' (Etingof.balancedSubgroup A N M)) a b,
+        map_add, map_add, ha, hb]
+
 /-! ### Part (i) -/
 
 /-- **Problem 8.2.6(i), `Tor₀`.** `Tor₀ᴬ(M, N)` is canonically isomorphic to `M ⊗_A N`. In the
@@ -174,6 +220,20 @@ theorem Problem_8_2_6_iii_tor
         (torSndMap A S.f.hom n₁ M) (torSndMap A S.g.hom n₁ M)
         δ
         (torSndMap A S.f.hom n₀ M) (torSndMap A S.g.hom n₀ M)).Exact := by
+  sorry
+
+/-! ### Part (iv): the balancing theorem -/
+
+/-- **Problem 8.2.6(iv), balancing.** `Torₙᴬ(M, N)` may be computed from a projective resolution
+of `N` tensored with `M`: the `n`-th left derived functor of `- ⊗_A N` evaluated at `M`
+(the definition `Etingof.Tor`) is canonically isomorphic to the `n`-th left derived functor of
+`M ⊗_A -` (the functor `tensorLeftFunctor A M`) evaluated at `N`. Equivalently, `Tor` is
+symmetric: it can be computed by resolving either argument. -/
+theorem Problem_8_2_6_iv
+    (A : Type u) [Ring A] (N : Type u) [AddCommGroup N] [Module A N]
+    (M : ModuleCat.{u} Aᵐᵒᵖ) (n : ℕ) :
+    Nonempty (Etingof.Tor A N M n ≅
+      (Functor.leftDerived (tensorLeftFunctor A M) n).obj (ModuleCat.of A N)) := by
   sorry
 
 /-! ### Part (v): long exact sequence in the first argument (`Ext` half) -/

--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_6.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_6.lean
@@ -41,9 +41,75 @@ These are statement-level formalizations (spec-first): the proofs are deferred (
 
 namespace Etingof
 
-open CategoryTheory
+open CategoryTheory TensorProduct
 
 universe u
+
+/-! ### Second-argument functoriality of `⊗_A` and `Tor`
+
+The `Tor` construction of Definition 8.2.3 is set up as the left derived functor of `- ⊗_A N`
+in the *first* argument `M`, with the left module `N` held fixed. To state the long exact `Tor`
+sequence in the *second* argument (part (iii)) we need `Torᵢᴬ(M, -)` to be functorial in `N`.
+
+This is genuinely constructible: a left `A`-module map `g : N → N'` induces a natural
+transformation `tensorRightFunctor A N ⟶ tensorRightFunctor A N'` of the functors being
+left-derived (apply `id ⊗ g` to the second tensor factor), and `NatTrans.leftDerived` turns it
+into a map `Torᵢᴬ(M, N) ⟶ Torᵢᴬ(M, N')` natural in `M`. We build exactly this here. -/
+
+/-- The additive map `M ⊗_A N → M ⊗_A N'` induced by a left `A`-module map `g : N → N'`
+(second-argument functoriality of `⊗_A`). It applies `g` to the right tensor factor and descends
+to the balanced quotient because `g` is `A`-linear. -/
+noncomputable def tensorSndMap
+    (A : Type u) [Ring A] {N N' : Type u} [AddCommGroup N] [Module A N]
+    [AddCommGroup N'] [Module A N'] (g : N →ₗ[A] N') (M : ModuleCat.{u} Aᵐᵒᵖ) :
+    Etingof.tensorOver A N M →+ Etingof.tensorOver A N' M :=
+  QuotientAddGroup.map (Etingof.balancedSubgroup A N M) (Etingof.balancedSubgroup A N' M)
+    (TensorProduct.map (LinearMap.id) g.toAddMonoidHom.toIntLinearMap).toAddMonoidHom
+    (by
+      -- the induced map sends the balancing relation of `N` into that of `N'`
+      refine AddSubgroup.closure_le _ |>.mpr ?_
+      rintro x ⟨a, m, n, rfl⟩
+      apply AddSubgroup.subset_closure
+      refine ⟨a, m, g n, ?_⟩
+      simp only [map_sub, TensorProduct.map_tmul, LinearMap.id_coe, id_eq,
+        LinearMap.toAddMonoidHom_coe, AddMonoidHom.coe_toIntLinearMap, map_smul])
+
+@[simp]
+lemma tensorSndMap_mk
+    (A : Type u) [Ring A] {N N' : Type u} [AddCommGroup N] [Module A N]
+    [AddCommGroup N'] [Module A N'] (g : N →ₗ[A] N') (M : ModuleCat.{u} Aᵐᵒᵖ)
+    (m : M) (n : N) :
+    tensorSndMap A g M (TensorProduct.tmul ℤ m n : Etingof.tensorOver A N M)
+      = (TensorProduct.tmul ℤ m (g n) : Etingof.tensorOver A N' M) :=
+  rfl
+
+/-- The natural transformation `- ⊗_A N ⟶ - ⊗_A N'` induced by a left `A`-module map
+`g : N → N'`; its components are `tensorSndMap`. -/
+noncomputable def tensorRightNatTrans
+    (A : Type u) [Ring A] {N N' : Type u} [AddCommGroup N] [Module A N]
+    [AddCommGroup N'] [Module A N'] (g : N →ₗ[A] N') :
+    Etingof.tensorRightFunctor A N ⟶ Etingof.tensorRightFunctor A N' where
+  app M := AddCommGrpCat.ofHom (tensorSndMap A g M)
+  naturality {M M'} f := by
+    ext x
+    obtain ⟨y, rfl⟩ := QuotientAddGroup.mk_surjective x
+    induction y with
+    | zero => simp
+    | tmul m n => rfl
+    | add a b ha hb =>
+      rw [show ((a + b : TensorProduct ℤ M N) : Etingof.tensorOver A N M)
+            = (a : Etingof.tensorOver A N M) + b from
+          map_add (QuotientAddGroup.mk' (Etingof.balancedSubgroup A N M)) a b,
+        map_add, map_add, ha, hb]
+
+/-- **Second-argument functoriality of `Tor`.** A left `A`-module map `g : N → N'` induces
+`Torᵢᴬ(M, N) ⟶ Torᵢᴬ(M, N')`, natural in the right module `M`. Defined as the `n`-th left
+derived natural transformation of `tensorRightNatTrans A g`. -/
+noncomputable def torSndMap
+    (A : Type u) [Ring A] {N N' : Type u} [AddCommGroup N] [Module A N]
+    [AddCommGroup N'] [Module A N'] (g : N →ₗ[A] N') (n : ℕ) (M : ModuleCat.{u} Aᵐᵒᵖ) :
+    Etingof.Tor A N M n ⟶ Etingof.Tor A N' M n :=
+  (NatTrans.leftDerived (tensorRightNatTrans A g) n).app M
 
 /-! ### Part (i) -/
 
@@ -89,6 +155,25 @@ theorem Problem_8_2_6_iii_ext
     {S : ShortComplex (ModuleCat.{u} A)} (hS : S.ShortExact)
     (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
     (Abelian.Ext.covariantSequence (X := M) hS n₀ n₁ h).Exact := by
+  sorry
+
+/-- **Problem 8.2.6(iii), `Tor`.** A short exact sequence `S : 0 → N₁ → N₂ → N₃ → 0` of left
+`A`-modules induces, for each right `A`-module `M` and each `n₀ + 1 = n₁`, a connecting
+homomorphism `δ : Torₙ₁(M, N₃) → Torₙ₀(M, N₁)` making the six-term homology window
+`Torₙ₁(M,N₁) → Torₙ₁(M,N₂) → Torₙ₁(M,N₃) →[δ] Torₙ₀(M,N₁) → Torₙ₀(M,N₂) → Torₙ₀(M,N₃)`
+exact. The horizontal maps are the second-argument functoriality `torSndMap` of `Etingof.Tor`;
+splicing these windows over all `n` gives the book's long exact `Tor` sequence in the second
+argument (ending in `M ⊗_A N₁ → M ⊗_A N₂ → M ⊗_A N₃ → 0`). Existence of `δ` is part of the
+claim. -/
+theorem Problem_8_2_6_iii_tor
+    (A : Type u) [Ring A] (M : ModuleCat.{u} Aᵐᵒᵖ)
+    {S : ShortComplex (ModuleCat.{u} A)} (hS : S.ShortExact)
+    (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
+    ∃ δ : Etingof.Tor A S.X₃ M n₁ ⟶ Etingof.Tor A S.X₁ M n₀,
+      (ComposableArrows.mk₅
+        (torSndMap A S.f.hom n₁ M) (torSndMap A S.g.hom n₁ M)
+        δ
+        (torSndMap A S.f.hom n₀ M) (torSndMap A S.g.hom n₀ M)).Exact := by
   sorry
 
 /-! ### Part (v): long exact sequence in the first argument (`Ext` half) -/

--- a/progress/2026-07-07T21-32-57Z_527f4600.md
+++ b/progress/2026-07-07T21-32-57Z_527f4600.md
@@ -1,0 +1,68 @@
+## Accomplished
+
+Executed issue **#5924** (Chapter 8 homological-algebra statement pass) via `/work` → `/feature`.
+Filled the two genuinely-remaining deliverables — the `Tor` parts of Problem 8.2.6 that were
+deferred by #5921 for lack of second-argument functoriality. All work is in
+`EtingofRepresentationTheory/Chapter8/Problem8_2_6.lean`; `lake build ...Chapter8` passes (2173
+jobs) with only the expected `sorry` warnings.
+
+New **constructed infrastructure** (real defs, no sorried bodies):
+- `Etingof.tensorSndMap A g M : M ⊗_A N →+ M ⊗_A N'` — the map on the balanced quotient induced
+  by a left `A`-module map `g : N → N'` (second-argument functoriality of `⊗_A`), with
+  `tensorSndMap_mk` simp lemma.
+- `Etingof.tensorRightNatTrans A g : tensorRightFunctor A N ⟶ tensorRightFunctor A N'` — the
+  induced natural transformation of the functors Definition 8.2.3 left-derives.
+- `Etingof.torSndMap A g n M : Tor A N M n ⟶ Tor A N' M n` — second-argument functoriality of
+  `Tor`, defined via `NatTrans.leftDerived (tensorRightNatTrans A g) n`.
+- `Etingof.tensorLeftFunctor A M : ModuleCat A ⥤ AddCommGrpCat` (`N ↦ M ⊗_A N`) with its
+  `Additive` instance — the functor whose left derived functors compute `Tor` by resolving the
+  second argument.
+
+New **statement theorems** (spec-first, `sorry` proofs):
+- `Problem_8_2_6_iii_tor` — the `Tor` long exact sequence in the second argument, as a six-term
+  homology window (`ComposableArrows _ 5`) with an existentially quantified connecting map `δ`,
+  horizontal maps `torSndMap`.
+- `Problem_8_2_6_v_tor` — the `Tor` long exact sequence in the first argument, same window shape,
+  horizontal maps the first-argument functoriality of `Etingof.TorFunctor`.
+- `Problem_8_2_6_iv` — the balancing theorem, stated as a canonical iso
+  `Tor A N M n ≅ (leftDerived (tensorLeftFunctor A M) n).obj N`.
+
+Updated the module docstring: all parts (i)–(v) are now formalized (both `Ext` and `Tor` sides).
+
+### Key modelling decision
+
+The book's "there are long exact sequences" is captured faithfully by asserting exactness of the
+six-term window `ComposableArrows _ 5` for each consecutive degree pair `n₀+1 = n₁`, with the
+connecting homomorphism `δ` existentially quantified — mirroring the shape of Mathlib's
+`Abelian.Ext.covariantSequence`/`contravariantSequence` used for the `Ext` halves. Mathlib's
+classical `Functor.leftDerived` has no packaged δ-functor / LES API, so the connecting maps are
+existential rather than pulled from a library construction.
+
+Deliverables 3 (Problem 8.2.7) and 4 (Problem 8.2.8) of #5924 were **already landed** by prior
+#5921 work (`Problem8_2_7.lean`, `Problem8_2_8.lean`, both `statement_formalized`); no `items.json`
+change was needed. `Chapter8/Problem8.2.6` stays `statement_formalized` (proofs still `sorry`).
+
+## Current frontier
+
+Problem 8.2.6 is fully statement-formalized across (i)–(v) for both `Ext` and `Tor`. The
+project-wide statement pass appears essentially complete: every exercise/problem item across
+chapters is `statement_formalized` or better in `items.json`.
+
+## Overall project progress
+
+Stage 3 formalization. Statement pass is at/near completion project-wide. The next natural phase
+is proofs. For Chapter 8 §8.2 specifically, all four exercises (8.2.6–8.2.9) plus 8.2.5 are
+statement-formalized; the `Tor`/`Ext` proofs (and the deep balancing/LES proofs) remain deferred.
+
+## Next step
+
+Proof phase for the §8.2 `Tor`/`Ext` problems. The new `Problem_8_2_6_iii_tor` /
+`Problem_8_2_6_v_tor` / `Problem_8_2_6_iv` sorries are the natural targets; proving them will
+likely require developing the δ-functor / long-exact-sequence API for `Etingof.TorFunctor` (or
+transporting through Mathlib's `DerivedCategory` machinery), and the balancing theorem for the
+bespoke Definition 8.2.3 `Tor`.
+
+## Blockers
+
+None. (The prior "second-argument functoriality" blocker that deferred these parts is now
+resolved by `tensorSndMap` / `tensorRightNatTrans` / `torSndMap` / `tensorLeftFunctor`.)


### PR DESCRIPTION
Closes #5924

This PR completes the Chapter 8 homological-algebra statement pass by formalizing the `Tor` parts of Problem 8.2.6 that #5921 deferred for lack of second-argument functoriality. It builds genuine second-argument infrastructure for the bespoke Definition 8.2.3 `Tor` — `tensorSndMap`, `tensorRightNatTrans`, `torSndMap`, and `tensorLeftFunctor` (all real `def`s / `instance`, no sorried bodies) — then states the deferred parts: `Problem_8_2_6_iii_tor` and `Problem_8_2_6_v_tor` (the `Tor` long exact sequences in the second and first argument, as six-term `ComposableArrows _ 5` windows with an existentially quantified connecting map `δ`, mirroring the `Ext` siblings) and `Problem_8_2_6_iv` (the balancing theorem, an iso between `Etingof.Tor` and the left derived functor of `M ⊗_A -`). All parts (i)–(v) of Problem 8.2.6 are now formalized for both `Ext` and `Tor`.

Deliverables 3 (Problem 8.2.7) and 4 (Problem 8.2.8) of #5924 were already landed by prior #5921 work and are unchanged. Statements only: proofs remain `sorry`. `lake build EtingofRepresentationTheory.Chapter8` passes (2173 jobs) with only the expected `sorry` warnings.

🤖 Prepared with Claude Code
