### PR TITLE
chore: record queue-cleanup turn (closed stale statement-pass issues)

### DIFF
--- a/progress/2026-07-07T21-38-51Z_e218cd1d.md
+++ b/progress/2026-07-07T21-38-51Z_e218cd1d.md
@@ -1,0 +1,53 @@
+## Accomplished
+
+Queue-cleanup turn (`/work`, meta session). The entire unclaimed feature queue
+consisted of stale statement-pass issues whose deliverables had already landed
+on `main` via other PRs. Verified each against `progress/items.json` status,
+file presence on `origin/main`, aggregator wiring, and the merged PRs that
+landed them, then closed the complete ones:
+
+- **#5902** (Ch7 7.8.7, 7.9.8) — closed. Both landed via #5918. Problem 7.8.7
+  has `tensorComplex`/`homologyZeroComplex` defs + parts (i)–(iv) incl. Künneth;
+  Exercise 7.9.8 has the part-(a) hom-set bijection, with part (b) faithfully
+  documented as `Exercise7_9_7` applied to that adjunction (a separate
+  categorical statement is unwritable because the Ch6 reflection functors are
+  bespoke `QuiverRepresentation` maps, not `CategoryTheory.Functor`s).
+- **#5914** (Ch9 9.4.6, 9.6.5) — closed. 9.4.6 via #5933, 9.6.5 via #5946.
+- **#5932** (Ch9 9.6.5) — closed as a duplicate of #5914's second half. The
+  "must construct the functor `G`" blocker is resolved by rendering the whole
+  problem as an *existential* (`exists_quasiInverse_tensor_functor`: `∃ G ξ, …`)
+  inside one `sorry`-proof theorem, so no standalone `def` is needed.
+- **#5907** (Ch8 8.2.6–8.2.9) — already auto-closed (by #5960's merge). All
+  parts present: 8.2.6 Ext parts + 8.2.9 via #5926, 8.2.6 Tor parts via #5960
+  (the split-off #5924), 8.2.7 via #5934, 8.2.8 via #5941.
+
+Also restored three tracked doc files (`feature.md`, `review.md`,
+`agent-worker-flow/SKILL.md`) that the reused worktree carried as uncommitted
+deletions reverting the just-landed #5957/#5959 guidance — leftover cruft, not
+real work.
+
+## Current frontier
+
+Unclaimed queue (all labels) is empty. #5910 (Ch5 remainder) is claimed by
+another agent and has genuine remaining work: Problem 5.24.1 **part (b)** (the
+sign-twist automorphism `φ(s)=(−1)^s s` sending `V ↦ V⊗ℂ_-`, and
+`V_λ ⊗ ℂ_- = V_{λ*}`) is not yet in `Problem5_24_1.lean` (only part (a) landed).
+
+## Overall project progress
+
+Statement-pass phase is effectively caught up across Chapters 5, 7, 8, 9 — the
+remaining planner-created statement-pass issues were all phantom (work already
+merged). Item statuses in `progress/items.json` for the closed items are
+`statement_formalized`.
+
+## Next step
+
+No feature work is queued. A planner should note that statement-pass issues are
+prone to going stale between creation and claim (see the "Check for
+Already-Landed Work First" section added to `feature.md` in #5959). Next
+substantive work is the proof phase (filling `sorry`s) or the residual
+Problem 5.24.1(b) once #5910's owner finishes.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR records a `/work` queue-cleanup turn: the entire unclaimed feature queue was stale statement-pass issues whose deliverables had already landed on `main` via other merged PRs. Closed #5902 (Ch7, via #5918), #5914 (Ch9, via #5933/#5946), and #5932 (Ch9 9.6.5 duplicate, via #5946); #5907 (Ch8) was already auto-closed by #5960. Each close comment points at the merged PRs and landed files. No code changes — this adds only the mandatory progress handoff file.

🤖 Prepared with Claude Code