### PR TITLE
Prove Problem 2.4.1: existence of maximal left/right/two-sided ideals

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Problem2_4_1.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_4_1.lean
@@ -20,8 +20,10 @@ exactly `IsCoatom` in the corresponding lattice of ideals:
 
 `IsCoatom I` says `I ≠ ⊤` and any ideal strictly containing `I` equals `⊤`, i.e. `I` is maximal.
 
-This is the **statement pass**: the three existence statements are recorded with `sorry` proofs
-(each is proved by Zorn's lemma in the proof phase).
+The left and right cases follow directly from Mathlib's Krull theorem `Ideal.exists_maximal`
+(the right case is the left case for `Aᵐᵒᵖ`). The two-sided case is proved by Zorn's lemma: the
+union of a chain of proper two-sided ideals is again a proper two-sided ideal, because `1` lies in
+none of them.
 -/
 
 namespace Etingof.Problem2_4_1
@@ -29,16 +31,56 @@ namespace Etingof.Problem2_4_1
 variable (A : Type*) [Ring A] [Nontrivial A]
 
 /-- Every nontrivial unital ring has a maximal **left** ideal. (Etingof Problem 2.4.1) -/
-theorem exists_maximal_left_ideal : ∃ I : Submodule A A, IsCoatom I := by
-  sorry
+theorem exists_maximal_left_ideal : ∃ I : Submodule A A, IsCoatom I :=
+  let ⟨I, hI⟩ := Ideal.exists_maximal A
+  ⟨I, Ideal.isMaximal_def.mp hI⟩
 
 /-- Every nontrivial unital ring has a maximal **right** ideal, modelled as a maximal left ideal
 of the opposite ring `Aᵐᵒᵖ`. (Etingof Problem 2.4.1) -/
-theorem exists_maximal_right_ideal : ∃ I : Submodule Aᵐᵒᵖ Aᵐᵒᵖ, IsCoatom I := by
-  sorry
+theorem exists_maximal_right_ideal : ∃ I : Submodule Aᵐᵒᵖ Aᵐᵒᵖ, IsCoatom I :=
+  let ⟨I, hI⟩ := Ideal.exists_maximal Aᵐᵒᵖ
+  ⟨I, Ideal.isMaximal_def.mp hI⟩
 
 /-- Every nontrivial unital ring has a maximal **two-sided** ideal. (Etingof Problem 2.4.1) -/
 theorem exists_maximal_twoSided_ideal : ∃ I : TwoSidedIdeal A, IsCoatom I := by
-  sorry
+  -- `⊥ ≠ ⊤` since `1 ≠ 0`.
+  have hbot : (⊥ : TwoSidedIdeal A) ≠ ⊤ := by
+    intro h
+    have h1 : (1 : A) ∈ (⊥ : TwoSidedIdeal A) := by rw [h]; trivial
+    simp only [TwoSidedIdeal.mem_bot] at h1
+    exact one_ne_zero h1
+  -- Every chain of proper ideals has a proper upper bound (its union).
+  have hbound : ∀ c ⊆ {I : TwoSidedIdeal A | I ≠ ⊤}, IsChain (· ≤ ·) c →
+      ∃ ub ∈ {I : TwoSidedIdeal A | I ≠ ⊤}, ∀ z ∈ c, z ≤ ub := by
+    intro c hcs hchain
+    rcases c.eq_empty_or_nonempty with rfl | ⟨I₀, hI₀⟩
+    · exact ⟨⊥, hbot, by simp⟩
+    · -- The union of the chain, as a two-sided ideal.
+      refine ⟨TwoSidedIdeal.mk' {x | ∃ I ∈ c, x ∈ I}
+        ⟨I₀, hI₀, I₀.zero_mem⟩ ?_ ?_ ?_ ?_, ?_, ?_⟩
+      · rintro x y ⟨I, hI, hx⟩ ⟨J, hJ, hy⟩
+        rcases hchain.total hI hJ with h | h
+        · exact ⟨J, hJ, J.add_mem (h hx) hy⟩
+        · exact ⟨I, hI, I.add_mem hx (h hy)⟩
+      · rintro x ⟨I, hI, hx⟩
+        exact ⟨I, hI, I.neg_mem hx⟩
+      · rintro x y ⟨I, hI, hy⟩
+        exact ⟨I, hI, I.mul_mem_left x y hy⟩
+      · rintro x y ⟨I, hI, hx⟩
+        exact ⟨I, hI, I.mul_mem_right x y hx⟩
+      · -- The union is proper: `1` is in it iff it is in some member of the chain.
+        intro hUtop
+        have h1 := (TwoSidedIdeal.one_mem_iff _).mpr hUtop
+        rw [TwoSidedIdeal.mem_mk'] at h1
+        obtain ⟨I, hI, h1⟩ := h1
+        exact (hcs hI) ((TwoSidedIdeal.one_mem_iff I).mp h1)
+      · -- The union is an upper bound of the chain.
+        intro z hz x hx
+        exact (TwoSidedIdeal.mem_mk' _ _ _ _ _ _ x).mpr ⟨z, hz, hx⟩
+  -- Zorn's lemma yields a maximal proper ideal, which is a coatom.
+  obtain ⟨m, hm⟩ := zorn_le₀ {I : TwoSidedIdeal A | I ≠ ⊤} hbound
+  refine ⟨m, hm.1, fun b hb => ?_⟩
+  by_contra hbne
+  exact absurd (lt_of_le_of_lt (hm.2 hbne hb.le) hb) (lt_irrefl b)
 
 end Etingof.Problem2_4_1

--- a/progress/2026-07-07T21-55-48Z_d8bdb34a.md
+++ b/progress/2026-07-07T21-55-48Z_d8bdb34a.md
@@ -1,0 +1,37 @@
+## Accomplished
+Proved Problem 2.4.1 (issue #5963): existence of maximal left, right, and two-sided
+ideals in a nontrivial unital ring.
+- `exists_maximal_left_ideal` and `exists_maximal_right_ideal`: discharged directly from
+  Mathlib's Krull theorem `Ideal.exists_maximal` (the right case is the left case for
+  `Aᵐᵒᵖ`), converting `Ideal.IsMaximal` to `IsCoatom` via `Ideal.isMaximal_def`.
+- `exists_maximal_twoSided_ideal`: proved by `zorn_le₀` on the set of proper two-sided
+  ideals `{I | I ≠ ⊤}`. The chain upper bound is the union, constructed concretely as a
+  `TwoSidedIdeal` via `TwoSidedIdeal.mk'` (directedness of the chain gives `add_mem`;
+  properness because `1 ∈ union → 1 ∈` some chain member `→` that member `= ⊤`, contradiction).
+  A Zorn-maximal proper ideal is then a coatom.
+- `#print axioms` on all three shows only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`.
+- Updated `progress/items.json`: `Chapter2/Problem2.4.1` → `sorry_free`.
+
+## Current frontier
+Issue #5963 complete. `lake build EtingofRepresentationTheory.Chapter2.Problem2_4_1` succeeds
+with zero sorry/warnings.
+
+## Overall project progress
+Phase 3 formalization ongoing (per-item proofs). Two feature issues remain unclaimed:
+#5964 (Exercise 3.6.1, character additivity on SES) and #5965 (Exercise 2.9.5, hat-map Lie iso).
+
+## Next step
+Claim #5964 or #5965.
+
+## Blockers
+None.
+
+## Notes for future workers
+- `TwoSidedIdeal.mk'` builds a two-sided ideal from a carrier set with the five closure
+  proofs; `mem_mk'` / `le_iff` (subset) / `one_mem_iff` (`1 ∈ I ↔ I = ⊤`) are the key API.
+- Watch out: in `TwoSidedIdeal/Lattice.lean` the section variable `R` is *explicit*, so
+  `TwoSidedIdeal.mem_top`/`mem_bot` need `R` supplied (or just use `trivial`/`simp`).
+- When building an `mk'` term inside a big anonymous constructor whose overall type is an
+  `∃`, deriving membership facts from a *fresh* `mem_mk' _ _ _ _ _ _ x` leaves the carrier a
+  metavariable. Derive them from a hypothesis that already pins the `mk'` term instead
+  (e.g. `(one_mem_iff _).mpr hUtop` then `rw [mem_mk'] at`).

--- a/progress/items.json
+++ b/progress/items.json
@@ -639,8 +639,8 @@
     "end_page": "15",
     "start_line": 15,
     "end_line": 15,
-    "status": "statement_formalized",
-    "coverage_note": "No Lean formalization on origin/main (re-derived 2026-07-02; prior 'sorry_free' was vacuous)."
+    "status": "sorry_free",
+    "coverage_note": "Proved 2026-07-07: left/right via Ideal.exists_maximal (Krull), two-sided via Zorn on proper ideals (chain union built with TwoSidedIdeal.mk'). No sorryAx."
   },
   {
     "id": "Chapter2/Discussion_2.5_heading",


### PR DESCRIPTION
Closes #5963

Session: `d8bdb34a-fae3-4195-b563-15a4f1b62292`

fe5758b4 feat(Ch2 #5963): prove existence of maximal left/right/two-sided ideals

🤖 Prepared with Claude Code