### PR TITLE
Prove Exercise 3.10.1: Mat_m(k) ⊗ Mat_n(k) ≅ Mat_{mn}(k) (kroneckerTMulAlgEquiv + reindex)

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/Exercise3_10_1.lean
+++ b/EtingofRepresentationTheory/Chapter3/Exercise3_10_1.lean
@@ -23,5 +23,7 @@ isomorphic, as a `k`-algebra, to the matrix algebra `Mat_{mn}(k)`. -/
 theorem Etingof.matrix_tensorProduct_matrix (k : Type*) [CommRing k] (m n : ℕ) :
     Nonempty
       ((Matrix (Fin m) (Fin m) k ⊗[k] Matrix (Fin n) (Fin n) k) ≃ₐ[k]
-        Matrix (Fin (m * n)) (Fin (m * n)) k) := by
-  sorry
+        Matrix (Fin (m * n)) (Fin (m * n)) k) :=
+  ⟨(Matrix.kroneckerTMulAlgEquiv (Fin m) (Fin n) k k k k).trans <|
+    ((Algebra.TensorProduct.rid k k k).mapMatrix).trans <|
+      Matrix.reindexAlgEquiv k _ finProdFinEquiv⟩

--- a/progress/2026-07-08T03-46-06Z_28cde199.md
+++ b/progress/2026-07-08T03-46-06Z_28cde199.md
@@ -1,0 +1,35 @@
+## Accomplished
+
+- Feature session (issue #5982): discharged the single `sorry` in
+  `EtingofRepresentationTheory/Chapter3/Exercise3_10_1.lean`, proving
+  `Etingof.matrix_tensorProduct_matrix` — `Mat_m(k) ⊗ Mat_n(k) ≅ Mat_{mn}(k)`
+  as `k`-algebras.
+- Construction is the three-step `AlgEquiv.trans` chain from the issue:
+  `Matrix.kroneckerTMulAlgEquiv (Fin m) (Fin n) k k k k` →
+  `(Algebra.TensorProduct.rid k k k).mapMatrix` →
+  `Matrix.reindexAlgEquiv k _ finProdFinEquiv`, wrapped in `⟨·⟩` for `Nonempty`.
+- Key detail: argument order of `kroneckerTMulAlgEquiv` is `m n R S A B`
+  (index types first), so the call is `(Fin m) (Fin n) k k k k`.
+- `lake build EtingofRepresentationTheory.Chapter3.Exercise3_10_1` succeeds,
+  no warnings.
+- `#print axioms` shows only `propext, Classical.choice, Quot.sound` — no `sorryAx`.
+- Updated `progress/items.json`: `Chapter3/Exercise3.10.1` → `status: sorry_free`,
+  `sorry_free: true`.
+
+## Current frontier
+
+Issue #5982 complete; ready for PR.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. This exercise is now fully `sorry_free`.
+Remaining unclaimed feature issues at session start: #5975 (Weyl algebra
+centrality, char p), #5976 (Problem 3.3.3(a) direct-sum irreducibles).
+
+## Next step
+
+Pick up #5975 or #5976. Both are moderate-difficulty proof work.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -2313,8 +2313,8 @@
     "end_page": "59",
     "start_line": 9,
     "end_line": 10,
-    "status": "statement_formalized",
-    "sorry_free": false,
+    "status": "sorry_free",
+    "sorry_free": true,
     "fidelity": "verified",
     "lean_file": "EtingofRepresentationTheory/Chapter3/Exercise3_10_1.lean"
   },


### PR DESCRIPTION
Closes #5982

Session: `28cde199-a149-4083-bbb0-e02c614947fc`

6014869a feat(Ch3 #5982): prove Exercise 3.10.1 Mat_m(k) ⊗ Mat_n(k) ≅ Mat_{mn}(k)

🤖 Prepared with Claude Code