### PR TITLE
doc: note abbrev-over-Finsupp leaks pointwise Mul (blocks #5979, filed #5987)

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -310,6 +310,31 @@ General rule: if an implicit type/ring/field appears only *inside* a definition'
 
 `MonoidAlgebra k G` is `def`-equal to `G →₀ k`, so `Finsupp.lhom_ext` *applies* to a goal `F = 0` for `F : MonoidAlgebra k G →ₗ[k] N` — but it unifies the domain with the bare `G →₀ k`, which pries the type open and breaks instance search for everything registered on `MonoidAlgebra` (`failed to synthesize Ring (G →₀ ℂ)` / `Algebra ℂ (G →₀ ℂ)` / `Module (G →₀ ℂ) (M i)`). **To show a linear functional on `MonoidAlgebra k G` vanishes**, keep the type intact: prove `∀ a, F a = 0` by `induction a using MonoidAlgebra.induction_on` (base case `of k G g` — exactly the group-element evaluation you have a bridge lemma for; `hadd`/`hsmul` close by `simp only [map_add, …]` / `simp only [map_smul, …]`), then package via `LinearMap.ext`. (#4908)
 
+### A `→₀`-based algebra must be a `def`, never an `abbrev` — `abbrev` leaks `Finsupp.instMul` (pointwise) (#5987)
+
+`MonoidAlgebra k G` is a `def` (semireducible) *on purpose*: it hides that the carrier is
+`G →₀ k`, so Mathlib's pointwise `Finsupp` instances (`Finsupp.instMul` from
+`Mathlib.Data.Finsupp.Pointwise`, etc.) do **not** apply and the convolution ring
+structure is the unique one. If you instead declare your algebra as a **reducible
+`abbrev`** (as `Chapter2/Definition2_8_4.lean` does: `abbrev PathAlgebra k Q :=
+QuiverPathIndex Q →₀ k`), then under `import Mathlib` the pointwise `Finsupp.instMul`
+becomes a valid `Mul` on your type and **outranks your intended (convolution/
+concatenation) multiplication**. The defining file itself compiles because it imports a
+*narrow* Mathlib slice excluding `Finsupp.Pointwise`; every downstream file that
+`import Mathlib` silently gets **pointwise** `*` instead.
+
+Symptoms: a `single_mul_single`-style lemma (stated in the defining file, so it carries
+the ring `Mul`) refuses to `rw`/`simp` in a downstream goal ("did not find pattern"
+though the term looks identical), because the goal's `*` is a *different* `Mul` instance.
+Worse, statements like `p_source * arrow = arrow` become **false** as elaborated
+(pointwise product of distinct-index basis singles is `0`). **Diagnose** with
+`set_option pp.all true` on the goal and look for `Finsupp.instMul` in the `HMul`.
+**Fix** = make the carrier a `def` (à la `MonoidAlgebra`) and re-provide the
+inherited module instances (`AddCommGroup`, `Module k`, …) via `inferInstanceAs`/
+`deriving`; expect to unfold the `def` in the defining file's proofs that used
+`Finsupp.single`/`induction_linear`/`lsum` through reducibility. This is a multi-file
+refactor, not a per-lemma tweak — file it as its own issue.
+
 ### Induced rep `Ind_H^G ℂ ≅ k[G]·a` as `Representation.Equiv`, and the MonoidAlgebra/Finsupp instance wall (#5171)
 
 Goal: `Etingof.Definition5_8_1 H (trivial) ≅ ℂ[G]·a` (left ideal). Recipe in

--- a/progress/2026-07-08T03-53-10Z_fdc8b65a.md
+++ b/progress/2026-07-08T03-53-10Z_fdc8b65a.md
@@ -1,0 +1,53 @@
+## Accomplished
+
+Session type: **feature** (via `/work` → `/feature`), claimed #5979 (prove
+Problem 2.8.6 relations (2)-(4)).
+
+Investigated the six relation lemmas and discovered a **definition-level bug**
+that blocks the issue. Wrote proof attempts, found `single_mul_single` would not
+rewrite the goals. Root cause (confirmed with `set_option pp.all true`): the `*`
+in the committed statements resolves to `Finsupp.instMul` — Mathlib's **pointwise**
+Finsupp multiplication — not the path-concatenation ring multiplication.
+
+`PathAlgebra` (Definition 2.8.4) is a reducible `abbrev` for `QuiverPathIndex Q →₀ k`,
+so under `import Mathlib` the pointwise `Finsupp.instMul` is a valid and higher-ranked
+`Mul (PathAlgebra k Q)`. Definition2_8_4 itself is fine only because it imports a narrow
+Mathlib slice excluding `Finsupp.Pointwise`. Consequence: relations (3) and (4)
+(`source_mul_arrowGen`, `arrowGen_mul_target`) are **false as elaborated** (pointwise
+product of distinct-index basis paths is 0, not the arrow), and the other four are only
+accidentally true pointwise.
+
+Verified a trial `abbrev`→`def` fix produces 13 errors in Definition2_8_4 alone plus
+downstream fallout (Discussion_quiver_rep_bijection, Chapter9/Problem9_4_6) — a real
+multi-file refactor, not a single-lemma change.
+
+Actions taken:
+- Filed **#5987** (feature) with full diagnosis + recommended MonoidAlgebra-style
+  `def` fix and verification steps.
+- `add-dep 5979 5987` (records dependency, marks #5979 blocked).
+- `coordination skip 5979` (released claim, marked replan) with a reason pointing at #5987.
+
+No code committed (working tree clean; the buggy proof edits were reverted).
+
+## Current frontier
+
+#5979 cannot proceed until #5987 lands. #5987 is the actionable next piece:
+convert `PathAlgebra` to a semireducible `def` so the ring `Mul` is the unique instance.
+
+## Overall project progress
+
+Chapter 2 problem formalization ongoing. Problem 2.8.6 is at `statement_formalized`
+but the statements silently use the wrong (pointwise) multiplication — a latent
+correctness bug now documented in #5987. `items.json` unchanged.
+
+## Next step
+
+Pick up **#5987**: make `PathAlgebra` a `def` (à la `MonoidAlgebra k G := G →₀ k`),
+re-provide inherited module instances, fix the ~13 Definition2_8_4 proofs that rely on
+abbrev reducibility, and re-check the two downstream consumers. Then #5979's six proofs
+go through as originally planned (`single_mul_single` + `compSingle_nil_*`).
+
+## Blockers
+
+#5979 blocked on #5987 (definition-level bug). No human action required; #5987 is a
+normal (if larger) work item.


### PR DESCRIPTION
This PR records the lesson from investigating #5979 (Problem 2.8.6 relations) and the definition-level bug it surfaced.

While proving the six path-algebra relation lemmas, `single_mul_single` would not rewrite the goals. Root cause (confirmed with `set_option pp.all true`): `PathAlgebra` is a reducible `abbrev` for `QuiverPathIndex Q →₀ k`, so under `import Mathlib` Mathlib's pointwise `Finsupp.instMul` becomes a valid `Mul` and outranks the intended path-concatenation ring multiplication. Consequently the `*` in Problem 2.8.6's committed statements is pointwise, making relations (3) and (4) false as elaborated. Definition2_8_4 itself is unaffected only because it imports a narrow Mathlib slice excluding `Finsupp.Pointwise`.

The full diagnosis and recommended `MonoidAlgebra`-style `def` fix are filed as #5987; #5979 is marked blocked on it. This PR adds a concise note to the `lean-formalization` skill (complementing the existing MonoidAlgebra/Finsupp instance-wall notes) plus the session progress file.

No Lean source changes; the actual fix is the multi-file refactor tracked in #5987.

🤖 Prepared with Claude Code