### PR TITLE
Prove Exercise 7.9.7: adjoint additive functors are right/left exact (adjunction preserves colimits/limits)

### DIFF
--- a/EtingofRepresentationTheory/Chapter7/Exercise7_9_7.lean
+++ b/EtingofRepresentationTheory/Chapter7/Exercise7_9_7.lean
@@ -26,4 +26,8 @@ theorem Etingof.Exercise7_9_7 {C : Type*} {D : Type*} [Category C] [Category D]
     [Abelian C] [Abelian D] (F : C ⥤ D) (G : D ⥤ C)
     [F.Additive] [G.Additive] (adj : F ⊣ G) :
     Etingof.RightExactFunctor F ∧ Etingof.LeftExactFunctor G := by
-  sorry
+  -- A left adjoint preserves all colimits, hence finite ones; a right adjoint
+  -- preserves all limits, hence finite ones.
+  haveI := adj.leftAdjoint_preservesColimits
+  haveI := adj.rightAdjoint_preservesLimits
+  exact ⟨inferInstance, inferInstance⟩

--- a/progress/2026-07-08T04-03-32Z_ce3ea12b.md
+++ b/progress/2026-07-08T04-03-32Z_ce3ea12b.md
@@ -1,0 +1,40 @@
+## Accomplished
+
+Session type: **feature** (via `/work` → `/feature`). Claimed and completed
+**#5984** (Exercise 7.9.7: adjoint additive functors are right/left exact).
+
+Discharged the single `sorry` in `Etingof.Exercise7_9_7`. The proof is three lines:
+```lean
+haveI := adj.leftAdjoint_preservesColimits   -- PreservesColimitsOfSize F
+haveI := adj.rightAdjoint_preservesLimits    -- PreservesLimitsOfSize G
+exact ⟨inferInstance, inferInstance⟩
+```
+`Etingof.RightExactFunctor F` / `LeftExactFunctor G` are reducible abbrevs for
+`PreservesFiniteColimits F` / `PreservesFiniteLimits G`; the finite versions are
+inferred from the size-general instances via Mathlib's instance chain. The additive
+and abelian hypotheses are unused (adjunction alone suffices) but kept for faithfulness.
+
+Confirmed current Mathlib names by grepping
+`Mathlib/CategoryTheory/Adjunction/Limits.lean`:
+`Adjunction.leftAdjoint_preservesColimits` and
+`Adjunction.rightAdjoint_preservesLimits` (both `lemma`s, not the churned camelCase).
+
+## Current frontier
+
+Item complete. `lake build EtingofRepresentationTheory.Chapter7.Exercise7_9_7`
+succeeds; `#print axioms` shows only `propext, Classical.choice, Quot.sound` (no
+`sorryAx`). `items.json` updated `Chapter7/Exercise7.9.7` → `sorry_free`.
+
+## Overall project progress
+
+Chapter 7 Exercise 7.9.7 now sorry-free. Two unclaimed feature issues remain from
+this batch: #5986 (Ex 2.11.5 base-change module) and #5990 (Prob 2.11.3, claimed).
+
+## Next step
+
+Open the PR for #5984. Next worker could pick up #5986 (base-change module
+instance, pure Mathlib tensor-product infrastructure).
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -6765,8 +6765,8 @@
     "end_page": "195",
     "start_line": 25,
     "end_line": 26,
-    "status": "statement_formalized",
-    "coverage_note": "Statement pass: EtingofRepresentationTheory/Chapter7/Exercise7_9_7.lean (Etingof.Exercise7_9_7), sorry proof."
+    "status": "sorry_free",
+    "coverage_note": "Proved: EtingofRepresentationTheory/Chapter7/Exercise7_9_7.lean (Etingof.Exercise7_9_7). Left adjoint preserves finite colimits (right exact), right adjoint preserves finite limits (left exact), via Adjunction.leftAdjoint_preservesColimits / rightAdjoint_preservesLimits. Axioms: propext, Classical.choice, Quot.sound."
   },
   {
     "id": "Chapter7/Exercise7.9.8",


### PR DESCRIPTION
Closes #5984

Session: `ce3ea12b-135d-4801-81e8-f43034eb7af0`

feda0988 feat(Ch7 #5984): prove Exercise 7.9.7 adjoint functors are right/left exact

🤖 Prepared with Claude Code