### PR TITLE
Fix PathAlgebra abbrev leaking Finsupp.instMul (pointwise) — hijacks * in downstream files, makes Problem2_8_6 relations (3),(4) false

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -310,6 +310,39 @@ General rule: if an implicit type/ring/field appears only *inside* a definition'
 
 `MonoidAlgebra k G` is `def`-equal to `G →₀ k`, so `Finsupp.lhom_ext` *applies* to a goal `F = 0` for `F : MonoidAlgebra k G →ₗ[k] N` — but it unifies the domain with the bare `G →₀ k`, which pries the type open and breaks instance search for everything registered on `MonoidAlgebra` (`failed to synthesize Ring (G →₀ ℂ)` / `Algebra ℂ (G →₀ ℂ)` / `Module (G →₀ ℂ) (M i)`). **To show a linear functional on `MonoidAlgebra k G` vanishes**, keep the type intact: prove `∀ a, F a = 0` by `induction a using MonoidAlgebra.induction_on` (base case `of k G g` — exactly the group-element evaluation you have a bridge lemma for; `hadd`/`hsmul` close by `simp only [map_add, …]` / `simp only [map_smul, …]`), then package via `LinearMap.ext`. (#4908)
 
+### Converting a reducible `abbrev` Finsupp-wrapper to a `def` to stop `Finsupp.instMul` leaking (#5987)
+
+A reducible `abbrev Foo … := ι →₀ k` (e.g. `PathAlgebra`) is a trap: under `import Mathlib`,
+instance synthesis unfolds it and picks up `Finsupp`'s **pointwise** `Finsupp.instMul`
+(`Mathlib.Data.Finsupp.Pointwise`), which outranks any custom ring `Mul` you build — silently
+making `f * g` the pointwise product (disjoint-support basis paths multiply to `0`). The file that
+*defines* `Foo` may look fine if it imports a narrow Mathlib slice without `Finsupp.Pointwise`; the
+breakage only appears in downstream files that `import Mathlib`. Confirm with
+`set_option pp.all true in #check (a * b)` — the `HMul` head should be your ring's `instHMul`, not
+`Finsupp.instMul`. **Fix = make it a semireducible `def`** (Mathlib's `MonoidAlgebra` pattern), so
+instance search (reducible-only) can no longer see the `Finsupp` instances. The conversion triggers
+a predictable cascade (cost ~10 build cycles in #5987, `Chapter2/Definition2_8_4.lean`):
+- **Re-expose module-level instances** via `inferInstanceAs` — `AddCommGroup`, `Module k`,
+  `Inhabited`, … (the `Finsupp`-derived ones are `noncomputable`). Elaboration still unfolds the
+  `def` at default transparency, so `Finsupp.single x c : Foo` etc. keep typechecking.
+- **`binop%` leak on `Finsupp.single` products.** `(Finsupp.single x a * Finsupp.single y b : Foo)`
+  fails (`failed to synthesize HMul (ι →₀ k) (ι →₀ k) ?`) — and *operand* ascriptions
+  `(Finsupp.single x a : Foo)` don't help, because `binop%` compares operand vs expected type at
+  *reducible* transparency, treats them as uncomparable, and defaults to the raw Finsupp type.
+  **Fix:** write the product with explicit `@HMul.hMul Foo Foo Foo _ (Finsupp.single …) (…)`. Keep the
+  atoms literal `Finsupp.single` (not a new wrapper `def`) so downstream `rw`/`simp` on goals holding
+  `Finsupp.single` (from `Finsupp.induction_linear`, unfolded `ofX := Finsupp.single …`) still match.
+- **`Finsupp.lsum`-based defs leak their LinearMap type.** A `def mul' : Foo →ₗ[k] Foo →ₗ[k] Foo :=
+  Finsupp.lsum …` compiles but any tactic that unfolds it hits "target not type-correct under
+  instances transparency", and `Finsupp.lsum_single` won't fire. **Fix:** type the internal
+  machinery on the *raw* `ι →₀ k` (`compSingle`, `mulLinear`) so it is leak-free, and bridge to `Foo`
+  only at the ring instance (`mul := fun f g => mulLinear f g`, `mul_def := rfl`). When a def *must*
+  stay `Foo`-domained (needed by `AlgHom.ofLinearMap` — the raw type has no algebra instance), prove
+  its apply-lemma by `change`-ing the goal to the raw-coercion form first, then `simp [Finsupp.lsum_single]`.
+- **simp can't match `Finsupp.smul_single`** on the `instModule`-typed smul that a `Foo`-ascribed RHS
+  produces (defeq but keyed on a different `SMul` head). **Fix:** use `rw [Finsupp.smul_single]` (rw
+  unifies instance args up to defeq) instead of `simp only [Finsupp.smul_single]`.
+
 ### Induced rep `Ind_H^G ℂ ≅ k[G]·a` as `Representation.Equiv`, and the MonoidAlgebra/Finsupp instance wall (#5171)
 
 Goal: `Etingof.Definition5_8_1 H (trivial) ≅ ℂ[G]·a` (left ideal). Recipe in

--- a/EtingofRepresentationTheory/Chapter2/Definition2_8_4.lean
+++ b/EtingofRepresentationTheory/Chapter2/Definition2_8_4.lean
@@ -64,12 +64,41 @@ end QuiverPathIndex
 
 /-- The path algebra of a quiver `Q` over a field `k`, in the sense of Etingof Definition 2.8.4.
 The basis consists of oriented paths in `Q`, with multiplication given by path concatenation
-(zero if the paths are not composable). -/
-abbrev PathAlgebra (k : Type*) (Q : Type*) [Field k] [Quiver Q]
+(zero if the paths are not composable).
+
+This is a (semireducible) `def`, not an `abbrev`, following Mathlib's `MonoidAlgebra` pattern
+(`def MonoidAlgebra k G := G →₀ k`). Were it a reducible `abbrev`, instance synthesis would unfold
+it to `QuiverPathIndex Q →₀ k` and pick up `Finsupp`'s *pointwise* multiplication
+(`Finsupp.instMul` from `Mathlib.Data.Finsupp.Pointwise`), which under `import Mathlib` outranks the
+intended path-concatenation ring multiplication built below. As a `def`, instance synthesis (which
+unfolds only reducible definitions) no longer sees the `Finsupp` instances, so the path-algebra ring
+structure is the unique `Mul`. The `Finsupp` module-level structure is re-exposed explicitly via
+`inferInstanceAs` in the instances immediately following; elaboration still unfolds the `def` at
+default transparency, so `Finsupp.single`/`Finsupp.lsum`/etc. continue to typecheck at type
+`PathAlgebra k Q`. -/
+def PathAlgebra (k : Type*) (Q : Type*) [Field k] [Quiver Q]
     [DecidableEq Q] : Type _ :=
   QuiverPathIndex Q →₀ k
 
 namespace PathAlgebra
+
+section Instances
+variable (k : Type*) (Q : Type*) [Field k] [Quiver Q] [DecidableEq Q]
+
+/-- The additive-group structure on `PathAlgebra k Q`, re-exposed from `Finsupp`. Needed because
+`PathAlgebra` is a `def` (not a reducible `abbrev`), so the `Finsupp` instance is no longer found
+for it by instance synthesis. -/
+noncomputable instance : AddCommGroup (PathAlgebra k Q) :=
+  inferInstanceAs (AddCommGroup (QuiverPathIndex Q →₀ k))
+
+/-- The `k`-module structure on `PathAlgebra k Q`, re-exposed from `Finsupp`. -/
+noncomputable instance : Module k (PathAlgebra k Q) :=
+  inferInstanceAs (Module k (QuiverPathIndex Q →₀ k))
+
+instance : Inhabited (PathAlgebra k Q) :=
+  inferInstanceAs (Inhabited (QuiverPathIndex Q →₀ k))
+
+end Instances
 
 variable (k : Type*) (Q : Type*) [Field k] [Quiver Q] [DecidableEq Q]
 
@@ -80,9 +109,13 @@ with coefficient `1`. -/
 noncomputable def ofPath (x : QuiverPathIndex Q) : PathAlgebra k Q :=
   Finsupp.single x 1
 
-/-- The product of two basis paths (as an element of the algebra): the concatenated path with
-coefficient `1` when composable, and `0` otherwise. -/
-noncomputable def compSingle (x y : QuiverPathIndex Q) : PathAlgebra k Q :=
+/-- The product of two basis paths (as a raw `Finsupp`): the concatenated path with coefficient `1`
+when composable, and `0` otherwise. This is deliberately typed as the underlying
+`QuiverPathIndex Q →₀ k` rather than `PathAlgebra k Q`, so that the bilinear multiplication
+`mulLinear` built from it has a single consistent (leak-free) `Finsupp` type; `PathAlgebra k Q` is
+definitionally this type, so `compSingle x y` is still usable wherever a `PathAlgebra k Q` value is
+expected. -/
+noncomputable def compSingle (x y : QuiverPathIndex Q) : QuiverPathIndex Q →₀ k :=
   (x.comp y).elim 0 (fun z => Finsupp.single z (1 : k))
 
 /-- On composable basis paths, `compSingle` is the single concatenated path. -/
@@ -93,7 +126,8 @@ theorem compSingle_eq {a b d : Q} (p : Quiver.Path a b) (q : Quiver.Path b d) :
 
 /-- On non-composable basis paths, `compSingle` is zero. -/
 theorem compSingle_eq_zero {a b c d : Q} (p : Quiver.Path a b) (q : Quiver.Path c d)
-    (h : b ≠ c) : compSingle (⟨a, b, p⟩ : QuiverPathIndex Q) ⟨c, d, q⟩ = (0 : PathAlgebra k Q) := by
+    (h : b ≠ c) :
+    compSingle (⟨a, b, p⟩ : QuiverPathIndex Q) ⟨c, d, q⟩ = (0 : QuiverPathIndex Q →₀ k) := by
   rw [compSingle, QuiverPathIndex.comp_eq_none _ _ h]; rfl
 
 /-- Multiplying a trivial path `p_i` on the left: the result is the original path if it starts at
@@ -122,7 +156,7 @@ variable (k Q)
 concatenation; it is extended bilinearly to the whole free module. Phrasing the product as a
 `LinearMap` makes all distributive laws hold definitionally (they are `map_add`/`map_zero`). -/
 noncomputable def mulLinear :
-    PathAlgebra k Q →ₗ[k] PathAlgebra k Q →ₗ[k] PathAlgebra k Q :=
+    (QuiverPathIndex Q →₀ k) →ₗ[k] (QuiverPathIndex Q →₀ k) →ₗ[k] (QuiverPathIndex Q →₀ k) :=
   Finsupp.lsum k fun x =>
     (LinearMap.id : k →ₗ[k] k).smulRight
       (Finsupp.lsum k fun y => (LinearMap.id : k →ₗ[k] k).smulRight (compSingle x y))
@@ -154,7 +188,8 @@ theorem mul_def (f g : PathAlgebra k Q) : f * g = mulLinear k Q f g := rfl
 /-- On basis paths the product is the concatenation `compSingle`, scaled by the product of the
 coefficients. -/
 theorem single_mul_single (x y : QuiverPathIndex Q) (a b : k) :
-    (Finsupp.single x a * Finsupp.single y b : PathAlgebra k Q)
+    (@HMul.hMul (PathAlgebra k Q) (PathAlgebra k Q) (PathAlgebra k Q) _
+        (Finsupp.single x a) (Finsupp.single y b))
       = (a * b) • compSingle x y := by
   rw [mul_def, mulLinear]
   simp only [Finsupp.lsum_single, LinearMap.smulRight_apply, LinearMap.id_coe, id_eq,
@@ -176,8 +211,14 @@ theorem mul_smul' (r : k) (a b : PathAlgebra k Q) : a * (r • b) = r • (a * b
 path concatenation (`Quiver.Path.comp_assoc`) enters; the partial composition cases all collapse
 to `0`. -/
 theorem single_mul_single_assoc (x y z : QuiverPathIndex Q) (a b c : k) :
-    (Finsupp.single x a * Finsupp.single y b * Finsupp.single z c : PathAlgebra k Q)
-      = Finsupp.single x a * (Finsupp.single y b * Finsupp.single z c) := by
+    (@HMul.hMul (PathAlgebra k Q) (PathAlgebra k Q) (PathAlgebra k Q) _
+        (@HMul.hMul (PathAlgebra k Q) (PathAlgebra k Q) (PathAlgebra k Q) _
+          (Finsupp.single x a) (Finsupp.single y b))
+        (Finsupp.single z c))
+      = (@HMul.hMul (PathAlgebra k Q) (PathAlgebra k Q) (PathAlgebra k Q) _
+          (Finsupp.single x a)
+          (@HMul.hMul (PathAlgebra k Q) (PathAlgebra k Q) (PathAlgebra k Q) _
+            (Finsupp.single y b) (Finsupp.single z c))) := by
   obtain ⟨xa, xb, xp⟩ := x
   obtain ⟨yc, yd, yq⟩ := y
   obtain ⟨ze, zf, zr⟩ := z
@@ -248,15 +289,17 @@ protected theorem one_mul [Fintype Q] (f : PathAlgebra k Q) : (1 : PathAlgebra k
   | single x a =>
     obtain ⟨xa, xb, xp⟩ := x
     rw [one_def, Finset.sum_mul]
-    have hterm : ∀ i : Q, (Finsupp.single (⟨i, i, Quiver.Path.nil⟩ : QuiverPathIndex Q) (1 : k)
-        * Finsupp.single (⟨xa, xb, xp⟩ : QuiverPathIndex Q) a : PathAlgebra k Q)
+    have hterm : ∀ i : Q,
+        (@HMul.hMul (PathAlgebra k Q) (PathAlgebra k Q) (PathAlgebra k Q) _
+          (Finsupp.single (⟨i, i, Quiver.Path.nil⟩ : QuiverPathIndex Q) (1 : k))
+          (Finsupp.single (⟨xa, xb, xp⟩ : QuiverPathIndex Q) a))
         = if i = xa then (Finsupp.single (⟨xa, xb, xp⟩ : QuiverPathIndex Q) a : PathAlgebra k Q)
           else 0 := by
       intro i
       rw [single_mul_single, compSingle_nil_left]
       by_cases h : i = xa
-      · simp only [if_pos h, one_mul, Finsupp.smul_single, smul_eq_mul, mul_one]
-      · simp only [if_neg h, smul_zero]
+      · rw [one_mul, if_pos h, Finsupp.smul_single, smul_eq_mul, mul_one, if_pos h]
+      · rw [if_neg h, smul_zero, if_neg h]
     rw [Finset.sum_congr rfl fun i _ => hterm i,
       Finset.sum_ite_eq' Finset.univ xa, if_pos (Finset.mem_univ xa)]
 
@@ -268,15 +311,17 @@ protected theorem mul_one [Fintype Q] (f : PathAlgebra k Q) : f * (1 : PathAlgeb
   | single x a =>
     obtain ⟨xa, xb, xp⟩ := x
     rw [one_def, Finset.mul_sum]
-    have hterm : ∀ i : Q, (Finsupp.single (⟨xa, xb, xp⟩ : QuiverPathIndex Q) a
-        * Finsupp.single (⟨i, i, Quiver.Path.nil⟩ : QuiverPathIndex Q) (1 : k) : PathAlgebra k Q)
+    have hterm : ∀ i : Q,
+        (@HMul.hMul (PathAlgebra k Q) (PathAlgebra k Q) (PathAlgebra k Q) _
+          (Finsupp.single (⟨xa, xb, xp⟩ : QuiverPathIndex Q) a)
+          (Finsupp.single (⟨i, i, Quiver.Path.nil⟩ : QuiverPathIndex Q) (1 : k)))
         = if xb = i then (Finsupp.single (⟨xa, xb, xp⟩ : QuiverPathIndex Q) a : PathAlgebra k Q)
           else 0 := by
       intro i
       rw [single_mul_single, compSingle_nil_right]
       by_cases h : xb = i
-      · simp only [if_pos h, mul_one, Finsupp.smul_single, smul_eq_mul]
-      · simp only [if_neg h, smul_zero]
+      · rw [mul_one, if_pos h, Finsupp.smul_single, smul_eq_mul, mul_one, if_pos h]
+      · rw [if_neg h, smul_zero, if_neg h]
     rw [Finset.sum_congr rfl fun i _ => hterm i,
       Finset.sum_ite_eq Finset.univ xb, if_pos (Finset.mem_univ xb)]
 

--- a/EtingofRepresentationTheory/Chapter2/Discussion_quiver_rep_bijection.lean
+++ b/EtingofRepresentationTheory/Chapter2/Discussion_quiver_rep_bijection.lean
@@ -319,7 +319,12 @@ noncomputable def toEndₗ (R : Etingof.QuiverRepresentation k Qᵒᵖ) :
 
 theorem toEndₗ_single (R : Etingof.QuiverRepresentation k Qᵒᵖ) (x : Etingof.QuiverPathIndex Q)
     (c : k) : toEndₗ R (Finsupp.single x c) = c • pathEnd R x := by
-  simp only [toEndₗ, Finsupp.lsum_single, LinearMap.smulRight_apply, LinearMap.id_coe, id_eq]
+  -- `PathAlgebra k Q` is a `def` (not a reducible `abbrev`), so unfolding `toEndₗ` leaves the
+  -- `Finsupp.lsum` applied at the `PathAlgebra` coercion, where `Finsupp.lsum_single` does not
+  -- fire. Restate the goal (defeq) with the underlying `QuiverPathIndex Q →₀ k` coercion.
+  change (Finsupp.lsum k fun x => (LinearMap.id : k →ₗ[k] k).smulRight (pathEnd R x))
+      (Finsupp.single x c) = c • pathEnd R x
+  simp only [Finsupp.lsum_single, LinearMap.smulRight_apply, LinearMap.id_coe, id_eq]
 
 theorem toEndₗ_ofPath (R : Etingof.QuiverRepresentation k Qᵒᵖ) (x : Etingof.QuiverPathIndex Q) :
     toEndₗ R (ofPath x) = pathEnd R x := by

--- a/progress/2026-07-08T04-23-30Z_63d90384.md
+++ b/progress/2026-07-08T04-23-30Z_63d90384.md
@@ -1,0 +1,59 @@
+## Accomplished
+
+Fixed issue #5987: `PathAlgebra` (Definition 2.8.4) was a reducible `abbrev` for
+`QuiverPathIndex Q →₀ k`, so under `import Mathlib` the pointwise `Finsupp.instMul` was a valid
+`Mul (PathAlgebra k Q)` and outranked the intended path-concatenation ring multiplication. This
+made relations (3)/(4) in `Problem2_8_6` false as elaborated (`vertexIdem i * arrowGen e`
+resolved to the pointwise `0`), blocking #5979.
+
+Changes (2 files):
+
+- `Chapter2/Definition2_8_4.lean`:
+  - `abbrev PathAlgebra` → `def PathAlgebra` (semireducible, MonoidAlgebra pattern), so instance
+    synthesis no longer unfolds it to find `Finsupp`'s pointwise instances.
+  - Re-exposed the module-level structure via `inferInstanceAs`: `AddCommGroup`, `Module k`,
+    `Inhabited` (the first two `noncomputable`).
+  - Retyped the internal multiplication machinery (`compSingle`, `mulLinear`) to the raw
+    `QuiverPathIndex Q →₀ k`, so `Finsupp.lsum`/`Finsupp.lsum_single` see a single consistent
+    (leak-free) type. `PathAlgebra` is defeq to it, so these values still flow into
+    `PathAlgebra`-typed positions.
+  - In `single_mul_single`, `single_mul_single_assoc`, and the two `one_mul`/`mul_one` `hterm`s,
+    wrote the products with explicit `@HMul.hMul (PathAlgebra k Q) …` because the `binop%`
+    elaborator otherwise infers the operand's raw type and fails to find the ring `Mul`. The
+    `hterm` smul closings changed from `simp only` to `rw` (simp couldn't match
+    `Finsupp.smul_single` against the `instModule`-typed smul, though it is defeq).
+
+- `Chapter2/Discussion_quiver_rep_bijection.lean`:
+  - `toEndₗ_single`: same `def`-leak — restated the goal (defeq) at the raw
+    `QuiverPathIndex Q →₀ k` coercion via `change` so `Finsupp.lsum_single` fires.
+
+## Verification
+
+- `set_option pp.all true` on `vertexIdem k Q i * arrowGen k Q e` (in a file that
+  `import Mathlib`) now shows `@instHMul (PathAlgebra …) (… PathAlgebra.instRingOfFintype …)`,
+  i.e. the ring multiplication — NOT `Finsupp.instMul`.
+- `lake build` of the whole project succeeds (9131 jobs, 0 errors).
+- All four `PathAlgebra` files build: `Definition2_8_4`, `Discussion_quiver_rep_bijection`,
+  `Problem2_8_6`, `Chapter9/Problem9_4_6`.
+- `#print axioms` on `single_mul_single`, `single_mul_single_assoc`, `one_mul`, `mul_one`,
+  `sum_trivialPaths_eq_one` shows only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`.
+
+## Current frontier
+
+Issue #5987 complete. `Problem2_8_6`'s six relation lemmas now elaborate against the correct
+ring multiplication (they remain `sorry`, to be discharged by #5979).
+
+## Overall project progress
+
+Stage 3 formalization ongoing. This was a foundational definition-correctness fix, highest
+priority per the escalation ladder ("definition seems wrong").
+
+## Next step
+
+#5979 can now prove `Problem2_8_6` relations (2)-(4) via `single_mul_single` +
+`compSingle_nil_left`/`compSingle_nil_right`. Other unclaimed work: #5984 (Exercise 7.9.7),
+#5986 (Exercise 2.11.5).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #5987

Session: `63d90384-f023-4bff-91de-ed7cf8aaa161`

ad2a991f fix(Ch2 #5987): make PathAlgebra a def so Finsupp pointwise Mul no longer leaks

🤖 Prepared with Claude Code