### PR TITLE
Prove Problem 4.12.1: dihedral irreps are 1- or 2-dimensional, and V⊗V character identity χ_V²=1+χ_ε+χ_{V₂}

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -768,6 +768,34 @@ directly — work with `ρ`-invariant `k`-subspaces of `V` and transport:
   `eq_top` from "two basis vectors span". For a 2-dim rep this is the "diagonal
   generator and swap share no common eigenline" argument.
 
+#### *Consuming* `IsSimpleModule k[G] ρ.asModule` to bound `finrank` (Ch4 Problem4.12.1, #5997)
+
+The reverse direction — given `hρ : IsSimpleModule k[G] ρ.asModule` as a hypothesis,
+deduce a *dimension bound* by exhibiting a concrete spanning invariant subspace — is
+cleanest via the **`Subrepresentation` structure** (root namespace, from
+`Mathlib.RepresentationTheory.Subrepresentation`), not `invtSubmodule`:
+- `Representation.IsIrreducible ρ` is `abbrev`-defined as `IsSimpleOrder (Subrepresentation ρ)`;
+  `haveI hirr : Representation.IsIrreducible ρ :=
+  (Representation.irreducible_iff_isSimpleModule_asModule ρ).mpr hρ` registers the instance
+  (and first `haveI := hρ` so `IsSimpleModule.nontrivial (R := k[G]) (M := ρ.asModule)` gives
+  `Nontrivial V` — `ρ.asModule` is *definitionally* `V`, so ascribe `Nontrivial V` directly).
+- Build the invariant subspace as a `Subrepresentation ρ` literal:
+  `{ toSubmodule := Submodule.span k S, apply_mem_toSubmodule := … }`. Prove invariance by
+  `intro g x hx; induction hx using Submodule.span_induction with | mem … | zero => simp
+  | add … => rw [map_add]; exact add_mem … | smul … => rw [map_smul]; exact smul_mem …`; the
+  `mem` case reduces to showing `ρ g` sends each generator into the span (case-split `g` on
+  the group's constructors).
+- `IsSimpleOrder.eq_bot_or_eq_top Sub : Sub = ⊥ ∨ Sub = ⊤`. `(⊥/⊤ : Subrepresentation ρ).toSubmodule`
+  is `⊥`/`⊤` **by `rfl`** but `rw [h]` won't auto-close it — append `; rfl`. Rule out `⊥` from a
+  nonzero member; then `Sub.toSubmodule = ⊤` gives `Submodule.span k S = ⊤` (defeq), and
+  `finrank_le_of_span_eq_top (v := ![…])` + `Module.finrank_pos` pin `finrank ∈ {1,…,#S}` (`omega`).
+- Gotchas: endomorphism-composition application is `Module.End.mul_apply` (**not**
+  `LinearMap.mul_apply`, which does not exist); eigenvector power law `f^n v = μ^n • v` is
+  `Module.End.HasEigenvector.pow_apply`; `Module.End.exists_eigenvalue` needs
+  `[IsAlgClosed k] [FiniteDimensional k V] [Nontrivial V]`. For `DihedralGroup N`,
+  `r j = (r 1)^j.val` via `DihedralGroup.r_one_pow` + `ZMod.natCast_zmod_val` (needs `[NeZero N]`),
+  and the relations are `r_mul_r`/`r_mul_sr`/`sr_mul_r`/`sr_mul_sr`.
+
 **Faithful "completely reducible / semisimple" statement (anti-vacuity, #5384).**
 To say a representation `ρ : Representation k G V` is *completely reducible*, write
 `IsSemisimpleModule (MonoidAlgebra k G) ρ.asModule` — semisimplicity of the

--- a/EtingofRepresentationTheory/Chapter4/Problem4_12_1.lean
+++ b/EtingofRepresentationTheory/Chapter4/Problem4_12_1.lean
@@ -24,6 +24,12 @@ generators `r k` = rotations, `sr k` = reflections).
   one-dimensional and `(N-2)/2` two-dimensional for even `N` — are recorded here in the
   docstring.)
 
+  The proof follows the book: pick an eigenvector `v` of the rotation `ρ (r 1)` (a nonzero
+  endomorphism of a nonzero finite-dimensional space over `ℂ` always has one). Then the span of
+  `v` and `s • v` (with `s = ρ (sr 0)` a reflection) is stable under the whole group, hence a
+  subrepresentation of dimension `≤ 2`; irreducibility forces it to be everything, so
+  `dim W ∈ {1, 2}`.
+
 * **(b)** Over `ℂ` the complexified standard representation `V` diagonalizes on rotations with
   eigenvalues `ζ^k, ζ^{-k}` (`ζ = exp(2πi/N)` a primitive `N`-th root of unity), and `V ⊗ V`
   decomposes as `𝟙 ⊕ ε ⊕ V₂`, where `𝟙` is trivial, `ε` is the sign (rotations act by `1`,
@@ -32,8 +38,6 @@ generators `r k` = rotations, `sr k` = reflections).
   class functions defined below, `χ_V(g)² = 1 + χ_ε(g) + χ_{V₂}(g)` for all `g`, which is
   exactly `V ⊗ V ≅ 𝟙 ⊕ ε ⊕ V₂` since the character of a tensor product is the product of
   characters.
-
-This is a statement pass: faithful signatures with `sorry` proofs.
 -/
 
 open Real
@@ -54,7 +58,85 @@ theorem irreducible_dim [NeZero N]
     (ρ : Representation ℂ (DihedralGroup N) W)
     (hρ : IsSimpleModule (MonoidAlgebra ℂ (DihedralGroup N)) ρ.asModule) :
     Module.finrank ℂ W = 1 ∨ Module.finrank ℂ W = 2 := by
-  sorry
+  classical
+  haveI : IsSimpleModule (MonoidAlgebra ℂ (DihedralGroup N)) ρ.asModule := hρ
+  haveI : Nontrivial W :=
+    IsSimpleModule.nontrivial (R := MonoidAlgebra ℂ (DihedralGroup N)) (M := ρ.asModule)
+  -- Irreducibility of `ρ`: the lattice of subrepresentations is simple.
+  haveI hirr : Representation.IsIrreducible ρ :=
+    (Representation.irreducible_iff_isSimpleModule_asModule ρ).mpr hρ
+  -- An eigenvector `v` of the rotation `ρ (r 1)`.
+  obtain ⟨μ, hμ⟩ := Module.End.exists_eigenvalue (ρ (DihedralGroup.r 1))
+  obtain ⟨v, hv⟩ := hμ.exists_hasEigenvector
+  have hv0 : v ≠ 0 := hv.2
+  -- The reflection applied to `v`.
+  set w₀ : W := ρ (DihedralGroup.sr 0) v with hw₀
+  -- The rotation `r j` acts on the eigenvector by the scalar `μ ^ j.val`.
+  have hA : ∀ j : ZMod N, ρ (DihedralGroup.r j) v = μ ^ j.val • v := by
+    intro j
+    have hj : DihedralGroup.r j = (DihedralGroup.r 1 : DihedralGroup N) ^ j.val := by
+      rw [DihedralGroup.r_one_pow, ZMod.natCast_zmod_val]
+    rw [hj, map_pow]
+    exact hv.pow_apply j.val
+  -- The reflection `sr j = sr 0 * r j` sends `v` to `μ ^ j.val • w₀`.
+  have hB : ∀ j : ZMod N, ρ (DihedralGroup.sr j) v = μ ^ j.val • w₀ := by
+    intro j
+    have hj : DihedralGroup.sr j = DihedralGroup.sr 0 * DihedralGroup.r j := by
+      rw [DihedralGroup.sr_mul_r, zero_add]
+    rw [hj, map_mul, Module.End.mul_apply, hA j, map_smul, hw₀]
+  -- The two generators of the span, as members.
+  have hvU : v ∈ Submodule.span ℂ ({v, w₀} : Set W) := Submodule.subset_span (by simp)
+  have hw₀U : w₀ ∈ Submodule.span ℂ ({v, w₀} : Set W) := Submodule.subset_span (by simp)
+  -- `ρ g` on `w₀` is `ρ (g * sr 0)` on `v`.
+  have hgsv : ∀ g : DihedralGroup N, ρ g w₀ = ρ (g * DihedralGroup.sr 0) v := by
+    intro g; rw [hw₀, map_mul, Module.End.mul_apply]
+  -- `span {v, w₀}` is a subrepresentation.
+  let Sub : Subrepresentation ρ :=
+    { toSubmodule := Submodule.span ℂ ({v, w₀} : Set W)
+      apply_mem_toSubmodule := by
+        intro g x hx
+        induction hx using Submodule.span_induction with
+        | mem y hy =>
+            simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hy
+            rcases hy with rfl | rfl
+            · cases g with
+              | r k => rw [hA k]; exact Submodule.smul_mem _ _ hvU
+              | sr k => rw [hB k]; exact Submodule.smul_mem _ _ hw₀U
+            · rw [hgsv g]
+              cases g with
+              | r k =>
+                  rw [DihedralGroup.r_mul_sr, hB (0 - k)]; exact Submodule.smul_mem _ _ hw₀U
+              | sr k =>
+                  rw [DihedralGroup.sr_mul_sr, hA (0 - k)]; exact Submodule.smul_mem _ _ hvU
+        | zero => simp
+        | add a b _ _ iha ihb => rw [map_add]; exact Submodule.add_mem _ iha ihb
+        | smul c a _ ih => rw [map_smul]; exact Submodule.smul_mem _ _ ih }
+  -- Irreducibility forces the subrepresentation to be everything.
+  have hSubTop : Sub.toSubmodule = ⊤ := by
+    rcases IsSimpleOrder.eq_bot_or_eq_top Sub with h | h
+    · exfalso
+      apply hv0
+      have hbot : Sub.toSubmodule = ⊥ := by rw [h]; rfl
+      have hv' : v ∈ (⊥ : Submodule ℂ W) := by rw [← hbot]; exact hvU
+      rwa [Submodule.mem_bot] at hv'
+    · rw [h]; rfl
+  have hspan : Submodule.span ℂ ({v, w₀} : Set W) = ⊤ := hSubTop
+  -- Two generators, so the dimension is at most `2`.
+  have hrange : Set.range ![v, w₀] = ({v, w₀} : Set W) := by
+    ext x
+    constructor
+    · rintro ⟨i, rfl⟩
+      fin_cases i <;> simp
+    · intro hx
+      simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hx
+      rcases hx with rfl | rfl
+      · exact ⟨0, rfl⟩
+      · exact ⟨1, rfl⟩
+  have hle : Module.finrank ℂ W ≤ 2 := by
+    have h := finrank_le_of_span_eq_top (R := ℂ) (v := ![v, w₀]) (by rw [hrange]; exact hspan)
+    simpa using h
+  have hpos : 0 < Module.finrank ℂ W := Module.finrank_pos
+  omega
 
 /-- Character of the complexified standard `2`-dimensional representation `V`:
 `χ_V(r k) = ζ^k + ζ^{-k}` on rotations and `0` on reflections. -/
@@ -78,6 +160,20 @@ noncomputable def chiRot2 (N : ℕ) : DihedralGroup N → ℂ
 representation). -/
 theorem tensor_square_character (N : ℕ) (g : DihedralGroup N) :
     chiStd N g ^ 2 = 1 + chiSign N g + chiRot2 N g := by
-  sorry
+  cases g with
+  | r k =>
+    simp only [chiStd, chiSign, chiRot2]
+    have hz : zeta N ≠ 0 := by unfold zeta; exact Complex.exp_ne_zero _
+    have hab : zeta N ^ k.val * (zeta N)⁻¹ ^ k.val = 1 := by
+      rw [← mul_pow, mul_inv_cancel₀ hz, one_pow]
+    have ha2 : zeta N ^ (2 * k.val) = (zeta N ^ k.val) ^ 2 := by
+      rw [← pow_mul, Nat.mul_comm]
+    have hb2 : (zeta N)⁻¹ ^ (2 * k.val) = ((zeta N)⁻¹ ^ k.val) ^ 2 := by
+      rw [← pow_mul, Nat.mul_comm]
+    rw [ha2, hb2]
+    linear_combination (2 : ℂ) * hab
+  | sr k =>
+    simp only [chiStd, chiSign, chiRot2]
+    ring
 
 end Etingof.Problem4_12_1

--- a/progress/2026-07-09T04-23-07Z_15587ece.md
+++ b/progress/2026-07-09T04-23-07Z_15587ece.md
@@ -1,0 +1,39 @@
+# Progress — 2026-07-09T04:23Z (session 15587ece, feature)
+
+## Accomplished
+Proved **Problem 4.12.1** (`EtingofRepresentationTheory/Chapter4/Problem4_12_1.lean`),
+issue #5997. Both theorems are now `sorry`-free:
+
+- **`irreducible_dim`** (part (a)): every finite-dimensional irreducible complex
+  representation of `DihedralGroup N` (`N ≥ 1`) is `1`- or `2`-dimensional. Proof follows
+  the book: obtain an eigenvector `v` of the rotation `ρ (r 1)` (via
+  `Module.End.exists_eigenvalue`, using `ℂ` algebraically closed + `Nontrivial W` from the
+  simple module). Then `span ℂ {v, ρ (sr 0) v}` is a subrepresentation — invariance checked
+  by `Submodule.span_induction` and case analysis on the two `DihedralGroup` element shapes
+  (`r k`, `sr k`), using `ρ (r j) v = μ^j.val • v` and `ρ (sr j) v = μ^j.val • ρ(sr 0) v`
+  plus the dihedral relations `r_mul_sr`, `sr_mul_sr`, `sr_mul_r`. Irreducibility
+  (`Representation.irreducible_iff_isSimpleModule_asModule` + `IsSimpleOrder` of the
+  `Subrepresentation` lattice) forces the subrep to be `⊤`, so `finrank W ≤ 2`; combined with
+  `Module.finrank_pos` gives `finrank W ∈ {1, 2}`.
+- **`tensor_square_character`** (part (b)): character identity
+  `χ_V(g)² = 1 + χ_ε(g) + χ_{V₂}(g)`. On rotations, expand `(ζ^k + ζ^{-k})²` and use
+  `ζ · ζ⁻¹ = 1` (`Complex.exp_ne_zero`) via `linear_combination`; on reflections both sides
+  are `0`.
+
+Moved `Chapter4/Problem4.12.1` from `statement_formalized` to `sorry_free` in
+`progress/items.json`. `#print axioms` on both theorems shows only
+`propext, Classical.choice, Quot.sound`.
+
+## Current frontier
+Issue #5997 complete. File builds clean (`lake build ...Problem4_12_1`, 0 warnings/errors).
+
+## Overall project progress
+Phase 3 formalization ongoing. This item is one more `sorry_free` entry in Chapter 4.
+
+## Next step
+Open unclaimed feature issues remain: #6000 (reflection functor adjunction),
+#6001 (Problem 3.8.4 Noether-Deuring), #6002 (Problem 3.9.4a formal deformations). All are
+heavier than 4.12.1. A next worker can claim the oldest.
+
+## Blockers
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3023,8 +3023,8 @@
     "end_page": "83",
     "start_line": 9,
     "end_line": 14,
-    "status": "statement_formalized",
-    "coverage_note": "Statement in EtingofRepresentationTheory/Chapter4/Problem4_12_1.lean (DihedralGroup N: (a) every irreducible is 1- or 2-dim; (b) V⊗V decomposition as character identity χ_V²=1+χ_sign+χ_V2; sorry proofs, statement pass)."
+    "status": "sorry_free",
+    "coverage_note": "Proved in EtingofRepresentationTheory/Chapter4/Problem4_12_1.lean (DihedralGroup N: (a) irreducible_dim — every irreducible is 1- or 2-dim, via eigenvector of ρ(r 1) and the span{v, ρ(sr 0) v} subrepresentation forced to be ⊤ by irreducibility; (b) tensor_square_character — V⊗V decomposition as character identity χ_V²=1+χ_sign+χ_V2). No sorries; #print axioms shows only propext/Classical.choice/Quot.sound."
   },
   {
     "id": "Chapter4/Problem4.12.2",


### PR DESCRIPTION
Closes #5997

Session: `15587ece-94c9-4075-90ca-9fd63cbf6056`

6ff7ec5c doc(skill): record recipe for bounding finrank of an irreducible rep via Subrepresentation
dc362719 feat(Ch4 #5997): prove Problem 4.12.1 dihedral irreps 1/2-dim + V⊗V character identity

🤖 Prepared with Claude Code