### PR TITLE
feat(Ch7): transportReversedTwice accessors + Exercise 7.9.8 blueprint

### DIFF
--- a/EtingofRepresentationTheory/Chapter7/Exercise7_9_8.lean
+++ b/EtingofRepresentationTheory/Chapter7/Exercise7_9_8.lean
@@ -47,6 +47,108 @@ applied to the adjunction of (a).
 
 open CategoryTheory
 
+namespace Etingof.QuiverRepresentation
+
+/-! ## Transport accessors for `transportReversedTwice`
+
+`transportReversedTwice X` moves a representation of the double-reversed quiver `(Q̄ᵢ)̄ᵢ`
+back to `Q` along the instance equality `reversedAtVertex_twice Q i : (Q̄ᵢ)̄ᵢ = Q`. Since
+the `obj` field of `QuiverRepresentation` does not mention the `Quiver` instance, transport
+leaves the vertex spaces unchanged; the `mapLinear` field does mention it (through the arrow
+type `v ⟶ w`), so it is transported through the arrow identification.
+
+These lemmas expose those two facts so downstream code (e.g. the adjunction of
+Exercise 7.9.8) can rewrite `(transportReversedTwice X).obj` / `.mapLinear` back in terms of
+`X` without unfolding the `▸`. They are stated first for two arbitrary equal `Quiver`
+instances (where `subst` discharges everything) and then specialized. -/
+
+/-- Transport of a representation along an equality of `Quiver` instances leaves the vertex
+spaces unchanged (the `obj` field is instance-independent). -/
+theorem obj_transport {k : Type*} [CommSemiring k] {Q : Type*}
+    {I₁ I₂ : Quiver Q} (h : I₁ = I₂)
+    (X : @Etingof.QuiverRepresentation k Q _ I₁) (v : Q) :
+    @Etingof.QuiverRepresentation.obj k Q _ I₂ (h ▸ X) v =
+    @Etingof.QuiverRepresentation.obj k Q _ I₁ X v := by
+  subst h; rfl
+
+/-- Transport of a representation along an equality of `Quiver` instances carries the arrow
+maps through the arrow identification: `(h ▸ X).mapLinear e` agrees heterogeneously with
+`X.mapLinear (h.symm ▸ e)`. -/
+theorem mapLinear_transport_heq {k : Type*} [CommSemiring k] {Q : Type*}
+    {I₁ I₂ : Quiver Q} (h : I₁ = I₂)
+    (X : @Etingof.QuiverRepresentation k Q _ I₁) (a b : Q) (e : @Quiver.Hom Q I₂ a b) :
+    HEq
+      (@Etingof.QuiverRepresentation.mapLinear k Q _ I₂ (h ▸ X) a b e)
+      (@Etingof.QuiverRepresentation.mapLinear k Q _ I₁ X a b (h.symm ▸ e)) := by
+  subst h; rfl
+
+variable {k : Type*} [CommSemiring k] {Q : Type*} [DecidableEq Q] [inst : Quiver Q] {i : Q}
+
+/-- The vertex spaces of `transportReversedTwice X` are those of `X`. -/
+theorem transportReversedTwice_obj
+    (X : @Etingof.QuiverRepresentation k Q _
+      (@Etingof.reversedAtVertex Q _ (Etingof.reversedAtVertex Q i) i)) (v : Q) :
+    @Etingof.QuiverRepresentation.obj k Q _ inst
+      (Etingof.QuiverRepresentation.transportReversedTwice X) v =
+    @Etingof.QuiverRepresentation.obj k Q _
+      (@Etingof.reversedAtVertex Q _ (Etingof.reversedAtVertex Q i) i) X v :=
+  obj_transport (Etingof.reversedAtVertex_twice Q i) X v
+
+/-- The arrow maps of `transportReversedTwice X` agree heterogeneously with those of `X`,
+after transporting the arrow `e` back to the double-reversed quiver. -/
+theorem transportReversedTwice_mapLinear_heq
+    (X : @Etingof.QuiverRepresentation k Q _
+      (@Etingof.reversedAtVertex Q _ (Etingof.reversedAtVertex Q i) i))
+    (a b : Q) (e : @Quiver.Hom Q inst a b) :
+    HEq
+      (@Etingof.QuiverRepresentation.mapLinear k Q _ inst
+        (Etingof.QuiverRepresentation.transportReversedTwice X) a b e)
+      (@Etingof.QuiverRepresentation.mapLinear k Q _
+        (@Etingof.reversedAtVertex Q _ (Etingof.reversedAtVertex Q i) i) X a b
+        ((Etingof.reversedAtVertex_twice Q i).symm ▸ e)) :=
+  mapLinear_transport_heq (Etingof.reversedAtVertex_twice Q i) X a b e
+
+end Etingof.QuiverRepresentation
+
+/-!
+## Proof blueprint for `Exercise7_9_8` (the adjunction bijection)
+
+Status: the two `transportReversedTwice` accessors above are proved sorry-free; the main
+bijection below is still `sorry`. The remaining assembly is large (comparable in size to
+`Proposition6_6_6`), so it is documented here for the next worker.
+
+**Key reduction.** Write `hi' := isSource_reversedAtVertex_isSink hi` (so `i` is a sink of
+`Q̄ᵢ`). Both hom-sets are equivalent to the *same* reduced data: a family
+`hᵥ : V.obj v →ₗ[k] W.obj v` for every `v ≠ i` such that
+
+* (A) for every arrow `e : a ⟶ b` of `Q` with `a ≠ i`, `b ≠ i` (these are exactly the
+  arrows of `Q̄ᵢ` not touching `i`), `W.mapLinear e ∘ hₐ = h_b ∘ V.mapLinear e`; and
+* (C) `∑ (a : ArrowsOutOf Q i), W.mapLinear (rev a) (h_{a.fst} (V.mapLinear a.snd x)) = 0`
+  for all `x : V.obj i`, where `rev a : a.fst ⟶ i` in `Q̄ᵢ` is the reversed arrow.
+
+*From `f : Hom(F⁻ᵢV, W)`* set `hᵥ := f.app v ∘ (reflFunctorMinus_equivAt_ne hi V v _).symm`.
+Naturality of `f` on a reversed arrow `a.fst → i` (case `ne_eq`, via
+`reflFunctorMinus_mapLinear_ne_eq`) forces the `a`-component of the induced map on
+`coker(sourceMap_V)` to be `W.mapLinear (rev a) ∘ hₐ`; well-definedness of `f.app i` on the
+cokernel is precisely (C).
+
+*From `g : Hom(V, transportReversedTwice (F⁺ᵢW))`* set `hᵥ := (reflFunctorPlus_equivAt_ne
+hi' W v _) ∘ g.app v` (using `transportReversedTwice_obj` to see `g.app v : V.obj v →
+W.obj v` for `v ≠ i`). Naturality of `g` on an arrow `i → a.fst` of `Q` (case `eq_ne`, via
+`reflFunctorPlus_mapLinear_eq_ne` and `transportReversedTwice_mapLinear_heq`) forces the
+`a`-component of `g.app i : V.obj i → ker(sinkMap_W)` to be `hₐ ∘ V.mapLinear a.snd`; landing
+in the kernel `sinkMap_W = 0` is precisely (C), which is `Φ_comp_source_eq_zero` after
+reindexing `ArrowsInto (Q̄ᵢ) i ≃ ArrowsOutOf Q i` via `arrowReindexEquiv hi'`.
+
+**Assembly.** Define `toFun`, `invFun` by extracting the reduced family and rebuilding on the
+other side (kernel corestriction via `LinearMap.codRestrict` + (C); cokernel factoring via
+`Submodule.liftQ` + (C)). Prove `left_inv`/`right_inv` by `QuiverRepresentationHom`
+extensionality: at `v ≠ i` both sides are `hᵥ` transported; at `v = i` use uniqueness of the
+cokernel map out of `mkQ` / the kernel `subtype` being injective. Reusable ingredients:
+`arrowReindexEquiv`, `sinkMap_reindex_surj`, `Φ_comp_source_eq_zero`, `exact_of_dim`, the
+`reversedArrow_*_twice` cast lemmas, and the `heq_apply` / `heq_linearMap_coe` toolkit.
+-/
+
 /-- Exercise 7.9.8(a): for a source `i` of a quiver `Q`, a representation `V` of `Q`, and a
 representation `W` of the reversed quiver `Q̄ᵢ`, there is a natural isomorphism (here: a
 bijection of hom-sets) between `Hom(F⁻ᵢ V, W)` (in `Rep(Q̄ᵢ)`) and `Hom(V, F⁺ᵢ W)` (in

--- a/progress/2026-07-09T04-31-27Z_7ca039ec.md
+++ b/progress/2026-07-09T04-31-27Z_7ca039ec.md
@@ -1,0 +1,56 @@
+## Accomplished
+
+Partial progress on #6000 (Exercise 7.9.8(a): reflection functor adjunction hom-set
+bijection `Hom(F⁻ᵢV, W) ≃ Hom(V, F⁺ᵢW)`).
+
+Landed the missing, reusable `transportReversedTwice` accessor API in
+`EtingofRepresentationTheory/Chapter7/Exercise7_9_8.lean`, all sorry-free
+(`#print axioms` shows only `Quot.sound`, no `sorryAx`):
+
+- `Etingof.QuiverRepresentation.obj_transport` / `mapLinear_transport_heq` — general
+  transport of a representation along an equality of `Quiver` instances (`subst`
+  discharges both).
+- `transportReversedTwice_obj` — `(transportReversedTwice X).obj v = X.obj v` (vertex
+  spaces unchanged, since `obj` is instance-independent).
+- `transportReversedTwice_mapLinear_heq` — `(transportReversedTwice X).mapLinear e`
+  agrees heterogeneously with `X.mapLinear (reversedAtVertex_twice.symm ▸ e)`.
+
+Before this, `transportReversedTwice` had **no** accessor lemmas anywhere in the repo,
+which is why the RHS hom-set `Hom(V, transportReversedTwice (F⁺ᵢW))` was intractable to
+unfold. These are the foundation the adjunction assembly needs.
+
+Also added a detailed proof blueprint as a doc comment before the main theorem: both
+hom-sets reduce to the same "reduced data" (a family `hᵥ : Vᵥ →ₗ Wᵥ` for `v ≠ i` plus
+arrow-compatibility (A) and the single constraint (C)
+`∑ₐ W(rev a)(hₐ(V(a.snd) x)) = 0`), and the constraint matches on both sides. The
+blueprint names the exact per-case reduction lemmas to use
+(`reflFunctorMinus_mapLinear_ne_eq`, `reflFunctorPlus_mapLinear_eq_ne`,
+`Φ_comp_source_eq_zero`, `arrowReindexEquiv`, `sinkMap_reindex_surj`, `exact_of_dim`).
+
+## Current frontier
+
+`Etingof.Exercise7_9_8` itself is still `sorry`. The scaffolding (accessors + blueprint)
+is in place; the remaining work is the `Equiv` assembly.
+
+## Overall project progress
+
+Phase 3 formalization, filling `sorry`s. Chapter 6 reflection-functor infrastructure is
+extensive and was clearly built anticipating this exercise (`Φ_comp_source_eq_zero`,
+`arrowReindexEquiv`, `sinkMap_reindex_surj`, `exact_of_dim`, the `reversedArrow_*_twice`
+cast lemmas). Exercise 7.9.8(a) remains the open item.
+
+## Next step
+
+Assemble the `Equiv` per the blueprint now embedded in `Exercise7_9_8.lean`. This is a
+large construction (comparable to `Proposition6_6_6`): build `toFun`/`invFun` by
+extracting the reduced family and rebuilding on the other side (kernel corestriction via
+`LinearMap.codRestrict` + constraint (C); cokernel factoring via `Submodule.liftQ` +
+(C)), then prove `left_inv`/`right_inv` by `QuiverRepresentationHom` extensionality.
+The two live naturality cases per direction are `(a≠i,b≠i)` and the arrow touching `i`
+(`i` is a source of `Q`, so no arrows into `i`; only two cases each). Recommend claiming
+this as a focused follow-up dedicated to the assembly.
+
+## Blockers
+
+None. The accessors unblock the RHS hom-set; all other ingredients already exist in
+Chapter 6. The remaining task is size, not a missing dependency.


### PR DESCRIPTION
Partial progress on #6000

Session: `7ca039ec-a08b-4239-9ae7-7f00ed097e73`

ccb393db feat(Ch7 #6000): add sorry-free transportReversedTwice accessors + adjunction blueprint

🤖 Prepared with Claude Code