### PR TITLE
feat(Ch2): prove Problem 2.13.1(b) — arccos(1/3)/π is irrational

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Problem2_13_1.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_13_1.lean
@@ -18,15 +18,88 @@ The cleanly-statable core is part **(b)**: the irrationality of `arccos(1/3)/π`
 require the Dehn-invariant construction on polyhedra (the tensor product `ℝ ⊗_ℚ (ℝ/ℚ)` and a model
 of polyhedra with edges/dihedral angles) and are deferred to a dedicated follow-up item.
 
-This is the **statement pass**: part (b) is recorded with a `sorry` proof.
+## Proof of (b)
+
+We follow the book's hint. Set `θ = arccos(1/3)`, so `cos θ = 1/3`. Define the integer sequence
+`b₀ = 1`, `b₁ = 1`, `bₖ₊₂ = 2 bₖ₊₁ - 9 bₖ`. Multiplying the Chebyshev recurrence
+`cos((k+2)θ) = 2 cos θ · cos((k+1)θ) - cos(kθ)` by `3^(k+2)` shows `bₖ = 3^k · cos(kθ)`.
+Reducing the recurrence mod `3` gives `3 ∤ bₖ` for every `k`.
+
+Now if `α = θ/π` were rational, say `α = r` with denominator `q = r.den`, then
+`cos((2q)·θ) = cos(r.num · 2π) = 1`, so `b_{2q} = 3^{2q} · 1 = 3^{2q}`. But `3 ∣ 3^{2q}`
+while `3 ∤ b_{2q}`, a contradiction.
 -/
 
 namespace Etingof.Problem2_13_1
 
 open Real
 
+/-- The integer sequence `b₀ = 1`, `b₁ = 1`, `bₖ₊₂ = 2 bₖ₊₁ - 9 bₖ`. One has `bₖ = 3^k cos(kθ)`
+for `θ = arccos(1/3)` (see `Problem2_13_1.b_eq`) and `3 ∤ bₖ` (see `Problem2_13_1.b_not_dvd`). -/
+private def b : ℕ → ℤ
+  | 0 => 1
+  | 1 => 1
+  | (n + 2) => 2 * b (n + 1) - 9 * b n
+
+/-- `bₖ = 3^k · cos(kθ)` whenever `cos θ = 1/3`. Proved by two-step induction using the Chebyshev
+recurrence `cos((k+2)θ) = 2 cos θ · cos((k+1)θ) - cos(kθ)`. -/
+private lemma b_eq (θ : ℝ) (hθ : cos θ = 1 / 3) (n : ℕ) :
+    (↑(b n) : ℝ) = 3 ^ n * cos (↑n * θ) ∧
+    (↑(b (n + 1)) : ℝ) = 3 ^ (n + 1) * cos (↑(n + 1) * θ) := by
+  induction n with
+  | zero => refine ⟨?_, ?_⟩ <;> norm_num [b, hθ]
+  | succ n ih =>
+    obtain ⟨hA, hB⟩ := ih
+    refine ⟨hB, ?_⟩
+    have hrec : (↑(b (n + 1 + 1)) : ℝ) = 2 * ↑(b (n + 1)) - 9 * ↑(b n) := by
+      have : b (n + 1 + 1) = 2 * b (n + 1) - 9 * b n := by simp only [b]
+      rw [this]; push_cast; ring
+    have R : cos ((↑(n + 1 + 1) : ℝ) * θ)
+        = 2 * cos θ * cos ((↑(n + 1) : ℝ) * θ) - cos ((↑n : ℝ) * θ) := by
+      have e1 : (↑(n + 1 + 1) : ℝ) * θ = (↑(n + 1) : ℝ) * θ + θ := by push_cast; ring
+      have e2 : (↑n : ℝ) * θ = (↑(n + 1) : ℝ) * θ - θ := by push_cast; ring
+      rw [e1, e2, Real.cos_add, Real.cos_sub]; ring
+    rw [hrec, hB, hA, R, hθ]
+    ring
+
+/-- `3 ∤ bₖ` for every `k`: reducing the recurrence mod `3` gives `bₖ₊₂ ≡ 2 bₖ₊₁ (mod 3)`, so the
+residue stays in `{1, 2}` starting from `b₀ = b₁ = 1`. -/
+private lemma b_not_dvd (n : ℕ) : ¬ (3 ∣ b n) := by
+  have H : ∀ m : ℕ, (b m % 3 = 1 ∨ b m % 3 = 2) ∧ (b (m + 1) % 3 = 1 ∨ b (m + 1) % 3 = 2) := by
+    intro m
+    induction m with
+    | zero => refine ⟨Or.inl ?_, Or.inl ?_⟩ <;> decide
+    | succ m ih =>
+      obtain ⟨_, h2⟩ := ih
+      refine ⟨h2, ?_⟩
+      have hrec : b (m + 1 + 1) = 2 * b (m + 1) - 9 * b m := by simp only [b]
+      omega
+  have := (H n).1
+  omega
+
 /-- **Problem 2.13.1(b).** The number `α = arccos(1/3)/π` is irrational. -/
 theorem irrational_arccos_third_div_pi : Irrational (arccos (1 / 3) / π) := by
-  sorry
+  intro h
+  obtain ⟨r, hr⟩ := h
+  set θ := arccos (1 / 3) with hθdef
+  have hθcos : cos θ = 1 / 3 := Real.cos_arccos (by norm_num) (by norm_num)
+  have hπ : (π : ℝ) ≠ 0 := Real.pi_ne_zero
+  rw [eq_div_iff hπ] at hr
+  -- `hr : ↑r * π = θ`.
+  have hden : (r.den : ℝ) ≠ 0 := by exact_mod_cast r.den_ne_zero
+  have hrq : (r : ℝ) * (r.den : ℝ) = (r.num : ℝ) := by
+    rw [Rat.cast_def]; field_simp
+  -- `cos ((2·den)·θ) = cos (num · 2π) = 1`.
+  have harg : (↑(2 * r.den) : ℝ) * θ = (r.num : ℝ) * (2 * π) := by
+    have hθ2 : θ = (r : ℝ) * π := hr.symm
+    rw [hθ2]; push_cast; linear_combination (2 * π) * hrq
+  have hcos1 : cos ((↑(2 * r.den) : ℝ) * θ) = 1 := by
+    rw [harg]; exact Real.cos_int_mul_two_pi r.num
+  -- Hence `b_{2·den} = 3^{2·den}`, but `3 ∤ b_{2·den}`.
+  have hkey := (b_eq θ hθcos (2 * r.den)).1
+  rw [hcos1, mul_one] at hkey
+  have hb_eq : b (2 * r.den) = 3 ^ (2 * r.den) := by exact_mod_cast hkey
+  have hn0 : 2 * r.den ≠ 0 := by have := r.den_pos; omega
+  exact b_not_dvd (2 * r.den) (hb_eq ▸ dvd_pow_self 3 hn0)
 
 end Etingof.Problem2_13_1

--- a/progress/2026-07-09T05-07-12Z_bcf23cad.md
+++ b/progress/2026-07-09T05-07-12Z_bcf23cad.md
@@ -1,0 +1,42 @@
+## Accomplished
+
+Completed issue #6030 — proved **Problem 2.13.1(b)**: `arccos(1/3)/π` is irrational,
+sorry-free, in `EtingofRepresentationTheory/Chapter2/Problem2_13_1.lean`.
+
+Proof structure (following the book's hint):
+- `b : ℕ → ℤ` integer sequence `b₀ = 1`, `b₁ = 1`, `bₖ₊₂ = 2 bₖ₊₁ - 9 bₖ`.
+- `b_eq`: `bₖ = 3^k · cos(kθ)` for `θ = arccos(1/3)`, by two-step induction on a bundled pair,
+  using the Chebyshev identity `cos((k+2)θ) = 2 cos θ cos((k+1)θ) - cos(kθ)` (derived from
+  `Real.cos_add`/`Real.cos_sub`) and `cos θ = 1/3`.
+- `b_not_dvd`: `3 ∤ bₖ`, by reducing the recurrence mod 3 (`omega` closes the step) from
+  `b₀ ≡ b₁ ≡ 1`.
+- Final contradiction: if `α = θ/π = r ∈ ℚ` with `q = r.den`, then `(2q)·θ = r.num·2π`, so
+  `cos((2q)θ) = 1` (`Real.cos_int_mul_two_pi`), giving `b_{2q} = 3^{2q}`. But `3 ∣ 3^{2q}`
+  contradicts `3 ∤ b_{2q}`.
+
+`#print axioms Etingof.Problem2_13_1.irrational_arccos_third_div_pi` →
+`[propext, Classical.choice, Quot.sound]` (no `sorryAx`). Clean build, no lint warnings.
+
+Updated `progress/items.json`: `Chapter2/Problem2.13.1` moved
+`statement_formalized` → `proof_complete`, with an honest coverage note that only part (b) is
+formalized.
+
+## Current frontier
+
+Issue #6030 fully done. PR opened; nothing left in scope on this item.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. This turn cleared one Chapter 2 exercise sorry. Parts (a)
+and (c) of Problem 2.13.1 (Dehn-invariant construction over `ℝ ⊗_ℚ (ℝ/ℚ)`) remain a deferred
+follow-up item, unchanged.
+
+## Next step
+
+Pick up another unclaimed `feature` issue (e.g. #6010 Ch4 Exercise 4.2.3, #6029 Ch3
+iso_pow_cancel). Someone could later plan the deferred Problem 2.13.1 (a)/(c) Dehn-invariant
+item now that (b) is available.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -1443,8 +1443,8 @@
     "end_page": "37",
     "start_line": 18,
     "end_line": 8,
-    "status": "statement_formalized",
-    "coverage_note": "No Lean formalization on origin/main (re-derived 2026-07-02; prior 'sorry_free' was vacuous)."
+    "status": "proof_complete",
+    "coverage_note": "Part (b) — irrationality of arccos(1/3)/π — proved sorry-free in EtingofRepresentationTheory/Chapter2/Problem2_13_1.lean (theorem irrational_arccos_third_div_pi; axioms propext/Classical.choice/Quot.sound only). Parts (a) and (c) (Dehn-invariant construction) remain deferred to a follow-up item."
   },
   {
     "id": "Chapter2/Discussion_2.14_heading",


### PR DESCRIPTION
Closes #6030

Session: `bcf23cad-03eb-4c52-8797-df402691f1b1`

70cd5351 feat(Ch2 #6030): prove Problem 2.13.1(b) — arccos(1/3)/π is irrational

🤖 Prepared with Claude Code