### PR TITLE
feat(Ch4 #6010): algebraic core of Exercise 4.2.3 — k[G] not semisimple in modular case

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -2536,6 +2536,21 @@ This construction appeared in BasicAlgebraExistence and was used in 3+ sessions.
 ### Workaround 2: Use `isUnit_of_sub_one_mem_jacobson_bot` alternatives
 The `isUnit_of_sub_one_mem_jacobson_bot` API requires `CommRing`. For non-commutative rings, use `IsNilpotent.isUnit_one_sub` instead (only requires `Ring`).
 
+**Jacobson-membership on `MonoidAlgebra k G` (noncommutative).** The clean unit
+characterization `Ideal.mem_jacobson_bot : x ∈ jacobson ⊥ ↔ ∀ y, IsUnit (x*y+1)` lives in
+the `CommRing` section — it fails instance synthesis on a group algebra. The
+**`Ring`-general** form is `Ideal.mem_jacobson_iff {x} : x ∈ jacobson I ↔ ∀ y, ∃ z, z*y*x + z - 1 ∈ I`;
+take `I = ⊥` and `Ideal.mem_bot` reduces each goal to `z*y*x + z - 1 = 0`. For a central
+nilpotent `x` (e.g. the group sum `P = ∑_g g` when `|G| = 0` in `k`): `y*x` is nilpotent
+(`Commute.isNilpotent_mul_left`), so `1 + y*x` is a unit (`IsNilpotent.isUnit_one_add`);
+pick `z = ↑u⁻¹` for that unit `u`. Bridge to `⊥` with the **`Ring`-general**
+`Ideal.jacobson_bot : jacobson ⊥ = Ring.jacobson R` and
+`IsSemisimpleRing.jacobson_eq_bot : Ring.jacobson R = ⊥`. This proves "nonzero central
+nilpotent ⇒ `¬ IsSemisimpleRing k[G]`" — the algebraic core of Exercise 4.2.3
+(`Etingof.not_isSemisimpleRing_of_card_eq_zero`). NB: many
+`Ideal.jacobson`/`mem_jacobson_bot`/`IsReduced` lemmas are `CommRing`-only; confirm the
+lemma's section before reaching for it on `MonoidAlgebra k G`.
+
 ### Workaround 3: Avoid `linarith`/`linear_combination` over non-commutative rings
 These tactics need `CommSemiring`. Use manual algebra (`calc` blocks with `mul_assoc`, `mul_comm` where applicable, or `ring_nf` after establishing commutativity of specific elements).
 

--- a/EtingofRepresentationTheory/Chapter4/Exercise4_2_3.lean
+++ b/EtingofRepresentationTheory/Chapter4/Exercise4_2_3.lean
@@ -43,6 +43,109 @@ def IrrepClasses (k G : Type*) [Field k] [Monoid G] : Type _ :=
   Quotient (isIsomorphicSetoid
     (ObjectProperty.FullSubcategory (fun V : FDRep k G => Simple V)))
 
+/-! ### The group sum `P = ∑_g g` and non-semisimplicity in the modular case
+
+In the modular case (`|G| = 0` in `k`) the element `P = ∑_{g ∈ G} g` of the group
+algebra `k[G]` is a nonzero, central, nilpotent element: `P² = |G| · P = 0`. Its
+existence shows that `k[G]` is **not** semisimple — a nonzero central nilpotent lies in
+the Jacobson radical, which vanishes for a semisimple ring. This is the algebraic core of
+Exercise 4.2.3; the counting comparison
+`Nat.card (IrrepClasses k G) < Nat.card (ConjClasses G)` builds on top of it. -/
+
+section GroupSum
+
+variable (k G : Type*) [Field k] [Group G] [Fintype G]
+
+/-- The sum `P = ∑_{g ∈ G} g` of all group elements, viewed in the group algebra `k[G]`. -/
+noncomputable def groupSum : MonoidAlgebra k G := ∑ g : G, MonoidAlgebra.single g (1 : k)
+
+variable {k G}
+
+omit [Group G] in
+/-- Every coefficient of `P = ∑_g g` equals `1`. -/
+@[simp] lemma groupSum_apply (x : G) : (groupSum k G) x = 1 := by
+  classical
+  rw [groupSum, Finset.sum_apply',
+    Finset.sum_eq_single x (fun b _ hb => by simp [hb])
+      (fun hx => absurd (Finset.mem_univ x) hx)]
+  simp
+
+/-- Left-multiplying `P` by a group element fixes it: `g · P = P`. -/
+lemma single_mul_groupSum (g : G) :
+    MonoidAlgebra.single g (1 : k) * groupSum k G = groupSum k G := by
+  simp only [groupSum, Finset.mul_sum, MonoidAlgebra.single_mul_single, one_mul]
+  exact Fintype.sum_equiv (Equiv.mulLeft g) _ _ (fun _ => rfl)
+
+/-- Right-multiplying `P` by a group element fixes it: `P · g = P`. -/
+lemma groupSum_mul_single (g : G) :
+    groupSum k G * MonoidAlgebra.single g (1 : k) = groupSum k G := by
+  simp only [groupSum, Finset.sum_mul, MonoidAlgebra.single_mul_single, mul_one]
+  exact Fintype.sum_equiv (Equiv.mulRight g) _ _ (fun _ => rfl)
+
+/-- `P = ∑_g g` is central in `k[G]`. -/
+lemma groupSum_mem_center :
+    groupSum k G ∈ Subalgebra.center k (MonoidAlgebra k G) := by
+  rw [Subalgebra.mem_center_iff]
+  intro b
+  induction b using MonoidAlgebra.induction_on with
+  | hM g =>
+    rw [show (MonoidAlgebra.of k G g : MonoidAlgebra k G) = MonoidAlgebra.single g 1 from rfl,
+      single_mul_groupSum, groupSum_mul_single]
+  | hadd x y hx hy => rw [add_mul, mul_add, hx, hy]
+  | hsmul r x hx => rw [Algebra.smul_mul_assoc, Algebra.mul_smul_comm, hx]
+
+/-- In the modular case `|G| = 0` the group sum squares to zero: `P² = |G| · P = 0`. -/
+lemma groupSum_mul_self (hcard : (Fintype.card G : k) = 0) :
+    groupSum k G * groupSum k G = 0 := by
+  have hdef : groupSum k G = ∑ g : G, MonoidAlgebra.single g (1 : k) := rfl
+  calc groupSum k G * groupSum k G
+      = ∑ g : G, MonoidAlgebra.single g (1 : k) * groupSum k G := by rw [← Finset.sum_mul, ← hdef]
+    _ = ∑ _g : G, groupSum k G := by simp only [single_mul_groupSum]
+    _ = 0 := by
+        rw [Finset.sum_const, Finset.card_univ, ← Nat.cast_smul_eq_nsmul k, hcard, zero_smul]
+
+/-- In the modular case the group sum is nilpotent. -/
+lemma groupSum_isNilpotent (hcard : (Fintype.card G : k) = 0) :
+    IsNilpotent (groupSum k G) :=
+  ⟨2, by rw [pow_two]; exact groupSum_mul_self hcard⟩
+
+/-- The group sum is nonzero (its coefficient at `1` is `1 ≠ 0`). -/
+lemma groupSum_ne_zero : groupSum k G ≠ 0 := by
+  intro h
+  have h1 := groupSum_apply (k := k) (G := G) (1 : G)
+  rw [h] at h1
+  simp at h1
+
+/-- **Non-semisimplicity in the modular case.** If `|G| = 0` in `k` then the group algebra
+`k[G]` is not semisimple: the nonzero central nilpotent `P = ∑_g g` lies in the Jacobson
+radical, which vanishes for a semisimple ring. -/
+theorem not_isSemisimpleRing_of_card_eq_zero (hcard : (Fintype.card G : k) = 0) :
+    ¬ IsSemisimpleRing (MonoidAlgebra k G) := by
+  intro hss
+  haveI := hss
+  refine groupSum_ne_zero (k := k) (G := G) ?_
+  have hmem : groupSum k G ∈ Ideal.jacobson (⊥ : Ideal (MonoidAlgebra k G)) := by
+    rw [Ideal.mem_jacobson_iff]
+    intro y
+    -- `y · P` is nilpotent (`P` is central and squares to zero), so `1 + y·P` is a unit.
+    have hcomm : Commute y (groupSum k G) := Subalgebra.mem_center_iff.mp groupSum_mem_center y
+    have hnil : IsNilpotent (y * groupSum k G) :=
+      hcomm.isNilpotent_mul_left (groupSum_isNilpotent hcard)
+    obtain ⟨u, hu⟩ := hnil.isUnit_one_add
+    refine ⟨↑u⁻¹, ?_⟩
+    have key : (↑u⁻¹ : MonoidAlgebra k G) * (y * groupSum k G) + ↑u⁻¹ = 1 := by
+      have h := u.inv_mul
+      rw [hu, mul_add, mul_one, add_comm] at h
+      exact h
+    rw [Ideal.mem_bot, mul_assoc, key, sub_self]
+  have hjb : Ideal.jacobson (⊥ : Ideal (MonoidAlgebra k G))
+      = Ring.jacobson (MonoidAlgebra k G) := Ideal.jacobson_bot
+  have hmem' : groupSum k G ∈ Ring.jacobson (MonoidAlgebra k G) := hjb ▸ hmem
+  rw [IsSemisimpleRing.jacobson_eq_bot, Ideal.mem_bot] at hmem'
+  exact hmem'
+
+end GroupSum
+
 /-- **Exercise 4.2.3.** If `|G| = 0` in `k` (the characteristic of `k` divides the order
 of the finite group `G`), then the number of isomorphism classes of irreducible
 representations of `G` over `k` is strictly less than the number of conjugacy classes of
@@ -50,6 +153,13 @@ representations of `G` over `k` is strictly less than the number of conjugacy cl
 theorem Exercise4_2_3 (k G : Type*) [Field k] [Group G] [Fintype G]
     (h : (Fintype.card G : k) = 0) :
     Nat.card (IrrepClasses k G) < Nat.card (ConjClasses G) := by
+  -- The algebraic core is `not_isSemisimpleRing_of_card_eq_zero h`: `k[G]` is not
+  -- semisimple because `groupSum k G = ∑_g g` is a nonzero central nilpotent.
+  -- Remaining (the counting comparison): relate `Nat.card (IrrepClasses k G)` to the
+  -- dimension of the centre of the semisimple quotient `k[G] / rad`, and
+  -- `Nat.card (ConjClasses G)` to `dim_k Z(k[G])` (class sums are a basis of the centre,
+  -- cf. `finrank_center_monoidAlgebra` in `Chapter4/Corollary4_2_2.lean`), then use the
+  -- strict drop coming from `0 ≠ groupSum ∈ rad`. This modular counting half is deferred.
   sorry
 
 end Etingof

--- a/progress/2026-07-09T05-41-14Z_9e260476.md
+++ b/progress/2026-07-09T05-41-14Z_9e260476.md
@@ -1,0 +1,36 @@
+## Accomplished
+Landed the **algebraic core** of Exercise 4.2.3 (issue #6010) in
+`EtingofRepresentationTheory/Chapter4/Exercise4_2_3.lean`, all sorry-free:
+
+- `Etingof.groupSum k G : MonoidAlgebra k G` — the element `P = ∑_{g ∈ G} g`.
+- Supporting lemmas: `groupSum_apply` (every coefficient is 1), `single_mul_groupSum`,
+  `groupSum_mul_single` (P is fixed by left/right multiplication by a group element),
+  `groupSum_mem_center` (P central), `groupSum_mul_self` (`P² = |G|·P = 0` when
+  `(Fintype.card G : k) = 0`), `groupSum_isNilpotent`, `groupSum_ne_zero`.
+- `Etingof.not_isSemisimpleRing_of_card_eq_zero` — in the modular case `k[G]` is **not**
+  semisimple: the nonzero central nilpotent P lies in the Jacobson radical, which vanishes
+  for a semisimple ring. `#print axioms` = `[propext, Classical.choice, Quot.sound]`.
+
+Key API used: `Ideal.mem_jacobson_iff` (the noncommutative membership characterization —
+`Ideal.mem_jacobson_bot` is CommRing-only in this Mathlib), `IsNilpotent.isUnit_one_add`,
+`Commute.isNilpotent_mul_left`, `Ideal.jacobson_bot`, `IsSemisimpleRing.jacobson_eq_bot`.
+
+## Current frontier
+`Etingof.Exercise4_2_3` still has a `sorry` (the counting comparison
+`Nat.card (IrrepClasses k G) < Nat.card (ConjClasses G)`).
+
+## Overall project progress
+Stage 3 formalization ongoing. This turn added reusable non-semisimplicity infrastructure
+for Chapter 4. `Chapter4/Exercise4.2.3` remains `statement_formalized` (the algebraic core
+is proved but the headline theorem is not yet sorry-free).
+
+## Next step
+Pick up #6039 (the counting half): connect `Nat.card (IrrepClasses k G)` to
+`dim_k Z(k[G]/rad)` and `Nat.card (ConjClasses G)` to `dim_k Z(k[G])` (reuse
+`finrank_center_monoidAlgebra` from `Corollary4_2_2.lean`), then derive the strict drop
+from `0 ≠ groupSum ∈ rad` and `not_isSemisimpleRing_of_card_eq_zero`. This is deep modular
+representation theory and may warrant further decomposition.
+
+## Blockers
+None. The counting half is genuinely hard (equivalent to "# simple modules = # p-regular
+classes") and is deferred to #6039, not blocked.


### PR DESCRIPTION
Partial progress on #6010

Session: `9e260476-63a0-4ab9-b2f1-5a3749fd2e6f`

c89845cd progress: Exercise 4.2.3 algebraic core (#6010), counting half deferred to #6039
9acca57b feat(Ch4 #6010): algebraic core of Exercise 4.2.3 — k[G] not semisimple in modular case

🤖 Prepared with Claude Code