### PR TITLE
feat(Ch7): prove Problem 7.8.5(ii) — long exact sequence of cohomology from a short exact sequence of complexes

### DIFF
--- a/EtingofRepresentationTheory/Chapter7/Problem7_8_5.lean
+++ b/EtingofRepresentationTheory/Chapter7/Problem7_8_5.lean
@@ -47,5 +47,7 @@ theorem Etingof.Problem7_8_5
       (HomologicalComplex.homologyMap S.g i)
       (by rw [← HomologicalComplex.homologyMap_comp, S.zero,
           HomologicalComplex.homologyMap_zero])).Exact ∧
-    (ShortComplex.mk _ _ (ShortComplex.ShortExact.comp_δ hS i j hij)).Exact := by
-  sorry
+    (ShortComplex.mk _ _ (ShortComplex.ShortExact.comp_δ hS i j hij)).Exact :=
+  -- The three exactness statements are exactly Mathlib's long-exact-homology-sequence
+  -- lemmas for a short exact sequence of homological complexes (the snake-lemma chase).
+  ⟨hS.homology_exact₁ i j hij, hS.homology_exact₂ i, hS.homology_exact₃ i j hij⟩

--- a/progress/2026-07-09T05-46-19Z_e5d83777.md
+++ b/progress/2026-07-09T05-46-19Z_e5d83777.md
@@ -1,0 +1,36 @@
+## Accomplished
+
+Proved `Etingof.Problem7_8_5` (Ch7, issue #6041) — the long exact sequence of
+cohomology of a short exact sequence `0 → C → D → E → 0` of complexes of abelian
+groups. Removed the `sorry` in
+`EtingofRepresentationTheory/Chapter7/Problem7_8_5.lean`.
+
+The three exactness conjuncts matched Mathlib's homology-sequence lemmas exactly:
+`hS.homology_exact₁ i j hij`, `hS.homology_exact₂ i`, `hS.homology_exact₃ i j hij`
+(from `Mathlib.Algebra.Homology.HomologySequence`, `CategoryTheory.ShortComplex.ShortExact`
+namespace). Conjunct 2's zero-proof term is byte-identical to Mathlib's, so proof
+irrelevance makes the `ShortComplex.mk` defeq — no `exact_of_iso` bridging was needed.
+
+Proof is a single anonymous constructor. Moved `Chapter7/Problem7.8.5` from
+`statement_formalized` to `sorry_free` in `progress/items.json`.
+
+## Current frontier
+
+Issue #6041 complete. `lake build EtingofRepresentationTheory.Chapter7.Problem7_8_5`
+succeeds; `#print axioms Etingof.Problem7_8_5` shows only
+`propext, Classical.choice, Quot.sound`.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. This closes one more Ch7 sorry. Other unclaimed
+Ch7/Ch4 items remain (#6032 transport-side adjunction, #6039 Ex4.2.3 counting,
+#6042 Prob7.7.3 abelian subcategory).
+
+## Next step
+
+Pick up another unclaimed feature item. #6042 (Problem 7.7.3, f.g.-modules abelian)
+is the next most tractable Mathlib-API application.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -6612,8 +6612,8 @@
     "end_page": "193",
     "start_line": 9,
     "end_line": 20,
-    "status": "statement_formalized",
-    "coverage_note": "Statement pass: EtingofRepresentationTheory/Chapter7/Problem7_8_5.lean (Etingof.Problem7_8_5 + connecting hom), sorry proof."
+    "status": "sorry_free",
+    "coverage_note": "Sorry-free: EtingofRepresentationTheory/Chapter7/Problem7_8_5.lean (Etingof.Problem7_8_5 + connecting hom). LES exactness from hS.homology_exact₁/₂/₃; axioms propext, Classical.choice, Quot.sound."
   },
   {
     "id": "Chapter7/Definition7.8.6",


### PR DESCRIPTION
Closes #6041

Session: `e5d83777-5e78-473f-9b53-e26f6ccc9370`

199b8cc7 feat(Ch7 #6041): prove Problem 7.8.5(ii) — long exact sequence of cohomology

🤖 Prepared with Claude Code