### PR TITLE
feat(Ch8 #8.2.5): prove Tor/Ext independent of projective resolution — morphism + homotopy equivalence

### DIFF
--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_5.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_5.lean
@@ -31,7 +31,8 @@ on the homology of any additive functor applied to the resolution, i.e. on `Tor_
 and any two lifts are homotopic (so the induced maps agree). We record this as the existence of
 a homotopy equivalence between the two complexes.
 
-These are statement-level formalizations (spec-first): the proofs are deferred (`sorry`).
+Both facts are discharged directly by Mathlib's `ProjectiveResolution.lift`/`lift_commutes`
+(morphism of resolutions) and `ProjectiveResolution.homotopyEquiv` (homotopy equivalence).
 -/
 
 namespace Etingof
@@ -46,8 +47,8 @@ variable {A : Type u} [Ring A] {M : ModuleCat.{u} A}
 resolutions*: a chain map `f : P_• → Q_•` compatible with the augmentations to `M`. -/
 theorem Problem_8_2_5_morphism_of_resolutions
     (P Q : ProjectiveResolution M) :
-    ∃ f : P.complex ⟶ Q.complex, f ≫ Q.π = P.π := by
-  sorry
+    ∃ f : P.complex ⟶ Q.complex, f ≫ Q.π = P.π :=
+  ⟨ProjectiveResolution.lift (𝟙 M) P Q, by simp⟩
 
 /-- **Problem 8.2.5(iii)–(v).** Any two projective resolutions of `M` are homotopy equivalent.
 Applying an additive functor and taking homology, this shows the induced maps on `Tor_i` and
@@ -55,7 +56,7 @@ Applying an additive functor and taking homology, this shows the induced maps on
 `Ext^i` do not depend on the resolution. -/
 theorem Problem_8_2_5_independence
     (P Q : ProjectiveResolution M) :
-    Nonempty (HomotopyEquiv P.complex Q.complex) := by
-  sorry
+    Nonempty (HomotopyEquiv P.complex Q.complex) :=
+  ⟨ProjectiveResolution.homotopyEquiv P Q⟩
 
 end Etingof

--- a/progress/2026-07-10T04-31-23Z_f99bc22f.md
+++ b/progress/2026-07-10T04-31-23Z_f99bc22f.md
@@ -1,0 +1,33 @@
+## Accomplished
+
+Discharged both `sorry`s in `EtingofRepresentationTheory/Chapter8/Problem8_2_5.lean`
+(issue #6045 — Tor/Ext independence from the projective resolution):
+
+- `Problem_8_2_5_morphism_of_resolutions`: `⟨ProjectiveResolution.lift (𝟙 M) P Q, by simp⟩`.
+  `lift_commutes` is a `@[simp]` lemma, so `simp` closes `lift (𝟙 M) P Q ≫ Q.π = P.π`
+  after reducing `(single₀ C).map (𝟙 M)` to the identity.
+- `Problem_8_2_5_independence`: `⟨ProjectiveResolution.homotopyEquiv P Q⟩`.
+
+Signatures were not weakened; no helper `sorry`s added. Corrected the file's docstring
+line that still claimed the proofs were deferred. Updated
+`progress/items.json`: `Chapter8/Problem8.2.5` → `sorry_free`.
+
+## Current frontier
+
+`lake build EtingofRepresentationTheory.Chapter8.Problem8_2_5` succeeds (1551 jobs).
+`#print axioms` on both theorems: `[propext, Classical.choice, Quot.sound]` only.
+No `sorry` remains in the file.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. This turn closed one Chapter 8 item to `sorry_free`.
+Merged ready PR #6051 (Ch3 finite-extension case of Problem 3.8.4(i)) at start of turn.
+
+## Next step
+
+Unclaimed feature issues remain: #6046, #6047 (Ch4 modular counting), #6049, #6050
+(Ch3 Problem 3.8.4 cancellation/descent chain). #6049 is a prereq for #6050 part (ii).
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -7026,8 +7026,8 @@
     "end_page": "209",
     "start_line": 23,
     "end_line": 8,
-    "status": "statement_formalized",
-    "coverage_note": "No Lean formalization on origin/main (re-derived 2026-07-02; prior 'sorry_free' was vacuous)."
+    "status": "sorry_free",
+    "coverage_note": "Both theorems proved sorry-free (#6045): morphism-of-resolutions via ProjectiveResolution.lift/lift_commutes, independence via ProjectiveResolution.homotopyEquiv. #print axioms: propext, Classical.choice, Quot.sound."
   },
   {
     "id": "Chapter8/Problem8.2.6",


### PR DESCRIPTION
Closes #6045

Session: `f99bc22f-214b-4f2f-ab7c-98c3ae46a4e3`

c193682b feat(Ch8 #6045): prove Tor/Ext independent of projective resolution

🤖 Prepared with Claude Code