### PR TITLE
feat(Ch8 #8.1.4): prove Exercise 8.1.4 — lift maps from projectives along a short exact sequence

### DIFF
--- a/EtingofRepresentationTheory/Chapter8/Exercise8_1_4.lean
+++ b/EtingofRepresentationTheory/Chapter8/Exercise8_1_4.lean
@@ -42,6 +42,15 @@ theorem Exercise_8_1_4 (A : Type*) [Ring A]
     ∃ f : (P₁ × P₂) →ₗ[A] M,
       f.comp (LinearMap.inl A P₁ P₂) = ι.comp f₁ ∧
       π.comp (f.comp (LinearMap.inr A P₁ P₂)) = f₂ := by
-  sorry
+  -- `P₂` is projective and `π` is surjective, so lift `f₂ : P₂ → M₂` to `g₂ : P₂ → M`.
+  obtain ⟨g₂, hg₂⟩ := Module.projective_lifting_property π f₂ hπ
+  -- Assemble `f (p₁, p₂) = ι (f₁ p₁) + g₂ p₂`.
+  refine ⟨(ι.comp f₁).comp (LinearMap.fst A P₁ P₂) + g₂.comp (LinearMap.snd A P₁ P₂), ?_, ?_⟩
+  · -- On `(p₁, 0)` the `g₂ ∘ snd` term vanishes, leaving `ι (f₁ p₁)`.
+    ext p₁
+    simp
+  · -- On `(0, p₂)` the `ι ∘ f₁ ∘ fst` term vanishes, leaving `π (g₂ p₂) = f₂ p₂`.
+    ext p₂
+    simpa using congrArg (fun h => h p₂) hg₂
 
 end Etingof

--- a/progress/2026-07-10T04-40-22Z_ff1ccc4a.md
+++ b/progress/2026-07-10T04-40-22Z_ff1ccc4a.md
@@ -1,0 +1,21 @@
+## Accomplished
+Discharged the `sorry` in `Etingof.Exercise_8_1_4` (Chapter8/Exercise8.1.4).
+Used `Module.projective_lifting_property` to lift `f₂ : P₂ → M₂` along the
+surjection `π : M → M₂` to `g₂ : P₂ → M`, then assembled
+`f = (ι ∘ f₁) ∘ fst + g₂ ∘ snd : P₁ × P₂ → M`. Verified `#print axioms`
+shows only `propext, Classical.choice, Quot.sound`. Marked the item
+`sorry_free` in `progress/items.json`. Statement unchanged (`hι`, `hexact`
+retained as exact-sequence framing per the issue).
+
+## Current frontier
+Chapter8/Exercise8.1.4 complete. Issue #6055 ready to close via PR.
+
+## Overall project progress
+Stage 3 formalization ongoing. This turn moved one Ch8 item from
+`statement_formalized` to `sorry_free`.
+
+## Next step
+Pick up remaining unclaimed feature issues (#6053 Ch8 8.1.3, #6054 Ch5 5.8.4).
+
+## Blockers
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -6878,8 +6878,8 @@
     "end_page": "206",
     "start_line": 17,
     "end_line": 18,
-    "status": "statement_formalized",
-    "coverage_note": "No Lean formalization on origin/main (re-derived 2026-07-02; prior 'sorry_free' was vacuous)."
+    "status": "sorry_free",
+    "coverage_note": "Proved 2026-07-10 via Module.projective_lifting_property: lift f₂ along π, assemble f = ι∘f₁∘fst + g₂∘snd. Axioms: propext, Classical.choice, Quot.sound."
   },
   {
     "id": "Chapter8/Discussion_after_Exercise8.1.4",


### PR DESCRIPTION
Closes #6055

Session: `ff1ccc4a-0d92-456d-a5bb-a9c8802985df`

a3adf857 feat(Ch8 #6055): prove Exercise 8.1.4 — lift maps from projectives along a short exact sequence

🤖 Prepared with Claude Code