### PR TITLE
chore(Ch3 #6050): decompose general-L descent of Problem 3.8.4 into #6056/#6057/#6058

### DIFF
--- a/progress/2026-07-10T04-40-54Z_d99dc7dd.md
+++ b/progress/2026-07-10T04-40-54Z_d99dc7dd.md
@@ -1,0 +1,50 @@
+## Accomplished
+
+Claimed #6050 (general-`L` descent for Problem 3.8.4(i),(ii)) and, after scope
+assessment, **decomposed** it into three sub-issues rather than attempting a
+single-session heroic proof:
+
+- **#6056** — `bcMod` base-change *pushforward* functoriality along a coefficient
+  `K`-algebra hom `S →ₐ[K] T` (generalize `rep`/`repTensor`/`bcMod` from `[Field L]`
+  to `[CommRing S]`, then transport an `S⊗A`-iso to a `T⊗A`-iso via
+  `Algebra.TensorProduct.cancelBaseChange`). Reusable infra, no dependencies.
+- **#6057** — descend a general `L⊗A`-iso to a finitely generated `K`-subalgebra
+  `R ⊆ L` (matrix-entries of `e`, `e.symm` generate `R`; relations are polynomial,
+  so they hold over `R`/`R_f`). The crux step. Depends on #6056.
+- **#6058** — assemble (i) and (ii): apply **Zariski's lemma**
+  (`finite_of_finite_type_of_isJacobsonRing K (R_f ⧸ m)`) to get a residue field
+  `κ` finite over `K`, push forward (#6056), apply the finite case
+  (`iso_of_baseChange_iso_finite` for (i); the `directSummand_pow_cancel` analog for
+  (ii)). Discharges both sorries. Depends on #6056, #6057, and #6049.
+
+Key finding that improves the plan: the issue flagged that "a finitely generated
+subextension need not be finite" (matrix entries can be transcendental). This is
+resolved cleanly by **Zariski's lemma** — the residue field of a maximal ideal of
+the finitely generated coefficient algebra `R_f` is automatically finite over `K`
+(`Mathlib/RingTheory/Jacobson/Ring.lean`, `finite_of_finite_type_of_isJacobsonRing`).
+This avoids the transcendence-basis + pole-avoidance specialization bookkeeping the
+book's "finitely generated, then finite extension" phrasing suggests.
+
+## Current frontier
+
+`Problem3_8_4.lean` still has the two general-`L` sorries; the finite case
+(`iso_of_baseChange_iso_finite`, #6051) and prerequisites (`baseChange_alinEquiv_pow`,
+`iso_pow_cancel`) are sorry-free on `main`. No code changes landed this turn — the
+deliverable is the decomposition.
+
+## Overall project progress
+
+Problem 3.8.4 finite-case machinery is complete on `main`. General-`L` descent is now
+a three-issue chain (#6056 → #6057 → #6058), plus part (ii)'s extra dependency #6049
+(direct-summand power cancellation, still claimed/unmerged).
+
+## Next step
+
+A worker should claim **#6056** first (unblocked, reusable infra). Then #6057, then
+#6058. #6058 also waits on #6049. The next planner should triage the `replan` on #6050
+(the sub-issues fully cover it → close #6050 with a forward link).
+
+## Blockers
+
+None for #6056. #6057 blocked on #6056; #6058 blocked on #6056, #6057, #6049 (labels
+applied via `coordination add-dep`).


### PR DESCRIPTION
This PR records the progress handoff for the decomposition of #6050 (general field-extension descent for Problem 3.8.4(i),(ii)).

After scope assessment, #6050 was split into three sub-issues rather than attempted in one session: #6056 (`bcMod` base-change pushforward functoriality), #6057 (descent of an `L⊗A`-iso to a finitely generated `K`-subalgebra), and #6058 (Zariski's-lemma specialization + finite-case assembly, discharging both sorries). The transcendental-subextension subtlety is resolved by Zariski's lemma (`finite_of_finite_type_of_isJacobsonRing`): the residue field of the finitely generated coefficient algebra is automatically finite over `K`.

No Lean source changes; adds a progress file only.

🤖 Prepared with Claude Code