### PR TITLE
feat(Ch4 #6046): field-general FDRep↔module simple bridge + Rep/Module iso-class equivalence

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Exercise4_2_3.lean
+++ b/EtingofRepresentationTheory/Chapter4/Exercise4_2_3.lean
@@ -1,4 +1,5 @@
 import Mathlib
+import EtingofRepresentationTheory.Chapter7.Introduction_7_4
 
 /-!
 # Exercise 4.2.3: fewer irreducibles than conjugacy classes in the modular case
@@ -145,6 +146,111 @@ theorem not_isSemisimpleRing_of_card_eq_zero (hcard : (Fintype.card G : k) = 0) 
   exact hmem'
 
 end GroupSum
+
+/-! ### Field-general bridge between simple `FDRep`s and simple `k[G]`-modules
+
+The counting half of Exercise 4.2.3 requires relating the categorical count
+`Nat.card (IrrepClasses k G)` to an algebraic count of simple `k[G]`-modules. The bridge must
+be **field-general** — no `IsAlgClosed`, no `NeZero (|G| : k)` — because the exercise lives in
+the modular (non-semisimple) case. This section develops:
+
+* `simple_fdRepOf_of_isSimpleModule`: a simple `k[G]`-module gives a simple `FDRep k G` object
+  (a field-general restatement of `FDRep.simple_of_isSimpleModule_asModule`, which carries a
+  spurious `[NeZero (Nat.card G : k)]` inherited from its `IsAlgClosed` section);
+* `Simple` viewed as an `ObjectProperty` closed under isomorphism;
+* `repSimpleClassesEquivModuleSimpleClasses`: the bijection between isomorphism classes of
+  simple objects of `Rep k G` and of `ModuleCat k[G]`, induced by
+  `Rep.equivalenceModuleMonoidAlgebra` via `Etingof.isoClassesEquivOfEquivalence`.
+
+The remaining links (`IrrepClasses k G ≃` simple-object classes of `Rep k G`, the
+`Finite` instance, and the final count) are tracked in the sibling issues. -/
+
+section Bridge
+
+open CategoryTheory ObjectProperty
+
+universe u v
+
+/-- A fully faithful functor preserving monomorphisms reflects simple objects. This is a
+field-general (and namespace-local) copy of the private lemma used in
+`Infrastructure/IrreducibleEnumeration`, restated here without any `IsAlgClosed` context. -/
+private lemma simple_of_fullyFaithful_preservesMono {C D : Type*} [Category C] [Category D]
+    [Limits.HasZeroMorphisms C] [Limits.HasZeroMorphisms D]
+    (F : C ⥤ D) [F.Full] [F.Faithful] [F.PreservesMonomorphisms] (X : C)
+    [Simple (F.obj X)] : Simple X where
+  mono_isIso_iff_nonzero {Y} f := by
+    intro _
+    constructor
+    · intro hiso
+      haveI : IsIso (F.map f) := Functor.map_isIso F f
+      exact fun h => (Simple.mono_isIso_iff_nonzero (F.map f)).mp inferInstance
+        (by rw [h]; simp)
+    · intro hne
+      haveI : Mono (F.map f) := inferInstance
+      haveI : IsIso (F.map f) := (Simple.mono_isIso_iff_nonzero (F.map f)).mpr
+        (fun h => hne (F.map_injective (by rwa [F.map_zero])))
+      exact isIso_of_fully_faithful F f
+
+variable {k : Type u} {G : Type v} [Field k] [Group G]
+
+/-- **Field-general bridge (module ⟹ representation).** If `ρ.asModule` is a simple
+`k[G]`-module, then `FDRep.of ρ` is a simple object of `FDRep k G`. No `NeZero (Nat.card G : k)`
+or `IsAlgClosed k` hypothesis is required: the proof only uses the equivalence
+`Rep k G ≌ ModuleCat k[G]` and the fully faithful forgetful functor `FDRep k G ⥤ Rep k G`. -/
+theorem simple_fdRepOf_of_isSimpleModule
+    {V : Type u} [AddCommGroup V] [Module k V] [Module.Finite k V]
+    (ρ : Representation k G V)
+    [hρ : @IsSimpleModule (MonoidAlgebra k G) _ ρ.asModule _
+      (Representation.instModuleMonoidAlgebraAsModule ρ)] :
+    Simple (FDRep.of ρ) := by
+  letI : Module (MonoidAlgebra k G) ρ.asModule :=
+    Representation.instModuleMonoidAlgebraAsModule ρ
+  haveI := hρ
+  let E := Rep.equivalenceModuleMonoidAlgebra (k := k) (G := G)
+  haveI : Simple (E.functor.obj ((forget₂ (FDRep k G) (Rep k G)).obj (FDRep.of ρ))) :=
+    @simple_of_isSimpleModule (MonoidAlgebra k G) ρ.asModule _ _
+      (Representation.instModuleMonoidAlgebraAsModule ρ) hρ
+  haveI : Simple ((forget₂ (FDRep k G) (Rep k G)).obj (FDRep.of ρ)) :=
+    simple_of_fullyFaithful_preservesMono E.functor _
+  exact simple_of_fullyFaithful_preservesMono (forget₂ (FDRep k G) (Rep k G)) _
+
+/-- Being a simple object, packaged as an `ObjectProperty`. -/
+def simpleProp (C : Type*) [Category C] [Limits.HasZeroMorphisms C] : ObjectProperty C :=
+  fun X => Simple X
+
+instance (C : Type*) [Category C] [Limits.HasZeroMorphisms C] :
+    (simpleProp C).IsClosedUnderIsomorphisms where
+  of_iso e hX := (Simple.iff_of_iso e).mp hX
+
+/-- An equivalence of categories preserves and reflects simple objects. -/
+lemma simpleProp_iff_of_equivalence {A B : Type*} [Category A] [Category B]
+    [Limits.HasZeroMorphisms A] [Limits.HasZeroMorphisms B]
+    (E : A ≌ B) [E.functor.PreservesMonomorphisms] [E.inverse.PreservesMonomorphisms]
+    (X : A) : Simple (E.functor.obj X) ↔ Simple X := by
+  constructor
+  · intro _
+    exact simple_of_fullyFaithful_preservesMono E.functor X
+  · intro hX
+    haveI := hX
+    haveI : Simple (E.inverse.obj (E.functor.obj X)) :=
+      Simple.of_iso (Y := X) (E.unitIso.symm.app X)
+    exact simple_of_fullyFaithful_preservesMono E.inverse (E.functor.obj X)
+
+variable (k G) in
+/-- **Counting bridge (representation side).** The isomorphism classes of simple objects of
+`Rep k G` are in bijection with those of `ModuleCat k[G]`, induced by the equivalence
+`Rep.equivalenceModuleMonoidAlgebra` through `Etingof.isoClassesEquivOfEquivalence`. -/
+noncomputable def repSimpleClassesEquivModuleSimpleClasses :
+    Quotient (isIsomorphicSetoid (simpleProp (Rep k G)).FullSubcategory) ≃
+      Quotient (isIsomorphicSetoid
+        (simpleProp (ModuleCat (MonoidAlgebra k G))).FullSubcategory) := by
+  refine isoClassesEquivOfEquivalence
+    (Equivalence.congrFullSubcategory (Rep.equivalenceModuleMonoidAlgebra (k := k) (G := G))
+      (P := simpleProp (Rep k G)) (Q := simpleProp (ModuleCat (MonoidAlgebra k G))) ?_)
+  exact funext fun X => propext
+    (simpleProp_iff_of_equivalence (Rep.equivalenceModuleMonoidAlgebra (k := k) (G := G)) X)
+
+end Bridge
 
 /-- **Exercise 4.2.3.** If `|G| = 0` in `k` (the characteristic of `k` divides the order
 of the finite group `G`), then the number of isomorphism classes of irreducible

--- a/EtingofRepresentationTheory/Chapter4/Exercise4_2_3.lean
+++ b/EtingofRepresentationTheory/Chapter4/Exercise4_2_3.lean
@@ -214,6 +214,23 @@ theorem simple_fdRepOf_of_isSimpleModule
     simple_of_fullyFaithful_preservesMono E.functor _
   exact simple_of_fullyFaithful_preservesMono (forget₂ (FDRep k G) (Rep k G)) _
 
+/-- **Simple `k[G]`-modules are finite-dimensional.** Since `k[G]` is a finite-dimensional
+`k`-algebra (for finite `G`), any simple `k[G]`-module is a cyclic (hence finitely generated)
+`k[G]`-module, and finite over `k` by transitivity. This is the input to essential
+surjectivity of `FDRep k G ⥤ Rep k G` on simple objects. -/
+theorem finite_k_of_isSimpleModule [Finite G] {M : Type u} [AddCommGroup M]
+    [Module k M] [Module (MonoidAlgebra k G) M] [IsScalarTower k (MonoidAlgebra k G) M]
+    [IsSimpleModule (MonoidAlgebra k G) M] : Module.Finite k M := by
+  haveI : Nontrivial M := IsSimpleModule.nontrivial (MonoidAlgebra k G) M
+  obtain ⟨m, hm0⟩ := exists_ne (0 : M)
+  have htop : Submodule.span (MonoidAlgebra k G) {m} = ⊤ :=
+    (IsSimpleOrder.eq_bot_or_eq_top _).resolve_left (by
+      rw [Submodule.span_singleton_eq_bot]; exact hm0)
+  haveI : Module.Finite (MonoidAlgebra k G) M := ⟨⟨{m}, by simpa using htop⟩⟩
+  haveI : Module.Finite k (MonoidAlgebra k G) :=
+    Module.Finite.of_basis (Finsupp.basisSingleOne (ι := G) (R := k))
+  exact Module.Finite.trans (MonoidAlgebra k G) M
+
 /-- Being a simple object, packaged as an `ObjectProperty`. -/
 def simpleProp (C : Type*) [Category C] [Limits.HasZeroMorphisms C] : ObjectProperty C :=
   fun X => Simple X

--- a/progress/2026-07-10T04-49-24Z_eaf01a91.md
+++ b/progress/2026-07-10T04-49-24Z_eaf01a91.md
@@ -1,0 +1,53 @@
+## Accomplished
+
+Session type: **feature** (issue #6046 — the "make `Nat.card (IrrepClasses k G)` a
+genuine finite algebraic count" prerequisite for Exercise 4.2.3).
+
+Landed the **field-general** counting-bridge infrastructure in
+`Chapter4/Exercise4_2_3.lean` (new `Bridge` section; imports
+`Chapter7.Introduction_7_4` for `isoClassesEquivOfEquivalence`):
+
+- `simple_fdRepOf_of_isSimpleModule` — a simple `k[G]`-module gives a simple `FDRep k G`
+  object, with **no** `NeZero (Nat.card G : k)` / `IsAlgClosed k` hypothesis. This is
+  deliverable D1 of #6046 (the existing `FDRep.simple_of_isSimpleModule_asModule` carries
+  those spurious hypotheses because it lives in an `IsAlgClosed` section).
+- `simpleProp C : ObjectProperty C` (`fun X => Simple X`) + `IsClosedUnderIsomorphisms`
+  instance; `simpleProp_iff_of_equivalence` (an equivalence preserves and reflects `Simple`).
+- `repSimpleClassesEquivModuleSimpleClasses` — the bijection between iso-classes of simple
+  objects of `Rep k G` and of `ModuleCat k[G]`, via
+  `Equivalence.congrFullSubcategory Rep.equivalenceModuleMonoidAlgebra` +
+  `isoClassesEquivOfEquivalence`. This is the **Rep-side half of D3**.
+- `finite_k_of_isSimpleModule` — a simple `k[G]`-module is `Module.Finite k` (cyclic ⟹ f.g.
+  over `k[G]`, then transitivity through the finite-dimensional algebra `k[G]`). This is the
+  essential-surjectivity input for the remaining FDRep↔Rep step.
+
+Builds clean (`lake build EtingofRepresentationTheory.Chapter4.Exercise4_2_3`), only the
+pre-existing `sorry` in the main theorem `Exercise4_2_3` remains.
+
+## Current frontier
+
+The FDRep↔Rep bridge on simple objects is not yet built. The hard remaining fact is
+**preservation of `Simple` by `forget₂ (FDRep k G) (Rep k G)`** (subobjects of a
+finite-dimensional rep are finite-dimensional, so a `k[G]`-submodule of `V.ρ.asModule`
+comes from a mono in `FDRep`), together with essential surjectivity (using
+`finite_k_of_isSimpleModule`). These assemble the equivalence needed to connect
+`IrrepClasses k G` to `repSimpleClassesEquivModuleSimpleClasses`, then to the final count
+and the `Finite` instance.
+
+## Overall project progress
+
+Phase 3 formalization, Chapter 4. Exercise 4.2.3's algebraic core (non-semisimplicity of
+`k[G]` in the modular case) was already done in prior work; this session added the
+field-general categorical/counting bridge. The counting comparison in the main theorem is
+still deferred.
+
+## Next step
+
+Execute sub-issue **#6061** (`feat(Ch4 #6046): FDRep↔Rep simple equivalence +
+Finite(IrrepClasses) + count lemma`), which has a precise plan for deliverables 1–3
+building directly on the `Bridge` section landed here. Sibling issues #6047 (cocenter
+counting bound) and #6048 (assembly) remain.
+
+## Blockers
+
+None. The remaining work is well-scoped in #6061.


### PR DESCRIPTION
Partial progress on #6046

Session: `eaf01a91-12f9-47a2-9f20-fdcc5cb9a2be`

f8554f4b docs(#6046): progress file — field-general counting bridge landed, remainder in #6061
d7e54820 feat(Ch4 #6046): simple k[G]-modules are finite over k
70c7d271 feat(Ch4 #6046): field-general FDRep↔module simple bridge + Rep/Module iso-class equiv

🤖 Prepared with Claude Code