### PR TITLE
feat(Ch3 #6022): direct-summand power cancellation Vⁿ|Wⁿ ⟹ V|W (Problem 3.8.4(ii) prereq)

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/Problem3_8_4_Cancellation.lean
+++ b/EtingofRepresentationTheory/Chapter3/Problem3_8_4_Cancellation.lean
@@ -20,6 +20,8 @@ This file supplies the reusable helper `Etingof.IsIndecomposable.of_linearEquiv`
 (indecomposability is an isomorphism invariant) and the main theorem `iso_pow_cancel`.
 -/
 
+open scoped DirectSum
+
 namespace Etingof.Problem3_8_4
 
 /-- Indecomposability is invariant under `A`-linear isomorphism: if `V` is indecomposable
@@ -358,5 +360,62 @@ theorem iso_pow_cancel (k A V W : Type*) [Field k] [Ring A] [Algebra k A]
   let mid := DFinsupp.mapRange.linearEquiv (R := A) (fun i => (hiso i).some)
   exact ⟨(LinearEquiv.ofBijective (DirectSum.coeLinearMap DV) hIntV).symm ≪≫ₗ mid ≪≫ₗ
     LinearEquiv.ofBijective (DirectSum.coeLinearMap (fun i => DW (τ i))) hIntWτ⟩
+
+/-- **Direct summand from an index embedding.** Given internal indecomposable decompositions
+`DV : Fin p → Submodule A V` and `DW : Fin q → Submodule A W`, together with an injection
+`φ : Fin p → Fin q` matching each summand of `V` with an isomorphic summand of `W`
+(`DV i ≅ DW (φ i)`), the module `V` is a direct summand of `W`: there are `A`-linear maps
+`ι : V →ₗ W`, `π : W →ₗ V` with `π ∘ ι = id`.
+
+The split is assembled at the level of the internal direct sums: `ιS` places the `i`-th summand
+of `⨁ DV` into coordinate `φ i` of `⨁ DW` via the given iso, and `πS` reads coordinate `φ i`
+back out. Injectivity of `φ` makes `πS ∘ ιS = id` (each coordinate `φ i` is hit exactly once). -/
+private theorem summand_of_index_embedding {A V W : Type*} [Ring A]
+    [AddCommGroup V] [Module A V] [AddCommGroup W] [Module A W]
+    {p q : ℕ} (DV : Fin p → Submodule A V) (DW : Fin q → Submodule A W)
+    (hIntV : DirectSum.IsInternal DV) (hIntW : DirectSum.IsInternal DW)
+    {φ : Fin p → Fin q} (hφ : Function.Injective φ)
+    (hiso : ∀ i, Nonempty ((DV i) ≃ₗ[A] (DW (φ i)))) :
+    ∃ (ι : V →ₗ[A] W) (π : W →ₗ[A] V), π.comp ι = LinearMap.id := by
+  classical
+  let θ : ∀ i, (DV i) ≃ₗ[A] (DW (φ i)) := fun i => (hiso i).some
+  let eV : V ≃ₗ[A] (⨁ i, (DV i)) :=
+    (LinearEquiv.ofBijective (DirectSum.coeLinearMap DV) hIntV).symm
+  let eW : (⨁ j, (DW j)) ≃ₗ[A] W := LinearEquiv.ofBijective (DirectSum.coeLinearMap DW) hIntW
+  -- Place summand `i` of `⨁ DV` into coordinate `φ i` of `⨁ DW`.
+  let ιS : (⨁ i, (DV i)) →ₗ[A] (⨁ j, (DW j)) :=
+    DirectSum.toModule A (Fin p) _ (fun i =>
+      (DirectSum.lof A (Fin q) (fun j => (DW j)) (φ i)).comp (θ i).toLinearMap)
+  -- Read coordinate `φ i` back out into summand `i` of `⨁ DV`.
+  let πS : (⨁ j, (DW j)) →ₗ[A] (⨁ i, (DV i)) :=
+    ∑ i : Fin p, (DirectSum.lof A (Fin p) (fun i => (DV i)) i).comp
+      (((θ i).symm.toLinearMap).comp (DirectSum.component A (Fin q) (fun j => (DW j)) (φ i)))
+  have hsplit : πS.comp ιS = LinearMap.id := by
+    apply DirectSum.linearMap_ext
+    intro i₀
+    apply LinearMap.ext
+    intro x
+    simp only [LinearMap.comp_apply, LinearMap.id_coe, id_eq]
+    -- `ιS (lof i₀ x) = lof (φ i₀) (θ i₀ x)`
+    have hι : ιS (DirectSum.lof A (Fin p) (fun i => (DV i)) i₀ x)
+        = DirectSum.lof A (Fin q) (fun j => (DW j)) (φ i₀) (θ i₀ x) := by
+      simp only [ιS, DirectSum.toModule_lof, LinearMap.comp_apply, LinearEquiv.coe_coe]
+    rw [hι]
+    simp only [πS, LinearMap.sum_apply, LinearMap.comp_apply, LinearEquiv.coe_coe]
+    rw [Finset.sum_eq_single i₀]
+    · rw [DirectSum.component.lof_self]
+      simp only [LinearEquiv.symm_apply_apply]
+    · intro b _ hb
+      rw [DirectSum.component.of, dif_neg (fun h => hb (hφ h.symm))]
+      simp only [map_zero]
+    · intro h; exact absurd (Finset.mem_univ i₀) h
+  refine ⟨(eW : (⨁ j, (DW j)) →ₗ[A] W).comp (ιS.comp (eV : V →ₗ[A] (⨁ i, (DV i)))),
+      (eV.symm : (⨁ i, (DV i)) →ₗ[A] V).comp (πS.comp (eW.symm : W →ₗ[A] (⨁ j, (DW j)))), ?_⟩
+  apply LinearMap.ext
+  intro v
+  simp only [LinearMap.comp_apply, LinearMap.id_coe, id_eq, LinearEquiv.coe_coe]
+  rw [eW.symm_apply_apply]
+  have he : πS (ιS (eV v)) = eV v := LinearMap.congr_fun hsplit (eV v)
+  rw [he, eV.symm_apply_apply]
 
 end Etingof.Problem3_8_4

--- a/EtingofRepresentationTheory/Chapter3/Problem3_8_4_Cancellation.lean
+++ b/EtingofRepresentationTheory/Chapter3/Problem3_8_4_Cancellation.lean
@@ -361,6 +361,65 @@ theorem iso_pow_cancel (k A V W : Type*) [Field k] [Ring A] [Algebra k A]
   exact ⟨(LinearEquiv.ofBijective (DirectSum.coeLinearMap DV) hIntV).symm ≪≫ₗ mid ≪≫ₗ
     LinearEquiv.ofBijective (DirectSum.coeLinearMap (fun i => DW (τ i))) hIntWτ⟩
 
+/-- **Fibre-counting inequality.** Suppose that after taking `n` disjoint copies of each fibre of
+`f : Fin p → C` and adjoining an extra family `d : Fin r → C`, the result is equinumerous with the
+`n`-fold copies of the fibres of `g : Fin q → C` — witnessed by a bijection
+`σ : ((Fin n × Fin p) ⊕ Fin r) ≃ (Fin n × Fin q)` matching the `C`-labels. Then each `f`-fibre is
+no larger than the corresponding `g`-fibre, so there is an injection `φ : Fin p ↪ Fin q` with
+`g (φ i) = f i`. This is the multiplicity comparison `n • s ≤ n • t ⟹ s ≤ t` (for `n > 0`)
+underlying "if `Vⁿ` is a direct summand of `Wⁿ` then `V` is a direct summand of `W`". -/
+private theorem fibre_le {C : Type*} {p q n r : ℕ} (hn : 0 < n)
+    (f : Fin p → C) (g : Fin q → C) (d : Fin r → C)
+    (σ : ((Fin n × Fin p) ⊕ Fin r) ≃ (Fin n × Fin q))
+    (hσ : ∀ x, g (σ x).2 = Sum.elim (fun a : Fin n × Fin p => f a.2) d x) :
+    ∃ φ : Fin p → Fin q, Function.Injective φ ∧ ∀ i, g (φ i) = f i := by
+  classical
+  -- For each label `c`, the `f`-fibre is no larger than the `g`-fibre.
+  have key : ∀ c : C, Fintype.card {i // f i = c} ≤ Fintype.card {j // g j = c} := by
+    intro c
+    -- `σ` restricts to a bijection between the label-`c` fibres of the two indices.
+    have e : {x : (Fin n × Fin p) ⊕ Fin r // Sum.elim (fun a : Fin n × Fin p => f a.2) d x = c}
+        ≃ {y : Fin n × Fin q // g y.2 = c} :=
+      { toFun := fun x => ⟨σ x.1, by rw [hσ]; exact x.2⟩
+        invFun := fun y => ⟨σ.symm y.1, by
+          have h := hσ (σ.symm y.1); rw [σ.apply_symm_apply] at h; rw [← h]; exact y.2⟩
+        left_inv := fun x => Subtype.ext (σ.symm_apply_apply x.1)
+        right_inv := fun y => Subtype.ext (σ.apply_symm_apply y.1) }
+    -- The `n`-fold `f`-fibre injects (via `inl`) into the label-`c` fibre of the sum index.
+    have hinj : Fintype.card {a : Fin n × Fin p // f a.2 = c}
+        ≤ Fintype.card {x : (Fin n × Fin p) ⊕ Fin r //
+            Sum.elim (fun a : Fin n × Fin p => f a.2) d x = c} :=
+      Fintype.card_le_of_injective (fun a => ⟨Sum.inl a.1, a.2⟩) (by
+        intro a b h
+        simp only [Subtype.mk.injEq, Sum.inl.injEq] at h
+        exact Subtype.ext h)
+    -- Each `n`-fold fibre is `Fin n` copies of the corresponding plain fibre.
+    have eF : {a : Fin n × Fin p // f a.2 = c} ≃ Fin n × {i // f i = c} :=
+      { toFun := fun a => (a.1.1, ⟨a.1.2, a.2⟩)
+        invFun := fun y => ⟨(y.1, y.2.1), y.2.2⟩
+        left_inv := fun a => by rcases a with ⟨⟨s, t⟩, h⟩; rfl
+        right_inv := fun y => by rcases y with ⟨s, t, h⟩; rfl }
+    have eG : {y : Fin n × Fin q // g y.2 = c} ≃ Fin n × {j // g j = c} :=
+      { toFun := fun y => (y.1.1, ⟨y.1.2, y.2⟩)
+        invFun := fun z => ⟨(z.1, z.2.1), z.2.2⟩
+        left_inv := fun y => by rcases y with ⟨⟨s, t⟩, h⟩; rfl
+        right_inv := fun z => by rcases z with ⟨s, t, h⟩; rfl }
+    have hFF : Fintype.card {a : Fin n × Fin p // f a.2 = c} = n * Fintype.card {i // f i = c} := by
+      rw [Fintype.card_congr eF, Fintype.card_prod, Fintype.card_fin]
+    have hGG : Fintype.card {y : Fin n × Fin q // g y.2 = c} = n * Fintype.card {j // g j = c} := by
+      rw [Fintype.card_congr eG, Fintype.card_prod, Fintype.card_fin]
+    have hle : n * Fintype.card {i // f i = c} ≤ n * Fintype.card {j // g j = c} := by
+      rw [← hFF, ← hGG, ← Fintype.card_congr e]; exact hinj
+    exact Nat.le_of_mul_le_mul_left hle hn
+  -- Assemble a fibre-wise embedding into a single injection `Fin p ↪ Fin q`.
+  let emb : ∀ c : C, {i // f i = c} ↪ {j // g j = c} :=
+    fun c => (Function.Embedding.nonempty_of_card_le (key c)).some
+  let Φ : (Σ c, {i // f i = c}) ↪ (Σ c, {j // g j = c}) :=
+    Function.Embedding.sigmaMap (Function.Embedding.refl C) emb
+  let ψ : Fin p ↪ Fin q :=
+    (Equiv.sigmaFiberEquiv f).symm.toEmbedding.trans (Φ.trans (Equiv.sigmaFiberEquiv g).toEmbedding)
+  exact ⟨ψ, ψ.injective, fun i => (emb (f i) ⟨i, rfl⟩).2⟩
+
 /-- **Direct summand from an index embedding.** Given internal indecomposable decompositions
 `DV : Fin p → Submodule A V` and `DW : Fin q → Submodule A W`, together with an injection
 `φ : Fin p → Fin q` matching each summand of `V` with an isomorphic summand of `W`

--- a/EtingofRepresentationTheory/Chapter3/Problem3_8_4_Cancellation.lean
+++ b/EtingofRepresentationTheory/Chapter3/Problem3_8_4_Cancellation.lean
@@ -134,6 +134,67 @@ private theorem iSupIndep_prod_of_blocks {α : Type*} [CompleteLattice α] [IsMo
     _ = s k i ⊓ X := by rw [hYBk, sup_bot_eq]
     _ = ⊥ := disjoint_iff.mp hX
 
+/-- **Two-block independence.** In a modular lattice, if two internally independent families
+`s : κ → α` and `t : ι → α` have disjoint total suprema, then the family `Sum.elim s t` indexed by
+`κ ⊕ ι` is independent. This is the lattice fact behind combining a decomposition of a direct
+summand `R` with a decomposition of its complement `Y` into a single decomposition of `R ⊔ Y`. -/
+private theorem iSupIndep_sum_of_blocks {α : Type*} [CompleteLattice α] [IsModularLattice α]
+    {κ ι : Type*} (s : κ → α) (t : ι → α)
+    (hdisj : Disjoint (⨆ a, s a) (⨆ b, t b))
+    (hs : iSupIndep s) (ht : iSupIndep t) :
+    iSupIndep (Sum.elim s t) := by
+  set S : α := ⨆ a, s a with hS
+  set T : α := ⨆ b, t b with hT
+  rintro (a | b)
+  · -- `Disjoint (s a) (⨆ x ≠ inl a, Sum.elim s t x)`.
+    set X : α := ⨆ (a') (_ : a' ≠ a), s a' with hX_def
+    have hsS : s a ≤ S := le_iSup s a
+    have hXS : X ≤ S := iSup₂_le fun a' _ => le_iSup s a'
+    have hX : Disjoint (s a) X := hs a
+    have hcov : (⨆ (x : κ ⊕ ι) (_ : x ≠ Sum.inl a), Sum.elim s t x) ≤ X ⊔ T := by
+      refine iSup₂_le fun x hx => ?_
+      rcases x with a' | b'
+      · have : a' ≠ a := fun h => hx (by rw [h])
+        calc Sum.elim s t (Sum.inl a') = s a' := rfl
+          _ ≤ X := le_iSup₂ (f := fun a' (_ : a' ≠ a) => s a') a' this
+          _ ≤ X ⊔ T := le_sup_left
+      · calc Sum.elim s t (Sum.inr b') = t b' := rfl
+          _ ≤ T := le_iSup t b'
+          _ ≤ X ⊔ T := le_sup_right
+    refine Disjoint.mono_right hcov ?_
+    rw [disjoint_iff]
+    have hTS : T ⊓ S = ⊥ := by rw [inf_comm]; exact disjoint_iff.mp hdisj
+    calc s a ⊓ (X ⊔ T)
+        = s a ⊓ (S ⊓ (X ⊔ T)) := by rw [← inf_assoc, inf_eq_left.mpr hsS]
+      _ = s a ⊓ ((X ⊔ T) ⊓ S) := by rw [inf_comm S]
+      _ = s a ⊓ (X ⊔ T ⊓ S) := by rw [sup_inf_assoc_of_le _ hXS]
+      _ = s a ⊓ X := by rw [hTS, sup_bot_eq]
+      _ = ⊥ := disjoint_iff.mp hX
+  · -- `Disjoint (t b) (⨆ x ≠ inr b, Sum.elim s t x)`.
+    set X : α := ⨆ (b') (_ : b' ≠ b), t b' with hX_def
+    have htT : t b ≤ T := le_iSup t b
+    have hXT : X ≤ T := iSup₂_le fun b' _ => le_iSup t b'
+    have hX : Disjoint (t b) X := ht b
+    have hcov : (⨆ (x : κ ⊕ ι) (_ : x ≠ Sum.inr b), Sum.elim s t x) ≤ X ⊔ S := by
+      refine iSup₂_le fun x hx => ?_
+      rcases x with a' | b'
+      · calc Sum.elim s t (Sum.inl a') = s a' := rfl
+          _ ≤ S := le_iSup s a'
+          _ ≤ X ⊔ S := le_sup_right
+      · have : b' ≠ b := fun h => hx (by rw [h])
+        calc Sum.elim s t (Sum.inr b') = t b' := rfl
+          _ ≤ X := le_iSup₂ (f := fun b' (_ : b' ≠ b) => t b') b' this
+          _ ≤ X ⊔ S := le_sup_left
+    refine Disjoint.mono_right hcov ?_
+    rw [disjoint_iff]
+    have hST : S ⊓ T = ⊥ := disjoint_iff.mp hdisj
+    calc t b ⊓ (X ⊔ S)
+        = t b ⊓ (T ⊓ (X ⊔ S)) := by rw [← inf_assoc, inf_eq_left.mpr htT]
+      _ = t b ⊓ ((X ⊔ S) ⊓ T) := by rw [inf_comm T]
+      _ = t b ⊓ (X ⊔ S ⊓ T) := by rw [sup_inf_assoc_of_le _ hXT]
+      _ = t b ⊓ X := by rw [hST, sup_bot_eq]
+      _ = ⊥ := disjoint_iff.mp hX
+
 open LinearMap in
 /-- The `n`-fold power `Fin n → M` of a module carrying an internal indecomposable decomposition
 `D : Fin p → Submodule A M` itself carries an internal indecomposable decomposition, indexed by

--- a/EtingofRepresentationTheory/Chapter3/Problem3_8_4_Cancellation.lean
+++ b/EtingofRepresentationTheory/Chapter3/Problem3_8_4_Cancellation.lean
@@ -538,4 +538,156 @@ private theorem summand_of_index_embedding {A V W : Type*} [Ring A]
   have he : πS (ιS (eV v)) = eV v := LinearMap.congr_fun hsplit (eV v)
   rw [he, eV.symm_apply_apply]
 
+/-- **Direct-summand power cancellation** (Problem 3.8.4(ii) prerequisite / Noether-Deuring shape).
+For finite dimensional representations `V`, `W` of an algebra `A` over an arbitrary field `k`, if
+`Vⁿ` is a direct summand of `Wⁿ` for some `n > 0`, then `V` is a direct summand of `W`.
+
+Proof: the split injection presents `Wⁿ ≅ Vⁿ ⊕ Y` with `Y` the (finite dimensional) complement.
+Krull-Schmidt (Problem 3.8.3) decomposes `V`, `W`, `Y` into indecomposables; assembling the
+`Vⁿ`-power decomposition of the summand `R ≅ Vⁿ` with a decomposition of `Y` gives one
+indecomposable decomposition of `Wⁿ`, which Krull-Schmidt uniqueness matches against the
+`Wⁿ`-power decomposition. Comparing fibres per indecomposable iso-class gives, after cancelling
+the common factor `n`, an injection `φ : Fin p ↪ Fin q` with `DV i ≅ DW (φ i)`; feeding it to
+`summand_of_index_embedding` exhibits `V` as a direct summand of `W`. -/
+theorem directSummand_pow_cancel (k A V W : Type*) [Field k] [Ring A] [Algebra k A]
+    [AddCommGroup V] [Module k V] [Module A V] [IsScalarTower k A V]
+    [AddCommGroup W] [Module k W] [Module A W] [IsScalarTower k A W]
+    [FiniteDimensional k V] [FiniteDimensional k W]
+    {n : ℕ} (hn : 0 < n)
+    (h : ∃ (i : (Fin n → V) →ₗ[A] (Fin n → W)) (p : (Fin n → W) →ₗ[A] (Fin n → V)),
+           p.comp i = LinearMap.id) :
+    ∃ (i : V →ₗ[A] W) (p : W →ₗ[A] V), p.comp i = LinearMap.id := by
+  classical
+  obtain ⟨imap, pmap, hpi⟩ := h
+  have hi_inj : Function.Injective imap :=
+    Function.LeftInverse.injective (g := pmap) (fun x => LinearMap.congr_fun hpi x)
+  -- The split idempotent presents `Wⁿ = R ⊕ Y'` with `R = range imap ≅ Vⁿ`.
+  set R : Submodule A (Fin n → W) := LinearMap.range imap with hR
+  set iRange : (Fin n → V) ≃ₗ[A] R := LinearEquiv.ofInjective imap hi_inj with hiRange
+  set f0 : (Fin n → W) →ₗ[A] R := iRange.toLinearMap.comp pmap with hf0def
+  have hf0 : ∀ x : R, f0 x = x := by
+    intro x
+    obtain ⟨v, hv⟩ := LinearMap.mem_range.mp x.2
+    apply Subtype.ext
+    have hpv : pmap (x : Fin n → W) = v := by rw [← hv]; exact LinearMap.congr_fun hpi v
+    have hfx : f0 (x : Fin n → W) = iRange v := by
+      simp only [f0, LinearMap.comp_apply, LinearEquiv.coe_coe, hpv]
+    rw [hfx]
+    change (imap v : Fin n → W) = (x : Fin n → W)
+    exact hv
+  have hCompl : IsCompl R (LinearMap.ker f0) := LinearMap.isCompl_of_proj hf0
+  set Y' : Submodule A (Fin n → W) := LinearMap.ker f0 with hY'
+  -- `Y'` is finite dimensional over `k` (a `k`-subspace of the finite dimensional `Wⁿ`).
+  haveI : FiniteDimensional k (Y' : Submodule A (Fin n → W)) := by
+    have hsub : Function.Injective ⇑(Y'.subtype.restrictScalars k) := Y'.injective_subtype
+    exact FiniteDimensional.of_injective (Y'.subtype.restrictScalars k) hsub
+  -- Krull-Schmidt decompositions of `V`, `W`, and the complement `Y'`.
+  obtain ⟨p, DV, hDV_indec, hDV_sup, hDV_ind⟩ := Problem3_8_3.krull_schmidt_existence k A V
+  obtain ⟨q, DW, hDW_indec, hDW_sup, hDW_ind⟩ := Problem3_8_3.krull_schmidt_existence k A W
+  obtain ⟨r, DY, hDY_indec, hDY_sup, hDY_ind⟩ :=
+    Problem3_8_3.krull_schmidt_existence k A (Y' : Submodule A (Fin n → W))
+  have hDV_ne : ∀ i, DV i ≠ ⊥ := fun i => Submodule.nontrivial_iff_ne_bot.mp (hDV_indec i).1
+  have hDW_ne : ∀ j, DW j ≠ ⊥ := fun j => Submodule.nontrivial_iff_ne_bot.mp (hDW_indec j).1
+  have hDY_ne : ∀ j, DY j ≠ ⊥ := fun j => Submodule.nontrivial_iff_ne_bot.mp (hDY_indec j).1
+  -- Coordinate inclusions and the power decompositions of `Vⁿ` and `Wⁿ`.
+  set sgV : Fin n → (V →ₗ[A] (Fin n → V)) :=
+    fun c => LinearMap.single A (fun _ : Fin n => V) c with hsgV
+  set sgW : Fin n → (W →ₗ[A] (Fin n → W)) :=
+    fun c => LinearMap.single A (fun _ : Fin n => W) c with hsgW
+  obtain ⟨hPV_indec, hPV_ne, hPV_sup, hPV_ind⟩ :=
+    powerDecomp (n := n) DV hDV_indec hDV_ne hDV_sup hDV_ind
+  obtain ⟨hPW_indec, hPW_ne, hPW_sup, hPW_ind⟩ :=
+    powerDecomp (n := n) DW hDW_indec hDW_ne hDW_sup hDW_ind
+  -- The `Wⁿ`-power decomposition `D'` (index `Fin n × Fin q`).
+  set D' : Fin n × Fin q → Submodule A (Fin n → W) := fun cj => (DW cj.2).map (sgW cj.1) with hD'
+  -- Combined decomposition of `Wⁿ = R ⊕ Y'` (index `(Fin n × Fin p) ⊕ Fin r`).
+  set EL : Fin n × Fin p → Submodule A (Fin n → W) :=
+    fun ci => ((DV ci.2).map (sgV ci.1)).map imap with hEL
+  set ER : Fin r → Submodule A (Fin n → W) := fun jr => (DY jr).map Y'.subtype with hER
+  let E : ((Fin n × Fin p) ⊕ Fin r) → Submodule A (Fin n → W) := Sum.elim EL ER
+  have hEL_sup : iSup EL = R := by
+    simp only [EL]; rw [← Submodule.map_iSup, hPV_sup, Submodule.map_top, hR]
+  have hER_sup : iSup ER = Y' := by
+    simp only [ER]; rw [← Submodule.map_iSup, hDY_sup, Submodule.map_top, Submodule.range_subtype]
+  have hEL_indec : ∀ ci, Etingof.IsIndecomposable A (EL ci) := fun ci =>
+    (hPV_indec ci).of_linearEquiv (Submodule.equivMapOfInjective imap hi_inj _)
+  have hER_indec : ∀ jr, Etingof.IsIndecomposable A (ER jr) := fun jr =>
+    (hDY_indec jr).of_linearEquiv (Submodule.equivMapOfInjective Y'.subtype Y'.injective_subtype _)
+  have hEL_ne : ∀ ci, EL ci ≠ ⊥ := fun ci =>
+    Submodule.nontrivial_iff_ne_bot.mp (hEL_indec ci).1
+  have hER_ne : ∀ jr, ER jr ≠ ⊥ := fun jr =>
+    Submodule.nontrivial_iff_ne_bot.mp (hER_indec jr).1
+  have hEL_ind : iSupIndep EL := LinearMap.iSupIndep_map imap hi_inj hPV_ind
+  have hER_ind : iSupIndep ER := LinearMap.iSupIndep_map Y'.subtype Y'.injective_subtype hDY_ind
+  -- Properties of the combined family `E = Sum.elim EL ER`.
+  have hE_indec : ∀ x, Etingof.IsIndecomposable A (E x) := by
+    rintro (ci | jr)
+    · exact hEL_indec ci
+    · exact hER_indec jr
+  have hE_ne : ∀ x, E x ≠ ⊥ := by
+    rintro (ci | jr)
+    · exact hEL_ne ci
+    · exact hER_ne jr
+  have hE_sup : iSup E = ⊤ := by
+    change iSup (Sum.elim EL ER) = ⊤
+    rw [iSup_sum]
+    simp only [Sum.elim_inl, Sum.elim_inr]
+    rw [hEL_sup, hER_sup, hCompl.sup_eq_top]
+  have hE_ind : iSupIndep E :=
+    iSupIndep_sum_of_blocks EL ER (by rw [hEL_sup, hER_sup]; exact hCompl.disjoint) hEL_ind hER_ind
+  -- Krull-Schmidt uniqueness matches the combined decomposition with the `Wⁿ`-power decomposition.
+  obtain ⟨σ, hks⟩ := ks_uniqueness_index k A (Fin n → W) E D'
+    hE_indec hPW_indec hE_ne hPW_ne hE_sup hE_ind hPW_sup hPW_ind
+  -- Isomorphisms of each combined/power summand with the underlying `DV`/`DW`/`DY` summand.
+  have isoV : ∀ ci : Fin n × Fin p, (DV ci.2) ≃ₗ[A] EL ci := fun ci =>
+    (Submodule.equivMapOfInjective (sgV ci.1) (single_injective _) (DV ci.2)).trans
+      (Submodule.equivMapOfInjective imap hi_inj _)
+  have isoW : ∀ cj : Fin n × Fin q, (DW cj.2) ≃ₗ[A] D' cj := fun cj =>
+    Submodule.equivMapOfInjective (sgW cj.1) (single_injective _) (DW cj.2)
+  have isoY : ∀ jr : Fin r, (DY jr) ≃ₗ[A] ER jr := fun jr =>
+    Submodule.equivMapOfInjective Y'.subtype Y'.injective_subtype (DY jr)
+  -- Iso-class labels for the three families, as a quotient of `Fin p ⊕ Fin q ⊕ Fin r`.
+  let rel : (Fin p ⊕ Fin q ⊕ Fin r) → (Fin p ⊕ Fin q ⊕ Fin r) → Prop := fun a b =>
+    match a, b with
+    | Sum.inl i, Sum.inl i' => Nonempty (DV i ≃ₗ[A] DV i')
+    | Sum.inl i, Sum.inr (Sum.inl j) => Nonempty (DV i ≃ₗ[A] DW j)
+    | Sum.inl i, Sum.inr (Sum.inr jr) => Nonempty (DV i ≃ₗ[A] DY jr)
+    | Sum.inr (Sum.inl j), Sum.inl i => Nonempty (DW j ≃ₗ[A] DV i)
+    | Sum.inr (Sum.inl j), Sum.inr (Sum.inl j') => Nonempty (DW j ≃ₗ[A] DW j')
+    | Sum.inr (Sum.inl j), Sum.inr (Sum.inr jr) => Nonempty (DW j ≃ₗ[A] DY jr)
+    | Sum.inr (Sum.inr jr), Sum.inl i => Nonempty (DY jr ≃ₗ[A] DV i)
+    | Sum.inr (Sum.inr jr), Sum.inr (Sum.inl j) => Nonempty (DY jr ≃ₗ[A] DW j)
+    | Sum.inr (Sum.inr jr), Sum.inr (Sum.inr jr') => Nonempty (DY jr ≃ₗ[A] DY jr')
+  have hrefl : ∀ x, rel x x := by rintro (i | j | jr) <;> exact ⟨LinearEquiv.refl A _⟩
+  have hsymm : ∀ {x y}, rel x y → rel y x := by
+    rintro (i | j | jr) (i' | j' | jr') ⟨φ⟩ <;> exact ⟨φ.symm⟩
+  have htrans : ∀ {x y z}, rel x y → rel y z → rel x z := by
+    rintro (i | j | jr) (i' | j' | jr') (i'' | j'' | jr'') ⟨φ⟩ ⟨ψ⟩ <;> exact ⟨φ.trans ψ⟩
+  letI S : Setoid (Fin p ⊕ Fin q ⊕ Fin r) := ⟨rel, hrefl, hsymm, htrans⟩
+  let fC : Fin p → Quotient S := fun i => ⟦Sum.inl i⟧
+  let gC : Fin q → Quotient S := fun j => ⟦Sum.inr (Sum.inl j)⟧
+  let dC : Fin r → Quotient S := fun jr => ⟦Sum.inr (Sum.inr jr)⟧
+  have hfg_vw : ∀ i j, fC i = gC j ↔ Nonempty (DV i ≃ₗ[A] DW j) := fun i j => Quotient.eq
+  have hfg_yw : ∀ jr j, dC jr = gC j ↔ Nonempty (DY jr ≃ₗ[A] DW j) := fun jr j => Quotient.eq
+  -- The permutation `σ` respects iso-classes.
+  have hσ : ∀ x, gC (σ x).2 = Sum.elim (fun a : Fin n × Fin p => fC a.2) dC x := by
+    intro x
+    obtain ⟨χ⟩ := hks x
+    rcases x with ci | jr
+    · change gC (σ (Sum.inl ci)).2 = fC ci.2
+      rw [eq_comm, hfg_vw ci.2 (σ (Sum.inl ci)).2]
+      exact ⟨(isoV ci).trans (χ.trans (isoW (σ (Sum.inl ci))).symm)⟩
+    · change gC (σ (Sum.inr jr)).2 = dC jr
+      rw [eq_comm, hfg_yw jr (σ (Sum.inr jr)).2]
+      exact ⟨(isoY jr).trans (χ.trans (isoW (σ (Sum.inr jr))).symm)⟩
+  obtain ⟨φ, hφ_inj, hφ_lab⟩ := fibre_le hn fC gC dC σ hσ
+  have hiso' : ∀ i, Nonempty (DV i ≃ₗ[A] DW (φ i)) := fun i =>
+    (hfg_vw i (φ i)).mp (hφ_lab i).symm
+  -- Assemble the direct summand via the index embedding `φ`.
+  have hIntV : DirectSum.IsInternal DV :=
+    (DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top DV).mpr ⟨hDV_ind, hDV_sup⟩
+  have hIntW : DirectSum.IsInternal DW :=
+    (DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top DW).mpr ⟨hDW_ind, hDW_sup⟩
+  exact summand_of_index_embedding DV DW hIntV hIntW hφ_inj hiso'
+
 end Etingof.Problem3_8_4

--- a/progress/2026-07-10T04-57-12Z_1069586a.md
+++ b/progress/2026-07-10T04-57-12Z_1069586a.md
@@ -1,0 +1,53 @@
+## Accomplished
+
+Completed issue #6049: proved `Etingof.Problem3_8_4.directSummand_pow_cancel` (Problem 3.8.4(ii)
+prerequisite) — for finite dimensional `A`-modules `V`, `W` over an arbitrary field `k`, if `Vⁿ`
+is a direct summand of `Wⁿ` (`n > 0`) then `V` is a direct summand of `W`. Added to
+`EtingofRepresentationTheory/Chapter3/Problem3_8_4_Cancellation.lean`.
+`#print axioms directSummand_pow_cancel` shows only `propext, Classical.choice, Quot.sound` —
+no `sorryAx`. File is fully sorry-free; downstream (`Problem3_8_4_Finite.lean`, `Chapter3.lean`)
+still builds.
+
+Four new sorry-free helpers were added to the same file (reusing the existing private
+`powerDecomp`, `single_injective`, `ks_uniqueness_index`, `IsIndecomposable.of_linearEquiv`):
+
+- `summand_of_index_embedding` — the linear-algebra core: given internal indecomposable
+  decompositions `DV`, `DW` and an injection `φ : Fin p ↪ Fin q` with `DV i ≅ DW (φ i)`, builds
+  `ι : V →ₗ W`, `π : W →ₗ V` with `π ∘ ι = id`. Assembled at the `⨁`-level: `ιS` places summand
+  `i` into coordinate `φ i`, `πS` reads it back; `φ` injective ⟹ `πS ∘ ιS = id`
+  (`DirectSum.toModule` + `component.of` + `Finset.sum_eq_single`).
+- `fibre_le` — combinatorial: from a label-preserving bijection
+  `σ : ((Fin n × Fin p) ⊕ Fin r) ≃ (Fin n × Fin q)` derive per-class `n·#fibre_f ≤ n·#fibre_g`,
+  cancel `n`, and assemble a fibre-wise `Function.Embedding.sigmaMap` into `φ`. Sibling of the
+  existing `fibre_cancel`.
+- `iSupIndep_sum_of_blocks` — two-block independence in a modular lattice: independent families
+  `s`, `t` with disjoint total suprema give `iSupIndep (Sum.elim s t)`. Sum analogue of the
+  existing `iSupIndep_prod_of_blocks`.
+
+Main-proof route: split idempotent `imap ∘ pmap` presents `Wⁿ = R ⊕ Y'` with `R = range imap ≅ Vⁿ`,
+`Y'` its complement (finite dimensional via `FiniteDimensional.of_injective` on the `k`-restricted
+subtype). Krull-Schmidt decomposes `V`, `W`, `Y'`; the combined `R`-block (DV-power mapped by
+`imap`) ⊕ `Y'`-block (DY mapped by `Y'.subtype`) is an indecomposable decomposition of `Wⁿ`
+(`iSupIndep_sum_of_blocks` + `iSup_sum` + `IsCompl`). `ks_uniqueness_index` matches it against the
+`Wⁿ`-power decomposition; `fibre_le` (with iso-classes a `Quotient` of `Fin p ⊕ Fin q ⊕ Fin r`)
+yields `φ`; `summand_of_index_embedding` finishes.
+
+## Current frontier
+
+Issue #6049 complete. `Problem3_8_4_Cancellation.lean` is sorry-free and warning-free.
+
+## Overall project progress
+
+Phase 3 (formalization) ongoing. The direct-summand power cancellation is now available as a
+sorry-free lemma, unblocking the Noether-Deuring assembly of Problem 3.8.4(ii) (issue #6050, part
+(ii)).
+
+## Next step
+
+Issue #6050 (finite-extension descent for Problem 3.8.4(i) and (ii)) can now consume
+`directSummand_pow_cancel` for the part (ii) direct-summand descent, mirroring how
+`Problem3_8_4_Finite.lean` consumes `iso_pow_cancel` for part (i).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6049

Session: `1069586a-28a4-4d74-9191-670413d1a5f6`

b020992d progress: 2026-07-10T04-57-12Z — #6049 directSummand_pow_cancel complete
803b5906 feat(Ch3 #6049): prove directSummand_pow_cancel — Vⁿ|Wⁿ ⟹ V|W
66275a46 feat(Ch3 #6049): WIP add iSupIndep_sum_of_blocks (two-block independence)
0e36a2f7 feat(Ch3 #6049): WIP add fibre_le (fibre-counting inequality → index embedding)
0bf79bf2 feat(Ch3 #6049): WIP add summand_of_index_embedding helper (direct-sum split from index embedding)

🤖 Prepared with Claude Code