### PR TITLE
feat(Ch7): prove Problem 7.7.3 — category of finitely generated modules over a finite-type ℤ-algebra is abelian

### DIFF
--- a/EtingofRepresentationTheory/Chapter7/Problem7_7_3.lean
+++ b/EtingofRepresentationTheory/Chapter7/Problem7_7_3.lean
@@ -20,12 +20,55 @@ on the object property `fun M => Module.Finite A M`, i.e.
 `CategoryTheory.ObjectProperty.FullSubcategory (fun M : ModuleCat A => Module.Finite A M)`.
 -/
 
-open CategoryTheory
+open CategoryTheory Limits
 
 /-- The object property "`M` is a finitely generated `A`-module" on `ModuleCat A`. -/
 def Etingof.isFinitelyGenerated (A : Type*) [CommRing A] :
     ObjectProperty (ModuleCat.{0} A) :=
   fun M => Module.Finite A M
+
+namespace Etingof.Problem7_7_3
+
+variable {A : Type} [CommRing A]
+
+/-- Over a Noetherian ring, a submodule of a finitely generated module is finitely
+generated, so `isFinitelyGenerated A` is closed under subobjects in `ModuleCat A`. -/
+instance isClosedUnderSubobjects [IsNoetherianRing A] :
+    (Etingof.isFinitelyGenerated A).IsClosedUnderSubobjects where
+  prop_of_mono {X Y} f _ hY := by
+    haveI : Module.Finite A Y := hY
+    haveI : IsNoetherian A Y := isNoetherian_of_isNoetherianRing_of_finite A Y
+    exact Module.Finite.of_injective f.hom ((ModuleCat.mono_iff_injective f).mp inferInstance)
+
+/-- A quotient of a finitely generated module is finitely generated, so
+`isFinitelyGenerated A` is closed under quotients in `ModuleCat A`. -/
+instance isClosedUnderQuotients :
+    (Etingof.isFinitelyGenerated A).IsClosedUnderQuotients where
+  prop_of_epi {X Y} f _ hX := by
+    haveI : Module.Finite A X := hX
+    exact Module.Finite.of_surjective f.hom ((ModuleCat.epi_iff_surjective f).mp inferInstance)
+
+/-- The zero module is finitely generated, so `isFinitelyGenerated A` contains a zero
+object. -/
+instance containsZero : (Etingof.isFinitelyGenerated A).ContainsZero where
+  exists_zero :=
+    ⟨ModuleCat.of A PUnit, ModuleCat.isZero_of_subsingleton _,
+      Module.Finite.of_surjective (0 : A →ₗ[A] PUnit) fun _ => ⟨0, Subsingleton.elim _ _⟩⟩
+
+/-- A finite product of finitely generated modules is finitely generated, so
+`isFinitelyGenerated A` is closed under finite products in `ModuleCat A`. -/
+instance isClosedUnderFiniteProducts :
+    (Etingof.isFinitelyGenerated A).IsClosedUnderFiniteProducts := by
+  apply ObjectProperty.IsClosedUnderFiniteProducts.of_isClosedUnderLimitsOfShape.{0}
+  intro J _
+  apply ObjectProperty.IsClosedUnderLimitsOfShape.mk'
+  rintro _ ⟨F, hF⟩
+  haveI : ∀ j : J, Module.Finite A (F.obj ⟨j⟩) := fun j => hF ⟨j⟩
+  haveI : Module.Finite A (ModuleCat.of A (∀ j : J, (F.obj ⟨j⟩ : Type))) := Module.Finite.pi
+  exact (Etingof.isFinitelyGenerated A).prop_of_iso
+    (Iso.symm (HasLimit.isoOfNatIso Discrete.natIsoFunctor ≪≫ ModuleCat.piIsoPi _)) this
+
+end Etingof.Problem7_7_3
 
 /-- Problem 7.7.3: for a finitely generated commutative ring `A` (a finite-type
 `ℤ`-algebra), the full subcategory of `ModuleCat A` on the finitely generated modules
@@ -33,4 +76,5 @@ is abelian. -/
 theorem Etingof.Problem7_7_3 (A : Type) [CommRing A] [Algebra ℤ A]
     [Algebra.FiniteType ℤ A] :
     Nonempty (Abelian (Etingof.isFinitelyGenerated A).FullSubcategory) := by
-  sorry
+  haveI : IsNoetherianRing A := Algebra.FiniteType.isNoetherianRing ℤ A
+  exact ⟨inferInstance⟩

--- a/progress/2026-07-10T05-09-23Z_c38bbfea.md
+++ b/progress/2026-07-10T05-09-23Z_c38bbfea.md
@@ -1,0 +1,46 @@
+## Accomplished
+
+Feature session (`/work` → `/feature`), claimed and completed issue #6042:
+proved `Etingof.Problem7_7_3` (Chapter 7) — the category of finitely generated
+modules over a finitely generated commutative ring (a finite-type `ℤ`-algebra) is
+abelian.
+
+Proof structure in `EtingofRepresentationTheory/Chapter7/Problem7_7_3.lean`:
+- `A` is Noetherian via `Algebra.FiniteType.isNoetherianRing ℤ A`.
+- Four `ObjectProperty` closure instances for `isFinitelyGenerated A`:
+  - `IsClosedUnderSubobjects` — submodule of a f.g. module over a Noetherian ring
+    is f.g. (`Module.Finite.of_injective` + `isNoetherian_of_isNoetherianRing_of_finite`,
+    mono ⟹ injective). This also yields `IsClosedUnderKernels` and
+    `IsClosedUnderIsomorphisms` for free.
+  - `IsClosedUnderQuotients` — quotient of a f.g. module is f.g.
+    (`Module.Finite.of_surjective`, epi ⟹ surjective). Yields `IsClosedUnderCokernels`.
+  - `ContainsZero` — `ModuleCat.of A PUnit` with `isZero_of_subsingleton`.
+  - `IsClosedUnderFiniteProducts` — via `IsClosedUnderLimitsOfShape.mk'` over each
+    finite `J`, transporting `limit F ≅ ModuleCat.of A (∀ j, F.obj ⟨j⟩)`
+    (`HasLimit.isoOfNatIso Discrete.natIsoFunctor ≪≫ ModuleCat.piIsoPi`) and using
+    `Module.Finite.pi`.
+- The Mathlib instance
+  `CategoryTheory.ObjectProperty.Subcategory` then assembles
+  `Abelian (isFinitelyGenerated A).FullSubcategory` automatically.
+
+`#print axioms Etingof.Problem7_7_3` → `[propext, Classical.choice, Quot.sound]`
+(no `sorryAx`). `progress/items.json`: `Chapter7/Problem7.7.3` moved to `sorry_free`.
+
+## Current frontier
+
+Issue #6042 done; ready for PR.
+
+## Overall project progress
+
+Phase 3 formalization ongoing. This turn removed one `sorry` (the Problem 7.7.3
+main theorem) with a fully axiom-clean proof.
+
+## Next step
+
+Open the PR for #6042 and let auto-merge land it. Remaining unclaimed feature
+issues: #6032 (Ch7 reflection-functor adjunction), #6054 (Ch5 induction in stages),
+#6064 (Ch4 trace-form linear independence).
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -6481,8 +6481,8 @@
     "end_page": "191",
     "start_line": 3,
     "end_line": 6,
-    "status": "statement_formalized",
-    "coverage_note": "Statement pass: EtingofRepresentationTheory/Chapter7/Problem7_7_3.lean (Etingof.Problem7_7_3), sorry proof."
+    "status": "sorry_free",
+    "coverage_note": "Proved: EtingofRepresentationTheory/Chapter7/Problem7_7_3.lean (Etingof.Problem7_7_3). A is Noetherian via Algebra.FiniteType.isNoetherianRing; the full subcategory of f.g. modules is abelian via the ObjectProperty closure instances (subobjects/quotients/containsZero/finite products). Axioms: propext, Classical.choice, Quot.sound."
   },
   {
     "id": "Chapter7/Discussion_after_Problem7.7.3",


### PR DESCRIPTION
Closes #6042

Session: `c38bbfea-ba93-4f87-a4a7-49e095084e72`

12bdb6ce feat(Ch7 #6042): prove Problem 7.7.3 — f.g. modules over a finite-type ℤ-algebra form an abelian category

🤖 Prepared with Claude Code