### PR TITLE
feat(Ch5 #6069): Problem 5.16.2 — centrality + Schur reduction to a single coefficient identity

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Problem5_16_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_16_2.lean
@@ -120,18 +120,31 @@ lemma sumTranspositions_central (n : ℕ) (y : SymGroupAlgebra n) :
   | hadd f₁ f₂ h₁ h₂ => rw [mul_add, add_mul, h₁, h₂]
   | hsmul r f h => rw [mul_smul_comm, smul_mul_assoc, h]
 
-/-- The coefficient of the identity permutation in `C · c_λ` equals the content `c(λ)`.
+/-- The combinatorial heart of the problem: summing the coefficient of each transposition `(ij)`
+in the Young symmetrizer `c_λ = b_λ a_λ` gives the content `c(λ)`.
 
-This is the combinatorial heart of the problem. Expanding `(C · c_λ)(e) = ∑_{i<j} c_λ((ij))`, the
-coefficient of a transposition `(ab)` in the Young symmetrizer `c_λ = b_λ a_λ` is `+1` when `a, b`
-lie in the same row, `-1` when they lie in the same column, and the remaining (cross) contributions
-cancel in the signed sum. Summing gives
+By the convolution formula `c_λ((ij)) = ∑_{q ∈ Q_λ, q⁻¹(ij) ∈ P_λ} sign(q)`, the coefficient is
+`+1` when `i, j` share a row (`q = 1`, `(ij) ∈ P_λ`), `-1` when they share a column
+(`q = (ij) ∈ Q_λ`, `p = 1`), and the remaining (cross) contributions cancel in the signed sum.
+Summing over `i < j` gives
 `∑_rows C(row_len, 2) − ∑_cols C(col_height, 2) = ∑_cells (col − row) = c(λ)`.
 
 TODO: discharge this finite coefficient computation. The main theorem is otherwise complete. -/
+private lemma youngSymmetrizer_transposition_sum_eq_content (n : ℕ) (la : Nat.Partition n) :
+    ∑ p ∈ Finset.univ.filter (fun p : Fin n × Fin n => p.1 < p.2),
+      (YoungSymmetrizer n la : SymGroupAlgebra n) (Equiv.swap p.1 p.2) = (content la : ℂ) := by
+  sorry
+
+/-- The coefficient of the identity permutation in `C · c_λ` equals the content `c(λ)`.
+Expanding `C = ∑_{i<j} (ij)` and using `((ij) · c_λ)(e) = c_λ((ij))` reduces this to the
+combinatorial identity `youngSymmetrizer_transposition_sum_eq_content`. -/
 private lemma sumTranspositions_youngSymmetrizer_coeff_one (n : ℕ) (la : Nat.Partition n) :
     (sumTranspositions n * YoungSymmetrizer n la : SymGroupAlgebra n) 1 = (content la : ℂ) := by
-  sorry
+  rw [← youngSymmetrizer_transposition_sum_eq_content n la, sumTranspositions, Finset.sum_mul,
+    Finsupp.finset_sum_apply]
+  refine Finset.sum_congr rfl (fun p _ => ?_)
+  rw [MonoidAlgebra.of_apply, MonoidAlgebra.single_mul_apply]
+  simp [Equiv.swap_inv]
 
 /-- `C · c_λ = c(λ) • c_λ`: left multiplication by the central element `C` acts on the simple
 module `V_λ` as the scalar `c(λ)`. Existence of *some* scalar is Schur's lemma; its value is

--- a/EtingofRepresentationTheory/Chapter5/Problem5_16_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_16_2.lean
@@ -18,10 +18,17 @@ transpositions. Show that `C` acts on the Specht module `V_λ` by multiplication
   `i − j` with `i` = column, `j` = row).
 
 `C` is central in `ℂ[S_n]` (a sum over a full conjugacy class), so left multiplication by `C`
-preserves the left ideal `V_λ = ℂ[S_n]·c_λ` and, `V_λ` being irreducible, acts as a scalar.
-The claim is that this scalar is `c(λ)`: for every `x ∈ V_λ`, `C · x = c(λ) • x`.
+preserves the left ideal `V_λ = ℂ[S_n]·c_λ` and, `V_λ` being irreducible, acts as a scalar
+(Schur's lemma over the algebraically closed field `ℂ`). The scalar is read off by evaluating on
+the Young symmetrizer `c_λ` and taking the coefficient of the identity permutation; that scalar is
+the content `c(λ)`.
 
-Statement pass: the proof is left as `sorry`.
+## Proof structure
+
+* `sumTranspositions_central`: `C` commutes with every element of `ℂ[S_n]`.
+* `sumTranspositions_mul_youngSymmetrizer`: `C · c_λ = c(λ) • c_λ`, proved by Schur (scalar
+  existence) plus the coefficient identity `sumTranspositions_youngSymmetrizer_coeff_one`.
+* The main theorem reduces to the eigenvalue equation on `c_λ` using centrality.
 -/
 
 namespace Etingof
@@ -38,12 +45,146 @@ noncomputable def sumTranspositions (n : ℕ) : SymGroupAlgebra n :=
 noncomputable def content {n : ℕ} (la : Nat.Partition n) : ℤ :=
   ∑ c ∈ la.toYoungDiagram.cells, ((c.2 : ℤ) - (c.1 : ℤ))
 
+/-- Reindexing the transposition sum by an arbitrary permutation `h`: summing the conjugated
+transpositions `swap (h i) (h j)` over pairs `i < j` recovers `C = ∑_{i<j} (ij)`, because
+`(i, j) ↦ {h i, h j}` is a bijection of the set of unordered pairs. -/
+private lemma sumTranspositions_reindex (n : ℕ) (h : Equiv.Perm (Fin n)) :
+    ∑ p ∈ Finset.univ.filter (fun p : Fin n × Fin n => p.1 < p.2),
+      (MonoidAlgebra.of ℂ (Equiv.Perm (Fin n)) (Equiv.swap (h p.1) (h p.2)) : SymGroupAlgebra n)
+      = sumTranspositions n := by
+  rw [sumTranspositions]
+  refine Finset.sum_nbij'
+    (i := fun p => if h p.1 < h p.2 then (h p.1, h p.2) else (h p.2, h p.1))
+    (j := fun p => if h⁻¹ p.1 < h⁻¹ p.2 then (h⁻¹ p.1, h⁻¹ p.2) else (h⁻¹ p.2, h⁻¹ p.1))
+    ?_ ?_ ?_ ?_ ?_
+  · -- image lands in the filter
+    intro p hp
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hp ⊢
+    have hne : h p.1 ≠ h p.2 := fun e => (ne_of_lt hp) (h.injective e)
+    split_ifs with hc
+    · exact hc
+    · exact lt_of_le_of_ne (not_lt.mp hc) (Ne.symm hne)
+  · -- inverse image lands in the filter
+    intro p hp
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hp ⊢
+    have hne : h⁻¹ p.1 ≠ h⁻¹ p.2 := fun e => (ne_of_lt hp) (h⁻¹.injective e)
+    split_ifs with hc
+    · exact hc
+    · exact lt_of_le_of_ne (not_lt.mp hc) (Ne.symm hne)
+  · -- left inverse
+    intro p hp
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hp
+    by_cases hc : h p.1 < h p.2
+    · simp only [if_pos hc, Equiv.Perm.coe_inv, Equiv.symm_apply_apply, if_pos hp, Prod.mk.eta]
+    · simp only [if_neg hc, Equiv.Perm.coe_inv, Equiv.symm_apply_apply,
+        if_neg (not_lt.mpr hp.le), Prod.mk.eta]
+  · -- right inverse
+    intro p hp
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hp
+    by_cases hc : h⁻¹ p.1 < h⁻¹ p.2
+    · simp only [if_pos hc]
+      simp only [Equiv.Perm.coe_inv, Equiv.apply_symm_apply, if_pos hp, Prod.mk.eta]
+    · simp only [if_neg hc]
+      simp only [Equiv.Perm.coe_inv, Equiv.apply_symm_apply, if_neg (not_lt.mpr hp.le), Prod.mk.eta]
+  · -- summands match
+    intro p hp
+    by_cases hc : h p.1 < h p.2
+    · simp only [if_pos hc]
+    · simp only [if_neg hc]
+      rw [Equiv.swap_comm]
+
+/-- `C = ∑_{i<j}(ij)` commutes with every group-algebra element: it is the sum over the full
+conjugacy class of transpositions, hence central in `ℂ[S_n]`. -/
+lemma sumTranspositions_central (n : ℕ) (y : SymGroupAlgebra n) :
+    sumTranspositions n * y = y * sumTranspositions n := by
+  -- Reduce to `y = of g` by linearity.
+  induction y using MonoidAlgebra.induction_on with
+  | hM g =>
+    -- `C * (of g) = ∑_{i<j} of(g · swap(g⁻¹ i)(g⁻¹ j))`, using `swap · g = g · swap(g⁻¹·)(g⁻¹·)`.
+    have e1 : sumTranspositions n * MonoidAlgebra.of ℂ (Equiv.Perm (Fin n)) g
+        = ∑ p ∈ Finset.univ.filter (fun p : Fin n × Fin n => p.1 < p.2),
+            MonoidAlgebra.of ℂ (Equiv.Perm (Fin n)) (g * Equiv.swap (g⁻¹ p.1) (g⁻¹ p.2)) := by
+      rw [sumTranspositions, Finset.sum_mul]
+      refine Finset.sum_congr rfl (fun p _ => ?_)
+      rw [← map_mul, Equiv.swap_mul_eq_mul_swap]
+    -- Factor `of g` back out and reindex the remaining transposition sum.
+    have e2 : ∑ p ∈ Finset.univ.filter (fun p : Fin n × Fin n => p.1 < p.2),
+          MonoidAlgebra.of ℂ (Equiv.Perm (Fin n)) (g * Equiv.swap (g⁻¹ p.1) (g⁻¹ p.2))
+        = MonoidAlgebra.of ℂ (Equiv.Perm (Fin n)) g
+            * ∑ p ∈ Finset.univ.filter (fun p : Fin n × Fin n => p.1 < p.2),
+                MonoidAlgebra.of ℂ (Equiv.Perm (Fin n)) (Equiv.swap (g⁻¹ p.1) (g⁻¹ p.2)) := by
+      rw [Finset.mul_sum]
+      refine Finset.sum_congr rfl (fun p _ => ?_)
+      rw [map_mul]
+    rw [e1, e2, sumTranspositions_reindex n g⁻¹]
+  | hadd f₁ f₂ h₁ h₂ => rw [mul_add, add_mul, h₁, h₂]
+  | hsmul r f h => rw [mul_smul_comm, smul_mul_assoc, h]
+
+/-- The coefficient of the identity permutation in `C · c_λ` equals the content `c(λ)`.
+
+This is the combinatorial heart of the problem. Expanding `(C · c_λ)(e) = ∑_{i<j} c_λ((ij))`, the
+coefficient of a transposition `(ab)` in the Young symmetrizer `c_λ = b_λ a_λ` is `+1` when `a, b`
+lie in the same row, `-1` when they lie in the same column, and the remaining (cross) contributions
+cancel in the signed sum. Summing gives
+`∑_rows C(row_len, 2) − ∑_cols C(col_height, 2) = ∑_cells (col − row) = c(λ)`.
+
+TODO: discharge this finite coefficient computation. The main theorem is otherwise complete. -/
+private lemma sumTranspositions_youngSymmetrizer_coeff_one (n : ℕ) (la : Nat.Partition n) :
+    (sumTranspositions n * YoungSymmetrizer n la : SymGroupAlgebra n) 1 = (content la : ℂ) := by
+  sorry
+
+/-- `C · c_λ = c(λ) • c_λ`: left multiplication by the central element `C` acts on the simple
+module `V_λ` as the scalar `c(λ)`. Existence of *some* scalar is Schur's lemma; its value is
+pinned down by the coefficient of the identity, using `c_λ(e) = 1`. -/
+lemma sumTranspositions_mul_youngSymmetrizer (n : ℕ) (la : Nat.Partition n) :
+    sumTranspositions n * YoungSymmetrizer n la = (content la : ℂ) • YoungSymmetrizer n la := by
+  set A := SymGroupAlgebra n with hA
+  set V := SpechtModule n la with hV
+  -- Left multiplication by `C` as an `A`-linear endomorphism of `A` (centrality gives linearity).
+  let LC : A →ₗ[A] A :=
+    { toFun := fun x => sumTranspositions n * x
+      map_add' := fun x y => mul_add _ _ _
+      map_smul' := fun a x => by
+        simp only [smul_eq_mul, RingHom.id_apply]
+        rw [← mul_assoc, sumTranspositions_central n a, mul_assoc] }
+  have hmaps : ∀ x ∈ V, LC x ∈ V := by
+    intro x hx
+    show sumTranspositions n * x ∈ V
+    rw [← smul_eq_mul]
+    exact V.smul_mem _ hx
+  -- Restrict `LC` to the simple submodule `V`.
+  let L : Module.End A V := LC.restrict hmaps
+  -- Schur: any `A`-endomorphism of the simple module `V` is a scalar.
+  haveI : IsSimpleModule A V := Theorem5_12_2_irreducible n la
+  obtain ⟨μ, hμ⟩ := (IsSimpleModule.algebraMap_end_bijective_of_isAlgClosed
+    (k := ℂ) (A := A) (V := V)).surjective L
+  -- Evaluate on `c_λ ∈ V`.
+  have hcl : YoungSymmetrizer n la ∈ V := Submodule.subset_span rfl
+  have hLc : (L ⟨YoungSymmetrizer n la, hcl⟩ : A) = sumTranspositions n * YoungSymmetrizer n la :=
+    LinearMap.restrict_coe_apply LC hmaps _
+  have hscal : (L ⟨YoungSymmetrizer n la, hcl⟩ : A) = μ • (YoungSymmetrizer n la : A) := by
+    rw [← hμ]
+    simp [Module.algebraMap_end_apply]
+  have hCeq : sumTranspositions n * YoungSymmetrizer n la = μ • YoungSymmetrizer n la := by
+    rw [← hLc, hscal]
+  -- Identify `μ` by reading off the coefficient at the identity permutation.
+  have hμval : μ = (content la : ℂ) := by
+    have h1 : (sumTranspositions n * YoungSymmetrizer n la : SymGroupAlgebra n) 1
+        = (μ • YoungSymmetrizer n la : SymGroupAlgebra n) 1 := by rw [hCeq]
+    rw [sumTranspositions_youngSymmetrizer_coeff_one] at h1
+    rw [Finsupp.smul_apply, smul_eq_mul, youngSymmetrizer_identity_coeff, mul_one] at h1
+    exact h1.symm
+  rw [hCeq, hμval]
+
 /-- Problem 5.16.2. The sum of all transpositions `C = ∑_{i<j}(ij)` acts on the Specht module
 `V_λ = ℂ[S_n]·c_λ` (by left multiplication) as multiplication by the content `c(λ)`. -/
 theorem sumTranspositions_mul_eq_content_smul
     (n : ℕ) (la : Nat.Partition n)
     (x : SymGroupAlgebra n) (hx : x ∈ SpechtModule n la) :
     sumTranspositions n * x = (content la : ℂ) • x := by
-  sorry
+  -- Every `x ∈ V_λ` is `a · c_λ`; use centrality to move `C` past `a`.
+  obtain ⟨a, rfl⟩ := Submodule.mem_span_singleton.mp hx
+  rw [smul_eq_mul, ← mul_assoc, sumTranspositions_central, mul_assoc,
+    sumTranspositions_mul_youngSymmetrizer, mul_smul_comm]
 
 end Etingof

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_12_2_Irreducible.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_12_2_Irreducible.lean
@@ -129,7 +129,7 @@ private lemma columnAntisymmetrizer_apply_not_mem (n : ℕ) (la : Nat.Partition 
 /-- The coefficient of the identity permutation in the Young symmetrizer is 1.
 This uses the fact that P_λ ∩ Q_λ = {id}: only the pair (id, id) in Q × P
 maps to the identity permutation. -/
-private lemma youngSymmetrizer_identity_coeff (n : ℕ) (la : Nat.Partition n) :
+lemma youngSymmetrizer_identity_coeff (n : ℕ) (la : Nat.Partition n) :
     (YoungSymmetrizer n la : A' n) 1 = 1 := by
   -- (b * a)(1) = ∑_{g} b(g) * a(g⁻¹). Only g ∈ P ∩ Q = {1} contributes.
   change (ColumnAntisymmetrizer n la * RowSymmetrizer n la : A' n) 1 = 1

--- a/progress/2026-07-10T06-07-06Z_dc9cabab.md
+++ b/progress/2026-07-10T06-07-06Z_dc9cabab.md
@@ -1,0 +1,41 @@
+## Accomplished
+
+Formalized the bulk of **Problem 5.16.2** (issue #6069) in
+`EtingofRepresentationTheory/Chapter5/Problem5_16_2.lean`. The file compiles; the whole theorem
+`sumTranspositions_mul_eq_content_smul` is proved **modulo one combinatorial lemma**.
+
+Proved sorry-free:
+- `sumTranspositions_reindex` — conjugating the transposition sum by any `h ∈ S_n` recovers `C`
+  (bijection of unordered pairs, via `Finset.sum_nbij'`).
+- `sumTranspositions_central` — `C = ∑_{i<j}(ij)` commutes with every element of `ℂ[S_n]`
+  (reduce to generators by `MonoidAlgebra.induction_on`, use `Equiv.swap_mul_eq_mul_swap` + reindex).
+- `sumTranspositions_mul_youngSymmetrizer` — `C · c_λ = c(λ) • c_λ`. Uses Schur's lemma over ℂ
+  (`IsSimpleModule.algebraMap_end_bijective_of_isAlgClosed`) applied to the left-mult endomorphism
+  `LinearMap.restrict`-ed to the simple module `V_λ`, then reads off the scalar via the identity
+  coefficient (`youngSymmetrizer_identity_coeff`, made public in `Theorem5_12_2_Irreducible.lean`).
+- `sumTranspositions_youngSymmetrizer_coeff_one` — `(C · c_λ)(e) = ∑_{i<j} c_λ((ij))`.
+- Main theorem — reduces to the eigenvalue on `c_λ` using centrality
+  (`x = a·c_λ`, move `C` past `a`).
+
+## Current frontier
+
+One `sorry` remains: `youngSymmetrizer_transposition_sum_eq_content`:
+`∑_{i<j} c_λ((ij)) = content la`. This is a pure finite combinatorial identity (no more
+group-algebra/Schur machinery needed).
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. Problem 5.16.2 reduced from a full `sorry` to a single isolated
+combinatorial coefficient identity. Follow-up issue **#6076** created with the full proof strategy
+(convolution coefficient formula, unique `q·p` decomposition from `P∩Q={1}`, +1/−1/0 trichotomy
+for transposition coefficients, cross-term cancellation, and bridging `toYoungDiagram.cells` with
+`sortedParts`/`rowOfPos`/`colOfPos`).
+
+## Next step
+
+Claim #6076 and discharge `youngSymmetrizer_transposition_sum_eq_content`. The hardest sub-step is
+the cross case (coefficient 0 for a transposition swapping cells in different rows and columns).
+
+## Blockers
+
+None. The remaining work is self-contained (issue #6076).


### PR DESCRIPTION
This PR proves the bulk of Problem 5.16.2: the sum of all transpositions `C = ∑_{i<j}(ij)` acts on the Specht module `V_λ` as multiplication by the content `c(λ)`. It establishes that `C` is central in `ℂ[S_n]`, applies Schur's lemma over `ℂ` to show left multiplication by `C` acts on the simple module `V_λ` as a scalar, and reduces the whole statement to the single combinatorial coefficient identity `∑_{i<j} c_λ((ij)) = c(λ)`.

Partial completion: the remaining `sorry` is isolated to `youngSymmetrizer_transposition_sum_eq_content`, a self-contained finite combinatorial identity. Follow-up tracked in https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/issues/6076 (feat(Ch5 #6069): prove ∑_{i<j} c_λ((ij)) = content — coefficient sum for Problem 5.16.2), which carries the full proof strategy. Also makes `youngSymmetrizer_identity_coeff` public in `Theorem5_12_2_Irreducible.lean`.

Closes #6069.

🤖 Prepared with Claude Code