### PR TITLE
feat(Ch5 #5.8.4): prove ind_ind_iso_ind modulo abstract ind_stages_exists; prove indStages_ker_eq + relabel equivariance

### DIFF
--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -168,6 +168,13 @@ Check that the plan's assumptions still hold:
 - Quality metrics match what the issue says
 - Files mentioned in the issue still exist and haven't been restructured
 - No recently merged PR invalidates the plan
+- **For "final assembly" issues that consume prerequisites**: verify the
+  infrastructure it depends on actually exists sorry-free. `check-blocked`
+  unblocks an issue when its `depends-on` deps *close* — but a dep closed
+  as `replan` (decomposed) means its real work moved to still-open
+  sub-issues, so the assembly is not actually ready. Confirm the named
+  lemmas/defs exist in the Lean files before working; if not, re-add
+  `depends-on` on the real open sub-issues and `skip`.
 
 If stale:
 ```

--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -4343,3 +4343,30 @@ drags the `K`-module along. Instead build a genuine `M →ₗ[A] N` from scratch
 `LinearEquiv.ofBijective thatMap e.bijective`. `⇑thatMap` is defeq to `⇑e`, so `e.bijective`
 typechecks directly. `A`-linearity of the `tmul` case is `smul_comm (c : K) (a : A) v` after the
 scalar identity `a • (l ⊗ v) = l ⊗ (a • v)`.
+
+## Induced representations: the `Rep.indResAdjunction` universe trap
+
+For isomorphisms between induced representations (`Representation.ind`/`IndV`,
+Chapter 5 induction items), the slick categorical route — `Rep.indResAdjunction`
++ `Adjunction.comp` + `Adjunction.leftAdjointUniq` to get e.g. induction-in-stages
+`Ind_ψ(Ind_φ τ) ≅ Ind_{ψ∘φ} τ` — **only works when `univ(V) ≥ univ(G)`.**
+`indResAdjunction` is stated at a *single* universe `Rep.{max w v' u}` (see its
+`resFunctor.{max w v' u}` and `indResHomEquiv (A B : Rep.{max w v' u} …)`), so
+composing adjunctions and applying the functor iso at a genuine `Rep.of ρ`
+(module `V : Type u_V`) fails with `stuck at solving universe constraint` whenever
+`u_V < u_G`. A theorem with independent `V G : Type*` is not provable this way.
+
+**Fix: build the iso explicitly at the module level** (`Coinvariants.lift` /
+`TensorProduct.lift` / `Submodule.quotEquivOfEq`), which has no universe coupling.
+Useful facts: `leftRegular ℂ G g` is *left* multiplication by `single g 1`
+(`ofMulAction_single`); `ind φ τ h` acts on `⟦a⊗v⟧` by *right* mult `a * single h⁻¹ 1`;
+`ind φ τ h = Coinvariants.map ⟨(lmapDomain (·*h⁻¹)).rTensor _, _⟩`, and the `G`-action
+touches only the `ℂ[G]` factor. When two inductions share the module `ℂ[G]⊗V` and
+differ only by relabelling the coinvariance subgroup along an iso `σ` (the `f∘σ` vs
+`f` case), their `Coinvariants.ker`s are *equal* (generating set reindexed by `σ`),
+so the iso is `Submodule.quotEquivOfEq` and its equivariance is `rfl`-on-generators
+after `ind_apply`/`Coinvariants.map_mk`/`quotEquivOfEq_mk`. Keep the composite-hom
+and inner-rep in *syntactic* agreement between the kernel-equality lemma and the
+`quotEquivOfEq` call (pass the composite `fφ` and inner rep `τ'` as explicit args
+with `hfφ`/`hτ` equations and `subst` them) — else defeq-but-not-syntactic forms
+like `H.subtype.comp K.subtype` vs `K.subtype.comp σ` make `exact`/`rw` fail.

--- a/EtingofRepresentationTheory/Chapter5/Problem5_8_4.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_8_4.lean
@@ -24,6 +24,8 @@ Statement pass: the proof (assembling the coset/tensor models of the two iterate
 is left as `sorry`.
 -/
 
+open CategoryTheory
+
 namespace Etingof
 
 section Problem584
@@ -38,6 +40,50 @@ noncomputable def indStagesInnerRep
     Representation ℂ (K.subgroupOf H) V :=
   ρ.comp (Subgroup.subgroupOfEquivOfLe hKH).toMonoidHom
 
+/-- **Change of source group along an isomorphism.** For an isomorphism `σ : S ≃* K` and a
+map `f : K →* G`, inducing `ρ` along `f` and inducing the pulled-back representation `ρ ∘ σ`
+along `f ∘ σ` give the *same* underlying module `(ℂ[G] ⊗ V)` and the same `G`-action; only the
+subgroup by which one takes coinvariants is reindexed by the bijection `σ`. Hence the two
+coinvariant kernels coincide as submodules. -/
+theorem indStages_ker_eq {K S : Type*} [Group K] [Group S]
+    (fφ : S →* G) (τ' : Representation ℂ S V) (f : K →* G) (σ : S →* K)
+    (τ : Representation ℂ K V) (hfφ : fφ = f.comp σ) (hτ : τ' = τ.comp σ)
+    (hσ : Function.Bijective σ) :
+    Representation.Coinvariants.ker
+        (Representation.tprod ((Representation.leftRegular ℂ G).comp fφ) τ') =
+      Representation.Coinvariants.ker
+        (Representation.tprod ((Representation.leftRegular ℂ G).comp f) τ) := by
+  subst hfφ hτ
+  have hpt : ∀ (s : S), (Representation.tprod
+        ((Representation.leftRegular ℂ G).comp (f.comp σ)) (τ.comp σ)) s
+      = (Representation.tprod ((Representation.leftRegular ℂ G).comp f) τ) (σ s) := fun s => rfl
+  unfold Representation.Coinvariants.ker
+  congr 1
+  ext y
+  constructor
+  · rintro ⟨⟨s, m⟩, rfl⟩
+    exact ⟨(σ s, m), by simp only [hpt]⟩
+  · rintro ⟨⟨k, m⟩, rfl⟩
+    obtain ⟨s, rfl⟩ := hσ.surjective k
+    exact ⟨(s, m), by simp only [hpt]⟩
+
+/-- **Induction in stages, abstract form.** For group homomorphisms `φ : S →* H` and `ψ : H →* G`
+and a representation `τ` of `S`, the two-step induction `Ind_ψ (Ind_φ τ)` is `G`-equivariantly
+isomorphic to the direct induction `Ind_{ψ∘φ} τ`. In the tensor/coinvariants model of `ind` this is
+the associativity identity `⟦g ⊗ ⟦h ⊗ v⟧⟧ ↦ ⟦g · ψ(h) ⊗ v⟧`.
+
+Stated as an existence lemma so the two-step reindexing can be supplied later; the surrounding
+`ind_ind_iso_ind` reduces the subgroup statement to this via a change-of-source-group relabelling
+(`indStages_ker_eq`). -/
+theorem ind_stages_exists {S H : Type*} [Group S] [Group H]
+    (φ : S →* H) (ψ : H →* G) (τ : Representation ℂ S V) :
+    ∃ e : Representation.IndV ψ (Representation.ind φ τ)
+            ≃ₗ[ℂ] Representation.IndV (ψ.comp φ) τ,
+      ∀ (g : G) x,
+        e (Representation.ind ψ (Representation.ind φ τ) g x)
+          = Representation.ind (ψ.comp φ) τ g (e x) := by
+  sorry
+
 /-- Problem 5.8.4. For `K ≤ H ≤ G` and a representation `ρ` of `K`, the two-step induction
 `Ind_H^G (Ind_K^H V)` is `G`-equivariantly isomorphic to the direct induction `Ind_K^G V`. -/
 theorem ind_ind_iso_ind
@@ -49,7 +95,41 @@ theorem ind_ind_iso_ind
         e (Etingof.Definition5_8_1 H
               (Etingof.Definition5_8_1 (K.subgroupOf H) (indStagesInnerRep H K hKH ρ)) g x)
           = Etingof.Definition5_8_1 K ρ g (e x) := by
-  sorry
+  classical
+  have hσbij : Function.Bijective (Subgroup.subgroupOfEquivOfLe hKH).toMonoidHom :=
+    (Subgroup.subgroupOfEquivOfLe hKH).bijective
+  -- STAGES: `Ind_H^G (Ind_{K.subgroupOf H} ρ') ≅ Ind_{ψ∘φ} ρ'` (abstract induction in stages).
+  obtain ⟨e1, he1⟩ := ind_stages_exists (K.subgroupOf H).subtype H.subtype
+    (indStagesInnerRep H K hKH ρ)
+  -- RELABEL: `Ind_{ψ∘φ} (ρ∘σ) ≅ Ind_K^G ρ`, the two quotients share the module `ℂ[G]⊗V`, the same
+  -- `G`-action, and (by `indStages_ker_eq`) equal coinvariant kernels.
+  have hker := indStages_ker_eq (V := V)
+    (H.subtype.comp (K.subgroupOf H).subtype) (indStagesInnerRep H K hKH ρ)
+    K.subtype (Subgroup.subgroupOfEquivOfLe hKH).toMonoidHom ρ rfl rfl hσbij
+  let relabelLE : Representation.IndV (H.subtype.comp (K.subgroupOf H).subtype)
+        (indStagesInnerRep H K hKH ρ) ≃ₗ[ℂ] Representation.IndV K.subtype ρ :=
+    Submodule.quotEquivOfEq _ _ hker
+  -- the relabelling intertwines the two `ind` actions (both descend the same base map on `ℂ[G]⊗V`)
+  have stepB : ∀ (g : G) (y : Representation.IndV (H.subtype.comp (K.subgroupOf H).subtype)
+        (indStagesInnerRep H K hKH ρ)),
+      relabelLE (Representation.ind (H.subtype.comp (K.subgroupOf H).subtype)
+          (indStagesInnerRep H K hKH ρ) g y)
+        = Representation.ind K.subtype ρ g (relabelLE y) := by
+    have hrel : ∀ w : TensorProduct ℂ (G →₀ ℂ) V,
+        relabelLE (Representation.Coinvariants.mk _ w)
+          = Representation.Coinvariants.mk _ w := by
+      intro w
+      exact Submodule.quotEquivOfEq_mk _ _ hker w
+    intro g y
+    refine Representation.Coinvariants.induction_on y (fun m => ?_)
+    rw [Representation.ind_apply, Representation.ind_apply,
+      Representation.Coinvariants.map_mk, hrel, hrel,
+      Representation.Coinvariants.map_mk]
+    rfl
+  refine ⟨e1.trans relabelLE, ?_⟩
+  intro g x
+  simp only [LinearEquiv.trans_apply, Etingof.Definition5_8_1]
+  rw [he1, stepB]
 
 end Problem584
 

--- a/progress/2026-07-10T07-05-43Z_c6c1de58.md
+++ b/progress/2026-07-10T07-05-43Z_c6c1de58.md
@@ -1,0 +1,58 @@
+## Accomplished
+
+Feature session (`/work` → `/feature`).
+
+First, triaged and released **#6048** (final assembly of Exercise 4.2.3): its
+prerequisites #6046/#6047 were closed-as-`replan` (decomposed), so the count
+bridge (#6061), trace-form independence (#6064), and cocenter trace form (#6074)
+it consumes do not exist sorry-free yet. `check-blocked` had unblocked #6048
+prematurely (it keys on issue closure, not completion). Re-added the real
+`depends-on` edges and `coordination skip`ped it for planner re-triage.
+
+Then claimed and made substantial progress on **#6054** (Problem 5.8.4,
+induction in stages, `Ind_H^G Ind_K^H V ≅ Ind_K^G V`), in
+`EtingofRepresentationTheory/Chapter5/Problem5_8_4.lean`:
+
+- **Proved `Etingof.indStages_ker_eq`** (axiom-clean): for an iso `σ : S ≃* K` and
+  `f : K →* G`, inducing `τ` along `f` and inducing `τ∘σ` along `f∘σ` share the
+  same module `ℂ[G]⊗V` and the same coinvariant kernel (the generating set is
+  reindexed by the bijection `σ`). This is the change-of-source-group relabelling.
+- **Proved `Etingof.ind_ind_iso_ind`** (the subgroup statement) **modulo** one
+  abstract existence lemma. The reduction: stages iso (abstract) then relabel via
+  `Submodule.quotEquivOfEq` (kernels equal by `indStages_ker_eq`); the relabel's
+  equivariance (`stepB`) is proven directly by `Coinvariants.induction_on` +
+  `ind_apply`/`map_mk`/`quotEquivOfEq_mk`; final assembly composes the two.
+- The one remaining `sorry` is `Etingof.ind_stages_exists` — the tensor/coinvariants
+  associativity `Ind_ψ(Ind_φ τ) ≅ Ind_{ψ∘φ} τ`, stated as a Prop-level existential
+  (so no `def`/data is sorried, per project rules).
+
+Key finding: the clean categorical route (`Rep.indResAdjunction` + `Adjunction.comp`
++ `leftAdjointUniq`) is **blocked by a universe obstruction** — `indResAdjunction`
+pins the whole adjunction to `Rep.{max w v' u}` (single universe), but the
+statement's `V` and `G` universes are independent, so `.app A₀` fails to unify
+(`stuck at solving universe constraint`) unless `univ(V) ≥ univ(G)`. Hence the
+remaining lemma must be built explicitly at the module level. #6088 carries the
+full explicit construction plan (forward `⟦a_G⊗⟦a_H⊗v⟧⟧ ↦ ⟦ψ_*(a_H)·a_G ⊗ v⟧`,
+inverse via `single 1 1`, well-definedness by chaining inner/outer coinvariance
+relations, mutual-inverse and equivariance).
+
+## Current frontier
+
+Partial PR for #6054 (this branch). `ind_stages_exists` is the sole `sorry`.
+
+## Overall project progress
+
+Phase 3 formalization ongoing. This turn: proved `indStages_ker_eq` (new,
+axiom-clean) and `ind_ind_iso_ind` modulo `ind_stages_exists`. Decomposed the
+remaining tensor-associativity core into #6088 with a complete construction plan.
+
+## Next step
+
+Pick up **#6088** (prove `ind_stages_exists`) following the construction plan in
+its body. Once landed, `#print axioms Etingof.ind_ind_iso_ind` is clean and
+`Chapter5/Problem5.8.4` moves to `sorry_free`.
+
+## Blockers
+
+None. #6088 is self-contained and the file compiles with the single Prop-level
+`sorry`.


### PR DESCRIPTION
Partial progress on #6054

Session: `c6c1de58-f4ff-43b3-8448-7f29b0fd65b7`

9fa7f030 chore(Ch5 #6054): progress file; decompose ind_stages_exists into #6088
8f6085e6 feat(Ch5 #5.8.4): reduce induction in stages to abstract ind_stages_exists

🤖 Prepared with Claude Code