### PR TITLE
feat(Ch4 #6064): counting-bound packaging (card_le_conjClasses_of_traceForm_linearIndependent)

### DIFF
--- a/EtingofRepresentationTheory/Chapter4.lean
+++ b/EtingofRepresentationTheory/Chapter4.lean
@@ -46,6 +46,7 @@ import EtingofRepresentationTheory.Chapter4.Lemma4_10_3
 -- Section 4.1, 4.12: Exercises (statement pass)
 import EtingofRepresentationTheory.Chapter4.Exercise4_2_3
 import EtingofRepresentationTheory.Chapter4.Exercise4_2_3_Cocenter
+import EtingofRepresentationTheory.Chapter4.Exercise4_2_3_CountingBound
 import EtingofRepresentationTheory.Chapter4.Problem4_5_2
 import EtingofRepresentationTheory.Chapter4.Problem4_1_4
 import EtingofRepresentationTheory.Chapter4.Exercise4_3_1

--- a/EtingofRepresentationTheory/Chapter4/Exercise4_2_3_CountingBound.lean
+++ b/EtingofRepresentationTheory/Chapter4/Exercise4_2_3_CountingBound.lean
@@ -1,0 +1,85 @@
+import EtingofRepresentationTheory.Chapter4.Exercise4_2_3_Cocenter
+
+/-!
+# The counting bound from linear independence of cocenter trace forms (Exercise 4.2.3)
+
+`Exercise4_2_3_Cocenter.lean` builds the cocenter `C = k[G] / [k[G], k[G]]`, proves
+`finrank k C = Nat.card (ConjClasses G)` (deliverable 1), and constructs the cocenter trace
+functionals `traceFormQ k M : C →ₗ[k] k` of finite-dimensional `k[G]`-modules (deliverable 2).
+
+This file supplies the **packaging step** that turns linear independence of a family of such
+functionals into the cardinality bound: a linearly independent family of `n` functionals on
+`C` forces
+```
+  n ≤ finrank k (C →ₗ[k] k) = finrank k C = Nat.card (ConjClasses G).
+```
+The dual `C →ₗ[k] k` (`Module.Dual k C`) has the same finite dimension as `C`
+(`Subspace.dual_finrank_eq`), and a linearly independent family in a finite-dimensional space
+is bounded by that dimension (`LinearIndependent.fintype_card_le_finrank`).
+
+The result is purely linear-algebraic and completely field-general (only `[Field k]`); it does
+**not** itself prove that the trace forms of distinct simple modules are independent — that is
+the remaining, genuinely field-sensitive content of Exercise 4.2.3's counting half (it can
+fail over a non-splitting field and is handled via base change to a splitting field). Once such
+a linear independence result is available, it plugs directly into
+`card_le_conjClasses_of_traceForm_linearIndependent` to yield
+`#(simple k[G]-modules) ≤ Nat.card (ConjClasses G)`.
+-/
+
+open MonoidAlgebra
+
+-- `[Fintype G]`/`[DecidableEq G]` are used at proof time (to invoke
+-- `finrank_cocenter_eq_card_conjClasses`) but not in the statement types.
+set_option linter.unusedFintypeInType false
+set_option linter.unusedDecidableInType false
+
+namespace Etingof
+
+namespace CocenterMonoidAlgebra
+
+variable {k G : Type*} [Field k] [Group G] [Fintype G] [DecidableEq G]
+
+/-- **Packaging bound (Exercise 4.2.3, counting half).** A `Fintype`-indexed family of
+functionals on the cocenter `C = k[G] / [k[G], k[G]]` that is `LinearIndependent` over `k` has
+at most `Nat.card (ConjClasses G)` members. This is the linear-algebraic core that converts any
+future linear-independence statement about trace forms into the actual counting bound.
+
+Field-general: only `[Field k]`, no `IsAlgClosed`, no invertibility of `|G|`. -/
+theorem card_le_conjClasses_of_linearIndependent
+    {ι : Type*} [Fintype ι] {f : ι → (Cocenter k G →ₗ[k] k)}
+    (hf : LinearIndependent k f) :
+    Fintype.card ι ≤ Nat.card (ConjClasses G) := by
+  haveI : Module.Finite k (Cocenter k G →ₗ[k] k) := inferInstance
+  have h1 : Fintype.card ι ≤ Module.finrank k (Cocenter k G →ₗ[k] k) :=
+    hf.fintype_card_le_finrank
+  rwa [Module.finrank_linearMap_self, finrank_cocenter_eq_card_conjClasses] at h1
+
+/-- `Nat.card` form of `card_le_conjClasses_of_linearIndependent`, for indexing types that are
+only known to be `Finite`. -/
+theorem natCard_le_conjClasses_of_linearIndependent
+    {ι : Type*} [Finite ι] {f : ι → (Cocenter k G →ₗ[k] k)}
+    (hf : LinearIndependent k f) :
+    Nat.card ι ≤ Nat.card (ConjClasses G) := by
+  cases nonempty_fintype ι
+  rw [Nat.card_eq_fintype_card]
+  exact card_le_conjClasses_of_linearIndependent hf
+
+/-- **Counting bound from independent trace forms.** If the cocenter trace forms
+`τ_{S i} = traceFormQ k (S i)` of a finite family of finite-dimensional `k[G]`-modules `S i`
+are linearly independent over `k`, then the family has at most `Nat.card (ConjClasses G)`
+members. Specialising to a family of pairwise non-isomorphic simple modules (once their trace
+forms are shown independent) yields `#(simple k[G]-modules) ≤ Nat.card (ConjClasses G)`.
+
+This is the named packaging theorem the counting assembly consumes. -/
+theorem card_le_conjClasses_of_traceForm_linearIndependent
+    {ι : Type*} [Fintype ι]
+    {S : ι → Type*} [∀ i, AddCommGroup (S i)] [∀ i, Module k (S i)]
+    [∀ i, Module (MonoidAlgebra k G) (S i)] [∀ i, IsScalarTower k (MonoidAlgebra k G) (S i)]
+    [∀ i, Module.Finite k (S i)]
+    (h : LinearIndependent k (fun i => (traceFormQ k (S i) : Cocenter k G →ₗ[k] k))) :
+    Fintype.card ι ≤ Nat.card (ConjClasses G) :=
+  card_le_conjClasses_of_linearIndependent h
+
+end CocenterMonoidAlgebra
+
+end Etingof

--- a/progress/2026-07-10T07-39-33Z_502829ed.md
+++ b/progress/2026-07-10T07-39-33Z_502829ed.md
@@ -1,0 +1,55 @@
+## Accomplished
+
+Worked issue #6064 (Ch4, counting bound for Exercise 4.2.3). Landed **deliverable 2** (the
+packaging step) in a new file
+`EtingofRepresentationTheory/Chapter4/Exercise4_2_3_CountingBound.lean`, sorry-free
+(`#print axioms` reports only `propext`/`Classical.choice`/`Quot.sound`):
+
+- `card_le_conjClasses_of_linearIndependent` — the linear-algebraic core: a `Fintype`-indexed
+  family of functionals on the cocenter `C = k[G]/[k[G],k[G]]` that is `LinearIndependent k`
+  has `Fintype.card ι ≤ Nat.card (ConjClasses G)`. Proof: `LinearIndependent.fintype_card_le_finrank`
+  bounds the count by `finrank k (C →ₗ[k] k)`; `Module.finrank_linearMap_self` collapses the
+  dual dimension to `finrank k C`; `finrank_cocenter_eq_card_conjClasses` (from the Cocenter
+  file) finishes. Field-general (only `[Field k]`).
+- `natCard_le_conjClasses_of_linearIndependent` — the `Nat.card` form for `Finite ι`.
+- `card_le_conjClasses_of_traceForm_linearIndependent` — the named packaging theorem the
+  assembly consumes: given `LinearIndependent k (fun i => traceFormQ k (S i))` for a finite
+  family of finite-dimensional `k[G]`-modules `S i`, concludes `Fintype.card ι ≤
+  Nat.card (ConjClasses G)`. This is exactly the theorem the original #6064 plan assumed
+  pre-existed ("never existed and must be built here").
+
+Added the import to `EtingofRepresentationTheory/Chapter4.lean`.
+
+Key detail: pin `G` in the trace-form wrapper's hypothesis with the ascription
+`(traceFormQ k (S i) : Cocenter k G →ₗ[k] k)`, else Lean leaves `G` a metavariable when
+inferring `traceFormQ`'s implicit group. Rewrite the dual dimension with
+`Module.finrank_linearMap_self` (not `Subspace.dual_finrank_eq` behind a `show ... = Module.Dual`
+type-rewrite, which produces a "motive is not type correct" failure).
+
+## Current frontier
+
+**Deliverable 1** — the actual `LinearIndependent k (fun i => traceFormQ k (S i))` for
+pairwise non-isomorphic simple `k[G]`-modules — is NOT done. It is genuinely field-sensitive:
+over a non-splitting field an individual `τ_{S_i}` can be identically zero (the pitfall the
+issue flags), so the naive statement is false and the count bound must go through base change
+to a splitting field. Split out as a new sub-issue (see below), with the base-change route
+(#6064 route (a)) recommended.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. This turn added the reusable counting-bound packaging for
+Exercise 4.2.3: any future linear-independence result about cocenter trace forms now plugs
+directly into `card_le_conjClasses_of_traceForm_linearIndependent` to yield
+`#(simple k[G]-modules) ≤ Nat.card (ConjClasses G)`.
+
+## Next step
+
+Pick up the new deliverable-1 sub-issue: prove the field-general count bound
+`#(iso-classes of simple k[G]-modules) ≤ Nat.card (ConjClasses G)` via base change to a
+splitting field (every Wedderburn block becomes `Matrix dᵢ(K)` with ordinary trace,
+`τ(E₁₁)=1≠0`, disjoint-support independence, then `#simple_k ≤ #simple_K ≤ #ConjClasses`,
+conjugacy classes being field-independent).
+
+## Blockers
+
+None. Deliverable 1 deferred to the new sub-issue (separable, as the issue anticipated).


### PR DESCRIPTION
Partial progress on #6064

Session: `502829ed-4a78-4878-890f-ac99659879d8`

7755fe02 feat(Ch4 #6064): counting-bound packaging — LinearIndependent trace forms ⟹ #simple ≤ #ConjClasses

🤖 Prepared with Claude Code