### PR TITLE
review(Ch4): audit Exercise 4.2.3 Bridge (D1/D2) + Problem 4.12.2(c) for vacuousness and statement faithfulness

### DIFF
--- a/progress/2026-07-10T08-04-04Z_fe2f5f53.md
+++ b/progress/2026-07-10T08-04-04Z_fe2f5f53.md
@@ -1,0 +1,97 @@
+# Review #6102 — Ch4 Exercise 4.2.3 Bridge (D1/D2) + Problem 4.12.2(c) audit
+
+Session type: **review**. Audit for vacuousness, statement faithfulness, and axiom
+cleanliness of the two Chapter 4 counting/character results that landed sorry-free this
+session (`Exercise4_2_3.lean` Bridge section, #6092; `Problem4_12_2.lean` part (c), #6095).
+
+No proof/statement edits were made (review-only). One minor faithfulness gap was found and
+filed as a follow-up feature issue (#6104).
+
+## Accomplished
+
+### 1. Vacuousness / definition audit — CLEAN
+
+- Enumerated every `def`/`noncomputable def`/`instance`/`abbrev` in both files. **None has a
+  sorried body.** The only two `sorry`s in the two files are on the *out-of-scope deferred
+  theorems* `Exercise4_2_3` (line 424, tracked by #6048) and `irreducible_dim` (line 638,
+  tracked by #6094) — both are declared with faithful statements as intended in the
+  statement pass.
+- All reviewed definitions are genuine constructions:
+  - `Exercise4_2_3.lean`: `IrrepClasses`, `groupSum`, `simpleProp`,
+    `repSimpleClassesEquivModuleSimpleClasses`, `subInclusion`, `fdRepSimpleToRepSimple`
+    (abbrev), `irrepClassesEquivRepSimpleClasses`, `SimpleModuleClasses` (abbrev), plus the
+    `IsClosedUnderIsomorphisms` / `EssSurj` / `IsEquivalence` instances — all real bodies.
+  - `Problem4_12_2.lean`: the `Heisenberg` structure and its `Mul`/`One`/`Inv`/`Group`/
+    `DecidableEq`/`Fintype` instances, `xGen`, `yGen`, `equivProd`, `rhoLin`, `rhoHom`,
+    `abHom` — all real.
+- Hypotheses of the reviewed theorems are satisfiable (not vacuous): e.g. `Simple V` is
+  realized by simple `FDRep`s; the generator-action hypotheses of `irreducible_iff` /
+  `R1_decomposes` are realized by `rhoHom`; `[Fact p.Prime]` is satisfiable.
+- **Universe pin check.** `SimpleModuleClasses.{u} (MonoidAlgebra k G)` in
+  `card_irrepClasses_eq_card_simpleModuleClasses` is consistent: with `k : Type u` the
+  `FDRep k G` / `Rep k G` carriers and `ModuleCat.{u} (MonoidAlgebra k G)` are all pinned to
+  universe `u`, and the count equality is proved by an *actual* `Equiv`
+  (`Nat.card_congr` of `irrepClassesEquivRepSimpleClasses` composed with
+  `isoClassesEquivOfEquivalence (Equivalence.congrFullSubcategory Rep.equivalenceModuleMonoidAlgebra.{u} …)`).
+  A universe mismatch would be a compile error, not a silent miscount; the file compiles, so
+  the RHS genuinely counts iso-classes of simple `k[G]`-modules. No "wrong set" risk.
+
+### 2. Statement-faithfulness audit — 1 minor gap (filed as #6104)
+
+- `Exercise4_2_3` main statement faithful to the book: `Nat.card (IrrepClasses k G) <
+  Nat.card (ConjClasses G)` under `(Fintype.card G : k) = 0`. (Proof deferred; out of scope.)
+- Bridge theorems (`isSimpleModule_asModule_of_simple`, `simple_rep_iff_isSimpleModule`,
+  `fdRepSimpleToRepSimple`, `irrepClassesEquivRepSimpleClasses`,
+  `card_irrepClasses_eq_card_simpleModuleClasses`) are faithful as the intended intermediate
+  count-transfer infrastructure.
+- `one_dim_reps_card`: `Nat.card (Heisenberg p →* ℂˣ) = p ^ 2` — faithful to (c)'s
+  classification count (1-dim reps ≅ characters `G → ℂˣ`; abelianization `(ZMod p)²`).
+  `abHom (a,b,c) = ofAdd (a,b)` is the genuine abelianization; kernel = center = commutator
+  is established via `central_mem_commutator` / `abHom_ker_le_ker`.
+- **Gap (filed #6104):** `R1_decomposes` faithfully captures "`R_1` decomposes into a direct
+  sum of `p` one-dimensional `G`-invariant subspaces" (`Fin p`-indexed `IsInternal`, each
+  `finrank = 1`), but **omits the book's "where each of them occurs exactly once"**
+  (multiplicity-free / pairwise-non-isomorphic constituents) clause. The existing proof
+  already builds the lines from eigenvectors with distinct eigenvalues (`hμinj`), so the
+  strengthening is true and essentially already proved — it is just not exposed in the
+  statement. Not a soundness/vacuousness bug and nothing downstream is blocked (part (d),
+  #6094, uses only the sum-of-squares count). Follow-up: **#6104**.
+
+### 3. Axiom + build check — CLEAN
+
+- `lake build EtingofRepresentationTheory.Chapter4.Exercise4_2_3
+  EtingofRepresentationTheory.Chapter4.Problem4_12_2` succeeds. Only sorry warnings are the
+  two out-of-scope deferred theorems. Remaining warnings are style-linter nits (unused simp
+  args at lines 387/466, `show`-vs-`change` at 430/554, unused binder names at 466) — cosmetic
+  only, not defects.
+- `#print axioms` on all 16 reviewed / supporting sorry-free theorems
+  (`isSimpleModule_asModule_of_simple`, `simple_rep_iff_isSimpleModule`,
+  `simple_forget₂_of_simple`, `irrepClassesEquivRepSimpleClasses`,
+  `card_irrepClasses_eq_card_simpleModuleClasses`, `not_isSemisimpleRing_of_card_eq_zero`,
+  `simple_fdRepOf_of_isSimpleModule`, `finite_k_of_isSimpleModule`,
+  `repSimpleClassesEquivModuleSimpleClasses`, `one_dim_reps_card`, `R1_decomposes`,
+  `abHom_surjective`, `abHom_ker_le_ker`, `central_mem_commutator`, `exists_unique_rep`,
+  `irreducible_iff`) reports only `[propext, Classical.choice, Quot.sound]` — **no `sorryAx`**.
+  So the reviewed theorems are honest and do not transitively depend on the two deferred
+  sorries sharing their files.
+
+## Current frontier
+
+Audit finished. No code changes to the two audited files. One follow-up feature issue
+(#6104) opened for the `R1_decomposes` multiplicity-free strengthening.
+
+## Overall project progress
+
+Phase 3 formalization ongoing. Chapter 4 counting/character results (#6092, #6095) verified
+clean and honest. Downstream assembly issues (#6048 for 4.2.3, #6094 for 4.12.2(d)) can build
+on these with confidence.
+
+## Next step
+
+- A `feature` agent picks up #6104 to strengthen `R1_decomposes`.
+- Unrelated: `#6100` (Ch9 projective dimension) and `#6101` (Ch8 enough projectives) remain
+  unclaimed for feature agents.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR records the review audit for #6102: a vacuousness, statement-faithfulness, and axiom check of the two Chapter 4 counting/character results that landed sorry-free this session (`Exercise4_2_3.lean` Bridge D1/D2, #6092; `Problem4_12_2.lean` part (c), #6095). It changes no mathematical statements or proofs; it adds only the review report as a `progress/` note.

Findings:

- **Vacuousness/definition audit — clean.** No `def`/`instance`/`abbrev` body is sorried. The only two `sorry`s in these files are the out-of-scope deferred theorems `Exercise4_2_3` (#6048) and `irreducible_dim` (#6094). The universe-pinned `SimpleModuleClasses.{u}` is consistent with the `Rep`/`FDRep` carrier universe (the count equality is proved by a genuine `Equiv`), so D2 counts the right set.
- **Statement-faithfulness — one minor gap.** `one_dim_reps_card` (= `p²`) and `abHom` (genuine abelianization) are faithful. `R1_decomposes` faithfully gives the `Fin p`-indexed internal direct sum of one-dimensional invariant lines, but omits the book's "each of them occurs exactly once" (multiplicity-free) clause. The proof already builds the lines from eigenvectors with distinct eigenvalues, so the strengthening is true but unexposed. Filed as follow-up #6104.
- **Axiom + build check — clean.** The two files build sorry-free (modulo the two deferred theorems), and `#print axioms` on all 16 reviewed/supporting sorry-free theorems reports only `propext`/`Classical.choice`/`Quot.sound` — no `sorryAx`.

🤖 Prepared with Claude Code
