### PR TITLE
feat(Ch4 #6095): strengthen R1_decomposes to encode 'each 1-dim rep occurs exactly once' (multiplicity-free)

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Problem4_12_2.lean
+++ b/EtingofRepresentationTheory/Chapter4/Problem4_12_2.lean
@@ -519,8 +519,11 @@ theorem one_dim_reps_card [Fact p.Prime] :
   ring
 
 /-- **Part (c), decomposition of `R_1`.** When `z = 1` the representation `R_1` decomposes as
-an internal direct sum of `p` one-dimensional `G`-invariant subspaces (the `p` distinct
-characters of the cyclic quotient, each occurring exactly once). -/
+an internal direct sum of `p` one-dimensional `G`-invariant subspaces, and **each occurs
+exactly once**: each line `S i` is the isotypic line of a character `χ i : G →* ℂˣ` (so `ρ g`
+acts on `S i` as the scalar `χ i g`), and the `p` characters `χ` are pairwise distinct
+(`Function.Injective χ`). Thus `R_1` is the multiplicity-free sum of the `p` distinct
+characters of the cyclic quotient. -/
 theorem R1_decomposes [Fact p.Prime]
     (ρ : Representation ℂ (Heisenberg p) (ZMod p → ℂ))
     (hx : ∀ (f : ZMod p → ℂ) (t : ZMod p), (ρ (xGen p) f) t = f (t - 1))
@@ -528,7 +531,10 @@ theorem R1_decomposes [Fact p.Prime]
     ∃ S : Fin p → Submodule ℂ (ZMod p → ℂ),
       (∀ i, ∀ (g : Heisenberg p), ∀ v ∈ S i, ρ g v ∈ S i) ∧
       (∀ i, Module.finrank ℂ (S i) = 1) ∧
-      DirectSum.IsInternal S := by
+      DirectSum.IsInternal S ∧
+      ∃ χ : Fin p → (Heisenberg p →* ℂˣ),
+        Function.Injective χ ∧
+        ∀ i, ∀ (g : Heisenberg p), ∀ w ∈ S i, ρ g w = (χ i g : ℂ) • w := by
   haveI : NeZero p := ⟨(Fact.out : p.Prime).ne_zero⟩
   -- A primitive `p`-th root of unity `ζ`.
   obtain ⟨ζ, hζ⟩ : ∃ ζ : ℂ, IsPrimitiveRoot ζ p :=
@@ -614,7 +620,59 @@ theorem R1_decomposes [Fact p.Prime]
     intro i
     rw [Module.End.hasEigenvector_iff]
     exact ⟨Module.End.mem_eigenspace_iff.mpr (hxeig _), chi_ne_zero _⟩
-  refine ⟨fun i => Submodule.span ℂ {v i}, ?_, ?_, ?_⟩
+  -- Read the scalar of the `G`-action on each line off the value at `0` (where `v i` is `1`).
+  have hv0 : ∀ i : Fin p, v i 0 = 1 := by
+    intro i
+    change ζ ^ (((i : ℕ) : ZMod p) * 0).val = 1
+    rw [mul_zero, ZMod.val_zero, pow_zero]
+  have hxeig' : ∀ i : Fin p, ρ (xGen p) (v i) = μ i • v i :=
+    fun i => hxeig ((i : ℕ) : ZMod p)
+  -- Each `ρ g` is injective (it is invertible in the group representation).
+  have hρinj : ∀ (g : Heisenberg p), Function.Injective (ρ g) := by
+    intro g
+    have hlinv : Function.LeftInverse (ρ g⁻¹) (ρ g) := by
+      intro w
+      rw [← Module.End.mul_apply, ← map_mul, inv_mul_cancel, map_one, Module.End.one_apply]
+    exact hlinv.injective
+  -- Each line is `ρ g`-stable, so `ρ g (v i) = (ρ g (v i) 0) • v i`.
+  have hscale : ∀ (i : Fin p) (g : Heisenberg p), ρ g (v i) = (ρ g (v i) 0) • v i := by
+    intro i g
+    have hmem : ρ g (v i) ∈ Submodule.span ℂ {v i} :=
+      hinv ((i : ℕ) : ZMod p) g (v i) (Submodule.mem_span_singleton_self _)
+    rw [Submodule.mem_span_singleton] at hmem
+    obtain ⟨a, ha⟩ := hmem
+    have hval : ρ g (v i) 0 = a := by rw [← ha, Pi.smul_apply, smul_eq_mul, hv0 i, mul_one]
+    rw [hval]; exact ha.symm
+  have hc_ne : ∀ (i : Fin p) (g : Heisenberg p), ρ g (v i) 0 ≠ 0 := by
+    intro i g h0
+    have hz : ρ g (v i) = 0 := by rw [hscale i g, h0, zero_smul]
+    exact chi_ne_zero ((i : ℕ) : ZMod p) (hρinj g (hz.trans (map_zero (ρ g)).symm))
+  -- The scalar is multiplicative in `g`: `g ↦ ρ g (v i) 0` is a character.
+  have hmul : ∀ (i : Fin p) (g h : Heisenberg p),
+      ρ (g * h) (v i) 0 = ρ g (v i) 0 * ρ h (v i) 0 := by
+    intro i g h
+    have hgh : ρ (g * h) (v i) = ρ h (v i) 0 • ρ g (v i) := by
+      rw [map_mul, Module.End.mul_apply]
+      nth_rewrite 1 [hscale i h]
+      rw [map_smul]
+    rw [hgh, Pi.smul_apply, smul_eq_mul]; ring
+  -- The `p` characters carried by the lines.
+  let χ : Fin p → (Heisenberg p →* ℂˣ) := fun i =>
+    { toFun := fun g => Units.mk0 (ρ g (v i) 0) (hc_ne i g)
+      map_one' := by
+        apply Units.ext
+        change ρ (1 : Heisenberg p) (v i) 0 = 1
+        rw [map_one, Module.End.one_apply]; exact hv0 i
+      map_mul' := fun g h => by
+        apply Units.ext
+        change ρ (g * h) (v i) 0 = ρ g (v i) 0 * ρ h (v i) 0
+        exact hmul i g h }
+  -- On the `xGen` generator the character equals the (pairwise distinct) eigenvalue `μ i`.
+  have hχx : ∀ i : Fin p, (χ i (xGen p) : ℂ) = μ i := by
+    intro i
+    change ρ (xGen p) (v i) 0 = μ i
+    rw [hxeig' i, Pi.smul_apply, smul_eq_mul, hv0 i, mul_one]
+  refine ⟨fun i => Submodule.span ℂ {v i}, ?_, ?_, ?_, χ, ?_, ?_⟩
   · intro i g w hw
     exact hinv ((i : ℕ) : ZMod p) g w hw
   · intro i
@@ -625,6 +683,17 @@ theorem R1_decomposes [Fact p.Prime]
         rw [Fintype.card_fin, Module.finrank_fintype_fun_eq_card, ZMod.card]
       have hspan_top := hli.span_eq_top_of_card_eq_finrank hcard
       rw [← hspan_top, ← Set.iUnion_singleton_eq_range, Submodule.span_iUnion]
+  · -- `χ` is injective: its value at `xGen` is the distinct eigenvalue `μ`.
+    intro i i' hii
+    apply hμinj
+    have key : (χ i (xGen p) : ℂ) = (χ i' (xGen p) : ℂ) := by rw [hii]
+    rwa [hχx i, hχx i'] at key
+  · -- Each `S i` is the `χ i`-isotypic line: `ρ g` acts on it by the scalar `χ i g`.
+    intro i g w hw
+    rw [Submodule.mem_span_singleton] at hw
+    obtain ⟨a, rfl⟩ := hw
+    have hg : ρ g (v i) = (χ i g : ℂ) • v i := hscale i g
+    rw [map_smul, hg, smul_comm]
 
 /-- **Part (d).** Every irreducible complex representation of the Heisenberg group has
 dimension `1` or `p`. (Combined with (c) and the sum-of-squares formula

--- a/progress/2026-07-10T08-16-32Z_986ce9d1.md
+++ b/progress/2026-07-10T08-16-32Z_986ce9d1.md
@@ -1,0 +1,53 @@
+# Feature #6104 — strengthen `R1_decomposes` to encode "each 1-dim rep occurs exactly once"
+
+Session type: **feature**. Closes the statement-faithfulness gap found in the #6102 review:
+`R1_decomposes` (Problem 4.12.2(c)) formalized the direct-sum decomposition but silently
+dropped the book's "where each of them occurs exactly once" (multiplicity-free) clause.
+
+## Accomplished
+
+- Strengthened `R1_decomposes` in
+  `EtingofRepresentationTheory/Chapter4/Problem4_12_2.lean` with a fourth existential
+  conjunct exposing the multiplicity-free content:
+  ```
+  ∃ χ : Fin p → (Heisenberg p →* ℂˣ),
+    Function.Injective χ ∧
+    ∀ i, ∀ (g : Heisenberg p), ∀ w ∈ S i, ρ g w = (χ i g : ℂ) • w
+  ```
+  So each line `S i` is the isotypic line of a character `χ i : G →* ℂˣ` (`ρ g` acts on it
+  by the scalar `χ i g`), and the `p` characters are pairwise distinct — i.e. the `p` distinct
+  characters of the cyclic quotient, each occurring exactly once. The original three conjuncts
+  (invariance, `finrank = 1`, `DirectSum.IsInternal`) are unchanged.
+- Proof reuses the existing eigenvector machinery. The scalar of the `G`-action on line
+  `S i = span {v i}` is read off at coordinate `0` (where `v i 0 = 1`), giving
+  `χ i g := Units.mk0 (ρ g (v i) 0) …`. Injectivity of `χ` follows from
+  `χ i (xGen p) = μ i` composed with the pre-existing `hμinj` (distinct eigenvalues of the
+  shift operator). Helper facts added: `hv0`, `hxeig'`, `hρinj` (each `ρ g` injective),
+  `hscale` (`ρ g (v i) = (ρ g (v i) 0) • v i`), `hc_ne` (scalar nonzero), `hmul`
+  (multiplicativity → the character is a `MonoidHom`).
+- `lake build EtingofRepresentationTheory.Chapter4.Problem4_12_2` succeeds. Only remaining
+  `sorry` in the file is the out-of-scope deferred `irreducible_dim` (part (d), tracked by
+  #6094) — untouched.
+- `#print axioms R1_decomposes` reports `[propext, Classical.choice, Quot.sound]` — no
+  `sorryAx`. The strengthened theorem is honest.
+- Diff: +73/-4, one file. No other statement weakened; the module docstring already described
+  the multiplicity-free content, so only the theorem docstring was updated.
+
+## Current frontier
+
+Deliverable complete. PR to be opened closing #6104.
+
+## Overall project progress
+
+Phase 3 formalization ongoing. Chapter 4 counting/character results are now faithful to the
+book text through part (c). Part (d) (`irreducible_dim`, #6094) still `sorry` and unclaimed.
+
+## Next step
+
+- A feature agent picks up #6094 (Problem 4.12.2(d), `irreducible_dim`) — it can now cite the
+  fully-faithful part (c) if useful, though it only needs the sum-of-squares count.
+- Ch9 #6100 (projective dimension) and Ch8 #6103 (Tor₀/Ext⁰ base cases) remain unclaimed.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6104

Session: `986ce9d1-5da8-4f96-a5c4-c41f022b5dc9`

311fa9c8 feat(Ch4 #6104): strengthen R1_decomposes to encode multiplicity-freeness

🤖 Prepared with Claude Code