### PR TITLE
feat(Ch5 #6054): prove ind_stages_exists — Ind_ψ(Ind_φ τ) ≅ Ind_{ψ∘φ} τ (tensor/coinvariants associativity, the core of induction in stages)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Problem5_8_4.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_8_4.lean
@@ -20,8 +20,10 @@ canonical isomorphism `K.subgroupOf H ≃* K` (`Subgroup.subgroupOfEquivOfLe`). 
 The claim is a `G`-equivariant linear isomorphism between the carrier of
 `Ind_H^G (Ind_K^H V)` and the carrier of `Ind_K^G V`.
 
-Statement pass: the proof (assembling the coset/tensor models of the two iterated inductions)
-is left as `sorry`.
+The mathematical core is the abstract associativity `Ind_ψ (Ind_φ τ) ≅ Ind_{ψ∘φ} τ`
+(`ind_stages_exists`): in Mathlib's tensor/coinvariants model of `Representation.ind` the forward
+map sends `⟦a_G ⊗ ⟦a_H ⊗ v⟧⟧ ↦ ⟦ψ_*(a_H)·a_G ⊗ v⟧`. The subgroup statement `ind_ind_iso_ind`
+reduces to this via the change-of-source-group relabelling `indStages_ker_eq`.
 -/
 
 open CategoryTheory
@@ -67,14 +69,300 @@ theorem indStages_ker_eq {K S : Type*} [Group K] [Group S]
     obtain ⟨s, rfl⟩ := hσ.surjective k
     exact ⟨(s, m), by simp only [hpt]⟩
 
+namespace IndStages
+
+open Representation TensorProduct
+
+variable {S H : Type*} [Group S] [Group H]
+  (φ : S →* H) (ψ : H →* G) (τ : Representation ℂ S V)
+
+/-- The target representation of the direct induction `Ind_{ψ∘φ} τ`. -/
+private noncomputable abbrev ρT : Representation ℂ S (TensorProduct ℂ (G →₀ ℂ) V) :=
+  Representation.tprod ((Representation.leftRegular ℂ G).comp (ψ.comp φ)) τ
+
+/-- Group-algebra multiplication, kept `Finsupp`-typed so it can sit in tensor factors.
+Defined through `LinearMap.mul` to force the `MonoidAlgebra` convolution product (not the
+pointwise `Finsupp` product available under `import Mathlib`). -/
+private noncomputable def gmul {K : Type*} [Group K] (x y : K →₀ ℂ) : K →₀ ℂ :=
+  LinearMap.mul ℂ (MonoidAlgebra ℂ K) x y
+
+private theorem gmul_single {K : Type*} [Group K] (a b : K) (r s : ℂ) :
+    gmul (Finsupp.single a r) (Finsupp.single b s) = Finsupp.single (a * b) (r * s) := by
+  simp only [gmul, LinearMap.mul_apply']
+  exact MonoidAlgebra.single_mul_single a b r s
+
+private theorem gmul_assoc {K : Type*} [Group K] (x y z : K →₀ ℂ) :
+    gmul (gmul x y) z = gmul x (gmul y z) := by
+  simp only [gmul, LinearMap.mul_apply']; rw [mul_assoc]
+
+private theorem gmul_one_left {K : Type*} [Group K] (x : K →₀ ℂ) :
+    gmul (Finsupp.single (1 : K) 1) x = x :=
+  @one_mul (MonoidAlgebra ℂ K) _ x
+
+private theorem gmul_add_left {K : Type*} [Group K] (x y z : K →₀ ℂ) :
+    gmul (x + y) z = gmul x z + gmul y z := by
+  simp only [gmul, LinearMap.mul_apply']; rw [add_mul]
+
+private theorem gmul_add_right {K : Type*} [Group K] (x y z : K →₀ ℂ) :
+    gmul x (y + z) = gmul x y + gmul x z := by
+  simp only [gmul, LinearMap.mul_apply']; rw [mul_add]
+
+private theorem gmul_smul_left {K : Type*} [Group K] (c : ℂ) (x y : K →₀ ℂ) :
+    gmul (c • x) y = c • gmul x y := by
+  simp only [gmul, LinearMap.mul_apply']; rw [smul_mul_assoc]
+
+/-- Left multiplication by `x`, as a linear map (`Finsupp`-typed). -/
+private noncomputable def gmulLeftMap {K : Type*} [Group K] (x : K →₀ ℂ) :
+    (K →₀ ℂ) →ₗ[ℂ] (K →₀ ℂ) :=
+  LinearMap.mul ℂ (MonoidAlgebra ℂ K) x
+
+private theorem gmulLeftMap_apply {K : Type*} [Group K] (x y : K →₀ ℂ) :
+    gmulLeftMap x y = gmul x y := rfl
+
+/-- `ψ_* : ℂ[H] →ₗ ℂ[G]`, the pushforward of coefficients along `ψ` (`Finsupp`-typed). -/
+private noncomputable def psiL : (H →₀ ℂ) →ₗ[ℂ] (G →₀ ℂ) := Finsupp.lmapDomain ℂ ℂ ψ
+
+private theorem psiL_eq_mapDomainAlgHom (a : H →₀ ℂ) :
+    psiL ψ a = MonoidAlgebra.mapDomainAlgHom ℂ ℂ ψ a := by
+  rw [psiL, Finsupp.lmapDomain_apply, MonoidAlgebra.mapDomainAlgHom_apply]
+
+/-- `ψ_*` sends `single h r` to `single (ψ h) r`. -/
+private theorem psiStar_single (h : H) (r : ℂ) :
+    psiL ψ (Finsupp.single h r) = Finsupp.single (ψ h) r := by
+  rw [psiL, Finsupp.lmapDomain_apply, Finsupp.mapDomain_single]
+
+/-- `ψ_*` is multiplicative. -/
+private theorem psiStar_gmul (x y : H →₀ ℂ) :
+    psiL ψ (gmul x y) = gmul (psiL ψ x) (psiL ψ y) := by
+  rw [psiL_eq_mapDomainAlgHom, psiL_eq_mapDomainAlgHom, psiL_eq_mapDomainAlgHom]
+  simp only [gmul, LinearMap.mul_apply']; rw [map_mul]
+
+/-- `leftRegular` acts by left multiplication in the group algebra. -/
+private theorem leftRegular_gmul {K : Type*} [Group K] (g : K) (b : K →₀ ℂ) :
+    Representation.leftRegular ℂ K g b = gmul (Finsupp.single g 1) b := by
+  induction b using MonoidAlgebra.induction_linear with
+  | zero => simp [gmul]
+  | add x y hx hy => rw [map_add, hx, hy, gmul_add_right]
+  | single x r =>
+    rw [Representation.ofMulAction_single, gmul_single, one_mul, smul_eq_mul]
+
+/-- `lmapDomain (· * g)` is right multiplication by `single g 1`. -/
+private theorem lmapDomain_gmul {K : Type*} [Group K] (g : K) (a : K →₀ ℂ) :
+    Finsupp.lmapDomain ℂ ℂ (· * g) a = gmul a (Finsupp.single g 1) := by
+  induction a using MonoidAlgebra.induction_linear with
+  | zero => simp [gmul]
+  | add x y hx hy => rw [map_add, hx, hy, gmul_add_left]
+  | single x r =>
+    rw [Finsupp.lmapDomain_apply, Finsupp.mapDomain_single, gmul_single, mul_one]
+
+/-- `ind` on a coinvariants generator: right multiply the group-algebra factor. -/
+private theorem ind_mk_tmul {K L : Type*} [Group K] [Group L] (χ : K →* L)
+    {W : Type*} [AddCommGroup W] [Module ℂ W] (υ : Representation ℂ K W)
+    (l : L) (a : L →₀ ℂ) (w : W) :
+    Representation.ind χ υ l (Coinvariants.mk _ (a ⊗ₜ[ℂ] w))
+      = Coinvariants.mk _ (gmul a (Finsupp.single l⁻¹ 1) ⊗ₜ[ℂ] w) := by
+  rw [Representation.ind_apply, Coinvariants.map_mk]
+  congr 1
+  rw [Representation.IntertwiningMap.coe_mk, LinearMap.rTensor_tmul, lmapDomain_gmul]
+
+/-- The elementary building block of the forward map: for `aH, v`, the linear map
+`aG ↦ ⟦(ψ_*(aH) * aG) ⊗ v⟧`. -/
+private noncomputable def elt (aH : H →₀ ℂ) (v : V) :
+    (G →₀ ℂ) →ₗ[ℂ] Representation.IndV (ψ.comp φ) τ :=
+  Coinvariants.mk _ ∘ₗ (TensorProduct.mk ℂ (G →₀ ℂ) V).flip v ∘ₗ
+    gmulLeftMap (psiL ψ aH)
+
+private theorem elt_apply (aH : H →₀ ℂ) (v : V) (aG : G →₀ ℂ) :
+    elt φ ψ τ aH v aG
+      = Coinvariants.mk (ρT φ ψ τ)
+          (gmul (psiL ψ aH) aG ⊗ₜ[ℂ] v) := by
+  simp only [elt, LinearMap.comp_apply, LinearMap.flip_apply, TensorProduct.mk_apply,
+    gmulLeftMap_apply]
+
+/-- The bilinear map `(aH, v) ↦ elt aH v`. -/
+private noncomputable def Cbil : (H →₀ ℂ) →ₗ[ℂ] V →ₗ[ℂ] ((G →₀ ℂ) →ₗ[ℂ]
+    Representation.IndV (ψ.comp φ) τ) :=
+  LinearMap.mk₂ ℂ (fun aH v => elt φ ψ τ aH v)
+    (fun aH aH' v => by
+      refine LinearMap.ext fun aG => ?_
+      simp only [elt_apply, LinearMap.add_apply, map_add, gmul_add_left,
+        TensorProduct.add_tmul, map_add])
+    (fun c aH v => by
+      refine LinearMap.ext fun aG => ?_
+      simp only [elt_apply, LinearMap.smul_apply, map_smul, gmul_smul_left]
+      rw [← TensorProduct.smul_tmul', map_smul])
+    (fun aH v v' => by
+      refine LinearMap.ext fun aG => ?_
+      simp only [elt_apply, LinearMap.add_apply, TensorProduct.tmul_add, map_add])
+    (fun c aH v => by
+      refine LinearMap.ext fun aG => ?_
+      simp only [elt_apply, LinearMap.smul_apply, TensorProduct.tmul_smul, map_smul])
+
+private theorem Cbil_apply (aH : H →₀ ℂ) (v : V) : Cbil φ ψ τ aH v = elt φ ψ τ aH v := rfl
+
+/-- The map `⟦aH ⊗ v⟧ ↦ (aG ↦ ⟦ψ_*(aH)·aG ⊗ v⟧)` before descending the outer coinvariants. -/
+private noncomputable def h0 :
+    TensorProduct ℂ (H →₀ ℂ) V →ₗ[ℂ] ((G →₀ ℂ) →ₗ[ℂ] Representation.IndV (ψ.comp φ) τ) :=
+  TensorProduct.lift (Cbil φ ψ τ)
+
+private theorem h0_tmul (aH : H →₀ ℂ) (v : V) : h0 φ ψ τ (aH ⊗ₜ[ℂ] v) = elt φ ψ τ aH v := by
+  rw [h0, TensorProduct.lift.tmul, Cbil_apply]
+
+/-- `S`-invariance of `h0` (descends the inner induction's coinvariants). -/
+private theorem h0_invariant (s : S) :
+    h0 φ ψ τ ∘ₗ (Representation.tprod ((Representation.leftRegular ℂ H).comp φ) τ) s
+      = h0 φ ψ τ := by
+  refine TensorProduct.ext' fun aH v => ?_
+  refine LinearMap.ext fun aG => ?_
+  simp only [LinearMap.comp_apply, Representation.tprod_apply, TensorProduct.map_tmul,
+    MonoidHom.coe_comp, Function.comp_apply, h0_tmul, elt_apply]
+  rw [leftRegular_gmul, psiStar_gmul, psiStar_single, gmul_assoc]
+  have hkey := Coinvariants.mk_self_apply (ρT φ ψ τ) s
+    (gmul (psiL ψ aH) aG ⊗ₜ[ℂ] v)
+  rw [ρT, Representation.tprod_apply, TensorProduct.map_tmul, MonoidHom.coe_comp,
+    Function.comp_apply, leftRegular_gmul] at hkey
+  exact hkey
+
+/-- The forward map descended over the inner coinvariants, as a map into `Hom(G →₀ ℂ, ·)`. -/
+private noncomputable def bflip :
+    Representation.IndV φ τ →ₗ[ℂ] ((G →₀ ℂ) →ₗ[ℂ] Representation.IndV (ψ.comp φ) τ) :=
+  Coinvariants.lift _ (h0 φ ψ τ) (h0_invariant φ ψ τ)
+
+private theorem bflip_mk (aH : H →₀ ℂ) (v : V) :
+    bflip φ ψ τ (Coinvariants.mk _ (aH ⊗ₜ[ℂ] v)) = elt φ ψ τ aH v := by
+  rw [bflip, Coinvariants.lift_mk, h0_tmul]
+
+/-- The forward map before descending the outer coinvariants. -/
+private noncomputable def f0 :
+    TensorProduct ℂ (G →₀ ℂ) (Representation.IndV φ τ) →ₗ[ℂ]
+      Representation.IndV (ψ.comp φ) τ :=
+  TensorProduct.lift (bflip φ ψ τ).flip
+
+private theorem f0_tmul (aG : G →₀ ℂ) (w : Representation.IndV φ τ) :
+    f0 φ ψ τ (aG ⊗ₜ[ℂ] w) = bflip φ ψ τ w aG := by
+  rw [f0, TensorProduct.lift.tmul, LinearMap.flip_apply]
+
+/-- `H`-invariance of `f0` (descends the outer induction's coinvariants). -/
+private theorem f0_invariant (h : H) :
+    f0 φ ψ τ ∘ₗ
+        (Representation.tprod ((Representation.leftRegular ℂ G).comp ψ)
+          (Representation.ind φ τ)) h
+      = f0 φ ψ τ := by
+  refine TensorProduct.ext' fun aG w => ?_
+  refine Coinvariants.induction_on w fun t => ?_
+  refine t.induction_on ?_ (fun aH v => ?_) (fun t₁ t₂ h₁ h₂ => ?_)
+  · simp
+  · simp only [LinearMap.comp_apply, Representation.tprod_apply, TensorProduct.map_tmul,
+      MonoidHom.coe_comp, Function.comp_apply, ind_mk_tmul, f0_tmul, bflip_mk, elt_apply,
+      leftRegular_gmul, psiStar_gmul, psiStar_single]
+    rw [gmul_assoc, ← gmul_assoc (Finsupp.single (ψ h⁻¹) 1) (Finsupp.single (ψ h) 1) aG,
+      gmul_single, show ψ h⁻¹ * ψ h = (1 : G) from by rw [← map_mul, inv_mul_cancel, map_one],
+      mul_one, gmul_one_left]
+  · simp only [map_add, TensorProduct.tmul_add]; rw [h₁, h₂]
+
+/-- The forward linear map `Ind_ψ (Ind_φ τ) →ₗ Ind_{ψ∘φ} τ`. -/
+private noncomputable def fwd :
+    Representation.IndV ψ (Representation.ind φ τ) →ₗ[ℂ]
+      Representation.IndV (ψ.comp φ) τ :=
+  Coinvariants.lift _ (f0 φ ψ τ) (f0_invariant φ ψ τ)
+
+private theorem fwd_mk (aG : G →₀ ℂ) (aH : H →₀ ℂ) (v : V) :
+    fwd φ ψ τ (Coinvariants.mk _ (aG ⊗ₜ[ℂ] Coinvariants.mk _ (aH ⊗ₜ[ℂ] v)))
+      = Coinvariants.mk _ (gmul (psiL ψ aH) aG ⊗ₜ[ℂ] v) := by
+  rw [fwd, Coinvariants.lift_mk, f0_tmul, bflip_mk, elt_apply]
+
+/-- The inverse building block: `⟦aG ⊗ v⟧ ↦ ⟦aG ⊗ ⟦single 1 1 ⊗ v⟧⟧`. -/
+private noncomputable def g1 :
+    TensorProduct ℂ (G →₀ ℂ) V →ₗ[ℂ]
+      Representation.IndV ψ (Representation.ind φ τ) :=
+  Coinvariants.mk _ ∘ₗ TensorProduct.map LinearMap.id (Representation.IndV.mk φ τ 1)
+
+private theorem g1_tmul (aG : G →₀ ℂ) (v : V) :
+    g1 φ ψ τ (aG ⊗ₜ[ℂ] v)
+      = Coinvariants.mk _ (aG ⊗ₜ[ℂ]
+          Coinvariants.mk _ (Finsupp.single (1 : H) 1 ⊗ₜ[ℂ] v)) := by
+  rw [g1, LinearMap.comp_apply, TensorProduct.map_tmul, LinearMap.id_apply]
+  rfl
+
+/-- `S`-invariance of `g1` (descends the target coinvariants). -/
+private theorem g1_invariant (s : S) :
+    g1 φ ψ τ ∘ₗ (ρT φ ψ τ) s = g1 φ ψ τ := by
+  refine TensorProduct.ext' fun aG v => ?_
+  simp only [LinearMap.comp_apply, ρT, Representation.tprod_apply, TensorProduct.map_tmul,
+    MonoidHom.coe_comp, Function.comp_apply, g1_tmul, leftRegular_gmul]
+  -- inner S-relation: ⟦single 1 1 ⊗ τ s v⟧ = ⟦single (φ s)⁻¹ 1 ⊗ v⟧
+  have hinner : Coinvariants.mk (Representation.tprod ((Representation.leftRegular ℂ H).comp φ) τ)
+        (Finsupp.single (1 : H) 1 ⊗ₜ[ℂ] τ s v)
+      = Coinvariants.mk _ (Finsupp.single (φ s)⁻¹ 1 ⊗ₜ[ℂ] v) := by
+    have hh := Coinvariants.mk_self_apply
+      (Representation.tprod ((Representation.leftRegular ℂ H).comp φ) τ) s
+      (Finsupp.single (φ s)⁻¹ 1 ⊗ₜ[ℂ] v)
+    rw [Representation.tprod_apply, TensorProduct.map_tmul, MonoidHom.coe_comp,
+      Function.comp_apply, leftRegular_gmul, gmul_single, mul_inv_cancel, mul_one] at hh
+    exact hh
+  -- outer H-relation at h = φ s
+  have houter := Coinvariants.mk_self_apply
+    (Representation.tprod ((Representation.leftRegular ℂ G).comp ψ) (Representation.ind φ τ))
+    (φ s)
+    (aG ⊗ₜ[ℂ] Coinvariants.mk _ (Finsupp.single (1 : H) 1 ⊗ₜ[ℂ] v))
+  rw [Representation.tprod_apply, TensorProduct.map_tmul, MonoidHom.coe_comp,
+    Function.comp_apply, leftRegular_gmul, ind_mk_tmul, gmul_one_left] at houter
+  rw [hinner]
+  exact houter
+
+/-- The inverse linear map `Ind_{ψ∘φ} τ →ₗ Ind_ψ (Ind_φ τ)`. -/
+private noncomputable def inv :
+    Representation.IndV (ψ.comp φ) τ →ₗ[ℂ]
+      Representation.IndV ψ (Representation.ind φ τ) :=
+  Coinvariants.lift _ (g1 φ ψ τ) (g1_invariant φ ψ τ)
+
+private theorem inv_mk (aG : G →₀ ℂ) (v : V) :
+    inv φ ψ τ (Coinvariants.mk _ (aG ⊗ₜ[ℂ] v))
+      = Coinvariants.mk _ (aG ⊗ₜ[ℂ]
+          Coinvariants.mk _ (Finsupp.single (1 : H) 1 ⊗ₜ[ℂ] v)) := by
+  rw [inv, Coinvariants.lift_mk, g1_tmul]
+
+/-- `fwd ∘ inv = id`. -/
+private theorem fwd_comp_inv : (fwd φ ψ τ).comp (inv φ ψ τ) = LinearMap.id := by
+  refine Representation.IndV.hom_ext (ψ.comp φ) τ fun g => ?_
+  refine LinearMap.ext fun v => ?_
+  simp only [LinearMap.comp_apply, LinearMap.id_apply, Representation.IndV.mk,
+    TensorProduct.mk_apply]
+  rw [inv_mk, fwd_mk, psiStar_single, map_one, gmul_one_left]
+
+/-- `inv ∘ fwd = id`. -/
+private theorem inv_comp_fwd : (inv φ ψ τ).comp (fwd φ ψ τ) = LinearMap.id := by
+  refine Representation.IndV.hom_ext ψ (Representation.ind φ τ) fun g => ?_
+  refine Representation.IndV.hom_ext φ τ fun h => ?_
+  refine LinearMap.ext fun v => ?_
+  simp only [LinearMap.comp_apply, LinearMap.id_apply, Representation.IndV.mk,
+    TensorProduct.mk_apply]
+  rw [fwd_mk, inv_mk, psiStar_single, gmul_single, one_mul]
+  have hkey := Coinvariants.mk_self_apply
+    (Representation.tprod ((Representation.leftRegular ℂ G).comp ψ) (Representation.ind φ τ)) h
+    (Finsupp.single g 1 ⊗ₜ[ℂ] Coinvariants.mk _ (Finsupp.single h 1 ⊗ₜ[ℂ] v))
+  rw [Representation.tprod_apply, TensorProduct.map_tmul, MonoidHom.coe_comp,
+    Function.comp_apply, leftRegular_gmul, gmul_single, ind_mk_tmul, gmul_single,
+    mul_inv_cancel] at hkey
+  simp only [mul_one] at hkey
+  exact hkey
+
+/-- `fwd` intertwines the `G`-actions of the two inductions. -/
+private theorem fwd_equivariant (g : G) :
+    (fwd φ ψ τ).comp (Representation.ind ψ (Representation.ind φ τ) g)
+      = (Representation.ind (ψ.comp φ) τ g).comp (fwd φ ψ τ) := by
+  refine Representation.IndV.hom_ext ψ (Representation.ind φ τ) fun g' => ?_
+  refine Representation.IndV.hom_ext φ τ fun h => ?_
+  refine LinearMap.ext fun v => ?_
+  simp only [LinearMap.comp_apply, Representation.IndV.mk, TensorProduct.mk_apply]
+  rw [ind_mk_tmul, fwd_mk, fwd_mk, ind_mk_tmul, gmul_assoc]
+
+end IndStages
+
 /-- **Induction in stages, abstract form.** For group homomorphisms `φ : S →* H` and `ψ : H →* G`
 and a representation `τ` of `S`, the two-step induction `Ind_ψ (Ind_φ τ)` is `G`-equivariantly
 isomorphic to the direct induction `Ind_{ψ∘φ} τ`. In the tensor/coinvariants model of `ind` this is
-the associativity identity `⟦g ⊗ ⟦h ⊗ v⟧⟧ ↦ ⟦g · ψ(h) ⊗ v⟧`.
-
-Stated as an existence lemma so the two-step reindexing can be supplied later; the surrounding
-`ind_ind_iso_ind` reduces the subgroup statement to this via a change-of-source-group relabelling
-(`indStages_ker_eq`). -/
+the associativity identity `⟦g ⊗ ⟦h ⊗ v⟧⟧ ↦ ⟦g · ψ(h) ⊗ v⟧`. -/
 theorem ind_stages_exists {S H : Type*} [Group S] [Group H]
     (φ : S →* H) (ψ : H →* G) (τ : Representation ℂ S V) :
     ∃ e : Representation.IndV ψ (Representation.ind φ τ)
@@ -82,7 +370,11 @@ theorem ind_stages_exists {S H : Type*} [Group S] [Group H]
       ∀ (g : G) x,
         e (Representation.ind ψ (Representation.ind φ τ) g x)
           = Representation.ind (ψ.comp φ) τ g (e x) := by
-  sorry
+  refine ⟨LinearEquiv.ofLinear (IndStages.fwd φ ψ τ) (IndStages.inv φ ψ τ)
+    (IndStages.fwd_comp_inv φ ψ τ) (IndStages.inv_comp_fwd φ ψ τ), ?_⟩
+  intro g x
+  simp only [LinearEquiv.ofLinear_apply]
+  exact LinearMap.congr_fun (IndStages.fwd_equivariant φ ψ τ g) x
 
 /-- Problem 5.8.4. For `K ≤ H ≤ G` and a representation `ρ` of `K`, the two-step induction
 `Ind_H^G (Ind_K^H V)` is `G`-equivariantly isomorphic to the direct induction `Ind_K^G V`. -/

--- a/progress/2026-07-10T08-16-52Z_106a7118.md
+++ b/progress/2026-07-10T08-16-52Z_106a7118.md
@@ -1,0 +1,52 @@
+## Accomplished
+
+Worked issue #6088 (Ch5, Problem 5.8.4 — induction in stages). Proved
+`Etingof.ind_stages_exists` sorry-free, completing the last `sorry` in
+`EtingofRepresentationTheory/Chapter5/Problem5_8_4.lean`. Both `ind_stages_exists`
+and the assembled subgroup theorem `ind_ind_iso_ind` now report only
+`propext, Classical.choice, Quot.sound` (no `sorryAx`).
+
+The abstract associativity `Ind_ψ (Ind_φ τ) ≅ Ind_{ψ∘φ} τ` is built explicitly in
+Mathlib's tensor/coinvariants model (`Representation.IndV`/`Representation.ind`):
+
+- Forward map `fwd ⟦a_G ⊗ ⟦a_H ⊗ v⟧⟧ = ⟦(ψ_*(a_H)·a_G) ⊗ v⟧`, built with nested
+  `Coinvariants.lift` + `TensorProduct.lift` (via the flip trick so no manual
+  `map_add`/`map_smul` packaging is needed for the descent).
+- Inverse `inv ⟦a_G ⊗ v⟧ = ⟦a_G ⊗ ⟦1 ⊗ v⟧⟧`.
+- Both inverse identities and equivariance reduce, via `Representation.IndV.hom_ext`
+  applied twice, to coefficient-1 `single` generators, where each becomes a single
+  application of `Coinvariants.mk_self_apply` plus `single`-multiplication arithmetic
+  — no Finsupp/tensor induction in the assembly.
+
+Key technique discovered (added to lean-formalization skill): under `import Mathlib`,
+`K →₀ ℂ` carries a **pointwise** `Finsupp.instMul`, so writing `x * y` for
+group-algebra elements silently picks the wrong product (and `binop%` leaks the
+Finsupp type even with operand ascriptions). Localized all group-algebra
+multiplication into a `Finsupp`-typed helper `gmul x y := LinearMap.mul ℂ
+(MonoidAlgebra ℂ K) x y`, with lemmas proved by `simp only [gmul,
+LinearMap.mul_apply']` to expose the genuine `MonoidAlgebra` convolution. Similarly
+`ψ_*` is a `Finsupp`-typed `psiL := Finsupp.lmapDomain ℂ ℂ ψ` (so its `map_add`/
+`map_smul` stay Finsupp-typed and match the `gmul` lemmas). This keeps every tensor
+factor `Finsupp`-typed and avoids the `MonoidAlgebra`-vs-`Finsupp` head mismatch that
+otherwise breaks `⊗ₜ`, `simp`, and `rw`.
+
+## Current frontier
+
+Problem 5.8.4 is complete and sorry-free. PR #6089 (the scaffolding sibling) merged
+to main mid-session; this branch was rebased onto the post-6089 main, so the diff is
+now just the `IndStages` helper section + the `ind_stages_exists` proof filling the
+sorry that 6089 left.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. This turn closed the induction-in-stages item
+(Ch5 Problem 5.8.4), removing one sorry from the project.
+
+## Next step
+
+Pick up the next unclaimed feature issue (e.g. #6064 Ch4 counting-bound trace-form
+independence, or #6057 Ch3 descent).
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3819,8 +3819,8 @@
     "end_page": "108",
     "start_line": 27,
     "end_line": 28,
-    "status": "statement_formalized",
-    "coverage_note": "Statement pass: Chapter5/Problem5_8_4.lean states the G-equivariant iso Ind_H^G(Ind_K^H V) ≅ Ind_K^G V for K ≤ H ≤ G, sorry proof."
+    "status": "sorry_free",
+    "coverage_note": "Sorry-free: Chapter5/Problem5_8_4.lean proves the G-equivariant iso Ind_H^G(Ind_K^H V) ≅ Ind_K^G V for K ≤ H ≤ G via the abstract induction-in-stages lemma ind_stages_exists (tensor/coinvariants associativity)."
   },
   {
     "id": "Chapter5/Exercise5.8.5",


### PR DESCRIPTION
Closes #6088

Session: `106a7118-88f5-4272-9011-155d1b17abf9`

644e2744 feat(Ch5 #6088): prove ind_stages_exists — induction in stages Ind_ψ(Ind_φ τ) ≅ Ind_{ψ∘φ} τ

🤖 Prepared with Claude Code