### PR TITLE
feat(Ch2 #stmt): prove Problem 2.16.1 (Lie's theorem) — finrank_eq_one_of_isSolvable via Mathlib exists_nontrivial_weightSpace_of_isSolvable

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Problem2_16_1.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_16_1.lean
@@ -15,7 +15,11 @@ Solvability is Mathlib's `LieAlgebra.IsSolvable` (defined via the derived series
 subrepresentations are `0` and `V`") is `IsSimpleOrder (LieSubmodule ℂ 𝔤 V)`. The conclusion
 "`V` is 1-dimensional" is `Module.finrank ℂ V = 1`.
 
-This is the **statement pass**: the statement is recorded with a `sorry` proof.
+The proof wraps Mathlib's Lie's theorem
+(`LieModule.exists_nontrivial_weightSpace_of_isSolvable`), which supplies a common eigenvector
+`v` for the whole solvable Lie algebra. The line `ℂ ∙ v` is then an `L`-invariant submodule (each
+`x` sends `v` to the scalar multiple `χ x • v`), hence a nonzero `LieSubmodule`; irreducibility
+forces it to be all of `V`, so `V` is one-dimensional.
 -/
 
 namespace Etingof.Problem2_16_1
@@ -30,6 +34,26 @@ solvable complex Lie algebra `L` is one-dimensional. -/
 theorem finrank_eq_one_of_isSolvable [LieAlgebra.IsSolvable L]
     [FiniteDimensional ℂ V] [Nontrivial V] (hirr : IsSimpleOrder (LieSubmodule ℂ L V)) :
     finrank ℂ V = 1 := by
-  sorry
+  -- Lie's theorem: a common eigenvector `v` for the action of every `x ∈ L` exists.
+  obtain ⟨χ, hχ⟩ := LieModule.exists_nontrivial_weightSpace_of_isSolvable ℂ L V
+  obtain ⟨⟨v, hv⟩, hv0⟩ := exists_ne (0 : LieModule.weightSpace V χ)
+  rw [LieModule.mem_weightSpace] at hv
+  have hv0 : v ≠ 0 := fun h => hv0 (Subtype.ext h)
+  -- The line `ℂ ∙ v` is `L`-invariant, hence a `LieSubmodule`.
+  let N : LieSubmodule ℂ L V :=
+    { __ := Submodule.span ℂ {v}
+      lie_mem := fun {x m} hm => by
+        have hm' : m ∈ Submodule.span ℂ {v} := hm
+        rw [Submodule.mem_span_singleton] at hm'
+        obtain ⟨c, rfl⟩ := hm'
+        exact Submodule.mem_span_singleton.mpr ⟨c * χ x, by rw [lie_smul, hv x, smul_smul]⟩ }
+  -- It is nonzero (contains `v ≠ 0`), so by irreducibility it is all of `V`.
+  have hN : N ≠ ⊥ := fun h => hv0 (by
+    have : v ∈ N := Submodule.mem_span_singleton_self v
+    rwa [h, LieSubmodule.mem_bot] at this)
+  have hspan : Submodule.span ℂ {v} = ⊤ := by
+    have : N = ⊤ := (IsSimpleOrder.eq_bot_or_eq_top N).resolve_left hN
+    rwa [← LieSubmodule.toSubmodule_eq_top] at this
+  rw [← finrank_top ℂ V, ← hspan, finrank_span_singleton hv0]
 
 end Etingof.Problem2_16_1

--- a/progress/2026-07-10T08-48-41Z_69024991.md
+++ b/progress/2026-07-10T08-48-41Z_69024991.md
@@ -1,0 +1,35 @@
+## Accomplished
+
+Proved **Problem 2.16.1 (Lie's theorem)** — issue #6116, feature session.
+`Etingof.Problem2_16_1.finrank_eq_one_of_isSolvable` is now sorry-free:
+a finite dimensional irreducible representation `V` of a solvable complex Lie
+algebra `L` has `finrank ℂ V = 1`.
+
+- Wrapped Mathlib's `LieModule.exists_nontrivial_weightSpace_of_isSolvable`
+  (instances `IsAlgClosed ℂ → IsTriangularizable` and `CharZero ℂ` discharge its
+  hypotheses) to obtain a common eigenvector `v` with `∀ x, ⁅x, v⁆ = χ x • v`.
+- Built the `LieSubmodule ℂ L V` carried by `ℂ ∙ v` (L-invariant since each `x`
+  sends `v` to `χ x • v`), showed it is nonzero, and used
+  `IsSimpleOrder.eq_bot_or_eq_top` to force it to be `⊤`, hence `ℂ ∙ v = ⊤` and
+  `finrank_span_singleton` gives dimension 1.
+- Updated `progress/items.json`: `Chapter2/Problem2.16.1` → `sorry_free`.
+
+## Current frontier
+
+Item complete. `lake build EtingofRepresentationTheory.Chapter2.Problem2_16_1`
+passes; `grep -c sorry` = 0; `#print axioms` lists only
+`[propext, Classical.choice, Quot.sound]` (no `sorryAx`).
+
+## Overall project progress
+
+Stage 3 formalization ongoing. This turn closed one Chapter 2 statement-pass
+item. Remaining unclaimed feature issues: #6098 (Ch4 field-general count bound),
+#6057 (Ch3 finitely-generated descent).
+
+## Next step
+
+Land the PR for #6116, then pick up #6098 or #6057.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -1547,8 +1547,8 @@
     "end_page": "40",
     "start_line": 18,
     "end_line": 4,
-    "status": "statement_formalized",
-    "coverage_note": "No Lean formalization on origin/main (re-derived 2026-07-02; prior 'sorry_free' was vacuous)."
+    "status": "sorry_free",
+    "coverage_note": "Proved via Mathlib LieModule.exists_nontrivial_weightSpace_of_isSolvable (#6116, 2026-07-10). Axioms: propext, Classical.choice, Quot.sound."
   },
   {
     "id": "Chapter2/Problem2.16.2",


### PR DESCRIPTION
Closes #6116

Session: `69024991-3bcc-42be-ae7f-1de9cbccab4c`

e2724bf7 feat(Ch2 #6116): prove Problem 2.16.1 (Lie's theorem) — finrank_eq_one_of_isSolvable

🤖 Prepared with Claude Code