### PR TITLE
feat(Ch8 #Problem8.2.6): prove the two Ext long-exact-sequence parts (iii)_ext, (v)_ext via Mathlib Abelian.Ext.*Sequence_exact

### DIFF
--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_6.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_6.lean
@@ -201,8 +201,8 @@ theorem Problem_8_2_6_iii_ext
     (A : Type u) [Ring A] (M : ModuleCat.{u} A)
     {S : ShortComplex (ModuleCat.{u} A)} (hS : S.ShortExact)
     (n₀ n₁ : ℕ) (h : n₀ + 1 = n₁) :
-    (Abelian.Ext.covariantSequence (X := M) hS n₀ n₁ h).Exact := by
-  sorry
+    (Abelian.Ext.covariantSequence (X := M) hS n₀ n₁ h).Exact :=
+  Abelian.Ext.covariantSequence_exact M hS n₀ n₁ h
 
 /-- **Problem 8.2.6(iii), `Tor`.** A short exact sequence `S : 0 → N₁ → N₂ → N₃ → 0` of left
 `A`-modules induces, for each right `A`-module `M` and each `n₀ + 1 = n₁`, a connecting
@@ -248,8 +248,8 @@ theorem Problem_8_2_6_v_ext
     (A : Type u) [Ring A] (N : ModuleCat.{u} A)
     {S : ShortComplex (ModuleCat.{u} A)} (hS : S.ShortExact)
     (n₀ n₁ : ℕ) (h : 1 + n₀ = n₁) :
-    (Abelian.Ext.contravariantSequence hS N n₀ n₁ h).Exact := by
-  sorry
+    (Abelian.Ext.contravariantSequence hS N n₀ n₁ h).Exact :=
+  Abelian.Ext.contravariantSequence_exact hS N n₀ n₁ h
 
 /-- **Problem 8.2.6(v), `Tor`.** A short exact sequence `S : 0 → M₁ → M₂ → M₃ → 0` of right
 `A`-modules (objects of `ModuleCat Aᵐᵒᵖ`) induces, for each left `A`-module `N` and each

--- a/progress/2026-07-10T09-16-22Z_5b89cf10.md
+++ b/progress/2026-07-10T09-16-22Z_5b89cf10.md
@@ -1,0 +1,35 @@
+## Accomplished
+Feature #6125 (Ch8, Problem 8.2.6): discharged the two `Ext` long-exact-sequence
+`sorry`s in `EtingofRepresentationTheory/Chapter8/Problem8_2_6.lean`.
+
+- `Problem_8_2_6_iii_ext` (covariant LES in the second argument) proved by
+  `Abelian.Ext.covariantSequence_exact M hS n₀ n₁ h`.
+- `Problem_8_2_6_v_ext` (contravariant LES in the first argument) proved by
+  `Abelian.Ext.contravariantSequence_exact hS N n₀ n₁ h`.
+
+Both are thin wrappers over Mathlib's Ext exact-sequence API
+(`Mathlib/Algebra/Homology/DerivedCategory/Ext/ExactSequences.lean`), matching the
+statements exactly (no signature change). `#print axioms` on each shows only
+`[propext, Classical.choice, Quot.sound]` — sorry-free.
+
+## Key patterns / decisions
+- `Etingof.Ext` is an `abbrev` over `CategoryTheory.Abelian.Ext`, so the Mathlib
+  `*Sequence_exact` lemmas apply directly. The `HasExt` instance for `ModuleCat.{u} A`
+  is already resolved by the file's imports (part (i) compiles).
+- Argument order mirrors the def: `covariantSequence X hS n₀ n₁ h` (X explicit first)
+  and `contravariantSequence hS Y n₀ n₁ h` (hS first, then Y).
+
+## Current frontier
+Problem 8.2.6 now has parts (i) and the two Ext LES halves of (iii)/(v) sorry-free.
+Out of scope and still `sorry`: (ii), (iii)_tor, (iv) balancing, (v)_tor.
+
+## Overall project progress
+Stage 3 formalization ongoing. This closes the low-risk Ext-LES subset of Problem 8.2.6.
+
+## Next step
+The Tor long-exact-sequence parts ((iii)_tor, (v)_tor) require constructing the
+connecting map δ; part (iv) is the balancing isomorphism. These need genuine proofs,
+not wrappers.
+
+## Blockers
+None.


### PR DESCRIPTION
Closes #6125

Session: `5b89cf10-937a-430f-bccb-7bf4ed4eb7b5`

c98f4e56 feat(Ch8 #6125): prove Problem 8.2.6 (iii)_ext, (v)_ext via Mathlib Ext exact-sequence API

🤖 Prepared with Claude Code