### PR TITLE
feat(Ch5 #Exercise5.8.5): prove ind_chiRep_iso_charLeftIdeal — Ind_K^G ℂ_χ ≅ ℂ[G]·e_χ

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -4480,3 +4480,27 @@ and inner-rep in *syntactic* agreement between the kernel-equality lemma and the
 `quotEquivOfEq` call (pass the composite `fφ` and inner rep `τ'` as explicit args
 with `hfφ`/`hτ` equations and `subst` them) — else defeq-but-not-syntactic forms
 like `H.subtype.comp K.subtype` vs `K.subtype.comp σ` make `exact`/`rw` fail.
+
+### Two follow-on gotchas when proving `IndV` isomorphisms via `Coinvariants.lift`
+
+- **`Representation.IndV.mk` is a `noncomputable abbrev`, so `simp` unfolds it.**
+  `Representation.IndV.mk φ ρ h = Coinvariants.mk _ ∘ₗ TensorProduct.mk _ _ _ (single h 1)`.
+  Inside a `hom_ext` proof, `simp only [LinearMap.comp_apply]` (or any `simp` touching the
+  composition) rewrites `(f ∘ₗ IndV.mk φ ρ h) z` all the way to
+  `f (Coinvariants.mk _ (TensorProduct.mk .. (single h 1) z))`, after which `rw [fwd_mk]` /
+  `Representation.ind_mk` (stated with the folded `IndV.mk`) no longer match. Fix: prove the
+  generator identity as a standalone pointwise `have hpt : ∀ h z, f (IndV.mk φ ρ h z) = …` (these
+  `rw`s match because the argument stays `IndV.mk φ ρ h z`), then discharge the `hom_ext` +
+  `LinearMap.ext` goal with a definitional `change f (IndV.mk φ ρ h z) = … ; exact hpt h z`
+  (`LinearMap.comp_apply`/`mulLeft_apply`/`id` are all rfl, so `change` bridges it). Never `simp`
+  the composition itself.
+
+- **Unit-inverse coercions get normalised by a `norm_cast` simp lemma.**
+  `((χ g : ℂˣ)⁻¹ : ℂ)` elaborates as `↑((χ g)⁻¹)` but the `@[simp, norm_cast]` lemma
+  `Units.val_inv_eq_inv_val` rewrites it to `(↑(χ g))⁻¹` after any `simp`/`field_simp`. So
+  `Units.inv_mul`/`Units.mul_inv` (pattern `↑u⁻¹ * ↑u`) stop matching; use
+  `inv_mul_cancel₀ (Units.ne_zero _)` / `mul_inv_cancel₀ (Units.ne_zero _)` on the complex-inverse
+  form instead. To convert a bare `(↑(χ g))⁻¹` into `↑(χ g⁻¹)` (e.g. to feed a twisted
+  coinvariance lemma `IndV.mk (κ·x) (χ κ • w) = IndV.mk x w`), `rw [map_inv, Units.val_inv_eq_inv_val]`
+  in reverse via a small `have`. For character sums, reindex the defining sum of `e_χ` with
+  `Equiv.mulLeft k` and `Equiv.sum_comp` to get `of k * e_χ = χ(k) • e_χ`.

--- a/EtingofRepresentationTheory/Chapter5/Exercise5_8_5.lean
+++ b/EtingofRepresentationTheory/Chapter5/Exercise5_8_5.lean
@@ -25,12 +25,16 @@ The induced representation is `Etingof.Definition5_8_1 K (chiRep χ)`. The claim
 `G`-equivariant `ℂ`-linear isomorphism `e` between its carrier and the left ideal `ℂ[G] e_χ`,
 expressed by the intertwining identity `↑(e (ρ_ind g x)) = of(g) * ↑(e x)` in `ℂ[G]`.
 
-Statement pass: the proof is left as `sorry`.
+The isomorphism sends `⟦single h 1 ⊗ z⟧` to `z • (of h⁻¹ * e_χ)`; its inverse sends
+`single g c` to `c • ⟦single g⁻¹ 1 ⊗ 1⟧`. Well-definedness on the coinvariants uses
+`of k * e_χ = χ(k) • e_χ` for `k ∈ K`, and the two composites are the identity by the
+idempotence `e_χ * e_χ = e_χ` and the coinvariant relation.
 -/
 
 namespace Etingof
 
 open scoped Classical
+open Representation MonoidAlgebra
 
 variable {G : Type*} [Group G] [Fintype G] (K : Subgroup G)
 
@@ -53,6 +57,182 @@ noncomputable def idempotentOfChar (χ : K →* ℂˣ) : MonoidAlgebra ℂ G :=
 noncomputable def charLeftIdeal (χ : K →* ℂˣ) : Submodule (MonoidAlgebra ℂ G) (MonoidAlgebra ℂ G) :=
   Submodule.span (MonoidAlgebra ℂ G) {idempotentOfChar K χ}
 
+section Proof
+
+variable (χ : K →* ℂˣ)
+
+/-- Abbreviation for the underlying `K`-representation on `ℂ[G] ⊗ ℂ` whose coinvariants form
+`Ind_K^G ℂ_χ`. -/
+private noncomputable abbrev indRep :
+    Representation ℂ K (TensorProduct ℂ (G →₀ ℂ) ℂ) :=
+  Representation.tprod ((leftRegular ℂ G).comp K.subtype) (chiRep K χ)
+
+private lemma chiRep_apply (k : K) (z : ℂ) : chiRep K χ k z = ((χ k : ℂˣ) : ℂ) • z := rfl
+
+/-- Key relation: left multiplication of the idempotent `e_χ` by `of k` (for `k ∈ K`)
+scales it by `χ k`. -/
+private lemma of_smul_idempotentOfChar (k : K) :
+    MonoidAlgebra.of ℂ G (k : G) * idempotentOfChar K χ
+      = ((χ k : ℂˣ) : ℂ) • idempotentOfChar K χ := by
+  classical
+  have ha : ((χ k : ℂˣ) : ℂ) ≠ 0 := Units.ne_zero _
+  rw [idempotentOfChar, mul_smul_comm, smul_comm]
+  congr 1
+  rw [Finset.mul_sum, Finset.smul_sum,
+    ← Equiv.sum_comp (Equiv.mulLeft k)
+      (fun g : K => ((χ k : ℂˣ) : ℂ) • (((χ g : ℂˣ)⁻¹ : ℂ) • MonoidAlgebra.of ℂ G (g : G)))]
+  refine Finset.sum_congr rfl (fun g _ => ?_)
+  simp only [Equiv.coe_mulLeft]
+  rw [mul_smul_comm, ← map_mul, ← Subgroup.coe_mul, smul_smul]
+  congr 1
+  -- scalar identity: `↑(χ g)⁻¹ = ↑(χ k) * ↑(χ (k*g))⁻¹`
+  have hb : ((χ g : ℂˣ) : ℂ) ≠ 0 := Units.ne_zero _
+  simp only [map_mul, Units.val_mul]
+  field_simp
+
+/-- The idempotent `e_χ` is idempotent: `e_χ * e_χ = e_χ`. -/
+private lemma idempotentOfChar_mul_self :
+    idempotentOfChar K χ * idempotentOfChar K χ = idempotentOfChar K χ := by
+  classical
+  have hn : (Nat.card K : ℂ) ≠ 0 := by
+    have : 0 < Nat.card K := Nat.card_pos
+    exact_mod_cast this.ne'
+  have hdef : idempotentOfChar K χ
+      = (Nat.card K : ℂ)⁻¹ • ∑ g : K, ((χ g : ℂˣ)⁻¹ : ℂ) • MonoidAlgebra.of ℂ G (g : G) := rfl
+  nth_rewrite 1 [hdef]
+  rw [Finset.smul_sum, Finset.sum_mul]
+  have hstep : ∀ g : K, ((Nat.card K : ℂ)⁻¹ • ((χ g : ℂˣ)⁻¹ : ℂ) • MonoidAlgebra.of ℂ G (g : G))
+      * idempotentOfChar K χ
+      = (Nat.card K : ℂ)⁻¹ • idempotentOfChar K χ := by
+    intro g
+    rw [smul_mul_assoc, smul_mul_assoc, of_smul_idempotentOfChar, smul_smul, smul_smul]
+    congr 1
+    rw [mul_assoc, inv_mul_cancel₀ (Units.ne_zero (χ g)), mul_one]
+  rw [Finset.sum_congr rfl (fun g _ => hstep g), Finset.sum_const, Finset.card_univ,
+    ← Nat.cast_smul_eq_nsmul ℂ, ← Nat.card_eq_fintype_card, smul_smul,
+    mul_inv_cancel₀ hn, one_smul]
+
+/-- The linear functional `ℂ[G] → ℂ[G]`, `single g c ↦ c • (of g⁻¹ * e_χ)`, that (after tensoring
+down) underlies the forward map. -/
+private noncomputable abbrev fwdFin : (G →₀ ℂ) →ₗ[ℂ] MonoidAlgebra ℂ G :=
+  Finsupp.linearCombination ℂ (fun g : G => MonoidAlgebra.of ℂ G g⁻¹ * idempotentOfChar K χ)
+
+/-- The invariance step: pushing the `K`-action through `fwdFin` scales by `χ k` and cancels. -/
+private lemma fwdFin_leftRegular (k : K) (a : G →₀ ℂ) :
+    ((χ k : ℂˣ) : ℂ) • fwdFin K χ ((leftRegular ℂ G) (K.subtype k) a) = fwdFin K χ a := by
+  classical
+  have ha : ((χ k : ℂˣ) : ℂ) ≠ 0 := Units.ne_zero _
+  induction a using Finsupp.induction_linear with
+  | zero => simp
+  | add p q hp hq => simp only [map_add, smul_add, hp, hq]
+  | single x c =>
+    simp only [fwdFin, Subgroup.coe_subtype, ofMulAction_single, smul_eq_mul,
+      Finsupp.linearCombination_single]
+    rw [smul_smul, mul_comm ((χ k : ℂˣ) : ℂ) c, ← smul_smul]
+    congr 1
+    rw [mul_inv_rev, ← Subgroup.coe_inv, map_mul, mul_assoc, of_smul_idempotentOfChar,
+      mul_smul_comm, smul_smul, map_inv, Units.val_inv_eq_inv_val,
+      mul_inv_cancel₀ ha, one_smul]
+
+/-- The forward map `Ind_K^G ℂ_χ → ℂ[G]` underlying the isomorphism, sending
+`⟦single h 1 ⊗ z⟧` to `z • (of h⁻¹ * e_χ)`. -/
+private noncomputable def fwd :
+    Representation.IndV K.subtype (chiRep K χ) →ₗ[ℂ] MonoidAlgebra ℂ G :=
+  Coinvariants.lift (indRep K χ)
+    ((fwdFin K χ) ∘ₗ (TensorProduct.rid ℂ (G →₀ ℂ)).toLinearMap)
+    (by
+      intro k
+      refine TensorProduct.ext' (fun a z => ?_)
+      simp only [LinearMap.comp_apply, LinearEquiv.coe_coe, indRep, Representation.tprod_apply,
+        TensorProduct.map_tmul, TensorProduct.rid_tmul, chiRep_apply, MonoidHom.comp_apply,
+        smul_eq_mul, map_smul]
+      rw [mul_comm ((χ k : ℂˣ) : ℂ) z, ← smul_smul, fwdFin_leftRegular])
+
+/-- Evaluation of `fwd` on a generator `⟦single h 1 ⊗ z⟧`. -/
+private lemma fwd_mk (h : G) (z : ℂ) :
+    fwd K χ (Representation.IndV.mk K.subtype (chiRep K χ) h z)
+      = z • (MonoidAlgebra.of ℂ G h⁻¹ * idempotentOfChar K χ) := by
+  simp only [fwd, Representation.IndV.mk, LinearMap.comp_apply, LinearEquiv.coe_coe,
+    TensorProduct.mk_apply, Coinvariants.lift_mk, TensorProduct.rid_tmul, fwdFin, map_smul,
+    Finsupp.linearCombination_single, one_smul]
+
+/-- The range of `fwdFin`, and hence of `fwd`, lands in the left ideal. -/
+private lemma fwdFin_eq (y : G →₀ ℂ) :
+    fwdFin K χ y
+      = (Finsupp.linearCombination ℂ (fun g : G => MonoidAlgebra.of ℂ G g⁻¹) y)
+        * idempotentOfChar K χ := by
+  induction y using Finsupp.induction_linear with
+  | zero => simp
+  | add p q hp hq => simp only [map_add, hp, hq, add_mul]
+  | single x c =>
+    simp only [fwdFin, Finsupp.linearCombination_single, smul_mul_assoc]
+
+private lemma fwd_mem (x : Representation.IndV K.subtype (chiRep K χ)) :
+    fwd K χ x ∈ charLeftIdeal K χ := by
+  obtain ⟨v, rfl⟩ := Coinvariants.mk_surjective (indRep K χ) x
+  have hfx : fwd K χ (Coinvariants.mk (indRep K χ) v)
+      = (Finsupp.linearCombination ℂ (fun g : G => MonoidAlgebra.of ℂ G g⁻¹)
+          ((TensorProduct.rid ℂ (G →₀ ℂ)) v)) * idempotentOfChar K χ := by
+    rw [show fwd K χ (Coinvariants.mk (indRep K χ) v)
+        = fwdFin K χ ((TensorProduct.rid ℂ (G →₀ ℂ)) v) from rfl, fwdFin_eq]
+  rw [hfx, charLeftIdeal]
+  exact Submodule.mem_span_singleton.2 ⟨_, smul_eq_mul _ _⟩
+
+/-- The backward map `ℂ[G] → Ind_K^G ℂ_χ`, `single g c ↦ c • ⟦single g⁻¹ 1 ⊗ 1⟧`. -/
+private noncomputable def bwd :
+    MonoidAlgebra ℂ G →ₗ[ℂ] Representation.IndV K.subtype (chiRep K χ) :=
+  Finsupp.linearCombination ℂ (fun g : G => Representation.IndV.mk K.subtype (chiRep K χ) g⁻¹ 1)
+
+private lemma bwd_of (x : G) :
+    bwd K χ (MonoidAlgebra.of ℂ G x) = Representation.IndV.mk K.subtype (chiRep K χ) x⁻¹ 1 := by
+  change Finsupp.linearCombination ℂ
+      (fun g : G => Representation.IndV.mk K.subtype (chiRep K χ) g⁻¹ 1) (Finsupp.single x 1) = _
+  rw [Finsupp.linearCombination_single, one_smul]
+
+/-- The coinvariant relation: `⟦single (κ·x) 1 ⊗ χ(κ)·w⟧ = ⟦single x 1 ⊗ w⟧`. -/
+private lemma indV_mk_smul (κ : K) (x : G) (w : ℂ) :
+    Representation.IndV.mk K.subtype (chiRep K χ) ((κ : G) * x) (((χ κ : ℂˣ) : ℂ) • w)
+      = Representation.IndV.mk K.subtype (chiRep K χ) x w := by
+  have h := Coinvariants.mk_self_apply (indRep K χ) κ (Finsupp.single x 1 ⊗ₜ[ℂ] w)
+  simpa only [Representation.IndV.mk, LinearMap.comp_apply, TensorProduct.mk_apply, indRep,
+    Representation.tprod_apply, TensorProduct.map_tmul, MonoidHom.comp_apply,
+    Subgroup.coe_subtype, ofMulAction_single, smul_eq_mul, chiRep_apply] using h
+
+/-- Key computation for the left inverse: `bwd (of h⁻¹ · e_χ) = ⟦single h 1 ⊗ 1⟧`. -/
+private lemma bwd_of_inv_mul_idem (h : G) :
+    bwd K χ (MonoidAlgebra.of ℂ G h⁻¹ * idempotentOfChar K χ)
+      = Representation.IndV.mk K.subtype (chiRep K χ) h 1 := by
+  classical
+  have hn : (Nat.card K : ℂ) ≠ 0 := by
+    have : 0 < Nat.card K := Nat.card_pos
+    exact_mod_cast this.ne'
+  rw [idempotentOfChar, mul_smul_comm, map_smul, Finset.mul_sum, map_sum]
+  have hsummand : ∀ g : K,
+      bwd K χ (MonoidAlgebra.of ℂ G h⁻¹ *
+          (((χ g : ℂˣ)⁻¹ : ℂ) • MonoidAlgebra.of ℂ G (g : G)))
+        = Representation.IndV.mk K.subtype (chiRep K χ) h 1 := by
+    intro g
+    rw [mul_smul_comm, map_smul, ← map_mul, bwd_of, mul_inv_rev, inv_inv, ← Subgroup.coe_inv,
+      ← indV_mk_smul K χ g⁻¹ h 1, ← map_smul]
+    congr 1
+    rw [map_inv, Units.val_inv_eq_inv_val]
+  rw [Finset.sum_congr rfl (fun g _ => hsummand g), Finset.sum_const, Finset.card_univ,
+    ← Nat.cast_smul_eq_nsmul ℂ, ← Nat.card_eq_fintype_card, smul_smul,
+    inv_mul_cancel₀ hn, one_smul]
+
+/-- The composite `fwd ∘ bwd` is right multiplication by `e_χ`. -/
+private lemma fwd_bwd (x : MonoidAlgebra ℂ G) :
+    fwd K χ (bwd K χ x) = x * idempotentOfChar K χ := by
+  induction x using Finsupp.induction_linear with
+  | zero => simp
+  | add p q hp hq => simp only [map_add, hp, hq, add_mul]
+  | single g c =>
+    rw [show (Finsupp.single g c : MonoidAlgebra ℂ G) = c • MonoidAlgebra.of ℂ G g by
+          rw [MonoidAlgebra.of_apply, Finsupp.smul_single, smul_eq_mul, mul_one],
+      map_smul, map_smul, bwd_of, fwd_mk, inv_inv, one_smul, smul_mul_assoc]
+
+end Proof
+
 /-- Exercise 5.8.5. The induced representation `Ind_K^G ℂ_χ` is `G`-equivariantly isomorphic
 to the left ideal `ℂ[G] e_χ` (with `G` acting by left multiplication). The intertwining is
 recorded via the coercion to `ℂ[G]`: `↑(e (ρ_ind g x)) = of(g) * ↑(e x)`. -/
@@ -61,6 +241,60 @@ theorem ind_chiRep_iso_charLeftIdeal (χ : K →* ℂˣ) :
       ∀ (g : G) x,
         (e (Etingof.Definition5_8_1 K (chiRep K χ) g x) : MonoidAlgebra ℂ G)
           = MonoidAlgebra.of ℂ G g * (e x : MonoidAlgebra ℂ G) := by
-  sorry
+  classical
+  -- pointwise computations on generators `⟦single h 1 ⊗ z⟧`
+  have hpt_left : ∀ (h : G) (z : ℂ),
+      bwd K χ (fwd K χ (Representation.IndV.mk K.subtype (chiRep K χ) h z))
+        = Representation.IndV.mk K.subtype (chiRep K χ) h z := by
+    intro h z
+    rw [fwd_mk, map_smul, bwd_of_inv_mul_idem, ← map_smul, smul_eq_mul, mul_one]
+  have key_left : bwd K χ ∘ₗ fwd K χ = LinearMap.id := by
+    apply Representation.IndV.hom_ext
+    intro h
+    apply LinearMap.ext
+    intro z
+    change bwd K χ (fwd K χ (Representation.IndV.mk K.subtype (chiRep K χ) h z))
+        = Representation.IndV.mk K.subtype (chiRep K χ) h z
+    exact hpt_left h z
+  refine ⟨LinearEquiv.ofLinear
+      ((fwd K χ).codRestrict ((charLeftIdeal K χ).restrictScalars ℂ) (fun x => fwd_mem K χ x))
+      ((bwd K χ).comp ((charLeftIdeal K χ).subtype.restrictScalars ℂ)) ?_ ?_, ?_⟩
+  · -- `fwd ∘ bwd = id` on the left ideal (right inverse)
+    apply LinearMap.ext
+    intro x
+    apply Subtype.ext
+    change fwd K χ (bwd K χ (x : MonoidAlgebra ℂ G)) = (x : MonoidAlgebra ℂ G)
+    rw [fwd_bwd]
+    obtain ⟨r, hr⟩ := Submodule.mem_span_singleton.1
+      ((Submodule.restrictScalars_mem ℂ _ _).1 x.2)
+    rw [← hr, smul_eq_mul, mul_assoc, idempotentOfChar_mul_self]
+  · -- left inverse
+    apply LinearMap.ext
+    intro y
+    change bwd K χ (fwd K χ y) = y
+    exact LinearMap.congr_fun key_left y
+  · -- intertwining identity
+    intro g x
+    have hpt : ∀ (h : G) (z : ℂ),
+        fwd K χ (Representation.ind K.subtype (chiRep K χ) g
+            (Representation.IndV.mk K.subtype (chiRep K χ) h z))
+          = MonoidAlgebra.of ℂ G g *
+              fwd K χ (Representation.IndV.mk K.subtype (chiRep K χ) h z) := by
+      intro h z
+      rw [Representation.ind_mk, fwd_mk, fwd_mk, mul_inv_rev, inv_inv, map_mul, mul_assoc,
+        mul_smul_comm]
+    have key_intw : (fwd K χ) ∘ₗ (Representation.ind K.subtype (chiRep K χ) g)
+        = (LinearMap.mulLeft ℂ (MonoidAlgebra.of ℂ G g)) ∘ₗ (fwd K χ) := by
+      apply Representation.IndV.hom_ext
+      intro h
+      apply LinearMap.ext
+      intro z
+      change fwd K χ (Representation.ind K.subtype (chiRep K χ) g
+          (Representation.IndV.mk K.subtype (chiRep K χ) h z))
+        = MonoidAlgebra.of ℂ G g *
+            fwd K χ (Representation.IndV.mk K.subtype (chiRep K χ) h z)
+      exact hpt h z
+    simp only [LinearEquiv.ofLinear_apply]
+    exact LinearMap.congr_fun key_intw x
 
 end Etingof

--- a/progress/2026-07-10T09-33-51Z_3c97d822.md
+++ b/progress/2026-07-10T09-33-51Z_3c97d822.md
@@ -1,0 +1,51 @@
+## Accomplished
+
+Proved `ind_chiRep_iso_charLeftIdeal` (Exercise 5.8.5), the single remaining `sorry` in
+`EtingofRepresentationTheory/Chapter5/Exercise5_8_5.lean`. The file is now sorry-free and
+`Chapter5/Exercise5.8.5` is marked `sorry_free` in `progress/items.json`.
+
+The theorem builds the `G`-equivariant `ℂ`-linear isomorphism between the induced representation
+`Ind_K^G ℂ_χ` (Mathlib's `Representation.IndV K.subtype (chiRep K χ)`, coinvariants of
+`ℂ[G] ⊗ ℂ`) and the left ideal `ℂ[G] · e_χ`. Construction:
+
+- Forward map `fwd`: `⟦single h 1 ⊗ z⟧ ↦ z • (of h⁻¹ * e_χ)`, built via `Coinvariants.lift`.
+  Well-definedness on coinvariants reduces to the key algebraic lemma
+  `of_smul_idempotentOfChar`: `of k * e_χ = χ(k) • e_χ` for `k ∈ K` (proved by reindexing the
+  defining sum of `e_χ` under `Equiv.mulLeft k`).
+- Backward map `bwd`: `single g c ↦ c • ⟦single g⁻¹ 1 ⊗ 1⟧` via `Finsupp.linearCombination`.
+- Left inverse (`bwd ∘ fwd = id`) uses `bwd_of_inv_mul_idem` (`bwd (of h⁻¹ · e_χ) = ⟦single h 1 ⊗ 1⟧`),
+  itself resting on the coinvariant relation `indV_mk_smul`.
+- Right inverse (`fwd ∘ bwd = id` on the ideal) uses `fwd_bwd` (`fwd (bwd x) = x * e_χ`) plus
+  idempotence `idempotentOfChar_mul_self` (`e_χ * e_χ = e_χ`).
+- Intertwining `↑(e (ρ_ind g x)) = of(g) * ↑(e x)` from `Representation.ind_mk` + `fwd_mk`.
+
+The `↥(charLeftIdeal)` is a `ℂ[G]`-submodule, so the forward map lands in its `restrictScalars ℂ`
+and the inclusion is taken through `LinearMap.restrictScalars ℂ` to keep everything `ℂ`-linear.
+
+Key implementation notes for successors:
+- `Representation.IndV.mk` is a `noncomputable abbrev`; `simp [LinearMap.comp_apply]` unfolds it
+  into `Coinvariants.mk (TensorProduct.mk …)`, breaking `rw [fwd_mk]`/`ind_mk`. Prove the
+  generator identities as pointwise `have`s and bridge the `hom_ext` goal with a definitional
+  `change`, avoiding `simp` on the composition.
+- The unit coercion `((χ g : ℂˣ)⁻¹ : ℂ)` gets normalised by the `norm_cast` simp lemma
+  `Units.val_inv_eq_inv_val` to `(↑(χ g))⁻¹`; use `inv_mul_cancel₀ (Units.ne_zero _)` rather than
+  `Units.inv_mul` after any simp pass.
+
+## Current frontier
+
+Chapter 5 Exercise 5.8.5 complete. Verified with
+`lake build EtingofRepresentationTheory.Chapter5.Exercise5_8_5` (8581 jobs, success, no sorry).
+
+## Overall project progress
+
+Phase 3 formalization ongoing. This item moved from `statement_formalized` to `sorry_free`.
+Other open feature issues (#6057 Ch3 descent, #6098 Ch4 counting bound) remain.
+
+## Next step
+
+Pick up another unclaimed feature issue (e.g. #6098 field-general simple-module count bound, or
+#6057 the Ch3 finitely-generated-subalgebra descent).
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3830,8 +3830,8 @@
     "end_page": "108",
     "start_line": 29,
     "end_line": 33,
-    "status": "statement_formalized",
-    "coverage_note": "Statement pass: Chapter5/Exercise5_8_5.lean states Ind_K^G C_chi is G-equivariantly isomorphic to the left ideal C[G]·e_chi, sorry proof."
+    "status": "sorry_free",
+    "coverage_note": "Chapter5/Exercise5_8_5.lean proves Ind_K^G C_chi is G-equivariantly isomorphic to the left ideal C[G]·e_chi via the map [single h 1 ⊗ z] ↦ z·(of h⁻¹ · e_chi); sorry-free."
   },
   {
     "id": "Chapter5/Introduction_5.9",


### PR DESCRIPTION
Closes #6119

Session: `3c97d822-31ee-4191-8c88-22c66e44843a`

27de53ed feat(Ch5 #6119): prove ind_chiRep_iso_charLeftIdeal — Ind_K^G ℂ_χ ≅ ℂ[G]·e_χ

🤖 Prepared with Claude Code