### PR TITLE
feat(Ch4 #6143): prove Std_injective (deliverable 1); defer exhaustiveness+count to #6150

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Exercise4_2_3_SplitSimples.lean
+++ b/EtingofRepresentationTheory/Chapter4/Exercise4_2_3_SplitSimples.lean
@@ -158,10 +158,46 @@ simple `K[G]`-modules, and the resulting count `Nat.card (SimpleModuleClasses K[
 surjection `π` (only surjectivity is used in that machinery). They are stated here and proved in
 the follow-up sub-issue. -/
 
-/-- **Deliverable 3 (pairwise non-isomorphic).** Distinct standard modules are not isomorphic. -/
+/-- The `K[G]`-action on a standard module factors through `blockHom`: `x • v` is the matrix
+`blockHom i x` acting on the column vector `v`. This is definitional (`Module.compHom`), exposed
+here as a rewrite lemma. -/
+lemma smul_Std_eq (D : SplitData K G) (i : Fin D.n) (x : MonoidAlgebra K G) (v : D.Std i) :
+    x • v = D.blockHom i x • v := rfl
+
+/-- **Deliverable 3 (pairwise non-isomorphic).** Distinct standard modules are not isomorphic.
+If `i ≠ j`, pick a preimage `e ∈ K[G]` of the block idempotent `Pi.single i 1`; then `e` acts as
+the identity on `Std i` (its `i`-block is the identity matrix) and as `0` on `Std j` (its `j`-block
+is the zero matrix). Any `K[G]`-linear map `Std i → Std j` therefore vanishes, so no isomorphism
+can exist. -/
 theorem Std_injective (D : SplitData K G) (i j : Fin D.n)
     (h : Nonempty (D.Std i ≃ₗ[MonoidAlgebra K G] D.Std j)) : i = j := by
-  sorry
+  obtain ⟨φ⟩ := h
+  by_contra hij
+  -- A preimage of the `i`-th block idempotent `Pi.single i 1`.
+  obtain ⟨e, he⟩ := D.π_surj (Pi.single i 1)
+  -- `e` acts as the identity on `Std i`.
+  have hei : ∀ v : D.Std i, e • v = v := by
+    intro v
+    have hblock : D.blockHom i e = 1 := by
+      simp only [SplitData.blockHom, AlgHom.comp_apply, he, Pi.evalAlgHom_apply, Pi.single_eq_same]
+    rw [smul_Std_eq, hblock, one_smul]
+  -- `e` acts as `0` on `Std j` (since `i ≠ j`).
+  have hej : ∀ w : D.Std j, e • w = 0 := by
+    intro w
+    have hblock : D.blockHom j e = 0 := by
+      simp only [SplitData.blockHom, AlgHom.comp_apply, he, Pi.evalAlgHom_apply,
+        Pi.single_eq_of_ne (Ne.symm hij)]
+    rw [smul_Std_eq, hblock, zero_smul]
+  -- Hence `φ` kills every vector.
+  have hzero : ∀ v : D.Std i, φ v = 0 := fun v => by
+    calc φ v = φ (e • v) := by rw [hei v]
+      _ = e • φ v := map_smul φ e v
+      _ = 0 := hej (φ v)
+  -- But `Std i` is nontrivial (`d i ≠ 0`), contradicting injectivity of `φ`.
+  haveI := D.d_pos i
+  have hv : (fun _ => (1 : K)) ≠ (0 : D.Std i) := fun hcontra =>
+    one_ne_zero (congr_fun hcontra ⟨0, Nat.pos_of_ne_zero (NeZero.ne _)⟩)
+  exact hv (φ.injective ((hzero _).trans (map_zero φ).symm))
 
 /-- **Deliverable 3 (exhaustive).** Every simple `K[G]`-module is isomorphic to some standard
 module `Std i`. -/

--- a/progress/2026-07-10T10-09-24Z_967c277c.md
+++ b/progress/2026-07-10T10-09-24Z_967c277c.md
@@ -1,0 +1,51 @@
+## Accomplished
+
+Worked issue #6143 (Ch4 #6137: modular split-simples enumeration). Discharged
+**deliverable 1**, `SplitData.Std_injective`, in
+`EtingofRepresentationTheory/Chapter4/Exercise4_2_3_SplitSimples.lean`:
+
+- Added helper `SplitData.smul_Std_eq` exposing the `Module.compHom` action
+  (`x • v = blockHom i x • v`, definitional).
+- Proved `Std_injective` via the central-idempotent argument: a preimage `e` of the
+  block idempotent `Pi.single i 1` acts as the identity matrix on `Std i` and the zero
+  matrix on `Std j` (`i ≠ j`), so any `K[G]`-linear map `Std i → Std j` vanishes,
+  contradicting injectivity of an iso from the nontrivial `Std i`.
+
+File builds (`lake build ...Exercise4_2_3_SplitSimples` succeeds); the only remaining
+`sorry`s are deliverables 2 and 3.
+
+## Key finding: deliverables 2 & 3 are FALSE for a general `SplitData`
+
+`SplitData` only requires `π` **surjective**, so `ker π` can exceed `rad(K[G])`.
+Counterexample: `G = ℤ/2`, `K = ℂ`, `n = 1`, `π = proj₀ ∘ Wedderburn` — a valid
+`SplitData` whose single `Std 0` (trivial rep) does not exhaust the simples (the sign rep
+is missed), so `exists_Std_linearEquiv` fails and `card_simpleModuleClasses` claims
+`2 = 1`. The #6143 route silently assumed "radical = ker π", true only for `SplitData.of`.
+
+Rather than change the `SplitData` interface (explicitly forbidden by #6143), I filed
+**#6150** with the corrected plan: strengthen `SplitData` with a `π_ker : ker π = rad`
+field (update `SplitData.of`), then prove exhaustiveness (a simple `K[G]`-module factors
+through `π` onto a simple `Π Matrix`-module ≅ some column space) and the count (from
+deliverables 1 + 2 via `Nat.card_congr`).
+
+## Current frontier
+
+Deliverable 1 landed. Deliverables 2 & 3 blocked on the `SplitData` interface fix,
+tracked in #6150.
+
+## Overall project progress
+
+Phase 3 formalization, Chapter 4, Exercise 4.2.3 modular enumeration. Foundation
+(`SplitData`, `Std`, simplicity) from #6137 in place; `Std_injective` now proved;
+exhaustiveness + count deferred to #6150 with a corrected interface.
+
+## Next step
+
+Pick up #6150: strengthen `SplitData` (add `π_ker`), prove `exists_Std_linearEquiv`
+and `card_simpleModuleClasses`. The simple-`Π Matrix`-module classification overlaps with
+#6146 (`natCard_simpleModuleClasses_pi`) — reuse where possible.
+
+## Blockers
+
+Deliverables 2 & 3 of #6143 are unprovable as stated (false for general `SplitData`);
+corrected work tracked in #6150.


### PR DESCRIPTION
This PR proves deliverable 1 of #6143, `SplitData.Std_injective` (distinct standard modules are non-isomorphic), in `Exercise4_2_3_SplitSimples.lean`, via the central-idempotent argument: a preimage `e` of the block idempotent `Pi.single i 1` acts as the identity matrix on `Std i` and the zero matrix on `Std j` (`i ≠ j`), so any `K[G]`-linear map `Std i → Std j` vanishes. Adds the helper `SplitData.smul_Std_eq` exposing the `Module.compHom` action.

Deliverables 2 and 3 (`exists_Std_linearEquiv`, `card_simpleModuleClasses`) are deferred to #6150: as stated for a general `SplitData` they are FALSE (`π` is only required surjective, so `ker π` can exceed `rad(K[G])`; counterexample `G = ℤ/2` over `ℂ`, `n = 1`, `π = proj₀ ∘ Wedderburn` misses the sign rep). Fixing them requires strengthening the `SplitData` interface (`ker π = rad`), which #6143 forbids changing — hence the corrected plan lives in #6150. `#6143` is marked `replan`.

The file builds; the only remaining `sorry`s are the two deferred theorems.

🤖 Prepared with Claude Code