### PR TITLE
feat(Ch4 #6136): prove nonempty_baseChange_pi_matrix_algEquiv — K⊗ distributes over the Wedderburn product ∏ Matrix(D i)

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -472,6 +472,35 @@ Once `bcMod` is a (file-scoped) instance, `Module L (L⊗A)`, `Algebra L (L⊗A)
 Encode "`X` is a direct summand of `Y`" as a split injection `∃ i p, p ∘ₗ i = id` (avoids
 quantifying over a complement type/universe).
 
+### Base change distributes over a Wedderburn `∏ Matrix(D i)` — compose three `Algebra.TensorProduct` isos (#6147)
+
+For "scalar extension commutes with a product of matrix algebras" (the semisimple base-change
+count #6136 → field-general monotonicity #6127), `K ⊗[k] A ≃ₐ[K] ∏ᵢ Matrix (K ⊗[k] D i)` from
+`A ≃ₐ[k] ∏ᵢ Matrix (D i)` is a clean three-step compose (all sorry-free, axiom-clean in
+`Chapter4/Exercise4_2_3_BaseChangePiMatrix.lean`):
+1. `Algebra.TensorProduct.congr (AlgEquiv.refl (R := K) (A₁ := K)) e` base-changes `e` along `k→K`
+   (`congr (f : A ≃ₐ[S] C) (g : B ≃ₐ[R] D) : A ⊗[R] B ≃ₐ[S] C ⊗[R] D` — put `refl K` in the `f`/`S`
+   slot, `e` in the `g`/`R=k` slot).
+2. `Algebra.TensorProduct.piRight k K K (fun i => Matrix … (D i))` moves `K ⊗[k] -` inside the
+   finite product (needs `[Fintype ι] [DecidableEq ι]`; `Fin n` has both).
+3. `AlgEquiv.piCongrRight` glues a per-factor `matrixBaseChange`.
+
+The per-factor `K ⊗[k] Matrix n n D ≃ₐ[K] Matrix n n (K ⊗[k] D)` is the only fiddly piece:
+`congr refl (matrixEquivTensor n k D)` → `(Algebra.TensorProduct.assoc k k K K D (Matrix n n k)).symm`
+→ **the `k`→`K` upgrade of `(matrixEquivTensor n k (K ⊗[k] D)).symm`**. `matrixEquivTensor` is only
+stated `≃ₐ[k]`, but it *is* `K`-linear, so upgrade with a tiny helper:
+```
+def upgradeToK (f : X ≃ₐ[k] Y) (h : ∀ (c : K) x, f (c • x) = c • f x) : X ≃ₐ[K] Y :=
+  { f with commutes' := fun r => by
+      have hh := h r 1; rw [map_one] at hh
+      rw [Algebra.algebraMap_eq_smul_one, Algebra.algebraMap_eq_smul_one]; exact hh }
+```
+(needs `[Algebra K X] [Algebra K Y] [IsScalarTower k K X] [IsScalarTower k K Y]`). The `map_smul`
+hypothesis `h` for `(matrixEquivTensor …).symm` is a `TensorProduct` induction: `tmul` case is
+`rw [TensorProduct.smul_tmul']; simp only [matrixEquivTensor_apply_symm]; exact smul_assoc c b _`.
+`Algebra.TensorProduct.assoc`'s explicit args are `(T C D)` (here `T=K`); the `commRight`/
+`cancelBaseChange` detour is unnecessary once you have `upgradeToK`.
+
 ### Upgrading `dim V_λ = 1` to the book's representation-iso claim (trivial/sign, #5637)
 
 A recurring Chapter 5 fidelity-gap shape: the book says "`V_{(n)}` is the *trivial*

--- a/EtingofRepresentationTheory/Chapter4.lean
+++ b/EtingofRepresentationTheory/Chapter4.lean
@@ -45,6 +45,7 @@ import EtingofRepresentationTheory.Chapter4.Lemma4_10_3
 
 -- Section 4.1, 4.12: Exercises (statement pass)
 import EtingofRepresentationTheory.Chapter4.Exercise4_2_3
+import EtingofRepresentationTheory.Chapter4.Exercise4_2_3_BaseChangePiMatrix
 import EtingofRepresentationTheory.Chapter4.Exercise4_2_3_Cocenter
 import EtingofRepresentationTheory.Chapter4.Exercise4_2_3_CountingBound
 import EtingofRepresentationTheory.Chapter4.Exercise4_2_3_FieldGeneral

--- a/EtingofRepresentationTheory/Chapter4/Exercise4_2_3_BaseChangePiMatrix.lean
+++ b/EtingofRepresentationTheory/Chapter4/Exercise4_2_3_BaseChangePiMatrix.lean
@@ -1,0 +1,107 @@
+import Mathlib
+
+/-!
+# Base change distributes over a Wedderburn product of matrix algebras
+
+This file proves that scalar extension along a field extension `K ⊇ k` commutes with a finite
+product of matrix algebras over division rings: if a `k`-algebra `A` is Wedderburn-isomorphic to
+`∏ᵢ Matrix (Fin (d i)) (Fin (d i)) (D i)`, then
+
+  `K ⊗[k] A ≃ₐ[K] ∏ᵢ Matrix (Fin (d i)) (Fin (d i)) (K ⊗[k] D i)`.
+
+This is one of two reusable, fully self-contained lemmas consumed by the semisimple base-change
+crux `Etingof.natCard_simpleModuleClasses_le_baseChange_of_isSemisimpleRing`
+(`Exercise4_2_3_SemisimpleBaseChange.lean`, issue #6136), itself a separability-free ingredient of
+the field-general base-change monotonicity `#(simple k[G]) ≤ #(simple K[G])` (issue #6127, parent
+#6098).
+
+The statement is phrased purely in terms of Mathlib types, so it stands on its own (issue #6147).
+
+## Main result
+
+* `Etingof.nonempty_baseChange_pi_matrix_algEquiv` — base change distributes over `∏ Matrix (D i)`.
+
+## Route
+
+The isomorphism composes three standard base-change equivalences:
+
+1. `Algebra.TensorProduct.congr (AlgEquiv.refl K) e` base-changes `e` along `k → K`;
+2. `Algebra.TensorProduct.piRight` moves `K ⊗[k] -` inside the finite product;
+3. `matrixBaseChange` (a helper here) commutes `K ⊗[k] -` past each `Matrix (D i)`, built from
+   `matrixEquivTensor`, `Algebra.TensorProduct.assoc`, and a `k`-to-`K` linearity upgrade of the
+   matrix-tensor identification.
+-/
+
+open scoped TensorProduct
+
+universe u
+
+namespace Etingof
+
+noncomputable section
+
+variable (k K : Type u) [Field k] [Field K] [Algebra k K]
+
+/-- Upgrade a `k`-algebra equivalence that is *also* `K`-linear to a `K`-algebra equivalence.
+The ring-equivalence data is scalar-independent; only the `K`-scalar compatibility `commutes'`
+requires the extra `K`-linearity hypothesis `h`. -/
+private def upgradeToK {X Y : Type u} [Semiring X] [Semiring Y]
+    [Algebra k X] [Algebra k Y] [Algebra K X] [Algebra K Y]
+    [IsScalarTower k K X] [IsScalarTower k K Y]
+    (f : X ≃ₐ[k] Y) (h : ∀ (c : K) (x : X), f (c • x) = c • f x) : X ≃ₐ[K] Y :=
+  { f with
+    commutes' := fun r => by
+      have hh := h r 1
+      rw [map_one] at hh
+      rw [Algebra.algebraMap_eq_smul_one, Algebra.algebraMap_eq_smul_one]
+      exact hh }
+
+/-- Base change commutes with matrices: `K ⊗[k] Matrix n n D ≃ₐ[K] Matrix n n (K ⊗[k] D)`. -/
+private def matrixBaseChange (n : ℕ) (D : Type u) [Ring D] [Algebra k D] :
+    K ⊗[k] Matrix (Fin n) (Fin n) D ≃ₐ[K] Matrix (Fin n) (Fin n) (K ⊗[k] D) :=
+  -- `K ⊗[k] Matrix n n D  ≃  K ⊗[k] (D ⊗[k] Matrix n n k)`
+  let c1 : K ⊗[k] Matrix (Fin n) (Fin n) D ≃ₐ[K]
+      K ⊗[k] (D ⊗[k] Matrix (Fin n) (Fin n) k) :=
+    Algebra.TensorProduct.congr (AlgEquiv.refl (R := K) (A₁ := K)) (matrixEquivTensor (Fin n) k D)
+  -- reassociate, keeping `K` on the left: `≃ (K ⊗[k] D) ⊗[k] Matrix n n k`
+  let c2 : K ⊗[k] (D ⊗[k] Matrix (Fin n) (Fin n) k) ≃ₐ[K]
+      (K ⊗[k] D) ⊗[k] Matrix (Fin n) (Fin n) k :=
+    (Algebra.TensorProduct.assoc k k K K D (Matrix (Fin n) (Fin n) k)).symm
+  -- `(K ⊗[k] D) ⊗[k] Matrix n n k ≃ Matrix n n (K ⊗[k] D)`: `k`→`K` upgrade of `matrixEquivTensor`
+  let c3 : (K ⊗[k] D) ⊗[k] Matrix (Fin n) (Fin n) k ≃ₐ[K]
+      Matrix (Fin n) (Fin n) (K ⊗[k] D) :=
+    upgradeToK k K (matrixEquivTensor (Fin n) k (K ⊗[k] D)).symm (fun c x => by
+      induction x with
+      | zero => simp
+      | add a b ha hb => simp [ha, hb]
+      | tmul b M =>
+        rw [TensorProduct.smul_tmul']
+        simp only [matrixEquivTensor_apply_symm]
+        exact smul_assoc c b _)
+  c1.trans (c2.trans c3)
+
+/-- Scalar extension along a field extension `K ⊇ k` commutes with a Wedderburn product of matrix
+algebras over division rings: a `k`-algebra iso `A ≃ₐ[k] ∏ᵢ Matrix (D i)` base-changes to a
+`K`-algebra iso `K ⊗[k] A ≃ₐ[K] ∏ᵢ Matrix (K ⊗[k] D i)`. -/
+theorem nonempty_baseChange_pi_matrix_algEquiv
+    {n : ℕ} (D : Fin n → Type u) [∀ i, DivisionRing (D i)] [∀ i, Algebra k (D i)]
+    (d : Fin n → ℕ) {A : Type u} [Ring A] [Algebra k A]
+    (e : A ≃ₐ[k] (∀ i, Matrix (Fin (d i)) (Fin (d i)) (D i))) :
+    Nonempty (K ⊗[k] A ≃ₐ[K] (∀ i, Matrix (Fin (d i)) (Fin (d i)) (K ⊗[k] D i))) := by
+  refine ⟨?_⟩
+  -- base-change `e` along `k → K`
+  let s1 : K ⊗[k] A ≃ₐ[K] K ⊗[k] (∀ i, Matrix (Fin (d i)) (Fin (d i)) (D i)) :=
+    Algebra.TensorProduct.congr (AlgEquiv.refl (R := K) (A₁ := K)) e
+  -- distribute `K ⊗[k] -` over the finite product
+  let s2 : K ⊗[k] (∀ i, Matrix (Fin (d i)) (Fin (d i)) (D i)) ≃ₐ[K]
+      (∀ i, K ⊗[k] Matrix (Fin (d i)) (Fin (d i)) (D i)) :=
+    Algebra.TensorProduct.piRight k K K (fun i => Matrix (Fin (d i)) (Fin (d i)) (D i))
+  -- commute `K ⊗[k] -` past each matrix factor
+  let s3 : (∀ i, K ⊗[k] Matrix (Fin (d i)) (Fin (d i)) (D i)) ≃ₐ[K]
+      (∀ i, Matrix (Fin (d i)) (Fin (d i)) (K ⊗[k] D i)) :=
+    AlgEquiv.piCongrRight (fun i => matrixBaseChange k K (d i) (D i))
+  exact s1.trans (s2.trans s3)
+
+end
+
+end Etingof

--- a/progress/2026-07-10T10-49-53Z_0bb92eb2.md
+++ b/progress/2026-07-10T10-49-53Z_0bb92eb2.md
@@ -1,0 +1,48 @@
+## Accomplished
+
+Proved `Etingof.nonempty_baseChange_pi_matrix_algEquiv` (issue #6147, feature) in a new
+standalone file `EtingofRepresentationTheory/Chapter4/Exercise4_2_3_BaseChangePiMatrix.lean`:
+
+  `A ≃ₐ[k] ∏ᵢ Matrix (Fin (d i)) (Fin (d i)) (D i)`
+    ⟹ `K ⊗[k] A ≃ₐ[K] ∏ᵢ Matrix (Fin (d i)) (Fin (d i)) (K ⊗[k] D i)`.
+
+The proof composes three base-change equivalences:
+1. `Algebra.TensorProduct.congr (AlgEquiv.refl K) e` — base-change `e` along `k → K`;
+2. `Algebra.TensorProduct.piRight` — distribute `K ⊗[k] -` over the finite product;
+3. a private helper `matrixBaseChange : K ⊗[k] Matrix n n D ≃ₐ[K] Matrix n n (K ⊗[k] D)`,
+   itself built from `matrixEquivTensor`, `Algebra.TensorProduct.assoc`, and a small
+   `k`→`K` linearity upgrade (`upgradeToK`) of `(matrixEquivTensor _ k (K ⊗[k] D)).symm`.
+
+Key detail: `matrixEquivTensor` is only stated `≃ₐ[k]`, so the last step needs an explicit
+upgrade to `≃ₐ[K]`. The upgrade's `commutes'` is a one-liner via
+`Algebra.algebraMap_eq_smul_one` + `map_one`; the `K`-linearity hypothesis is proved by
+`TensorProduct` induction (the `tmul` case is `TensorProduct.smul_tmul'` +
+`matrixEquivTensor_apply_symm` + `smul_assoc`).
+
+Verification: `lake build EtingofRepresentationTheory.Chapter4.Exercise4_2_3_BaseChangePiMatrix`
+passes with no warnings; `#print axioms Etingof.nonempty_baseChange_pi_matrix_algEquiv` shows
+only `propext, Classical.choice, Quot.sound` (no `sorryAx`). Added the file to the Chapter4
+aggregator.
+
+## Current frontier
+
+Issue #6147 complete. The sibling #6146 (`natCard_simpleModuleClasses_pi`) is the other
+standalone lemma feeding the crux #6136; both together unblock the semisimple base-change
+count `Etingof.natCard_simpleModuleClasses_le_baseChange_of_isSemisimpleRing`
+(`Exercise4_2_3_SemisimpleBaseChange.lean`, landing via PR #6148), which in turn feeds the
+parent field-general monotonicity #6127.
+
+## Overall project progress
+
+Phase 3 formalization, Chapter 4 base-change monotonicity chain (#6098). This is a self-contained
+infrastructure lemma; the parent file will import it to discharge one of its two deferred `sorry`s.
+
+## Next step
+
+A worker can claim #6146 (the product-of-rings simple count) if still open, then #6136 (the crux
+assembly consuming both #6146 and #6147). The parent file `Exercise4_2_3_SemisimpleBaseChange.lean`
+should reference `Etingof.nonempty_baseChange_pi_matrix_algEquiv` from this file once on `main`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6147

Session: `0bb92eb2-d5d7-49e0-abb6-062ad087b0cb`

3eceb48a chore(skill): record base-change over Wedderburn product recipe (#6147)
4e4c4cd2 feat(Ch4 #6147): prove nonempty_baseChange_pi_matrix_algEquiv

🤖 Prepared with Claude Code