### PR TITLE
feat(Ch3 #6156): prove Problem 3.9.1(c) + reusable part-(d) ⇐ helper

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/Problem3_9_1.lean
+++ b/EtingofRepresentationTheory/Chapter3/Problem3_9_1.lean
@@ -147,11 +147,11 @@ noncomputable def coboundaryLinear : (W →ₗ[k] V) →ₗ[k] (A →ₗ[k] (W �
   toFun := coboundaryOf k A V W
   map_add' X Y := by
     ext a w
-    simp only [coboundaryOf_apply, LinearMap.add_apply, map_add, smul_add]
+    simp only [coboundaryOf_apply, LinearMap.add_apply, smul_add]
     abel
   map_smul' c X := by
     ext a w
-    simp only [coboundaryOf_apply, LinearMap.smul_apply, RingHom.id_apply, map_smul, smul_sub,
+    simp only [coboundaryOf_apply, LinearMap.smul_apply, RingHom.id_apply, smul_sub,
       smul_comm a c]
 
 @[simp] theorem coboundaryLinear_apply (X : W →ₗ[k] V) :
@@ -212,9 +212,9 @@ theorem iso_of_sub_mem_coboundaries (f f' : A →ₗ[k] (W →ₗ[k] V))
     LinearMap.prod (LinearMap.fst k V W - X ∘ₗ LinearMap.snd k V W) (LinearMap.snd k V W)
     with hLinv
   have Lapp : ∀ p : V × W, L p = (p.1 + X p.2, p.2) := fun p => by
-    simp [hL, LinearMap.coe_prod, Function.prod_apply]
+    simp [hL, Function.prod_apply]
   have Linvapp : ∀ p : V × W, Linv p = (p.1 - X p.2, p.2) := fun p => by
-    simp [hLinv, LinearMap.coe_prod, Function.prod_apply]
+    simp [hLinv, Function.prod_apply]
   refine ⟨LinearEquiv.ofLinear L Linv ?_ ?_, ?_⟩
   · apply LinearMap.ext
     rintro ⟨v, w⟩
@@ -256,9 +256,9 @@ theorem ext_iso_of_sub_smul_mem_coboundaries (f f' : A →ₗ[k] (W →ₗ[k] V)
     LinearMap.prod (LinearMap.fst k V W - c⁻¹ • (X ∘ₗ LinearMap.snd k V W))
       (c⁻¹ • LinearMap.snd k V W) with hLinv
   have Lapp : ∀ p : V × W, L p = (p.1 + X p.2, c • p.2) := fun p => by
-    simp [hL, LinearMap.coe_prod, Function.prod_apply]
+    simp [hL, Function.prod_apply]
   have Linvapp : ∀ p : V × W, Linv p = (p.1 - c⁻¹ • X p.2, c⁻¹ • p.2) := fun p => by
-    simp [hLinv, LinearMap.coe_prod, Function.prod_apply]
+    simp [hLinv, Function.prod_apply]
   refine ⟨LinearEquiv.ofLinear L Linv ?_ ?_, ?_⟩
   · apply LinearMap.ext
     rintro ⟨v, w⟩

--- a/EtingofRepresentationTheory/Chapter3/Problem3_9_1.lean
+++ b/EtingofRepresentationTheory/Chapter3/Problem3_9_1.lean
@@ -236,6 +236,53 @@ theorem iso_of_sub_mem_coboundaries (f f' : A →ₗ[k] (W →ₗ[k] V))
   refine ⟨?_, rfl⟩
   simp only [add_assoc, ← key]
 
+/-- The "proportional ⇒ isomorphic" direction of Problem 3.9.1(d), in the nondegenerate case
+`c ≠ 0`. If `f − c • f'` is a coboundary for some nonzero scalar `c`, then the extensions
+`U_f` and `U_{f'}` are isomorphic representations, via the block map `φ = [[1, X], [0, c]]`.
+
+This holds over any field (no irreducibility or finite dimensionality needed) and is the
+reusable half of part (d). The degenerate case `c = 0` reduces to `f` being a coboundary,
+which makes `U_f` split but says nothing about `U_{f'}`; it does *not* give
+`U_f ≅ U_{f'}` in general. -/
+theorem ext_iso_of_sub_smul_mem_coboundaries (f f' : A →ₗ[k] (W →ₗ[k] V))
+    (c : k) (hc : c ≠ 0) (hsub : f - c • f' ∈ coboundaries k A V W) :
+    ∃ φ : (V × W) ≃ₗ[k] (V × W), IntertwinesExt k A V W f f' φ := by
+  obtain ⟨X, hX⟩ := (mem_coboundaries_iff k A V W (f - c • f')).1 hsub
+  -- `φ = [[1, X], [0, c]]`, i.e. `(v, w) ↦ (v + X w, c • w)`.
+  set L : (V × W) →ₗ[k] (V × W) :=
+    LinearMap.prod (LinearMap.fst k V W + X ∘ₗ LinearMap.snd k V W) (c • LinearMap.snd k V W)
+    with hL
+  set Linv : (V × W) →ₗ[k] (V × W) :=
+    LinearMap.prod (LinearMap.fst k V W - c⁻¹ • (X ∘ₗ LinearMap.snd k V W))
+      (c⁻¹ • LinearMap.snd k V W) with hLinv
+  have Lapp : ∀ p : V × W, L p = (p.1 + X p.2, c • p.2) := fun p => by
+    simp [hL, LinearMap.coe_prod, Function.prod_apply]
+  have Linvapp : ∀ p : V × W, Linv p = (p.1 - c⁻¹ • X p.2, c⁻¹ • p.2) := fun p => by
+    simp [hLinv, LinearMap.coe_prod, Function.prod_apply]
+  refine ⟨LinearEquiv.ofLinear L Linv ?_ ?_, ?_⟩
+  · apply LinearMap.ext
+    rintro ⟨v, w⟩
+    simp only [LinearMap.comp_apply, Lapp, Linvapp, LinearMap.id_coe, id_eq, map_smul,
+      smul_inv_smul₀ hc, sub_add_cancel]
+  · apply LinearMap.ext
+    rintro ⟨v, w⟩
+    simp only [LinearMap.comp_apply, Lapp, Linvapp, LinearMap.id_coe, id_eq, map_smul,
+      inv_smul_smul₀ hc, add_sub_cancel_right]
+  intro a
+  apply LinearMap.ext
+  rintro ⟨v, w⟩
+  -- Off-diagonal identity: `(f - c • f') a w = a • X w - X (a • w)`.
+  have key : a • X w + c • f' a w = f a w + X (a • w) := by
+    have h := LinearMap.congr_fun (LinearMap.congr_fun hX a) w
+    simp only [coboundaryOf_apply, LinearMap.sub_apply, LinearMap.smul_apply] at h
+    exact sub_eq_sub_iff_add_eq_add.1 h
+  simp only [LinearMap.comp_apply, LinearEquiv.coe_coe, LinearEquiv.ofLinear_apply, blockOp_apply,
+    Lapp, smul_add, map_smul]
+  rw [Prod.mk.injEq]
+  refine ⟨?_, ?_⟩
+  · simp only [add_assoc, ← key]
+  · rw [smul_comm]
+
 /-- **Problem 3.9.1(d).** For finite dimensional irreducible `V` and `W`, the extensions
 `U_f` and `U_{f'}` are isomorphic if and only if the cocycles `f` and `f'` are proportional
 modulo coboundaries (their classes in `Ext¹` are proportional). -/

--- a/EtingofRepresentationTheory/Chapter3/Problem3_9_1.lean
+++ b/EtingofRepresentationTheory/Chapter3/Problem3_9_1.lean
@@ -104,6 +104,12 @@ noncomputable def coboundaryOf (X : W →ₗ[k] V) : A →ₗ[k] (W →ₗ[k] V)
   ((LinearMap.llcomp k W V V).flip X).comp (Algebra.lsmul k k V).toLinearMap
     - (LinearMap.llcomp k W W V X).comp (Algebra.lsmul k k W).toLinearMap
 
+/-- Pointwise formula for a coboundary: `dX(a)(w) = a • X w - X (a • w)`. -/
+theorem coboundaryOf_apply (X : W →ₗ[k] V) (a : A) (w : W) :
+    coboundaryOf k A V W X a w = a • X w - X (a • w) := by
+  simp only [coboundaryOf, LinearMap.sub_apply, LinearMap.comp_apply, LinearMap.llcomp_apply,
+    LinearMap.flip_apply, AlgHom.toLinearMap_apply, Algebra.lsmul_coe]
+
 /-- **Problem 3.9.1(b), first part.** Every coboundary `dX` is a 1-cocycle. -/
 theorem coboundaryOf_isCocycle (X : W →ₗ[k] V) : IsCocycle k A V W (coboundaryOf k A V W X) := by
   intro a b
@@ -136,6 +142,37 @@ the range. -/
 def coboundaries : Submodule k (A →ₗ[k] (W →ₗ[k] V)) :=
   Submodule.span k (Set.range (coboundaryOf k A V W))
 
+/-- The coboundary map `X ↦ dX` bundled as a `k`-linear map. Its range is `coboundaries`. -/
+noncomputable def coboundaryLinear : (W →ₗ[k] V) →ₗ[k] (A →ₗ[k] (W →ₗ[k] V)) where
+  toFun := coboundaryOf k A V W
+  map_add' X Y := by
+    ext a w
+    simp only [coboundaryOf_apply, LinearMap.add_apply, map_add, smul_add]
+    abel
+  map_smul' c X := by
+    ext a w
+    simp only [coboundaryOf_apply, LinearMap.smul_apply, RingHom.id_apply, map_smul, smul_sub,
+      smul_comm a c]
+
+@[simp] theorem coboundaryLinear_apply (X : W →ₗ[k] V) :
+    coboundaryLinear k A V W X = coboundaryOf k A V W X := rfl
+
+/-- `coboundaries` is exactly the range of the coboundary map. -/
+theorem coboundaries_eq_range :
+    coboundaries k A V W = LinearMap.range (coboundaryLinear k A V W) := by
+  apply le_antisymm
+  · rw [coboundaries, Submodule.span_le]
+    rintro _ ⟨X, rfl⟩
+    exact ⟨X, rfl⟩
+  · rintro _ ⟨X, rfl⟩
+    exact Submodule.subset_span ⟨X, rfl⟩
+
+/-- Membership in `coboundaries` means being a coboundary `dX` for some `X`. -/
+theorem mem_coboundaries_iff (g : A →ₗ[k] (W →ₗ[k] V)) :
+    g ∈ coboundaries k A V W ↔ ∃ X : W →ₗ[k] V, coboundaryOf k A V W X = g := by
+  rw [coboundaries_eq_range, LinearMap.mem_range]
+  simp only [coboundaryLinear_apply]
+
 /-- **Problem 3.9.1(b).** Coboundaries are cocycles: `B¹ ⊆ Z¹`. -/
 theorem coboundaries_le_cocycles :
     coboundaries k A V W ≤ cocycles k A V W := by
@@ -166,7 +203,38 @@ theorem iso_of_sub_mem_coboundaries (f f' : A →ₗ[k] (W →ₗ[k] V))
     (hf : IsCocycle k A V W f) (hf' : IsCocycle k A V W f')
     (hsub : f - f' ∈ coboundaries k A V W) :
     ∃ φ : (V × W) ≃ₗ[k] (V × W), IntertwinesExt k A V W f f' φ := by
-  sorry
+  obtain ⟨X, hX⟩ := (mem_coboundaries_iff k A V W (f - f')).1 hsub
+  -- `φ = [[1, X], [0, 1]]`, i.e. `(v, w) ↦ (v + X w, w)`, with inverse `(v, w) ↦ (v - X w, w)`.
+  set L : (V × W) →ₗ[k] (V × W) :=
+    LinearMap.prod (LinearMap.fst k V W + X ∘ₗ LinearMap.snd k V W) (LinearMap.snd k V W)
+    with hL
+  set Linv : (V × W) →ₗ[k] (V × W) :=
+    LinearMap.prod (LinearMap.fst k V W - X ∘ₗ LinearMap.snd k V W) (LinearMap.snd k V W)
+    with hLinv
+  have Lapp : ∀ p : V × W, L p = (p.1 + X p.2, p.2) := fun p => by
+    simp [hL, LinearMap.coe_prod, Function.prod_apply]
+  have Linvapp : ∀ p : V × W, Linv p = (p.1 - X p.2, p.2) := fun p => by
+    simp [hLinv, LinearMap.coe_prod, Function.prod_apply]
+  refine ⟨LinearEquiv.ofLinear L Linv ?_ ?_, ?_⟩
+  · apply LinearMap.ext
+    rintro ⟨v, w⟩
+    simp [Lapp, Linvapp]
+  · apply LinearMap.ext
+    rintro ⟨v, w⟩
+    simp [Lapp, Linvapp]
+  intro a
+  apply LinearMap.ext
+  rintro ⟨v, w⟩
+  -- The off-diagonal identity: `(f - f') a w = a • X w - X (a • w)`.
+  have key : a • X w + f' a w = f a w + X (a • w) := by
+    have h := LinearMap.congr_fun (LinearMap.congr_fun hX a) w
+    rw [coboundaryOf_apply, LinearMap.sub_apply] at h
+    exact sub_eq_sub_iff_add_eq_add.1 h
+  simp only [LinearMap.comp_apply, LinearEquiv.coe_coe, LinearEquiv.ofLinear_apply, blockOp_apply,
+    Lapp, smul_add]
+  rw [Prod.mk.injEq]
+  refine ⟨?_, rfl⟩
+  simp only [add_assoc, ← key]
 
 /-- **Problem 3.9.1(d).** For finite dimensional irreducible `V` and `W`, the extensions
 `U_f` and `U_{f'}` are isomorphic if and only if the cocycles `f` and `f'` are proportional

--- a/progress/2026-07-10T11-24-49Z_a7d72bdc.md
+++ b/progress/2026-07-10T11-24-49Z_a7d72bdc.md
@@ -1,0 +1,32 @@
+## Accomplished
+Worked issue #6156 (Problem 3.9.1 parts (c),(d)) in `Chapter3/Problem3_9_1.lean`.
+
+- **Part (c) `iso_of_sub_mem_coboundaries` — PROVED (sorry-free).** Added supporting API:
+  `coboundaryOf_apply` (pointwise `dX(a)(w) = a•Xw − X(a•w)`), a bundled `coboundaryLinear`,
+  `coboundaries_eq_range`, and `mem_coboundaries_iff`. The iso is the block-unitriangular map
+  `φ = [[1, X], [0, 1]]`.
+- **Part (d) ⇐ helper `ext_iso_of_sub_smul_mem_coboundaries` — PROVED (sorry-free).** The
+  nondegenerate `c ≠ 0` "proportional ⇒ isomorphic" direction via `φ = [[1, X], [0, c]]`, valid
+  over any field.
+- **Part (d) main iff `irreducible_ext_iso_iff_proportional` — left as `sorry`; NOT provable as
+  literally stated.** Two obstructions (documented in follow-up issue #6164):
+  1. ⇒ needs `[IsAlgClosed k]` (Schur scalars, `Corollary_2_3_10`), absent from the signature.
+  2. ⇐ is false at `c = 0` (`f` trivial does not force `U_f ≅ U_{f'}`); the book classifies
+     *nontrivial* extensions by `ℙ Ext¹`.
+
+Sorry count in this file: 2 → 1.
+
+## Current frontier
+`Problem3_9_1.lean` builds with a single remaining `sorry` (part (d) main theorem).
+
+## Overall project progress
+Stage 3 formalization ongoing. Problem 3.9.1 now has (a),(b),(c) sorry-free plus the reusable
+(d) ⇐ helper. Only the mis-stated (d) iff remains.
+
+## Next step
+Planner should triage #6164: decide the corrected statement for part (d) (add `IsAlgClosed k`,
+restate as ℙ Ext¹ classification / exclude the `c=0` trivial class). The ⇐ `c≠0` case and the
+both-trivial case are already covered; the ⇒ direction needs Schur block-decomposition.
+
+## Blockers
+Part (d) main theorem is unprovable as literally written — a spec revision is required (#6164).


### PR DESCRIPTION
This PR proves Problem 3.9.1(c) `iso_of_sub_mem_coboundaries` sorry-free and adds the reusable ⇐ helper `ext_iso_of_sub_smul_mem_coboundaries` for part (d), in `EtingofRepresentationTheory/Chapter3/Problem3_9_1.lean`.

Part (c) builds the isomorphism of extensions from the block-unitriangular map `φ = [[1, X], [0, 1]]`, supported by new API: `coboundaryOf_apply` (pointwise `dX(a)(w) = a•Xw − X(a•w)`), a bundled `coboundaryLinear`, `coboundaries_eq_range`, and `mem_coboundaries_iff`. The helper proves the nondegenerate `c ≠ 0` proportional ⇒ isomorphic direction via `φ = [[1, X], [0, c]]`, valid over any field.

Part (d)'s main iff `irreducible_ext_iso_iff_proportional` remains `sorry` because it is not provable as literally stated: the ⇒ direction needs `[IsAlgClosed k]` (Schur scalars, `Corollary_2_3_10`), which is absent from the signature, and the ⇐ direction is false at `c = 0` (a coboundary `f` splits `U_f` but constrains nothing about `U_{f'}`; the book classifies nontrivial extensions by ℙ Ext¹). This is split into #6164 with corrected-statement options. Partial completion of #6156.

🤖 Prepared with Claude Code