### PR TITLE
feat(Ch4 #6146): prove natCard_simpleModuleClasses_pi via a Σ-bijection over the factors

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Exercise4_2_3_SemisimpleBaseChange.lean
+++ b/EtingofRepresentationTheory/Chapter4/Exercise4_2_3_SemisimpleBaseChange.lean
@@ -115,14 +115,262 @@ theorem subsingleton_simpleModuleClasses_divisionRing (D : Type u) [DivisionRing
   exact Quotient.sound
     ⟨(simpleProp (ModuleCat.{u} D)).fullyFaithfulι.preimageIso (eP.trans eQ.symm).toModuleIso⟩
 
-/-- **Simple modules of a finite product of rings (deferred; sub-issue).** The simple modules of a
-finite product `∏ i, R i` are exactly the simple modules of the individual factors (pulled back
-along the projections): a simple `∏ R i`-module is annihilated by all but one factor's identity
-idempotent, so it is a simple module over that factor. Hence the counts add. -/
-theorem natCard_simpleModuleClasses_pi {n : ℕ} (R : Fin n → Type u) [∀ i, Ring (R i)] :
+/-! ### Simple modules of a finite product of rings
+
+The simple modules of a finite product `∏ i, R i` are the disjoint union, over `i`, of the simple
+modules of the factors, pulled back along the (surjective) projections `Pi.evalRingHom R i`. A
+simple `∏ R i`-module is "supported" at exactly one factor: the central idempotent
+`e i = Pi.single i 1` acts as the identity on it (existence follows from `∑ i, e i = 1`), so the
+module is a simple `R i`-module. Conversely every simple `R i`-module inflates to a simple
+`∏ R j`-module, and different factors give non-isomorphic modules (an `∏ R j`-isomorphism carries
+the action of each `e i` to itself). This yields a bijection
+`(Σ i, SimpleModuleClasses (R i)) ≃ SimpleModuleClasses (∏ i, R i)`. -/
+
+section Pi
+
+variable {n : ℕ} (R : Fin n → Type u) [∀ i, Ring (R i)]
+
+/-- The identity map as an isomorphism of `ModuleCat` objects that share a carrier and have equal
+scalar actions (used to identify a module with the restriction-then-inflation of itself). -/
+private def idModuleIso {S : Type*} [Ring S] {M : Type u} [AddCommGroup M]
+    (i₁ i₂ : Module S M) (h : ∀ (s : S) (x : M), (letI := i₁; s • x) = (letI := i₂; s • x)) :
+    (letI := i₁; ModuleCat.of S M) ≅ (letI := i₂; ModuleCat.of S M) :=
+  @LinearEquiv.toModuleIso S _ M M _ _ i₁ i₂
+    (@AddEquiv.toLinearEquiv S M M _ _ _ i₁ i₂ (AddEquiv.refl M) h)
+
+/-- **Inflation of a simple factor module.** Restriction of scalars of a simple `R i`-module along
+the surjective projection `Pi.evalRingHom R i : (∀ j, R j) →+* R i` is a simple `∏ R j`-module. -/
+private noncomputable def inflatePiObj (i : Fin n)
+    (P : (simpleProp (ModuleCat.{u} (R i))).FullSubcategory) :
+    (simpleProp (ModuleCat.{u} (∀ j, R j))).FullSubcategory := by
+  haveI : Simple P.obj := P.property
+  haveI hsP : IsSimpleModule (R i) (P.obj : ModuleCat.{u} (R i)) := isSimpleModule_of_simple _
+  letI : Module (∀ j, R j) (P.obj : ModuleCat.{u} (R i)) :=
+    Module.compHom _ (Pi.evalRingHom R i)
+  haveI : RingHomSurjective (Pi.evalRingHom R i) := ⟨fun x => ⟨Pi.single i x, by simp⟩⟩
+  haveI : IsSimpleModule (∀ j, R j) (P.obj : ModuleCat.{u} (R i)) :=
+    (LinearMap.isSimpleModule_iff_of_bijective
+      ({ toFun := id, map_add' := fun _ _ => rfl, map_smul' := fun _ _ => rfl } :
+        (P.obj : ModuleCat.{u} (R i)) →ₛₗ[Pi.evalRingHom R i]
+          (P.obj : ModuleCat.{u} (R i))) Function.bijective_id).mpr hsP
+  exact ⟨ModuleCat.of (∀ j, R j) (P.obj : ModuleCat.{u} (R i)), simple_of_isSimpleModule⟩
+
+/-- Inflation on iso-classes: a well-defined map `SimpleModuleClasses (R i) → SimpleModuleClasses
+(∏ R j)`. -/
+private noncomputable def inflatePiClass (i : Fin n) :
+    SimpleModuleClasses.{u} (R i) → SimpleModuleClasses.{u} (∀ j, R j) :=
+  Quotient.map (inflatePiObj R i) (by
+    rintro P P' ⟨iso⟩
+    haveI : Simple P.obj := P.property
+    haveI : Simple P'.obj := P'.property
+    haveI : IsSimpleModule (R i) (P.obj : ModuleCat.{u} (R i)) := isSimpleModule_of_simple _
+    haveI : IsSimpleModule (R i) (P'.obj : ModuleCat.{u} (R i)) := isSimpleModule_of_simple _
+    have eR : (P.obj : ModuleCat.{u} (R i)) ≃ₗ[R i] (P'.obj : ModuleCat.{u} (R i)) :=
+      ((ObjectProperty.ι _).mapIso iso).toLinearEquiv
+    letI : Module (∀ j, R j) (P.obj : ModuleCat.{u} (R i)) :=
+      Module.compHom _ (Pi.evalRingHom R i)
+    letI : Module (∀ j, R j) (P'.obj : ModuleCat.{u} (R i)) :=
+      Module.compHom _ (Pi.evalRingHom R i)
+    refine ⟨(simpleProp (ModuleCat.{u} (∀ j, R j))).fullyFaithfulι.preimageIso
+      (LinearEquiv.toModuleIso
+        { toFun := eR, invFun := eR.symm, left_inv := eR.left_inv, right_inv := eR.right_inv,
+          map_add' := eR.map_add,
+          map_smul' := fun s x => eR.map_smul (Pi.evalRingHom R i s) x })⟩)
+
+/-- The backward map `(Σ i, SimpleModuleClasses (R i)) → SimpleModuleClasses (∏ R j)`. -/
+private noncomputable def sigmaToPi :
+    (Σ i, SimpleModuleClasses.{u} (R i)) → SimpleModuleClasses.{u} (∀ j, R j) :=
+  fun p => inflatePiClass R p.1 p.2
+
+/-- **Support index.** A simple `∏ R j`-module has a factor `i` at which the identity idempotent
+`e i = Pi.single i 1` acts as the identity. -/
+private theorem exists_support_index (M : Type u) [AddCommGroup M] [Module (∀ j, R j) M]
+    [IsSimpleModule (∀ j, R j) M] :
+    ∃ i, ∀ m : M, (Pi.single i (1 : R i) : ∀ j, R j) • m = m := by
+  haveI : Nontrivial M := IsSimpleModule.nontrivial (∀ j, R j) M
+  obtain ⟨m₀, hm₀⟩ := exists_ne (0 : M)
+  have hsum : ∑ i, (Pi.single i (1 : R i) : ∀ j, R j) = 1 := by
+    funext j
+    rw [Finset.sum_apply, Finset.sum_eq_single j
+      (fun b _ hbj => by simp [hbj]) (fun hj => absurd (Finset.mem_univ j) hj)]
+    simp
+  have hne : ∃ i, (Pi.single i (1 : R i) : ∀ j, R j) • m₀ ≠ 0 := by
+    by_contra h
+    simp only [not_exists, ne_eq, not_not] at h
+    apply hm₀
+    calc m₀ = (1 : ∀ j, R j) • m₀ := (one_smul _ _).symm
+      _ = (∑ i, (Pi.single i (1 : R i) : ∀ j, R j)) • m₀ := by rw [hsum]
+      _ = ∑ i, (Pi.single i (1 : R i) : ∀ j, R j) • m₀ := Finset.sum_smul
+      _ = 0 := Finset.sum_eq_zero (fun i _ => h i)
+  obtain ⟨i, hi⟩ := hne
+  refine ⟨i, ?_⟩
+  set e : (∀ j, R j) := Pi.single i (1 : R i) with he
+  have hcentral : ∀ s : ∀ j, R j, e * s = s * e := by
+    intro s; funext j
+    rcases eq_or_ne i j with h | h
+    · subst h; simp [he, Pi.single_eq_same]
+    · simp [he, Pi.single_eq_of_ne (Ne.symm h)]
+  have hidem : e * e = e := by
+    funext j
+    rcases eq_or_ne i j with h | h
+    · subst h; simp [he, Pi.single_eq_same]
+    · simp [he, Pi.single_eq_of_ne (Ne.symm h)]
+  let g : M →ₗ[∀ j, R j] M :=
+    { toFun := fun m => e • m
+      map_add' := fun a b => smul_add _ _ _
+      map_smul' := fun s m => by
+        simp only [RingHom.id_apply]
+        rw [← mul_smul, ← mul_smul, hcentral s] }
+  have hg : ∀ m, g m = e • m := fun _ => rfl
+  have hrange : LinearMap.range g = ⊤ := by
+    rcases eq_bot_or_eq_top (LinearMap.range g) with h | h
+    · exfalso
+      apply hi
+      have hmem : g m₀ ∈ LinearMap.range g := ⟨m₀, rfl⟩
+      rw [h, Submodule.mem_bot] at hmem
+      exact hmem
+    · exact h
+  intro m
+  obtain ⟨x, hx⟩ := LinearMap.range_eq_top.mp hrange m
+  rw [hg] at hx
+  rw [← hx, ← mul_smul, hidem]
+
+/-- The backward map is injective: an `∏ R j`-isomorphism of inflated modules forces the factor
+indices to agree, and then descends to an `R i`-isomorphism. -/
+private theorem sigmaToPi_injective : Function.Injective (sigmaToPi R) := by
+  rintro ⟨i, c⟩ ⟨i', c'⟩ hEq
+  induction c using Quotient.inductionOn with | _ P => ?_
+  induction c' using Quotient.inductionOn with | _ P' => ?_
+  have hEq' : (Quotient.mk _ (inflatePiObj R i P) : SimpleModuleClasses.{u} (∀ j, R j))
+      = Quotient.mk _ (inflatePiObj R i' P') := hEq
+  obtain ⟨iso⟩ := Quotient.exact hEq'
+  haveI : Simple P.obj := P.property
+  haveI : Simple P'.obj := P'.property
+  haveI hsP : IsSimpleModule (R i) (P.obj : ModuleCat.{u} (R i)) := isSimpleModule_of_simple _
+  haveI hsP' : IsSimpleModule (R i') (P'.obj : ModuleCat.{u} (R i')) := isSimpleModule_of_simple _
+  letI : Module (∀ j, R j) (P.obj : ModuleCat.{u} (R i)) := Module.compHom _ (Pi.evalRingHom R i)
+  letI : Module (∀ j, R j) (P'.obj : ModuleCat.{u} (R i')) :=
+    Module.compHom _ (Pi.evalRingHom R i')
+  have φ : (P.obj : ModuleCat.{u} (R i)) ≃ₗ[∀ j, R j] (P'.obj : ModuleCat.{u} (R i')) :=
+    ((ObjectProperty.ι _).mapIso iso).toLinearEquiv
+  have hii : i = i' := by
+    by_contra hne
+    have hsrc : ∀ p : (P.obj : ModuleCat.{u} (R i)),
+        (Pi.single i (1 : R i) : ∀ j, R j) • p = p := by
+      intro p
+      change (Pi.single i (1 : R i)) i • p = p
+      rw [Pi.single_eq_same, one_smul]
+    have htgt : ∀ q : (P'.obj : ModuleCat.{u} (R i')),
+        (Pi.single i (1 : R i) : ∀ j, R j) • q = 0 := by
+      intro q
+      change (Pi.single i (1 : R i)) i' • q = 0
+      rw [Pi.single_eq_of_ne (Ne.symm hne), zero_smul]
+    haveI : Nontrivial (P.obj : ModuleCat.{u} (R i)) := IsSimpleModule.nontrivial (R i) _
+    obtain ⟨p, hp⟩ := exists_ne (0 : (P.obj : ModuleCat.{u} (R i)))
+    have hz : φ p = 0 := by
+      have hmap := φ.map_smul (Pi.single i (1 : R i)) p
+      rw [hsrc p] at hmap
+      rw [htgt (φ p)] at hmap
+      exact hmap
+    exact hp (φ.injective (hz.trans (map_zero φ).symm))
+  subst hii
+  refine congrArg (Sigma.mk i) (Quotient.sound ?_)
+  refine ⟨(simpleProp (ModuleCat.{u} (R i))).fullyFaithfulι.preimageIso (LinearEquiv.toModuleIso
+    { toFun := φ, invFun := φ.symm, left_inv := φ.left_inv, right_inv := φ.right_inv,
+      map_add' := φ.map_add,
+      map_smul' := fun r p => by
+        simp only [RingHom.id_apply]
+        have h1 : (r : R i) • (p : (P.obj : ModuleCat.{u} (R i)))
+            = (Pi.single i r : ∀ j, R j) • p := by
+          change r • p = (Pi.single i r) i • p
+          rw [Pi.single_eq_same]
+        have h2 : (r : R i) • (φ p : (P'.obj : ModuleCat.{u} (R i)))
+            = (Pi.single i r : ∀ j, R j) • φ p := by
+          change r • φ p = (Pi.single i r) i • φ p
+          rw [Pi.single_eq_same]
+        rw [h1, h2, φ.map_smul] })⟩
+
+/-- The backward map is surjective: a simple `∏ R j`-module is the inflation of a simple module over
+its support factor. -/
+private theorem sigmaToPi_surjective : Function.Surjective (sigmaToPi R) := by
+  intro c
+  induction c using Quotient.inductionOn with | _ M => ?_
+  haveI : Simple M.obj := M.property
+  haveI hsM : IsSimpleModule (∀ j, R j) (M.obj : ModuleCat.{u} (∀ j, R j)) :=
+    isSimpleModule_of_simple _
+  obtain ⟨i, hsupp⟩ := exists_support_index R (M.obj : ModuleCat.{u} (∀ j, R j))
+  letI factor : Module (R i) (M.obj : ModuleCat.{u} (∀ j, R j)) :=
+    { smul := fun r m => (Pi.single i r : ∀ j, R j) • m
+      one_smul := fun m => hsupp m
+      mul_smul := fun r r' m => by
+        change (Pi.single i (r * r') : ∀ j, R j) • m
+            = (Pi.single i r : ∀ j, R j) • ((Pi.single i r' : ∀ j, R j) • m)
+        rw [← mul_smul]
+        congr 1
+        funext j
+        rcases eq_or_ne i j with h | h
+        · subst h; simp [Pi.single_eq_same]
+        · simp [Pi.single_eq_of_ne (Ne.symm h)]
+      smul_zero := fun r => smul_zero _
+      smul_add := fun r a b => smul_add _ _ _
+      add_smul := fun r r' m => by
+        change (Pi.single i (r + r') : ∀ j, R j) • m
+            = (Pi.single i r : ∀ j, R j) • m + (Pi.single i r' : ∀ j, R j) • m
+        rw [Pi.single_add, add_smul]
+      zero_smul := fun m => by
+        change (Pi.single i (0 : R i) : ∀ j, R j) • m = 0
+        rw [Pi.single_zero, zero_smul] }
+  have hrecover : ∀ (s : ∀ j, R j) (m : (M.obj : ModuleCat.{u} (∀ j, R j))),
+      (Pi.single i (s i) : ∀ j, R j) • m = s • m := by
+    intro s m
+    have hs : (Pi.single i (s i) : ∀ j, R j) = s * Pi.single i (1 : R i) := by
+      funext j
+      rcases eq_or_ne i j with h | h
+      · subst h; simp [Pi.single_eq_same]
+      · simp [Pi.single_eq_of_ne (Ne.symm h)]
+    rw [hs, mul_smul, hsupp m]
+  haveI hsFactor : letI := factor; IsSimpleModule (R i) (M.obj : ModuleCat.{u} (∀ j, R j)) := by
+    letI := factor
+    haveI : RingHomSurjective (Pi.evalRingHom R i) := ⟨fun x => ⟨Pi.single i x, by simp⟩⟩
+    -- Restricting the `factor` structure back along `evalRingHom` recovers the original action
+    -- (`hrecover`), so the identity is a semilinear bijection from the original module to `factor`.
+    exact (LinearMap.isSimpleModule_iff_of_bijective
+      (σ := Pi.evalRingHom R i)
+      ({ toFun := id, map_add' := fun _ _ => rfl, map_smul' := fun s m => (hrecover s m).symm } :
+        (M.obj : ModuleCat.{u} (∀ j, R j)) →ₛₗ[Pi.evalRingHom R i]
+          (M.obj : ModuleCat.{u} (∀ j, R j))) Function.bijective_id).mp hsM
+  let P₀ : (simpleProp (ModuleCat.{u} (R i))).FullSubcategory :=
+    ⟨letI := factor; ModuleCat.of (R i) (M.obj : ModuleCat.{u} (∀ j, R j)),
+     letI := factor; letI := hsFactor; simple_of_isSimpleModule⟩
+  refine ⟨⟨i, Quotient.mk _ P₀⟩, ?_⟩
+  have hiso := idModuleIso
+    (Module.compHom (M.obj : ModuleCat.{u} (∀ j, R j)) (Pi.evalRingHom R i))
+    M.obj.isModule
+    (fun s m => by
+      change (Pi.single i (s i) : ∀ j, R j) • m = s • m
+      exact hrecover s m)
+  exact Quotient.sound
+    ⟨(simpleProp (ModuleCat.{u} (∀ j, R j))).fullyFaithfulι.preimageIso hiso⟩
+
+/-- **Simple modules of a finite product of rings.** The isomorphism classes of simple modules over
+`∏ i, R i` are in bijection with the disjoint union over `i` of the classes of simple `R i`-modules,
+via inflation along the projections. -/
+private noncomputable def simpleModuleClassesPiEquiv :
+    (Σ i, SimpleModuleClasses.{u} (R i)) ≃ SimpleModuleClasses.{u} (∀ j, R j) :=
+  Equiv.ofBijective (sigmaToPi R) ⟨sigmaToPi_injective R, sigmaToPi_surjective R⟩
+
+end Pi
+
+/-- **Counting simple modules of a finite product.** When each factor has finitely many simple
+modules, the simple count of `∏ i, R i` is the sum of the factors' simple counts. (The finiteness
+hypothesis is necessary: a factor with infinitely many simple modules makes both sides diverge
+independently, e.g. `k × k[x]`.) -/
+theorem natCard_simpleModuleClasses_pi {n : ℕ} (R : Fin n → Type u) [∀ i, Ring (R i)]
+    [∀ i, Finite (SimpleModuleClasses.{u} (R i))] :
     Nat.card (SimpleModuleClasses.{u} (∀ i, R i))
       = ∑ i, Nat.card (SimpleModuleClasses.{u} (R i)) := by
-  sorry
+  rw [← Nat.card_sigma]
+  exact (Nat.card_congr (simpleModuleClassesPiEquiv R)).symm
 
 /-- **Base change of the Wedderburn product (deferred; sub-issue).** For a field extension `K ⊇ k`,
 base change carries a `k`-algebra isomorphism `A ≃ₐ[k] ∏ i, Matrix (Fin (d i)) (Fin (d i)) (D i)`
@@ -163,6 +411,12 @@ theorem natCard_simpleModuleClasses_le_baseChange_of_isSemisimpleRing
     exact Nat.card_eq_one_iff_unique.mpr ⟨hss, hne⟩
   -- LHS count: `#(simple A) = n`.
   have hL : Nat.card (SimpleModuleClasses.{u} A) = n := by
+    haveI : ∀ i, Finite (SimpleModuleClasses.{u} (Matrix (Fin (d i)) (Fin (d i)) (D i))) := by
+      intro i
+      haveI : NeZero (d i) := hd i
+      haveI : Subsingleton (SimpleModuleClasses.{u} (D i)) :=
+        subsingleton_simpleModuleClasses_divisionRing (D i)
+      exact Finite.of_equiv _ (simpleModuleClassesMatrixEquiv (R := D i) (d i)).symm
     rw [Nat.card_congr (simpleModuleClassesCongrRingEquiv (e.toRingEquiv)),
       natCard_simpleModuleClasses_pi]
     have : ∀ i, Nat.card
@@ -173,6 +427,12 @@ theorem natCard_simpleModuleClasses_le_baseChange_of_isSemisimpleRing
     simp [this]
   -- RHS count: `#(simple (K ⊗ A)) = ∑ i, #(simple (K ⊗ D i)) ≥ n`.
   obtain ⟨f⟩ := nonempty_baseChange_pi_matrix_algEquiv k K D d e
+  haveI : ∀ i, Finite (SimpleModuleClasses.{u} (Matrix (Fin (d i)) (Fin (d i)) (K ⊗[k] D i))) := by
+    intro i
+    haveI : NeZero (d i) := hd i
+    haveI := hDfin i
+    haveI : Finite (SimpleModuleClasses.{u} (K ⊗[k] D i)) := finite_simpleModuleClasses K
+    exact Finite.of_equiv _ (simpleModuleClassesMatrixEquiv (R := K ⊗[k] D i) (d i)).symm
   rw [Nat.card_congr (simpleModuleClassesCongrRingEquiv (f.toRingEquiv)),
     natCard_simpleModuleClasses_pi, hL]
   -- `1 ≤ #(simple (K ⊗ D i))` for each factor, so `∑ i, … ≥ ∑ i, 1 = n`.

--- a/progress/2026-07-10T11-31-11Z_c9507f7f.md
+++ b/progress/2026-07-10T11-31-11Z_c9507f7f.md
@@ -1,0 +1,54 @@
+## Accomplished
+
+Feature session for issue #6146: proved `Etingof.natCard_simpleModuleClasses_pi` (the simple-count
+of a finite product of rings) in
+`EtingofRepresentationTheory/Chapter4/Exercise4_2_3_SemisimpleBaseChange.lean`, replacing the
+`sorry`. `#print axioms` shows only `propext, Classical.choice, Quot.sound` (no `sorryAx`).
+
+The mathematical core is a new unconditional bijection
+`simpleModuleClassesPiEquiv : (Σ i, SimpleModuleClasses (R i)) ≃ SimpleModuleClasses (∀ i, R i)`,
+built from:
+- `inflatePiObj` / `inflatePiClass` — a simple `R i`-module inflates (restriction of scalars along
+  the surjective `Pi.evalRingHom R i`) to a simple `∏ R j`-module.
+- `exists_support_index` — a simple `∏ R j`-module is supported at one factor: some central
+  idempotent `e i = Pi.single i 1` acts as the identity (existence from `∑ i, e i = 1`).
+- `sigmaToPi_injective` (distinct factors give non-isomorphic inflations; same factor descends to an
+  `R i`-iso) and `sigmaToPi_surjective` (a simple module is the inflation of its support factor,
+  using a hand-built `R i`-module structure `r • m := Pi.single i r • m`).
+- A local `idModuleIso` helper (mirrors the sibling file) to identify a module with the
+  restriction-then-inflation of itself along `evalRingHom`.
+
+## Statement correction (important)
+
+The issue asked to "keep the statement", but the stated `Nat.card` equality is **false without a
+finiteness hypothesis**: `Nat.card_sigma` requires `[∀ i, Finite (β i)]`. Counterexample:
+`R = ![k, k[x]]` gives LHS `Nat.card = 0` (infinitely many simples) but RHS `= 1 + 0 = 1`. I added
+the minimal hypothesis `[∀ i, Finite (SimpleModuleClasses.{u} (R i))]`. The bijection itself is
+unconditional; only the final `Nat.card (Σ …) = ∑ …` step needs finiteness.
+
+The parent theorem `natCard_simpleModuleClasses_le_baseChange_of_isSemisimpleRing` in the same file
+uses this lemma only with division-ring / matrix-over-division-ring factors, which each have exactly
+one simple module. I fixed the two call sites to supply the `Finite` instances
+(`subsingleton_simpleModuleClasses_divisionRing` + `simpleModuleClassesMatrixEquiv`, and
+`finite_simpleModuleClasses K` + matrix equiv). The parent still compiles.
+
+## Current frontier
+
+`lake build EtingofRepresentationTheory.Chapter4.Exercise4_2_3_SemisimpleBaseChange` succeeds.
+Remaining sorries in the file are unrelated: `nonempty_baseChange_pi_matrix_algEquiv` (the other
+sub-issue of #6136) and `Exercise4_2_3.lean:687` (Std machinery).
+
+## Overall project progress
+
+Stage 3 formalization ongoing. This discharges one of the two deferred lemmas the semisimple
+base-change crux (#6136) depends on; the Wedderburn-distributes lemma
+(`nonempty_baseChange_pi_matrix_algEquiv`) remains.
+
+## Next step
+
+Prove `nonempty_baseChange_pi_matrix_algEquiv` (base change distributes over the Wedderburn product),
+the last `sorry` gating the parent `natCard_simpleModuleClasses_le_baseChange_of_isSemisimpleRing`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6146

Session: `c9507f7f-0f0e-4c87-b8cb-3cd64247faef`

95dcdf89 feat(Ch4 #6146): prove natCard_simpleModuleClasses_pi via a Σ-bijection

🤖 Prepared with Claude Code