### PR TITLE
feat(Ch4 #6136): wire proved nonempty_baseChange_pi_matrix_algEquiv into SemisimpleBaseChange — drop stale sorried duplicate, make the base-change crux sorry-free

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Exercise4_2_3_SemisimpleBaseChange.lean
+++ b/EtingofRepresentationTheory/Chapter4/Exercise4_2_3_SemisimpleBaseChange.lean
@@ -1,5 +1,6 @@
 import Mathlib
 import EtingofRepresentationTheory.Chapter4.Exercise4_2_3
+import EtingofRepresentationTheory.Chapter4.Exercise4_2_3_BaseChangePiMatrix
 
 /-!
 # Base change of a semisimple algebra can only increase the number of simple modules
@@ -371,17 +372,6 @@ theorem natCard_simpleModuleClasses_pi {n : ℕ} (R : Fin n → Type u) [∀ i, 
       = ∑ i, Nat.card (SimpleModuleClasses.{u} (R i)) := by
   rw [← Nat.card_sigma]
   exact (Nat.card_congr (simpleModuleClassesPiEquiv R)).symm
-
-/-- **Base change of the Wedderburn product (deferred; sub-issue).** For a field extension `K ⊇ k`,
-base change carries a `k`-algebra isomorphism `A ≃ₐ[k] ∏ i, Matrix (Fin (d i)) (Fin (d i)) (D i)`
-to a `K`-algebra isomorphism `K ⊗ A ≃ₐ[K] ∏ i, Matrix (Fin (d i)) (Fin (d i)) (K ⊗ D i)`, by
-distributing `K ⊗ -` over the finite product and over each matrix ring. -/
-theorem nonempty_baseChange_pi_matrix_algEquiv (k K : Type u) [Field k] [Field K] [Algebra k K]
-    {n : ℕ} (D : Fin n → Type u) [∀ i, DivisionRing (D i)] [∀ i, Algebra k (D i)]
-    (d : Fin n → ℕ) {A : Type u} [Ring A] [Algebra k A]
-    (e : A ≃ₐ[k] (∀ i, Matrix (Fin (d i)) (Fin (d i)) (D i))) :
-    Nonempty (K ⊗[k] A ≃ₐ[K] (∀ i, Matrix (Fin (d i)) (Fin (d i)) (K ⊗[k] D i))) := by
-  sorry
 
 /-- **Base change of a semisimple algebra can only increase the number of simple modules.**
 For a finite-dimensional **semisimple** `k`-algebra `A` and any field extension `K ⊇ k`,

--- a/progress/2026-07-10T14-22-00Z_8c8dd921.md
+++ b/progress/2026-07-10T14-22-00Z_8c8dd921.md
@@ -1,0 +1,37 @@
+## Accomplished
+
+Feature session — issue #6174 (Ch4): wired the already-proved
+`Etingof.nonempty_baseChange_pi_matrix_algEquiv` into
+`Exercise4_2_3_SemisimpleBaseChange.lean`.
+
+- Added `import EtingofRepresentationTheory.Chapter4.Exercise4_2_3_BaseChangePiMatrix`.
+- Deleted the local sorried duplicate `nonempty_baseChange_pi_matrix_algEquiv`
+  (declaration + docstring, formerly ~lines 375-384). The call site inside
+  `natCard_simpleModuleClasses_le_baseChange_of_isSemisimpleRing` resolves to the
+  imported proved version with no other edits (`k K` are explicit `variable`s in the
+  leaf file, so the elaborated signature matches the `... k K D d e` call verbatim).
+- `lake build` of the file succeeds; `grep` shows no `sorry` remaining.
+- `#print axioms Etingof.natCard_simpleModuleClasses_le_baseChange_of_isSemisimpleRing`
+  → `[propext, Classical.choice, Quot.sound]` (no `sorryAx`). The crux is now sorry-free.
+
+## Current frontier
+
+Issue #6174 complete; PR being created. This closes the last gap in the
+separability-free base-change chain that #6127 and #6139 sit on.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. The semisimple base-change count crux
+(`natCard_simpleModuleClasses_le_baseChange_of_isSemisimpleRing`) is now fully
+proved, unblocking the count-monotonicity work in #6127/#6136 and strict
+`Exercise_4_2_3` (#6139).
+
+## Next step
+
+Downstream consumers #6127 (`natCard_irrepClasses_le_of_ringHom_field`) and #6139
+(strict `Exercise_4_2_3`) can now build on a sorry-free crux. Note the remaining
+`sorry` at `Exercise4_2_3.lean:687` is a separate declaration, out of scope here.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6174

Session: `8c8dd921-74b0-4af8-a15c-b8ae023e65ba`

658db280 chore(#6174): progress file for base-change wiring cleanup
5125adb3 feat(Ch4 #6174): wire proved nonempty_baseChange_pi_matrix_algEquiv into SemisimpleBaseChange

🤖 Prepared with Claude Code