### PR TITLE
feat(Ch2 #6179): prove finrank_eq_zero_of_charZero via trace argument

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Problem2_7_4.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_7_4.lean
@@ -4,6 +4,7 @@ import Mathlib.RingTheory.SimpleModule.Basic
 import Mathlib.Algebra.Algebra.Subalgebra.Basic
 import Mathlib.Algebra.CharP.Basic
 import Mathlib.LinearAlgebra.FiniteDimensional.Defs
+import Mathlib.LinearAlgebra.Trace
 
 /-!
 # Problem 2.7.4: Representations and ideals of the Weyl algebra
@@ -113,8 +114,23 @@ representation: any finite dimensional `A`-module (as a `k`-vector space) is zer
 theorem finrank_eq_zero_of_charZero (k : Type*) [Field k] [CharZero k]
     (V : Type*) [AddCommGroup V] [Module k V] [Module (WeylAlgebra k) V]
     [IsScalarTower k (WeylAlgebra k) V] [FiniteDimensional k V] :
-    Module.finrank k V = 0 :=
-  sorry
+    Module.finrank k V = 0 := by
+  -- The action of `A` on `V` gives `k`-linear endomorphisms `X, Y` with `Y * X = X * Y + 1`
+  -- (the image of the defining relation `yx = xy + 1`).
+  haveI : SMulCommClass (WeylAlgebra k) k V :=
+    ⟨fun a c v => by
+      simp only [← algebraMap_smul (WeylAlgebra k) c, ← mul_smul, Algebra.commutes]⟩
+  let φ : WeylAlgebra k →ₐ[k] Module.End k V := Algebra.lsmul k k V
+  set X := φ (WeylAlgebra.x k) with hX
+  set Y := φ (WeylAlgebra.y k) with hY
+  have hcomm : Y * X = X * Y + 1 := by
+    rw [hX, hY, ← map_mul, ← map_mul, ← map_one φ, ← map_add, WeylAlgebra.yx_eq]
+  -- Take traces: `Tr(Y*X) = Tr(X*Y)`, but `Y*X = X*Y + 1`, so `Tr(1) = 0`, i.e. `finrank = 0`.
+  have htr : LinearMap.trace k V (Y * X) = LinearMap.trace k V (X * Y) :=
+    LinearMap.trace_mul_comm k Y X
+  rw [hcomm, map_add, LinearMap.trace_one] at htr
+  have hfin : (Module.finrank k V : k) = 0 := by linear_combination htr
+  exact_mod_cast hfin
 
 /-- **(a)** In characteristic `0`, the Weyl algebra is a simple ring: its only two-sided ideals
 are `0` and the whole algebra. -/

--- a/progress/2026-07-10T14-36-33Z_ffce94a9.md
+++ b/progress/2026-07-10T14-36-33Z_ffce94a9.md
@@ -1,0 +1,43 @@
+## Accomplished
+
+Session type: **feature** (issue #6179, char-`0` part (a) of Etingof Problem 2.7.4).
+
+Proved `finrank_eq_zero_of_charZero` sorry-free in
+`EtingofRepresentationTheory/Chapter2/Problem2_7_4.lean` (deliverable 1 of #6179):
+
+- Introduced the `SMulCommClass (WeylAlgebra k) k V` instance locally (from the scalar tower +
+  centrality of the algebra map) so that `Algebra.lsmul k k V : WeylAlgebra k →ₐ[k] Module.End k V`
+  is available.
+- Let `X = φ x`, `Y = φ y` be the endomorphisms of the action; the defining relation
+  `WeylAlgebra.yx_eq` transports through the algebra hom to `Y * X = X * Y + 1`.
+- `LinearMap.trace_mul_comm` gives `Tr(Y*X) = Tr(X*Y)`; combined with `Y*X = X*Y+1` and
+  `LinearMap.trace_one` (`= (finrank : k)`), this forces `(finrank k V : k) = 0`, hence
+  `finrank k V = 0` in `CharZero` (`exact_mod_cast`).
+- Added `import Mathlib.LinearAlgebra.Trace`.
+
+Deliverable 2 (`isSimpleRing_charZero`) was **not** attempted: after scoping it, it requires a
+bidegree function on `WeylAlgebra k` (from the char-`0` monomial basis `Proposition_2_7_1`) plus
+the two `ad`-lowering lemmas and a leading-term argument — much larger than deliverable 1, which
+issue #6179 explicitly anticipated. Decomposed into #6187 with a detailed proof strategy.
+
+## Current frontier
+
+`Problem2_7_4.lean` builds. Remaining sorries in the file:
+- `isSimpleRing_charZero` — now owned by #6187.
+- `center_charP`, `finrank_irreducible_charP` — owned by sibling #6178 (char-`p`, untouched).
+
+## Overall project progress
+
+Chapter 2 Problem 2.7.4: part (a) trace result done; part (a) simple-ring (#6187), parts (b)/(c)
+(#6178) remain. Statement-pass structure intact.
+
+## Next step
+
+Claim #6187: build the bidegree infrastructure and prove `isSimpleRing_charZero`. See the issue
+body for the full strategy (ad_x lowers y-degree, ad_y lowers x-degree, reduce a nonzero ideal
+element to a nonzero scalar = unit).
+
+## Blockers
+
+None. #6187 is self-contained (depends only on already-proved lemmas in the same file and
+`Proposition2_7_1.lean`).


### PR DESCRIPTION
Partial progress on #6179

Session: `ffce94a9-83a2-4a2f-bb29-3ce758cc91d9`

288ba78a chore(#6179): progress entry — deliverable 1 done, deliverable 2 split into #6187
c9e7dc1f feat(Ch2 #6179): prove finrank_eq_zero_of_charZero via trace argument

🤖 Prepared with Claude Code