### PR TITLE
feat(Ch8 #6184): horseshoe chain maps α,β + degreewise-split ShortExact of complexes

### DIFF
--- a/EtingofRepresentationTheory/Chapter8/Horseshoe.lean
+++ b/EtingofRepresentationTheory/Chapter8/Horseshoe.lean
@@ -229,6 +229,66 @@ instance horseshoeComplex_projective (n : ℕ) :
   dsimp [horseshoeComplex, ChainComplex.of]
   infer_instance
 
+/-! ### The chain maps and the degreewise-split short exact sequence
+
+The horseshoe complex sits in a short exact sequence of complexes
+`0 → P₁.complex →ᵅ horseshoeComplex →ᵝ P₃.complex → 0`, with `α` the degreewise `biprod.inl` and
+`β` the degreewise `biprod.snd`. Each degree is the split biproduct short exact sequence, so the
+whole sequence is degreewise split and hence `ShortExact`. -/
+
+/-- The horseshoe chain map `α : P₁.complex ⟶ horseshoeComplex`, degreewise `biprod.inl`. The
+chain-map square holds because the twisted differential is lower triangular:
+`biprod.inl ≫ horseshoeD n = biprod.lift d¹ 0 = d¹ ≫ biprod.inl`. -/
+noncomputable def horseshoeα : P₁.complex ⟶ horseshoeComplex hS P₁ P₃ :=
+  ChainComplex.ofHom
+    (fun i => (biprod.inl : P₁.complex.X i ⟶ P₁.complex.X i ⊞ P₃.complex.X i))
+    (fun n => by
+      simp only [horseshoeComplex, ChainComplex.of_d, horseshoeD_inl]
+      apply biprod.hom_ext <;> simp)
+
+/-- The horseshoe chain map `β : horseshoeComplex ⟶ P₃.complex`, degreewise `biprod.snd`. The
+chain-map square holds because `horseshoeD n ≫ biprod.snd = biprod.desc 0 d³ = biprod.snd ≫ d³`. -/
+noncomputable def horseshoeβ : horseshoeComplex hS P₁ P₃ ⟶ P₃.complex :=
+  ChainComplex.ofHom
+    (fun i => (biprod.snd : P₁.complex.X i ⊞ P₃.complex.X i ⟶ P₃.complex.X i))
+    (fun n => by
+      simp only [horseshoeComplex, ChainComplex.of_d, horseshoeD_snd]
+      apply biprod.hom_ext' <;> simp)
+
+@[simp] lemma horseshoeα_f (i : ℕ) :
+    (horseshoeα hS P₁ P₃).f i
+      = (biprod.inl : P₁.complex.X i ⟶ P₁.complex.X i ⊞ P₃.complex.X i) := rfl
+
+@[simp] lemma horseshoeβ_f (i : ℕ) :
+    (horseshoeβ hS P₁ P₃).f i
+      = (biprod.snd : P₁.complex.X i ⊞ P₃.complex.X i ⟶ P₃.complex.X i) := rfl
+
+/-- `α ≫ β = 0`, degreewise `biprod.inl ≫ biprod.snd = 0`. -/
+lemma horseshoeα_comp_horseshoeβ :
+    horseshoeα hS P₁ P₃ ≫ horseshoeβ hS P₁ P₃ = 0 := by
+  ext n
+  simp
+
+/-- The horseshoe short complex of chain complexes
+`0 → P₁.complex → horseshoeComplex → P₃.complex → 0`. -/
+noncomputable def horseshoeShortComplex : ShortComplex (ChainComplex C ℕ) :=
+  ShortComplex.mk (horseshoeα hS P₁ P₃) (horseshoeβ hS P₁ P₃) (horseshoeα_comp_horseshoeβ hS P₁ P₃)
+
+/-- The explicit degreewise splitting of the horseshoe short complex: in each degree `i` it is the
+split biproduct sequence `0 → P₁ᵢ → P₁ᵢ ⊞ P₃ᵢ → P₃ᵢ → 0`. Keeping the splitting explicit lets a
+downstream additive functor transport it, so the image sequence stays short exact. -/
+noncomputable def horseshoeSplitting (i : ℕ) :
+    ((horseshoeShortComplex hS P₁ P₃).map
+      (HomologicalComplex.eval C (ComplexShape.down ℕ) i)).Splitting :=
+  ShortComplex.Splitting.ofHasBinaryBiproduct (P₁.complex.X i) (P₃.complex.X i)
+
+/-- **The horseshoe short exact sequence of complexes.** Degreewise it is the split biproduct
+sequence, hence short exact in each degree, hence short exact as a sequence of complexes. -/
+lemma horseshoeShortComplex_shortExact :
+    (horseshoeShortComplex hS P₁ P₃).ShortExact :=
+  HomologicalComplex.shortExact_of_degreewise_shortExact _
+    (fun i => (horseshoeSplitting hS P₁ P₃ i).shortExact)
+
 end Augmentation
 
 /-- **The horseshoe lemma.** A short exact sequence `S : 0 → X₁ → X₂ → X₃ → 0` in an abelian

--- a/progress/2026-07-10T15-16-40Z_0ae0232e.md
+++ b/progress/2026-07-10T15-16-40Z_0ae0232e.md
@@ -1,0 +1,47 @@
+## Accomplished
+
+Feature session on issue #6196 (Ch8 #6184): built the horseshoe chain maps and the
+degreewise-split short exact sequence of complexes, on top of the twisted `horseshoeComplex`
+data from #6195. In `EtingofRepresentationTheory/Chapter8/Horseshoe.lean`:
+
+- `horseshoeα : P₁.complex ⟶ horseshoeComplex` — degreewise `biprod.inl`, via `ChainComplex.ofHom`.
+  Chain-map square: `biprod.inl ≫ horseshoeD n = biprod.lift d¹ 0 = d¹ ≫ biprod.inl` (lower
+  triangular), discharged by `horseshoeD_inl` + `biprod.hom_ext`.
+- `horseshoeβ : horseshoeComplex ⟶ P₃.complex` — degreewise `biprod.snd`. Square via
+  `horseshoeD_snd` (`horseshoeD n ≫ biprod.snd = biprod.desc 0 d³ = biprod.snd ≫ d³`) +
+  `biprod.hom_ext'`.
+- `horseshoeα_f`, `horseshoeβ_f` simp lemmas exposing the degreewise components.
+- `horseshoeα_comp_horseshoeβ` (`w`): `α ≫ β = 0`, degreewise `biprod.inl ≫ biprod.snd = 0`.
+- `horseshoeShortComplex := ShortComplex.mk α β w`.
+- `horseshoeSplitting i` — the explicit degreewise `ShortComplex.Splitting` of the mapped short
+  complex, via `ShortComplex.Splitting.ofHasBinaryBiproduct` (the mapped short complex is defeq to
+  the split biproduct sequence `0 → P₁ᵢ → P₁ᵢ ⊞ P₃ᵢ → P₃ᵢ → 0`). Kept explicit so the successor
+  (Tor/Ext LES) can transport it through additive functors.
+- `horseshoeShortComplex_shortExact` — the SES of complexes, via
+  `HomologicalComplex.shortExact_of_degreewise_shortExact` + `Splitting.shortExact`.
+
+`#print axioms` on `horseshoeα`, `horseshoeβ`, `horseshoeShortComplex_shortExact`: only
+`propext, Classical.choice, Quot.sound` (no `sorryAx`).
+
+## Current frontier
+
+The `def`s are sorry-free. The only remaining `sorry` in the file is the top-level `horseshoe`
+theorem, which the issue explicitly permits to stay sorried.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. Horseshoe infrastructure (#6184) now has: twisted differential +
+chain complex `P₂` (#6195), and chain maps + degreewise-split SES of complexes (#6196, this turn).
+Remaining for the parent: assemble the `ProjectiveResolution S.X₂` (quasi-iso via homology LES) and
+close the `horseshoe` theorem — that is issue #6197, previously blocked on #6196, now unblocked.
+
+## Next step
+
+Pick up #6197: prove `horseshoeComplex` is a projective resolution of `S.X₂` (homology LES forces
+exactness off degree 0 with H₀ = X₂), assemble the `ProjectiveResolution`, and discharge the
+`horseshoe` theorem sorry using `horseshoeShortComplex_shortExact` + the augmentation squares
+(`horseshoeπZero_*`).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6196

Session: `0ae0232e-5982-43a9-9791-e7fa5d39a37f`

8593221d feat(Ch8 #6196): horseshoe chain maps α,β + degreewise-split ShortExact of complexes

🤖 Prepared with Claude Code