### PR TITLE
doc(Ch8): review horseshoe construction; correct differential to upper triangular

### DIFF
--- a/EtingofRepresentationTheory/Chapter8/Horseshoe.lean
+++ b/EtingofRepresentationTheory/Chapter8/Horseshoe.lean
@@ -42,7 +42,8 @@ Write `S.f : X₁ ⟶ X₂`, `S.g : X₂ ⟶ X₃`, `ε₁ := P₁.π.f 0`, `ε�
 * Augmentation: choose a lift `h₀ : P₃₀ ⟶ X₂` of `ε₃` through the epi `S.g` (projectivity of
   `P₃₀`; `g ∘ h₀ = ε₃`). Set `ε₂ := biprod.desc (ε₁ ≫ S.f) h₀ : P₁₀ ⊞ P₃₀ ⟶ X₂`; it is epi and
   satisfies `α.f 0 ≫ ε₂ = ε₁ ≫ S.f` and `β.f 0 ≫ S.g ∘ ... = ...` giving the two squares.
-* Differentials `d²ₙ = ⟪⟪d¹ₙ, sₙ⟫, ⟪0, d³ₙ⟫⟫` (lower triangular biproduct matrix) with
+* Differentials `d²ₙ = ⟪⟪d¹ₙ, sₙ⟫, ⟪0, d³ₙ⟫⟫`, the upper triangular biproduct matrix
+  `[[d¹, s], [0, d³]]` (zero below the diagonal), with
   off-diagonal lift `sₙ : P₃ₙ ⟶ P₁_{n-1}` built by induction: projectivity of `P₃ₙ` against the
   epi `d¹_{n-1} : P₁ₙ ↠ ker …` (equivalently `Exercise_8_1_4`) produces `sₙ` making
   `d¹_{n-1} ≫ sₙ = - sₙ₋₁ ≫ d³ₙ` and `ε₂`-compatibility hold; this uses the exactness of the
@@ -111,7 +112,7 @@ lemma horseshoeπZero_comp_g :
 /-! ### The twisted differential and the horseshoe chain complex
 
 We now construct the *data* of the horseshoe resolution `P₂` of `S.X₂`: the terms
-`P₁.X n ⊞ P₃.X n`, the lower-triangular twisted differential `⟪⟪d¹, s⟫, ⟪0, d³⟫⟫`, and the
+`P₁.X n ⊞ P₃.X n`, the upper-triangular twisted differential `⟪⟪d¹, s⟫, ⟪0, d³⟫⟫`, and the
 off-diagonal lift family `s` built by induction against the exactness of the *given* resolutions
 `P₁`, `P₃`. -/
 
@@ -187,8 +188,9 @@ lemma horseshoeTwist_comp (n : ℕ) :
       = -(P₃.complex.d (n + 2) (n + 1)) ≫ horseshoeTwist hS P₁ P₃ n := by
   rw [horseshoeTwist_succ]; exact (horseshoeTwistAux hS P₁ P₃ n).2.2
 
-/-- The lower-triangular twisted differential
-`d²ₙ = ⟪⟪d¹ₙ, sₙ⟫, ⟪0, d³ₙ⟫⟫ : P₁_{n+1} ⊞ P₃_{n+1} ⟶ P₁_n ⊞ P₃_n`. -/
+/-- The upper-triangular twisted differential
+`d²ₙ = ⟪⟪d¹ₙ, sₙ⟫, ⟪0, d³ₙ⟫⟫ : P₁_{n+1} ⊞ P₃_{n+1} ⟶ P₁_n ⊞ P₃_n` (matrix `[[d¹, s], [0, d³]]`,
+zero below the diagonal). -/
 noncomputable def horseshoeD (n : ℕ) :
     P₁.complex.X (n + 1) ⊞ P₃.complex.X (n + 1) ⟶ P₁.complex.X n ⊞ P₃.complex.X n :=
   biprod.lift (biprod.desc (P₁.complex.d (n + 1) n) (horseshoeTwist hS P₁ P₃ n))
@@ -237,8 +239,8 @@ The horseshoe complex sits in a short exact sequence of complexes
 whole sequence is degreewise split and hence `ShortExact`. -/
 
 /-- The horseshoe chain map `α : P₁.complex ⟶ horseshoeComplex`, degreewise `biprod.inl`. The
-chain-map square holds because the twisted differential is lower triangular:
-`biprod.inl ≫ horseshoeD n = biprod.lift d¹ 0 = d¹ ≫ biprod.inl`. -/
+chain-map square holds because the twisted differential is upper triangular, so its `P₁` column
+has no `P₃` component: `biprod.inl ≫ horseshoeD n = biprod.lift d¹ 0 = d¹ ≫ biprod.inl`. -/
 noncomputable def horseshoeα : P₁.complex ⟶ horseshoeComplex hS P₁ P₃ :=
   ChainComplex.ofHom
     (fun i => (biprod.inl : P₁.complex.X i ⟶ P₁.complex.X i ⊞ P₃.complex.X i))

--- a/progress/2026-07-10T15-48-43Z_e7d49403.md
+++ b/progress/2026-07-10T15-48-43Z_e7d49403.md
@@ -1,0 +1,69 @@
+## Accomplished
+
+Review session for #6211 — audit of the Chapter 8 horseshoe-lemma construction
+(`EtingofRepresentationTheory/Chapter8/Horseshoe.lean`) for vacuousness, statement
+fidelity, and axiom cleanliness. **Verdict: PASS**, with one docstring correction applied.
+
+### 1. Non-vacuousness of the `def`s — PASS
+Every landed `def`/`instance` builds a real object:
+- `horseshoeD n = biprod.lift (biprod.desc d¹ s) (biprod.desc 0 d³)` is genuinely the
+  twisted differential `[[d¹, s], [0, d³]]`; confirmed via `horseshoeD_inl`
+  (`biprod.inl ≫ D = biprod.lift d¹ 0`), `horseshoeD_snd`, and `horseshoeD_inr`.
+  `horseshoeComplex` uses it as its `ChainComplex.of` differential, and
+  `horseshoeD_comp_horseshoeD` proves `d ≫ d = 0` with the `P₃ → P₁` corner discharged
+  by the twist relation.
+- `horseshoeTwist n = (horseshoeTwistAux n).1` is the recursively-built lift; `horseshoeTwistAux`
+  is a genuine `ℕ`-recursion (base pair seeded from the augmentation `h₀ = factorThru (P₃.π.f 0) S.g`
+  via `hS.exact.lift`, step via `ProjectiveResolution.exact_succ`). `horseshoeTwist_comp` proves
+  `sₙ₊₁ ≫ d¹ = -(d³) ≫ sₙ`.
+- `horseshoeSplitting i = ShortComplex.Splitting.ofHasBinaryBiproduct (P₁.X i) (P₃.X i)` is a
+  genuine splitting of the *mapped* short complex `(horseshoeShortComplex.map (eval i))` — it
+  typechecks only because that mapped complex is defeq to the split biproduct sequence
+  `0 → P₁ᵢ → P₁ᵢ ⊞ P₃ᵢ → P₃ᵢ → 0`. `horseshoeShortComplex_shortExact` is derived degreewise from it
+  via `HomologicalComplex.shortExact_of_degreewise_shortExact`.
+
+### 2. Statement fidelity — PASS
+- `horseshoeShortComplex` is `0 → P₁.complex → horseshoeComplex → P₃.complex → 0` with
+  `horseshoeComplex.X n = P₁.X n ⊞ P₃.X n`; `horseshoeα_f`/`horseshoeβ_f` confirm `α`/`β` are the
+  expected `biprod.inl`/`biprod.snd` degreewise (both `rfl`).
+- The two degree-0 augmentation lemmas exactly supply the theorem's conclusion squares:
+  `horseshoeπZero_inl` gives `α.f 0 ≫ π = P₁.π.f 0 ≫ S.f`, and `horseshoeπZero_comp_g` gives
+  `β.f 0 ≫ P₃.π.f 0 = π ≫ S.g`.
+- The top-level `horseshoe` signature (`∃ P₂ α β w, ShortExact ∧ aug₁ ∧ aug₂`) is the correct
+  abstract horseshoe lemma. Its `ShortExact`-only conclusion (not degreewise-split) is **sufficient**
+  for the downstream six-term LES: `LeftDerivedSequence.lean:70-74` recovers the split via
+  `shortExact_map_of_degreewise_projective F hSE (fun i => P₃.projective i)` — projectivity of the
+  `P₃` terms, not an extra hypothesis. So no fidelity gap. `horseshoe`'s `sorry` (#6197) left alone.
+
+### 3. Axiom cleanliness — PASS
+`#print axioms` on all 25 landed declarations: each depends only on
+`[propext, Classical.choice, Quot.sound]`. Only `horseshoe` itself carries `sorryAx`, exactly as
+expected (in-flight #6197). No `sorryAx` leaks anywhere else.
+
+### Docstring correction applied
+The differential matrix `[[d¹, s], [0, d³]]` (zero below the diagonal, lift `s` above) is
+**upper triangular**, but four docstrings (module overview lines 45/114, `horseshoeD`, `horseshoeα`)
+called it "lower triangular". Corrected to "upper triangular", matching the issue's own description
+and the actual biproduct matrix. Docstring-only; construction unchanged; file still builds
+(`lake build EtingofRepresentationTheory.Chapter8.Horseshoe`, only the expected `horseshoe` sorry
+warning).
+
+## Current frontier
+
+Review complete. No follow-up `feature` issue needed — the construction is a faithful, non-vacuous
+formalization of the horseshoe lemma. The only remaining `sorry` is the top-level `horseshoe`
+theorem, tracked by #6197 (out of scope here).
+
+## Overall project progress
+
+Chapter 8 homological cluster: horseshoe *data* landed sorry-free and now audited clean. The
+six-term left-derived exact sequence (#6210) consumes it. Only `horseshoe` (#6197) remains sorried.
+
+## Next step
+
+Land #6197 (prove `horseshoe`) — assemble the audited pieces into a `ProjectiveResolution S.X₂`
+plus the SES and augmentation squares.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6211

Session: `e7d49403-e353-4e38-af1f-160d56e6926e`

0f5f436e doc(Ch8 #6211): correct horseshoe differential to upper triangular

🤖 Prepared with Claude Code