### PR TITLE
feat(Ch5 #Problem5.24.1a): prove rowColIdeal_iso_spechtModule (two Young-symmetrizer orderings give isomorphic Sₙ-reps)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Problem5_24_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_24_1.lean
@@ -24,7 +24,13 @@ We write `rowColIdeal la := ℂ[S_n] · (a_λ b_λ)` (the book's `V_λ`) and com
 left multiplication, which is exactly the `ℂ[S_n]`-module scalar action `of(g) • ·`. The claim
 is a `ℂ`-linear isomorphism intertwining these actions.
 
-Statement pass: the proof is left as `sorry`.
+The proof follows the book's hint: `f(x) = x · a_λ` maps `V_λ → V'_λ` and `g(y) = y · b_λ`
+maps `V'_λ → V_λ`; both are right multiplications, hence left-`ℂ[S_n]`-linear (so they
+intertwine the `of(g) • ·` action). The composites `g ∘ f` and `f ∘ g` are right
+multiplication by `a_λ b_λ` and `b_λ a_λ`; the Young-symmetrizer scalar identity
+`c_λ² = α · c_λ` (Lemma 5.13.3, with the mirror identity from `Lemma5_13_1_dual`, both
+scalars equal via `c_λ³ = α² c_λ`) makes each composite `α · id` with `α ≠ 0`, so `f` is
+bijective.
 -/
 
 namespace Etingof
@@ -45,6 +51,112 @@ theorem rowColIdeal_iso_spechtModule (n : ℕ) (la : Nat.Partition n) :
       ∀ (g : Equiv.Perm (Fin n)) (x : ↥(rowColIdeal n la)),
         e ((MonoidAlgebra.of ℂ (Equiv.Perm (Fin n)) g) • x)
           = (MonoidAlgebra.of ℂ (Equiv.Perm (Fin n)) g) • e x := by
-  sorry
+  classical
+  -- Scalar identities from the Young-symmetrizer machinery.
+  obtain ⟨α, hα⟩ := Etingof.Lemma5_13_3 n la
+  obtain ⟨ℓ, hℓ⟩ := Etingof.Lemma5_13_1_dual n la
+  have hsq := young_symmetrizer_sq_ne_zero n la
+  -- Abbreviate the row symmetrizer `a`, the column antisymmetrizer `b`.
+  set a := RowSymmetrizer n la with ha_def
+  set b := ColumnAntisymmetrizer n la with hb_def
+  have hY : YoungSymmetrizer n la = b * a := rfl
+  rw [hY] at hα hsq
+  -- `c = b * a` satisfies `c² = α c` with `α ≠ 0`; `hℓ x : a * x * b = ℓ x • (a * b)`.
+  have hα_ne : α ≠ 0 := fun h => hsq (by rw [hα, h, zero_smul])
+  have hbne : b * a ≠ 0 := fun h => hsq (by rw [h, mul_zero])
+  -- The mirror identity: `d² = ℓ(b*a) • d` for `d = a * b`.
+  have hd2 : (a * b) * (a * b) = ℓ (b * a) • (a * b) := by
+    have h := hℓ (b * a)
+    calc (a * b) * (a * b) = a * (b * a) * b := by simp only [mul_assoc]
+      _ = ℓ (b * a) • (a * b) := h
+  -- The two scalars agree: `ℓ(b*a) = α` (both come from `c³ = α² c`).
+  have hβα : ℓ (b * a) = α := by
+    have cube1 : b * ((a * b) * (a * b)) * a = (α * α) • (b * a) := by
+      have e : b * ((a * b) * (a * b)) * a = ((b * a) * (b * a)) * (b * a) := by
+        simp only [mul_assoc]
+      rw [e, hα, smul_mul_assoc, hα, smul_smul]
+    have cube2 : b * ((a * b) * (a * b)) * a = (ℓ (b * a) * α) • (b * a) := by
+      rw [hd2, mul_smul_comm, smul_mul_assoc]
+      have e2 : b * (a * b) * a = (b * a) * (b * a) := by simp only [mul_assoc]
+      rw [e2, hα, smul_smul]
+    have hαβ : (α * α) • (b * a) = (ℓ (b * a) * α) • (b * a) := by rw [← cube1, cube2]
+    have hzero : (α * α - ℓ (b * a) * α) • (b * a) = (0 : SymGroupAlgebra n) := by
+      rw [sub_smul, hαβ, sub_self]
+    rcases smul_eq_zero.mp hzero with h | h
+    · exact (mul_right_cancel₀ hα_ne (sub_eq_zero.mp h)).symm
+    · exact absurd h hbne
+  rw [hβα] at hd2
+  -- Describe the two left ideals as span of a single generator.
+  have hRC : rowColIdeal n la = Submodule.span (SymGroupAlgebra n) {a * b} := by
+    simp only [rowColIdeal, ← ha_def, ← hb_def]
+  have hSM : SpechtModule n la = Submodule.span (SymGroupAlgebra n) {b * a} := by
+    simp only [SpechtModule, hY]
+  -- Right multiplication by `a` (resp. `b`), as a left-`ℂ[Sₙ]`-linear endomorphism.
+  let Fa : SymGroupAlgebra n →ₗ[SymGroupAlgebra n] SymGroupAlgebra n :=
+    { toFun := fun x => x * a
+      map_add' := fun x y => add_mul x y a
+      map_smul' := fun s x => by simp only [RingHom.id_apply, smul_eq_mul, mul_assoc] }
+  let Gb : SymGroupAlgebra n →ₗ[SymGroupAlgebra n] SymGroupAlgebra n :=
+    { toFun := fun x => x * b
+      map_add' := fun x y => add_mul x y b
+      map_smul' := fun s x => by simp only [RingHom.id_apply, smul_eq_mul, mul_assoc] }
+  have hFa_maps : ∀ x ∈ rowColIdeal n la, Fa x ∈ SpechtModule n la := by
+    intro x hx
+    rw [hRC, Submodule.mem_span_singleton] at hx
+    obtain ⟨r, hr⟩ := hx
+    rw [hSM, Submodule.mem_span_singleton]
+    refine ⟨r * a, ?_⟩
+    change (r * a) • (b * a) = x * a
+    rw [← hr]; simp only [smul_eq_mul, mul_assoc]
+  have hGb_maps : ∀ y ∈ SpechtModule n la, Gb y ∈ rowColIdeal n la := by
+    intro y hy
+    rw [hSM, Submodule.mem_span_singleton] at hy
+    obtain ⟨s, hs⟩ := hy
+    rw [hRC, Submodule.mem_span_singleton]
+    refine ⟨s * b, ?_⟩
+    change (s * b) • (a * b) = y * b
+    rw [← hs]; simp only [smul_eq_mul, mul_assoc]
+  let F : ↥(rowColIdeal n la) →ₗ[SymGroupAlgebra n] ↥(SpechtModule n la) := Fa.restrict hFa_maps
+  let G : ↥(SpechtModule n la) →ₗ[SymGroupAlgebra n] ↥(rowColIdeal n la) := Gb.restrict hGb_maps
+  -- The composites are `α • id`.
+  have hGF : ∀ x : ↥(rowColIdeal n la), G (F x) = α • x := by
+    intro x
+    apply Subtype.ext
+    rw [Submodule.coe_smul_of_tower]
+    change (x.val * a) * b = α • x.val
+    have hx : (x : SymGroupAlgebra n) ∈ Submodule.span (SymGroupAlgebra n) {a * b} := by
+      rw [← hRC]; exact x.property
+    obtain ⟨r, hr⟩ := Submodule.mem_span_singleton.mp hx
+    rw [← hr]; simp only [smul_eq_mul]
+    rw [show (r * (a * b)) * a * b = r * ((a * b) * (a * b)) by simp only [mul_assoc],
+      hd2, mul_smul_comm]
+  have hFG : ∀ y : ↥(SpechtModule n la), F (G y) = α • y := by
+    intro y
+    apply Subtype.ext
+    rw [Submodule.coe_smul_of_tower]
+    change (y.val * b) * a = α • y.val
+    have hy : (y : SymGroupAlgebra n) ∈ Submodule.span (SymGroupAlgebra n) {b * a} := by
+      rw [← hSM]; exact y.property
+    obtain ⟨s, hs⟩ := Submodule.mem_span_singleton.mp hy
+    rw [← hs]; simp only [smul_eq_mul]
+    rw [show (s * (b * a)) * b * a = s * ((b * a) * (b * a)) by simp only [mul_assoc],
+      hα, mul_smul_comm]
+  -- `F` restricted to a `ℂ`-linear map is bijective, giving the `ℂ`-linear equivalence.
+  let Fℂ : ↥(rowColIdeal n la) →ₗ[ℂ] ↥(SpechtModule n la) := F.restrictScalars ℂ
+  have hinj : Function.Injective Fℂ := by
+    intro x y hxy
+    have h1 : G (F x) = G (F y) := by rw [show F x = F y from hxy]
+    rw [hGF, hGF] at h1
+    have h2 : α⁻¹ • (α • x) = α⁻¹ • (α • y) := by rw [h1]
+    rwa [smul_smul, smul_smul, inv_mul_cancel₀ hα_ne, one_smul, one_smul] at h2
+  have hsurj : Function.Surjective Fℂ := by
+    intro y
+    refine ⟨α⁻¹ • G y, ?_⟩
+    have h1 : Fℂ (α⁻¹ • G y) = α⁻¹ • (α • y) := by
+      rw [map_smul, show Fℂ (G y) = α • y from hFG y]
+    rw [h1, smul_smul, inv_mul_cancel₀ hα_ne, one_smul]
+  refine ⟨LinearEquiv.ofBijective Fℂ ⟨hinj, hsurj⟩, ?_⟩
+  intro g x
+  exact F.map_smul (MonoidAlgebra.of ℂ (Equiv.Perm (Fin n)) g) x
 
 end Etingof

--- a/progress/2026-07-10T16-04-17Z_4be5a3da.md
+++ b/progress/2026-07-10T16-04-17Z_4be5a3da.md
@@ -1,0 +1,47 @@
+## Accomplished
+
+Claimed and fully delivered issue #6214: proved `Etingof.rowColIdeal_iso_spechtModule`
+(Problem 5.24.1(a)) in `EtingofRepresentationTheory/Chapter5/Problem5_24_1.lean`,
+sorry-free and axiom-clean (`propext`, `Classical.choice`, `Quot.sound` only).
+
+The theorem shows the two orderings of the Young symmetrizer generate isomorphic
+`S_n`-representations: `ℂ[S_n]·(a_λ b_λ) = V_λ ≅ ℂ[S_n]·(b_λ a_λ) = V'_λ`, via a `ℂ`-linear
+equivalence intertwining the left-multiplication (`of(g) • ·`) actions.
+
+Proof structure (following the book hint):
+- The two ideal generators are `d = a·b` (rowColIdeal) and `c = b·a` (SpechtModule =
+  YoungSymmetrizer). Maps `f(x) = x·a : V_λ → V'_λ` and `g(y) = y·b : V'_λ → V_λ` are right
+  multiplications, built as **left-`ℂ[S_n]`-linear** endomorphisms of the group algebra and
+  `LinearMap.restrict`-ed to the ideals. Left-linearity makes the `of(g) • ·` intertwining
+  automatic (`F.map_smul`).
+- Composites: `g∘f` = right-mult by `d`, `f∘g` = right-mult by `c`. Reused
+  `Lemma5_13_3` (`c² = α·c`), `young_symmetrizer_sq_ne_zero` (`α ≠ 0`), and
+  `Lemma5_13_1_dual` (`a·x·b = ℓ(x)•(a·b)`, giving `d² = ℓ(b·a)•d`).
+- Key new step: the two scalars coincide (`ℓ(b·a) = α`), proved by computing
+  `b·d²·a = c³ = α²·c` two ways and cancelling the nonzero `c = b·a`. Hence both composites
+  are `α·id` with `α ≠ 0`, so `f` (restricted to `ℂ`) is bijective; packaged via
+  `LinearEquiv.ofBijective`.
+
+Updated `progress/items.json` (`Chapter5/Problem5.24.1` coverage note: part (a) now proved;
+part (b) remains statement-only in `Problem5_24_1_b.lean`, out of scope for this issue).
+
+## Current frontier
+
+Problem 5.24.1(a) complete. Part (b) (`V_λ ⊗ ℂ_- = V_{λ*}` via the sign-twist automorphism)
+is still statement-only in `Problem5_24_1_b.lean` — separate item, not claimed here.
+
+## Overall project progress
+
+Phase 3 formalization ongoing. Chapter 5 Specht/Young machinery gains another sorry-free
+result. Remaining unclaimed feature issues at session start: #6213 (Ch4 icosahedral A₅
+decompositions, 3 sorries), #6215 (Ch5 Exercise 5.3.3, odd-order irreducibles are complex
+type).
+
+## Next step
+
+Merge the PR for #6214. A worker can then pick up #6213 or #6215. Part (b) of Problem 5.24.1
+could be a future item now that part (a) is available to cite.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -4944,7 +4944,7 @@
     "start_line": 3,
     "end_line": 14,
     "status": "statement_formalized",
-    "coverage_note": "Statement pass. Part (a): Chapter5/Problem5_24_1.lean states the S_n-equivariant iso C[S_n]·(a_lambda b_lambda) = V_lambda ≅ C[S_n]·(b_lambda a_lambda) = V'_lambda (sorry proof). Part (b): Chapter5/Problem5_24_1_b.lean constructs the sign-twist algebra automorphism phi (signTwist, phi(g)=sign(g)·g) and the conjugate partition lambda* (conjugatePartition, via Young-diagram transpose), and states: phi twists the g-action to sign(g)·(g·-) i.e. maps V to V⊗C_- (signTwist_smul_of); phi(C[S_n]·a)=C[S_n]·phi(a) (signTwist_map_leftIdeal); and V_lambda⊗C_- ≅ V_{lambda*} (spechtModule_signTwist_iso_conjugate). All proofs sorry; conjugatePartition parts_sum obligation sorried."
+    "coverage_note": "Part (a) PROVED sorry-free (rowColIdeal_iso_spechtModule, axiom-clean: propext/Classical.choice/Quot.sound). Chapter5/Problem5_24_1.lean gives the S_n-equivariant iso C[S_n]·(a_lambda b_lambda) = V_lambda ≅ C[S_n]·(b_lambda a_lambda) = V'_lambda via mutually-inverse right-multiplication maps f(x)=x·a, g(y)=y·b, using c_lambda²=α·c_lambda (Lemma5_13_3) and its mirror (Lemma5_13_1_dual). Part (b) still statement-only: Chapter5/Problem5_24_1_b.lean constructs the sign-twist algebra automorphism phi (signTwist, phi(g)=sign(g)·g) and the conjugate partition lambda* (conjugatePartition, via Young-diagram transpose), and states: phi twists the g-action to sign(g)·(g·-) i.e. maps V to V⊗C_- (signTwist_smul_of); phi(C[S_n]·a)=C[S_n]·phi(a) (signTwist_map_leftIdeal); and V_lambda⊗C_- ≅ V_{lambda*} (spechtModule_signTwist_iso_conjugate). All proofs sorry; conjugatePartition parts_sum obligation sorried."
   },
   {
     "id": "Chapter5/Problem5.24.2",


### PR DESCRIPTION
Closes #6214

Session: `4be5a3da-e24c-405d-904a-2638577bbea8`

15aba4fa feat(Ch5 #6214): prove rowColIdeal_iso_spechtModule (Problem 5.24.1(a))

🤖 Prepared with Claude Code