### PR TITLE
feat(Ch5 #6215): prove Schur dichotomy — self-dual irreducible is of real or quaternionic type

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Exercise5_3_3.lean
+++ b/EtingofRepresentationTheory/Chapter5/Exercise5_3_3.lean
@@ -1,5 +1,6 @@
 import Mathlib
 import EtingofRepresentationTheory.Chapter5.Definition5_1_1
+import EtingofRepresentationTheory.Chapter5.FrobeniusSchurRealType
 
 /-!
 # Exercise 5.3.3: nontrivial irreducibles of an odd-order group are of complex type
@@ -59,14 +60,33 @@ one-dimensional (Schur's lemma), so an invariant nondegenerate form and its tran
 proportional with proportionality constant `±1`; the `+1` case gives a symmetric form (real
 type), the `-1` case a skew-symmetric form (quaternionic type).
 
-TODO (#6215): prove using Schur's lemma for `IsSimpleModule ρ.asModule` over the algebraically
-closed field `ℂ`. -/
+The equivariant isomorphism `e : V ≃ V*` supplied by self-duality makes the character
+self-dual: `χ_ρ(g⁻¹) = χ_{ρ*}(g) = χ_ρ(g)` (the middle step is `char_dual`, the last is
+conjugation-invariance of the trace, `ρ.dual g = e.conj (ρ g)`). We then invoke the
+character-level dichotomy `Etingof.isRealType_or_isQuaternionicType_of_self_dual`, which
+symmetrises/antisymmetrises a nonzero invariant form (nonzero by `⟨χ, χ⟩ = 1`) and uses
+simplicity for nondegeneracy. -/
 theorem isRealType_or_isQuaternionicType_of_selfDual
     (ρ : Representation ℂ G V)
     (hirr : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule)
     (hsd : ∃ e : V ≃ₗ[ℂ] Module.Dual ℂ V, ∀ g v, e (ρ g v) = ρ.dual g (e v)) :
     Etingof.IsRealType ρ ∨ Etingof.IsQuaternionicType ρ := by
-  sorry
+  classical
+  obtain ⟨e, he⟩ := hsd
+  -- The equivariant iso `e : V ≃ V*` conjugates `ρ g` to `ρ.dual g`, so the character is
+  -- self-dual: `χ(g⁻¹) = χ_{ρ*}(g) = χ(g)`.
+  have hchar : ∀ g, Representation.character ρ g⁻¹ = Representation.character ρ g := by
+    intro g
+    have hconj : ρ.dual g = e.conj (ρ g) := by
+      ext w
+      rw [LinearEquiv.conj_apply_apply, he g (e.symm w), LinearEquiv.apply_symm_apply]
+    calc Representation.character ρ g⁻¹
+        = Representation.character ρ.dual g := (ρ.char_dual g).symm
+      _ = LinearMap.trace ℂ (Module.Dual ℂ V) (e.conj (ρ g)) := by rw [Representation.character,
+            hconj]
+      _ = LinearMap.trace ℂ V (ρ g) := LinearMap.trace_conj' (ρ g) e
+      _ = Representation.character ρ g := rfl
+  exact isRealType_or_isQuaternionicType_of_self_dual ρ hirr hchar
 
 /-- For a finite group of **odd** order, no nontrivial irreducible representation is of real
 type: the only real-type irreducible is the trivial representation.

--- a/progress/2026-07-10T16-29-36Z_3f489861.md
+++ b/progress/2026-07-10T16-29-36Z_3f489861.md
@@ -1,0 +1,42 @@
+## Accomplished
+
+Feature session for issue #6232: proved `Etingof.isRealType_or_isQuaternionicType_of_selfDual`
+(the **Schur dichotomy** sub-lemma of Exercise 5.3.3) in
+`EtingofRepresentationTheory/Chapter5/Exercise5_3_3.lean`, removing its `sorry`.
+
+Key discovery: the character-level dichotomy `isRealType_or_isQuaternionicType_of_self_dual`
+already exists (fully proved) in `Chapter5/FrobeniusSchurRealType.lean`, keyed on **character**
+self-duality `χ(g⁻¹) = χ(g)`. The target lemma is keyed on an **equivariant iso** `e : V ≃ V*`.
+So the proof is just the bridge:
+
+- `e` conjugates `ρ g` to `ρ.dual g`: `ρ.dual g = e.conj (ρ g)`
+  (from `he g (e.symm w)` + `LinearEquiv.conj_apply_apply` + `apply_symm_apply`).
+- Hence `χ_{ρ*}(g) = trace(e.conj (ρ g)) = trace(ρ g) = χ_ρ(g)` by `LinearMap.trace_conj'`.
+- Combined with `Representation.char_dual : ρ.dual.character g = ρ.character g⁻¹`, this gives
+  `χ_ρ(g⁻¹) = χ_ρ(g)`, feeding the existing character-level dichotomy.
+
+Verified sorry-free and axiom-clean (`propext, Classical.choice, Quot.sound` only).
+
+## Current frontier
+
+`Exercise5_3_3.lean` now has 2 sorries remaining (down from 3), both **out of scope** for #6232:
+- `not_isRealType_of_odd_order_of_nontrivial_irreducible` (#6233) — Brauer permutation lemma.
+- `not_isQuaternionicType_of_odd_order_of_irreducible` (#6234) — dim divides order + even-dim.
+
+## Overall project progress
+
+Chapter 5 Exercise 5.3.3 assembly: top-level theorem + Schur dichotomy done; the two odd-order
+character-theoretic halves remain (#6233, #6234). Note L3
+(`even_finrank_of_isQuaternionicType`) already exists in `FrobeniusSchurRealType.lean` and will
+help #6234's even-dimension half.
+
+## Next step
+
+Pick up #6233 or #6234. For #6234, reuse `even_finrank_of_isQuaternionicType` (already proved in
+`FrobeniusSchurRealType.lean`) for the even-dimension half; the remaining work is "finrank of an
+irreducible divides |G|". For #6233, the Brauer permutation lemma is the main not-in-Mathlib
+piece; the "odd order ⇒ only real class is {1}" group-theory helper is self-contained.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6232

Session: `3f489861-4472-4793-9b1a-430067da7ec1`

c5680f2e docs(#6232): progress file — Schur dichotomy via char self-duality bridge
27384749 feat(Ch5 #6232): prove Schur dichotomy — self-dual irreducible is real or quaternionic type

🤖 Prepared with Claude Code