### PR TITLE
feat(Ch5 #6233): reduce not_isRealType to Frobenius-Schur crux (#6242)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Exercise5_3_3.lean
+++ b/EtingofRepresentationTheory/Chapter5/Exercise5_3_3.lean
@@ -32,6 +32,141 @@ section Exercise533
 variable {G : Type*} [Group G] [Fintype G]
   {V : Type*} [AddCommGroup V] [Module ℂ V] [Module.Finite ℂ V]
 
+/-! ### The squaring bijection on an odd-order group
+
+In a finite group of odd order the map `g ↦ g²` is a bijection: with `|G| = 2m - 1`
+odd, `(g²)^m = g^(2m) = g^(|G|+1) = g` (using `g^|G| = 1`), so `g ↦ g^((|G|+1)/2)` is a
+two-sided inverse. This lets us re-index a sum over `g²` as a sum over `g`. -/
+
+/-- In a finite group of odd order, `g ↦ g²` is a bijection, with inverse
+`g ↦ g^((|G|+1)/2)`. -/
+def sqEquivOfOdd (hodd : Odd (Fintype.card G)) : G ≃ G where
+  toFun g := g ^ 2
+  invFun g := g ^ ((Fintype.card G + 1) / 2)
+  left_inv g := by
+    have hdvd : 2 ∣ Fintype.card G + 1 := hodd.add_one.two_dvd
+    show (g ^ 2) ^ ((Fintype.card G + 1) / 2) = g
+    rw [← pow_mul, Nat.mul_div_cancel' hdvd, pow_succ, pow_card_eq_one, one_mul]
+  right_inv g := by
+    have hdvd : 2 ∣ Fintype.card G + 1 := hodd.add_one.two_dvd
+    show (g ^ ((Fintype.card G + 1) / 2)) ^ 2 = g
+    rw [← pow_mul, Nat.div_mul_cancel hdvd, pow_succ, pow_card_eq_one, one_mul]
+
+@[simp] theorem sqEquivOfOdd_apply (hodd : Odd (Fintype.card G)) (g : G) :
+    sqEquivOfOdd hodd g = g ^ 2 := rfl
+
+/-- Re-indexing the character sum by the squaring bijection: for `|G|` odd,
+`∑ g, χ(g²) = ∑ g, χ(g)`. -/
+theorem sum_char_sq_eq_sum_char (hodd : Odd (Fintype.card G)) (ρ : Representation ℂ G V) :
+    ∑ g : G, ρ.character (g ^ 2) = ∑ g : G, ρ.character g :=
+  Equiv.sum_comp (sqEquivOfOdd hodd) ρ.character
+
+/-! ### Vanishing of the invariants of a nontrivial irreducible -/
+
+/-- A `ℂ`-submodule `P` of `ρ.asModule` stable under every `ρ g` packages (with the same
+underlying set) as a `ℂ[G]`-submodule. This is a local copy of the standard construction;
+closure under the whole group algebra follows from closure under each `ρ g` and the scalars
+by linearity. -/
+private def stableSubmodule (ρ : Representation ℂ G V) (P : Submodule ℂ ρ.asModule)
+    (hP : ∀ (g : G), ∀ x ∈ P, ρ g (ρ.asModuleEquiv x) ∈ P) :
+    Submodule (MonoidAlgebra ℂ G) ρ.asModule where
+  carrier := P
+  add_mem' hx hy := P.add_mem hx hy
+  zero_mem' := P.zero_mem
+  smul_mem' r x hx := by
+    induction r using MonoidAlgebra.induction_linear with
+    | zero => simp
+    | add r₁ r₂ h₁ h₂ => rw [add_smul]; exact P.add_mem h₁ h₂
+    | single g a =>
+        have hsingle : (MonoidAlgebra.single g a : MonoidAlgebra ℂ G) =
+            a • MonoidAlgebra.single g (1 : ℂ) := by
+          rw [Finsupp.smul_single, smul_eq_mul, mul_one]
+        rw [hsingle, smul_assoc]
+        apply P.smul_mem
+        rw [Representation.single_smul, one_smul]
+        exact hP g x hx
+
+private theorem mem_stableSubmodule (ρ : Representation ℂ G V) (P : Submodule ℂ ρ.asModule)
+    (hP : ∀ (g : G), ∀ x ∈ P, ρ g (ρ.asModuleEquiv x) ∈ P) (x : ρ.asModule) :
+    x ∈ stableSubmodule ρ P hP ↔ x ∈ P :=
+  Iff.rfl
+
+/-- A nontrivial irreducible representation has no nonzero invariant vectors: the invariants
+form a subrepresentation, which by simplicity is `⊥` or `⊤`; if `⊤` then every `ρ g` is the
+identity, contradicting nontriviality. -/
+theorem invariants_eq_bot_of_nontrivial_irreducible (ρ : Representation ℂ G V)
+    (hirr : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule) (hnontriv : ∃ g, ρ g ≠ 1) :
+    Representation.invariants ρ = ⊥ := by
+  have hP : ∀ (g : G), ∀ x ∈ Representation.invariants ρ,
+      ρ g (ρ.asModuleEquiv x) ∈ Representation.invariants ρ := by
+    intro g x hx
+    have hxx : ρ g (ρ.asModuleEquiv x) = x :=
+      (Representation.mem_invariants ρ x).mp hx g
+    rw [hxx]; exact hx
+  rcases hirr.eq_bot_or_eq_top (stableSubmodule ρ (Representation.invariants ρ) hP) with h | h
+  · rw [Submodule.eq_bot_iff] at h ⊢
+    intro x hx
+    exact h x ((mem_stableSubmodule ρ _ hP x).mpr hx)
+  · exfalso
+    obtain ⟨g, hg⟩ := hnontriv
+    apply hg
+    ext v
+    have hv : v ∈ Representation.invariants ρ :=
+      (mem_stableSubmodule ρ _ hP v).mp (h ▸ Submodule.mem_top)
+    rw [Module.End.one_apply]
+    exact (Representation.mem_invariants ρ v).mp hv g
+
+/-- For a nontrivial irreducible representation of a finite group of odd order,
+`∑ g, χ(g²) = 0`: the squaring bijection turns this into `∑ g, χ(g)`, which equals
+`|G|·dim(invariants) = 0` because the invariants vanish. -/
+theorem sum_char_sq_eq_zero (hodd : Odd (Fintype.card G)) (ρ : Representation ℂ G V)
+    (hirr : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule) (hnontriv : ∃ g, ρ g ≠ 1) :
+    ∑ g : G, ρ.character (g ^ 2) = 0 := by
+  rw [sum_char_sq_eq_sum_char hodd ρ]
+  have hcard : (Nat.card G : ℂ) ≠ 0 := by
+    rw [Nat.card_eq_fintype_card]; exact_mod_cast Fintype.card_ne_zero
+  haveI : Invertible (Nat.card G : ℂ) := invertibleOfNonzero hcard
+  have hkey := Representation.card_inv_mul_sum_char_eq_finrank ρ
+  rw [invariants_eq_bot_of_nontrivial_irreducible ρ hirr hnontriv, finrank_bot,
+    Nat.cast_zero] at hkey
+  rcases mul_eq_zero.mp hkey with h | h
+  · exact absurd (inv_eq_zero.mp h) hcard
+  · exact h
+
+/-! ### Frobenius–Schur crux (open)
+
+For a self-dual (in particular real-type) irreducible representation, the Frobenius–Schur
+indicator `(1/|G|)·∑ χ(g²)` equals `+1`, i.e. `∑ χ(g²) = |G|`. This is the substantive
+piece that is not yet in Mathlib; see the sub-issue. It requires the symmetric/exterior
+square decomposition of `V ⊗ V` (equivalently, the swap operator on `(V ⊗ V)^G`, which is
+one-dimensional by Schur for a self-dual irreducible, and acts by `+1` on the symmetric
+invariant tensor supplied by the real-type form). -/
+
+/-- **Frobenius–Schur crux (open).** For a real-type irreducible representation of a finite
+group, `∑ g, χ(g²) = |G|`. -/
+theorem sum_char_sq_eq_card_of_isRealType (ρ : Representation ℂ G V)
+    (hirr : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule)
+    (h : Etingof.IsRealType ρ) :
+    ∑ g : G, ρ.character (g ^ 2) = (Fintype.card G : ℂ) := by
+  sorry
+
+/-- Odd-order groups have no nontrivial real-type irreducible. Combining the vanishing
+`∑ χ(g²) = 0` (squaring bijection + no invariants) with the Frobenius–Schur value
+`∑ χ(g²) = |G| ≠ 0` for real type gives a contradiction. -/
+theorem not_isRealType_of_odd_order_of_nontrivial_irreducible
+    (hodd : Odd (Fintype.card G))
+    (ρ : Representation ℂ G V)
+    (hirr : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule)
+    (hnontriv : ∃ g, ρ g ≠ 1) :
+    ¬ Etingof.IsRealType ρ := by
+  intro hreal
+  have h0 : ∑ g : G, ρ.character (g ^ 2) = 0 :=
+    sum_char_sq_eq_zero hodd ρ hirr hnontriv
+  have hc : ∑ g : G, ρ.character (g ^ 2) = (Fintype.card G : ℂ) :=
+    sum_char_sq_eq_card_of_isRealType ρ hirr hreal
+  rw [h0] at hc
+  exact (Nat.cast_ne_zero.mpr Fintype.card_ne_zero) hc.symm
+
 /-- Exercise 5.3.3. Every nontrivial irreducible representation of a finite group of odd
 order is of complex type (`V ≇ V*`). -/
 theorem isComplexType_of_odd_order_of_nontrivial_irreducible

--- a/progress/2026-07-10T16-37-44Z_af13364a.md
+++ b/progress/2026-07-10T16-37-44Z_af13364a.md
@@ -1,0 +1,46 @@
+## Accomplished
+
+Feature session on #6233 (Ch5 Exercise 5.3.3: odd-order groups have no nontrivial real-type
+irreducible). Merged ready PR #6235 at the start of the cycle.
+
+Found the file `Chapter5/Exercise5_3_3.lean` did **not** yet contain the three sub-lemmas the
+issue referenced (the #6215 partial was only a statement pass). Added the `not_isRealType`
+lemma and its full reduction, landing the following (all compile, 0 new sorries except the
+isolated Frobenius–Schur crux):
+
+- `sqEquivOfOdd`: for `|G|` odd, `g ↦ g²` is a bijection (inverse `g ↦ g^((|G|+1)/2)`, via
+  `g^|G| = 1`).
+- `sum_char_sq_eq_sum_char`: `∑ χ(g²) = ∑ χ(g)` by re-indexing along that bijection.
+- `stableSubmodule` / `mem_stableSubmodule` (local copies): package a `ρ`-stable `ℂ`-subspace
+  as a `ℂ[G]`-submodule.
+- `invariants_eq_bot_of_nontrivial_irreducible`: a nontrivial irreducible has no invariants
+  (simplicity dichotomy: invariants is `⊥` or `⊤`; `⊤` forces every `ρ g = 1`).
+- `sum_char_sq_eq_zero`: hence `∑ χ(g²) = 0` (uses `card_inv_mul_sum_char_eq_finrank`).
+- `not_isRealType_of_odd_order_of_nontrivial_irreducible`: **the #6233 deliverable**, proven
+  modulo one crux — `0 = ∑ χ(g²) = |G| ≠ 0` gives the contradiction.
+
+## Current frontier
+
+The single remaining `sorry` in the `not_isRealType` chain is the Frobenius–Schur crux
+`sum_char_sq_eq_card_of_isRealType`: `∑ χ(g²) = |G|` for a real-type irreducible. This is the
+genuine "not in Mathlib" piece (needs Sym²/Λ² representation characters or the swap-on-tensor
+trace identity `Tr(τ∘(A⊗A)) = Tr(A²)` + Schur 1-dimensionality of `(V⊗V)^G`). Filed as a
+self-contained sub-issue **#6242** with the full strategy.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. Ch5 Exercise 5.3.3 is being tackled as three sub-lemmas
+(#6232 dichotomy, #6233 not-real [this], #6234 not-quaternionic). #6233 is reduced to #6242.
+`lake build EtingofRepresentationTheory.Chapter5.Exercise5_3_3` succeeds (2 sorries: the FS
+crux #6242, and the pre-existing top-level `isComplexType_...` assembly).
+
+## Next step
+
+Pick up **#6242** (Frobenius–Schur crux). Once it lands, `not_isRealType` is sorry-free and
+#6233 is fully closed. The book's hint ("quaternionic ⇒ even-dimensional") is #6234's route,
+independent of this.
+
+## Blockers
+
+None. #6233's residual is tracked by #6242 (no `blocked` dependency needed — the partial PR
+lands the reduction; #6242 fills the crux).


### PR DESCRIPTION
Partial progress on #6233

Session: `af13364a-60a0-46d4-82a2-15359133c0e5`

28d1f143 progress(#6233 af13364a): reduce not_isRealType to Frobenius-Schur crux #6242
27b24c82 feat(Ch5 #6233): squaring bijection, invariants vanishing, reduce not_isRealType to Frobenius-Schur crux

🤖 Prepared with Claude Code