### PR TITLE
feat(Ch5 #6234): odd-order groups have no quaternionic irreducible

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Exercise5_3_3.lean
+++ b/EtingofRepresentationTheory/Chapter5/Exercise5_3_3.lean
@@ -1,6 +1,8 @@
 import Mathlib
 import EtingofRepresentationTheory.Chapter5.Definition5_1_1
 import EtingofRepresentationTheory.Chapter5.FrobeniusSchurRealType
+import EtingofRepresentationTheory.Chapter5.Theorem5_3_1
+import EtingofRepresentationTheory.Chapter4.Exercise4_2_3
 
 /-!
 # Exercise 5.3.3: nontrivial irreducibles of an odd-order group are of complex type
@@ -41,10 +43,12 @@ isomorphism `V ≃ V*` and derive a contradiction:
    hint: a nondegenerate skew-symmetric form exists only on even-dimensional spaces), while the
    dimension of an irreducible divides `|G|`, which is odd.
 
-The top-level assembly is complete and sorry-free; the three sub-lemmas carry the remaining
-`sorry`s, each a self-contained statement requiring character-theoretic infrastructure
-(Frobenius–Schur / Brauer, "dimension divides the order", "nondegenerate alternating ⇒ even
-dimension") that is not yet available in Mathlib. See the tracking issues for #6215.
+The top-level assembly is complete and sorry-free. Sub-lemma 3
+(`not_isQuaternionicType_of_odd_order_of_irreducible`) is proved by combining the even
+dimension of quaternionic type (`Etingof.even_finrank_of_isQuaternionicType`) with "the
+dimension of an irreducible divides `|G|`" (`Etingof.Theorem5_3_1`). The only remaining
+`sorry` is the Frobenius–Schur crux `sum_char_sq_eq_card_of_isRealType` feeding sub-lemma 2
+(tracked as issue #6242). See the tracking issues for #6215.
 -/
 
 namespace Etingof
@@ -52,7 +56,7 @@ namespace Etingof
 section Exercise533
 
 variable {G : Type*} [Group G] [Fintype G]
-  {V : Type*} [AddCommGroup V] [Module ℂ V] [Module.Finite ℂ V]
+  {V : Type} [AddCommGroup V] [Module ℂ V] [Module.Finite ℂ V]
 
 /-! ### The squaring bijection on an odd-order group
 
@@ -224,18 +228,31 @@ theorem not_isRealType_of_odd_order_of_nontrivial_irreducible
   exact (Nat.cast_ne_zero.mpr Fintype.card_ne_zero) hc.symm
 
 /-- For a finite group of **odd** order, no irreducible representation is of quaternionic
-type. A quaternionic representation is even-dimensional (a nondegenerate skew-symmetric form
-exists only in even dimension), whereas the dimension of an irreducible divides `|G|`, which
-is odd.
-
-TODO (#6215): prove by combining "nondegenerate alternating form ⇒ even `finrank`" with
-"`finrank` of an irreducible divides `Fintype.card G`". -/
+type. A quaternionic representation is even-dimensional
+(`Etingof.even_finrank_of_isQuaternionicType`: a nondegenerate skew-symmetric form exists only
+in even dimension), whereas the dimension of an irreducible divides `|G|`
+(`Etingof.Theorem5_3_1`), which is odd. An even number dividing an odd number is impossible. -/
 theorem not_isQuaternionicType_of_odd_order_of_irreducible
     (hodd : Odd (Fintype.card G))
     (ρ : Representation ℂ G V)
     (hirr : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule) :
     ¬ Etingof.IsQuaternionicType ρ := by
-  sorry
+  classical
+  intro hquat
+  -- Quaternionic type supplies a nondegenerate skew-symmetric form, so `finrank ℂ V` is even.
+  have heven : Even (Module.finrank ℂ V) :=
+    Etingof.even_finrank_of_isQuaternionicType ρ hquat
+  -- Irreducibility makes `FDRep.of ρ` a simple object, whose dimension divides `|G|`.
+  haveI : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule := hirr
+  haveI := Etingof.simple_fdRepOf_of_isSimpleModule ρ
+  -- `Module.finrank ℂ (FDRep.of ρ)` is definitionally `Module.finrank ℂ V`.
+  have hdvd : Module.finrank ℂ V ∣ Fintype.card G := Etingof.Theorem5_3_1 G (FDRep.of ρ)
+  -- `Even (finrank)` and `finrank ∣ (odd |G|)` give `2 ∣ |G|`, contradicting oddness.
+  obtain ⟨k, hk⟩ := heven
+  obtain ⟨m, hm⟩ := hdvd
+  rw [Nat.odd_iff] at hodd
+  have hcard : Fintype.card G = 2 * (k * m) := by rw [hm, hk]; ring
+  omega
 
 /-- Exercise 5.3.3. Every nontrivial irreducible representation of a finite group of odd
 order is of complex type (`V ≇ V*`).

--- a/EtingofRepresentationTheory/Chapter5/Proposition5_3_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Proposition5_3_2.lean
@@ -31,7 +31,7 @@ scalar `λ · id` on `V` by Schur's lemma. Taking the trace gives `λ = |C| · �
 The scalar `λ` is an algebraic integer because `σ` lies in the image of the integral
 group ring `ℤ[G]`, which is module-finite over `ℤ`. -/
 theorem Etingof.Proposition5_3_2
-    (G : Type) [Group G] [Fintype G] [DecidableEq G]
+    (G : Type*) [Group G] [Fintype G] [DecidableEq G]
     (V : FDRep ℂ G) [Simple V]
     (g : G)
     (hn : 0 < Module.finrank ℂ V) :

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_3_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_3_1.lean
@@ -39,7 +39,7 @@ open CategoryTheory Polynomial Matrix in
 element is an algebraic integer: it is the sum of the eigenvalues of `V.ρ g`, each of which is
 a root of unity (since `g` has finite order). -/
 theorem FDRep.character_isIntegral
-    {G : Type} [Group G] [Fintype G]
+    {G : Type*} [Group G] [Fintype G]
     (V : FDRep ℂ G) (g : G) :
     IsIntegral ℤ (V.character g) := by
   classical
@@ -89,7 +89,7 @@ open CategoryTheory in
 /-- **Theorem 5.3.1.** The dimension of an irreducible complex representation `V` of a finite
 group `G` divides the order of `G`. (Etingof Theorem 5.3.1) -/
 theorem Etingof.Theorem5_3_1
-    (G : Type) [Group G] [Fintype G]
+    (G : Type*) [Group G] [Fintype G]
     (V : FDRep ℂ G) [Simple V] :
     Module.finrank ℂ V ∣ Fintype.card G := by
   classical

--- a/progress/2026-07-10T17-33-27Z_1f1f80aa.md
+++ b/progress/2026-07-10T17-33-27Z_1f1f80aa.md
@@ -1,0 +1,43 @@
+## Accomplished
+
+Discharged issue #6234 (Ch5 #6215): proved
+`Etingof.not_isQuaternionicType_of_odd_order_of_irreducible` in
+`EtingofRepresentationTheory/Chapter5/Exercise5_3_3.lean`, removing its `sorry`.
+
+The proof combines two existing results:
+- `Etingof.even_finrank_of_isQuaternionicType` (already in the imported
+  `FrobeniusSchurRealType`): a quaternionic representation is even-dimensional.
+- `Etingof.Theorem5_3_1`: the dimension of an irreducible divides `|G|`.
+An even number dividing an odd `|G|` is a contradiction (`omega`).
+
+Supporting change: `Etingof.Theorem5_3_1` (and its helpers
+`FDRep.character_isIntegral`, `Etingof.Proposition5_3_2`) were universe-generalized from
+`G : Type` to `G : Type*` so the odd-order exercise (`G : Type*`) can apply them. This is a
+strict generalization — all three still compile and their only other consumer
+(`Remark5_2_8`) builds unchanged.
+
+The bridge from `IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule` to a simple `FDRep` object
+(`Etingof.simple_fdRepOf_of_isSimpleModule`) and the `FDRep` machinery require the carrier in
+`Type 0`, so `Exercise5_3_3.lean`'s section variable `V` was narrowed from `Type*` to `Type`.
+Nothing outside the file's own aggregator imports it, so this is safe.
+
+## Current frontier
+
+`Exercise5_3_3.lean` builds. `#print axioms
+Etingof.not_isQuaternionicType_of_odd_order_of_irreducible` shows only
+`propext, Classical.choice, Quot.sound` (no `sorryAx`).
+
+## Overall project progress
+
+Exercise 5.3.3 now has a single remaining `sorry`: the Frobenius–Schur crux
+`sum_char_sq_eq_card_of_isRealType` (`∑ χ(g²) = |G|` for real type), tracked as issue #6242.
+Once that lands, the whole exercise (`isComplexType_of_odd_order_of_nontrivial_irreducible`)
+is sorry-free.
+
+## Next step
+
+Pick up issue #6242 (Frobenius–Schur crux) to fully close #6215 / #6233.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6234

Session: `1f1f80aa-683a-471a-9a80-6216ee1374e6`

ee74e10d feat(Ch5 #6234): prove odd-order groups have no quaternionic irreducible

🤖 Prepared with Claude Code