### PR TITLE
feat(Ch5 #6233): prove Frobenius-Schur crux ∑ χ(g²) = |G| for real-type irreducible

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Exercise5_3_3.lean
+++ b/EtingofRepresentationTheory/Chapter5/Exercise5_3_3.lean
@@ -43,12 +43,13 @@ isomorphism `V ≃ V*` and derive a contradiction:
    hint: a nondegenerate skew-symmetric form exists only on even-dimensional spaces), while the
    dimension of an irreducible divides `|G|`, which is odd.
 
-The top-level assembly is complete and sorry-free. Sub-lemma 3
+The whole development is now sorry-free. Sub-lemma 3
 (`not_isQuaternionicType_of_odd_order_of_irreducible`) is proved by combining the even
 dimension of quaternionic type (`Etingof.even_finrank_of_isQuaternionicType`) with "the
-dimension of an irreducible divides `|G|`" (`Etingof.Theorem5_3_1`). The only remaining
-`sorry` is the Frobenius–Schur crux `sum_char_sq_eq_card_of_isRealType` feeding sub-lemma 2
-(tracked as issue #6242). See the tracking issues for #6215.
+dimension of an irreducible divides `|G|`" (`Etingof.Theorem5_3_1`). The Frobenius–Schur crux
+`sum_char_sq_eq_card_of_isRealType` feeding sub-lemma 2 (issue #6242) is discharged by clearing
+the `|G|⁻¹` factor in the reverse indicator bridge
+`Etingof.frobeniusSchurIndicator_eq_one_of_isRealType`. See the tracking issues for #6215.
 -/
 
 namespace Etingof
@@ -159,22 +160,33 @@ theorem sum_char_sq_eq_zero (hodd : Odd (Fintype.card G)) (ρ : Representation �
   · exact absurd (inv_eq_zero.mp h) hcard
   · exact h
 
-/-! ### Frobenius–Schur crux (open)
+/-! ### Frobenius–Schur crux
 
 For a self-dual (in particular real-type) irreducible representation, the Frobenius–Schur
 indicator `(1/|G|)·∑ χ(g²)` equals `+1`, i.e. `∑ χ(g²) = |G|`. This is the substantive
-piece that is not yet in Mathlib; see the sub-issue. It requires the symmetric/exterior
-square decomposition of `V ⊗ V` (equivalently, the swap operator on `(V ⊗ V)^G`, which is
-one-dimensional by Schur for a self-dual irreducible, and acts by `+1` on the symmetric
-invariant tensor supplied by the real-type form). -/
+piece that is not in Mathlib; it is now supplied by the reverse indicator bridge
+`Etingof.frobeniusSchurIndicator_eq_one_of_isRealType` (in `FrobeniusSchurRealType.lean`),
+whose proof carries out the symmetric/exterior square analysis (the swap operator on
+`(V ⊗ V)^G`, one-dimensional by Schur for a self-dual irreducible, acting by `+1` on the
+symmetric invariant tensor supplied by the real-type form). Here we only clear the `|G|⁻¹`
+factor to convert the indicator value `1` into the character-sum identity `∑ χ(g²) = |G|`. -/
 
-/-- **Frobenius–Schur crux (open).** For a real-type irreducible representation of a finite
-group, `∑ g, χ(g²) = |G|`. -/
+/-- **Frobenius–Schur crux.** For a real-type irreducible representation of a finite
+group, `∑ g, χ(g²) = |G|`. Unfolding `Etingof.frobeniusSchurIndicator ρ = |G|⁻¹·∑ χ(g²)`,
+the value `1` (from `frobeniusSchurIndicator_eq_one_of_isRealType`) clears to `∑ χ(g²) = |G|`. -/
 theorem sum_char_sq_eq_card_of_isRealType (ρ : Representation ℂ G V)
     (hirr : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule)
     (h : Etingof.IsRealType ρ) :
     ∑ g : G, ρ.character (g ^ 2) = (Fintype.card G : ℂ) := by
-  sorry
+  classical
+  have hcard : (Fintype.card G : ℂ) ≠ 0 := by exact_mod_cast Fintype.card_ne_zero
+  have hFS : Etingof.frobeniusSchurIndicator ρ = 1 :=
+    Etingof.frobeniusSchurIndicator_eq_one_of_isRealType ρ hirr h
+  rw [Etingof.frobeniusSchurIndicator, inv_mul_eq_one₀ hcard] at hFS
+  -- `hFS : (Fintype.card G : ℂ) = ∑ g, trace (ρ (g * g))`; the summands match `χ (g ^ 2)`.
+  rw [hFS]
+  refine Finset.sum_congr rfl fun g _ => ?_
+  rw [Representation.character, pow_two]
 
 /-- **Schur dichotomy.** A self-dual irreducible representation is of real or quaternionic
 type. The space of `G`-invariant bilinear forms on an irreducible `V` is at most

--- a/progress/2026-07-10T18-56-04Z_52f3ac01.md
+++ b/progress/2026-07-10T18-56-04Z_52f3ac01.md
@@ -1,0 +1,40 @@
+## Accomplished
+
+Feature session on **#6242** (Frobenius–Schur crux `sum_char_sq_eq_card_of_isRealType`:
+`∑ g, χ(g²) = |G|` for a real-type irreducible). The `sorry` in
+`Chapter5/Exercise5_3_3.lean` is discharged.
+
+The issue was planned before the reverse indicator bridge landed. As the prior progress note
+predicted, the crux is now a short reduction: `Etingof.frobeniusSchurIndicator_eq_one_of_isRealType`
+(in `FrobeniusSchurRealType.lean`) gives `frobeniusSchurIndicator ρ = 1`; unfolding the
+definition `frobeniusSchurIndicator ρ = |G|⁻¹·∑ g, trace(ρ(g·g))` and clearing the `|G|⁻¹`
+factor via `inv_mul_eq_one₀` yields `∑ trace(ρ(g·g)) = |G|`. A `Finset.sum_congr` aligns the
+summands with `ρ.character (g^2)` (`Representation.character` is definitionally the trace, and
+`pow_two` turns `g^2` into `g·g`).
+
+- `lake build EtingofRepresentationTheory.Chapter5.Exercise5_3_3` succeeds (8589 jobs).
+- `#print axioms Etingof.sum_char_sq_eq_card_of_isRealType` → `propext, Classical.choice,
+  Quot.sound` only (no `sorryAx`).
+- `#print axioms Etingof.isComplexType_of_odd_order_of_nontrivial_irreducible` → same: the
+  **entire** Exercise 5.3.3 main theorem is now genuinely sorry-free.
+- Updated the module docstring (removed the "only remaining sorry" note) and
+  `progress/items.json` (`Chapter5/Exercise5.3.3` → status `proved`).
+
+## Current frontier
+
+#6242 complete. PR pending.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. Exercise 5.3.3 (odd-order groups have only complex-type
+nontrivial irreducibles) is fully closed. The Frobenius–Schur real-type infrastructure
+(`FrobeniusSchurRealType.lean` bridge) is now consumed by both #6253 (Problem 5.12.5) and
+#6242 (Exercise 5.3.3).
+
+## Next step
+
+Pick up the next unclaimed feature issue (#6239, #6245, #6247, #6255 remain).
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3467,8 +3467,8 @@
     "end_page": "100",
     "start_line": 3,
     "end_line": 4,
-    "status": "statement_formalized",
-    "coverage_note": "Reduced pass: Chapter5/Exercise5_3_3.lean proves the main theorem isComplexType_of_odd_order_of_nontrivial_irreducible as a sorry-free assembly of three faithful sub-lemmas (Schur dichotomy self-dual=>real or quaternionic; odd order=>not real for nontrivial irreducible; odd order=>not quaternionic). The three sub-lemmas carry sorry, each needing Frobenius-Schur/Brauer or dim-divides-order infrastructure absent from Mathlib. Tracked by sub-issues of #6215."
+    "status": "proved",
+    "coverage_note": "Complete: Chapter5/Exercise5_3_3.lean proves the main theorem isComplexType_of_odd_order_of_nontrivial_irreducible sorry-free (axioms: propext, Classical.choice, Quot.sound only). All three sub-lemmas are proved (Schur dichotomy self-dual=>real or quaternionic; odd order=>not real for nontrivial irreducible; odd order=>not quaternionic). The Frobenius-Schur crux sum_char_sq_eq_card_of_isRealType (#6242) is discharged by clearing the |G|^-1 factor in the reverse indicator bridge frobeniusSchurIndicator_eq_one_of_isRealType."
   },
   {
     "id": "Chapter5/Introduction_5.4",


### PR DESCRIPTION
Closes #6242

Session: `52f3ac01-0784-434c-a6d7-75040959a61a`

a8f6670f feat(Ch5 #6242): prove Frobenius-Schur crux ∑ χ(g²) = |G| for real-type irreducible

🤖 Prepared with Claude Code