### PR TITLE
feat(Ch2 #Problem2.8.11b): prove free-algebra Hilbert series — mⁿ words of length n and (1-mt)·h=1

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Problem2_8_11.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_8_11.lean
@@ -57,15 +57,30 @@ theorem hilbertSeries_mvPolynomial (k : Type*) [Field k] (m : ℕ) :
 length-`n` graded piece of the free algebra `k⟨x₁,…,x_m⟩` (whose basis is the set of words).
 Equivalently the Hilbert series is `1/(1-mt)`. -/
 theorem card_words_length (m n : ℕ) :
-    Nat.card {l : List (Fin m) // l.length = n} = m ^ n :=
-  sorry
+    Nat.card {l : List (Fin m) // l.length = n} = m ^ n := by
+  -- A length-`n` word over `Fin m` is exactly a `List.Vector (Fin m) n`, equivalent to
+  -- `Fin n → Fin m`, of which there are `mⁿ`.
+  have e : {l : List (Fin m) // l.length = n} ≃ (Fin n → Fin m) :=
+    Equiv.vectorEquivFin (Fin m) n
+  rw [Nat.card_congr e, Nat.card_eq_fintype_card, Fintype.card_fun,
+    Fintype.card_fin, Fintype.card_fin]
 
 /-- **(b)**, generating-function form: the Hilbert series of `k⟨x₁,…,x_m⟩` is `1/(1-mt)`,
 expressed as the power-series identity `(1 - m·t) · h_A = 1`. -/
 theorem hilbertSeries_freeAlgebra (k : Type*) [Field k] (m : ℕ) :
     (1 - (m : ℕ) • PowerSeries.X : PowerSeries k) *
-      PowerSeries.mk (fun n => ((m ^ n : ℕ) : k)) = 1 :=
-  sorry
+      PowerSeries.mk (fun n => ((m ^ n : ℕ) : k)) = 1 := by
+  -- Geometric series `(1 - m·X)·∑ mⁿ Xⁿ = 1`, checked coefficient by coefficient.
+  ext d
+  rw [sub_mul, one_mul, smul_mul_assoc, map_sub, map_nsmul, PowerSeries.coeff_mk,
+    PowerSeries.coeff_one]
+  rcases d with _ | e
+  · -- constant coefficient: `m⁰ - m·(coeff₀ (X·h)) = 1 - 0 = 1`
+    simp [PowerSeries.coeff_zero_eq_constantCoeff_apply]
+  · -- coefficient of `t^(e+1)`: `m^(e+1) - m·m^e = 0`
+    rw [PowerSeries.coeff_succ_X_mul, PowerSeries.coeff_mk, nsmul_eq_mul]
+    push_cast [pow_succ]
+    ring
 
 /-! ## (c) Exterior (Grassmann) algebra `⋀_k[x₁,…,x_m]` -/
 

--- a/progress/2026-07-10T20-00-00Z_871d6c82.md
+++ b/progress/2026-07-10T20-00-00Z_871d6c82.md
@@ -1,0 +1,24 @@
+## Accomplished
+- Claimed and executed issue #6265 (Problem 2.8.11 part (b), free algebra Hilbert series).
+- Proved `card_words_length`: `Nat.card {l : List (Fin m) // l.length = n} = m ^ n`.
+  A length-`n` word over `Fin m` is a `List.Vector (Fin m) n`, equivalent to `Fin n → Fin m`
+  via `Equiv.vectorEquivFin`; the count is then `Fintype.card_fun` = `mⁿ`.
+- Proved `hilbertSeries_freeAlgebra`: `(1 - m·X) · ∑ mⁿ Xⁿ = 1` (geometric series),
+  checked coefficient-wise with `PowerSeries.ext`, `coeff_succ_X_mul`, and `push_cast; ring`.
+- Both theorems are axiom-clean (`propext, Classical.choice, Quot.sound` only).
+- `lake build EtingofRepresentationTheory.Chapter2.Problem2_8_11` succeeds.
+
+## Current frontier
+Problem 2.8.11 parts (a) and (c) remain sorry (lines 43/49 and 90/96) — those are
+issues #6267 and #6266 respectively, independent of this work.
+
+## Overall project progress
+Stage 3 (formalization) ongoing. Problem 2.8.11: parts (b) and (d) now fully proved;
+parts (a), (c) still stated-with-sorry (separate open issues).
+
+## Next step
+Work #6266 (part c, exterior algebra) or #6267 (part a, polynomial algebra) — both
+touch the same file, so serialize them to avoid merge conflicts.
+
+## Blockers
+None.


### PR DESCRIPTION
Closes #6265

Session: `871d6c82-3de4-4f68-86e0-5afb576914fe`

4557642a docs(#6265): progress file for Problem 2.8.11 part (b)
8ecbca67 feat(Ch2 #Problem2.8.11b): prove free-algebra Hilbert series — mⁿ words and (1-mt)·h=1

🤖 Prepared with Claude Code