### PR TITLE
feat(Ch2 #Problem2.8.11c): prove exterior-algebra Hilbert series — finrank ⋀ⁿ=C(m,n) and ∑C(m,n)tⁿ=(1+t)^m

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Problem2_8_11.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_8_11.lean
@@ -1,5 +1,6 @@
 import Mathlib.RingTheory.MvPolynomial.Homogeneous
 import Mathlib.LinearAlgebra.ExteriorPower.Basic
+import Mathlib.LinearAlgebra.ExteriorPower.Basis
 import Mathlib.RingTheory.PowerSeries.Basic
 import Mathlib.Combinatorics.Quiver.Path
 import Mathlib.Data.Matrix.Mul
@@ -88,14 +89,22 @@ theorem hilbertSeries_freeAlgebra (k : Type*) [Field k] (m : ℕ) :
 exterior power of the `m`-dimensional space, of dimension `C(m, n)`. Equivalently the Hilbert
 series is `(1+t)^m`. -/
 theorem finrank_exteriorPower (k : Type*) [Field k] (m n : ℕ) :
-    Module.finrank k (⋀[k]^n (Fin m → k)) = m.choose n :=
-  sorry
+    Module.finrank k (⋀[k]^n (Fin m → k)) = m.choose n := by
+  -- `⋀^n` of a rank-`m` free module has rank `C(m, n)`; here `finrank k (Fin m → k) = m`.
+  rw [exteriorPower.finrank_eq, Module.finrank_fintype_fun_eq_card, Fintype.card_fin]
 
 /-- **(c)**, generating-function form: the Hilbert series of the exterior algebra on `m`
 generators is the polynomial `(1+t)^m`. -/
 theorem hilbertSeries_exteriorAlgebra (k : Type*) [Field k] (m : ℕ) :
-    PowerSeries.mk (fun n => ((m.choose n : ℕ) : k)) = (1 + PowerSeries.X : PowerSeries k) ^ m :=
-  sorry
+    PowerSeries.mk (fun n => ((m.choose n : ℕ) : k)) = (1 + PowerSeries.X : PowerSeries k) ^ m := by
+  -- Coerce the polynomial identity `((1 + X)^m).coeff n = C(m, n)` to power series and match
+  -- coefficients: `(1 + X)^m` as a power series is the coercion of the polynomial `(1 + X)^m`.
+  have hcoe : ((1 + PowerSeries.X : PowerSeries k) ^ m) =
+      ((((1 + Polynomial.X) ^ m : Polynomial k) : PowerSeries k)) := by
+    rw [Polynomial.coe_pow, Polynomial.coe_add, Polynomial.coe_one, Polynomial.coe_X]
+  rw [hcoe]
+  ext n
+  rw [PowerSeries.coeff_mk, Polynomial.coeff_coe, Polynomial.coeff_one_add_X_pow]
 
 /-! ## (d) Path algebra `P_Q` -/
 

--- a/progress/2026-07-10T20-20-00Z_f15f983f.md
+++ b/progress/2026-07-10T20-20-00Z_f15f983f.md
@@ -1,0 +1,25 @@
+## Accomplished
+- Claimed and executed issue #6266 (Problem 2.8.11 part (c), exterior-algebra Hilbert series).
+- Proved `finrank_exteriorPower`: `finrank k (⋀[k]^n (Fin m → k)) = C(m, n)` via
+  `exteriorPower.finrank_eq` (needs the `ExteriorPower.Basis` import, which I added) combined
+  with `Module.finrank_fintype_fun_eq_card` and `Fintype.card_fin`.
+- Proved `hilbertSeries_exteriorAlgebra`: `∑ C(m,n) tⁿ = (1 + X)^m` as power series, by
+  coercing the polynomial identity `Polynomial.coeff_one_add_X_pow` to power series
+  (`Polynomial.coe_pow/coe_add/coe_one/coe_X`, `PowerSeries.coeff_mk`, `Polynomial.coeff_coe`).
+- Both theorems are axiom-clean (`propext, Classical.choice, Quot.sound` only).
+- `lake build EtingofRepresentationTheory.Chapter2.Problem2_8_11` succeeds.
+
+## Current frontier
+Problem 2.8.11 part (a) remains sorry (lines ~44/50) — that is issue #6267, independent of this
+work. Parts (b), (c), (d) are now fully proved.
+
+## Overall project progress
+Stage 3 (formalization) ongoing. Problem 2.8.11: parts (b), (c), (d) fully proved; part (a)
+still stated-with-sorry (open issue #6267). Item status stays `statement_formalized` per the
+issue's instruction (all of (a)-(c) not yet done).
+
+## Next step
+Work #6267 (part a, polynomial algebra) or #6271 (Ch4 part e, unit quaternions ≅ SU(2)).
+
+## Blockers
+None.


### PR DESCRIPTION
Closes #6266

Session: `f15f983f-0742-4955-b321-7163be93c23b`

829c21d6 chore: progress note for #6266 (Problem 2.8.11 part c)
27e819f0 feat(Ch2 #Problem2.8.11c): prove exterior-algebra Hilbert series

🤖 Prepared with Claude Code