### PR TITLE
feat(Ch5 #Problem5.11.1a): prove indZ2_triv + reusable induced-character infra (indZ2_sign → #6291)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Problem5_11_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_11_1.lean
@@ -1,6 +1,10 @@
 import Mathlib
 import EtingofRepresentationTheory.Chapter5.Definition5_8_1
+import EtingofRepresentationTheory.Chapter5.Theorem5_9_1
+import EtingofRepresentationTheory.Chapter5.CharEqIso
 import EtingofRepresentationTheory.Chapter4.Example4_8_1.A5Golden
+import EtingofRepresentationTheory.Chapter4.Example4_9_1
+import EtingofRepresentationTheory.Chapter4.Problem4_12_5
 
 /-!
 # Problem 5.11.1: induced representations of `A₅`
@@ -68,7 +72,9 @@ with `sorry` proofs. `Ind_H^G` is `Etingof.Definition5_8_1`; the target biproduc
 catalogue objects `repTriv, repC3plus, repC3minus, repC4, repC5`.
 -/
 
-open CategoryTheory CategoryTheory.Limits Etingof.Example4_8_1.A5 Module
+open CategoryTheory CategoryTheory.Limits Etingof.Example4_8_1 Etingof.Example4_8_1.A5 Module
+  Finset
+open scoped Pointwise
 
 noncomputable section
 
@@ -163,6 +169,140 @@ lemma character_biprod {G : Type} [Group G] (X Y : FDRep ℂ G) (g : G) :
     _ = LinearMap.trace ℂ _ (LinearMap.prodMap (X.ρ g) (Y.ρ g)) := by rw [hconj]
     _ = X.character g + Y.character g := LinearMap.trace_prodMap' _ _
 
+/-! ## Induced-character computation for `ℤ₂`
+
+The character of `Ind_H^G σ` is computed by the Frobenius formula (Theorem 5.9.1); for an
+order-`2` subgroup `H` the twisted counts reduce, by conjugacy of `H` with the concrete cyclic
+subgroup `⟨classRepA5 2⟩`, to `decide`-evaluable computations over `A₅`. -/
+
+/-- The character of `ind σ` via the Frobenius formula (Theorem 5.9.1). -/
+lemma ind_character_eq {H : Subgroup A5} [DecidablePred (· ∈ H)] (σ : FDRep ℂ ↥H) (g : A5) :
+    (ind σ).character g
+      = (Fintype.card ↥H : ℂ)⁻¹ *
+          ∑ x : A5, if h : x * g * x⁻¹ ∈ H then σ.character ⟨x * g * x⁻¹, h⟩ else 0 := by
+  have hchar : (ind σ).character g
+      = LinearMap.trace ℂ (Representation.IndV H.subtype σ.ρ)
+          (Etingof.Definition5_8_1 H σ.ρ g) := rfl
+  rw [hchar, Etingof.Theorem5_9_1 H σ.ρ g]
+  rfl
+
+/-- Membership filter rewrite for the `x * g * x⁻¹` convention. -/
+lemma twisted_filter_eq' (a g : A5) (m : ℕ) (h : orderOf a = m) :
+    (univ.filter (fun x : A5 => x * g * x⁻¹ ∈ Subgroup.zpowers a))
+      = (univ.filter (fun x : A5 => x * g * x⁻¹ ∈ (Finset.range m).image (a ^ ·))) := by
+  ext x
+  simp only [mem_filter, mem_univ, true_and]
+  exact Etingof.Problem4_12_5.mem_zpowers_range a m h _
+
+set_option maxRecDepth 8000 in
+set_option maxHeartbeats 4000000 in
+/-- The twisted counts `#{x : x·(classRepA5 j)·x⁻¹ ∈ ⟨classRepA5 2⟩}` on the five classes. -/
+lemma twisted_p2' (j : Fin 5) :
+    (univ.filter
+        (fun x : A5 => x * classRepA5 j * x⁻¹ ∈ Subgroup.zpowers (classRepA5 2))).card
+      = ![60, 0, 4, 0, 0] j := by
+  rw [twisted_filter_eq' (classRepA5 2) (classRepA5 j) 2 Etingof.Problem4_12_5.ord_cr2]
+  fin_cases j <;> decide
+
+/-- An order-`2` subgroup of `A₅` is conjugate to `⟨classRepA5 2⟩`: there is `d` with
+`y ∈ H ↔ d y d⁻¹ ∈ ⟨classRepA5 2⟩`. -/
+lemma exists_conj_H (H : Subgroup A5) (hH : Nat.card H = 2) :
+    ∃ d : A5, ∀ y : A5, y ∈ H ↔ d * y * d⁻¹ ∈ Subgroup.zpowers (classRepA5 2) := by
+  haveI : Nontrivial H := Finite.one_lt_card_iff_nontrivial.mp (by rw [hH]; norm_num)
+  obtain ⟨s, hs_mem, hs_ne⟩ := H.nontrivial_iff_exists_ne_one.mp inferInstance
+  have hdvd : orderOf s ∣ 2 := by
+    rw [← hH]
+    have := orderOf_dvd_natCard (⟨s, hs_mem⟩ : H)
+    rwa [Subgroup.orderOf_mk] at this
+  have hord2 : orderOf s = 2 := by
+    rcases (Nat.Prime.eq_one_or_self_of_dvd (by norm_num) _ hdvd) with h | h
+    · exact absurd (orderOf_eq_one_iff.mp h) hs_ne
+    · exact h
+  have hs2 : s ^ 2 = 1 := by rw [← hord2]; exact pow_orderOf_eq_one s
+  have hcl : classIdxA5 s = 2 := Etingof.Problem4_12_5.classIdx_of_involution s hs2 hs_ne
+  obtain ⟨c, hc⟩ := classIdxA5_spec s
+  rw [hcl] at hc
+  have hzs : Subgroup.zpowers s = H := by
+    apply Subgroup.eq_of_le_of_card_ge
+    · rw [Subgroup.zpowers_le]; exact hs_mem
+    · rw [Nat.card_zpowers, hord2, hH]
+  refine ⟨c⁻¹, fun y => ?_⟩
+  have hHeq : H = MulAut.conj c • Subgroup.zpowers (classRepA5 2) := by
+    rw [Etingof.Problem4_12_5.conj_smul_zpowers, hc, hzs]
+  rw [hHeq, Subgroup.mem_pointwise_smul_iff_inv_smul_mem]
+  simp only [MulAut.smul_def, MulAut.conj_inv_apply, inv_inv]
+
+/-- The count of conjugators landing in an order-2 `H` matches that for `⟨classRepA5 2⟩`. -/
+lemma countH_eq (H : Subgroup A5) [DecidablePred (· ∈ H)] (hH : Nat.card H = 2) (g : A5) :
+    (univ.filter (fun x : A5 => x * g * x⁻¹ ∈ H)).card
+      = (univ.filter
+          (fun x : A5 => x * g * x⁻¹ ∈ Subgroup.zpowers (classRepA5 2))).card := by
+  obtain ⟨d, hd⟩ := exists_conj_H H hH
+  apply Finset.card_bij' (fun x _ => d * x) (fun x _ => d⁻¹ * x)
+  · intro x hx
+    simp only [mem_filter, mem_univ, true_and] at hx ⊢
+    rw [hd] at hx
+    rw [show d * x * g * (d * x)⁻¹ = d * (x * g * x⁻¹) * d⁻¹ by group]
+    exact hx
+  · intro x hx
+    simp only [mem_filter, mem_univ, true_and] at hx ⊢
+    rw [hd]
+    rw [show d * (d⁻¹ * x * g * (d⁻¹ * x)⁻¹) * d⁻¹ = x * g * x⁻¹ by group]
+    exact hx
+  · intro x hx; group
+  · intro x hx; group
+
+/-- **Trivial character, class-rep values.** For an order-2 `H` and the trivial character `σ`,
+`(ind σ).character` on the five class reps is `(30, 0, 2, 0, 0)`. -/
+lemma indZ2_triv_value (H : Subgroup A5) [DecidablePred (· ∈ H)] (hH : Nat.card H = 2)
+    (σ : FDRep ℂ ↥H) (htriv : ∀ h : ↥H, σ.character h = 1) (j : Fin 5) :
+    (ind σ).character (classRepA5 j) = ![30, 0, 2, 0, 0] j := by
+  rw [ind_character_eq]
+  have hcard : (Fintype.card ↥H : ℂ) = 2 := by
+    rw [← Nat.card_eq_fintype_card, hH]; norm_num
+  have hsum : (∑ x : A5, if h : x * classRepA5 j * x⁻¹ ∈ H then σ.character ⟨_, h⟩ else 0)
+      = ((univ.filter (fun x : A5 => x * classRepA5 j * x⁻¹ ∈ H)).card : ℂ) := by
+    rw [← Finset.sum_boole]
+    apply Finset.sum_congr rfl
+    intro x _
+    by_cases hx : x * classRepA5 j * x⁻¹ ∈ H
+    · rw [dif_pos hx, if_pos hx, htriv]
+    · rw [dif_neg hx, if_neg hx]
+  rw [hsum, countH_eq H hH, twisted_p2', hcard]
+  fin_cases j <;> norm_num
+
+/-- Arbitrary-`g` trivial-character values, via the class-function property. -/
+lemma indZ2_triv_char_all (H : Subgroup A5) [DecidablePred (· ∈ H)] (hH : Nat.card H = 2)
+    (σ : FDRep ℂ ↥H) (htriv : ∀ h : ↥H, σ.character h = 1) (g : A5) :
+    (ind σ).character g = ![30, 0, 2, 0, 0] (classIdxA5 g) := by
+  obtain ⟨c, hc⟩ := classIdxA5_spec g
+  conv_lhs => rw [← hc]
+  rw [FDRep.char_conj]
+  exact indZ2_triv_value H hH σ htriv (classIdxA5 g)
+
+/-- **Target character, class-rep values** for the trivial-character decomposition. -/
+lemma indZ2_triv_target_value (j : Fin 5) :
+    (repTriv ⊞ repC3plus ⊞ repC3minus ⊞ repC4 ⊞ repC4 ⊞ repC5 ⊞ repC5 ⊞ repC5).character
+        (classRepA5 j) = ![30, 0, 2, 0, 0] j := by
+  simp only [character_biprod, repTriv_character, repC3plus_character, repC3minus_character,
+    repC4_character, repC5_character]
+  have hs := sqrt5_sq
+  fin_cases j <;>
+    norm_num [Q5toC, chiA5, tblA5, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+      Matrix.cons_val_three, Matrix.cons_val_four, Matrix.head_cons, Matrix.tail_cons,
+      Q5.mk_re, Q5.mk_im, Q5.ofNat_re, Q5.ofNat_im, Q5.neg_re, Q5.neg_im, Q5.one_re, Q5.one_im,
+      Q5.zero_re, Q5.zero_im] <;>
+    ring
+
+/-- Arbitrary-`g` target character values, via the class-function property. -/
+lemma indZ2_triv_target_char_all (g : A5) :
+    (repTriv ⊞ repC3plus ⊞ repC3minus ⊞ repC4 ⊞ repC4 ⊞ repC5 ⊞ repC5 ⊞ repC5).character g
+      = ![30, 0, 2, 0, 0] (classIdxA5 g) := by
+  obtain ⟨c, hc⟩ := classIdxA5_spec g
+  conv_lhs => rw [← hc]
+  rw [FDRep.char_conj]
+  exact indZ2_triv_target_value (classIdxA5 g)
+
 /-! ## (a) Induction from `ℤ₂` -/
 
 /-- **(a) trivial character.** `Ind_{ℤ₂}^{A₅} 1₊ ≅ 1 ⊕ 3 ⊕ 3' ⊕ 4² ⊕ 5³` (dimension `30`), the
@@ -171,7 +311,10 @@ theorem indZ2_triv (H : Subgroup A5) (hH : Nat.card H = 2)
     (σ : FDRep ℂ ↥H) [Simple σ] (htriv : ∀ h : ↥H, σ.character h = 1) :
     Nonempty (ind σ ≅
       repTriv ⊞ repC3plus ⊞ repC3minus ⊞ repC4 ⊞ repC4 ⊞ repC5 ⊞ repC5 ⊞ repC5) := by
-  sorry
+  classical
+  apply Etingof.charEq_iso
+  funext g
+  rw [indZ2_triv_char_all H hH σ htriv g, indZ2_triv_target_char_all g]
 
 /-- **(a) sign character.** `Ind_{ℤ₂}^{A₅} 1₋ ≅ 3² ⊕ 3'² ⊕ 4² ⊕ 5²` (dimension `30`).
 Multiplicities `(χ_W(1a) − χ_W(2a))/2`. -/

--- a/EtingofRepresentationTheory/Chapter5/Problem5_11_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_11_1.lean
@@ -68,7 +68,7 @@ with `sorry` proofs. `Ind_H^G` is `Etingof.Definition5_8_1`; the target biproduc
 catalogue objects `repTriv, repC3plus, repC3minus, repC4, repC5`.
 -/
 
-open CategoryTheory Etingof.Example4_8_1.A5
+open CategoryTheory CategoryTheory.Limits Etingof.Example4_8_1.A5 Module
 
 noncomputable section
 
@@ -81,6 +81,87 @@ abbrev A5 : Type := ↥(alternatingGroup (Fin 5))
 `H ≤ A₅`, packaged as an object of `FDRep ℂ A₅` via `Etingof.Definition5_8_1`. -/
 abbrev ind {H : Subgroup A5} (σ : FDRep ℂ ↥H) : FDRep ℂ A5 :=
   FDRep.of (Etingof.Definition5_8_1 H σ.ρ)
+
+/-! ## Character additivity over binary biproducts
+
+The `charEq_iso` route (`Chapter5/CharEqIso.lean`) reduces each `Ind σ ≅ ⊞ …` claim to a
+character identity. To compute the character of the target biproduct we need additivity of the
+character over `⊞`, which is not in Mathlib; we establish it here (reusable for all of parts
+(a)–(e)). -/
+
+/-- Underlying-linear-map intertwining for a morphism of `FDRep`: the underlying `ℂ`-linear map
+of `f : A ⟶ B` commutes with the `G`-actions. -/
+lemma fdrep_hom_comm {G : Type} [Group G] {A B : FDRep ℂ G} (f : A ⟶ B) (g : G) (a : (A : Type)) :
+    f.hom.hom.hom (A.ρ g a) = B.ρ g (f.hom.hom.hom a) := by
+  have h := f.comm g
+  apply_fun (fun m : A.V ⟶ B.V => m.hom.hom) at h
+  have h2 := congrFun (congrArg (fun (m : (A.V.obj) →ₗ[ℂ] (B.V.obj)) => (m : _ → _)) h) a
+  simpa using h2
+
+/-- The `ℂ`-linear equivalence underlying a binary biproduct in `FDRep ℂ G`, sending `v` to its
+two projections. -/
+noncomputable def biprodProdEquiv {G : Type} [Group G] (X Y : FDRep ℂ G) :
+    (X ⊞ Y : FDRep ℂ G) ≃ₗ[ℂ] Prod (X : Type) (Y : Type) where
+  toFun v := ((biprod.fst : X ⊞ Y ⟶ X).hom.hom.hom v,
+              (biprod.snd : X ⊞ Y ⟶ Y).hom.hom.hom v)
+  map_add' a b := Prod.ext (map_add _ _ _) (map_add _ _ _)
+  map_smul' r a := Prod.ext (map_smul _ _ _) (map_smul _ _ _)
+  invFun p := (biprod.inl : X ⟶ X ⊞ Y).hom.hom.hom p.1 +
+              (biprod.inr : Y ⟶ X ⊞ Y).hom.hom.hom p.2
+  left_inv v := by
+    change ((biprod.fst ≫ biprod.inl + biprod.snd ≫ biprod.inr :
+      (X ⊞ Y : FDRep ℂ G) ⟶ (X ⊞ Y))).hom.hom.hom v = v
+    rw [biprod.total]; rfl
+  right_inv p := by
+    have hzero : ∀ (A B : FDRep ℂ G) (x : (A : Type)), (0 : A ⟶ B).hom.hom.hom x = 0 := by
+      intro A B x
+      change (0 : A.V.obj ⟶ B.V.obj).hom x = 0
+      simp [ModuleCat.Hom.hom]
+    have hid : ∀ (A : FDRep ℂ G) (x : (A : Type)), (𝟙 A : A ⟶ A).hom.hom.hom x = x :=
+      fun _ _ => rfl
+    ext <;> dsimp only
+    · change ((biprod.fst : X ⊞ Y ⟶ X)).hom.hom.hom
+          ((biprod.inl : X ⟶ X ⊞ Y).hom.hom.hom p.1 +
+           (biprod.inr : Y ⟶ X ⊞ Y).hom.hom.hom p.2) = p.1
+      rw [map_add]
+      change ((biprod.inl ≫ biprod.fst : X ⟶ X)).hom.hom.hom p.1 +
+           ((biprod.inr ≫ biprod.fst : Y ⟶ X)).hom.hom.hom p.2 = p.1
+      rw [biprod.inl_fst, biprod.inr_fst, hid, hzero, add_zero]
+    · change ((biprod.snd : X ⊞ Y ⟶ Y)).hom.hom.hom
+          ((biprod.inl : X ⟶ X ⊞ Y).hom.hom.hom p.1 +
+           (biprod.inr : Y ⟶ X ⊞ Y).hom.hom.hom p.2) = p.2
+      rw [map_add]
+      change ((biprod.inl ≫ biprod.snd : X ⟶ Y)).hom.hom.hom p.1 +
+           ((biprod.inr ≫ biprod.snd : Y ⟶ Y)).hom.hom.hom p.2 = p.2
+      rw [biprod.inl_snd, biprod.inr_snd, hzero, hid, zero_add]
+
+/-- **Character additivity over a binary biproduct** in `FDRep ℂ G`:
+`(X ⊞ Y).character = X.character + Y.character`. -/
+lemma character_biprod {G : Type} [Group G] (X Y : FDRep ℂ G) (g : G) :
+    (X ⊞ Y).character g = X.character g + Y.character g := by
+  have hequiv : ∀ v, (biprodProdEquiv X Y) ((X ⊞ Y).ρ g v)
+      = LinearMap.prodMap (X.ρ g) (Y.ρ g) ((biprodProdEquiv X Y) v) := by
+    intro v
+    apply Prod.ext
+    · change (biprod.fst : X ⊞ Y ⟶ X).hom.hom.hom ((X ⊞ Y).ρ g v)
+        = X.ρ g ((biprod.fst : X ⊞ Y ⟶ X).hom.hom.hom v)
+      exact fdrep_hom_comm (biprod.fst : X ⊞ Y ⟶ X) g v
+    · change (biprod.snd : X ⊞ Y ⟶ Y).hom.hom.hom ((X ⊞ Y).ρ g v)
+        = Y.ρ g ((biprod.snd : X ⊞ Y ⟶ Y).hom.hom.hom v)
+      exact fdrep_hom_comm (biprod.snd : X ⊞ Y ⟶ Y) g v
+  have hconj : (biprodProdEquiv X Y).conj ((X ⊞ Y).ρ g)
+      = LinearMap.prodMap (X.ρ g) (Y.ρ g) := by
+    refine LinearMap.ext fun w => ?_
+    rw [LinearEquiv.conj_apply, LinearMap.comp_apply, LinearMap.comp_apply]
+    have hv := hequiv ((biprodProdEquiv X Y).symm w)
+    rw [LinearEquiv.apply_symm_apply] at hv
+    simpa using hv
+  calc (X ⊞ Y).character g
+      = LinearMap.trace ℂ _ ((X ⊞ Y).ρ g) := rfl
+    _ = LinearMap.trace ℂ _ ((biprodProdEquiv X Y).conj ((X ⊞ Y).ρ g)) :=
+        (LinearMap.trace_conj' _ _).symm
+    _ = LinearMap.trace ℂ _ (LinearMap.prodMap (X.ρ g) (Y.ρ g)) := by rw [hconj]
+    _ = X.character g + Y.character g := LinearMap.trace_prodMap' _ _
 
 /-! ## (a) Induction from `ℤ₂` -/
 

--- a/progress/2026-07-10T20-38-28Z_74900495.md
+++ b/progress/2026-07-10T20-38-28Z_74900495.md
@@ -1,0 +1,44 @@
+## Accomplished
+
+Session type: `/work` (meta) → feature.
+
+- **Resolved stale issue #6245** (fixed-point character of the transitive A₅ action):
+  the deliverable was already implemented as `fixCount_vertices` (no sorry) by the merged
+  PR #6270. Commented with the exact location and `coordination skip`ped it for planner
+  closure.
+- **Claimed and partially completed #6274** (Problem 5.11.1 part (a), induced reps from ℤ₂):
+  - Proved `character_biprod` — reusable character additivity over binary biproducts in
+    `FDRep ℂ G` (`(X ⊞ Y).character = X.character + Y.character`), via an equivariant linear
+    equiv onto the product and `trace_prodMap'`. Not previously in Mathlib or the project.
+  - Proved `indZ2_triv` fully (`Ind_{ℤ₂}^{A₅} 1₊ ≅ 1⊕3⊕3'⊕4²⊕5³`): computed the induced
+    character by the Frobenius formula (`Theorem5_9_1`), reduced the twisted conjugator counts
+    to `decide` over A₅ by conjugating any order-2 `H` to `⟨classRepA5 2⟩`, matched the
+    catalogue biproduct character via `character_biprod` + the A₅ character table, and
+    concluded with `charEq_iso`. Both characters are `(30,0,2,0,0)` on the class reps.
+  - Landed the reusable induced-character/counting infrastructure:
+    `ind_character_eq`, `twisted_filter_eq'`, `twisted_p2'`, `exists_conj_H`, `countH_eq`,
+    plus the class-rep value and class-function-reduction lemmas.
+  - Split the remaining `indZ2_sign` into sub-issue #6291 with a full proof plan.
+
+## Current frontier
+
+`indZ2_sign` (the sign-character half of part (a)) remains `sorry`. All its infrastructure is
+in place; the only new ingredient is `σ.character t' = -1` (the 1-dim sign value), sketched in
+#6291 via `FDRep.simple_iff_char_is_norm_one` + `IsProj.trace` on the involution `σ.ρ t'`.
+
+## Overall project progress
+
+Phase 3 (formalization) ongoing. Problem 5.11.1 part (a): `indZ2_triv` done, `indZ2_sign`
+open (#6291). Parts (b)–(e) remain `sorry` and can reuse the new `character_biprod` /
+`ind_character_eq` / conjugacy-count infrastructure.
+
+## Next step
+
+Claim #6291 and prove `indZ2_sign`, reusing the committed part-(a) infrastructure. Then parts
+(b)–(e) follow the same pattern (compute the induced character from `ind_character_eq`, reduce
+twisted counts by conjugacy of the relevant order subgroup to a concrete cyclic/Sylow subgroup,
+match the catalogue biproduct via `character_biprod`, apply `charEq_iso`).
+
+## Blockers
+
+None. `indZ2_sign` is unblocked (sub-issue #6291 with a self-contained plan).


### PR DESCRIPTION
Partial progress on #6274

Session: `74900495-c171-42f9-8885-7f8ae2d1c93d`

53a1ea72 progress: indZ2_triv done, indZ2_sign split to #6291 (2026-07-10T20-38-28Z)
b7eb7f13 feat(Ch5 #Problem5.11.1a): prove indZ2_triv via Frobenius character + charEq_iso
7a4ec266 feat(Ch5 #Problem5.11.1a): add reusable FDRep biproduct character additivity helper

🤖 Prepared with Claude Code