### PR TITLE
feat(Ch5 #Problem5.16.1): prove branching part (b) ind_spechtModule_multiplicity

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Problem5_16_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_16_1.lean
@@ -72,6 +72,22 @@ theorem res_spechtModule_character (n : ℕ) (μ : Nat.Partition (n + 1))
     (σ : Equiv.Perm (Fin n)) :
     spechtModuleCharacter (n + 1) μ (permEmb n σ) =
       ∑ la ∈ removeSquare μ, spechtModuleCharacter n la σ := by
+  -- Proof strategy (Frobenius character formula / Pieri rule for `p₁`), scoped as a
+  -- separate work item. Bridge both sides to `charValue` (Proposition5_21_1) over `N = n+1`
+  -- variables via `charValue_eq_spechtModuleCharacter` and
+  -- `exists_boundedPartition_weightToPartition_eq`. Writing `Δ = det(alternantMatrix (vandermondeExps))`
+  -- and `g = Δ · psumPart (fullCycleTypePartition σ)` (antisymmetric, since `psumPart` is symmetric
+  -- and `Δ` antisymmetric), the key facts are:
+  --   1. `fullCycleType (n+1) (permEmb n σ) = 1 ::ₘ fullCycleType n σ` (embedding adds a fixed point),
+  --      hence `psumPart (fullCycleTypePartition (permEmb n σ)) = psum 1 * psumPart (fullCycleTypePartition σ)`
+  --      where `psum 1 = ∑ⱼ Xⱼ`.
+  --   2. `coeff_{μ+ρ}((∑ⱼ Xⱼ) · g) = ∑ⱼ coeff_{μ+ρ-eⱼ}(g)` (`MvPolynomial.coeff_X_mul` termwise).
+  --   3. `coeff_{μ+ρ-eⱼ}(g) = charValue` of the box-removal `λ = μ - eⱼ` when that is a valid
+  --      partition (`μⱼ > μⱼ₊₁`), and `= 0` otherwise, because `μ+ρ-eⱼ` then has a repeated entry and
+  --      `g` is antisymmetric (`coeff_zero_of_antisym_repeated`, `rename_alternant_det`).
+  --   4. The legal box-removal rows `j` biject with `removeSquare μ = {λ ⊢ n : λ.toYoungDiagram ≤
+  --      μ.toYoungDiagram}`, matching `shiftedExps (bp_λ.parts) = μ+ρ-eⱼ`.
+  -- See GitHub issue tracking this sub-task.
   sorry
 
 /-- Problem 5.16.1(b). Branching rule for induction: for `μ ⊢ n`, the induced module

--- a/EtingofRepresentationTheory/Chapter5/Problem5_16_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_16_1.lean
@@ -84,6 +84,32 @@ theorem ind_spechtModule_multiplicity (n : ℕ) (μ : Nat.Partition n)
     branchingPairing n (spechtModuleCharacter n μ)
         (fun σ => spechtModuleCharacter (n + 1) la (permEmb n σ)) =
       if μ.toYoungDiagram ≤ la.toYoungDiagram then 1 else 0 := by
-  sorry
+  classical
+  have hcard : (Fintype.card (Equiv.Perm (Fin n)) : ℂ) = (Nat.factorial n : ℂ) := by
+    rw [Fintype.card_perm, Fintype.card_fin]
+  have hne : (Nat.factorial n : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.factorial_ne_zero n)
+  -- Expand the pairing using part (a) (restriction branching) and character orthonormality.
+  have hexpand :
+      ∑ σ : Equiv.Perm (Fin n),
+        spechtModuleCharacter n μ σ *
+          spechtModuleCharacter (n + 1) la (permEmb n σ⁻¹)
+        = (Nat.factorial n : ℂ) *
+            ∑ ρ ∈ removeSquare la, (if μ = ρ then (1 : ℂ) else 0) := by
+    -- Apply the restriction rule at `σ⁻¹`, distribute, swap the sums, and use orthonormality.
+    have e1 : ∑ σ : Equiv.Perm (Fin n),
+        spechtModuleCharacter n μ σ *
+          spechtModuleCharacter (n + 1) la (permEmb n σ⁻¹)
+        = ∑ σ : Equiv.Perm (Fin n),
+            ∑ ρ ∈ removeSquare la,
+              spechtModuleCharacter n μ σ * spechtModuleCharacter n ρ σ⁻¹ := by
+      refine Finset.sum_congr rfl (fun σ _ => ?_)
+      rw [res_spechtModule_character n la σ⁻¹, Finset.mul_sum]
+    rw [e1, Finset.sum_comm, Finset.mul_sum]
+    refine Finset.sum_congr rfl (fun ρ _ => ?_)
+    rw [specht_char_inner n μ ρ]
+  unfold branchingPairing
+  dsimp only
+  rw [hexpand, hcard, ← mul_assoc, inv_mul_cancel₀ hne, one_mul]
+  simp only [Finset.sum_ite_eq, removeSquare, Finset.mem_filter, Finset.mem_univ, true_and]
 
 end Etingof

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_15_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_15_1.lean
@@ -2310,7 +2310,7 @@ private theorem coeff_eq_youngsRule_expansion'
 
 /-- Character inner product for Specht modules:
 ∑_σ χ_ν(σ) · χ_μ(σ⁻¹) = n! · δ_{ν,μ}. -/
-private theorem specht_char_inner (n : ℕ) (ν μ : Nat.Partition n) :
+theorem specht_char_inner (n : ℕ) (ν μ : Nat.Partition n) :
     ∑ σ : Equiv.Perm (Fin n),
       spechtModuleCharacter n ν σ * spechtModuleCharacter n μ σ⁻¹ =
     (Nat.factorial n : ℂ) * if ν = μ then 1 else 0 := by

--- a/progress/2026-07-10T20-56-57Z_e1b96bc8.md
+++ b/progress/2026-07-10T20-56-57Z_e1b96bc8.md
@@ -1,0 +1,29 @@
+## Accomplished
+- Claimed and worked issue #6282 (Problem 5.16.1, symmetric-group branching rule).
+- Selected #6282 over #6283 after assessing infrastructure: #6283 (derived Ext¹ ≅ cocycle
+  Ext¹) needs a Yoneda↔derived-Ext bridge absent from Mathlib; #6282 has a real Frobenius-
+  character-formula route (`charValue`) and orthonormality already in the project.
+- **Proved part (b) `ind_spechtModule_multiplicity`** fully: reduces to part (a) plus
+  `specht_char_inner` (Specht-character orthonormality). Substitute Res χ_{V_λ}, swap sums
+  (`Finset.sum_comm`), collapse ∑_σ χ_μ(σ)χ_ρ(σ⁻¹)=n!·δ to the indicator [μ ⊆ λ].
+- Exposed `specht_char_inner` in Theorem5_15_1.lean (removed `private`) so it is usable here.
+- Part (a) `res_spechtModule_character` remains `sorry`, now carrying a detailed
+  Frobenius/Pieri proof-strategy comment.
+
+## Current frontier
+Part (a) is the sole remaining sorry in Problem5_16_1.lean. It is the genuine hard content
+(restriction branching = Pieri rule for p₁ on the Frobenius alternant), requiring: cycle type
+of `permEmb` (= adds a 1-part), `psumPart` factoring out `psum 1`, the `(∑Xⱼ)·g` coefficient
+shift, antisymmetry vanishing (`coeff_zero_of_antisym_repeated`), and a box-removal ↔
+`removeSquare` bijection matching `shiftedExps`.
+
+## Overall project progress
+Stage 3 (formalization) ongoing. Problem 5.16.1: part (b) proved, part (a) scoped to #6300.
+
+## Next step
+Work #6300 (prove `res_spechtModule_character`) following the strategy comment in the file and
+the issue body. `charValue_eq_spechtModuleCharacter` + `exists_boundedPartition_weightToPartition_eq`
+give the bridge; `Proposition5_21_1.lean` has the alternant/antisymmetry machinery.
+
+## Blockers
+None. Part (a) is large but self-contained; decomposed to #6300.


### PR DESCRIPTION
Partial progress on #6282

Session: `e1b96bc8-7a0c-4183-b56b-668ab018f0e0`

5b8257dd progress: Ch5 #6282 part (b) proved, part (a) scoped to #6300
fe8453c5 doc(Ch5 #6282): record part-(a) Frobenius/Pieri proof strategy in sorry comment
4fa74e40 feat(Ch5 #6282): prove ind_spechtModule_multiplicity (branching part b) via Frobenius reciprocity

🤖 Prepared with Claude Code