### PR TITLE
feat(Ch5 #Exercise5.1.7): prove exists_irreducible_not_realType_of_odd_order via existence of a nontrivial irreducible + 5.3.3

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Exercise5_1_7.lean
+++ b/EtingofRepresentationTheory/Chapter5/Exercise5_1_7.lean
@@ -1,5 +1,7 @@
 import Mathlib
 import EtingofRepresentationTheory.Chapter5.Definition5_1_1
+import EtingofRepresentationTheory.Chapter5.Exercise5_3_3
+import EtingofRepresentationTheory.Infrastructure.IrreducibleEnumeration
 
 /-!
 # Exercise 5.1.7: an odd-order group has an irreducible not defined over ℝ
@@ -19,7 +21,21 @@ The statement below asserts the existence of a nontrivial irreducible complex re
 real type. Exercise 5.3.3 strengthens this to: every nontrivial irreducible is of complex
 type.
 
-Statement pass: the proof is left as `sorry`.
+## Proof
+
+The odd-order hypothesis is used only by the reduction lemma
+`not_isRealType_of_odd_order_of_nontrivial_irreducible` (Exercise 5.3.3), which turns any
+nontrivial irreducible into one that is not of real type. So the entire content here is to
+**produce one nontrivial irreducible complex representation** of the nontrivial finite group
+`G`, then feed it to that lemma.
+
+We use the Wedderburn-Artin enumeration `IrrepDecomp.mk'` of the irreducibles of `ℂ[G]` as
+its column representations `D.columnRep i` (each simple by
+`isSimpleModule_columnRep_asModule`). At least one of them has nontrivial `G`-action: if every
+`D.columnRep i` acted trivially, then for a chosen `g₀ ≠ 1` each matrix factor
+`D.projRingHom i (of g₀)` would be the identity (`Matrix.mulVecLin` is injective), forcing
+`D.iso (of g₀) = 1 = D.iso (of 1)` and hence `g₀ = 1` (injectivity of the Wedderburn
+isomorphism and of `MonoidAlgebra.of`), a contradiction.
 -/
 
 namespace Etingof
@@ -37,7 +53,40 @@ theorem exists_irreducible_not_realType_of_odd_order
       IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule ∧
       (∃ g, ρ g ≠ 1) ∧
       ¬ Etingof.IsRealType ρ := by
-  sorry
+  haveI : NeZero (Nat.card G : ℂ) := by
+    rw [Nat.card_eq_fintype_card]
+    exact ⟨Nat.cast_ne_zero.mpr (Fintype.card_pos (α := G)).ne'⟩
+  -- The Wedderburn-Artin enumeration of the irreducibles of `ℂ[G]`.
+  let D := IrrepDecomp.mk' (k := ℂ) (G := G)
+  -- Some column representation has nontrivial `G`-action.
+  obtain ⟨j, g₀, hj⟩ : ∃ (j : Fin D.n) (g : G), (D.columnRep j) g ≠ 1 := by
+    by_contra h
+    simp only [not_exists, not_ne_iff] at h
+    obtain ⟨g₀, hg₀⟩ := exists_ne (1 : G)
+    -- Each matrix factor of `of g₀` is the identity.
+    have hmat : ∀ j : Fin D.n, D.projRingHom j (MonoidAlgebra.of ℂ G g₀) = 1 := by
+      intro j
+      have hdef : (D.columnRep j) g₀ =
+          Matrix.mulVecLin (D.projRingHom j (MonoidAlgebra.of ℂ G g₀)) := rfl
+      apply Matrix.toLin'.injective
+      rw [Matrix.toLin'_apply', Matrix.toLin'_apply', Matrix.mulVecLin_one, ← hdef, h j g₀]
+      rfl
+    -- Hence `D.iso (of g₀) = 1`, so `of g₀ = of 1`, so `g₀ = 1`.
+    have hprod : D.iso (MonoidAlgebra.of ℂ G g₀) = 1 := by
+      funext i
+      rw [Pi.one_apply]
+      have := hmat i
+      simpa [IrrepDecomp.projRingHom, Pi.evalRingHom] using this
+    have hof : MonoidAlgebra.of ℂ G g₀ = 1 := by
+      apply D.iso.injective
+      rw [hprod, map_one]
+    exact hg₀ (MonoidAlgebra.of_injective (hof.trans (map_one (MonoidAlgebra.of ℂ G)).symm))
+  -- This column representation is a nontrivial irreducible; apply Exercise 5.3.3.
+  haveI : NeZero (D.d j) := D.d_pos j
+  refine ⟨Fin (D.d j) → ℂ, inferInstance, inferInstance, inferInstance, D.columnRep j,
+    D.isSimpleModule_columnRep_asModule j, ⟨g₀, hj⟩, ?_⟩
+  exact not_isRealType_of_odd_order_of_nontrivial_irreducible hodd (D.columnRep j)
+    (D.isSimpleModule_columnRep_asModule j) ⟨g₀, hj⟩
 
 end Exercise517
 

--- a/progress/2026-07-10T20-59-49Z_c98f020d.md
+++ b/progress/2026-07-10T20-59-49Z_c98f020d.md
@@ -1,0 +1,41 @@
+## Accomplished
+
+Proved `exists_irreducible_not_realType_of_odd_order` (Exercise 5.1.7, issue #6294),
+removing the last `sorry` from `EtingofRepresentationTheory/Chapter5/Exercise5_1_7.lean`.
+The signature was kept verbatim.
+
+Approach:
+- The odd-order hypothesis is consumed entirely by the sorry-free reduction lemma
+  `not_isRealType_of_odd_order_of_nontrivial_irreducible` (Exercise 5.3.3). So the only
+  remaining content was to exhibit **one nontrivial irreducible complex representation** of
+  the nontrivial finite group `G`.
+- Reused the Wedderburn-Artin enumeration `IrrepDecomp.mk'` from
+  `Infrastructure/IrreducibleEnumeration.lean`: its column representations `D.columnRep i`
+  are simple (`IrrepDecomp.isSimpleModule_columnRep_asModule`, universe-polymorphic, needs
+  only `NeZero (Nat.card G : ℂ)`).
+- Nontriviality of the action of at least one column rep: by contradiction. If every
+  `D.columnRep i` acted trivially, then for `g₀ ≠ 1` each `D.projRingHom i (of g₀)` is the
+  identity matrix (`Matrix.mulVecLin` injective via the `Matrix.toLin'` equiv +
+  `Matrix.mulVecLin_one`), forcing `D.iso (of g₀) = 1 = D.iso (of 1)`, hence `g₀ = 1`
+  (injectivity of `D.iso` and `MonoidAlgebra.of_injective`) — contradiction with
+  `Nontrivial G`.
+
+## Current frontier
+
+`Exercise5_1_7.lean` builds clean (no `sorry`, no new warnings).
+`lake build EtingofRepresentationTheory.Chapter5.Exercise5_1_7` succeeds (8591 jobs).
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. This turn closed one Chapter 5 exercise. Remaining
+unclaimed feature issues at start of turn: #6285 (Problem 5.16.3a, large), #6295
+(Problem 4.12.6 statement fix).
+
+## Next step
+
+Pick up #6295 (fix the false `one_dim_reps_card` statement for `K = 𝔽₂`) or #6285
+(Problem 5.16.3a, `E = Cₙ − Cₙ₋₁`, depends-on #6284 which is now closed/merged).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6294

Session: `c98f020d-6b3f-4150-9d1c-0d6375883c06`

9bd7c38f feat(Ch5 #Exercise5.1.7): prove exists_irreducible_not_realType_of_odd_order

🤖 Prepared with Claude Code