### PR TITLE
feat(Ch6 #Problem6.1.6a): prove mult_symm — McKay multiplicities r_ij = r_ji via self-duality of the 2-dim SU(2) rep

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/Problem6_1_6.lean
+++ b/EtingofRepresentationTheory/Chapter6/Problem6_1_6.lean
@@ -75,12 +75,60 @@ noncomputable def mckayCartan (i j : Fin m) : ℤ :=
 
 /-! ## Part (a): symmetry of the multiplicities -/
 
+omit [Finite G] in
+/-- The character of the tautological representation is the matrix trace of the
+`SU(2)`-element. -/
+lemma charV_eq (g : G) :
+    (V G).character g =
+      Matrix.trace ((g.val : specialUnitaryGroup (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ) := by
+  simp only [FDRep.character, V, FDRep.of_ρ']
+  exact Matrix.trace_toLin'_eq _
+
+omit [Finite G] in
+/-- **Reality/self-duality of `χ_V`.** For `g ∈ SU(2)` the trace is invariant
+under inversion: `χ_V(g⁻¹) = χ_V(g)`. This holds because for a `2×2` matrix `A`
+of determinant `1` one has `A⁻¹ = adj A`, and `tr (adj A) = tr A`. -/
+lemma charV_inv (g : G) : (V G).character g⁻¹ = (V G).character g := by
+  rw [charV_eq, charV_eq]
+  set A : Matrix (Fin 2) (Fin 2) ℂ :=
+    ((g.val : specialUnitaryGroup (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ) with hA
+  set B : Matrix (Fin 2) (Fin 2) ℂ :=
+    ((g⁻¹.val : specialUnitaryGroup (Fin 2) ℂ) : Matrix (Fin 2) (Fin 2) ℂ) with hB
+  -- `B` is a left inverse of `A` (group law pushed to matrices).
+  have hBA : B * A = 1 := by
+    rw [hB, hA, ← MulMemClass.coe_mul, ← MulMemClass.coe_mul, inv_mul_cancel]
+    rfl
+  -- `det A = 1` from `SU(2)`-membership.
+  have hdet : A.det = 1 := (Matrix.mem_specialUnitaryGroup_iff.mp g.val.property).2
+  -- Hence `B = A⁻¹ = adj A`, whose trace equals `tr A`.
+  have hBinv : B = A⁻¹ := (Matrix.inv_eq_left_inv hBA).symm
+  rw [hBinv, Matrix.inv_def, hdet, Ring.inverse_one, one_smul, Matrix.adjugate_fin_two,
+    Matrix.trace_fin_two_of, Matrix.trace_fin_two]
+  ring
+
 /-- **(a)** `rᵢⱼ = rⱼᵢ`. (Because `V` is self-dual: `V ≅ V*` as `V` is the
 `2`-dimensional `SU(2)`-representation, so `dim Hom(Wᵢ, V ⊗ Wⱼ) =
 dim Hom(Wⱼ, V ⊗ Wᵢ)`.) -/
 theorem mult_symm (hW : IsCompleteIrreps W) (i j : Fin m) :
     mult W i j = mult W j i := by
-  sorry
+  classical
+  have : Fintype G := Fintype.ofFinite G
+  have : Invertible (Fintype.card G : ℂ) :=
+    invertibleOfNonzero (Nat.cast_ne_zero.mpr Fintype.card_ne_zero)
+  have h1 := FDRep.scalar_product_char_eq_finrank_equivariant (W i) (V G ⊗ W j)
+  have h2 := FDRep.scalar_product_char_eq_finrank_equivariant (W j) (V G ⊗ W i)
+  have hC : (mult W i j : ℂ) = (mult W j i : ℂ) := by
+    simp only [mult]
+    rw [← h1, ← h2]
+    congr 1
+    simp only [FDRep.char_tensor, Pi.mul_apply]
+    rw [← Equiv.sum_comp (Equiv.inv G)
+      (fun g => (V G).character g * (W i).character g * (W j).character g⁻¹)]
+    refine Finset.sum_congr rfl (fun g _ => ?_)
+    simp only [Equiv.inv_apply, inv_inv]
+    rw [charV_inv]
+    ring
+  exact_mod_cast hC
 
 /-! ## Part (b): the McKay graph is connected -/
 

--- a/progress/2026-07-10T22-14-56Z_fe125359.md
+++ b/progress/2026-07-10T22-14-56Z_fe125359.md
@@ -1,0 +1,31 @@
+## Accomplished
+Proved `mult_symm` (Problem 6.1.6a): the McKay multiplicities satisfy
+`rᵢⱼ = rⱼᵢ`. Added two supporting lemmas in
+`EtingofRepresentationTheory/Chapter6/Problem6_1_6.lean`:
+- `charV_eq`: the tautological character `χ_V(g)` equals the matrix trace of the
+  `SU(2)`-element (`FDRep.character` + `Matrix.trace_toLin'_eq`).
+- `charV_inv`: `χ_V(g⁻¹) = χ_V(g)` (self-duality/reality of `χ_V`), via
+  `A⁻¹ = adjugate A` for `det A = 1` and `tr (adj A) = tr A` for `2×2`.
+
+The main proof reduces `mult W i j = finrank ℂ (Wᵢ ⟶ V ⊗ Wⱼ)` to a character
+scalar product via `FDRep.scalar_product_char_eq_finrank_equivariant`, applies
+`char_tensor`, and reindexes the group sum by `g ↦ g⁻¹` (`Equiv.sum_comp`),
+using `charV_inv` to swap `i ↔ j`.
+
+All sorry-free: `#print axioms mult_symm` → `[propext, Classical.choice,
+Quot.sound]` only. No `sorryAx`.
+
+## Current frontier
+Problem 6.1.6 parts (b)/(c)/(e) remain `sorry` (separate follow-up items), as
+directed by the issue.
+
+## Overall project progress
+Stage 3 formalization ongoing. This closes #6312, unblocking the McKay-graph
+parts (b), (c), (e) that reuse the symmetry.
+
+## Next step
+Parts (b) connectivity (uses Problem 4.12.10), (c) affine-Dynkin
+positive-semidefiniteness, (e) marks — each is a separate planned item.
+
+## Blockers
+None.


### PR DESCRIPTION
Closes #6312

Session: `fe125359-2506-4ba6-83ed-61d1d15fd31d`

d0e05da6 feat(Ch6 #Problem6.1.6a): prove mult_symm — McKay multiplicities rᵢⱼ=rⱼᵢ via self-duality of V

🤖 Prepared with Claude Code