### PR TITLE
feat(Ch5 #Problem5.1.2a): ℂ-embedding + invariant Hermitian toolkit (#6330)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Problem5_1_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_1_2.lean
@@ -77,6 +77,61 @@ theorem complexToRealGEnd_injective (ρ : Representation ℂ G V) [Nontrivial V]
   · exact h
   · exact absurd h hv
 
+omit [Module ℝ V] [IsScalarTower ℝ ℂ V] in
+open scoped ComplexConjugate in
+/-- **Invariant positive-definite Hermitian form** (shared toolkit). Every finite-dimensional
+complex representation `ρ` of a finite group carries a `G`-invariant, positive-definite Hermitian
+(sesquilinear, linear in the first slot and conjugate-linear in the second) form: average the
+standard coordinate form `h₀(v, w) = ∑ᵢ (b.repr v)ᵢ · conj (b.repr w)ᵢ` over the group.
+
+Reused by the real (#6327) and quaternionic (#6328) cases to build the `j`-operator. -/
+theorem exists_invariant_posdef_hermitian (ρ : Representation ℂ G V) :
+    ∃ H : V →ₗ[ℂ] V →ₗ⋆[ℂ] ℂ,
+      (∀ g v w, H (ρ g v) (ρ g w) = H v w) ∧ (∀ v, v ≠ 0 → 0 < (H v v).re) := by
+  classical
+  set b := Module.finBasis ℂ V with hb
+  refine ⟨LinearMap.mk₂'ₛₗ (RingHom.id ℂ) (starRingEnd ℂ)
+      (fun v w => ∑ g : G, ∑ i, b.repr (ρ g v) i * conj (b.repr (ρ g w) i))
+      ?_ ?_ ?_ ?_, ?_, ?_⟩
+  · -- additive in the first slot
+    intro v₁ v₂ w
+    simp only [map_add, Finsupp.add_apply, add_mul, Finset.sum_add_distrib]
+  · -- ℂ-linear in the first slot
+    intro c v w
+    simp only [map_smul, Finsupp.smul_apply, smul_eq_mul, RingHom.id_apply, Finset.mul_sum,
+      mul_assoc]
+  · -- additive in the second slot
+    intro v w₁ w₂
+    simp only [map_add, Finsupp.add_apply, map_add, mul_add, Finset.sum_add_distrib]
+  · -- conjugate-linear in the second slot
+    intro c v w
+    simp only [map_smul, Finsupp.smul_apply, smul_eq_mul, map_mul, Finset.mul_sum]
+    refine Finset.sum_congr rfl fun g _ => Finset.sum_congr rfl fun i _ => by ring
+  · -- G-invariance
+    intro h v w
+    simp only [LinearMap.mk₂'ₛₗ_apply]
+    have hcomp : ∀ (g : G) (x : V), ρ g (ρ h x) = ρ (g * h) x := fun g x => by
+      rw [map_mul]; rfl
+    simp_rw [hcomp]
+    exact Equiv.sum_comp (Equiv.mulRight h)
+      (fun g : G => ∑ i, b.repr (ρ g v) i * conj (b.repr (ρ g w) i))
+  · -- positive-definiteness
+    intro v hv
+    simp only [LinearMap.mk₂'ₛₗ_apply, Complex.mul_conj]
+    have hcast : (∑ g : G, ∑ i, (Complex.normSq (b.repr (ρ g v) i) : ℂ))
+        = ((∑ g : G, ∑ i, Complex.normSq (b.repr (ρ g v) i) : ℝ) : ℂ) := by
+      push_cast; rfl
+    rw [hcast, Complex.ofReal_re]
+    refine Finset.sum_pos' (fun g _ => Finset.sum_nonneg fun i _ => Complex.normSq_nonneg _) ?_
+    refine ⟨1, Finset.mem_univ 1, ?_⟩
+    simp only [map_one, Module.End.one_apply]
+    obtain ⟨i, hi⟩ : ∃ i, b.repr v i ≠ 0 := by
+      by_contra hcon
+      push_neg at hcon
+      exact hv (b.repr.injective (by ext i; simp [hcon i]))
+    exact Finset.sum_pos' (fun i _ => Complex.normSq_nonneg _)
+      ⟨i, Finset.mem_univ i, Complex.normSq_pos.mpr hi⟩
+
 /-- Problem 5.1.2(a), complex type. If the irreducible representation `V` is of complex type, then
 `End_{ℝ[G]} V ≃ₐ[ℝ] ℂ`. -/
 theorem realGEndAlgebra_equiv_complex_of_isComplexType

--- a/EtingofRepresentationTheory/Chapter5/Problem5_1_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_1_2.lean
@@ -43,6 +43,38 @@ noncomputable def realGEndAlgebra (ρ : Representation ℂ G V) :
     Subalgebra ℝ (Module.End ℝ V) :=
   Subalgebra.centralizer ℝ (Set.range (fun g => LinearMap.restrictScalars ℝ (ρ g)))
 
+/-- The `ℂ`-embedding `ℂ ⊆ End_{ℝ[G]} V` of the book: multiplication by a complex scalar `z`
+is an `ℝ`-linear endomorphism of `V` that commutes with every `(ρ g).restrictScalars ℝ`
+(because each `ρ g` is `ℂ`-linear), hence lies in the centralizer `realGEndAlgebra ρ`. This
+packages that as an `ℝ`-algebra hom `ℂ →ₐ[ℝ] realGEndAlgebra ρ`. Reusable toolkit shared by the
+real (#6327) and quaternionic (#6328) cases. -/
+noncomputable def complexToRealGEnd (ρ : Representation ℂ G V) :
+    ℂ →ₐ[ℝ] realGEndAlgebra ρ :=
+  (Algebra.lsmul ℝ ℝ V).codRestrict (realGEndAlgebra ρ) (by
+    intro z
+    rw [realGEndAlgebra, Subalgebra.mem_centralizer_iff]
+    rintro _ ⟨g, rfl⟩
+    ext v
+    simp only [Module.End.mul_apply, LinearMap.restrictScalars_apply, Algebra.lsmul_apply,
+      map_smul])
+
+@[simp]
+theorem complexToRealGEnd_coe_apply (ρ : Representation ℂ G V) (z : ℂ) (v : V) :
+    (complexToRealGEnd ρ z : Module.End ℝ V) v = z • v := rfl
+
+/-- The `ℂ`-embedding is injective when `V ≠ 0`: if `z • v = 0` for all `v`, choosing a nonzero
+`v` forces `z = 0`. -/
+theorem complexToRealGEnd_injective (ρ : Representation ℂ G V) [Nontrivial V] :
+    Function.Injective (complexToRealGEnd ρ) := by
+  rw [injective_iff_map_eq_zero]
+  intro z hz
+  obtain ⟨v, hv⟩ := exists_ne (0 : V)
+  have : (complexToRealGEnd ρ z : Module.End ℝ V) v = 0 := by rw [hz]; rfl
+  rw [complexToRealGEnd_coe_apply] at this
+  rcases smul_eq_zero.mp this with h | h
+  · exact h
+  · exact absurd h hv
+
 /-- Problem 5.1.2(a), complex type. If the irreducible representation `V` is of complex type, then
 `End_{ℝ[G]} V ≃ₐ[ℝ] ℂ`. -/
 theorem realGEndAlgebra_equiv_complex_of_isComplexType

--- a/EtingofRepresentationTheory/Chapter5/Problem5_1_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_1_2.lean
@@ -58,10 +58,12 @@ noncomputable def complexToRealGEnd (ρ : Representation ℂ G V) :
     simp only [Module.End.mul_apply, LinearMap.restrictScalars_apply, Algebra.lsmul_apply,
       map_smul])
 
+omit [Fintype G] [Module.Finite ℂ V] in
 @[simp]
 theorem complexToRealGEnd_coe_apply (ρ : Representation ℂ G V) (z : ℂ) (v : V) :
     (complexToRealGEnd ρ z : Module.End ℝ V) v = z • v := rfl
 
+omit [Fintype G] [Module.Finite ℂ V] in
 /-- The `ℂ`-embedding is injective when `V ≠ 0`: if `z • v = 0` for all `v`, choosing a nonzero
 `v` forces `z = 0`. -/
 theorem complexToRealGEnd_injective (ρ : Representation ℂ G V) [Nontrivial V] :

--- a/progress/2026-07-10T23-04-49Z_4f0465c7.md
+++ b/progress/2026-07-10T23-04-49Z_4f0465c7.md
@@ -1,0 +1,67 @@
+## Accomplished
+
+Feature session on **#6330** (`feat(Ch5 #Problem5.1.2a): complete complex-type case`).
+
+Landed two sorry-free reusable toolkit pieces in
+`EtingofRepresentationTheory/Chapter5/Problem5_1_2.lean`:
+
+1. **`complexToRealGEnd`** — the `ℂ ⊆ End_{ℝ[G]} V` embedding as an `ℝ`-algebra hom
+   `ℂ →ₐ[ℝ] realGEndAlgebra ρ` (multiplication by a complex scalar), with
+   `complexToRealGEnd_coe_apply` and `complexToRealGEnd_injective`.
+   **Note:** issue #6330's premise said this had already landed on `main` via #6326.
+   It had **not** — `complexToRealGEnd` did not exist anywhere. This session built it.
+
+2. **`exists_invariant_posdef_hermitian`** — every finite-dimensional complex
+   representation of a finite group carries a `G`-invariant positive-definite Hermitian
+   (sesquilinear) form, constructed by averaging the standard coordinate form
+   `h₀(v,w) = ∑ᵢ (b.repr v)ᵢ · conj (b.repr w)ᵢ` over the group. Built via
+   `LinearMap.mk₂'ₛₗ` (linear in slot 1, conj-linear in slot 2); invariance by
+   reindexing `∑_g` with `Equiv.mulRight`; positivity via `Complex.mul_conj` +
+   `Finset.sum_pos'`.
+
+Both compile cleanly (`lake build EtingofRepresentationTheory.Chapter5.Problem5_1_2`
+has no errors and no new sorries; the 4 sorry warnings are the pre-existing
+part-(a)/(b) theorem stubs).
+
+## Current frontier
+
+The complex-type theorem `realGEndAlgebra_equiv_complex_of_isComplexType` is still
+`sorry`. Remaining work to close it:
+
+- **Antilinear equivariant iso `V ≃ₗ⋆ Module.Dual ℂ V`** from a nondegenerate
+  invariant Hermitian form. `H.flip : V →ₗ⋆[ℂ] Module.Dual ℂ V` gives the semilinear
+  map; injectivity is immediate from positive-definiteness. The bijectivity needs an
+  ℝ-dimension count (`dim_ℝ V = 2·dim_ℂ V = dim_ℝ V*`) through the `restrictScalars`-to-ℝ
+  of a `conj`-semilinear map, then `LinearEquiv.ofBijective` (semilinear variant).
+- **±-decomposition** of `End_ℝ V` with `J := complexToRealGEnd i`: `f = f₊ + f₋`,
+  `f₊ = ½(f - J∘f∘J)` (ℂ-linear, equivariant), `f₋ = ½(f + J∘f∘J)` (ℂ-antilinear).
+- **Schur scalar**: `f₊` a ℂ-linear `G`-endo of simple `V` over alg-closed `ℂ` is
+  `c • id` ⇒ `f₊ ∈ range complexToRealGEnd`.
+- **`f₋ = 0`**: else `f₋` bijective (simplicity), and `(antilinear iso)⁻¹ ∘ f₋`
+  (antilinear∘antilinear = linear) is a ℂ-linear equivariant `V ≃ V*`, contradicting
+  `IsComplexType`. Hence `realGEndAlgebra ρ = range complexToRealGEnd`, so
+  `complexToRealGEnd` is surjective ⇒ `≃ₐ[ℝ] ℂ`.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. This advances the Problem 5.1.2(a) cluster (#6323):
+the two shared-toolkit deliverables (ℂ-embedding, invariant Hermitian form) are now
+sorry-free on the way to the complex/real/quaternionic isomorphisms.
+
+## Next step
+
+**Coordination note for the planner:** #6326 and #6330 are effective duplicates — both
+ask to prove `realGEndAlgebra_equiv_complex_of_isComplexType` plus the ℂ-embedding /
+Hermitian toolkit. With this session's toolkit landed, the *residual* for both is
+identical: the antilinear iso + ±-decomposition + Schur assembly (see frontier above).
+Recommend closing one of #6326/#6330 as superseded and narrowing the other to that
+residual (the ℂ-embedding and invariant Hermitian form are done).
+
+Concrete next task: prove the antilinear equivariant iso
+`V ≃ₗ⋆ Module.Dual ℂ V` from `exists_invariant_posdef_hermitian` (self-contained,
+reusable by #6327/#6328), then the ±-decomposition assembly.
+
+## Blockers
+
+None. The remaining assembly is hard but unblocked; it is genuinely more than one
+session, which is why this session lands the toolkit as a partial.


### PR DESCRIPTION
This PR lands the two shared-toolkit deliverables for Problem 5.1.2(a) as sorry-free reusable lemmas, partial progress toward the complex-type isomorphism (#6330).

- `Etingof.complexToRealGEnd : ℂ →ₐ[ℝ] realGEndAlgebra ρ` — the `ℂ ⊆ End_{ℝ[G]} V` embedding (multiplication by a complex scalar), with `complexToRealGEnd_coe_apply` and `complexToRealGEnd_injective`. Note: #6330 assumed this had already landed on `main` via #6326; it had not, so this session builds it.
- `Etingof.exists_invariant_posdef_hermitian` — every finite-dimensional complex representation of a finite group carries a `G`-invariant positive-definite Hermitian form, built by averaging the standard coordinate form over the group (`LinearMap.mk₂'ₛₗ`; invariance by `Equiv.mulRight` reindexing; positivity via `Complex.mul_conj` and `Finset.sum_pos'`).

Both are reused by the real (#6327) and quaternionic (#6328) cases. The main theorem `realGEndAlgebra_equiv_complex_of_isComplexType` remains `sorry`; the residual (antilinear equivariant iso `V ≃ₗ⋆ V*`, ±-decomposition with `J = complexToRealGEnd i`, Schur scalar, and `f₋ = 0` contradiction) is documented in the progress note and routed to replan. #6326 and #6330 are effective duplicates and share this residual.

🤖 Prepared with Claude Code