### PR TITLE
feat(Ch5 #Problem5.16.3a): diagonalizability + |μ|≤n−1 bound via unitarizability

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -2064,6 +2064,24 @@ For proofs requiring algebraic integer arguments (e.g., Lemma 5.4.5):
 
 This two-step norm approach works whenever you need to show an algebraic quantity equals zero or a root of unity.
 
+### Unitarizability: diagonalize a `ℂ[G]`-operator via the spectral theorem (#6311)
+
+When a finite-group operator must be shown diagonalizable / to have bounded real eigenvalues, put an invariant inner product on `V` and use self-adjointness. Recipe (from `Problem5_16_3`, `sumTranspositionsWith1_diagonalizable_integer_eigenvalues`):
+
+```lean
+obtain ⟨c, hc⟩ := Etingof.Theorem4_6_2_existence G V ρ   -- c : InnerProductSpace.Core ℂ V, hc = G-invariance
+letI icore : InnerProductSpace.Core ℂ V := c
+letI : NormedAddCommGroup V := c.toNormedAddCommGroup           -- reuses the ambient AddCommGroup...
+letI : InnerProductSpace ℂ V := InnerProductSpace.ofCore inferInstance  -- ...so Module.End ℂ V is unchanged
+```
+
+Key points:
+- **No diamond:** `Core.toNormedAddCommGroup` goes through `AddGroupNorm.toNormedAddCommGroup`, which keeps `.toAddCommGroup` defeq to the ambient one. So `T : Module.End ℂ V` and any produced `Module.Basis` still match the pre-existing goal types.
+- **`ofCore` wants a `PreInnerProductSpace.Core`.** Make `c` a local instance (`letI icore := c`) and pass `inferInstance` — the `[InnerProductSpace.Core] → PreInnerProductSpace.Core` instance fires. Then `inner ℂ` is defeq to `c.inner`, so the invariance hypothesis `hc` is reusable verbatim (`have hc' : ∀ g v w, inner ℂ (ρ g v) (ρ g w) = inner ℂ v w := hc`).
+- **`ρ g` is an isometry** (`‖ρ g x‖ = ‖x‖`): square both sides, `rw [← inner_self_eq_norm_sq (𝕜 := ℂ), …, hc']`, finish with `Real.sqrt_sq`.
+- **Self-adjoint:** a unitary involution `s` (with `s * s = 1`, e.g. `Equiv.swap_mul_self`) gives `(ρ s).IsSymmetric` from `⟪ρ s x, y⟫ = ⟪ρ s x, ρ s (ρ s y)⟫ = ⟪x, ρ s y⟫`; sums stay symmetric (`sum_inner`/`inner_sum`).
+- **Spectral theorem:** `hT.eigenvectorBasis rfl |>.toBasis` (+ `OrthonormalBasis.coe_toBasis`, `hT.apply_eigenvectorBasis rfl i`) gives the eigenbasis; eigenvalue bounds come from `μ = ⟪w', T w'⟫` on a normalized eigenvector plus `norm_inner_le_norm` (Cauchy–Schwarz) and `norm_sum_le`.
+
 ### `sorry : Prop` for Unprovable Statements
 
 When Mathlib lacks the types to express a theorem's statement at all (not just the proof), use:
@@ -2898,6 +2916,8 @@ These naming mismatches have bitten multiple agents across waves 44-47. Check th
 | `DFinsupp.smul_apply` | `DFinsupp.smul_apply` | Use `Finsupp.smul_apply` via `change` | `DFinsupp` and `Finsupp` have different APIs. MonoidAlgebra is `Finsupp`-based. |
 | `p` splits over its field | `p.Splits (RingHom.id k)` | `p.Splits` | **`Polynomial.Splits` is now single-argument** (`Splits (f : k[X]) : Prop`, splits over `k` itself). The ring-hom form is deprecated; `p.Splits (RingHom.id k)` fails to elaborate ("Function expected at p.Splits"). Use `IsAlgClosed.splits p : p.Splits` (not `splits_codomain`), and `Splits.eq_prod_roots_of_monic (hf : p.Splits) hm : p = (p.roots.map (X - C ·)).prod`. (#5235) |
 | Integer induction case names | `\| hz \| hp \| hn` | `\| zero \| succ \| pred` | `induction n using Int.induction_on with` alternatives are `zero` (`P 0`), `succ k ih` (`P k → P (k+1)`, `k : ℕ` cast to `ℤ`), `pred k ih` (`P (-k) → P (-k-1)`). Using `hz/hp/hn` gives "Invalid alternative name". (#5365) |
+| Inner product | `inner x y` | `inner ℂ x y` | **`inner` now takes the scalar field as an explicit first arg** (`inner (𝕜) : E → E → 𝕜`). Bare `inner x y` fails with "argument … expected to have type `Type`". Either write `inner ℂ x y`, or `open scoped InnerProductSpace` and use `⟪x, y⟫_ℂ`. (#6311) |
+| `(f * g) x`, `(1) x` for `Module.End` | `LinearMap.mul_apply` / `one_apply` | `Module.End.mul_apply` / `Module.End.one_apply` | `LinearMap.mul_apply` does not exist. |
 
 **Combining `↑(q ^ a)` Units.val / zpow scalars in a `↑(q^a) * (↑(q^b) * c) = …` goal (quantum-torus / twisted-cocycle arithmetic, #5365).** Don't guess `rw` order on a mix of `Units.val`, `•`/`*`, and `zpow`. Normalize *both* sides to a single `↑(q ^ E) * c` first with `simp only [smul_eq_mul, ← mul_assoc, ← Units.val_mul]` (collapses each side's two unit factors into one `↑(q^a * q^b)`), then discharge with pre-proved unit-level equalities `have : (q ^ a * q ^ b : kˣ) = q ^ E := by rw [← zpow_add]; congr 1; ring` and `rw [hL, hR]`. `ring` does **not** equate `q ^ A` with `q ^ B` for equal `ℤ`-exponents — you must combine to one `zpow` (`← zpow_add`) and prove the exponent equality separately.
 

--- a/EtingofRepresentationTheory/Chapter5/Problem5_16_3.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_16_3.lean
@@ -1,4 +1,5 @@
 import Mathlib
+import EtingofRepresentationTheory.Chapter4.Theorem4_6_2
 import EtingofRepresentationTheory.Chapter5.Theorem5_12_2_Irreducible
 import EtingofRepresentationTheory.Chapter5.Problem5_16_2
 import EtingofRepresentationTheory.Chapter5.SumTranspositionsEigenvalues
@@ -260,18 +261,96 @@ theorem sumTranspositionsWith1_diagonalizable_integer_eigenvalues
       (∀ μ : ℂ, Module.End.HasEigenvalue
           ((Representation.asAlgebraHom ρ) (sumTranspositionsWith1 n)) μ →
         ∃ m : ℤ, μ = (m : ℂ) ∧ (1 - (n : ℤ)) ≤ m ∧ m ≤ (n : ℤ) - 1) := by
+  classical
   obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 :=
     ⟨n - 1, (Nat.succ_pred_eq_of_pos (Nat.pos_of_ne_zero (NeZero.ne n))).symm⟩
+  haveI : FiniteDimensional ℂ V := inferInstance
+  -- Unitarizability: an invariant positive-definite Hermitian form from Theorem 4.6.2 turns `V`
+  -- into an inner product space in which every `ρ g` is a unitary.
+  obtain ⟨c, hc⟩ := Theorem4_6_2_existence (Equiv.Perm (Fin (m + 1))) V ρ
+  letI icore : InnerProductSpace.Core ℂ V := c
+  letI : NormedAddCommGroup V := c.toNormedAddCommGroup
+  letI : InnerProductSpace ℂ V := InnerProductSpace.ofCore inferInstance
+  -- `G`-invariance of the inner product.
+  have hc' : ∀ (g : Equiv.Perm (Fin (m + 1))) (v w : V),
+      (inner ℂ (ρ g v) (ρ g w) : ℂ) = (inner ℂ v w : ℂ) := hc
+  -- Each `ρ g` is an isometry.
+  have hnorm : ∀ (g : Equiv.Perm (Fin (m + 1))) (x : V), ‖ρ g x‖ = ‖x‖ := by
+    intro g x
+    have h1 : ‖ρ g x‖ ^ 2 = ‖x‖ ^ 2 := by
+      rw [← inner_self_eq_norm_sq (𝕜 := ℂ), ← inner_self_eq_norm_sq (𝕜 := ℂ), hc' g x x]
+    rw [← Real.sqrt_sq (norm_nonneg (ρ g x)), ← Real.sqrt_sq (norm_nonneg x), h1]
+  -- The sum of transpositions through `0`, and its cardinality.
+  set S : Finset (Fin (m + 1)) :=
+    Finset.univ.filter (fun j : Fin (m + 1) => (0 : Fin (m + 1)) < j) with hSdef
+  have hScard : S.card = m := by
+    have hSe : S = Finset.univ.erase (0 : Fin (m + 1)) := by
+      ext j; simp [hSdef, Fin.pos_iff_ne_zero, Finset.mem_erase]
+    rw [hSe, Finset.card_erase_of_mem (Finset.mem_univ _), Finset.card_univ, Fintype.card_fin,
+      Nat.add_sub_cancel]
+  set T : Module.End ℂ V :=
+    Representation.asAlgebraHom ρ (sumTranspositionsWith1 (m + 1)) with hTdef
+  -- `T = ∑_{0<j} ρ(0 j)`.
+  have hTsum : T = ∑ j ∈ S, ρ (Equiv.swap 0 j) := by
+    rw [hTdef, sumTranspositionsWith1, map_sum]
+    exact Finset.sum_congr rfl (fun j _ => Representation.asAlgebraHom_of ρ (Equiv.swap 0 j))
+  -- Each `ρ(0 j)` is symmetric: it is a unitary involution.
+  have hswap_symm : ∀ j : Fin (m + 1), (ρ (Equiv.swap (0 : Fin (m + 1)) j)).IsSymmetric := by
+    intro j x y
+    have hinv : ρ (Equiv.swap (0 : Fin (m + 1)) j) (ρ (Equiv.swap 0 j) y) = y := by
+      rw [← Module.End.mul_apply, ← map_mul, Equiv.swap_mul_self, map_one, Module.End.one_apply]
+    calc (inner ℂ (ρ (Equiv.swap 0 j) x) y : ℂ)
+        = (inner ℂ (ρ (Equiv.swap 0 j) x)
+            (ρ (Equiv.swap 0 j) (ρ (Equiv.swap 0 j) y)) : ℂ) := by rw [hinv]
+      _ = (inner ℂ x (ρ (Equiv.swap 0 j) y) : ℂ) := hc' _ _ _
+  -- Hence `T` is symmetric.
+  have hTsym : T.IsSymmetric := by
+    intro x y
+    rw [hTsum, LinearMap.sum_apply, LinearMap.sum_apply, sum_inner, inner_sum]
+    exact Finset.sum_congr rfl (fun j _ => hswap_symm j x y)
   refine ⟨?_, ?_⟩
-  · -- Eigenbasis via unitarizability (self-adjoint operator has an eigenbasis).
-    sorry
+  · -- Eigenbasis via the spectral theorem for the self-adjoint operator `T`.
+    refine ⟨(hTsym.eigenvectorBasis rfl).toBasis, fun i => ⟨(hTsym.eigenvalues rfl i : ℂ), ?_⟩⟩
+    rw [OrthonormalBasis.coe_toBasis]
+    exact hTsym.apply_eigenvectorBasis rfl i
   · intro μ hμ
     obtain ⟨z, hz⟩ := sumTranspositionsWith1_hasEigenvalue_integer m ρ μ hμ
+    -- Bound the eigenvalue via a normalized eigenvector `w'` with `‖w'‖ = 1`.
+    obtain ⟨w, hwmem, hwne⟩ := hμ.exists_hasEigenvector
+    have hTw : T w = μ • w := Module.End.mem_eigenspace_iff.mp hwmem
+    have hwnorm_pos : (0 : ℝ) < ‖w‖ := norm_pos_iff.mpr hwne
+    set w' : V := ((‖w‖⁻¹ : ℝ) : ℂ) • w with hw'def
+    have hw'norm : ‖w'‖ = 1 := by
+      rw [hw'def, norm_smul, Complex.norm_real, Real.norm_eq_abs,
+        abs_of_nonneg (by positivity), inv_mul_cancel₀ (ne_of_gt hwnorm_pos)]
+    have hTw' : T w' = μ • w' := by rw [hw'def, map_smul, hTw, smul_comm]
+    -- `μ = ⟪w', T w'⟫`.
+    have hμeq : (inner ℂ w' (T w') : ℂ) = μ := by
+      rw [hTw', inner_smul_right, inner_self_eq_norm_sq_to_K, hw'norm]; simp
+    -- `‖μ‖ ≤ m`, since `⟪w', T w'⟫` is a sum of `m` terms each of modulus `≤ 1`.
+    have hbound : ‖μ‖ ≤ (m : ℝ) := by
+      rw [← hμeq]
+      have hexp : (inner ℂ w' (T w') : ℂ)
+          = ∑ j ∈ S, (inner ℂ w' (ρ (Equiv.swap 0 j) w') : ℂ) := by
+        rw [hTsum, LinearMap.sum_apply, inner_sum]
+      rw [hexp]
+      calc ‖∑ j ∈ S, (inner ℂ w' (ρ (Equiv.swap 0 j) w') : ℂ)‖
+          ≤ ∑ j ∈ S, ‖(inner ℂ w' (ρ (Equiv.swap 0 j) w') : ℂ)‖ := norm_sum_le _ _
+        _ ≤ ∑ j ∈ S, (1 : ℝ) := by
+            refine Finset.sum_le_sum (fun j _ => ?_)
+            calc ‖(inner ℂ w' (ρ (Equiv.swap 0 j) w') : ℂ)‖
+                ≤ ‖w'‖ * ‖ρ (Equiv.swap 0 j) w'‖ := norm_inner_le_norm _ _
+              _ = 1 := by rw [hnorm, hw'norm]; norm_num
+        _ = (m : ℝ) := by rw [Finset.sum_const, hScard]; simp
+    -- Combine with integrality of `μ = z`.
+    have hzabs : |z| ≤ (m : ℤ) := by
+      have hnormμ : ‖μ‖ = |(z : ℝ)| := by rw [hz, Complex.norm_intCast]
+      rw [hnormμ] at hbound
+      exact_mod_cast hbound
+    obtain ⟨hb1, hb2⟩ := abs_le.mp hzabs
     refine ⟨z, hz, ?_, ?_⟩
-    · -- lower bound `1 - n ≤ z` from `|μ| ≤ n - 1` (unitarizability).
-      sorry
-    · -- upper bound `z ≤ n - 1` from `|μ| ≤ n - 1` (unitarizability).
-      sorry
+    · push_cast; omega
+    · push_cast; omega
 
 /-- Problem 5.16.3(b). The element `E = (12) + ⋯ + (1n)` acts on the Specht module
 `V_λ = ℂ[S_n]·c_λ` (by left multiplication) by a scalar if and only if `λ` is a rectangular

--- a/progress/2026-07-10T23-21-55Z_cd378a68.md
+++ b/progress/2026-07-10T23-21-55Z_cd378a68.md
@@ -1,0 +1,42 @@
+## Accomplished
+
+Discharged the three `sorry`s in `sumTranspositionsWith1_diagonalizable_integer_eigenvalues`
+(Problem 5.16.3(a), `EtingofRepresentationTheory/Chapter5/Problem5_16_3.lean`, issue #6311)
+via **unitarizability**:
+
+- Built the `ρ`-invariant inner product from `Etingof.Theorem4_6_2_existence`, promoting the
+  resulting `InnerProductSpace.Core ℂ V` to a local `NormedAddCommGroup V` + `InnerProductSpace ℂ V`
+  (`c.toNormedAddCommGroup` reuses the ambient `AddCommGroup`, so `T : Module.End ℂ V` is unchanged
+  and the produced `Module.Basis` matches the goal type).
+- Showed each `ρ (swap 0 j)` is `IsSymmetric` (a self-adjoint unitary involution), hence
+  `T = ∑_{0<j} ρ(swap 0 j)` is symmetric.
+- **Eigenbasis** (first conjunct): `hTsym.eigenvectorBasis rfl |>.toBasis` with
+  `apply_eigenvectorBasis`.
+- **Bound** `|μ| ≤ n − 1` (second conjunct): normalized eigenvector `w'` gives
+  `μ = ⟪w', T w'⟫ = ∑_{0<j} ⟪w', ρ(swap 0 j) w'⟫`, each term of modulus `≤ 1` (Cauchy–Schwarz +
+  isometry), `m = n−1` summands; combined with integrality (`sumTranspositionsWith1_hasEigenvalue_integer`)
+  gives `1 − n ≤ z ≤ n − 1`.
+
+Added the missing `import EtingofRepresentationTheory.Chapter4.Theorem4_6_2`.
+
+## Current frontier
+
+`sumTranspositionsWith1_diagonalizable_integer_eigenvalues` is sorry-free and axiom-clean
+(`propext, Classical.choice, Quot.sound`). `lake build EtingofRepresentationTheory.Chapter5.Problem5_16_3`
+succeeds.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. Problem 5.16.3(a) is now fully proved. The only remaining `sorry`
+in this file is part (b) `sumTranspositionsWith1_acts_scalar_iff_rectangular` (issue #6286, blocked
+on the module-level `S_n ↓ S_{n-1}` branching rule).
+
+## Next step
+
+Part (b) (#6286) remains blocked on the module-level branching decomposition — a planner should
+sequence that prerequisite. Other unclaimed feature issues (#6317 bar differential, #6324 Lie algebra
+dimensions, #6326/#6330 5.1.2a complex type) are available.
+
+## Blockers
+
+None for this item.


### PR DESCRIPTION
Closes #6311

Session: `cd378a68-5509-4950-a831-fd086641363f`

b99d37f0 feat(Ch5 #Problem5.16.3a): prove diagonalizability + |μ|≤n−1 bound via unitarizability

🤖 Prepared with Claude Code