### PR TITLE
feat(Ch7 #Problem7.8.7iv): tensor-of-complexes distributes over binary biproducts (tensorObj (X⊞Y) Z ≅ tensorObj X Z ⊞ tensorObj Y Z, both slots)

### DIFF
--- a/EtingofRepresentationTheory/Chapter7.lean
+++ b/EtingofRepresentationTheory/Chapter7.lean
@@ -36,6 +36,7 @@ import EtingofRepresentationTheory.Chapter7.Problem7_7_3
 import EtingofRepresentationTheory.Chapter7.Problem7_8_5
 import EtingofRepresentationTheory.Chapter7.Exercise7_9_7
 import EtingofRepresentationTheory.Chapter7.Exercise7_9_8
+import EtingofRepresentationTheory.Chapter7.TensorComplexBiprod
 import EtingofRepresentationTheory.Chapter7.Problem7_8_7
 
 /-!

--- a/EtingofRepresentationTheory/Chapter7/Problem7_8_7.lean
+++ b/EtingofRepresentationTheory/Chapter7/Problem7_8_7.lean
@@ -1,5 +1,6 @@
 import Mathlib
 import EtingofRepresentationTheory.Chapter7.Exercise7_8_4
+import EtingofRepresentationTheory.Chapter7.TensorComplexBiprod
 
 /-!
 # Problem 7.8.7: The tensor product of complexes and the Künneth formula
@@ -52,13 +53,6 @@ open CategoryTheory Limits MonoidalCategory
 namespace Etingof
 
 variable {k : Type} [Field k]
-
-/-- Etingof's tensor product complex `(C ⊗ D)•`, with degree-`i` object `⨁_{j+m=i} Cⱼ ⊗ Dₘ`
-and the Koszul-signed differential `dᶜ ⊗ 1 + (-1)ʲ · 1 ⊗ dᴰ`. This is Mathlib's
-`HomologicalComplex.tensorObj`. -/
-noncomputable def tensorComplex (C D : CochainComplex (ModuleCat.{0} k) ℤ) :
-    CochainComplex (ModuleCat.{0} k) ℤ :=
-  HomologicalComplex.tensorObj C D
 
 /-- The complex whose degree-`i` object is the homology `Hⁱ(C)` and whose differentials are
 all zero (used in part (iii)). -/

--- a/EtingofRepresentationTheory/Chapter7/TensorComplexBiprod.lean
+++ b/EtingofRepresentationTheory/Chapter7/TensorComplexBiprod.lean
@@ -1,0 +1,80 @@
+import Mathlib
+
+/-!
+# Distributivity of the tensor product of complexes over binary biproducts
+
+Mathlib equips `HomologicalComplex (ModuleCat.{0} k) (ComplexShape.up ℤ)` with a monoidal
+category structure whose tensor product is `HomologicalComplex.tensorObj` (the total complex of
+the bicomplex `Cⱼ ⊗ Dₘ`). This file records that this monoidal structure is *preadditive*
+(`MonoidalPreadditive`), i.e. tensoring is additive in each variable. Preadditivity makes the
+two endofunctors `tensorLeft X` and `tensorRight Z` additive, hence they preserve binary
+biproducts. We package the resulting distributivity isomorphisms as
+
+* `Etingof.tensorComplex_biprodLeftIso`  : `(X ⊞ Y) ⊗ Z ≅ (X ⊗ Z) ⊞ (Y ⊗ Z)`
+* `Etingof.tensorComplex_biprodRightIso` : `X ⊗ (Y ⊞ Z) ≅ (X ⊗ Y) ⊞ (X ⊗ Z)`
+
+phrased in terms of `Etingof.tensorComplex` (Etingof's `(C ⊗ D)•`). This is the missing
+infrastructure for the Künneth splitting in `Problem7_8_7_iv`.
+-/
+
+open CategoryTheory Limits MonoidalCategory HomologicalComplex
+
+namespace Etingof
+
+variable {k : Type} [Field k]
+
+/-- Etingof's tensor product complex `(C ⊗ D)•`, with degree-`i` object `⨁_{j+m=i} Cⱼ ⊗ Dₘ`
+and the Koszul-signed differential `dᶜ ⊗ 1 + (-1)ʲ · 1 ⊗ dᴰ`. This is Mathlib's
+`HomologicalComplex.tensorObj`. -/
+noncomputable def tensorComplex (C D : CochainComplex (ModuleCat.{0} k) ℤ) :
+    CochainComplex (ModuleCat.{0} k) ℤ :=
+  HomologicalComplex.tensorObj C D
+
+/-- Tensoring homological complexes over `ModuleCat.{0} k` is additive in each variable. -/
+noncomputable instance :
+    MonoidalPreadditive (HomologicalComplex (ModuleCat.{0} k) (ComplexShape.up ℤ)) where
+  whiskerLeft_zero {X Y Z} := by
+    change mapBifunctorMap (𝟙 X) (0 : Y ⟶ Z) _ _ = 0
+    refine HomologicalComplex.hom_ext _ _ fun j =>
+      mapBifunctor.hom_ext fun i₁ i₂ h => ?_
+    simp only [ι_mapBifunctorMap, HomologicalComplex.zero_f, Functor.map_zero, comp_zero, zero_comp]
+  zero_whiskerRight {X Y Z} := by
+    change mapBifunctorMap (0 : Y ⟶ Z) (𝟙 X) _ _ = 0
+    refine HomologicalComplex.hom_ext _ _ fun j =>
+      mapBifunctor.hom_ext fun i₁ i₂ h => ?_
+    simp only [ι_mapBifunctorMap, HomologicalComplex.zero_f, Functor.map_zero,
+      NatTrans.app_zero, zero_comp, comp_zero]
+  whiskerLeft_add {X Y Z} f g := by
+    change mapBifunctorMap (𝟙 X) (f + g) _ _ =
+      mapBifunctorMap (𝟙 X) f _ _ + mapBifunctorMap (𝟙 X) g _ _
+    refine HomologicalComplex.hom_ext _ _ fun j =>
+      mapBifunctor.hom_ext fun i₁ i₂ h => ?_
+    simp only [ι_mapBifunctorMap, HomologicalComplex.add_f_apply, Functor.map_add,
+      Preadditive.comp_add, Preadditive.add_comp]
+  add_whiskerRight {X Y Z} f g := by
+    change mapBifunctorMap (f + g) (𝟙 X) _ _ =
+      mapBifunctorMap f (𝟙 X) _ _ + mapBifunctorMap g (𝟙 X) _ _
+    refine HomologicalComplex.hom_ext _ _ fun j =>
+      mapBifunctor.hom_ext fun i₁ i₂ h => ?_
+    simp only [ι_mapBifunctorMap, HomologicalComplex.add_f_apply, Functor.map_add,
+      NatTrans.app_add, Preadditive.comp_add, Preadditive.add_comp]
+
+/-- Distributivity of the tensor product of complexes over a binary biproduct in the left
+variable: `(X ⊞ Y) ⊗ Z ≅ (X ⊗ Z) ⊞ (Y ⊗ Z)`. -/
+noncomputable def tensorComplex_biprodLeftIso
+    (X Y Z : CochainComplex (ModuleCat.{0} k) ℤ) :
+    tensorComplex (X ⊞ Y) Z ≅ tensorComplex X Z ⊞ tensorComplex Y Z :=
+  haveI : PreservesBinaryBiproduct X Y (tensorRight Z) :=
+    preservesBinaryBiproduct_of_preservesBiproduct _ _ _
+  (tensorRight Z).mapBiprod X Y
+
+/-- Distributivity of the tensor product of complexes over a binary biproduct in the right
+variable: `X ⊗ (Y ⊞ Z) ≅ (X ⊗ Y) ⊞ (X ⊗ Z)`. -/
+noncomputable def tensorComplex_biprodRightIso
+    (X Y Z : CochainComplex (ModuleCat.{0} k) ℤ) :
+    tensorComplex X (Y ⊞ Z) ≅ tensorComplex X Y ⊞ tensorComplex X Z :=
+  haveI : PreservesBinaryBiproduct Y Z (tensorLeft X) :=
+    preservesBinaryBiproduct_of_preservesBiproduct _ _ _
+  (tensorLeft X).mapBiprod Y Z
+
+end Etingof

--- a/progress/2026-07-11T00-19-01Z_a670de16.md
+++ b/progress/2026-07-11T00-19-01Z_a670de16.md
@@ -1,0 +1,49 @@
+## Accomplished
+
+Claimed and completed **#6344** (Ch7 Problem 7.8.7iv infrastructure): tensor-of-complexes
+distributes over binary biproducts in each slot. Added a new file
+`EtingofRepresentationTheory/Chapter7/TensorComplexBiprod.lean` (sorry-free) containing:
+
+- `MonoidalPreadditive (HomologicalComplex (ModuleCat.{0} k) (ComplexShape.up ℤ))` — the four
+  whiskering-additivity fields, each proved by reducing `X ◁ g = mapBifunctorMap (𝟙 X) g` (and
+  the `▷` analogue) to the degreewise `ιMapBifunctor` summands via
+  `HomologicalComplex.hom_ext` + `mapBifunctor.hom_ext` + the `@[simp]` `ι_mapBifunctorMap`,
+  then pushing additivity through `Functor.map_add` / `NatTrans.app_add` and `Preadditive`
+  `comp_add`/`add_comp`.
+- `Etingof.tensorComplex_biprodLeftIso  : tensorComplex (X ⊞ Y) Z ≅ tensorComplex X Z ⊞ tensorComplex Y Z`
+- `Etingof.tensorComplex_biprodRightIso : tensorComplex X (Y ⊞ Z) ≅ tensorComplex X Y ⊞ tensorComplex X Z`
+
+  Both are `(tensorRight Z).mapBiprod` / `(tensorLeft X).mapBiprod`: with `MonoidalPreadditive`
+  in scope `tensorLeft`/`tensorRight` are `Additive`, hence preserve finite biproducts. The
+  specific `PreservesBinaryBiproduct` instance is supplied by
+  `preservesBinaryBiproduct_of_preservesBiproduct` (not found by pure instance search).
+
+`#print axioms` on both isos shows only `propext, Classical.choice, Quot.sound` (no `sorryAx`).
+
+The canonical `Etingof.tensorComplex` definition was **moved** from `Problem7_8_7.lean` into the
+new file (to avoid a duplicate declaration once the file is imported); `Problem7_8_7.lean` now
+imports `TensorComplexBiprod` and keeps its own `tensorComplex` references working unchanged.
+Added the new module to the `Chapter7.lean` aggregator.
+
+## Current frontier
+
+Distributivity infrastructure for the Künneth splitting is in place. `Problem7_8_7_iv` itself is
+still `sorry` (that is the assembly step, plus the sibling helper #6345).
+
+## Overall project progress
+
+Stage 3 formalization. Chapter 7 Problem 7.8.7 parts (i)(ii)(iii) sorry-free; part (iv) now has
+one of its two infrastructure pieces (#6344 this turn). The other piece is #6345
+(`homologyTensorHomologyZeroIso`), still unclaimed.
+
+## Next step
+
+Claim **#6345** (homology of a tensor of two zero-differential complexes ≅ ∐ Hʲ⊗Hᵐ). Once both
+#6344 and #6345 are merged, a follow-up can assemble `Problem7_8_7_iv`: split
+`C ≅ E ⊞ homologyZeroComplex C` and `D ≅ F ⊞ homologyZeroComplex D` (part iii), distribute the
+tensor via `tensorComplex_biprodLeftIso`/`tensorComplex_biprodRightIso`, discard the three
+acyclic cross terms, and identify the surviving term with #6345.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -6639,7 +6639,7 @@
     "start_line": 23,
     "end_line": 18,
     "status": "statement_formalized",
-    "coverage_note": "Parts (i), (ii), (iii) proved sorry-free; (ii) proved 2026-07-10 (#6304) via the Exercise 7.8.4 contracting homotopy whiskered through the tensor bifunctor (mapBifunctorMapHomotopy₁/₂). Only part (iv) (full Künneth iso) remains sorry."
+    "coverage_note": "Parts (i), (ii), (iii) proved sorry-free; (ii) proved 2026-07-10 (#6304) via the Exercise 7.8.4 contracting homotopy whiskered through the tensor bifunctor (mapBifunctorMapHomotopy₁/₂). Only part (iv) (full Künneth iso) remains sorry. 2026-07-11 (#6344): landed distributivity infrastructure in Chapter7/TensorComplexBiprod.lean — MonoidalPreadditive instance for HomologicalComplex (ModuleCat.{0} k) (up ℤ) plus tensorComplex_biprodLeftIso / tensorComplex_biprodRightIso (tensor-of-complexes distributes over ⊞ in each slot). tensorComplex def moved to that file."
   },
   {
     "id": "Chapter7/Introduction_7.9",


### PR DESCRIPTION
Closes #6344

Session: `a670de16-d673-49e2-817a-0a9f7521d418`

e45f5a12 feat(Ch7 #6344): tensor-of-complexes distributes over binary biproducts

🤖 Prepared with Claude Code