### PR TITLE
chore: progress handoff — triage #6286, create prereq #6351

### DIFF
--- a/progress/2026-07-11T00-19-52Z.md
+++ b/progress/2026-07-11T00-19-52Z.md
@@ -1,0 +1,27 @@
+## Accomplished
+
+- `/work` session. Only one unclaimed issue existed: **#6286** (`Problem5.16.3b`, prove `sumTranspositionsWith1_acts_scalar_iff_rectangular`).
+- Verified on `main` (HEAD `0072372b`) that #6286 is genuinely blocked: `Problem5_16_1.lean` is sorry-free but provides **only** the character identity `res_spechtModule_character` — there is no module-level branching decomposition `Res V_λ ≅ ⨁_{μ∈R(λ)} V_μ` and nothing exposing the eigenvalue structure of `Cₙ₋₁` on `V_λ`, which part (b) requires.
+- Diagnosed the *loop*: #6286 kept resurfacing to workers because the `blocked` label was repeatedly stripped **and no open prerequisite issue existed** for anyone to actually build (prior prereq #6282 delivered only characters and is CLOSED).
+- **Broke the loop:** created prerequisite **#6351** — `feat(Ch5 #Problem5.16.1): module-level branching consequence — spectrum of Cₙ₋₁ on V_λ (unblocks 5.16.3b)`. It scopes the missing result two ways: Route A (full module iso) or the lighter Route B (character ⇒ isotypic decomposition via Maschke + irreducible-character independence + Schur), and specifies a clean consumable lemma.
+- Re-added `blocked` to #6286, left `replan` off, and commented `depends-on: #6351`.
+- Merged ready PR **#6348** (`feat(Ch2 #Problem2.16.3a): finrank_g_two = 4`) to `main`.
+
+## Current frontier
+
+- #6286 is correctly blocked pending #6351. No other unclaimed issues remain.
+- #6351 is unclaimed and is now the actual unblocking work.
+
+## Overall project progress
+
+- Stage 3 (formalization) ongoing across chapters. Ch5 Specht-module / branching thread is the active frontier for the 5.16.x problems.
+- The 5.16.x chain: 5.16.1 (branching, character-level, done), 5.16.2 (content scalar, done), 5.16.3a (done, #6338 merged), 5.16.3b (#6286, blocked on module-level branching #6351).
+
+## Next step
+
+- A worker should pick up **#6351** — build the module-level branching consequence (Route B is likely lighter: the character identity already pins isotypic multiplicities; combine with semisimplicity + Schur to get `Cₙ₋₁` diagonalizable on `V_λ` with eigenvalue set `{content(μ) : μ ∈ removeSquare λ}`).
+- Once #6351 lands, remove `blocked` from #6286; part (b) then follows from `E = Cₙ − Cₙ₋₁` + "single content ⟺ single removable corner ⟺ rectangular".
+
+## Blockers
+
+- #6286 blocked on #6351 (module-level branching). Definition-level dependency, now tracked with an open, scoped issue so it no longer loops back to workers.


### PR DESCRIPTION
This adds the progress handoff for a `/work` triage turn: the only unclaimed issue (#6286, Problem 5.16.3b) was verified genuinely blocked on a module-level branching result that does not exist, so this creates and links a scoped prerequisite (#6351) and re-applies `blocked` to #6286, breaking the loop that kept resurfacing it to workers. Ready PR #6348 was also merged.

🤖 Prepared with Claude Code