### PR TITLE
chore: progress handoff — decompose #6351 into #6356 + #6357

### DIFF
--- a/progress/2026-07-11T00-31-02Z_2f3d8345.md
+++ b/progress/2026-07-11T00-31-02Z_2f3d8345.md
@@ -1,0 +1,73 @@
+## Accomplished
+
+Session type: `/work` → `/feature`. Claimed #6351 (Ch5 module-level branching consequence:
+spectrum of `C_{n-1}` on `V_λ`, prereq unblocking 5.16.3(b) / #6286).
+
+After a thorough codebase investigation I concluded the issue as written is too large for one
+reliable session and **decomposed it** (agent-worker-flow Step 4b) into two self-contained
+sub-issues, then released the parent for planner triage:
+
+- **#6356** — `feat(Ch5 infra): general character⇒multiplicity bridge for Sₙ-reps`. The reusable
+  crux (~90% of the work): generalise the isotypic/multiplicity machinery from the permutation
+  module to an arbitrary fin-dim `Sₙ`-rep, giving `char = Σ_ν mult_ν·χ_ν`, `equal char ⇒ iso`,
+  and `mult>0 ⇒ V_ν embeds`.
+- **#6357** — `feat(Ch5 #Problem5.16.3b prereq): spectrum of C_{n-1} on V_λ = {content ν : ν ∈
+  removeSquare λ}`. Applies #6356 to `Res V_λ` to pin the spectrum and derive the rectangular
+  criterion; `depends-on: #6356` (auto-`blocked`). Unblocks #6286.
+- #6351 marked `replan` with a `Decomposed into #6356, #6357` breadcrumb.
+
+No code changed (clean decomposition). Restored three unrelated stray-modified files
+(`.claude/commands/feature.md`, `review.md`, `agent-worker-flow/SKILL.md`) that were dirty in the
+reused worktree, to keep the base clean.
+
+## Key findings (design note for #6356/#6357)
+
+- `SpechtModule n la` is a concrete `Submodule ℂ (SymGroupAlgebra n)` (left ideal `ℂ[Sₙ]·c_λ`).
+- **Free wins** from `SumTranspositionsEigenvalues.sumTranspositions_isSemisimple_and_integer_eigenvalues`:
+  on ANY fin-dim `Sₘ`-rep, `C_m` is semisimple and every eigenvalue is `content ν` for some `ν ⊢ m`.
+  So semisimplicity + "eigenvalues ⊆ all contents" is already done; only the removeSquare pinning
+  remains.
+- `sumTranspositions_mul_eq_content_smul` (5.16.2): `C_m` acts by scalar `content λ` on `V_λ`.
+- `res_spechtModule_character` (5.16.1): the branching **character** identity — but for `permEmb`
+  (last-point stabiliser).
+- The gap: `res_spechtModule_character` is only a character identity. Lifting to a module
+  decomposition needs "semisimple module char = Σ mult·χ_ν ⇒ equal char ⇒ iso / positive mult ⇒
+  submodule". The project HAS this only for `PermutationModule n mu`
+  (`Theorem5_15_1.trace_isotypic_eq_mult_character`, `permModule_isotypic_isInternal`,
+  `spechtMultiplicity`), NOT for a general rep. Chapter 4's FDRep world has `char_orthonormal`
+  (simple only) and `classFunction_eq_zero_of_orthogonal_simples`, but no packaged
+  multiplicity-as-inner-product / char-determines-rep.
+- Reusable tools for #6356: Mathlib `Mathlib/RingTheory/SimpleModule/Isotypic.lean`
+  (`isotypicComponent`, `isotypicComponents`, `sSup_isotypicComponents`,
+  `sSupIndep_isotypicComponents`); `classification_general_u` / `Theorem5_12_2_classification`
+  (every simple submodule `≃ₗ` some `V_ν`); `specht_char_inner` + `spechtModuleCharacter_injective`
+  (Specht chars orthonormal ⇒ linearly independent); Maschke instance
+  `IsSemisimpleModule (SymGroupAlgebra n) ρ.asModule`.
+- **Embedding-convention subtlety** (flagged in #6357): 5.16.1 branching uses `permEmb` (last point,
+  `Fin.castSuccEmb`); 5.16.3's `E = (12)+…+(1n)` and `sumTranspositionsStab`/`restrictRep`/
+  `permEmbZero` use the first-point stabiliser (`Fin.succ`). Same eigenvalue set (conjugate
+  subgroups), but the formal proof must bridge the two (prove branching for `permEmbZero`, or a
+  conjugation/`content`-invariance argument).
+
+## Current frontier
+
+`Problem5_16_3.lean` has 5.16.3(a) fully proved; only `sumTranspositionsWith1_acts_scalar_iff_rectangular`
+(part b, `#6286`) is `sorry`, blocked on the spectrum lemma now tracked as #6357 → #6356.
+
+## Overall project progress
+
+Phase 3 formalization, Chapter 5. Branching character identity (5.16.1) and content-scalar
+(5.16.2) done; 5.16.3(a) done; 5.16.3(b) awaits the module-level spectrum prerequisite, now
+decomposed into #6356 (general infra) → #6357 (application) → #6286 (part b).
+
+## Next step
+
+A worker should claim **#6356** (the general character⇒multiplicity bridge) — it is the
+unblocked, reusable crux. Once it lands, #6357 auto-unblocks and pins the `C_{n-1}` spectrum,
+which then unblocks #6286. Follow the isotypic template already in `Theorem5_15_1.lean`, just
+generalised from `PermutationModule` to an arbitrary `ρ`.
+
+## Blockers
+
+None for the pipeline (work is queued as #6356 unblocked, #6357/#6286 blocked on it). Parent
+#6351 is `replan` for the next planner to close (sub-issues fully cover it).


### PR DESCRIPTION
This PR records the session handoff for the module-level branching-spectrum prerequisite (originally #6351). After investigation I decomposed the work into a reusable general character⇒multiplicity bridge for arbitrary Sₙ-representations (#6356) and its application pinning the `C_{n-1}` spectrum on `V_λ` to `{content ν : ν ∈ removeSquare λ}` and deriving the rectangular criterion (#6357, which unblocks 5.16.3(b) / #6286). The parent #6351 is marked `replan`. No formalization code changes — this lands only the progress note capturing the design analysis (exact reusable lemmas, the free semisimplicity+content-bound win, and the permEmb/permEmbZero embedding-convention subtlety).

🤖 Prepared with Claude Code