### PR TITLE
feat(Ch8 #6336): bar-face infrastructure for d∘d=0 (contractNth simplicial identity, barFace, barDiff as alternating sum)

### DIFF
--- a/EtingofRepresentationTheory/Chapter8/BarResolution.lean
+++ b/EtingofRepresentationTheory/Chapter8/BarResolution.lean
@@ -202,6 +202,22 @@ theorem contractNth_update_of_ne {n : ℕ} (i : Fin n) (v : Fin (n + 1) → A) (
             intro e
             exact hk (by rw [← Fin.predAbove_succAbove i k, e]))]
 
+/-- **Simplicial identity for `Fin.contractNth`** with an associative operation `op`:
+merging at position `q` then at the lower position `p` equals merging at `p` first, then at
+`q - 1` (the original `q`-block's position after the lower merge shifts everything above `p` down
+by one). This is the merge-face version of the simplicial identity `dᵢ ∘ dⱼ = d_{j-1} ∘ dᵢ`
+(`i < j`); Mathlib has no `contractNth`-composition lemma, so we prove it here. -/
+theorem contractNth_contractNth {α : Type*} (op : α → α → α)
+    (hop : ∀ a b c, op (op a b) c = op a (op b c)) {n : ℕ}
+    (p : Fin (n + 1)) (q : Fin (n + 2)) (hpq : (p : ℕ) < (q : ℕ)) (v : Fin (n + 2) → α) :
+    Fin.contractNth p op (Fin.contractNth q op v)
+      = Fin.contractNth (q.pred (by rintro rfl; simp at hpq)) op
+          (Fin.contractNth p.castSucc op v) := by
+  ext r
+  simp only [Fin.contractNth, Fin.val_castSucc, Fin.val_succ, Fin.val_pred,
+    Fin.succ_castSucc]
+  split_ifs <;> first | rfl | (exfalso; omega) | rw [hop]
+
 /-- Pull off the first tensor factor: `tprod v ↦ v 0 ⊗ tprod (Fin.tail v)`. -/
 noncomputable def barConsSplit (n : ℕ) : (⨂[k]^(n + 1) A) →ₗ[k] A ⊗[k] (⨂[k]^n A) :=
   PiTensorProduct.lift <| LinearMap.uncurryLeft

--- a/EtingofRepresentationTheory/Chapter8/BarResolution.lean
+++ b/EtingofRepresentationTheory/Chapter8/BarResolution.lean
@@ -492,6 +492,27 @@ theorem barDiff_eq_sum_barFace (n : ℕ) :
   rw [barFace, coeffFace_last, ofCoeff_tmul, coeffFaceLast]
   simp [TensorProduct.smul_tmul']
 
+omit [Module A W] [IsScalarTower k A W] in
+/-- Two `A`-linear maps out of a bar term agree once they agree on the pure generators
+`a₀ ⊗ (tprod v ⊗ w)`. -/
+theorem barModule_hom_ext {n m : ℕ}
+    {F G : barModule k A W (n + 1) →ₗ[A] barModule k A W m}
+    (h : ∀ (a₀ : A) (v : Fin (n + 1) → A) (w : W),
+      F (a₀ ⊗ₜ[k] (tprod k v ⊗ₜ[k] w)) = G (a₀ ⊗ₜ[k] (tprod k v ⊗ₜ[k] w))) :
+    F = G := by
+  refine TensorProduct.AlgebraTensorModule.ext fun a₀ x => ?_
+  induction x using TensorProduct.induction_on with
+  | zero => simp
+  | tmul p w =>
+      induction p using PiTensorProduct.induction_on with
+      | smul_tprod r v =>
+          simp only [← TensorProduct.smul_tmul', TensorProduct.tmul_smul,
+            LinearMap.map_smul_of_tower]
+          rw [h a₀ v w]
+      | add x y hx hy =>
+          rw [TensorProduct.add_tmul, TensorProduct.tmul_add, map_add, map_add, hx, hy]
+  | add x y hx hy => rw [TensorProduct.tmul_add, map_add, map_add, hx, hy]
+
 end BarFaces
 
 end Etingof.BarResolution

--- a/EtingofRepresentationTheory/Chapter8/BarResolution.lean
+++ b/EtingofRepresentationTheory/Chapter8/BarResolution.lean
@@ -472,6 +472,26 @@ theorem barDiff_eq_sum_barFace (n : ℕ) :
   rw [barDiff_eq_ofCoeff, barCoeffD_eq_sum_coeffFace, ofCoeff_sum]
   simp only [ofCoeff_smul, barFace]
 
+/-! ### Evaluation of the individual faces on a pure generator -/
+
+@[simp] theorem barFace_zero_apply (n : ℕ) (a₀ : A) (v : Fin (n + 1) → A) (w : W) :
+    barFace k A W n 0 (a₀ ⊗ₜ[k] (tprod k v ⊗ₜ[k] w))
+      = (a₀ * v 0) ⊗ₜ[k] (tprod k (Fin.tail v) ⊗ₜ[k] w) := by
+  rw [barFace, coeffFace_zero, ofCoeff_tmul, coeffFaceZero]
+  simp [TensorProduct.smul_tmul']
+
+@[simp] theorem barFace_interior_apply (n : ℕ) (j : Fin n) (a₀ : A) (v : Fin (n + 1) → A) (w : W) :
+    barFace k A W n j.succ.castSucc (a₀ ⊗ₜ[k] (tprod k v ⊗ₜ[k] w))
+      = a₀ ⊗ₜ[k] (tprod k (Fin.contractNth (Fin.castSucc j) (· * ·) v) ⊗ₜ[k] w) := by
+  rw [barFace, coeffFace_interior, ofCoeff_tmul, coeffFaceInterior]
+  simp [TensorProduct.smul_tmul']
+
+@[simp] theorem barFace_last_apply (n : ℕ) (a₀ : A) (v : Fin (n + 1) → A) (w : W) :
+    barFace k A W n (Fin.last (n + 1)) (a₀ ⊗ₜ[k] (tprod k v ⊗ₜ[k] w))
+      = a₀ ⊗ₜ[k] (tprod k (Fin.init v) ⊗ₜ[k] (v (Fin.last n) • w)) := by
+  rw [barFace, coeffFace_last, ofCoeff_tmul, coeffFaceLast]
+  simp [TensorProduct.smul_tmul']
+
 end BarFaces
 
 end Etingof.BarResolution

--- a/EtingofRepresentationTheory/Chapter8/BarResolution.lean
+++ b/EtingofRepresentationTheory/Chapter8/BarResolution.lean
@@ -364,4 +364,114 @@ theorem barDiff_tmul (n : ℕ) (a₀ : A) (c : barCoeff k A W (n + 1)) :
 
 end BarDifferential
 
+/-! ### The bar faces `δᵢ` and the differential as their alternating sum
+
+To prove `d ∘ d = 0` we present `barDiff` as the alternating sum `∑ i, (-1)ⁱ • barFace i` of the
+`n + 2` individual faces `barFace i : Pₙ₊₁ → Pₙ`, each an `A`-linear map, and reduce the square-zero
+relation to the simplicial identities `barFace i ∘ barFace j = barFace (j-1) ∘ barFace i` (`i < j`),
+following Mathlib's `AlgebraicTopology.AlternatingFaceMapComplex.d_squared`. -/
+
+section BarFaces
+
+/-- Package a `k`-linear coefficient map `barCoeff (n+1) → barModule n` as an `A`-linear map
+`barModule (n+1) → barModule n`, `a₀ ⊗ c ↦ a₀ • f c` (the same lift used for `barDiff`). -/
+noncomputable def ofCoeff {n : ℕ} (f : barCoeff k A W (n + 1) →ₗ[k] barModule k A W n) :
+    barModule k A W (n + 1) →ₗ[A] barModule k A W n :=
+  TensorProduct.AlgebraTensorModule.lift
+    (LinearMap.toSpanSingleton A (barCoeff k A W (n + 1) →ₗ[k] barModule k A W n) f)
+
+omit [Module A W] [IsScalarTower k A W] in
+@[simp] theorem ofCoeff_tmul {n : ℕ} (f : barCoeff k A W (n + 1) →ₗ[k] barModule k A W n)
+    (a₀ : A) (c : barCoeff k A W (n + 1)) :
+    ofCoeff k A W f (a₀ ⊗ₜ[k] c) = a₀ • f c := by
+  simp [ofCoeff, LinearMap.toSpanSingleton_apply]
+
+theorem barDiff_eq_ofCoeff (n : ℕ) : barDiff k A W n = ofCoeff k A W (barCoeffD k A W n) := rfl
+
+/-- The `i = 0` bar face at coefficient level (multiply the leading factor into the first tensor
+slot): `tprod v ⊗ w ↦ v 0 ⊗ (tprod (tail v) ⊗ w)`. -/
+noncomputable def coeffFaceZero (n : ℕ) : barCoeff k A W (n + 1) →ₗ[k] barModule k A W n :=
+  (TensorProduct.assoc k A (⨂[k]^n A) W).toLinearMap
+    ∘ₗ TensorProduct.map (barConsSplit k A n) LinearMap.id
+
+/-- The interior bar face `1 ≤ i ≤ n` at coefficient level: merge tensor slots `j, j+1`. -/
+noncomputable def coeffFaceInterior (n : ℕ) (j : Fin n) :
+    barCoeff k A W (n + 1) →ₗ[k] barModule k A W n :=
+  oneTmul k A W n ∘ₗ TensorProduct.map (barMerge k A n j) LinearMap.id
+
+/-- The last bar face `i = n+1` at coefficient level: act the trailing tensor slot on `W`. -/
+noncomputable def coeffFaceLast (n : ℕ) : barCoeff k A W (n + 1) →ₗ[k] barModule k A W n :=
+  oneTmul k A W n ∘ₗ barSnocAct k A W n
+
+/-- The `i`-th bar face at coefficient level (`i : Fin (n+2)`): face `0` multiplies the leading
+factor into the first slot, faces `1 ≤ i ≤ n` merge adjacent slots, face `n+1` acts the last slot on
+`W`. -/
+noncomputable def coeffFace (n : ℕ) (i : Fin (n + 2)) :
+    barCoeff k A W (n + 1) →ₗ[k] barModule k A W n :=
+  if h0 : (i : ℕ) = 0 then coeffFaceZero k A W n
+  else if hl : (i : ℕ) = n + 1 then coeffFaceLast k A W n
+  else coeffFaceInterior k A W n ⟨(i : ℕ) - 1, by have := i.isLt; omega⟩
+
+@[simp] theorem coeffFace_zero (n : ℕ) : coeffFace k A W n 0 = coeffFaceZero k A W n := by
+  simp [coeffFace]
+
+@[simp] theorem coeffFace_last (n : ℕ) :
+    coeffFace k A W n (Fin.last (n + 1)) = coeffFaceLast k A W n := by
+  rw [coeffFace, dif_neg (by simp), dif_pos (by simp)]
+
+theorem coeffFace_interior (n : ℕ) (j : Fin n) :
+    coeffFace k A W n j.succ.castSucc = coeffFaceInterior k A W n j := by
+  rw [coeffFace]
+  have h1 : ¬ ((j.succ.castSucc : Fin (n + 2)) : ℕ) = 0 := by simp [Fin.val_succ]
+  have h2 : ¬ ((j.succ.castSucc : Fin (n + 2)) : ℕ) = n + 1 := by
+    simp only [Fin.val_castSucc, Fin.val_succ]; have := j.isLt; omega
+  rw [dif_neg h1, dif_neg h2]
+  congr 1
+
+/-- The `i`-th bar face as an `A`-linear map `Pₙ₊₁ → Pₙ`. The bar differential is the alternating
+sum `∑ i, (-1)^i • barFace i` (`barDiff_eq_sum_barFace`). -/
+noncomputable def barFace (n : ℕ) (i : Fin (n + 2)) :
+    barModule k A W (n + 1) →ₗ[A] barModule k A W n :=
+  ofCoeff k A W (coeffFace k A W n i)
+
+omit [Module A W] [IsScalarTower k A W] in
+theorem ofCoeff_add {n : ℕ} (f g : barCoeff k A W (n + 1) →ₗ[k] barModule k A W n) :
+    ofCoeff k A W (f + g) = ofCoeff k A W f + ofCoeff k A W g := by
+  refine TensorProduct.AlgebraTensorModule.ext (fun a₀ c => ?_)
+  simp [smul_add]
+
+omit [Module A W] [IsScalarTower k A W] in
+theorem ofCoeff_smul {n : ℕ} (c : k) (f : barCoeff k A W (n + 1) →ₗ[k] barModule k A W n) :
+    ofCoeff k A W (c • f) = c • ofCoeff k A W f := by
+  refine TensorProduct.AlgebraTensorModule.ext (fun a₀ x => ?_)
+  simp only [ofCoeff_tmul, LinearMap.smul_apply]
+  rw [smul_comm]
+
+omit [Module A W] [IsScalarTower k A W] in
+theorem ofCoeff_sum {n : ℕ} {ι : Type*} (s : Finset ι)
+    (f : ι → (barCoeff k A W (n + 1) →ₗ[k] barModule k A W n)) :
+    ofCoeff k A W (∑ i ∈ s, f i) = ∑ i ∈ s, ofCoeff k A W (f i) := by
+  classical
+  induction s using Finset.induction with
+  | empty => refine TensorProduct.AlgebraTensorModule.ext (fun a₀ c => ?_); simp [ofCoeff]
+  | insert x s hx ih => rw [Finset.sum_insert hx, Finset.sum_insert hx, ofCoeff_add, ih]
+
+/-- The coefficient-level bar differential is the alternating sum of the bar faces. -/
+theorem barCoeffD_eq_sum_coeffFace (n : ℕ) :
+    barCoeffD k A W n = ∑ i : Fin (n + 2), (-1 : k) ^ (i : ℕ) • coeffFace k A W n i := by
+  rw [Fin.sum_univ_succ, Fin.sum_univ_castSucc]
+  have hlast : ((Fin.last n).succ : Fin (n + 2)) = Fin.last (n + 1) := Fin.succ_last n
+  simp only [Fin.val_zero, pow_zero, one_smul, coeffFace_zero, Fin.val_succ, Fin.val_castSucc,
+    Fin.succ_castSucc, coeffFace_interior, hlast, coeffFace_last, Fin.val_last]
+  rw [barCoeffD]
+  abel
+
+/-- **The bar differential as an alternating sum of faces.** -/
+theorem barDiff_eq_sum_barFace (n : ℕ) :
+    barDiff k A W n = ∑ i : Fin (n + 2), (-1 : k) ^ (i : ℕ) • barFace k A W n i := by
+  rw [barDiff_eq_ofCoeff, barCoeffD_eq_sum_coeffFace, ofCoeff_sum]
+  simp only [ofCoeff_smul, barFace]
+
+end BarFaces
+
 end Etingof.BarResolution

--- a/progress/2026-07-11T00-53-56Z_aeaa72a3.md
+++ b/progress/2026-07-11T00-53-56Z_aeaa72a3.md
@@ -1,0 +1,43 @@
+## Accomplished
+
+Session type: feature (`/work` → `/feature`), issue #6336 (Ch8 bar resolution: `barComplex` +
+`barDiff_comp_barDiff`, `d ∘ d = 0`).
+
+Landed a sorry-free, building subset of the infrastructure for `d ∘ d = 0` in
+`EtingofRepresentationTheory/Chapter8/BarResolution.lean` (+167 lines, 5 commits):
+
+- `contractNth_contractNth` — the merge-face simplicial identity `dᵢ dⱼ = d_{j-1} dᵢ` (`i < j`) for
+  `Fin.contractNth` with an associative op. Reusable combinatorial core; Mathlib has no such lemma.
+  Proof: `ext` + unfold `contractNth` + `split_ifs <;> first | rfl | (exfalso; omega) | rw [hop]`.
+- `ofCoeff` / `coeffFace{Zero,Interior,Last}` / `coeffFace` / `barFace n (i : Fin (n+2))` — the
+  `n+2` individual bar faces as `A`-linear maps `Pₙ₊₁ → Pₙ`.
+- `barDiff_eq_sum_barFace : barDiff n = ∑ i, (-1)^i • barFace n i` (via `ofCoeff` `k`-linearity and
+  a `Fin.sum_univ_succ` / `Fin.sum_univ_castSucc` split).
+- `barFace_{zero,interior,last}_apply` — evaluate each face on a generator `a₀ ⊗ (tprod v ⊗ w)`.
+- `barModule_hom_ext` — reduce equality of two `A`-linear maps out of a bar term to pure generators.
+
+Also triaged the only other unclaimed item on entry, #6286: re-recorded its real prerequisite
+`depends-on: #6351` (a stale `check-blocked` had wrongly cleared it), so it stays correctly blocked.
+
+## Current frontier
+
+The remaining `d ∘ d = 0` proof is decomposed into follow-up #6367 (depends on #6336). It needs:
+`barFace_comp_barFace` (the face simplicial identity, ~5 index cases via `barModule_hom_ext` +
+`contractNth_contractNth` + ring assoc for boundary faces), then `barDiff_comp_barDiff` via the
+`AlternatingFaceMapComplex.d_squared` sign-reversing bijection, then `barComplex` via
+`ChainComplex.of`.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. Ch8 bar resolution chain: #6335 (barDiff) merged; #6336 infra
+landed (this PR, partial); completion in #6367; downstream #6318, #6298 still blocked.
+
+## Next step
+
+Claim #6367 and complete `barFace_comp_barFace` → `barDiff_comp_barDiff` → `barComplex`. The full
+blueprint (including the exact `d_squared` bijection to mirror and the boundary-case guidance) is in
+the #6367 body. All prerequisite lemmas are already on `main` once this partial PR merges.
+
+## Blockers
+
+None. #6367 is blocked only on #6336's partial PR merging (mechanical).


### PR DESCRIPTION
Partial progress on #6336

Session: `aeaa72a3-a257-4933-bb09-2b49891016c9`

74a23d8b chore(Ch8 #6336): progress handoff — bar-face infra landed, d∘d=0 tracked in #6367
e69edde4 Merge origin/main into agent/aeaa72a3-6336
fbced7d5 feet(Ch8 #6336): barModule_hom_ext generator-extensionality for bar-term maps
d4d42f77 feat(Ch8 #6336): per-face generator evaluation lemmas (barFace_*_apply)
51ba3cbd feat(Ch8 #6336): bar faces barFace and barDiff as alternating sum of faces
6a29b8b7 feat(Ch8 #6336): contractNth simplicial identity (contractNth_contractNth)

🤖 Prepared with Claude Code