### PR TITLE
chore(skill): sanity-check target statement is provable before attempting proof

### DIFF
--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -175,6 +175,17 @@ Check that the plan's assumptions still hold:
   sub-issues, so the assembly is not actually ready. Confirm the named
   lemmas/defs exist in the Lean files before working; if not, re-add
   `depends-on` on the real open sub-issues and `skip`.
+- **Sanity-check the target statement is actually provable** before
+  attempting the proof. A planner-written signature can be *false as
+  stated* (hypotheses too weak, wrong quantifier, missing finiteness).
+  Spend a moment trying to break it: do the hypotheses actually pin down
+  the conclusion, or can you build a counterexample? (E.g. "M has one
+  composition factor" does **not** imply finite length — `R=ℤ, M=ℤ` is
+  indecomposable with unlinked factors ℤ/2, ℤ/3.) If the statement is
+  unprovable, do **not** attempt it or silently strengthen the signature:
+  post a comment with the counterexample and suggested fix, then `skip`
+  for replan (Escalation ladder: "Ordering mistake in the plan → report,
+  request replan").
 
 If stale:
 ```

--- a/progress/2026-07-11T01-01-35Z_97445aaf.md
+++ b/progress/2026-07-11T01-01-35Z_97445aaf.md
@@ -1,0 +1,51 @@
+## Accomplished
+
+Session type: `/work` → `/feature`. Claimed issue #6362
+(`exists_block_of_indecomposable`, Problem 9.5.3(ii) decomposition half).
+
+During Step 4 (Verify Assumptions) found the theorem is **false as stated** and
+reported it rather than attempting an impossible proof:
+
+- Counterexample: `R = ℤ`, `M = ModuleCat.of ℤ ℤ`. `M` is `Indecomposable`
+  (ℤ is directly indecomposable), and `hfl` holds (`ℤ/2` is a composition factor).
+  But `ℤ/2` and `ℤ/3` are both composition factors and are **unlinked**
+  (`Ext¹_ℤ(ℤ/2, ℤ/3) = ℤ/gcd(2,3) = 0`, `ℤ/2 ≇ ℤ/3`), so no simple `S` can have
+  every composition factor of `M` linked to it. The goal is therefore unprovable.
+- Root cause: `hfl : ∃ S, IsCompositionFactor R M S` ("one composition factor")
+  was meant to encode finite length but does not. `Module.Finite` is also
+  insufficient (ℤ is f.g. over ℤ — the counterexample). Genuine finite length is
+  required (`Mathlib.RingTheory.FiniteLength.IsFiniteLength`, or a
+  `CompositionSeries`).
+- Also confirmed the issue's "Current state" (composition-factor infra +
+  sorry-free `hom_subsingleton_of_not_linked`) is NOT on `main`; it lives in the
+  still-open PR #6363 (issue #6354). #6354 is closed but its PR is unmerged.
+
+Posted a detailed comment with the counterexample and suggested fix, added
+`depends-on: #6354`, and `coordination skip`ped #6362 → `replan`.
+
+## Current frontier
+
+No code changes. Issue #6362 is now `replan` with a comment explaining the
+signature defect. `exists_block_of_indecomposable` remains `sorry` on the PR
+#6363 branch (and the stub on `main`).
+
+## Overall project progress
+
+Chapter 9 blocks (Problem 9.5.3): part (ii) orthogonality half proven in open PR
+#6363; part (ii) decomposition half (#6362) blocked on a false signature; part (i)
+(`blocks_equiv_indecomposableCentralIdempotents`) and part (iii) still `sorry`/deferred.
+
+## Next step
+
+Planner: fix the #6362 statement before re-issuing. Add a finite-length
+hypothesis (e.g. `[IsFiniteLength R M]` or a `CompositionSeries R M`) and re-open
+against `main` only after PR #6363 (composition-factor infra) merges. With finite
+length the book argument is sound: linkage is an equivalence relation on the
+finite factor set; a two-class split yields a nontrivial direct summand
+(Ext¹ vanishing between unlinked factors ⟹ extension splits), contradicting
+`Indecomposable M`.
+
+## Blockers
+
+- #6362 theorem is unprovable as written (missing finite-length hypothesis) — needs a replan of the statement.
+- Composition-factor infrastructure it builds on is in unmerged PR #6363.


### PR DESCRIPTION
This PR adds a worker Step 4 check to `agent-worker-flow`: before attempting a proof, sanity-check that the target theorem statement is actually provable, since a planner-written signature can be false as stated (hypotheses too weak, missing finiteness).

Prompted by issue #6362, whose `exists_block_of_indecomposable` is unprovable as written: `R=ℤ, M=ℤ` is `Indecomposable` and has a composition factor, yet its factors ℤ/2 and ℤ/3 are unlinked (`Ext¹_ℤ(ℤ/2,ℤ/3)=0`), so no simple `S` has all factors linked to it. The hypothesis 'one composition factor' does not encode finite length. #6362 has been skipped for replan with a counterexample comment.

Also includes the session progress note.

🤖 Prepared with Claude Code