### PR TITLE
feat(Ch9 #Problem9.4.6ii): cartanMatrix_pathAlgebra_eq_pathCount — Cartan matrix of an acyclic path algebra is the path-count matrix

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/Problem9_4_6.lean
+++ b/EtingofRepresentationTheory/Chapter9/Problem9_4_6.lean
@@ -1,5 +1,6 @@
 import Mathlib.Algebra.FreeAlgebra
 import Mathlib.Combinatorics.Quiver.Path
+import Mathlib.LinearAlgebra.Dimension.Constructions
 import EtingofRepresentationTheory.Chapter2.Definition2_8_4
 import EtingofRepresentationTheory.Chapter9.Definition9_3_1
 import EtingofRepresentationTheory.Chapter9.Definition9_4_3
@@ -79,7 +80,11 @@ theorem cartanMatrix_pathAlgebra_eq_pathCount
     [∀ i, SMulCommClass (Etingof.PathAlgebra k Q) k (P i)]
     (hcover : ∀ i j : Q,
       Nonempty ((P i →ₗ[Etingof.PathAlgebra k Q] P j) ≃ₗ[k] (Quiver.Path i j →₀ k))) :
-    Etingof.algebraCartanMatrix (k := k) (A := Etingof.PathAlgebra k Q) P = pathCountMatrix Q :=
-  sorry
+    Etingof.algebraCartanMatrix (k := k) (A := Etingof.PathAlgebra k Q) P = pathCountMatrix Q := by
+  ext i j
+  obtain ⟨e⟩ := hcover i j
+  have : Fintype (Quiver.Path i j) := Fintype.ofFinite _
+  simp only [Etingof.algebraCartanMatrix, pathCountMatrix, Matrix.of_apply]
+  rw [e.finrank_eq, Module.finrank_finsupp_self, Nat.card_eq_fintype_card]
 
 end Etingof.Problem946

--- a/progress/2026-07-11T01-05-55Z_8c306ada.md
+++ b/progress/2026-07-11T01-05-55Z_8c306ada.md
@@ -1,0 +1,30 @@
+## Accomplished
+Proved `Etingof.Problem946.cartanMatrix_pathAlgebra_eq_pathCount` (Problem 9.4.6 (ii),
+issue #6369) sorry-free, without weakening the signature. The Cartan matrix of the path
+algebra of a finite acyclic quiver equals the path-count matrix.
+
+Proof (pure dimension bookkeeping given `hcover`):
+- `ext i j`; `obtain ⟨e⟩ := hcover i j`; derive a `Fintype (Quiver.Path i j)` from the
+  `Finite` instance via `Fintype.ofFinite`.
+- `simp only [Etingof.algebraCartanMatrix, pathCountMatrix, Matrix.of_apply]` reduces each
+  entry to `finrank k (P i →ₗ[A] P j) = Nat.card (Quiver.Path i j)`.
+- `rw [e.finrank_eq, Module.finrank_finsupp_self, Nat.card_eq_fintype_card]` closes it.
+- Added import `Mathlib.LinearAlgebra.Dimension.Constructions` for `finrank_finsupp_self`.
+
+## Current frontier
+`Chapter9/Problem9_4_6.lean` builds; `#print axioms` on the target theorem shows only
+`propext, Classical.choice, Quot.sound`. Sorry count in the file dropped 4 → 3.
+`hacyclic` remains an (unused) hypothesis per the issue instruction to keep the signature
+as-is (benign unused-variable linter warning; CI does not treat warnings as errors).
+
+## Overall project progress
+Phase 3 formalization ongoing. Two `sorry`s remain in Problem9_4_6.lean, both part (i)
+(homological dimension): `homologicalDimension_pathAlgebra_eq_one` and
+`homologicalDimension_freeAlgebra_eq_one` — separate, harder future items.
+
+## Next step
+Tackle the two homological-dimension sorries (part (i)), and #6370
+(`not_finiteDimensional_g_four`, needs a characteristic-uniform argument).
+
+## Blockers
+None.


### PR DESCRIPTION
Closes #6369

Session: `8c306ada-e26b-4b39-af09-ad11ebb99389`

2374fec1 feat(Ch9 #6369): prove cartanMatrix_pathAlgebra_eq_pathCount sorry-free

🤖 Prepared with Claude Code