### PR TITLE
feat(Ch5 #6327): j-operator helper + normalized j' for real-type Problem 5.1.2(a)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Problem5_1_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_1_2.lean
@@ -307,6 +307,136 @@ private lemma schur_scalar
     have : v ∈ Module.End.eigenspace φ c := htop ▸ Submodule.mem_top
     rwa [Module.End.mem_eigenspace_iff] at this
 
+/-- **The `j`-operator** (shared toolkit for the real and quaternionic cases, #6327/#6328).
+Given a `G`-invariant nondegenerate bilinear form `B` on a simple representation `V`, together
+with the invariant positive-definite Hermitian form `(·,·)` from `exists_invariant_posdef_hermitian`,
+there is a `ℂ`-antilinear `G`-equivariant operator `j : V → V` characterized by `(v, j w) = B v w`,
+satisfying `j² = λ • id` for a real scalar `λ`. The sign of `λ` matches the (skew)symmetry sign `s`
+of `B` (hypothesis `B w v = s • B v w`): `s · λ > 0`. So for a **symmetric** `B` (`s = 1`, real
+type) one gets `λ > 0`, and for a **skew** `B` (`s = -1`, quaternionic type) `λ < 0`. -/
+theorem exists_antilinear_j_of_invariant_nondegenerate
+    (hirr : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule)
+    (B : V →ₗ[ℂ] V →ₗ[ℂ] ℂ)
+    (hnd : ∀ v, (∀ w, B v w = 0) → v = 0)
+    (hinvB : ∀ g v w, B (ρ g v) (ρ g w) = B v w)
+    (s : ℝ) (hs : ∀ v w, B w v = s • B v w) :
+    ∃ (j : V →ₗ⋆[ℂ] V) (lam : ℝ),
+      (∀ g v, j (ρ g v) = ρ g (j v)) ∧
+      (∀ v, j (j v) = (lam : ℂ) • v) ∧
+      0 < s * lam := by
+  classical
+  haveI : Nontrivial ρ.asModule := IsSimpleModule.nontrivial (MonoidAlgebra ℂ G) ρ.asModule
+  haveI hVnt : Nontrivial V := (Representation.asModuleEquiv ρ).symm.toEquiv.nontrivial
+  obtain ⟨H, hHinv, hHpos, hHsym⟩ := exists_invariant_posdef_hermitian ρ
+  -- `H v v` is a nonnegative real (conjugate symmetry ⇒ real; positive-definiteness ⇒ positive).
+  have hHreal : ∀ v, H v v = ((H v v).re : ℂ) := fun v => (Complex.conj_eq_iff_re.mp (hHsym v v)).symm
+  -- `s ≠ 0` (else `B = 0`, contradicting nondegeneracy on the nontrivial space `V`).
+  have hs0 : s ≠ 0 := by
+    intro h
+    obtain ⟨v, hv⟩ := exists_ne (0 : V)
+    exact hv (hnd v fun w => by have := hs w v; rw [h, zero_smul] at this; exact this)
+  -- `B.flip` is injective (second-slot nondegeneracy, obtained from `hs` + `hnd`).
+  have hBdinj : Function.Injective (B.flip) := by
+    rw [← LinearMap.ker_eq_bot, LinearMap.ker_eq_bot']
+    intro w hw
+    refine hnd w fun w' => ?_
+    have h1 : B w' w = 0 := DFunLike.congr_fun hw w'
+    have := hs w' w
+    rw [h1, smul_zero] at this
+    exact this
+  -- `hermToDual H` is bijective: injective by positive-definiteness, surjective by an
+  -- `ℝ`-dimension count (both `V` and `V*` have real dimension `2 · dim_ℂ V`).
+  have hΦinj : Function.Injective (hermToDual H) := hermToDual_injective H hHpos
+  have hΦsurj : Function.Surjective (hermToDual H) := by
+    let ΦR : V →ₗ[ℝ] Module.Dual ℂ V :=
+      { toFun := hermToDual H
+        map_add' := (hermToDual H).map_add
+        map_smul' := fun r w => by
+          simp only [RingHom.id_apply]
+          rw [show (r : ℝ) • w = ((r : ℂ)) • w from (real_coe_smul r w).symm, map_smulₛₗ,
+            Complex.conj_ofReal, ← IsScalarTower.algebraMap_smul ℂ r (hermToDual H w),
+            Complex.coe_algebraMap] }
+    have hΦRinj : Function.Injective ΦR := hΦinj
+    haveI : FiniteDimensional ℝ V := Module.Finite.trans (R := ℝ) ℂ V
+    haveI : FiniteDimensional ℝ (Module.Dual ℂ V) := Module.Finite.trans (R := ℝ) ℂ _
+    have hdimR : Module.finrank ℝ V = Module.finrank ℝ (Module.Dual ℂ V) := by
+      rw [← Module.finrank_mul_finrank ℝ ℂ V,
+        ← Module.finrank_mul_finrank ℝ ℂ (Module.Dual ℂ V), Subspace.dual_finrank_eq]
+    exact (LinearMap.injective_iff_surjective_of_finrank_eq_finrank hdimR).mp hΦRinj
+  -- Package `hermToDual H` as a conjugate-linear equivalence and define `j := herm⁻¹ ∘ B.flip`.
+  let hermEquiv : V ≃ₗ⋆[ℂ] Module.Dual ℂ V :=
+    LinearEquiv.ofBijective (hermToDual H) ⟨hΦinj, hΦsurj⟩
+  let j0 : V →ₗ⋆[ℂ] V := (hermEquiv.symm.toLinearMap).comp B.flip
+  -- Defining relation: `H v (j0 w) = B v w`.
+  have hj0dual : ∀ w, hermToDual H (j0 w) = B.flip w := fun w => by
+    show hermToDual H (hermEquiv.symm (B.flip w)) = B.flip w
+    have : hermEquiv (hermEquiv.symm (B.flip w)) = B.flip w := hermEquiv.apply_symm_apply _
+    simpa only [LinearEquiv.ofBijective_apply, hermEquiv] using this
+  have hdefn : ∀ v w, H v (j0 w) = B v w := fun v w => by
+    have := DFunLike.congr_fun (hj0dual w) v
+    simpa only [hermToDual_apply, LinearMap.flip_apply] using this
+  have hj0inj : Function.Injective j0 := by
+    have : Function.Injective (⇑j0) := by
+      show Function.Injective (⇑hermEquiv.symm ∘ ⇑B.flip)
+      exact hermEquiv.symm.injective.comp hBdinj
+    exact this
+  -- `j0` is `G`-equivariant (uniqueness via injectivity of `hermToDual H`).
+  have hj0equiv : ∀ g v, j0 (ρ g v) = ρ g (j0 v) := by
+    intro g w
+    apply hΦinj
+    rw [hj0dual]
+    ext v
+    rw [hermToDual_apply, LinearMap.flip_apply]
+    -- `B v (ρ g w) = H v (ρ g (j0 w))`
+    have hBv : B v (ρ g w) = B (ρ g⁻¹ v) w := by
+      have hgg : (ρ g) ((ρ g⁻¹) v) = v := by
+        rw [← Module.End.mul_apply, ← map_mul, mul_inv_cancel, map_one, Module.End.one_apply]
+      have := hinvB g (ρ g⁻¹ v) w
+      rwa [hgg] at this
+    rw [hBv, ← hdefn, ← hHinv g, ← Module.End.mul_apply, ← map_mul, mul_inv_cancel, map_one,
+      Module.End.one_apply]
+  -- `φ := j0 ∘ j0` is `ℂ`-linear equivariant, hence a scalar `c` by Schur.
+  let φ : V →ₗ[ℂ] V :=
+    { toFun := fun v => j0 (j0 v)
+      map_add' := fun a b => by simp only [map_add]
+      map_smul' := fun c v => by
+        simp only [RingHom.id_apply]
+        rw [map_smulₛₗ, map_smulₛₗ, Complex.conj_conj] }
+  have hφequiv : ∀ g v, φ (ρ g v) = ρ g (φ v) := fun g v => by
+    show j0 (j0 (ρ g v)) = ρ g (j0 (j0 v))
+    rw [hj0equiv, hj0equiv]
+  obtain ⟨c, hc⟩ := schur_scalar hirr φ hφequiv
+  have hcsq : ∀ v, j0 (j0 v) = c • v := hc
+  -- Positivity: pin down `c` as a real number of sign `s`, using one nonzero vector.
+  obtain ⟨w0, hw0⟩ := exists_ne (0 : V)
+  have hjw0 : j0 w0 ≠ 0 := fun h => hw0 (hj0inj (h.trans (map_zero j0).symm))
+  -- `conj c • H v w = B v (j0 w)` and `B v (j0 w) = s • H (j0 w) (j0 v)`.
+  have hI : ∀ v w, (starRingEnd ℂ) c * H v w = B v (j0 w) := fun v w => by
+    rw [← hdefn v (j0 w), hcsq w, map_smulₛₗ]; rfl
+  have hII : ∀ v w, B v (j0 w) = (s : ℂ) * H (j0 w) (j0 v) := fun v w => by
+    rw [hs (j0 w) v, hdefn (j0 w) v, Complex.real_smul]
+  have hkey : (starRingEnd ℂ) c * ((H w0 w0).re : ℂ)
+      = (s : ℂ) * ((H (j0 w0) (j0 w0)).re : ℂ) := by
+    rw [← hHreal, ← hHreal, hI w0 w0, hII w0 w0]
+  set p1 := (H w0 w0).re with hp1def
+  set p2 := (H (j0 w0) (j0 w0)).re with hp2def
+  have hp1 : 0 < p1 := hHpos w0 hw0
+  have hp2 : 0 < p2 := hHpos (j0 w0) hjw0
+  -- From `conj c * p1 = s * p2` deduce `conj c` is the real number `s * p2 / p1`.
+  have hconj : (starRingEnd ℂ) c = ((s * p2 / p1 : ℝ) : ℂ) := by
+    rw [Complex.ofReal_div, Complex.ofReal_mul, eq_div_iff (by exact_mod_cast hp1.ne')]
+    push_cast at hkey ⊢
+    linear_combination hkey
+  have hcre : c = ((s * p2 / p1 : ℝ) : ℂ) := by
+    have := congrArg (starRingEnd ℂ) hconj
+    rwa [Complex.conj_conj, Complex.conj_ofReal] at this
+  refine ⟨j0, s * p2 / p1, hj0equiv, ?_, ?_⟩
+  · intro v; rw [hcsq v, hcre]
+  · have hs2 : 0 < s ^ 2 := (sq_nonneg s).lt_of_ne' (pow_ne_zero 2 hs0)
+    have hrw : s * (s * p2 / p1) = s ^ 2 * (p2 / p1) := by ring
+    rw [hrw]
+    exact mul_pos hs2 (div_pos hp2 hp1)
+
 end ComplexTypeProof
 
 /-- Problem 5.1.2(a), complex type. If the irreducible representation `V` is of complex type, then

--- a/EtingofRepresentationTheory/Chapter5/Problem5_1_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_1_2.lean
@@ -437,6 +437,62 @@ theorem exists_antilinear_j_of_invariant_nondegenerate
     rw [hrw]
     exact mul_pos hs2 (div_pos hp2 hp1)
 
+/-- **Normalized `j'`-operator** for the real type (#6327). If the simple representation `V` is of
+real type, then `End_{ℝ[G]} V` contains an element `j'` (the antilinear operator `j` normalized so
+that `j'² = 1`) that **anticommutes** with `J = ·i`. Together with `J` (`J² = -1`) this exhibits the
+split-quaternion / `Mat₂(ℝ)` relations `J² = -1`, `j'² = 1`, `Jj' = -j'J`. -/
+theorem exists_normalized_antilinear_of_isRealType
+    (hirr : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule)
+    (h : Etingof.IsRealType ρ) :
+    ∃ j' : realGEndAlgebra ρ, j' * j' = 1 ∧ realJ ρ * j' = -(j' * realJ ρ) := by
+  obtain ⟨B, hsymm, hnd, hinvB⟩ := h
+  obtain ⟨j0, lam, hjequiv, hjsq, hpos⟩ :=
+    exists_antilinear_j_of_invariant_nondegenerate hirr B hnd hinvB 1
+      (fun v w => by rw [hsymm, one_smul])
+  rw [one_mul] at hpos
+  -- `(r : ℂ) • v = r • v` for real `r`, via the scalar tower.
+  have rcs : ∀ (r : ℝ) (v : V), (r : ℂ) • v = r • v := fun r v => by
+    rw [← IsScalarTower.algebraMap_smul ℂ r v, Complex.coe_algebraMap]
+  -- The underlying `ℝ`-linear map of the antilinear `j0`.
+  let jm : Module.End ℝ V :=
+    { toFun := j0
+      map_add' := j0.map_add
+      map_smul' := fun r v => by
+        simp only [RingHom.id_apply]
+        rw [← rcs r v, map_smulₛₗ, Complex.conj_ofReal, rcs r (j0 v)] }
+  have hmem : jm ∈ realGEndAlgebra ρ := by
+    rw [realGEndAlgebra, Subalgebra.mem_centralizer_iff]
+    rintro _ ⟨g, rfl⟩
+    ext v
+    simp only [Module.End.mul_apply, LinearMap.restrictScalars_apply]
+    exact (hjequiv g v).symm
+  set X : realGEndAlgebra ρ := ⟨jm, hmem⟩ with hXdef
+  -- `X² = lam • 1`.
+  have hjm2 : X * X = lam • 1 := by
+    apply Subtype.ext
+    rw [Subalgebra.coe_mul, hXdef]
+    ext v
+    simp only [Module.End.mul_apply, SetLike.val_smul, Subalgebra.coe_one, LinearMap.smul_apply,
+      Module.End.one_apply]
+    show j0 (j0 v) = lam • v
+    rw [hjsq v, rcs lam v]
+  -- `X` anticommutes with `J = ·i`.
+  have hanti0 : realJ ρ * X = -(X * realJ ρ) := by
+    apply Subtype.ext
+    rw [Subalgebra.coe_mul, Subalgebra.coe_neg, Subalgebra.coe_mul, hXdef]
+    ext v
+    simp only [Module.End.mul_apply, LinearMap.neg_apply, realJ, complexToRealGEnd_coe_apply]
+    show Complex.I • j0 v = -(j0 (Complex.I • v))
+    rw [map_smulₛₗ, Complex.conj_I, neg_smul, neg_neg]
+  have hsqrt : Real.sqrt lam * Real.sqrt lam = lam := Real.mul_self_sqrt hpos.le
+  have hsne : Real.sqrt lam ≠ 0 := (Real.sqrt_pos.mpr hpos).ne'
+  refine ⟨(Real.sqrt lam)⁻¹ • X, ?_, ?_⟩
+  · rw [smul_mul_smul_comm, hjm2, smul_smul]
+    have hscal : (Real.sqrt lam)⁻¹ * (Real.sqrt lam)⁻¹ * lam = 1 := by
+      rw [← mul_inv, hsqrt, inv_mul_cancel₀ hpos.ne']
+    rw [hscal, one_smul]
+  · rw [mul_smul_comm, smul_mul_assoc, ← smul_neg, hanti0]
+
 end ComplexTypeProof
 
 /-- Problem 5.1.2(a), complex type. If the irreducible representation `V` is of complex type, then

--- a/EtingofRepresentationTheory/Chapter5/Problem5_1_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_1_2.lean
@@ -146,12 +146,13 @@ standard coordinate form `h₀(v, w) = ∑ᵢ (b.repr v)ᵢ · conj (b.repr w)�
 Reused by the real (#6327) and quaternionic (#6328) cases to build the `j`-operator. -/
 theorem exists_invariant_posdef_hermitian (ρ : Representation ℂ G V) :
     ∃ H : V →ₗ[ℂ] V →ₗ⋆[ℂ] ℂ,
-      (∀ g v w, H (ρ g v) (ρ g w) = H v w) ∧ (∀ v, v ≠ 0 → 0 < (H v v).re) := by
+      (∀ g v w, H (ρ g v) (ρ g w) = H v w) ∧ (∀ v, v ≠ 0 → 0 < (H v v).re) ∧
+      (∀ v w, (starRingEnd ℂ) (H v w) = H w v) := by
   classical
   set b := Module.finBasis ℂ V with hb
   refine ⟨LinearMap.mk₂'ₛₗ (RingHom.id ℂ) (starRingEnd ℂ)
       (fun v w => ∑ g : G, ∑ i, b.repr (ρ g v) i * conj (b.repr (ρ g w) i))
-      ?_ ?_ ?_ ?_, ?_, ?_⟩
+      ?_ ?_ ?_ ?_, ?_, ?_, ?_⟩
   · -- additive in the first slot
     intro v₁ v₂ w
     simp only [map_add, Finsupp.add_apply, add_mul, Finset.sum_add_distrib]
@@ -190,6 +191,10 @@ theorem exists_invariant_posdef_hermitian (ρ : Representation ℂ G V) :
       exact hv (b.repr.injective (by ext i; simp [hcon i]))
     exact Finset.sum_pos' (fun i _ => Complex.normSq_nonneg _)
       ⟨i, Finset.mem_univ i, Complex.normSq_pos.mpr hi⟩
+  · -- conjugate symmetry: `conj (H v w) = H w v`
+    intro v w
+    simp only [LinearMap.mk₂'ₛₗ_apply, map_sum, map_mul, Complex.conj_conj]
+    exact Finset.sum_congr rfl fun g _ => Finset.sum_congr rfl fun i _ => mul_comm _ _
 
 section ComplexTypeProof
 
@@ -368,7 +373,7 @@ theorem realGEndAlgebra_equiv_complex_of_isComplexType
       rcases invSubmodule_eq_bot_or_top hirr (LinearMap.ker ψ) hkerinv with hkbot | hktop
       · -- `ψ` injective: produce a `ℂ`-linear equivariant `V ≃ V*`, contradicting complex type.
         have hψinj : Function.Injective ψ := LinearMap.ker_eq_bot.mp hkbot
-        obtain ⟨H, hHinv, hHpos⟩ := exists_invariant_posdef_hermitian ρ
+        obtain ⟨H, hHinv, hHpos, _⟩ := exists_invariant_posdef_hermitian ρ
         have hΦinj : Function.Injective (hermToDual H) := hermToDual_injective H hHpos
         let e : V →ₗ[ℂ] Module.Dual ℂ V :=
           { toFun := fun v => hermToDual H (ψ v)

--- a/progress/2026-07-11T01-08-24Z_976f40e4.md
+++ b/progress/2026-07-11T01-08-24Z_976f40e4.md
@@ -1,0 +1,44 @@
+## Accomplished
+
+Feature session on **#6327** (`feat(Ch5 #Problem5.1.2a): real-type iso End_ℝ[G]V ≃ₐ[ℝ] Mat₂(ℝ)
++ j-operator helper`). Landed the full algebraic foundation for the real-type case, sorry-free,
+in `EtingofRepresentationTheory/Chapter5/Problem5_1_2.lean` (3 commits):
+
+1. **Hermitian conjugate symmetry.** Extended `exists_invariant_posdef_hermitian` to also return
+   `conj (H v w) = H w v` (needed to show `H v v` is real). Updated the one use-site in the
+   complex-type proof.
+2. **The j-operator helper** `exists_antilinear_j_of_invariant_nondegenerate` (deliverable 1,
+   reusable, also unblocks the quaternionic #6328): from a G-invariant nondegenerate bilinear
+   form `B` and the invariant positive-definite Hermitian form, constructs the ℂ-antilinear
+   G-equivariant `j : V →ₗ⋆[ℂ] V` with `(v, j w) = B v w` and `j² = λ·id`, `λ : ℝ`, `s·λ > 0`
+   where `s` is `B`'s (skew)symmetry sign. Key steps: `hermToDual H` made bijective by an
+   ℝ-dimension count; `j := herm⁻¹ ∘ B.flip` (antilinear); Schur ⇒ `j² = c·id`; positivity from
+   `conj c · (H w,w) = s · (H jw,jw)` with both Hermitian diagonals real-positive.
+3. **Normalized j'** `exists_normalized_antilinear_of_isRealType` (deliverable 2): for real type,
+   an element `j' ∈ realGEndAlgebra ρ` with `j'² = 1` and `realJ ρ * j' = -(j' * realJ ρ)`. With
+   `J² = -1` these are the split-quaternion / Mat₂(ℝ) relations.
+
+All three declarations are sorry-free (`#print axioms` shows only propext/Classical.choice/Quot.sound).
+`lake build EtingofRepresentationTheory.Chapter5.Problem5_1_2` succeeds.
+
+## Current frontier
+
+Deliverable 3 (the explicit `≃ₐ[ℝ] Mat₂(ℝ)`) remains — `realGEndAlgebra_equiv_matrix_of_isRealType`
+still has `sorry`. This needs (a) the dimension-4 spanning `A = ℂ·1 ⊕ ℂ·j'` via the ±-decomposition
++ two Schur applications, and (b) the explicit algebra iso. Decomposed into follow-up issue **#6379**.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. Problem 5.1.2(a): complex type done (#6350); real type now has
+its full algebraic core (this session); Mat₂ assembly is #6379; quaternionic (#6328) and part (b)
+still open. The j-operator helper is shared infrastructure for #6328.
+
+## Next step
+
+Land the partial PR for #6327 (helper + normalized j'), then work **#6379** to assemble the
+Mat₂(ℝ) iso from `exists_normalized_antilinear_of_isRealType` + the ±-decomposition. The
+quaternionic case #6328 can now reuse `exists_antilinear_j_of_invariant_nondegenerate` with `s = -1`.
+
+## Blockers
+
+None. #6379 is a clean continuation once this partial PR merges to main.


### PR DESCRIPTION
Partial progress on #6327

Session: `976f40e4-c068-42c2-94a7-6f462e485560`

57f5c42b chore(#6327): progress — real-type algebraic core landed, Mat₂ assembly → #6379
5540aa38 feat(Ch5 #6327): normalized j'-operator for real type (j'²=1, Jj'=-j'J)
0753aff2 feat(Ch5 #6327): add reusable j-operator helper for real/quaternionic types
454365ff feat(Ch5 #6327): extend invariant Hermitian form with conjugate symmetry

🤖 Prepared with Claude Code