### PR TITLE
feat(Ch5 #6386): fix transport hypothesis in Exercise5_27_3 + proof skeleton

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Exercise5_27_3.lean
+++ b/EtingofRepresentationTheory/Chapter5/Exercise5_27_3.lean
@@ -32,7 +32,13 @@ map `transport`, characterised by the same defining identities. The hypothesis i
 **(iv)** — the character formula — and the conclusion is the conjunction of parts **(i)**, **(ii)**,
 and **(iii)**, stated with the identical expressions used in `Etingof.Theorem5_27_1`.
 
-Statement pass: the deduction is left as `sorry`.
+The hypothesis `_htransport` characterizes the otherwise-free `transport` map by the character
+identity `χ_{g(U)}(s) = χ_U(g⁻¹ s g)` (mirroring `transportRep_ρ_apply`/`conjStabHom_coe` in
+`Theorem5_27_1.lean`). Without it the theorem is refutable, since a universally quantified free
+`transport` admits the adversarial choice `transport _ _ _ _ U := U ⊞ U`.
+
+Proof pass: the three parts are split into labeled `sorry` goals for follow-up. Parts (i)/(ii)
+go through character orthogonality; part (iii) through the sum-of-squares dimension count.
 -/
 
 noncomputable section
@@ -57,6 +63,14 @@ theorem Exercise5_27_3
     (V : (χ : A →* ℂˣ) → FDRep ℂ ↥(stab χ) → FDRep ℂ (A ⋊[φ] G))
     (transport : (g : G) → (χ₁ χ₂ : A →* ℂˣ) → dualSmul g χ₁ = χ₂ →
       FDRep ℂ ↥(stab χ₁) → FDRep ℂ ↥(stab χ₂))
+    -- Characterizing hypothesis for `transport`, mirroring `transportRep` in
+    -- `Theorem5_27_1.lean` (`transportRep_ρ_apply` / `conjStabHom_coe`): the transported
+    -- representation `g(U)` acts by `ρ_{g(U)}(s) = ρ_U(g⁻¹ s g)`, so its character at `s` is
+    -- the character of `U` at the conjugate `g⁻¹ s g ∈ G_{χ₁}`. Without this the theorem is
+    -- refutable, since `transport` would otherwise be a free, unconstrained function (see #6383).
+    (_htransport : ∀ (g : G) (χ₁ χ₂ : A →* ℂˣ) (hg : dualSmul g χ₁ = χ₂)
+        (U : FDRep ℂ ↥(stab χ₁)) (s : ↥(stab χ₂)) (hs : g⁻¹ * (s : G) * g ∈ stab χ₁),
+        (transport g χ₁ χ₂ hg U).character s = U.character ⟨g⁻¹ * (s : G) * g, hs⟩)
     -- Hypothesis: part (iv), the character formula.
     (character_formula :
       ∀ (χ : A →* ℂˣ) (U : FDRep ℂ ↥(stab χ)), Simple U →
@@ -81,6 +95,24 @@ theorem Exercise5_27_3
     (∀ (W : FDRep ℂ (A ⋊[φ] G)), Simple W →
         ∃ (χ : A →* ℂˣ) (U : FDRep ℂ ↥(stab χ)),
           Simple U ∧ Nonempty (W ≅ V χ U)) := by
-  sorry
+  refine ⟨?_, ?_, ?_⟩
+  · -- Part (i): irreducibility of `V χ U`.
+    -- Strategy (character orthogonality): from the character formula (iv), compute
+    -- `⟨χ_{V χ U}, χ_{V χ U}⟩ = 1` (an induced-character inner product that collapses,
+    -- by Frobenius reciprocity / Mackey, to `⟨χ_U, χ_U⟩ = 1` since `U` is simple), then
+    -- apply the converse orthonormality criterion `⟨χ_W, χ_W⟩ = 1 ⇒ Simple W` (Maschke +
+    -- linear independence of irreducible characters over ℂ). Tracked in the (i)+(ii) sub-issue.
+    sorry
+  · -- Part (ii): pairwise non-isomorphism.
+    -- Strategy: an isomorphism `V χ₁ U₁ ≅ V χ₂ U₂` forces equal characters; feeding the
+    -- character formula (iv) into `⟨χ_{V χ₁ U₁}, χ_{V χ₂ U₂}⟩ ≠ 0` forces the orbit data to
+    -- match, i.e. `dualSmul g χ₁ = χ₂` for some `g` and, via `_htransport`, `U₂ ≅ g(U₁)`.
+    -- Tracked in the (i)+(ii) sub-issue.
+    sorry
+  · -- Part (iii): completeness — every simple `W` is some `V χ U`.
+    -- Strategy: the sum-of-squares count `Σ_{χ,U} dim(V χ U)² = |A ⋊[φ] G|` (from (iv) and the
+    -- orbit decomposition) exhausts the regular representation, so no simple is missed.
+    -- Tracked in the (iii) sub-issue.
+    sorry
 
 end Etingof

--- a/progress/2026-07-11T01-51-28Z_5cd90ac5.md
+++ b/progress/2026-07-11T01-51-28Z_5cd90ac5.md
@@ -1,0 +1,39 @@
+## Accomplished
+
+Feature session on #6386 (Ch5 Exercise 5.27.3). Fixed the soundness defect and
+restructured the proof top-down; landed as a partial PR.
+
+- **Statement fix.** Added the characterizing hypothesis `_htransport` to
+  `Etingof.Exercise5_27_3` in `EtingofRepresentationTheory/Chapter5/Exercise5_27_3.lean`,
+  pinning the previously-free `transport` map via the character identity
+  `χ_{g(U)}(s) = χ_U(g⁻¹ s g)` (mirrors `transportRep_ρ_apply` / `conjStabHom_coe` in
+  `Theorem5_27_1.lean`). This removes the `transport := fun _ _ _ _ U => U ⊞ U`
+  counterexample from #6383 that made the theorem refutable.
+- **Top-down restructure.** Replaced the single `sorry` with `refine ⟨?_, ?_, ?_⟩` and
+  three labeled `sorry` goals (parts i/ii/iii), each carrying its proof strategy as a comment.
+- Updated the module docstring and `progress/items.json` coverage note.
+- File builds (`lake build …Chapter5.Exercise5_27_3` succeeds); only the three labeled
+  `sorry`s remain, no new axioms.
+
+## Current frontier
+
+Statement is corrected and skeletal proof is in place. The three parts are unproved.
+
+## Overall project progress
+
+Ch5 classification (Theorem 5.27.1) is proved concretely; Exercise 5.27.3 re-derives its
+(i)-(iii) abstractly from character formula (iv). Statement now sound; proof pending.
+
+## Next step
+
+Two follow-up sub-issues created and ready:
+- #6395 — parts (i)+(ii) via character orthogonality (⟨χ_V,χ_V⟩=1 ⇒ Simple; orthogonality ⇒
+  non-iso). Needs converse-orthonormality infra (may not be in Mathlib — prove here).
+- #6396 — part (iii) via sum-of-squares dimension count `Σ dim(V χ U)² = |A ⋊ G|`.
+  Depends on #6395 (shared proof block; rebase after it lands).
+
+## Blockers
+
+None. #6396 is ordering-blocked on #6395 by design (same `refine` block). The full proof
+needs induced-character inner-product theory (Frobenius reciprocity / Mackey) and the
+sum-of-squares completeness count — that is the scope of the two sub-issues.

--- a/progress/items.json
+++ b/progress/items.json
@@ -5234,7 +5234,7 @@
     "start_line": 17,
     "end_line": 17,
     "status": "statement_formalized",
-    "coverage_note": "Statement pass: Chapter5/Exercise5_27_3.lean states, over the semidirect-product setup of Theorem 5.27.1 (dual action, stabilizers, V(chi,U), transport), that the character formula (iv) implies the classification properties (i) irreducibility, (ii) pairwise non-isomorphism, (iii) completeness. Sorry proof."
+    "coverage_note": "Statement pass (corrected): Chapter5/Exercise5_27_3.lean states, over the semidirect-product setup of Theorem 5.27.1 (dual action, stabilizers, V(chi,U), transport), that the character formula (iv) implies the classification properties (i) irreducibility, (ii) pairwise non-isomorphism, (iii) completeness. Statement defect from #6375/#6383 fixed by adding the _htransport characterizing hypothesis (chi_{g(U)}(s) = chi_U(g^-1 s g)), which pins down the otherwise-free transport map and removes the U ⊞ U counterexample. Proof split into three labeled sorry goals for follow-up: (i)+(ii) via character orthogonality, (iii) via sum-of-squares dimension count."
   },
   {
     "id": "Chapter6/Introduction",


### PR DESCRIPTION
Partial progress on #6386

Session: `5cd90ac5-1429-4782-a814-3ad3d56c8283`

9ec26bf6 feat(Ch5 #6386): fix transport hypothesis in Exercise5_27_3 + top-down proof skeleton

🤖 Prepared with Claude Code