### PR TITLE
feat(Ch9 #Problem9.4.5 ii-a): homologicalDimension(k[t]/tⁿ)=⊤ via 2-periodic syzygy of the residue module (n>1) + reusable homologicalDimension_eq_top reduction

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/HomologicalDimensionReduction.lean
+++ b/EtingofRepresentationTheory/Chapter9/HomologicalDimensionReduction.lean
@@ -1,0 +1,34 @@
+import EtingofRepresentationTheory.Chapter9.Definition9_4_3
+import Mathlib.Data.ENat.Lattice
+
+/-!
+# Reduction lemma for infinite homological dimension
+
+A small reusable reduction: the homological dimension of a ring `R` (Definition 9.4.3)
+equals `⊤` as soon as `R` fails to have homological dimension `≤ d` for *every* `d`.
+
+This is the packaging step used by the "infinite homological dimension" computations of
+Problem 9.4.5 (ii): one exhibits, for each `d`, a module of projective dimension `> d`
+(so `HasHomologicalDimensionLE R d` fails), and this lemma converts that into the
+statement `homologicalDimension R = ⊤`.
+-/
+
+universe u
+
+namespace Etingof
+
+/-- If a ring has homological dimension `≤ d` for no `d`, its homological dimension is `⊤`.
+
+`homologicalDimension R = ⨅ (d) (_ : HasHomologicalDimensionLE R d), (d : ℕ∞)`; under the
+hypothesis every inner infimum is over a false proposition, hence `⊤` (`iInf_neg`), and
+`⨅ d, ⊤ = ⊤` (`iInf_top`). -/
+theorem homologicalDimension_eq_top {R : Type u} [Ring R]
+    (h : ∀ d : ℕ, ¬ Etingof.HasHomologicalDimensionLE R d) :
+    Etingof.homologicalDimension R = ⊤ := by
+  unfold Etingof.homologicalDimension
+  have hd : ∀ d : ℕ,
+      (⨅ (_ : Etingof.HasHomologicalDimensionLE R d), (d : ℕ∞)) = ⊤ := fun d => iInf_neg (h d)
+  simp_rw [hd]
+  exact iInf_top
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter9/Problem9_4_5.lean
+++ b/EtingofRepresentationTheory/Chapter9/Problem9_4_5.lean
@@ -4,6 +4,7 @@ import Mathlib.RingTheory.Ideal.Quotient.Defs
 import EtingofRepresentationTheory.Chapter9.Definition9_3_1
 import EtingofRepresentationTheory.Chapter9.Definition9_4_3
 import EtingofRepresentationTheory.Chapter9.Problem9_3_2
+import EtingofRepresentationTheory.Chapter9.TruncatedPolynomial
 
 /-!
 # Problem 9.4.5: Cartan determinant and some homological dimensions
@@ -52,8 +53,8 @@ theorem cartan_det_eq_pm_one
 `k[t]/tⁿ` has infinite homological dimension. -/
 theorem homologicalDimension_polynomial_quotient_eq_top
     (k : Type u) [Field k] (n : ℕ) (hn : 1 < n) :
-    Etingof.homologicalDimension (k[X] ⧸ Ideal.span {(Polynomial.X : k[X]) ^ n}) = ⊤ := by
-  sorry
+    Etingof.homologicalDimension (k[X] ⧸ Ideal.span {(Polynomial.X : k[X]) ^ n}) = ⊤ :=
+  Etingof.TruncatedPoly.homologicalDimension_eq_top_truncated k n hn
 
 /-- **Problem 9.4.5 (ii), second algebra.** The four dimensional algebra
 `A = ℂ⟨g, x⟩/(gx+xg, x², g²-1)` of Problem 9.3.2 has infinite homological dimension. -/

--- a/EtingofRepresentationTheory/Chapter9/TruncatedPolynomial.lean
+++ b/EtingofRepresentationTheory/Chapter9/TruncatedPolynomial.lean
@@ -119,4 +119,133 @@ theorem tq_pow_pred_mul_self (hn : 1 < n) :
   obtain ⟨m, hm⟩ := Nat.exists_eq_add_of_le (show n ≤ (n - 1) + (n - 1) by omega)
   rw [hm, pow_add, tq_pow_n, zero_mul]
 
+/-- The cyclic module `A = (t) = range(·t)` is not projective over `R = k[X]/(Xⁿ)` (`n > 1`).
+A splitting section `σ` of `·t : R ↠ (t)` would give `e = σ(t)` with `t·e = t` and
+`tⁿ⁻¹·e = 0`; multiplying the first by `tⁿ⁻²` yields `tⁿ⁻¹·e = tⁿ⁻¹`, forcing `tⁿ⁻¹ = 0`. -/
+theorem not_projective_A (hn : 1 < n) :
+    ¬ Projective (ModuleCat.of (Rq k n)
+      ↥(LinearMap.range (LinearMap.mulLeft (Rq k n) (tq k n)))) := by
+  letI : Small.{u} (Rq k n) := ⟨⟨Rq k n, ⟨Equiv.refl _⟩⟩⟩
+  intro hProj
+  set ft := LinearMap.mulLeft (Rq k n) (tq k n) with hft
+  haveI : Projective (ModuleCat.of (Rq k n) ↥(LinearMap.range ft)) := hProj
+  haveI : Module.Projective (Rq k n) ↥(LinearMap.range ft) :=
+    (IsProjective.iff_projective _).mpr hProj
+  have hy0mem : (tq k n) ∈ LinearMap.range ft :=
+    LinearMap.mem_range.mpr ⟨1, by rw [hft, LinearMap.mulLeft_apply, mul_one]⟩
+  set y₀ : ↥(LinearMap.range ft) := ⟨tq k n, hy0mem⟩ with hy0
+  obtain ⟨σ, hσ⟩ := Module.projective_lifting_property ft.rangeRestrict
+    (LinearMap.id) ft.surjective_rangeRestrict
+  set e := σ y₀ with he_def
+  have hgen : (tq k n) * e = tq k n := by
+    have h1 := LinearMap.congr_fun hσ y₀
+    simp only [LinearMap.comp_apply, LinearMap.id_coe, id_eq] at h1
+    have h2 : ft e = tq k n := congrArg Subtype.val h1
+    rwa [hft, LinearMap.mulLeft_apply] at h2
+  have hann : (tq k n) ^ (n - 1) * e = 0 := by
+    have hz : ((tq k n) ^ (n - 1)) • y₀ = 0 := by
+      apply Subtype.ext
+      change (tq k n) ^ (n - 1) • (tq k n) = (0 : Rq k n)
+      rw [smul_eq_mul, ← pow_succ, show (n - 1) + 1 = n by omega, tq_pow_n]
+    have hmap : ((tq k n) ^ (n - 1)) • e = σ (((tq k n) ^ (n - 1)) • y₀) := (map_smul σ _ _).symm
+    rw [hz, map_zero] at hmap
+    rw [← smul_eq_mul]; exact hmap
+  apply tq_pow_pred_ne k n (by omega)
+  have key : (tq k n) ^ (n - 1) * e = (tq k n) ^ (n - 1) := by
+    have h3 : (tq k n) ^ (n - 2) * ((tq k n) * e) = (tq k n) ^ (n - 2) * (tq k n) := by rw [hgen]
+    rw [← mul_assoc, ← pow_succ, show (n - 2) + 1 = n - 1 by omega] at h3
+    exact h3
+  rw [hann] at key
+  exact key.symm
+
+/-- The cyclic module `B = (tⁿ⁻¹) = range(·tⁿ⁻¹)` is not projective over `R = k[X]/(Xⁿ)`
+(`n > 1`). A splitting section `σ` of `·tⁿ⁻¹ : R ↠ (tⁿ⁻¹)` would give `e = σ(tⁿ⁻¹)` with
+`tⁿ⁻¹·e = tⁿ⁻¹` and `t·e = 0`; multiplying the second by `tⁿ⁻²` yields `tⁿ⁻¹·e = 0`,
+forcing `tⁿ⁻¹ = 0`. -/
+theorem not_projective_B (hn : 1 < n) :
+    ¬ Projective (ModuleCat.of (Rq k n)
+      ↥(LinearMap.range (LinearMap.mulLeft (Rq k n) ((tq k n) ^ (n - 1))))) := by
+  letI : Small.{u} (Rq k n) := ⟨⟨Rq k n, ⟨Equiv.refl _⟩⟩⟩
+  intro hProj
+  set fs := LinearMap.mulLeft (Rq k n) ((tq k n) ^ (n - 1)) with hfs
+  haveI : Projective (ModuleCat.of (Rq k n) ↥(LinearMap.range fs)) := hProj
+  haveI : Module.Projective (Rq k n) ↥(LinearMap.range fs) :=
+    (IsProjective.iff_projective _).mpr hProj
+  have hy1mem : (tq k n) ^ (n - 1) ∈ LinearMap.range fs :=
+    LinearMap.mem_range.mpr ⟨1, by rw [hfs, LinearMap.mulLeft_apply, mul_one]⟩
+  set y₁ : ↥(LinearMap.range fs) := ⟨(tq k n) ^ (n - 1), hy1mem⟩ with hy1
+  obtain ⟨σ, hσ⟩ := Module.projective_lifting_property fs.rangeRestrict
+    (LinearMap.id) fs.surjective_rangeRestrict
+  set e := σ y₁ with he_def
+  have hgen : (tq k n) ^ (n - 1) * e = (tq k n) ^ (n - 1) := by
+    have h1 := LinearMap.congr_fun hσ y₁
+    simp only [LinearMap.comp_apply, LinearMap.id_coe, id_eq] at h1
+    have h2 : fs e = (tq k n) ^ (n - 1) := congrArg Subtype.val h1
+    rwa [hfs, LinearMap.mulLeft_apply] at h2
+  have hann : (tq k n) * e = 0 := by
+    have hz : (tq k n) • y₁ = 0 := by
+      apply Subtype.ext
+      change (tq k n) • (tq k n) ^ (n - 1) = (0 : Rq k n)
+      rw [smul_eq_mul, ← pow_succ', show (n - 1) + 1 = n by omega, tq_pow_n]
+    have hmap : (tq k n) • e = σ ((tq k n) • y₁) := (map_smul σ _ _).symm
+    rw [hz, map_zero] at hmap
+    rw [← smul_eq_mul]; exact hmap
+  apply tq_pow_pred_ne k n (by omega)
+  have key : (tq k n) ^ (n - 1) * e = 0 := by
+    have h3 : (tq k n) ^ (n - 2) * ((tq k n) * e) = (tq k n) ^ (n - 2) * 0 := by rw [hann]
+    rw [← mul_assoc, ← pow_succ, show (n - 2) + 1 = n - 1 by omega, mul_zero] at h3
+    exact h3
+  exact hgen.symm.trans key
+
+/-- **Problem 9.4.5 (ii), first algebra.** For `n > 1`, `homologicalDimension (k[X]/(Xⁿ)) = ⊤`. -/
+theorem homologicalDimension_eq_top_truncated (hn : 1 < n) :
+    Etingof.homologicalDimension (Rq k n) = ⊤ := by
+  letI : Small.{u} (Rq k n) := ⟨⟨Rq k n, ⟨Equiv.refl _⟩⟩⟩
+  set ft := LinearMap.mulLeft (Rq k n) (tq k n) with hft
+  set fs := LinearMap.mulLeft (Rq k n) ((tq k n) ^ (n - 1)) with hfs
+  set MA := ModuleCat.of (Rq k n) ↥(LinearMap.range ft) with hMA
+  set MB := ModuleCat.of (Rq k n) ↥(LinearMap.range fs) with hMB
+  haveI hRproj : Projective (ModuleCat.of (Rq k n) (Rq k n)) := inferInstance
+  -- The two short exact sequences `0 → ker(rangeRestrict) → R → M{A,B} → 0`.
+  have sesA : (ft.rangeRestrict).shortComplexKer.ShortExact :=
+    LinearMap.shortExact_shortComplexKer ft.surjective_rangeRestrict
+  have sesB : (fs.rangeRestrict).shortComplexKer.ShortExact :=
+    LinearMap.shortExact_shortComplexKer fs.surjective_rangeRestrict
+  -- Dimension shifting: pd(MA) ≤ d+1 ⟹ pd(MB) ≤ d, and symmetrically.
+  have shiftA : ∀ d, HasProjectiveDimensionLE MA (d + 1) → HasProjectiveDimensionLE MB d := by
+    intro d hA
+    have hker : HasProjectiveDimensionLT
+        (ModuleCat.of (Rq k n) ↥(LinearMap.ker ft.rangeRestrict)) (d + 1) := by
+      have := Etingof.Problem942.hasProjectiveDimensionLE_syzygy (Rq k n)
+        ft.rangeRestrict.shortComplexKer sesA hRproj (d + 1) (Nat.succ_pos d) hA
+      simpa only [Nat.add_sub_cancel] using this
+    haveI := hker
+    have heq : LinearMap.ker ft.rangeRestrict = LinearMap.range fs := by
+      rw [LinearMap.ker_rangeRestrict, hft, hfs]; exact ker_mulLeft_t k n (by omega)
+    exact hasProjectiveDimensionLT_of_iso ((LinearEquiv.ofEq _ _ heq).toModuleIso) (d + 1)
+  have shiftB : ∀ d, HasProjectiveDimensionLE MB (d + 1) → HasProjectiveDimensionLE MA d := by
+    intro d hB
+    have hker : HasProjectiveDimensionLT
+        (ModuleCat.of (Rq k n) ↥(LinearMap.ker fs.rangeRestrict)) (d + 1) := by
+      have := Etingof.Problem942.hasProjectiveDimensionLE_syzygy (Rq k n)
+        fs.rangeRestrict.shortComplexKer sesB hRproj (d + 1) (Nat.succ_pos d) hB
+      simpa only [Nat.add_sub_cancel] using this
+    haveI := hker
+    have heq : LinearMap.ker fs.rangeRestrict = LinearMap.range ft := by
+      rw [LinearMap.ker_rangeRestrict, hft, hfs]; exact ker_mulLeft_t_pow k n (by omega)
+    exact hasProjectiveDimensionLT_of_iso ((LinearEquiv.ofEq _ _ heq).toModuleIso) (d + 1)
+  -- Symmetric induction: neither MA nor MB has finite projective dimension.
+  have hQ : ∀ d, ¬ HasProjectiveDimensionLE MA d ∧ ¬ HasProjectiveDimensionLE MB d := by
+    intro d
+    induction d with
+    | zero =>
+      refine ⟨?_, ?_⟩
+      · rw [← projective_iff_hasProjectiveDimensionLE_zero]; exact not_projective_A k n hn
+      · rw [← projective_iff_hasProjectiveDimensionLE_zero]; exact not_projective_B k n hn
+    | succ d ih => exact ⟨fun hA => ih.2 (shiftA d hA), fun hB => ih.1 (shiftB d hB)⟩
+  -- MA witnesses `¬ HasHomologicalDimensionLE R d` for every `d`.
+  apply Etingof.homologicalDimension_eq_top
+  intro d hAll
+  exact (hQ d).1 (hAll MA)
+
 end Etingof.TruncatedPoly

--- a/EtingofRepresentationTheory/Chapter9/TruncatedPolynomial.lean
+++ b/EtingofRepresentationTheory/Chapter9/TruncatedPolynomial.lean
@@ -1,0 +1,122 @@
+import Mathlib.Algebra.Polynomial.Basic
+import Mathlib.Algebra.Polynomial.Degree.Domain
+import Mathlib.RingTheory.Polynomial.Basic
+import Mathlib.RingTheory.Ideal.Quotient.Operations
+import Mathlib.Algebra.Algebra.Bilinear
+import Mathlib.Algebra.Homology.ShortComplex.ModuleCat
+import Mathlib.Algebra.Category.ModuleCat.Projective
+import EtingofRepresentationTheory.Chapter9.HomologicalDimensionReduction
+import EtingofRepresentationTheory.Chapter9.Problem9_4_2
+
+/-!
+# Infinite homological dimension of `k[t]/tⁿ` (`n > 1`)
+
+For a field `k` and `n > 1`, the truncated polynomial algebra `R = k[X]/(Xⁿ)` has
+**infinite** homological dimension (Problem 9.4.5 (ii), first algebra).
+
+## Strategy
+
+`R` is self-injective and non-semisimple; the residue module has a `2`-periodic minimal
+free resolution. Concretely, write `t` for the image of `X` in `R`, and consider the two
+cyclic modules
+
+* `A = (t)   = range(·t : R → R)`,
+* `B = (tⁿ⁻¹) = range(·tⁿ⁻¹ : R → R)`.
+
+Multiplication by `t` and by `tⁿ⁻¹` gives two short exact sequences (using that `R` is free,
+hence projective, and `Ann(t) = (tⁿ⁻¹)`, `Ann(tⁿ⁻¹) = (t)`):
+
+* `0 → B → R → A → 0`   (`·t`),
+* `0 → A → R → B → 0`   (`·tⁿ⁻¹`).
+
+By dimension shifting (`Etingof.Problem942.hasProjectiveDimensionLE_syzygy`) `pd(A) ≤ d`
+(`d > 0`) forces `pd(B) ≤ d - 1`, and symmetrically. Since neither `A` nor `B` is projective
+(a splitting would force `tⁿ⁻¹ = 0`), a symmetric induction shows `pd(A) = pd(B) = ∞`, so `A`
+witnesses `¬ HasHomologicalDimensionLE R d` for every `d`, whence
+`homologicalDimension R = ⊤` by `Etingof.homologicalDimension_eq_top`.
+-/
+
+universe u
+
+open Polynomial CategoryTheory
+
+namespace Etingof.TruncatedPoly
+
+variable (k : Type u) [Field k] (n : ℕ)
+
+/-- The truncated polynomial algebra `R = k[X]/(Xⁿ)`. -/
+abbrev Rq : Type u := k[X] ⧸ Ideal.span {(X : k[X]) ^ n}
+
+/-- The image `t` of `X` in `R = k[X]/(Xⁿ)`. -/
+noncomputable def tq : Rq k n := Ideal.Quotient.mk (Ideal.span {(X : k[X]) ^ n}) X
+
+/-- `tⁿ = 0` in `R = k[X]/(Xⁿ)`. -/
+theorem tq_pow_n : (tq k n) ^ n = 0 := by
+  rw [tq, ← map_pow, Ideal.Quotient.eq_zero_iff_mem]
+  exact Ideal.mem_span_singleton_self _
+
+/-- `tⁿ⁻¹ ≠ 0` in `R = k[X]/(Xⁿ)` (for `n ≥ 1`). -/
+theorem tq_pow_pred_ne (hn : 0 < n) : (tq k n) ^ (n - 1) ≠ 0 := by
+  rw [tq, ← map_pow]
+  intro h
+  rw [Ideal.Quotient.eq_zero_iff_mem, Ideal.mem_span_singleton] at h
+  -- h : X^n ∣ X^(n-1)
+  have hne : (X : k[X]) ^ (n - 1) ≠ 0 := pow_ne_zero _ Polynomial.X_ne_zero
+  have := Polynomial.natDegree_le_of_dvd h hne
+  simp only [Polynomial.natDegree_X_pow] at this
+  omega
+
+/-- `Ann(t) = (tⁿ⁻¹)`: the kernel of `·t` equals the range of `·tⁿ⁻¹`. -/
+theorem ker_mulLeft_t (hn : 0 < n) :
+    LinearMap.ker (LinearMap.mulLeft (Rq k n) (tq k n)) =
+      LinearMap.range (LinearMap.mulLeft (Rq k n) ((tq k n) ^ (n - 1))) := by
+  apply le_antisymm
+  · intro x hx
+    rw [LinearMap.mem_ker, LinearMap.mulLeft_apply] at hx
+    obtain ⟨p, rfl⟩ := Ideal.Quotient.mk_surjective x
+    rw [LinearMap.mem_range]
+    have hmul : (tq k n) * (Ideal.Quotient.mk (Ideal.span {(X : k[X]) ^ n}) p)
+        = Ideal.Quotient.mk _ (X * p) := by rw [tq]; exact (map_mul _ _ _).symm
+    rw [hmul, Ideal.Quotient.eq_zero_iff_mem, Ideal.mem_span_singleton] at hx
+    have hsplit : (X : k[X]) ^ n = X * X ^ (n - 1) := by
+      conv_lhs => rw [show n = (n - 1) + 1 by omega, pow_succ']
+    rw [hsplit, mul_dvd_mul_iff_left (Polynomial.X_ne_zero)] at hx
+    obtain ⟨q, hq⟩ := hx
+    refine ⟨Ideal.Quotient.mk _ q, ?_⟩
+    rw [LinearMap.mulLeft_apply, tq, ← map_pow, ← map_mul, ← hq]
+  · rintro _ ⟨r, rfl⟩
+    rw [LinearMap.mem_ker, LinearMap.mulLeft_apply, LinearMap.mulLeft_apply, ← mul_assoc,
+      ← pow_succ', show (n - 1) + 1 = n by omega, tq_pow_n, zero_mul]
+
+/-- `Ann(tⁿ⁻¹) = (t)`: the kernel of `·tⁿ⁻¹` equals the range of `·t`. -/
+theorem ker_mulLeft_t_pow (hn : 0 < n) :
+    LinearMap.ker (LinearMap.mulLeft (Rq k n) ((tq k n) ^ (n - 1))) =
+      LinearMap.range (LinearMap.mulLeft (Rq k n) (tq k n)) := by
+  apply le_antisymm
+  · intro x hx
+    rw [LinearMap.mem_ker, LinearMap.mulLeft_apply] at hx
+    obtain ⟨p, rfl⟩ := Ideal.Quotient.mk_surjective x
+    rw [LinearMap.mem_range]
+    have hmul : (tq k n) ^ (n - 1) * (Ideal.Quotient.mk (Ideal.span {(X : k[X]) ^ n}) p)
+        = Ideal.Quotient.mk _ (X ^ (n - 1) * p) := by
+      rw [tq, ← map_pow]; exact (map_mul _ _ _).symm
+    rw [hmul, Ideal.Quotient.eq_zero_iff_mem, Ideal.mem_span_singleton] at hx
+    have hsplit : (X : k[X]) ^ n = X ^ (n - 1) * X := by
+      conv_lhs => rw [show n = (n - 1) + 1 by omega, pow_succ]
+    have hne : (X : k[X]) ^ (n - 1) ≠ 0 := pow_ne_zero _ Polynomial.X_ne_zero
+    rw [hsplit, mul_dvd_mul_iff_left hne] at hx
+    obtain ⟨q, hq⟩ := hx
+    refine ⟨Ideal.Quotient.mk _ q, ?_⟩
+    rw [LinearMap.mulLeft_apply, tq, ← map_mul, ← hq]
+  · rintro _ ⟨r, rfl⟩
+    rw [LinearMap.mem_ker, LinearMap.mulLeft_apply, LinearMap.mulLeft_apply, ← mul_assoc,
+      ← pow_succ, show (n - 1) + 1 = n by omega, tq_pow_n, zero_mul]
+
+/-- `tⁿ⁻¹ · tⁿ⁻¹ = 0` for `n > 1` (since `2(n-1) ≥ n`). -/
+theorem tq_pow_pred_mul_self (hn : 1 < n) :
+    (tq k n) ^ (n - 1) * (tq k n) ^ (n - 1) = 0 := by
+  rw [← pow_add]
+  obtain ⟨m, hm⟩ := Nat.exists_eq_add_of_le (show n ≤ (n - 1) + (n - 1) by omega)
+  rw [hm, pow_add, tq_pow_n, zero_mul]
+
+end Etingof.TruncatedPoly

--- a/progress/2026-07-11T02-01-16Z_3ebd77c3.md
+++ b/progress/2026-07-11T02-01-16Z_3ebd77c3.md
@@ -1,0 +1,43 @@
+## Accomplished
+
+Feature session on issue #6381 (Problem 9.4.5 ii-a): proved
+`homologicalDimension_polynomial_quotient_eq_top` — `homologicalDimension (k[X]/(Xⁿ)) = ⊤`
+for `n > 1` — sorry-free, plus the reusable reduction lemma the issue asked for.
+
+New files:
+- `Chapter9/HomologicalDimensionReduction.lean`: `Etingof.homologicalDimension_eq_top`
+  (`homologicalDimension R = ⊤` whenever `∀ d, ¬ HasHomologicalDimensionLE R d`), the ~10-line
+  `iInf_neg`/`iInf_top` packaging. Reusable by #6382 and #6384.
+- `Chapter9/TruncatedPolynomial.lean`: the full computation. Arithmetic core (`tⁿ = 0`,
+  `tⁿ⁻¹ ≠ 0`, the two annihilator identities `Ann(t) = (tⁿ⁻¹)`, `Ann(tⁿ⁻¹) = (t)` via
+  cancellation in the domain `k[X]`), the two non-projectivity lemmas, and the main theorem.
+
+Wired into `Chapter9/Problem9_4_5.lean` (import + one-line proof term). `#print axioms` on the
+target shows only `propext, Classical.choice, Quot.sound` (no `sorryAx`).
+
+## Current frontier
+
+Deliverable complete. The proof deviated from the issue's suggested route (explicit Ext
+2-periodicity / `Ext¹(k,k) ≠ 0`) in favour of a much shorter argument that reuses existing
+repo infrastructure: the two multiplication-by-`t` / `tⁿ⁻¹` short exact sequences
+`0 → (tⁿ⁻¹) → R → (t) → 0` and `0 → (t) → R → (tⁿ⁻¹) → 0` (built with
+`LinearMap.shortExact_shortComplexKer`, with `R` free hence projective), dimension shifting
+via `Etingof.Problem942.hasProjectiveDimensionLE_syzygy`, and a symmetric induction. Neither
+cyclic module `(t)`, `(tⁿ⁻¹)` is projective (a splitting section would force `tⁿ⁻¹ = 0`), so
+both have infinite projective dimension, and `(t)` witnesses `¬ HasHomologicalDimensionLE R d`
+for every `d`.
+
+## Overall project progress
+
+Phase 3 formalization. Problem 9.4.5 part (ii-a) proved. Remaining sorries in
+`Problem9_4_5.lean`: `cartan_det_eq_pm_one` (#6384) and `homologicalDimension_problem932_eq_top`
+(#6382, sibling, claimed by another session).
+
+## Next step
+
+#6382 (Problem932.A homological dimension) can reuse `Etingof.homologicalDimension_eq_top`
+from the new reduction file. #6384 (Cartan det) is the remaining part.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -7334,7 +7334,7 @@
     "start_line": 7,
     "end_line": 10,
     "status": "statement_formalized",
-    "coverage_note": "Statement pass (#5906): EtingofRepresentationTheory/Chapter9/Problem9_4_5.lean. Part (i) det(Cartan) = ±1 for finite homological dimension; part (ii) homologicalDimension of k[t]/tⁿ (n>1) and of the Problem 9.3.2 algebra are both ⊤. Faithful statements, sorry proofs. Decomposed (#6374) into three per-part sub-issues #6381 (ii-a: k[t]/tⁿ=⊤), #6382 (ii-b: Problem932.A=⊤), #6384 (i: Cartan det=±1) — each needs substantial new homological-algebra infrastructure (2-periodic-syzygy Ext-nonvanishing; K₀/Euler-characteristic)."
+    "coverage_note": "Statement pass (#5906): EtingofRepresentationTheory/Chapter9/Problem9_4_5.lean. Part (i) det(Cartan) = ±1 for finite homological dimension; part (ii) homologicalDimension of k[t]/tⁿ (n>1) and of the Problem 9.3.2 algebra are both ⊤. Decomposed (#6374) into three per-part sub-issues #6381 (ii-a: k[t]/tⁿ=⊤), #6382 (ii-b: Problem932.A=⊤), #6384 (i: Cartan det=±1). #6381 DONE: homologicalDimension_polynomial_quotient_eq_top is sorry-free (Chapter9/TruncatedPolynomial.lean), plus reusable Etingof.homologicalDimension_eq_top reduction lemma (Chapter9/HomologicalDimensionReduction.lean). Proof avoids explicit Ext periodicity: uses the two multiplication SESs (t) ↔ (tⁿ⁻¹) with R free, dimension shifting (Problem942.hasProjectiveDimensionLE_syzygy), and a symmetric induction from non-projectivity of the two cyclic modules. Still sorry: cartan_det_eq_pm_one (#6384), homologicalDimension_problem932_eq_top (#6382)."
   },
   {
     "id": "Chapter9/Problem9.4.6",


### PR DESCRIPTION
This PR proves `homologicalDimension (k[X]/(Xⁿ)) = ⊤` for `n > 1` (Problem 9.4.5 (ii), first algebra), removing its `sorry`, and adds the reusable reduction lemma `Etingof.homologicalDimension_eq_top` (`homologicalDimension R = ⊤` whenever `R` has homological dimension `≤ d` for no `d`).

The proof does not route through the explicit Ext 2-periodicity sketched in the issue. Writing `t` for the image of `X`, it uses the two multiplication short exact sequences `0 → (tⁿ⁻¹) → R → (t) → 0` and `0 → (t) → R → (tⁿ⁻¹) → 0` (built with `LinearMap.shortExact_shortComplexKer`, with `R` free hence projective and the annihilator identities `Ann(t) = (tⁿ⁻¹)`, `Ann(tⁿ⁻¹) = (t)` proved by cancellation in the domain `k[X]`), dimension shifting via `Etingof.Problem942.hasProjectiveDimensionLE_syzygy`, and a symmetric induction. Neither cyclic module `(t)` nor `(tⁿ⁻¹)` is projective, so both have infinite projective dimension and `(t)` witnesses `¬ HasHomologicalDimensionLE R d` for every `d`.

`#print axioms` on the target theorem shows only `propext, Classical.choice, Quot.sound` (no `sorryAx`). The other two `sorry`s in `Problem9_4_5.lean` (#6382, #6384) are untouched.

Closes #6381.

🤖 Prepared with Claude Code