### PR TITLE
feat(Ch8 #6318): augmentation chain map barπChainMap (ε∘d₀=0)

### DIFF
--- a/EtingofRepresentationTheory/Chapter8/BarResolution.lean
+++ b/EtingofRepresentationTheory/Chapter8/BarResolution.lean
@@ -728,4 +728,64 @@ noncomputable def barComplex : ChainComplex (ModuleCat.{u} A) ℕ :=
 
 end BarSquareZero
 
+/-! ### The augmentation as a chain map `barComplex ⟶ W[0]`
+
+The augmentation `ε : P₀ → W` extends to a chain map from `barComplex` to the complex `W`
+concentrated in degree `0`, because `ε ∘ d₀ = 0`: the first differential
+`d₀ : P₁ → P₀` sends `a₀ ⊗ (a₁ ⊗ w)` to `(a₀ a₁) ⊗ w - a₀ ⊗ (a₁ • w)`, and both summands have
+the same image `(a₀ a₁) • w` under `ε`, so they cancel. This chain map is the `π` datum of the
+projective resolution. -/
+
+section Augmentation
+
+omit [Module A W] [IsScalarTower k A W] in
+@[simp] lemma barCoeffZeroEquiv_tprod (v : Fin 0 → A) (w : W) :
+    barCoeffZeroEquiv k A W (tprod k v ⊗ₜ[k] w) = w := by
+  simp [barCoeffZeroEquiv, PiTensorProduct.isEmptyEquiv_apply_tprod]
+
+/-- The augmentation kills the image of the first bar differential: `ε ∘ d₀ = 0`. -/
+theorem ε_comp_barDiff_zero :
+    (ε k A W).comp (barDiff k A W 0) = 0 := by
+  refine TensorProduct.AlgebraTensorModule.ext fun a₀ x => ?_
+  induction x using TensorProduct.induction_on with
+  | zero => simp
+  | tmul p w =>
+      induction p using PiTensorProduct.induction_on with
+      | smul_tprod r v =>
+          have hgen : ε k A W (barDiff k A W 0 (a₀ ⊗ₜ[k] (tprod k v ⊗ₜ[k] w))) = 0 := by
+            rw [barDiff_tmul_tprod]
+            simp only [Finset.univ_eq_empty, Finset.sum_empty, add_zero, map_add,
+              LinearMap.map_smul_of_tower, ε_tmul, barCoeffZeroEquiv_tprod]
+            have hlast : v (Fin.last 0) = v 0 := rfl
+            rw [hlast, ← mul_smul, show ((-1 : k) ^ (0 + 1)) = -1 by norm_num,
+              neg_one_smul, add_neg_cancel]
+          simp only [LinearMap.comp_apply, LinearMap.zero_apply]
+          rw [← TensorProduct.smul_tmul', TensorProduct.tmul_smul,
+            LinearMap.map_smul_of_tower, LinearMap.map_smul_of_tower, hgen, smul_zero]
+      | add x y hx hy =>
+          simp only [LinearMap.comp_apply, LinearMap.zero_apply] at *
+          rw [TensorProduct.add_tmul, TensorProduct.tmul_add, map_add, map_add, hx, hy, add_zero]
+  | add x y hx hy =>
+      simp only [LinearMap.comp_apply, LinearMap.zero_apply] at *
+      rw [TensorProduct.tmul_add, map_add, map_add, hx, hy, add_zero]
+
+/-- The augmentation `ε : P₀ → W`, packaged as a chain map from the bar complex to the complex
+`W` concentrated in degree `0`. This is the `π` datum of the bar projective resolution. -/
+noncomputable def barπChainMap :
+    barComplex k A W ⟶ (ChainComplex.single₀ (ModuleCat.{u} A)).obj (ModuleCat.of A W) :=
+  (ChainComplex.toSingle₀Equiv (barComplex k A W) (ModuleCat.of A W)).symm
+    ⟨barπ k A W, by
+      have hd : (barComplex k A W).d 1 0 = ModuleCat.ofHom (barDiff k A W 0) :=
+        ChainComplex.of_d (fun n => barObj k A W n)
+          (fun n => ModuleCat.ofHom (barDiff k A W n)) 0
+      rw [hd, barπ]
+      ext x
+      exact LinearMap.congr_fun (ε_comp_barDiff_zero k A W) x⟩
+
+@[simp] lemma barπChainMap_f_zero :
+    (barπChainMap k A W).f 0 = barπ k A W := by
+  simp [barπChainMap]
+
+end Augmentation
+
 end Etingof.BarResolution

--- a/progress/2026-07-11T02-38-24Z_dc000201.md
+++ b/progress/2026-07-11T02-38-24Z_dc000201.md
@@ -1,0 +1,36 @@
+## Accomplished
+
+- Claimed #6318 (assemble `Etingof.barResolution : ProjectiveResolution`). Verified its
+  dependency #6367 is now closed and `barComplex` exists in the tree, so the issue is unblocked.
+- Assessed scope: the remaining work (contracting homotopy + quasi-iso + packaging, all
+  sorry-free) is a multi-session homological-algebra effort. Landed a coherent subset and
+  decomposed the rest.
+- **Landed** in `Chapter8/BarResolution.lean` (sorry-free, builds clean):
+  - `barCoeffZeroEquiv_tprod` (simp helper: `barCoeffZeroEquiv (tprod v ⊗ w) = w`).
+  - `ε_comp_barDiff_zero` — `ε ∘ barDiff 0 = 0` (the augmentation kills `im d₀`).
+  - `barπChainMap : barComplex ⟶ (single₀ _).obj (of A W)` — the augmentation as a chain map;
+    this is the `π` datum of the projective resolution. Plus `barπChainMap_f_zero`.
+
+## Current frontier
+
+`π` datum done. Remaining resolution pieces filed as sub-issues:
+- #6414 — the k-linear contracting homotopy `s(x)=1⊗x` and the identity `d∘s+s∘d=id`
+  (`ε∘s₋₁=id`). The hard combinatorial core (telescoping faces).
+- #6415 — from the k-linear contraction, derive `QuasiIso barπChainMap` (via the exact,
+  faithful restriction-of-scalars functor `ModuleCat A ⥤ ModuleCat k`) and assemble
+  `Etingof.barResolution`, sorry-free. Blocked on #6414.
+
+## Overall project progress
+
+Phase 3 formalization ongoing. This turn advanced Ch8 Problem 8.2.6 bar-resolution block by
+one datum (the augmentation chain map) and produced a clean 2-issue chain for the remaining
+homotopy/quasi-iso/assembly work. Parent #6318 decomposed (breadcrumb left; partial PR).
+
+## Next step
+
+Worker picks up #6414 (contracting homotopy identity), then #6415 (assembly) once #6414 lands.
+Both build on the already-landed `barComplex` / `barπChainMap`.
+
+## Blockers
+
+None. #6415 correctly marked blocked on #6414.


### PR DESCRIPTION
Partial progress on #6318

Session: `dc000201-16b6-4222-bd24-2d6878c49ffe`

de5064b6 docs(#6318): progress — augmentation chain map landed, remainder decomposed into #6414/#6415
94573834 feat(Ch8 #6318): augmentation chain map barπChainMap (ε ∘ d₀ = 0)

🤖 Prepared with Claude Code