### PR TITLE
chore(skill): check for pre-existing equivalent before implementing infra issues

### DIFF
--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -168,6 +168,16 @@ Check that the plan's assumptions still hold:
 - Quality metrics match what the issue says
 - Files mentioned in the issue still exist and haven't been restructured
 - No recently merged PR invalidates the plan
+- **For "infra"/"helper" issues, check the deliverable does not already
+  exist** — possibly under a different name or in a differently-named file.
+  Planners write these without full codebase knowledge, and this repo has
+  many overlapping per-chapter files. Before writing any code, grep for the
+  target lemma name *and* its mathematical content (key symbols in the
+  statement, e.g. `character.*Nonempty.*≅`). An equivalent (or more general)
+  sorry-free lemma already present means the issue is redundant: point to it
+  in a comment and `skip` for the planner to close. Do not re-prove it under
+  a new name. (Seen with #6425, whose deliverable was already
+  `Etingof.charEq_iso` from an earlier PR.)
 - **For "final assembly" issues that consume prerequisites**: verify the
   infrastructure it depends on actually exists sorry-free. `check-blocked`
   unblocks an issue when its `depends-on` deps *close* — but a dep closed

--- a/progress/2026-07-11T03-03-43Z_19bbc7af.md
+++ b/progress/2026-07-11T03-03-43Z_19bbc7af.md
@@ -1,0 +1,36 @@
+## Accomplished
+Investigated issue #6425 (feat Ch5 infra: character injectivity for FDRep ℂ —
+equal characters ⟹ isomorphic). Determined the deliverable is **already
+satisfied** by an existing sorry-free lemma:
+
+- `Etingof.charEq_iso` in `EtingofRepresentationTheory/Chapter5/CharEqIso.lean`
+  states `(V W : FDRep ℂ G) (h : V.character = W.character) : Nonempty (V ≅ W)`
+  for `{G} [Group G] [Finite G]`.
+
+This is equivalent to (and strictly more general than) the requested
+`FDRep.nonempty_iso_of_character_eq` (which asked for `[Fintype G]`; `Fintype G`
+implies `Finite G`, so any downstream consumer can apply `charEq_iso` directly).
+
+`charEq_iso` landed in PR #5253, which predates issue #6425 (created
+2026-07-11T03:00). The issue planner was evidently unaware the helper already
+existed. It is already in active use — `Problem5_11_1.lean` calls
+`Etingof.charEq_iso` in two places.
+
+Creating the requested new file/name would be pure duplication of existing,
+better-generalized infrastructure, so no code was written.
+
+## Current frontier
+Issue #6425 skipped (marked `replan`) with a pointer to `Etingof.charEq_iso`.
+Downstream consumer Exercise 5.27.3 part (ii) (issue #6395) is not blocked:
+`charEq_iso` is available, and part (ii)'s non-isomorphism argument goes through
+character orthogonality plus the existing forward direction `FDRep.char_iso`.
+
+## Overall project progress
+No change to formalization state; a redundant queue item was triaged out.
+
+## Next step
+A planner should close #6425 as redundant (deliverable already met by
+`Etingof.charEq_iso`, #5253). Workers should pick up #6410 or #6420 next.
+
+## Blockers
+None.


### PR DESCRIPTION
This PR adds a Step 4 verify-assumptions bullet to the `agent-worker-flow` skill: for infra/helper issues, grep for the deliverable — by lemma name *and* by mathematical content — before writing any code, since planners create such issues without full codebase knowledge and this repo has many overlapping per-chapter files.

Prompted by issue #6425, whose deliverable ("equal characters ⟹ isomorphic for FDRep ℂ") already existed sorry-free as `Etingof.charEq_iso` (Chapter5/CharEqIso.lean, from PR #5253, predating the issue and already in use). That issue was skipped as redundant; this codifies the check that caught it.

Also includes the session progress file. Touches only a skill doc — no Lean code.

🤖 Prepared with Claude Code