### PR TITLE
feat(Ch9 #6410): class-vector infra + reduce Cartan-det to Euler-char sorry

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/Problem9_4_5.lean
+++ b/EtingofRepresentationTheory/Chapter9/Problem9_4_5.lean
@@ -64,6 +64,64 @@ theorem det_eq_pm_one_of_mul_eq_one
     C.det = 1 ∨ C.det = -1 :=
   Int.eq_one_or_neg_one_of_mul_eq_one (by rw [← Matrix.det_mul, h, Matrix.det_one])
 
+/-- **Matrix assembly.** If every standard basis vector `eⱼ = Pi.single j 1` lies in the
+`ℤ`-column span of `C` (i.e. `C.mulVec d = eⱼ` for some integer vector `d`), then `C` has an
+integer right inverse `D`. Assemble `D` column by column from the witnessing vectors: column
+`j` of `D` is the vector `d` with `C.mulVec d = eⱼ`, so column `j` of `C * D` is `eⱼ`, giving
+`C * D = 1`. This packages the `K₀` change-of-basis identity `C · D = 1` into the elementary
+`∃ D, C * D = 1` consumed by `det_eq_pm_one_of_mul_eq_one`. -/
+theorem exists_right_inverse_of_forall_mulVec
+    {ι : Type*} [Fintype ι] [DecidableEq ι] (C : Matrix ι ι ℤ)
+    (h : ∀ j, ∃ d : ι → ℤ, C.mulVec d = Pi.single j 1) :
+    ∃ D : Matrix ι ι ℤ, C * D = 1 := by
+  choose d hd using h
+  refine ⟨Matrix.of fun i j => d j i, ?_⟩
+  ext i j
+  have hcol : (C * Matrix.of fun i j => d j i) i j = C.mulVec (d j) i := by
+    simp only [Matrix.mul_apply, Matrix.mulVec, Matrix.of_apply, dotProduct]
+  rw [hcol, hd j]
+  simp [Pi.single_apply, Matrix.one_apply, eq_comm]
+
+/-- **Composition-multiplicity class vector.** For an `A`-module `N`, the vector in `ℤ^ι`
+whose `i`-th entry is `dim_k Hom_A(Pᵢ, N)`. By Proposition 9.2.3
+(`Etingof.projective_cover_hom_multiplicity`) this equals the Jordan–Hölder multiplicity
+vector `([N : Mᵢ])ᵢ`, but the `Hom`-dimension form is manifestly independent of any choice
+of composition series and is additive on short exact sequences by
+`finrank_hom_additive_of_projective`. This is the concrete `K₀`-class function the Cartan
+determinant argument runs on. -/
+noncomputable def homClassVector
+    {k : Type*} [Field k] {A : Type*} [Ring A] [Algebra k A]
+    {ι : Type*} (P : ι → Type*)
+    [∀ i, AddCommGroup (P i)] [∀ i, Module A (P i)] [∀ i, Module k (P i)]
+    (N : Type*) [AddCommGroup N] [Module A N] [Module k N] [SMulCommClass A k N] : ι → ℤ :=
+  fun i => (Module.finrank k (P i →ₗ[A] N) : ℤ)
+
+/-- The class vector of the projective indecomposable `Pⱼ` is column `j` of the Cartan matrix:
+`homClassVector P (P j) i = Cᵢⱼ`. This is immediate from the definition of the Cartan matrix
+(`Etingof.algebraCartanMatrix`), whose `(i, j)` entry is exactly `dim_k Hom_A(Pᵢ, Pⱼ)`. -/
+theorem homClassVector_proj_eq_cartan_col
+    {k : Type*} [Field k] {A : Type*} [Ring A] [Algebra k A]
+    {ι : Type*} (P : ι → Type*)
+    [∀ i, AddCommGroup (P i)] [∀ i, Module A (P i)] [∀ i, Module k (P i)]
+    [∀ i, SMulCommClass A k (P i)] (i j : ι) :
+    homClassVector (k := k) (A := A) P (P j) i =
+      ((Etingof.algebraCartanMatrix (k := k) (A := A) P).map (Nat.cast : ℕ → ℤ)) i j := by
+  simp [homClassVector, Etingof.algebraCartanMatrix]
+
+/-- The class vector of the simple module `Mⱼ` is the standard basis vector `eⱼ`, from the
+essential-cover identity `dim_k Hom_A(Pᵢ, Mⱼ) = δᵢⱼ` (`hP_cover`). -/
+theorem homClassVector_simple_eq_single
+    {k : Type*} [Field k] {A : Type*} [Ring A] [Algebra k A]
+    {ι : Type*} [DecidableEq ι] (P : ι → Type*)
+    [∀ i, AddCommGroup (P i)] [∀ i, Module A (P i)] [∀ i, Module k (P i)]
+    (M : ι → Type*) [∀ i, AddCommGroup (M i)] [∀ i, Module A (M i)] [∀ i, Module k (M i)]
+    [∀ i, SMulCommClass A k (M i)]
+    (hP_cover : ∀ i j, Module.finrank k (P i →ₗ[A] M j) = if i = j then 1 else 0) (j : ι) :
+    homClassVector (k := k) (A := A) P (M j) = Pi.single j 1 := by
+  funext i
+  simp only [homClassVector, hP_cover i j, Pi.single_apply]
+  split <;> simp_all [eq_comm]
+
 /-- **Problem 9.4.5 (i).** If the finite dimensional algebra `A` has finite homological
 dimension, then the determinant of its Cartan matrix `C` is `±1`.
 
@@ -95,16 +153,28 @@ theorem cartan_det_eq_pm_one
   suffices h : ∃ D : Matrix ι ι ℤ, C * D = 1 by
     obtain ⟨D, hD⟩ := h
     exact det_eq_pm_one_of_mul_eq_one C D hD
-  -- Book argument. In `K₀(A)`, the classes `[Mⱼ]` of the simples and `[Pᵢ]` of the projective
-  -- indecomposables are two bases of the free abelian group `ℤ^ι`. The Cartan matrix `C`
-  -- expresses `[Pⱼ] = Σᵢ Cᵢⱼ [Mᵢ]` (its columns are the composition-multiplicity vectors,
-  -- Proposition 9.2.3). Finite homological dimension (`hfin`) gives each simple `Mⱼ` a finite
-  -- projective resolution `0 → Q_d → … → Q₀ → Mⱼ → 0` with each `Q_k` a finitely generated
-  -- projective, hence (Krull–Schmidt) a direct sum of the `Pᵢ`. Additivity of the class
-  -- function on short exact sequences gives `[Mⱼ] = Σₖ (-1)ᵏ [Q_k] = Σᵢ Dᵢⱼ [Pᵢ]` with an
-  -- **integer** matrix `D` (the Euler characteristic). Substituting shows `C * D = 1`.
-  -- Producing this `D` needs a `K₀`/Euler-characteristic invariant that does not yet exist in
-  -- the project; it is deferred to a dedicated sub-issue (see the PR description).
+  -- By the matrix assembly lemma, it suffices to express each standard basis vector `eⱼ` in
+  -- the `ℤ`-column span of `C`. Since `homClassVector P (M j) = eⱼ` (essential cover, `hP_cover`)
+  -- and the columns of `C` are the class vectors `homClassVector P (P i)`
+  -- (`homClassVector_proj_eq_cartan_col`), this is exactly the statement that the class of the
+  -- simple `Mⱼ` is an **integer** combination of the classes of the projective indecomposables.
+  refine exists_right_inverse_of_forall_mulVec C (fun j => ?_)
+  -- It suffices to express the class vector of the simple `Mⱼ` (which is `eⱼ` by `hP_cover`,
+  -- via `homClassVector_simple_eq_single`) as `C.mulVec d` for an integer vector `d`.
+  suffices hEuler : ∃ d : ι → ℤ, C.mulVec d = homClassVector (k := k) (A := A) P (M j) by
+    obtain ⟨d, hd⟩ := hEuler
+    exact ⟨d, by rw [hd, homClassVector_simple_eq_single P M hP_cover j]⟩
+  -- Remaining content (Euler characteristic of a finite projective resolution). Finite
+  -- homological dimension (`hfin`) gives each simple `Mⱼ` a finite projective resolution
+  -- `0 → Q_d → … → Q₀ → Mⱼ → 0` with each `Q_k` a finitely generated projective, hence
+  -- (Krull–Schmidt) a direct sum of the `Pᵢ` with multiplicity vector `aₖ : ι → ℤ`. Additivity
+  -- of `homClassVector` on short exact sequences (`finrank_hom_additive_of_projective`) gives
+  --   `homClassVector P (M j) = Σₖ (-1)ᵏ homClassVector P (Q_k) = Σₖ (-1)ᵏ C.mulVec aₖ`
+  --                          `= C.mulVec (Σₖ (-1)ᵏ aₖ)`,
+  -- so `d := Σₖ (-1)ᵏ aₖ` is the required integer vector. This needs finite projective
+  -- resolutions of simples (from `hfin`), Krull–Schmidt decomposition of f.g. projectives into
+  -- the `Pᵢ`, and the direct-sum additivity `homClassVector P (⊕ᵢ Pᵢ^{aᵢ}) = C.mulVec a`; it is
+  -- deferred to a dedicated sub-issue (see the PR description).
   sorry
 
 /-- **Problem 9.4.5 (ii), first algebra.** For `n > 1`, the truncated polynomial algebra

--- a/progress/2026-07-11T03-14-52Z_693c997f.md
+++ b/progress/2026-07-11T03-14-52Z_693c997f.md
@@ -1,0 +1,41 @@
+## Accomplished
+
+Worked issue #6410 (Problem 9.4.5(i): discharge `∃ D, C·D = 1` for the Cartan matrix).
+The full deliverable needs a `K₀`/Euler-characteristic invariant that did not exist. I landed
+the reusable foundation and reduced the main sorry to its honest mathematical core, then
+decomposed the remainder into two focused sub-issues.
+
+Changes in `EtingofRepresentationTheory/Chapter9/Problem9_4_5.lean` (all new lemmas sorry-free):
+
+- `homClassVector P N i := (finrank k (Pᵢ →ₗ[A] N) : ℤ)` — the composition-multiplicity class
+  vector. Using the `Hom`-dimension form (rather than a Jordan–Hölder count over a chosen
+  series) makes it manifestly series-independent and additive on SES via the existing
+  `finrank_hom_additive_of_projective`, sidestepping the need to prove JH-invariance.
+- `homClassVector_proj_eq_cartan_col`: `homClassVector P (P j) i = Cᵢⱼ` (definitional).
+- `homClassVector_simple_eq_single`: `homClassVector P (M j) = eⱼ` (from `hP_cover`).
+- `exists_right_inverse_of_forall_mulVec`: matrix assembly — `(∀ j, ∃ d, C.mulVec d = eⱼ) → ∃ D, C·D = 1`.
+- Restructured `cartan_det_eq_pm_one` to consume the above; its single remaining sorry is now
+  the honest `∀ j, ∃ d : ι → ℤ, C.mulVec d = homClassVector P (M j)` (Euler characteristic).
+
+## Current frontier
+
+`cartan_det_eq_pm_one` compiles with one precise sorry (the Euler-characteristic step). The
+part-(ii) sorry `homologicalDimension_problem932_eq_top` was left untouched (#6382 territory).
+
+## Overall project progress
+
+Stage 3 formalization ongoing. Problem 9.4.5(i) is now infrastructure-complete: the reduction
+chain `det = ±1 ⇐ ∃ D, C·D=1 ⇐ ∀ j ∃ d, C.mulVec d = eⱼ ⇐ homClassVector algebra + finite
+resolution` is fully wired sorry-free except the final Euler-characteristic node.
+
+## Next step
+
+Work #6439 first (homClassVector SES additivity + finite-direct-sum formula
+`homClassVector(⊕ᵢ Pᵢ^{aᵢ}) = C.mulVec a`; provable now from existing infra). Then #6440
+(depends on #6439): extract a finite projective resolution of each simple from
+`homologicalDimension A ≠ ⊤`, Krull–Schmidt-decompose the f.g. projective terms, and telescope
+SES additivity into the Euler characteristic to produce the integer vector `d`.
+
+## Blockers
+
+None. #6440 is correctly marked `blocked` on #6439.


### PR DESCRIPTION
Partial progress on #6410

Session: `693c997f-84ef-488f-87c5-a3a14280239b`

2d379b4c chore(#6410): progress entry — class-vector infra landed, decomposed into #6439/#6440
a0e0ee12 feat(Ch9 #6410): class-vector infra + reduce Cartan-det sorry to Euler char

🤖 Prepared with Claude Code