### PR TITLE
feat(Ch9 #Problem9.4.5 i): additivity of homClassVector — SES additivity + finite-direct-sum formula homClassVector(⊕ᵢ Pᵢ^{aᵢ}) = C.mulVec a

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -669,6 +669,34 @@ Then the 2-periodic Ext-nonvanishing is a short induction: `ext_extClass_comp_ne
 classes; `homologicalDimension R = ⊤` follows from `∀ d, ¬ HasHomologicalDimensionLE R d` by
 `le_antisymm le_top (le_iInf₂ (fun d hd => absurd hd (h d)))`.
 
+### `finrank k (M →ₗ[A] N)` and Hom-into-product additivity (Cartan/multiplicity counting, Ch9 #6439)
+
+Dimension-counting over a `k`-algebra `A` (Cartan matrices, `[N : Mᵢ]` multiplicities,
+Euler characteristics) repeatedly needs `finrank k (M →ₗ[A] N)`. Useful facts:
+
+- **Finiteness is automatic.** `LinearMap.finiteDimensional'` is an instance:
+  `FiniteDimensional k (M →ₗ[A] N)` given `[FiniteDimensional k M] [FiniteDimensional k N]`
+  and `[IsScalarTower k A M] [IsScalarTower k A N]` (it embeds `M →ₗ[A] N ↪ M →ₗ[k] N` via
+  `restrictScalarsₗ`). So carry `IsScalarTower k A ·` on every module and `Module.Finite k ·`
+  falls out — no manual subspace argument.
+- **Freeness is NOT automatic.** `Module.Free.of_divisionRing` is not a global instance; if you
+  need `Module.Free k ·` (e.g. for `Module.finrank_pi_fintype`), add
+  `attribute [local instance] Module.Free.of_divisionRing` in your section.
+- **Hom commutes with finite products in the 2nd arg**, always (no projectivity needed):
+  build `(M →ₗ[A] ∀ s, Q s) ≃ₗ[k] ∀ s, (M →ₗ[A] Q s)` by hand
+  (`toFun f s := (LinearMap.proj s).comp f`, `invFun := LinearMap.pi`), then
+  `finrank_pi_fintype` gives `finrank (Hom into ⨁/∏) = ∑ finrank`. Convert `⨁`→`∏` with
+  `DirectSum.linearEquivFunOnFintype`.
+- **k-linearity of a postcomposition** `f ↦ e.comp f` for `e : M ≃ₗ[A] N`: the `map_smul'`
+  goal reduces to `e (c • x) = c • e x` (`c : k`), closed by
+  `LinearMapClass.map_smul_of_tower e c x` (the `CompatibleSMul` instance comes from the two
+  `IsScalarTower k A ·`). `simp` will NOT fire the plain `LinearMap.map_smul_of_tower` on a
+  bundled `≃ₗ`.
+- **`Hom`-additivity on a SES with projective source** (`0→N'→N→N/N'→0`,
+  `finrank_hom_additive_of_projective`, needs `[Module.Projective A M]`) is the tool when the
+  sequence is not split; for an *explicit* finite direct sum the product-additivity above is
+  cleaner (no projectivity, no submodule identification).
+
 ### Tactic Selection Guide
 
 | Goal Shape | Try First | Then Try |

--- a/EtingofRepresentationTheory/Chapter9/Problem9_4_5.lean
+++ b/EtingofRepresentationTheory/Chapter9/Problem9_4_5.lean
@@ -157,6 +157,123 @@ theorem homClassVector_add_quotient
   push_cast
   ring
 
+section DirectSum
+
+open scoped DirectSum
+
+attribute [local instance] Module.Free.of_divisionRing
+
+/-- **Class-vector is a linear-isomorphism invariant.** If `M ≃ₗ[A] N` then `homClassVector P`
+agrees on `M` and `N`: post-composition with the `A`-linear isomorphism is a `k`-linear
+isomorphism `Hom_A(Pᵢ, M) ≃ₗ[k] Hom_A(Pᵢ, N)`, so the two `Hom`-dimensions coincide. -/
+theorem homClassVector_congr
+    {k : Type*} [Field k] {A : Type*} [Ring A] [Algebra k A]
+    {ι : Type*} (P : ι → Type*)
+    [∀ i, AddCommGroup (P i)] [∀ i, Module A (P i)] [∀ i, Module k (P i)]
+    {M : Type*} [AddCommGroup M] [Module A M] [Module k M] [IsScalarTower k A M]
+    [SMulCommClass A k M]
+    {N : Type*} [AddCommGroup N] [Module A N] [Module k N] [IsScalarTower k A N]
+    [SMulCommClass A k N]
+    (e : M ≃ₗ[A] N) :
+    homClassVector (k := k) (A := A) P M = homClassVector (k := k) (A := A) P N := by
+  funext i
+  simp only [homClassVector]
+  congr 1
+  refine LinearEquiv.finrank_eq
+    { toFun := fun f => e.toLinearMap.comp f
+      invFun := fun f => e.symm.toLinearMap.comp f
+      map_add' := fun f g => by ext x; simp
+      map_smul' := fun c f => by
+        ext x; simpa using LinearMapClass.map_smul_of_tower e c (f x)
+      left_inv := fun f => by ext x; simp
+      right_inv := fun f => by ext x; simp }
+
+/-- **Class-vector additivity over finite products.** For a finite family `Q : σ → Type*` of
+`A`-modules that are finite `k`-vector spaces, `homClassVector P (∀ s, Q s) = ∑ s, homClassVector
+P (Q s)`. `Hom_A(Pᵢ, ∏ₛ Qₛ) ≃ₗ[k] ∏ₛ Hom_A(Pᵢ, Qₛ)` (products commute with `Hom` in the second
+argument), and `finrank` of a finite product is the sum of the `finrank`s. -/
+theorem homClassVector_pi
+    {k : Type*} [Field k] {A : Type*} [Ring A] [Algebra k A]
+    {ι : Type*} (P : ι → Type*)
+    [∀ i, AddCommGroup (P i)] [∀ i, Module A (P i)] [∀ i, Module k (P i)]
+    [∀ i, IsScalarTower k A (P i)] [∀ i, Module.Finite k (P i)]
+    {σ : Type*} [Fintype σ] (Q : σ → Type*)
+    [∀ s, AddCommGroup (Q s)] [∀ s, Module A (Q s)] [∀ s, Module k (Q s)]
+    [∀ s, IsScalarTower k A (Q s)] [∀ s, SMulCommClass A k (Q s)] [∀ s, Module.Finite k (Q s)] :
+    homClassVector (k := k) (A := A) P (∀ s, Q s) =
+      ∑ s, homClassVector (k := k) (A := A) P (Q s) := by
+  funext l
+  rw [Finset.sum_apply]
+  simp only [homClassVector]
+  rw [← Nat.cast_sum]
+  congr 1
+  rw [LinearEquiv.finrank_eq
+    (show (P l →ₗ[A] ∀ s, Q s) ≃ₗ[k] ∀ s, (P l →ₗ[A] Q s) from
+      { toFun := fun f s => (LinearMap.proj s).comp f
+        invFun := fun g => LinearMap.pi g
+        map_add' := fun f g => by funext s; ext x; simp
+        map_smul' := fun c f => by funext s; ext x; simp
+        left_inv := fun f => by
+          refine LinearMap.ext fun x => ?_; funext s; simp
+        right_inv := fun g => by funext s; ext x; simp })]
+  exact Module.finrank_pi_fintype k
+
+/-- **Class-vector additivity over finite direct sums.** Same statement as `homClassVector_pi`
+for the internal direct sum `⨁ s, Q s`, which is `A`-linearly isomorphic to the product for a
+finite index type. -/
+theorem homClassVector_directSum
+    {k : Type*} [Field k] {A : Type*} [Ring A] [Algebra k A]
+    {ι : Type*} (P : ι → Type*)
+    [∀ i, AddCommGroup (P i)] [∀ i, Module A (P i)] [∀ i, Module k (P i)]
+    [∀ i, IsScalarTower k A (P i)] [∀ i, Module.Finite k (P i)]
+    {σ : Type*} [Fintype σ] (Q : σ → Type*)
+    [∀ s, AddCommGroup (Q s)] [∀ s, Module A (Q s)] [∀ s, Module k (Q s)]
+    [∀ s, IsScalarTower k A (Q s)] [∀ s, SMulCommClass A k (Q s)] [∀ s, Module.Finite k (Q s)] :
+    homClassVector (k := k) (A := A) P (⨁ s, Q s) =
+      ∑ s, homClassVector (k := k) (A := A) P (Q s) := by
+  rw [homClassVector_congr P (DirectSum.linearEquivFunOnFintype A σ Q)]
+  exact homClassVector_pi P Q
+
+/-- **Cartan-matrix class vector of a `Pᵢ`-isotypic projective.** For a multiplicity vector
+`a : ι → ℕ`, the direct sum `⨁ᵢ Pᵢ^{aᵢ}` (encoded as `⨁ (p : Σ i, Fin (a i)), P p.1`) has class
+vector `C.mulVec a`, where `C` is the (`ℤ`-cast) Cartan matrix. This is `homClassVector_directSum`
+combined with `homClassVector_proj_eq_cartan_col` (each `Pⱼ` contributes column `j` of `C`) and
+the reindexing `∑_{p : Σ i, Fin (a i)} f p.1 = ∑ᵢ (a i) • f i`. -/
+theorem homClassVector_isotypic
+    {k : Type*} [Field k] {A : Type*} [Ring A] [Algebra k A]
+    {ι : Type*} [Fintype ι] (P : ι → Type*)
+    [∀ i, AddCommGroup (P i)] [∀ i, Module A (P i)] [∀ i, Module k (P i)]
+    [∀ i, IsScalarTower k A (P i)] [∀ i, SMulCommClass A k (P i)] [∀ i, Module.Finite k (P i)]
+    (a : ι → ℕ) :
+    homClassVector (k := k) (A := A) P (⨁ p : (Σ i, Fin (a i)), P p.1) =
+      ((Etingof.algebraCartanMatrix (k := k) (A := A) P).map (Nat.cast : ℕ → ℤ)).mulVec
+        (fun i => (a i : ℤ)) := by
+  rw [homClassVector_directSum P (fun p : (Σ i, Fin (a i)) => P p.1)]
+  funext l
+  rw [Finset.sum_apply, Fintype.sum_sigma]
+  simp only [homClassVector_proj_eq_cartan_col, Matrix.mulVec, dotProduct]
+  refine Finset.sum_congr rfl (fun i _ => ?_)
+  rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin]
+  rw [nsmul_eq_mul, mul_comm]
+
+/-- **Class vector of a projective isomorphic to `⨁ᵢ Pᵢ^{aᵢ}`.** Krull–Schmidt-friendly form of
+`homClassVector_isotypic`: if `N` is `A`-linearly isomorphic to `⨁ᵢ Pᵢ^{aᵢ}` then its class
+vector is `C.mulVec a`. This is the form the Euler-characteristic step of Problem 9.4.5(i)
+consumes for each projective in a finite resolution of a simple module. -/
+theorem homClassVector_eq_mulVec_of_equiv
+    {k : Type*} [Field k] {A : Type*} [Ring A] [Algebra k A]
+    {ι : Type*} [Fintype ι] (P : ι → Type*)
+    [∀ i, AddCommGroup (P i)] [∀ i, Module A (P i)] [∀ i, Module k (P i)]
+    [∀ i, IsScalarTower k A (P i)] [∀ i, SMulCommClass A k (P i)] [∀ i, Module.Finite k (P i)]
+    (a : ι → ℕ) {N : Type*} [AddCommGroup N] [Module A N] [Module k N] [IsScalarTower k A N]
+    [SMulCommClass A k N] (e : N ≃ₗ[A] ⨁ p : (Σ i, Fin (a i)), P p.1) :
+    homClassVector (k := k) (A := A) P N =
+      ((Etingof.algebraCartanMatrix (k := k) (A := A) P).map (Nat.cast : ℕ → ℤ)).mulVec
+        (fun i => (a i : ℤ)) := by
+  rw [homClassVector_congr P e, homClassVector_isotypic]
+
+end DirectSum
+
 /-- **Problem 9.4.5 (i).** If the finite dimensional algebra `A` has finite homological
 dimension, then the determinant of its Cartan matrix `C` is `±1`.
 

--- a/EtingofRepresentationTheory/Chapter9/Problem9_4_5.lean
+++ b/EtingofRepresentationTheory/Chapter9/Problem9_4_5.lean
@@ -136,6 +136,27 @@ theorem homClassVector_simple_eq_single
   simp only [homClassVector, hP_cover i j, Pi.single_apply]
   split <;> simp_all [eq_comm]
 
+/-- **Class-vector additivity on short exact sequences.** For a submodule `N' ≤ N`,
+`homClassVector P N = homClassVector P N' + homClassVector P (N ⧸ N')`. Entrywise this is
+`finrank_hom_additive_of_projective` (Hom_A(Pᵢ, −) is exact on the short exact sequence
+`0 → N' → N → N/N' → 0` because each `Pᵢ` is projective), cast to `ℤ`. -/
+theorem homClassVector_add_quotient
+    {k : Type*} [Field k] {A : Type*} [Ring A] [Algebra k A]
+    {ι : Type*} (P : ι → Type*)
+    [∀ i, AddCommGroup (P i)] [∀ i, Module A (P i)] [∀ i, Module k (P i)]
+    [∀ i, Module.Projective A (P i)] [∀ i, IsScalarTower k A (P i)]
+    [∀ i, SMulCommClass A k (P i)] [∀ i, Module.Finite k (P i)]
+    (N : Type*) [AddCommGroup N] [Module A N] [Module k N]
+    [IsScalarTower k A N] [SMulCommClass A k N] [Module.Finite k N]
+    (N' : Submodule A N) :
+    homClassVector (k := k) (A := A) P N =
+      homClassVector (k := k) (A := A) P N' + homClassVector (k := k) (A := A) P (N ⧸ N') := by
+  funext i
+  simp only [homClassVector, Pi.add_apply]
+  rw [finrank_hom_additive_of_projective (P := P i) N']
+  push_cast
+  ring
+
 /-- **Problem 9.4.5 (i).** If the finite dimensional algebra `A` has finite homological
 dimension, then the determinant of its Cartan matrix `C` is `±1`.
 

--- a/progress/2026-07-11T03-32-13Z_f810a10e.md
+++ b/progress/2026-07-11T03-32-13Z_f810a10e.md
@@ -1,0 +1,38 @@
+## Accomplished
+Issue #6439 (Ch9 Problem 9.4.5 i): added the class-vector additivity /
+direct-sum infrastructure to `Chapter9/Problem9_4_5.lean`, all sorry-free:
+
+1. `homClassVector_add_quotient` — SES additivity
+   `homClassVector P N = homClassVector P N' + homClassVector P (N ⧸ N')`
+   (entrywise `finrank_hom_additive_of_projective`, cast to ℤ).
+2. `homClassVector_congr` — linear-iso invariance (postcomposition k-linear equiv).
+3. `homClassVector_pi` / `homClassVector_directSum` — additivity over finite
+   products / direct sums, via the Hom-into-product equiv
+   `Hom_A(Pᵢ, ∏ Qₛ) ≃ₗ[k] ∏ Hom_A(Pᵢ, Qₛ)` + `Module.finrank_pi_fintype`.
+4. `homClassVector_isotypic` — `⨁ᵢ Pᵢ^{aᵢ}` (as `⨁ (p:Σ i, Fin (a i)), P p.1`)
+   has class vector `C.mulVec a`.
+5. `homClassVector_eq_mulVec_of_equiv` — Krull–Schmidt-friendly form: any `N`
+   with `N ≃ₗ[A] ⨁ᵢ Pᵢ^{aᵢ}` has class vector `C.mulVec a`. This is the form
+   the Euler-characteristic step (#6440) consumes.
+
+`#print axioms` clean (propext/Classical.choice/Quot.sound only) for all six.
+The two pre-existing sorries in the file (`cartan_det_eq_pm_one` Euler-char step,
+`homologicalDimension_problem932_eq_top`) were left untouched as instructed.
+
+## Current frontier
+`Chapter9/Problem9_4_5.lean` builds; the Euler-characteristic sorry in
+`cartan_det_eq_pm_one` (line ~286) is now fully served by the new lemmas and is
+the subject of the (blocked) issue #6440.
+
+## Overall project progress
+Phase 3 formalization ongoing. This PR unblocks #6440 (the Cartan-det
+Euler-characteristic discharge). Two PRs (#6441, #6442) auto-merged this cycle.
+
+## Next step
+Pick up #6440 once this lands: build a finite projective resolution of each
+simple Mⱼ from `hfin`, apply Krull–Schmidt to each term, and feed
+`homClassVector_eq_mulVec_of_equiv` + `homClassVector_add_quotient` into the
+alternating sum to discharge the `∃ d, C.mulVec d = homClassVector P (M j)` goal.
+
+## Blockers
+None.


### PR DESCRIPTION
Closes #6439

Session: `f810a10e-7175-4957-abdf-611d0bd10c70`

696147ef doc(skill): finrank k (M →ₗ[A] N) and Hom-into-product additivity note (#6439)
d5424863 progress: #6439 homClassVector direct-sum infrastructure
ff23e20a feat(Ch9 #6439): homClassVector direct-sum formula = C.mulVec a
bba4f87e feat(Ch9 #6439): homClassVector SES additivity (add_quotient)

🤖 Prepared with Claude Code