### PR TITLE
feat(Ch5 #5.27.1 infra): expose forward functoriality of inducedRepV — V χ U₁ ≅ V χ U₂ from U₁ ≅ U₂ as a conjunct of Etingof.Theorem5_27_1

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_27_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_27_1.lean
@@ -2172,8 +2172,35 @@ private lemma inducedRepV_finrank {G A : Type} [Group G] [CommGroup A] [Fintype 
   rw [Module.finrank_pi_fintype, Finset.sum_const, Finset.card_univ, smul_eq_mul,
     Subgroup.index_eq_card, Nat.card_eq_fintype_card]
 
-
-
+-- Forward functoriality: an isomorphism `U ≅ U'` of stabilizer representations induces an
+-- isomorphism `V(χ, U) ≅ V(χ, U')` of induced representations, given by coset-wise
+-- post-composition with the underlying linear equivalence. Needed for completeness in the
+-- orbit-method assemblies (replacing `U` by its `charFDRep` model inside `V`).
+private noncomputable def inducedRepV_congr {G A : Type} [Group G] [CommGroup A] [Fintype G]
+    (φ : G →* MulAut A) (χ : A →* ℂˣ) {U U' : FDRep ℂ ↥(stabAux φ χ)} (α : U ≅ U') :
+    inducedRepV φ χ U ≅ inducedRepV φ χ U' := by
+  classical
+  -- The underlying linear equivalence `↥U ≃ₗ[ℂ] ↥U'` and its intertwining property.
+  set e : ↥U ≃ₗ[ℂ] ↥U' := FDRep.isoToLinearEquiv α with he
+  have hinter : ∀ (s : ↥(stabAux φ χ)) (v : ↥U),
+      e (FDRep.ρ U s v) = FDRep.ρ U' s (e v) := by
+    intro s v
+    rw [FDRep.Iso.conj_ρ α s, LinearEquiv.conj_apply_apply, LinearEquiv.symm_apply_apply]
+  -- Coset-wise post-composition on the underlying function spaces.
+  set Φ : ((G ⧸ stabAux φ χ) → ↥U) ≃ₗ[ℂ] ((G ⧸ stabAux φ χ) → ↥U') :=
+    LinearEquiv.piCongrRight (fun _ => e) with hΦ
+  refine Action.mkIso Φ.toFGModuleCatIso (fun ag => ?_)
+  ext f
+  funext q
+  -- The induced action is `scalar • ρ(s) (f (g⁻¹ • q))`, with scalar and `s` independent of `U`.
+  change e (FDRep.ρ (inducedRepV φ χ U) ag f q)
+    = FDRep.ρ (inducedRepV φ χ U') ag (fun q' => e (f q')) q
+  have hact : ∀ (W : FDRep ℂ ↥(stabAux φ χ)) (g : (G ⧸ stabAux φ χ) → ↥W),
+      FDRep.ρ (inducedRepV φ χ W) ag g q =
+        ((χ ((φ q.out⁻¹ : MulAut A) ag.left) : ℂˣ) : ℂ) •
+          FDRep.ρ W ⟨q.out⁻¹ * ag.right * (ag.right⁻¹ • q).out,
+            transition_mem_stab φ χ ag.right q⟩ (g (ag.right⁻¹ • q)) := fun W g => rfl
+  rw [hact U f, hact U' (fun q' => e (f q')), map_smul, hinter]
 
 
 open Classical in
@@ -2236,12 +2263,16 @@ theorem Etingof.Theorem5_27_1
       -- (v) Dimension formula: dim V(χ, U) = [G : G_χ] · dim U
       (∀ (χ : A →* ℂˣ) (U : FDRep ℂ ↥(stab χ)),
         Module.finrank ℂ (V χ U : Type) =
-          (stab χ).index * Module.finrank ℂ (U : Type)) := by
+          (stab χ).index * Module.finrank ℂ (U : Type)) ∧
+      -- (vi) Functoriality: `V(χ, -)` sends isomorphic stabilizer reps to isomorphic
+      -- induced reps. (Lets completeness replace `U` by its `charFDRep` model inside `V`.)
+      (∀ (χ : A →* ℂˣ) (U₁ U₂ : FDRep ℂ ↥(stab χ)),
+        Nonempty (U₁ ≅ U₂) → Nonempty (V χ U₁ ≅ V χ U₂)) := by
   -- Provide the dual action, stabilizer, and induced representation constructions
   refine ⟨dualSmulAux φ, fun g χ a => rfl, stabAux φ, fun χ g => Iff.rfl, ?_⟩
   -- Use the concrete induced representation V(χ, U) = Ind_{G_χ ⋉ A}^{G ⋉ A} (U ⊗ ℂ_χ)
   refine ⟨fun χ U => inducedRepV φ χ U,
-    fun _ _ _ hg U₁ => transportRep φ hg U₁, ?_, ?_, ?_, ?_, ?_⟩
+    fun _ _ _ hg U₁ => transportRep φ hg U₁, ?_, ?_, ?_, ?_, ?_, ?_⟩
   -- (i) Irreducibility: V(χ, U) is irreducible when U is irreducible
   · exact fun χ U hU => inducedRepV_simple φ χ U hU
   -- (ii) Classification: iso forces same G-orbit and isomorphic transported U-component
@@ -2369,3 +2400,5 @@ theorem Etingof.Theorem5_27_1
         exact Nat.cast_ne_zero.mpr (Fintype.card_pos.ne')
   -- (v) Dimension formula: dim V(χ, U) = [G : G_χ] · dim U
   · exact fun χ U => inducedRepV_finrank φ χ U
+  -- (vi) Functoriality: `U₁ ≅ U₂ ⟹ V(χ, U₁) ≅ V(χ, U₂)`
+  · exact fun χ U₁ U₂ ⟨α⟩ => ⟨inducedRepV_congr φ χ α⟩

--- a/progress/2026-07-13T02-24-16Z_2399caec.md
+++ b/progress/2026-07-13T02-24-16Z_2399caec.md
@@ -1,0 +1,54 @@
+## Accomplished
+
+Started on #6458 (affine-group orbit-method assembly, Exercise 5.27.2 / Problem 4.12.6)
+but during scope assessment found two blockers, decomposed, and landed the shared
+infrastructure piece:
+
+- **Statement bug in #6458.** `affine_classification` as stated is false for `K = F₂`
+  (q = 2): it fixes `n = card K = 2` and requires `filter(finrank=1).card = q-1 = 1`
+  and `filter(finrank=q-1).card = 1`, but the affine group over `F₂` is `ℤ/2` with two
+  1-dimensional irreps, so `filter(finrank=1).card = 2 ≠ 1`. Needs a `3 ≤ Fintype.card K`
+  hypothesis (exactly what `Chapter4/Problem4_12_6.one_dim_reps_card` uses). Reported on
+  #6458.
+
+- **Engine gap — forward functoriality of `V`.** Completeness in all three orbit-method
+  assemblies (#6458 affine, #6452 dihedral, Heisenberg) needs
+  `U ≅ charFDRep ξ ⟹ V χ U ≅ V χ (charFDRep ξ)`, but `Theorem5_27_1.lean` exposed only
+  the reverse (`inducedRepV_U_iso`) and the concrete constructions are `private`.
+  Extracted as #6469 and **completed it**:
+  - Added `inducedRepV_congr φ χ (α : U ≅ U') : inducedRepV φ χ U ≅ inducedRepV φ χ U'`
+    (coset-wise post-composition with `FDRep.isoToLinearEquiv α`, equivariance from
+    `FDRep.Iso.conj_ρ` since the induced action's scalar and stabilizer element are
+    `U`-independent).
+  - Added conjunct (vi) to `Etingof.Theorem5_27_1`:
+    `∀ χ U₁ U₂, Nonempty (U₁ ≅ U₂) → Nonempty (V χ U₁ ≅ V χ U₂)`, discharged by it.
+
+## Current frontier
+
+#6469 complete: `Theorem5_27_1.lean` builds sorry-free, `#print axioms
+Etingof.Theorem5_27_1` = `[propext, Classical.choice, Quot.sound]`, downstream
+`Exercise5_27_3` still builds. PR pending.
+
+## Overall project progress
+
+Stage 3 (formalization), Chapter 5. The orbit-method engine `Theorem5_27_1` now exposes
+forward functoriality, unblocking the completeness half of #6458, #6452, and the
+Heisenberg assembly. #6458 is decomposed (blocked on #6469, plus a statement fix pending).
+
+## Next step
+
+Once #6469 merges: pick up the residual of #6458 (a planner should narrow it and add
+the `3 ≤ Fintype.card K` hypothesis). The affine-specific residual is:
+- `stabAux (affineφ K) 1 = ⊤`; `∀ χ ≠ 1, stabAux (affineφ K) χ = ⊥` (both from
+  bijectivity of `b ↦ (a⁻¹-1)·b` on `K` for `a ≠ 1`);
+- transitivity of `Kˣ` on nontrivial characters via orbit-stabilizer counting
+  (`|orbit χ₀| = [Kˣ:⊥] = q-1 = #{nontrivial chars}`, all nontrivial since `1` is fixed);
+- dim-1 family characters via formula (iv): `character ⟨a,g⟩ = ξ(g)`, giving non-iso via
+  `FDRep.char_iso`;
+- the `Fin q` assembly under `3 ≤ card K`, using #6457 (`AbelianFDRep`) and conjunct (vi).
+The same functoriality now also unblocks #6452 (dihedral) completeness.
+
+## Blockers
+
+None for #6469. #6458 remains blocked on #6469 (merge) and needs the `3 ≤ card K`
+statement fix at assembly time.


### PR DESCRIPTION
Closes #6469

Session: `2399caec-eaed-4d78-a7c7-b8b780a6528e`

4b520a73 feat(Ch5 #6469): expose forward functoriality of inducedRepV as conjunct (vi) of Etingof.Theorem5_27_1

🤖 Prepared with Claude Code