### PR TITLE
feat(Ch5 engine): expose basepoint-independence (vii) + central-transport-triviality (viii) as public conjuncts of Theorem5_27_1 (shared orbit-method assembly infra)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Exercise5_27_2_Dihedral.lean
+++ b/EtingofRepresentationTheory/Chapter5/Exercise5_27_2_Dihedral.lean
@@ -201,7 +201,8 @@ theorem semidirect_classification :
         (Finset.univ.filter (fun i => finrank ℂ (W i : Type) = 1)).card = 4 ∧
         (Finset.univ.filter (fun i => finrank ℂ (W i : Type) = 2)).card = (N - 2) / 2) := by
   classical
-  obtain ⟨dualSmul, hdual, stab, hstab, V, transport, hi, hii, hiii, hiv, hv, hvi⟩ :=
+  obtain ⟨dualSmul, hdual, stab, hstab, V, transport, hi, hii, hiii, hiv, hv, hvi,
+      hvii, hviii, hix⟩ :=
     Etingof.Theorem5_27_1 (Multiplicative (ZMod 2)) (Multiplicative (ZMod N)) (dihedralφ N)
   -- The reflection generator is self-inverse in `ℤ/2`.
   have hgen_inv : (Multiplicative.ofAdd (1 : ZMod 2))⁻¹ = Multiplicative.ofAdd 1 := by decide

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_27_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_27_1.lean
@@ -2202,6 +2202,61 @@ private noncomputable def inducedRepV_congr {G A : Type} [Group G] [CommGroup A]
             transition_mem_stab φ χ ag.right q⟩ (g (ag.right⁻¹ • q)) := fun W g => rfl
   rw [hact U f, hact U' (fun q' => e (f q')), map_smul, hinter]
 
+-- An equivalence of categories preserves simple objects (transported through the
+-- monomorphism-reflecting inverse functor). Used to see `transportRep` — which is the
+-- restriction of scalars along the conjugation isomorphism of stabilizers — as simplicity
+-- preserving.
+open CategoryTheory in
+private lemma simple_equivalence_functor'
+    {C D : Type*} [Category C] [Category D]
+    [Limits.HasZeroMorphisms C] [Limits.HasZeroMorphisms D]
+    (E : C ≌ D) (X : C) [Simple X] : Simple (E.functor.obj X) := by
+  haveI : Simple ((𝟭 C).obj X) := inferInstanceAs (Simple X)
+  haveI : Simple (E.inverse.obj (E.functor.obj X)) := Simple.of_iso (E.unitIso.app X).symm
+  exact simple_of_full_faithful_preservesMono'' E.inverse (E.functor.obj X)
+
+-- The conjugation isomorphism `G_{χ₂} ≃* G_{χ₁}`, `h ↦ g⁻¹ h g`, upgrading `conjStabHom` to
+-- a `MulEquiv` (its inverse is conjugation by `g⁻¹`). This exhibits `transportRep` as the
+-- restriction-of-scalars functor along a group isomorphism.
+private noncomputable def conjStabEquiv {G A : Type} [Group G] [CommGroup A]
+    (φ : G →* MulAut A) {χ₁ χ₂ : A →* ℂˣ} {g : G} (hg : dualSmulAux φ g χ₁ = χ₂) :
+    ↥(stabAux φ χ₂) ≃* ↥(stabAux φ χ₁) where
+  toFun h := conjStabHom φ hg h
+  invFun k := ⟨g * (k : G) * g⁻¹, stabAux_conj_mem' φ hg k.2⟩
+  left_inv h := by apply Subtype.ext; simp only [conjStabHom_coe]; group
+  right_inv k := by apply Subtype.ext; simp only [conjStabHom_coe]; group
+  map_mul' a b := map_mul (conjStabHom φ hg) a b
+
+-- (ix): transporting a simple stabilizer representation along an orbit element keeps it
+-- simple, since `transportRep` is restriction of scalars along the group isomorphism
+-- `conjStabEquiv`, hence the image under an equivalence of representation categories.
+private lemma transportRep_simple {G A : Type} [Group G] [CommGroup A]
+    (φ : G →* MulAut A) {χ₁ χ₂ : A →* ℂˣ} {g : G} (hg : dualSmulAux φ g χ₁ = χ₂)
+    (U : FDRep ℂ ↥(stabAux φ χ₁)) [CategoryTheory.Simple U] :
+    CategoryTheory.Simple (transportRep φ hg U) := by
+  have hobj : transportRep φ hg U
+      = (Action.resEquiv (FGModuleCat ℂ) (conjStabEquiv φ hg)).functor.obj U := rfl
+  rw [hobj]
+  exact simple_equivalence_functor' (Action.resEquiv (FGModuleCat ℂ) (conjStabEquiv φ hg)) U
+
+-- (viii): when the orbit element `g` fixing `χ` is central, the conjugation `G_χ ≃* G_χ` it
+-- induces is the identity, so the transported representation is isomorphic to `U` itself.
+private noncomputable def transportRep_central_iso {G A : Type} [Group G] [CommGroup A]
+    (φ : G →* MulAut A) {χ : A →* ℂˣ} {g : G} (hg : dualSmulAux φ g χ = χ)
+    (hg_central : ∀ x : G, g * x = x * g) (U : FDRep ℂ ↥(stabAux φ χ)) :
+    transportRep φ hg U ≅ U := by
+  have hconj : ∀ h : ↥(stabAux φ χ), conjStabHom φ hg h = h := by
+    intro h
+    apply Subtype.ext
+    rw [conjStabHom_coe]
+    have hc := hg_central (h : G)
+    rw [mul_assoc, ← hc, ← mul_assoc, inv_mul_cancel, one_mul]
+  refine Action.mkIso (LinearEquiv.refl ℂ ↥U).toFGModuleCatIso (fun h => ?_)
+  ext v
+  change (LinearEquiv.refl ℂ ↥U) (FDRep.ρ (transportRep φ hg U) h v)
+      = FDRep.ρ U h ((LinearEquiv.refl ℂ ↥U) v)
+  simp only [LinearEquiv.refl_apply]
+  rw [transportRep_ρ_apply, hconj h]
 
 open Classical in
 /-- Classification of irreducible representations of semidirect products G ⋉ A
@@ -2267,12 +2322,26 @@ theorem Etingof.Theorem5_27_1
       -- (vi) Functoriality: `V(χ, -)` sends isomorphic stabilizer reps to isomorphic
       -- induced reps. (Lets completeness replace `U` by its `charFDRep` model inside `V`.)
       (∀ (χ : A →* ℂˣ) (U₁ U₂ : FDRep ℂ ↥(stab χ)),
-        Nonempty (U₁ ≅ U₂) → Nonempty (V χ U₁ ≅ V χ U₂)) := by
+        Nonempty (U₁ ≅ U₂) → Nonempty (V χ U₁ ≅ V χ U₂)) ∧
+      -- (vii) Base-point independence (orbit ⟹ iso): if `χ₂ = g · χ₁` then `V(χ₁, U)` is
+      -- isomorphic to `V(χ₂, g(U))`. (Lets completeness match an irrep parametrized by a
+      -- non-chosen orbit member to the family member built at the chosen representative.)
+      (∀ (χ₁ χ₂ : A →* ℂˣ) (U : FDRep ℂ ↥(stab χ₁)) (g : G) (hg : dualSmul g χ₁ = χ₂),
+        Nonempty (V χ₁ U ≅ V χ₂ (transport g χ₁ χ₂ hg U))) ∧
+      -- (viii) Central-transport triviality: if a central `g` fixes `χ` then transporting a
+      -- stabilizer representation along it changes nothing, `g(U) ≅ U`. (Lets injectivity
+      -- collapse the `U₂ ≅ g(U₁)` of (ii) to `U₂ ≅ U₁` over a fixed self-paired character.)
+      (∀ (χ : A →* ℂˣ) (g : G) (hg : dualSmul g χ = χ) (U : FDRep ℂ ↥(stab χ)),
+        (∀ x : G, g * x = x * g) → Nonempty (transport g χ χ hg U ≅ U)) ∧
+      -- (ix) Transport preserves simplicity: `g(U)` is simple whenever `U` is (conjugation is
+      -- an isomorphism of stabilizers, so `transport` is an equivalence of rep categories).
+      (∀ (χ₁ χ₂ : A →* ℂˣ) (U : FDRep ℂ ↥(stab χ₁)) (g : G) (hg : dualSmul g χ₁ = χ₂),
+        CategoryTheory.Simple U → CategoryTheory.Simple (transport g χ₁ χ₂ hg U)) := by
   -- Provide the dual action, stabilizer, and induced representation constructions
   refine ⟨dualSmulAux φ, fun g χ a => rfl, stabAux φ, fun χ g => Iff.rfl, ?_⟩
   -- Use the concrete induced representation V(χ, U) = Ind_{G_χ ⋉ A}^{G ⋉ A} (U ⊗ ℂ_χ)
   refine ⟨fun χ U => inducedRepV φ χ U,
-    fun _ _ _ hg U₁ => transportRep φ hg U₁, ?_, ?_, ?_, ?_, ?_, ?_⟩
+    fun _ _ _ hg U₁ => transportRep φ hg U₁, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   -- (i) Irreducibility: V(χ, U) is irreducible when U is irreducible
   · exact fun χ U hU => inducedRepV_simple φ χ U hU
   -- (ii) Classification: iso forces same G-orbit and isomorphic transported U-component
@@ -2402,3 +2471,11 @@ theorem Etingof.Theorem5_27_1
   · exact fun χ U => inducedRepV_finrank φ χ U
   -- (vi) Functoriality: `U₁ ≅ U₂ ⟹ V(χ, U₁) ≅ V(χ, U₂)`
   · exact fun χ U₁ U₂ ⟨α⟩ => ⟨inducedRepV_congr φ χ α⟩
+  -- (vii) Base-point independence: `V(χ₁, U) ≅ V(χ₂, g(U))`
+  · exact fun _χ₁ _χ₂ U _g hg => (Etingof.inducedRepV_basepoint_independent φ hg U).map (·.symm)
+  -- (viii) Central-transport triviality: `g(U) ≅ U` for central `g` fixing `χ`
+  · exact fun _χ _g hg U hcentral => ⟨transportRep_central_iso φ hg hcentral U⟩
+  -- (ix) Transport preserves simplicity
+  · intro _χ₁ _χ₂ U _g hg hU
+    haveI := hU
+    exact transportRep_simple φ hg U

--- a/progress/2026-07-13T09-00-53Z_80c1266d.md
+++ b/progress/2026-07-13T09-00-53Z_80c1266d.md
@@ -1,0 +1,40 @@
+## Accomplished
+Extended the public interface of `Etingof.Theorem5_27_1` (orbit-method
+classification of `A ⋊[φ] G` irreps) with three new conjuncts, discharging
+issue #6484. These are shared infrastructure that all three orbit-method
+assembly exercises (dihedral #6471, affine, Heisenberg) need but the original
+(i)-(vi) interface could not supply, because the assemblies receive
+`V`/`transport` as opaque existential witnesses:
+
+- **(vii) base-point independence** `V χ₁ U ≅ V χ₂ (transport g χ₁ χ₂ hg U)`
+  (proved from the existing private `inducedRepV_basepoint_independent`);
+- **(viii) central-transport triviality** `transport g χ χ hg U ≅ U` for central
+  `g` fixing `χ` (new private `transportRep_central_iso`; the conjugation
+  `conjStabHom` is the identity when `g` is central, and `(FDRep.of ρ).V` is
+  defeq to the underlying object so `Action.mkIso` on `LinearEquiv.refl` works);
+- **(ix) transport preserves simplicity** (new `conjStabEquiv : G_χ₂ ≃* G_χ₁`
+  upgrading `conjStabHom` to a `MulEquiv`, so `transportRep = res` along it is an
+  equivalence of rep categories; simplicity transported via a local
+  `simple_equivalence_functor'`).
+
+`Exercise5_27_2_Dihedral.lean`'s `semidirect_classification` destructure updated
+to bind `hvii, hviii, hix` (still one `sorry`, unchanged — that is #6471).
+
+## Current frontier
+Engine interface complete. `#print axioms Etingof.Theorem5_27_1` still
+`[propext, Classical.choice, Quot.sound]`. Both files build clean (no new
+errors; Dihedral keeps its single pre-existing sorry).
+
+## Overall project progress
+Phase 3 formalization. Theorem 5.27.1 engine now exposes (i)-(ix). The dihedral
+assembly #6471 (blocked on this) becomes tractable: injectivity of the two
+1-dim reps at a self-paired character uses (ii)+(viii); free-orbit completeness
+uses (vii)+(ix); counts via `DihedralCharacterCombinatorics`.
+
+## Next step
+Land this PR (#6484), then unblock and execute #6471 (roadmap steps 4-6): build
+the `Fin n` family over the inversion-orbit transversal and discharge the six
+classification conjuncts + Odd/Even counts.
+
+## Blockers
+None.


### PR DESCRIPTION
Closes #6484

Session: `80c1266d-27cc-4dae-af0c-951761244f3d`

8b7d6822 feat(Ch5 #6484): expose basepoint-independence (vii), central-transport-triviality (viii), transport-preserves-simplicity (ix) as public conjuncts of Theorem5_27_1

🤖 Prepared with Claude Code