### PR TITLE
feat(Ch5 #Problem5.24.2): reduce the FFT to the multihomogeneous Schur-Weyl core

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Exercise5_27_2_Heisenberg.lean
+++ b/EtingofRepresentationTheory/Chapter5/Exercise5_27_2_Heisenberg.lean
@@ -340,7 +340,7 @@ theorem heisenberg_classification :
       (Finset.univ.filter (fun i => finrank ℂ (W i : Type) = 1)).card = p ^ 2 ∧
       (Finset.univ.filter (fun i => finrank ℂ (W i : Type) = p)).card = p - 1 := by
   classical
-  obtain ⟨dualSmul, hdual, stab, hstab, V, transport, hi, hii, hiii, hiv, hv, hvi⟩ :=
+  obtain ⟨dualSmul, hdual, stab, hstab, V, transport, hi, hii, hiii, hiv, hv, hvi, _, _, _⟩ :=
     Etingof.Theorem5_27_1 (Multiplicative (ZMod p)) (Multiplicative (ZMod p × ZMod p))
       (heisenbergφ p)
   -- Dual action on the parametrized characters: `g · χ_{β,γ} = χ_{β − a·γ, γ}`.

--- a/EtingofRepresentationTheory/Chapter5/Problem5_24_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_24_2.lean
@@ -31,7 +31,14 @@ The claim: the invariant ring is generated as a `ℂ`-algebra by the `traceWord 
 
 The elementary `⊇` inclusion (`traceWord_mem_invariantSubalgebra`: each `T_w` is
 conjugation-invariant) is proved. The deep `⊆` inclusion (the First Fundamental Theorem, via
-Schur–Weyl) is isolated as `invariantSubalgebra_le_adjoin_traceWord`, currently a `sorry`.
+Schur–Weyl) is `invariantSubalgebra_le_adjoin_traceWord`. It is reduced to the multihomogeneous
+case following the book's hint: with the multidegree grading `matrixWeight` (variable `(i, r, c)`
+has weight `single i 1`), an invariant is the finite sum of its `matrixWeight`-homogeneous
+components, each of which is again invariant
+(`weightedHomogeneousComponent_mem_invariantSubalgebra`, proved via the fact that `conjAlgHom`
+preserves the grading). The remaining Schur–Weyl core — that a fixed-multidegree invariant lies in
+the trace subalgebra — is isolated as `weightedHomogeneous_invariant_mem_adjoin`, the single
+`sorry` (tracked as a follow-up issue).
 -/
 
 noncomputable section
@@ -121,19 +128,150 @@ theorem traceWord_mem_invariantSubalgebra (w : List (Fin k)) :
   rw [traceWord, AddMonoidHom.map_trace (conjAlgHom k N g), ← AlgHom.mapMatrix_apply, key,
     Matrix.trace_mul_comm, ← mul_assoc, hG'G, one_mul]
 
+open MvPolynomial
+
+/-- **Multidegree weight.** The entry variable `(i, r, c)` of the `i`-th generic matrix is given
+weight `single i 1`. A polynomial is `matrixWeight`-homogeneous of weight `d : Fin k →₀ ℕ` exactly
+when it is multihomogeneous of degree `d i` in the entries of `Xᵢ` for every `i` — the grading the
+book's hint uses ("invariant functions of degree `dᵢ` in each `Xᵢ`"). -/
+def matrixWeight : Fin k × Fin N × Fin N → (Fin k →₀ ℕ) := fun v => Finsupp.single v.1 1
+
+/-- Conjugation substitutes the entry variable `(i, r, c)` by an entry of `G · Xᵢ · G⁻¹`, a
+`ℂ`-linear combination of the entries of `Xᵢ`; hence `conjAlgHom g (X v)` is `matrixWeight`
+homogeneous of the same weight `single i 1` as `X v`. -/
+theorem conjAlgHom_X_isWeightedHomogeneous (g : (Matrix (Fin N) (Fin N) ℂ)ˣ)
+    (v : Fin k × Fin N × Fin N) :
+    IsWeightedHomogeneous (matrixWeight k N) (conjAlgHom k N g (X v)) (matrixWeight k N v) := by
+  obtain ⟨i, r, c⟩ := v
+  -- A single conjugated entry `C α · X (i,a,b) · C β` is weight-`single i 1` homogeneous.
+  have hCXC : ∀ (α β : ℂ) (a b : Fin N),
+      IsWeightedHomogeneous (matrixWeight k N)
+        (C α * X ((i, a, b) : Fin k × Fin N × Fin N) * C β) (Finsupp.single i 1) := by
+    intro α β a b
+    have hcxc : C α * X ((i, a, b) : Fin k × Fin N × Fin N) * C β
+        = C (α * β) * X ((i, a, b) : Fin k × Fin N × Fin N) := by
+      rw [mul_right_comm, ← map_mul]
+    rw [hcxc]
+    have hX : IsWeightedHomogeneous (matrixWeight k N)
+        (X ((i, a, b) : Fin k × Fin N × Fin N) : MatrixTupleRing k N) (Finsupp.single i 1) :=
+      isWeightedHomogeneous_X (R := ℂ) (matrixWeight k N) (i, a, b)
+    exact hX.C_mul _
+  -- Expand `conjAlgHom g (X (i,r,c))` as the matrix entry `(G · Xᵢ · G⁻¹) r c`, a double sum.
+  simp only [conjAlgHom, MvPolynomial.aeval_X]
+  rw [Matrix.mul_apply]
+  apply IsWeightedHomogeneous.sum
+  intro b _
+  rw [Matrix.mul_apply, Finset.sum_mul]
+  apply IsWeightedHomogeneous.sum
+  intro a _
+  simp only [Matrix.map_apply, MvPolynomial.algebraMap_eq, genericMatrix]
+  exact hCXC ((↑g : Matrix (Fin N) (Fin N) ℂ) r a) ((↑g⁻¹ : Matrix (Fin N) (Fin N) ℂ) b c) a b
+
+/-- Conjugation sends the monomial `X^u` to a `matrixWeight`-homogeneous polynomial of weight
+`weight u`: each variable `X v` maps to a weight-`matrixWeight v` homogeneous element, and taking
+products/powers adds the weights. -/
+theorem conjAlgHom_monomial_isWeightedHomogeneous (g : (Matrix (Fin N) (Fin N) ℂ)ˣ)
+    (u : (Fin k × Fin N × Fin N) →₀ ℕ) (a : ℂ) :
+    IsWeightedHomogeneous (matrixWeight k N) (conjAlgHom k N g (monomial u a))
+      (Finsupp.weight (matrixWeight k N) u) := by
+  have hbase : ∀ v, IsWeightedHomogeneous (matrixWeight k N)
+      (conjAlgHom k N g (X v)) (matrixWeight k N v) :=
+    conjAlgHom_X_isWeightedHomogeneous k N g
+  rw [monomial_eq, map_mul, ← MvPolynomial.algebraMap_eq, AlgHom.commutes,
+    MvPolynomial.algebraMap_eq]
+  apply IsWeightedHomogeneous.C_mul
+  simp only [Finsupp.prod, map_prod, map_pow]
+  rw [show Finsupp.weight (matrixWeight k N) u
+      = ∑ n ∈ u.support, (u n) • (matrixWeight k N n) by rw [Finsupp.weight_apply]; rfl]
+  exact IsWeightedHomogeneous.prod u.support
+    (fun n => (conjAlgHom k N g (X n)) ^ (u n)) (fun n => (u n) • matrixWeight k N n)
+    (fun n _ => (hbase n).pow (u n))
+
+/-- Conjugation commutes with taking `matrixWeight`-homogeneous components: since `conjAlgHom g`
+maps each weight-`d` homogeneous piece into the weight-`d` piece, it commutes with the projection
+`weightedHomogeneousComponent d`. -/
+theorem conjAlgHom_weightedHomogeneousComponent (g : (Matrix (Fin N) (Fin N) ℂ)ˣ)
+    (d : Fin k →₀ ℕ) (p : MatrixTupleRing k N) :
+    weightedHomogeneousComponent (matrixWeight k N) d (conjAlgHom k N g p)
+      = conjAlgHom k N g (weightedHomogeneousComponent (matrixWeight k N) d p) := by
+  induction p using MvPolynomial.induction_on' with
+  | monomial u a =>
+    have hm : IsWeightedHomogeneous (matrixWeight k N) (monomial u a)
+        (Finsupp.weight (matrixWeight k N) u) :=
+      isWeightedHomogeneous_monomial _ _ _ rfl
+    have hcm : IsWeightedHomogeneous (matrixWeight k N) (conjAlgHom k N g (monomial u a))
+        (Finsupp.weight (matrixWeight k N) u) :=
+      conjAlgHom_monomial_isWeightedHomogeneous k N g u a
+    by_cases hd : d = Finsupp.weight (matrixWeight k N) u
+    · subst hd
+      rw [hcm.weightedHomogeneousComponent_same, hm.weightedHomogeneousComponent_same]
+    · rw [hcm.weightedHomogeneousComponent_ne d hd, hm.weightedHomogeneousComponent_ne d hd,
+        map_zero]
+  | add p q hp hq =>
+    simp only [map_add, hp, hq]
+
+/-- Each `matrixWeight`-homogeneous component of a conjugation-invariant polynomial is itself
+conjugation-invariant. -/
+theorem weightedHomogeneousComponent_mem_invariantSubalgebra (d : Fin k →₀ ℕ)
+    {f : MatrixTupleRing k N} (hf : f ∈ invariantSubalgebra k N) :
+    weightedHomogeneousComponent (matrixWeight k N) d f ∈ invariantSubalgebra k N := by
+  rw [invariantSubalgebra, Algebra.mem_iInf] at hf ⊢
+  intro g
+  rw [AlgHom.mem_equalizer, AlgHom.id_apply]
+  have hg : conjAlgHom k N g f = f := by
+    have := hf g; rwa [AlgHom.mem_equalizer, AlgHom.id_apply] at this
+  rw [← conjAlgHom_weightedHomogeneousComponent k N g d f, hg]
+
+/-- **First Fundamental Theorem of matrix invariants, multihomogeneous case (Schur–Weyl core).**
+Every `matrixWeight`-homogeneous conjugation-invariant polynomial lies in the subalgebra generated
+by the trace-of-word functions `T_w`.
+
+This is the substantive content of Problem 5.24.2, isolated to a fixed multidegree `d`. Following
+the book's hint: the degree-`d` invariants form `⨂_i Sᵈⁱ(V ⊗ V*)`, which embeds into
+`(V ⊗ V*)^{⊗n} = End(V)^{⊗n}` with `n = ∑ dᵢ`; by Schur–Weyl duality (Theorem 5.18.4, the double
+centralizer theorem) the `GL(V)`-invariants of `End(V)^{⊗n}` are spanned by the permutation
+operators `σ ∈ Sₙ`, whose traces over the tensor factors are products of trace-of-word functions.
+The Schur–Weyl / permutation-spanning input is the remaining work (tracked as a follow-up issue). -/
+theorem weightedHomogeneous_invariant_mem_adjoin (d : Fin k →₀ ℕ)
+    {p : MatrixTupleRing k N}
+    (hhom : IsWeightedHomogeneous (matrixWeight k N) p d)
+    (hinv : p ∈ invariantSubalgebra k N) :
+    p ∈ Algebra.adjoin ℂ (Set.range (traceWord k N)) := by
+  sorry
+
 /-- **First Fundamental Theorem of matrix invariants (the deep inclusion).** Every polynomial
 invariant under simultaneous conjugation lies in the subalgebra generated by the trace-of-word
 functions `T_w`.
 
-This is the substantive content of Problem 5.24.2. Following the book's hint: the
-degree-`(d₁,…,d_k)` invariants form `⨂_i Sᵈ(V ⊗ V*)`, which embeds into
-`(V ⊗ V*)^{⊗n} = End(V)^{⊗n}`; by Schur–Weyl
-duality the `GL(V)`-invariants of `End(V)^{⊗n}` are spanned by the permutation operators, whose
-traces are products of trace-of-word functions. The Schur–Weyl / permutation-spanning input is the
-remaining work (tracked as a follow-up issue). -/
+Reduction to the multihomogeneous case: an invariant `f` is the (finite) sum of its
+`matrixWeight`-homogeneous components; each component is again invariant
+(`weightedHomogeneousComponent_mem_invariantSubalgebra`) and homogeneous, so lies in the trace
+subalgebra by `weightedHomogeneous_invariant_mem_adjoin` (the Schur–Weyl core), and the subalgebra
+is closed under the finite sum. -/
 theorem invariantSubalgebra_le_adjoin_traceWord :
     invariantSubalgebra k N ≤ Algebra.adjoin ℂ (Set.range (traceWord k N)) := by
-  sorry
+  intro f hf
+  set S := Algebra.adjoin ℂ (Set.range (traceWord k N)) with hS
+  rw [← sum_weightedHomogeneousComponent (matrixWeight k N) f]
+  -- The homogeneous components have finite support, contained in `weight '' f.support`.
+  set s : Finset (Fin k →₀ ℕ) := f.support.image (Finsupp.weight (matrixWeight k N)) with hs
+  have hsub : (Function.support fun m => weightedHomogeneousComponent (matrixWeight k N) m f)
+      ⊆ (s : Set (Fin k →₀ ℕ)) := by
+    intro m hm
+    simp only [Function.mem_support] at hm
+    by_contra hmem
+    apply hm
+    apply weightedHomogeneousComponent_eq_zero'
+    intro d hd hweq
+    apply hmem
+    rw [hs, Finset.coe_image, Set.mem_image]
+    exact ⟨d, hd, hweq⟩
+  rw [finsum_eq_finsetSum_of_support_subset _ hsub]
+  refine Subalgebra.sum_mem _ ?_
+  intro d _
+  exact weightedHomogeneous_invariant_mem_adjoin k N d
+    (weightedHomogeneousComponent_isWeightedHomogeneous d f)
+    (weightedHomogeneousComponent_mem_invariantSubalgebra k N d hf)
 
 /-- Problem 5.24.2. The invariant ring `R_{k,N}` of polynomials on `k`-tuples of `N × N` matrices,
 invariant under simultaneous conjugation, is generated as a `ℂ`-algebra by the trace-of-word

--- a/progress/2026-07-13T10-21-56Z_4a08e6bc.md
+++ b/progress/2026-07-13T10-21-56Z_4a08e6bc.md
@@ -1,0 +1,54 @@
+## Accomplished
+
+Worked issue #6485 (Ch5 Problem 5.24.2, the FFT/Schur–Weyl deep inclusion) as a top-down
+reduction, per the deliverable's "state the Schur–Weyl input as a named intermediate lemma
+(sorry), reduce this theorem to it, land the reduction."
+
+In `EtingofRepresentationTheory/Chapter5/Problem5_24_2.lean`:
+
+- Added the multidegree grading `matrixWeight` (entry variable `(i, r, c)` has weight
+  `single i 1`), matching the book hint's "invariant functions of degree `dᵢ` in each `Xᵢ`".
+- Proved that `conjAlgHom g` preserves this grading:
+  - `conjAlgHom_X_isWeightedHomogeneous`: each conjugated variable `conjAlgHom g (X v)` is
+    weight-`matrixWeight v` homogeneous (a `ℂ`-linear combination of block-`i` entries).
+  - `conjAlgHom_monomial_isWeightedHomogeneous`: `conjAlgHom g (Xᵘ)` is weight-`weight u`
+    homogeneous (products/powers add weights).
+  - `conjAlgHom_weightedHomogeneousComponent`: `conjAlgHom g` commutes with
+    `weightedHomogeneousComponent d` (via `induction_on'`).
+- Proved `weightedHomogeneousComponent_mem_invariantSubalgebra`: each homogeneous component of an
+  invariant is again invariant.
+- **Proved the main theorem** `invariantSubalgebra_le_adjoin_traceWord` (previously a bare
+  `sorry`): an invariant is the finite sum of its `matrixWeight`-homogeneous components, each of
+  which lands in the trace subalgebra by the isolated Schur–Weyl core, and the subalgebra is
+  closed under the finite sum.
+- Isolated the deep content as `weightedHomogeneous_invariant_mem_adjoin` (the multihomogeneous
+  FFT / Schur–Weyl-permutation-spanning input) — the single remaining `sorry`.
+
+`lake build EtingofRepresentationTheory.Chapter5.Problem5_24_2` succeeds.
+
+## Current frontier
+
+The file builds with exactly one `sorry`: `weightedHomogeneous_invariant_mem_adjoin` — a
+fixed-multidegree conjugation-invariant polynomial lies in the trace-word subalgebra. This is the
+genuine Schur–Weyl content (embed degree-`d` invariants into `End(V)^{⊗n}`, use double-centralizer
+Theorem 5.18.4 to span invariants by permutation operators, whose tensor-traces are products of
+trace-of-word functions).
+
+## Overall project progress
+
+Phase 3 formalization ongoing. Problem 5.24.2: elementary inclusion done previously; this turn the
+deep inclusion is reduced to its multihomogeneous core with all multidegree-decomposition glue
+proved. Sorry count in the file stays at 1 but the sorry is now a specific, standard lemma rather
+than the whole FFT.
+
+## Next step
+
+Discharge `weightedHomogeneous_invariant_mem_adjoin` (follow-up issue). This needs the Schur–Weyl /
+double-centralizer machinery (Theorem 5.18.4) connected to `End(V)^{⊗n}` and the trace pairing —
+likely itself a multi-issue effort (embedding the multidegree-`d` invariants into
+`(V ⊗ V*)^{⊗n}`, the permutation-spanning of `GL(V)`-invariants, and identifying permutation
+tensor-traces with products of `traceWord`).
+
+## Blockers
+
+None. The deep lemma is stated with a real signature and a `sorry` body; downstream is unblocked.

--- a/progress/2026-07-13T11-40-00Z_repair-6493.md
+++ b/progress/2026-07-13T11-40-00Z_repair-6493.md
@@ -1,0 +1,22 @@
+## Accomplished
+Repaired PR #6493 (feat Ch5 #Problem5.24.2). CI was red, but the failure
+was inherited from a pre-existing breakage on `main`: `Theorem5_27_1` grew
+conjuncts (vii),(viii),(ix) (PR #6488), while `Exercise5_27_2_Heisenberg.lean`
+still destructured `Etingof.Theorem5_27_1` through only `hvi`, so `hvi` bound
+the tail `(vi)∧(vii)∧(viii)∧(ix)` (an `And`) instead of the (vi) functoriality
+function — hence "Function expected" at lines 624/647. Fixed by extending the
+`obtain` pattern with three trailing `_` for the new conjuncts.
+
+## Current frontier
+Full `lake build` is green (9168 jobs, 0 errors). PR #6493 branch = origin/main
++ Problem5_24_2 change + this one-line destructuring fix.
+
+## Overall project progress
+Stage 3 formalization ongoing. `main` build was broken; this PR now also
+unbreaks it once merged.
+
+## Next step
+Let auto-merge land PR #6493. No further action.
+
+## Blockers
+None.


### PR DESCRIPTION
Partial progress on #6485

Session: `4a08e6bc-8304-46cf-8a87-9e772c823b34`

2c6e68b7 feat(Ch5 #Problem5.24.2): reduce FFT to the multihomogeneous Schur-Weyl core

🤖 Prepared with Claude Code