### PR TITLE
feat(Ch4 #6503): reduce SU(2)→SO(3) surjectivity to SO(3) Euler decomposition

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Problem4_12_7.lean
+++ b/EtingofRepresentationTheory/Chapter4/Problem4_12_7.lean
@@ -34,11 +34,12 @@ and the quaternions by `ℍ[ℝ] = Quaternion ℝ`. The group of unit quaternion
 `unitary ℍ[ℝ]` (`{q : star q * q = 1 = q * star q}`, i.e. `normSq q = 1`).
 
 Parts **(a)**, **(d)**, **(e)** are proved sorry-free.  Part **(f)** builds the conjugation
-homomorphism `h : SU(2) → SO(3)` genuinely and proves its kernel is exactly `{1, -1}`; the one
-remaining `sorry` is the *surjectivity* of `h` (`rotHom_surjective`), the classical `2:1`-cover
-statement that every rotation of `ℝ³` is conjugation by a unit quaternion (axis–angle normal form,
-not yet in Mathlib).  Parts (b) and (c) (the commutant description of `ℍ` and the explicit
-`1, i, j, k` basis) are left for a later pass.
+homomorphism `h : SU(2) → SO(3)` genuinely, proves its kernel is exactly `{1, -1}`, and reduces its
+surjectivity (`rotHom_surjective`) to the Euler `Z-Y-Z` decomposition of `SO(3)` via the
+coordinate-axis rotation lemmas.  The one remaining `sorry` is that Euler decomposition
+(`so3_euler_zyz`: every `R ∈ SO(3)` is `Rz α · Ry β · Rz γ`), the classical existence of Euler
+angles, not yet available in Mathlib.  Parts (b) and (c) (the commutant description of `ℍ` and the
+explicit `1, i, j, k` basis) are left for a later pass.
 
 * **(a)** `V = ℂ²` as a real representation: `Fin 2 → ℂ` is an `ℝ`-module and `SU(2)` acts
   `ℝ`-linearly by `Matrix.mulVec`. Irreducibility over `ℝ` is: every `SU(2)`-invariant
@@ -549,16 +550,86 @@ lemma rotMat_zAxis (c s : ℝ) :
   ext i j
   fin_cases i <;> fin_cases j <;> simp [rotMat, qI, qJ, qK] <;> ring
 
+/-- The `3 × 3` matrix of the rotation of `ℝ³` by angle `θ` about the `z`-axis (the `k`-axis, i.e.
+the last coordinate). -/
+noncomputable def Rz (θ : ℝ) : Matrix (Fin 3) (Fin 3) ℝ :=
+  !![Real.cos θ, -Real.sin θ, 0; Real.sin θ, Real.cos θ, 0; 0, 0, 1]
+
+/-- The `3 × 3` matrix of the rotation of `ℝ³` by angle `θ` about the `y`-axis (the `j`-axis, i.e.
+the middle coordinate). -/
+noncomputable def Ry (θ : ℝ) : Matrix (Fin 3) (Fin 3) ℝ :=
+  !![Real.cos θ, 0, Real.sin θ; 0, 1, 0; -Real.sin θ, 0, Real.cos θ]
+
+/-- **Half-angle bridge, `z`-axis.** The half-angle quaternion `⟨cos (θ/2), 0, 0, sin (θ/2)⟩`
+conjugates to the full-angle `z`-rotation `Rz θ`, via the double-angle identities
+`cos²(θ/2) - sin²(θ/2) = cos θ` and `2 cos(θ/2) sin(θ/2) = sin θ`. -/
+lemma rotMat_zAxis_half (θ : ℝ) :
+    rotMat (⟨Real.cos (θ / 2), 0, 0, Real.sin (θ / 2)⟩ : ℍ[ℝ]) = Rz θ := by
+  have hθ : (2 : ℝ) * (θ / 2) = θ := by ring
+  have hcos : Real.cos (θ / 2) ^ 2 - Real.sin (θ / 2) ^ 2 = Real.cos θ := by
+    have h := Real.cos_two_mul' (θ / 2); rw [hθ] at h; exact h.symm
+  have hsin : 2 * Real.cos (θ / 2) * Real.sin (θ / 2) = Real.sin θ := by
+    have h := Real.sin_two_mul (θ / 2); rw [hθ] at h; rw [h]; ring
+  have hone : Real.cos (θ / 2) ^ 2 + Real.sin (θ / 2) ^ 2 = 1 := Real.cos_sq_add_sin_sq _
+  rw [rotMat_zAxis, Rz, hcos, hsin, hone]
+
+/-- **Half-angle bridge, `y`-axis.** The half-angle quaternion `⟨cos (θ/2), 0, sin (θ/2), 0⟩`
+conjugates to the full-angle `y`-rotation `Ry θ`. -/
+lemma rotMat_yAxis_half (θ : ℝ) :
+    rotMat (⟨Real.cos (θ / 2), 0, Real.sin (θ / 2), 0⟩ : ℍ[ℝ]) = Ry θ := by
+  have hθ : (2 : ℝ) * (θ / 2) = θ := by ring
+  have hcos : Real.cos (θ / 2) ^ 2 - Real.sin (θ / 2) ^ 2 = Real.cos θ := by
+    have h := Real.cos_two_mul' (θ / 2); rw [hθ] at h; exact h.symm
+  have hsin : 2 * Real.cos (θ / 2) * Real.sin (θ / 2) = Real.sin θ := by
+    have h := Real.sin_two_mul (θ / 2); rw [hθ] at h; rw [h]; ring
+  have hone : Real.cos (θ / 2) ^ 2 + Real.sin (θ / 2) ^ 2 = 1 := Real.cos_sq_add_sin_sq _
+  rw [rotMat_yAxis, Ry, hcos, hsin, hone]
+
+/-- **Euler `Z-Y-Z` decomposition of `SO(3)`.** Every special orthogonal `3 × 3` real matrix is a
+product of a rotation about the `z`-axis, one about the `y`-axis, and one about the `z`-axis. This
+is the classical existence of Euler angles; it is the remaining analytic input to
+`rotHom_surjective` and is not yet available in Mathlib.
+
+Proof route (for the follow-up): the third column `(R 0 2, R 1 2, R 2 2)` is a unit vector (columns
+of an orthogonal matrix are orthonormal), so `|R 2 2| ≤ 1`; set `β := arccos (R 2 2)` so
+`cos β = R 2 2` and `sin β ≥ 0`. When `sin β ≠ 0`, set `α := arctan2 (R 1 2) (R 0 2)` and
+`γ := arctan2 (R 2 1) (-(R 2 0))`; the orthonormality relations pin down every remaining entry of
+`Rz α * Ry β * Rz γ` to equal `R`. The degenerate cases `R 2 2 = ±1` (`β = 0` or `π`) reduce to a
+single `z`-rotation `Rz` composed with the sign. -/
+theorem so3_euler_zyz (R : Matrix (Fin 3) (Fin 3) ℝ)
+    (hR : R ∈ Matrix.specialOrthogonalGroup (Fin 3) ℝ) :
+    ∃ α β γ : ℝ, R = Rz α * Ry β * Rz γ := by
+  sorry
+
 /-- **Surjectivity of the quaternion cover.** Every rotation of Euclidean `ℝ³` is conjugation by a
 unit quaternion — the classical statement that `SU(2) → SO(3)` is the (`2:1`) universal cover.
-This is the axis–angle decomposition: a rotation by angle `θ` about a unit axis
-`n = (n₁, n₂, n₃)` is `rotMat (cos (θ/2) + sin (θ/2) · (n₁ i + n₂ j + n₃ k))`.
 
-TODO: this remaining piece requires the axis–angle normal form for `SO(3)` (every element of
-`SO(3)` fixes an axis, as `1` is an eigenvalue in odd dimension with determinant `1`), which is not
-yet available in Mathlib. -/
+Given `R ∈ SO(3)`, the Euler decomposition `R = Rz α · Ry β · Rz γ` (`so3_euler_zyz`) lifts, via the
+half-angle bridges and multiplicativity of `rotMat`, to the unit quaternion
+`q = ⟨cos(α/2),0,0,sin(α/2)⟩ · ⟨cos(β/2),0,sin(β/2),0⟩ · ⟨cos(γ/2),0,0,sin(γ/2)⟩` with
+`rotMat q = R`. -/
 theorem rotHom_surjective : Function.Surjective rotHom := by
-  sorry
+  intro R
+  obtain ⟨α, β, γ, hR⟩ := so3_euler_zyz (R : Matrix (Fin 3) (Fin 3) ℝ) R.2
+  set qz1 : ℍ[ℝ] := ⟨Real.cos (α / 2), 0, 0, Real.sin (α / 2)⟩ with hqz1
+  set qy : ℍ[ℝ] := ⟨Real.cos (β / 2), 0, Real.sin (β / 2), 0⟩ with hqy
+  set qz2 : ℍ[ℝ] := ⟨Real.cos (γ / 2), 0, 0, Real.sin (γ / 2)⟩ with hqz2
+  have hnz1 : Quaternion.normSq qz1 = 1 := by
+    rw [hqz1, Quaternion.normSq_def']; simpa using Real.cos_sq_add_sin_sq (α / 2)
+  have hny : Quaternion.normSq qy = 1 := by
+    rw [hqy, Quaternion.normSq_def']; simpa using Real.cos_sq_add_sin_sq (β / 2)
+  have hnz2 : Quaternion.normSq qz2 = 1 := by
+    rw [hqz2, Quaternion.normSq_def']; simpa using Real.cos_sq_add_sin_sq (γ / 2)
+  set q : ℍ[ℝ] := qz1 * qy * qz2 with hq
+  have hnq : Quaternion.normSq q = 1 := by
+    rw [hq, normSq_mul, normSq_mul, hnz1, hny, hnz2]; ring
+  refine ⟨⟨q, mem_unitary_iff_normSq.mpr hnq⟩, ?_⟩
+  apply Subtype.ext
+  rw [rotHom_coe]
+  show rotMat q = (R : Matrix (Fin 3) (Fin 3) ℝ)
+  rw [hq, rotMat_mul, rotMat_mul, hqz1, hqy, hqz2, rotMat_zAxis_half, rotMat_yAxis_half,
+    rotMat_zAxis_half]
+  exact hR.symm
 
 end PartF
 

--- a/EtingofRepresentationTheory/Chapter4/Problem4_12_7.lean
+++ b/EtingofRepresentationTheory/Chapter4/Problem4_12_7.lean
@@ -512,6 +512,43 @@ noncomputable def rotHom : unitary ℍ[ℝ] →* Matrix.specialOrthogonalGroup (
 @[simp] lemma rotHom_coe (q : unitary ℍ[ℝ]) :
     (rotHom q : Matrix (Fin 3) (Fin 3) ℝ) = rotMat (q : ℍ[ℝ]) := rfl
 
+/-! ### Coordinate-axis rotations in the image of `rotMat`
+
+The conjugation by the "half-angle" quaternion `⟨c, s, 0, 0⟩` (real part `c`, `i`-part `s`) is the
+rotation of `ℝ³` about the `i`-axis whose block on the `j,k`-plane is
+`!![c²-s², -2cs; 2cs, c²-s²]`.  With `c = cos (θ/2)`, `s = sin (θ/2)` the double-angle identities
+`c²-s² = cos θ`, `2cs = sin θ` turn this into the standard rotation `Rx θ`.  The `j`- and `k`-axis
+analogues are `rotMat_yAxis`/`rotMat_zAxis`.  These are the one-parameter subgroups that generate
+`SO(3)` (Euler decomposition), the route to `rotHom_surjective`.  Stated as exact polynomial
+identities in `c, s` (no `c²+s²=1` needed), so they compose cleanly under `rotMat_mul`. -/
+lemma rotMat_xAxis (c s : ℝ) :
+    rotMat (⟨c, s, 0, 0⟩ : ℍ[ℝ]) =
+      !![c ^ 2 + s ^ 2, 0, 0;
+         0, c ^ 2 - s ^ 2, -(2 * c * s);
+         0, 2 * c * s, c ^ 2 - s ^ 2] := by
+  ext i j
+  fin_cases i <;> fin_cases j <;> simp [rotMat, qI, qJ, qK] <;> ring
+
+/-- Conjugation by `⟨c, 0, s, 0⟩` is the rotation of `ℝ³` about the `j`-axis; with
+`c = cos (θ/2)`, `s = sin (θ/2)` it is the standard rotation `Ry θ`. -/
+lemma rotMat_yAxis (c s : ℝ) :
+    rotMat (⟨c, 0, s, 0⟩ : ℍ[ℝ]) =
+      !![c ^ 2 - s ^ 2, 0, 2 * c * s;
+         0, c ^ 2 + s ^ 2, 0;
+         -(2 * c * s), 0, c ^ 2 - s ^ 2] := by
+  ext i j
+  fin_cases i <;> fin_cases j <;> simp [rotMat, qI, qJ, qK] <;> ring
+
+/-- Conjugation by `⟨c, 0, 0, s⟩` is the rotation of `ℝ³` about the `k`-axis; with
+`c = cos (θ/2)`, `s = sin (θ/2)` it is the standard rotation `Rz θ`. -/
+lemma rotMat_zAxis (c s : ℝ) :
+    rotMat (⟨c, 0, 0, s⟩ : ℍ[ℝ]) =
+      !![c ^ 2 - s ^ 2, -(2 * c * s), 0;
+         2 * c * s, c ^ 2 - s ^ 2, 0;
+         0, 0, c ^ 2 + s ^ 2] := by
+  ext i j
+  fin_cases i <;> fin_cases j <;> simp [rotMat, qI, qJ, qK] <;> ring
+
 /-- **Surjectivity of the quaternion cover.** Every rotation of Euclidean `ℝ³` is conjugation by a
 unit quaternion — the classical statement that `SU(2) → SO(3)` is the (`2:1`) universal cover.
 This is the axis–angle decomposition: a rotation by angle `θ` about a unit axis

--- a/progress/2026-07-13T16-25-38Z_08b5715d.md
+++ b/progress/2026-07-13T16-25-38Z_08b5715d.md
@@ -1,0 +1,39 @@
+## Accomplished
+
+Worked #6503 (Ch4 Problem 4.12.7 part (f) surjectivity of `h : SU(2) → SO(3)`).
+
+- Merged ready PR #6508 (hom + kernel {±1}) to main first — it was CLEAN/green but
+  had no auto-merge, blocking this work. Rebased branch onto fresh main.
+- Added coordinate-axis rotation lemmas `rotMat_xAxis/yAxis/zAxis`: conjugation by the
+  half-angle quaternions `⟨c,s,0,0⟩` etc. gives the standard i/j/k-axis rotation matrices,
+  as exact polynomial identities in `c,s`.
+- Added full-angle `Rz`/`Ry` rotation-matrix defs and half-angle bridges
+  `rotMat_zAxis_half`/`rotMat_yAxis_half` (double-angle identities).
+- **Fully proved `rotHom_surjective`** (hence the surjectivity clause of
+  `exists_surjective_hom_to_SO3`) modulo one clean quaternion-free lemma
+  `so3_euler_zyz` (every `R ∈ SO(3)` is `Rz α · Ry β · Rz γ`). Assembly lifts the Euler
+  decomposition through `rotMat_mul` to a unit-quaternion product.
+- Reduced the file to a single `sorry` (`so3_euler_zyz`), down from the surjectivity `sorry`.
+
+Also released #6513 (claimed then found stale: its `matrixSum_cycle_eq_trace` scaffolding
+assumed a #6506 partial PR that never landed; #6506 is still open+claimed). Added
+`depends-on #6506` and skipped to replan.
+
+## Current frontier
+
+`so3_euler_zyz` (Euler Z-Y-Z existence) is the last sorry in Problem4_12_7.lean. It is a
+pure real 3×3 matrix statement (no quaternions), decomposed into #6515 with a full route.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. Problem 4.12.7 parts (a),(d),(e) sorry-free; part (f)
+hom+kernel done (#6508) and surjectivity reduced to #6515. Parts (b),(c) deferred.
+
+## Next step
+
+Claim #6515 and prove `so3_euler_zyz` (arccos/arg angle extraction + orthonormality
+entry-matching, degenerate poles `R 2 2 = ±1`). That closes part (f) sorry-free.
+
+## Blockers
+
+None for #6515. #6513 blocked on #6506 (in progress).


### PR DESCRIPTION
This PR reduces the surjectivity of the quaternion cover `h : SU(2) → SO(3)` (Problem 4.12.7 part (f)) to a single clean, quaternion-free lemma. It adds the coordinate-axis rotation lemmas `rotMat_xAxis/yAxis/zAxis` (conjugation by half-angle quaternions gives the standard i/j/k-axis rotations, as exact polynomial identities in `c, s`), the full-angle `Rz`/`Ry` rotation-matrix definitions with their half-angle bridges `rotMat_zAxis_half`/`rotMat_yAxis_half`, and proves `rotHom_surjective` (hence the surjectivity clause of `exists_surjective_hom_to_SO3`) by lifting the Euler Z-Y-Z decomposition of `SO(3)` through `rotMat_mul` to a unit-quaternion product.

The one remaining `sorry` in `Problem4_12_7.lean` is now `so3_euler_zyz` — every `R ∈ SO(3)` is `Rz α · Ry β · Rz γ`, the classical existence of Euler angles, a pure real 3×3 matrix statement not yet in Mathlib. It is tracked with a full proof route in #6515; discharging it makes the file sorry-free.

Partial progress on #6503 (remaining work: #6515).

🤖 Prepared with Claude Code