### PR TITLE
feat(Ch9 #6541): graded cons-preimage — surjectivity of Φ onto top-degree components

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -488,6 +488,21 @@ wrapper (`map_add`/`add_add_add_comm` for the add cases; for the `smul_tprod r v
 `TensorProduct.smul_tmul` to move `r` onto `w` and reuse the generator lemma with `r • w`). The pointwise
 form is equivalent and directly usable downstream. Prefer it for any barModule-style map with symbolic degree.
 
+### A tensor RHS with `(m : M)` silently becomes `sorry` when the equation LHS is a `ModuleCat`-hom application (Ch9 induced modules `A ⊗_S M`, #6541)
+
+Writing a lemma `(someHom M).hom η = a ⊗ₜ[Q → k] (m : M)` where the RHS is a `TensorProduct` and
+`m : restrictObj M` **elaborates the whole RHS to `sorry`** — the error then surfaces later as a
+mysterious `⊢ … = sorry` in the *proof* goal, not as a statement error. Cause: `(someHom M).hom η`
+has type `↑(inducedRestrictObj M)` (a `ModuleCat` carrier), which is **not syntactically** a
+`TensorProduct`, so the elaborator can't propagate the second-factor module instance to the RHS
+`⊗ₜ` and gives up. This is why `inducedCoordMap_tmul`-style lemmas work (their LHS type *is*
+`inducedCarrier M = TensorProduct …`) but a hom-application LHS does not. **Fix:** annotate the RHS
+tensor with the concrete carrier: `= (a ⊗ₜ[Q → k] (m : M) : inducedCarrier M)`. Two related pins in
+the same file: `map_add` on `f (a + b)` where the argument is a `Nat` sum `n + 1` rewrites the
+`n + 1` instead of the `a + b` — use `LinearMap.map_add` to force the module map; and a lemma whose
+implicit `k` is fixed only by pure quiver/`Nat` data (`exists_ofPath_mul_arrowElt q hx`) leaves
+`Field ?k` stuck — pass `(k := k)`.
+
 ### Assembling a `ProjectiveResolution` / quasi-iso to `single₀` from a (k-linear) contracting homotopy (Ch8 bar resolution, #6415)
 
 To turn a chain complex `C : ChainComplex (ModuleCat A) ℕ` with augmentation

--- a/EtingofRepresentationTheory/Chapter9/PathAlgebraConsSplittingIso.lean
+++ b/EtingofRepresentationTheory/Chapter9/PathAlgebraConsSplittingIso.lean
@@ -388,6 +388,105 @@ theorem inducedCoordMap_stdd_shift_zero (s : inducedVtensObj M) :
   | add s t hs ht =>
       simp only [map_add, Finsupp.add_apply, hs, ht]; abel
 
+/-! ## Graded surjectivity of `Φ` (the cons-preimage of the top component)
+
+The cons-splitting `A_n ⊗_S V ≅ A_{n+1}`, tensored with `M`, says that `Φ` restricts to an
+isomorphism from the degree-`n` part of `A ⊗_S (V ⊗_S M)` onto the degree-`(n+1)` part of
+`A ⊗_S M`. The **surjectivity** half of that graded iso is the piece consumed by
+`standardResolution_shortExact` (#6512): the downward middle-exactness telescoping needs, for each
+`y : A ⊗_S M` and each `n`, a degree-`n` preimage `η` of the degree-`(n+1)` component of `y` under
+`Φ`. This is the noncommutative analogue of the cons-preimage `coordMapCHInv` in
+`koszulSES_shortExact` (`Chapter9/Example9_4_4.lean`), built here directly from the combinatorial
+core `exists_ofPath_mul_arrowElt` (`Chapter9/PathAlgebraConsSplitting.lean`) rather than from an
+abstract graded-piece isomorphism.
+
+Because `Φ (a ⊗ v ⊗ m) = (a·v) ⊗ m` raises the length degree by one
+(`lengthProj_mul_arrowInclusion`), the produced `η` is genuinely homogeneous of degree `n`
+(`inducedCoordMapGen (VtensObj M) η n = η` and vanishes in every other degree), so its degree-shift
+coordinate `inducedCoordMap_stdd_shift` collapses to `Φ η` at degree `n+1` and to `0` above. -/
+
+/-- **Single-path cons-preimage.** For a basis path `x` of length `n + 1` and any `m`, the pure
+tensor `(x, m)` of `A ⊗_S M` is `Φ η` for an `η` homogeneous of degree `n`: split `x = p·e` into its
+length-`n` initial path `p` and final arrow `e` (`exists_ofPath_mul_arrowElt`) and take
+`η = (c • p) ⊗ (e ⊗ m)`. The basis-level seed of `exists_stdΦ_preimage_topDegree`. -/
+theorem exists_stdΦ_preimage_single_tmul (x : QuiverPathIndex Q) (c : k) {n : ℕ}
+    (hx : pathLen x = n + 1) (m : restrictObj M) :
+    ∃ η : inducedVtensObj M,
+      inducedCoordMapGen (VtensObj M) η n = η ∧
+      (∀ j, j ≠ n → inducedCoordMapGen (VtensObj M) η j = 0) ∧
+      (stdΦ M).hom η
+        = ((Finsupp.single x c : PathAlgebra k Q) ⊗ₜ[Q → k] (m : M) : inducedCarrier M) := by
+  obtain ⟨a, cc, q⟩ := x
+  rw [pathLen_mk] at hx
+  obtain ⟨b, p, e, hcomp, hlen⟩ := exists_ofPath_mul_arrowElt (k := k) q hx
+  have hlp : lengthProj k Q n (ofPath (⟨a, b, p⟩ : QuiverPathIndex Q))
+      = ofPath (⟨a, b, p⟩ : QuiverPathIndex Q) := by
+    rw [ofPath, lengthProj_single, pathLen_mk, hlen, if_pos rfl]
+  have hlp0 : ∀ j, j ≠ n →
+      lengthProj k Q j (ofPath (⟨a, b, p⟩ : QuiverPathIndex Q)) = 0 := by
+    intro j hj
+    rw [ofPath, lengthProj_single, pathLen_mk, hlen, if_neg (fun h => hj h.symm)]
+  refine ⟨(c • ofPath (⟨a, b, p⟩ : QuiverPathIndex Q)) ⊗ₜ[Q → k]
+      ((Finsupp.single (⟨b, cc, e⟩ : ArrowIndex Q) 1 : ArrowTgt k Q)
+        ⊗ₜ[Q → k] m : VtensObj M), ?_, ?_, ?_⟩
+  · rw [inducedCoordMapGen_tmul, map_smul, hlp]
+  · intro j hj
+    rw [inducedCoordMapGen_tmul, map_smul, hlp0 j hj, smul_zero, TensorProduct.zero_tmul]
+  · have hmul : (c • ofPath (⟨a, b, p⟩ : QuiverPathIndex Q))
+        * arrowInclusion (Finsupp.single (⟨b, cc, e⟩ : ArrowIndex Q) 1 : ArrowTgt k Q)
+        = (Finsupp.single (⟨a, cc, q⟩ : QuiverPathIndex Q) c : PathAlgebra k Q) := by
+      rw [arrowInclusion_single, one_smul, smul_mul_assoc, ← hcomp, ofPath, Finsupp.smul_single,
+        smul_eq_mul, mul_one]
+    rw [stdΦ_tmul, hmul]
+
+/-- **Graded surjectivity of `Φ` onto the top component (cons-preimage).** For every `y : A ⊗_S M`
+and every `n`, the degree-`(n+1)` homogeneous component `inducedCoordMap M y (n+1)` is `Φ η` for a
+degree-`n`-homogeneous `η : A ⊗_S (V ⊗_S M)`. This is the surjectivity half of the cons-splitting
+`A_n ⊗_S V ≅ A_{n+1}` (tensored with `M`), the missing infra that
+`standardResolution_shortExact` (#6512) plugs into for the middle-exactness downward telescoping.
+Reduces, via additivity, to the single-path case `exists_stdΦ_preimage_single_tmul`. -/
+theorem exists_stdΦ_preimage_topDegree (y : inducedRestrictObj M) (n : ℕ) :
+    ∃ η : inducedVtensObj M,
+      inducedCoordMapGen (VtensObj M) η n = η ∧
+      (∀ j, j ≠ n → inducedCoordMapGen (VtensObj M) η j = 0) ∧
+      (stdΦ M).hom η = inducedCoordMap M y (n + 1) := by
+  -- Local abbreviation for the "reachable by a degree-`n` preimage" predicate. Kept out of the
+  -- proof goal (only used to type the closure lemmas) so tensor-defeq rewrites stay well-typed.
+  let G : inducedCarrier M → Prop := fun z =>
+    ∃ η : inducedVtensObj M,
+      inducedCoordMapGen (VtensObj M) η n = η ∧
+      (∀ j, j ≠ n → inducedCoordMapGen (VtensObj M) η j = 0) ∧
+      (stdΦ M).hom η = z
+  have hzero : G 0 := ⟨0, by simp, by simp, by simp⟩
+  have hadd : ∀ z₁ z₂ : inducedCarrier M, G z₁ → G z₂ → G (z₁ + z₂) := by
+    rintro z₁ z₂ ⟨η₁, h1n, h1j, h1⟩ ⟨η₂, h2n, h2j, h2⟩
+    refine ⟨η₁ + η₂, ?_, ?_, ?_⟩
+    · rw [map_add, Finsupp.add_apply, h1n, h2n]
+    · intro j hj; rw [map_add, Finsupp.add_apply, h1j j hj, h2j j hj, add_zero]
+    · rw [map_add, h1, h2]
+  -- The homogeneous-degree-`(n+1)` reduction: it suffices to reach every `A_{n+1}`-pure tensor.
+  suffices H : ∀ (a : PathAlgebra k Q) (m : restrictObj M),
+      G (lengthProj k Q (n + 1) a ⊗ₜ[Q → k] (m : M)) by
+    induction y using TensorProduct.induction_on with
+    | zero =>
+        have h0 : inducedCoordMap M (0 : inducedRestrictObj M) (n + 1) = 0 := by simp
+        rw [h0]; exact hzero
+    | tmul a m => rw [inducedCoordMap_tmul]; exact H a m
+    | add y₁ y₂ hy₁ hy₂ =>
+        have hsum : inducedCoordMap M (y₁ + y₂) (n + 1)
+            = inducedCoordMap M y₁ (n + 1) + inducedCoordMap M y₂ (n + 1) := by
+          rw [LinearMap.map_add, Finsupp.add_apply]
+        rw [hsum]; exact hadd _ _ hy₁ hy₂
+  intro a m
+  induction a using Finsupp.induction_linear with
+  | zero => rw [map_zero, TensorProduct.zero_tmul]; exact hzero
+  | add f g hf hg => rw [map_add, TensorProduct.add_tmul]; exact hadd _ _ hf hg
+  | single x c =>
+      rw [lengthProj_single]
+      split_ifs with hx
+      · exact exists_stdΦ_preimage_single_tmul M x c hx m
+      · rw [TensorProduct.zero_tmul]; exact hzero
+
 end Induced
 
 end Etingof.PathAlgebra

--- a/progress/2026-07-14T01-13-26Z_0c482111.md
+++ b/progress/2026-07-14T01-13-26Z_0c482111.md
@@ -1,0 +1,49 @@
+## Accomplished
+
+Feature session on **#6541** (Ch9 cons-splitting iso `A_n ⊗_S V ≅ A_{n+1}`).
+
+Landed the **surjectivity / cons-preimage** content — the operationally-critical half of the
+issue and exactly the infra gap #6512 flagged — sorry-free in
+`EtingofRepresentationTheory/Chapter9/PathAlgebraConsSplittingIso.lean` (+99 lines):
+
+- `exists_stdΦ_preimage_single_tmul` — single-path cons-preimage: for a length-`(n+1)` basis path
+  `x`, the pure tensor `(x, m)` of `A ⊗_S M` is `Φ η` for `η = (c·p) ⊗ (e ⊗ m)` homogeneous of
+  degree `n`, split via the combinatorial core `exists_ofPath_mul_arrowElt`.
+- `exists_stdΦ_preimage_topDegree` — for every `y : A ⊗_S M` and every `n`, the degree-`(n+1)`
+  component `inducedCoordMap M y (n+1)` is `Φ η` for a **degree-`n`-homogeneous** `η`. Proved by a
+  homogeneous-degree reduction (`TensorProduct.induction_on` → `Finsupp.induction_linear` →
+  single-path case), with a local "reachable" predicate kept out of the goal to keep tensor-defeq
+  rewrites well-typed.
+
+This is the surjectivity half of the cons-splitting (tensored with `M`) that
+`standardResolution_shortExact` (#6512) needs for the middle-exactness downward telescoping. The
+injectivity half was already on `main`. **#6512 is unblocked.**
+
+`lake build EtingofRepresentationTheory.Chapter9.PathAlgebraConsSplittingIso` succeeds;
+`grep -c sorry` = 0; no sorried `def`/`instance`/`abbrev`.
+
+## Current frontier
+
+The **literal** deliverable of #6541 — the bundled genuine `≃ₗ` isomorphism
+`A_n ⊗_S V ≅ A_{n+1}` (sub-bimodule `A_n` + fresh balanced tensor with diamond-avoidance +
+real inverse + S-linearity) — was NOT built. It is a large, separate construction. Captured as
+follow-up issue **#6545** (surjectivity + injectivity now landed), with a note that the bundled
+`≃ₗ` may be optional for #6512 given the landed cons-preimage. #6541 landed `--partial`.
+
+## Overall project progress
+
+Phase 3 formalization, Chapter 9 standard length-1 projective resolution (parent #6420). Analytic
+seed (#6526/#6535), combinatorial core (#6510/#6514), and now the graded cons-preimage are all
+landed. Remaining Ch9 resolution work: `standardResolution_shortExact` assembly (#6512, now
+unblocked) and optionally the bundled `≃ₗ` packaging (#6545).
+
+## Next step
+
+Claim **#6512** (`standardResolution_shortExact`): `Mono (stdd M)` via the top-degree argument
+(seeded by `inducedCoordMap_stdd_tmul_*` + `inducedCoordMap(Gen)_injective`) and middle exactness
+via the downward telescoping, now feeding on `exists_stdΦ_preimage_topDegree` for the cons-preimage
+at each positive degree.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Partial progress on #6541

Session: `0c482111-0d03-428a-9f93-6334c12eef59`

1e86ba89 progress: Ch9 #6541 graded cons-preimage landed; #6545 follow-up for bundled iso
4c2da093 feat(Ch9 #6541): graded cons-preimage — surjectivity of Φ onto top-degree components

🤖 Prepared with Claude Code