### PR TITLE
feat(Ch5 #6490): prove affine_classification via Theorem 5.27.1

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Exercise5_27_2_Affine.lean
+++ b/EtingofRepresentationTheory/Chapter5/Exercise5_27_2_Affine.lean
@@ -41,7 +41,8 @@ trivial). Theorem 5.27.1 then yields:
 Thus there are exactly `q` irreducibles: `q - 1` of dimension `1` and one of dimension `q - 1`
 (consistent with `∑ dim² = (q - 1)·1 + (q - 1)² = q(q - 1) = |AffineGroup K|`).
 
-Statement pass: the classification is stated; the proof is left as `sorry`.
+The classification `affine_classification` is proved below by feeding the two orbit facts above
+into Theorem 5.27.1 (for fields with `q > 2`; see the theorem docstring for the `q = 2` caveat).
 -/
 
 noncomputable section
@@ -187,8 +188,13 @@ open Classical in
 representations of the affine group `x ↦ a x + b` over a finite field `K` (`q = |K|` elements),
 obtained from Theorem 5.27.1: there are exactly `q` pairwise non-isomorphic irreducibles forming a
 complete set, of which `q - 1` have dimension `1` (the characters factoring through `Kˣ`) and one
-has dimension `q - 1` (over the free orbit of nontrivial characters). -/
-theorem affine_classification :
+has dimension `q - 1` (over the free orbit of nontrivial characters).
+
+The hypothesis `2 < q` excludes the degenerate field `K = 𝔽₂`, where `AffineGroup K ≅ ℤ/2` has two
+one-dimensional irreducibles: there the free-orbit rep also has dimension `q - 1 = 1`, so the two
+dimension filters would overlap and the counts `q - 1` and `1` could not both hold. For `q ≥ 3` the
+dimensions `1` and `q - 1 ≥ 2` are distinct, so the split is clean. -/
+theorem affine_classification (hq : 2 < Fintype.card K) :
     ∃ (n : ℕ) (W : Fin n → FDRep ℂ (AffineGroup K)),
       (∀ i, Simple (W i)) ∧
       (∀ i j, Nonempty (W i ≅ W j) → i = j) ∧
@@ -196,6 +202,228 @@ theorem affine_classification :
       n = Fintype.card K ∧
       (Finset.univ.filter (fun i => finrank ℂ (W i : Type) = 1)).card = Fintype.card K - 1 ∧
       (Finset.univ.filter (fun i => finrank ℂ (W i : Type) = Fintype.card K - 1)).card = 1 := by
-  sorry
+  classical
+  haveI : Nonempty Kˣ := ⟨1⟩
+  obtain ⟨dualSmul, hdual, stab, hstab, V, transport,
+    hi, hii, hiii, hiv, hv, hvi, hvii, hviii, hix⟩ :=
+    Etingof.Theorem5_27_1 Kˣ (Multiplicative K) (affineφ K)
+  -- Match the abstract dual action supplied by Theorem 5.27.1 to the concrete `affineDualSmul`.
+  have hds : ∀ (g : Kˣ) (χ : Multiplicative K →* ℂˣ), dualSmul g χ = affineDualSmul K g χ := by
+    intro g χ
+    refine MonoidHom.ext fun a => ?_
+    rw [hdual g χ a, affineDualSmul_apply]
+  -- The trivial character is fixed by all of `Kˣ`: its stabilizer is `⊤`.
+  have hstab_triv : stab (1 : Multiplicative K →* ℂˣ) = ⊤ := by
+    rw [eq_top_iff]
+    intro g _
+    exact (hstab 1 g).mpr (by rw [hds]; exact affineDualSmul_trivial K g)
+  -- A nontrivial character has trivial stabilizer `⊥`.
+  have hstab_ntriv : ∀ {χ : Multiplicative K →* ℂˣ}, χ ≠ 1 → stab χ = ⊥ := by
+    intro χ hχ
+    rw [eq_bot_iff]
+    intro g hg
+    rw [Subgroup.mem_bot]
+    have hgχ : affineDualSmul K g χ = χ := by rw [← hds]; exact (hstab χ g).mp hg
+    exact (affineDualSmul_eq_self_iff K g hχ).mp hgχ
+  -- `Kˣ` is abelian, so conjugation is trivial.
+  have hconj : ∀ h g : Kˣ, h * g * h⁻¹ = g := fun h g => by
+    rw [mul_right_comm, mul_inv_cancel, one_mul]
+  haveI : Fintype (Multiplicative K →* ℂˣ) := Fintype.ofFinite _
+  haveI : Fintype (Kˣ →* ℂˣ) := Fintype.ofFinite _
+  -- Cardinality of the character group of `(K, +)` equals `q`.
+  have hcardHom : Fintype.card (Multiplicative K →* ℂˣ) = Fintype.card K := by
+    have h := Etingof.AbelianFDRep.card_charFDRep_dual (G := Multiplicative K)
+    rw [Nat.card_eq_fintype_card, Nat.card_eq_fintype_card] at h
+    rwa [Fintype.card_congr (Multiplicative.toAdd : Multiplicative K ≃ K)] at h
+  -- Cardinality of the character group of `Kˣ` equals `q - 1`.
+  have hcardDual : Fintype.card (Kˣ →* ℂˣ) = Fintype.card K - 1 := by
+    rw [← Nat.card_eq_fintype_card, Etingof.AbelianFDRep.card_charFDRep_dual,
+      Nat.card_eq_fintype_card, Fintype.card_units]
+  -- Choose a nontrivial character to represent the single free orbit.
+  haveI : Nontrivial (Multiplicative K →* ℂˣ) := by
+    rw [← Fintype.one_lt_card_iff_nontrivial, hcardHom]; omega
+  obtain ⟨χ₀, hχ₀⟩ := exists_ne (1 : Multiplicative K →* ℂˣ)
+  -- The classifying family: `Sum.inl ρ` gives the 1-dim rep over the fixed character (indexed by a
+  -- character `ρ` of `Kˣ`); `Sum.inr ()` gives the single `(q-1)`-dim rep over the free orbit.
+  set F : (Kˣ →* ℂˣ) ⊕ Unit → FDRep ℂ (AffineGroup K) := fun a =>
+    a.elim
+      (fun ρ => V (1 : Multiplicative K →* ℂˣ)
+        (Etingof.AbelianFDRep.charFDRep (ρ.comp (stab (1 : Multiplicative K →* ℂˣ)).subtype)))
+      (fun _ => V χ₀ (Etingof.AbelianFDRep.charFDRep (1 : ↥(stab χ₀) →* ℂˣ))) with hF
+  -- **Closed-form character of the fixed-orbit (1-dim) reps:** at `⟨a, g⟩` it is `ρ g`.
+  have fixed_char : ∀ (ρ : Kˣ →* ℂˣ) (a : Multiplicative K) (g : Kˣ),
+      (V (1 : Multiplicative K →* ℂˣ)
+        (Etingof.AbelianFDRep.charFDRep
+          (ρ.comp (stab (1 : Multiplicative K →* ℂˣ)).subtype))).character ⟨a, g⟩
+      = (ρ g : ℂ) := by
+    intro ρ a g
+    have hSimpleU := Etingof.AbelianFDRep.charFDRep_simple
+      (ρ.comp (stab (1 : Multiplicative K →* ℂˣ)).subtype)
+    have hmemg : g ∈ stab (1 : Multiplicative K →* ℂˣ) := by
+      rw [hstab_triv]; exact Subgroup.mem_top g
+    have hmemall : ∀ h : Kˣ, h * g * h⁻¹ ∈ stab (1 : Multiplicative K →* ℂˣ) := by
+      intro h; rw [hstab_triv]; exact Subgroup.mem_top _
+    have hcard : Fintype.card ↥(stab (1 : Multiplicative K →* ℂˣ)) = Fintype.card Kˣ := by
+      rw [hstab_triv]; exact Fintype.card_congr Subgroup.topEquiv.toEquiv
+    have hterm : ∀ h : Kˣ,
+        (if hh : h * g * h⁻¹ ∈ stab (1 : Multiplicative K →* ℂˣ)
+          then ((1 : Multiplicative K →* ℂˣ)
+                ((affineφ K h : MulAut (Multiplicative K)) a) : ℂ)
+              * (Etingof.AbelianFDRep.charFDRep
+                  (ρ.comp (stab (1 : Multiplicative K →* ℂˣ)).subtype)).character
+                  ⟨h * g * h⁻¹, hh⟩
+          else 0)
+        = (ρ g : ℂ) := by
+      intro h
+      rw [dif_pos (hmemall h),
+        show (⟨h * g * h⁻¹, hmemall h⟩ : ↥(stab (1 : Multiplicative K →* ℂˣ))) = ⟨g, hmemg⟩ from
+          Subtype.ext (hconj h g),
+        Etingof.AbelianFDRep.charFDRep_character, MonoidHom.one_apply, Units.val_one, one_mul]
+      rfl
+    rw [hiv 1 _ hSimpleU a g, Finset.sum_congr rfl (fun h _ => hterm h),
+      Finset.sum_const, Finset.card_univ, nsmul_eq_mul, hcard,
+      inv_mul_cancel_left₀ (Nat.cast_ne_zero.mpr Fintype.card_ne_zero)]
+  -- Dimensions of the two kinds of family members.
+  have hdim_inl : ∀ ρ : Kˣ →* ℂˣ, finrank ℂ (F (Sum.inl ρ) : Type) = 1 := by
+    intro ρ
+    show finrank ℂ (V (1 : Multiplicative K →* ℂˣ)
+      (Etingof.AbelianFDRep.charFDRep
+        (ρ.comp (stab (1 : Multiplicative K →* ℂˣ)).subtype)) : Type) = 1
+    rw [hv, Etingof.AbelianFDRep.charFDRep_finrank, mul_one, hstab_triv, Subgroup.index_top]
+  have hdim_inr : finrank ℂ (F (Sum.inr () : (Kˣ →* ℂˣ) ⊕ Unit) : Type) = Fintype.card K - 1 := by
+    show finrank ℂ (V χ₀ (Etingof.AbelianFDRep.charFDRep
+      (1 : ↥(stab χ₀) →* ℂˣ)) : Type) = Fintype.card K - 1
+    rw [hv, Etingof.AbelianFDRep.charFDRep_finrank, mul_one, hstab_ntriv hχ₀,
+      Subgroup.index_bot, Nat.card_eq_fintype_card, Fintype.card_units]
+  -- Simplicity of every family member.
+  have hFsimple : ∀ a, Simple (F a) := by
+    rintro (ρ | _)
+    · exact hi 1 _ (Etingof.AbelianFDRep.charFDRep_simple _)
+    · exact hi χ₀ _ (Etingof.AbelianFDRep.charFDRep_simple _)
+  -- Pairwise non-isomorphism: an isomorphism forces equal index.
+  have hFinj : ∀ a b, Nonempty (F a ≅ F b) → a = b := by
+    rintro (ρ₁ | _) (ρ₂ | _) ⟨α⟩
+    · -- fixed vs fixed: characters recover `ρ`
+      have hchar := FDRep.char_iso α
+      have hρ : ρ₁ = ρ₂ := by
+        refine MonoidHom.ext fun g => ?_
+        have h := congrFun hchar ⟨(1 : Multiplicative K), g⟩
+        rw [show F (Sum.inl ρ₁) = V (1 : Multiplicative K →* ℂˣ)
+            (Etingof.AbelianFDRep.charFDRep
+              (ρ₁.comp (stab (1 : Multiplicative K →* ℂˣ)).subtype)) from rfl,
+          show F (Sum.inl ρ₂) = V (1 : Multiplicative K →* ℂˣ)
+            (Etingof.AbelianFDRep.charFDRep
+              (ρ₂.comp (stab (1 : Multiplicative K →* ℂˣ)).subtype)) from rfl,
+          fixed_char ρ₁ 1 g, fixed_char ρ₂ 1 g] at h
+        exact Units.ext h
+      rw [hρ]
+    · -- fixed vs free: dimensions `1` and `q - 1 ≥ 2` differ
+      exfalso
+      have h := congrFun (FDRep.char_iso α) 1
+      rw [FDRep.char_one, FDRep.char_one, hdim_inl ρ₁, hdim_inr, Nat.cast_inj] at h
+      omega
+    · -- free vs fixed: symmetric
+      exfalso
+      have h := congrFun (FDRep.char_iso α) 1
+      rw [FDRep.char_one, FDRep.char_one, hdim_inl ρ₂, hdim_inr, Nat.cast_inj] at h
+      omega
+    · -- free vs free: the free orbit is a single point
+      exact congrArg Sum.inr (Subsingleton.elim _ _)
+  -- Completeness: every simple rep is isomorphic to a family member.
+  have hFcomplete : ∀ S : FDRep ℂ (AffineGroup K), Simple S → ∃ a, Nonempty (S ≅ F a) := by
+    intro S hS
+    obtain ⟨χ, U, hU, hSU⟩ := hiii S hS
+    haveI : Simple U := hU
+    by_cases hχ : χ = 1
+    · -- fixed orbit: recover a character `ρ` of `Kˣ` from `U ≅ charFDRep ξ`
+      subst hχ
+      obtain ⟨ξ, hξ⟩ := Etingof.AbelianFDRep.exists_charFDRep_iso U
+      let eStab : ↥(stab (1 : Multiplicative K →* ℂˣ)) ≃* Kˣ :=
+        (MulEquiv.subgroupCongr hstab_triv).trans Subgroup.topEquiv
+      have heStab : ∀ s, eStab s = ((stab (1 : Multiplicative K →* ℂˣ)).subtype s) := fun _ => rfl
+      refine ⟨Sum.inl (ξ.comp eStab.symm.toMonoidHom), ?_⟩
+      have hρξ : (ξ.comp eStab.symm.toMonoidHom).comp
+          (stab (1 : Multiplicative K →* ℂˣ)).subtype = ξ := by
+        refine MonoidHom.ext fun s => ?_
+        show ξ (eStab.symm ((stab (1 : Multiplicative K →* ℂˣ)).subtype s)) = ξ s
+        rw [← heStab s, MulEquiv.symm_apply_apply]
+      have hFeq : F (Sum.inl (ξ.comp eStab.symm.toMonoidHom))
+          = V (1 : Multiplicative K →* ℂˣ) (Etingof.AbelianFDRep.charFDRep ξ) := by
+        show V (1 : Multiplicative K →* ℂˣ) (Etingof.AbelianFDRep.charFDRep
+            ((ξ.comp eStab.symm.toMonoidHom).comp (stab (1 : Multiplicative K →* ℂˣ)).subtype))
+          = V (1 : Multiplicative K →* ℂˣ) (Etingof.AbelianFDRep.charFDRep ξ)
+        rw [hρξ]
+      rw [hFeq]
+      exact ⟨hSU.some ≪≫ (hvi 1 U (Etingof.AbelianFDRep.charFDRep ξ) hξ).some⟩
+    · -- free orbit: move the base point to `χ₀` along the orbit
+      refine ⟨Sum.inr (), ?_⟩
+      obtain ⟨g, hg⟩ := affineDualSmul_transitive K hχ₀ hχ
+      have hg' : dualSmul g χ₀ = χ := by rw [hds]; exact hg
+      haveI : Subsingleton ↥(stab χ) := by
+        rw [hstab_ntriv hχ]
+        exact ⟨fun a b => Subtype.ext
+          (by rw [Subgroup.mem_bot.mp a.2, Subgroup.mem_bot.mp b.2])⟩
+      -- `U ≅ charFDRep 1`
+      obtain ⟨ξ, hξ⟩ := Etingof.AbelianFDRep.exists_charFDRep_iso U
+      have hξ1 : ξ = 1 := by
+        refine MonoidHom.ext fun x => ?_; rw [Subsingleton.elim x 1]; simp
+      rw [hξ1] at hξ
+      -- transport of `charFDRep 1` is again `≅ charFDRep 1`
+      haveI : Simple (transport g χ₀ χ hg' (Etingof.AbelianFDRep.charFDRep
+          (1 : ↥(stab χ₀) →* ℂˣ))) :=
+        hix χ₀ χ _ g hg' (Etingof.AbelianFDRep.charFDRep_simple _)
+      obtain ⟨ζ, hζ⟩ := Etingof.AbelianFDRep.exists_charFDRep_iso
+        (transport g χ₀ χ hg' (Etingof.AbelianFDRep.charFDRep (1 : ↥(stab χ₀) →* ℂˣ)))
+      have hζ1 : ζ = 1 := by
+        refine MonoidHom.ext fun x => ?_; rw [Subsingleton.elim x 1]; simp
+      rw [hζ1] at hζ
+      -- assemble: `V χ₀ (charFDRep 1) ≅ V χ (transport …) ≅ V χ (charFDRep 1) ≅ V χ U ≅ S`
+      have step1 : Nonempty (V χ₀ (Etingof.AbelianFDRep.charFDRep (1 : ↥(stab χ₀) →* ℂˣ))
+          ≅ V χ (transport g χ₀ χ hg'
+              (Etingof.AbelianFDRep.charFDRep (1 : ↥(stab χ₀) →* ℂˣ)))) :=
+        hvii χ₀ χ (Etingof.AbelianFDRep.charFDRep 1) g hg'
+      have step2 : Nonempty (V χ (transport g χ₀ χ hg'
+            (Etingof.AbelianFDRep.charFDRep (1 : ↥(stab χ₀) →* ℂˣ)))
+          ≅ V χ (Etingof.AbelianFDRep.charFDRep (1 : ↥(stab χ) →* ℂˣ))) :=
+        hvi χ _ _ hζ
+      have step3 : Nonempty (V χ (Etingof.AbelianFDRep.charFDRep (1 : ↥(stab χ) →* ℂˣ))
+          ≅ V χ U) :=
+        hvi χ _ _ ⟨hξ.some.symm⟩
+      show Nonempty (S ≅ V χ₀ (Etingof.AbelianFDRep.charFDRep (1 : ↥(stab χ₀) →* ℂˣ)))
+      exact ⟨hSU.some ≪≫ step3.some.symm ≪≫ step2.some.symm ≪≫ step1.some.symm⟩
+  -- Assemble into a `Fin n`-indexed family.
+  set e := Fintype.equivFin ((Kˣ →* ℂˣ) ⊕ Unit) with he
+  refine ⟨Fintype.card ((Kˣ →* ℂˣ) ⊕ Unit), fun i => F (e.symm i), ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · exact fun i => hFsimple _
+  · intro i j hij; exact e.symm.injective (hFinj _ _ hij)
+  · intro S hS
+    obtain ⟨a, ha⟩ := hFcomplete S hS
+    exact ⟨e a, by simpa only [Equiv.symm_apply_apply] using ha⟩
+  · rw [Fintype.card_sum, Fintype.card_unit, hcardDual]; omega
+  · -- count of dimension-1 reps
+    have hL1 : ∀ ρ : Kˣ →* ℂˣ,
+        (if finrank ℂ (F (Sum.inl ρ) : Type) = 1 then (1 : ℕ) else 0) = 1 :=
+      fun ρ => if_pos (hdim_inl ρ)
+    have hR1 : ∀ u : Unit,
+        (if finrank ℂ (F (Sum.inr u) : Type) = 1 then (1 : ℕ) else 0) = 0 := by
+      rintro ⟨⟩; exact if_neg (by rw [hdim_inr]; omega)
+    rw [Finset.card_filter,
+      Equiv.sum_comp e.symm (fun a => if finrank ℂ (F a : Type) = 1 then (1 : ℕ) else 0),
+      Fintype.sum_sum_type]
+    simp only [hL1, hR1, Finset.sum_const, Finset.card_univ, smul_eq_mul, mul_one,
+      mul_zero, add_zero, hcardDual]
+  · -- count of dimension-`(q-1)` reps
+    have hLp : ∀ ρ : Kˣ →* ℂˣ,
+        (if finrank ℂ (F (Sum.inl ρ) : Type) = Fintype.card K - 1 then (1 : ℕ) else 0) = 0 :=
+      fun ρ => if_neg (by rw [hdim_inl ρ]; omega)
+    have hRp : ∀ u : Unit,
+        (if finrank ℂ (F (Sum.inr u) : Type) = Fintype.card K - 1 then (1 : ℕ) else 0) = 1 := by
+      rintro ⟨⟩; exact if_pos hdim_inr
+    rw [Finset.card_filter,
+      Equiv.sum_comp e.symm
+        (fun a => if finrank ℂ (F a : Type) = Fintype.card K - 1 then (1 : ℕ) else 0),
+      Fintype.sum_sum_type]
+    simp only [hLp, hRp, Finset.sum_const, Finset.card_univ, Fintype.card_unit, smul_eq_mul,
+      mul_one, mul_zero, zero_add]
 
 end Etingof.Exercise5_27_2

--- a/progress/2026-07-14T08-21-49Z_1d090d21.md
+++ b/progress/2026-07-14T08-21-49Z_1d090d21.md
@@ -1,0 +1,46 @@
+## Accomplished
+
+Proved `Etingof.Exercise5_27_2.affine_classification` in
+`EtingofRepresentationTheory/Chapter5/Exercise5_27_2_Affine.lean` (issue #6490),
+removing the last `sorry` of the Exercise 5.27.2 trio. All three files
+(Affine, Dihedral, Heisenberg) are now sorry-free.
+
+- **Corrected the statement.** Added the hypothesis `2 < Fintype.card K`. The
+  previous hypothesis-free statement was false for `q = 2` (where `AffineGroup K ≅
+  ℤ/2` has two dimension-1 irreducibles): the free-orbit rep also has dimension
+  `q - 1 = 1`, so the two dimension filters overlap and the counts `q - 1` and `1`
+  cannot both hold. For `q ≥ 3` the dimensions `1` and `q - 1 ≥ 2` are distinct.
+- **Assembled from Theorem 5.27.1** using the orbit infrastructure already in the
+  file: matched the abstract `dualSmul` to the concrete `affineDualSmul` (`hds`),
+  derived the stabilizer dichotomy (`⊤` for the trivial character, `⊥` for
+  nontrivial), and used `affineDualSmul_transitive` for the single free orbit.
+- Family `(Kˣ →* ℂˣ) ⊕ Unit`: `Sum.inl ρ ↦ V 1 (charFDRep (ρ ∘ subtype))`
+  (dim 1), `Sum.inr () ↦ V χ₀ (charFDRep 1)` (dim `q - 1`), for a chosen
+  nontrivial `χ₀`. Closed-form fixed character `= ρ g`; dimensions via
+  `Subgroup.index_top` / `index_bot` + `Fintype.card_units`; simplicity from
+  `charFDRep_simple`; completeness via `exists_charFDRep_iso` plus base-point
+  move `hvii` and simplicity transport `hix`.
+- Updated `progress/items.json` (`Chapter5/Exercise5.27.2` → `proved`) and the
+  module docstring.
+
+Build: `lake build EtingofRepresentationTheory.Chapter5.Exercise5_27_2_Affine`
+completes successfully (8587 jobs), no `sorry`, no errors.
+
+## Current frontier
+
+Exercise 5.27.2 is fully formalized and sorry-free. The next Chapter 5 frontier
+item is Exercise 5.27.3 (`blobs/Chapter5/Exercise5.27.3.md`).
+
+## Overall project progress
+
+Chapter 5 orbit-method exercises (5.27.2) complete. Chapters 2, 4, 5, 9 have
+substantial formalized content; see `progress/items.json` for per-item status.
+
+## Next step
+
+Pick up the next unclaimed `feature` issue. Candidate math frontier:
+Exercise 5.27.3, or continue any open Chapter 4/9 items.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -5222,8 +5222,8 @@
     "end_page": "147",
     "start_line": 15,
     "end_line": 16,
-    "status": "statement_formalized",
-    "coverage_note": "Statement pass across three files, each redoing one Problem via Theorem 5.27.1. (4.12.6) Exercise5_27_2_Affine.lean: affine ax+b group over a finite field as Multiplicative K rtimes Kˣ, q irreducibles (q-1 of dim 1, one of dim q-1). (4.12.1(a)) Exercise5_27_2_Dihedral.lean: dihedral D_N (Mathlib DihedralGroup) as ZMod N rtimes ZMod 2 via inversion; classification by parity (N odd: two dim-1, (N-1)/2 dim-2; N even: four dim-1, (N-2)/2 dim-2). (4.12.2) Exercise5_27_2_Heisenberg.lean: Heisenberg group over F_p constructed as (ZMod p x ZMod p) rtimes ZMod p via the shear automorphism; p^2 irreducibles of dim 1 and p-1 of dim p. All sorry proofs."
+    "status": "proved",
+    "coverage_note": "COMPLETE and sorry-free across three files, each redoing one Problem via Theorem 5.27.1. (4.12.6) Exercise5_27_2_Affine.lean: affine ax+b group over a finite field as Multiplicative K rtimes Kˣ; affine_classification (hyp 2<q, excluding the degenerate 𝔽₂ where the free rep also has dim q-1=1) gives q irreducibles (q-1 of dim 1 over the fixed trivial character indexed by ρ:Kˣ→*ℂˣ, one of dim q-1 over the single free orbit). Assembled from Theorem 5.27.1: stabilizer dichotomy (⊤ for trivial χ, ⊥ for nontrivial) + transitivity on nontrivial chars, closed-form fixed character ρ g, dims via index_top/index_bot+card_units, completeness via exists_charFDRep_iso and orbit base-point move (hvii/hix). (4.12.1(a)) Exercise5_27_2_Dihedral.lean: dihedral D_N as ZMod N rtimes ZMod 2 via inversion; parity classification. (4.12.2) Exercise5_27_2_Heisenberg.lean: Heisenberg over F_p as (ZMod p)² rtimes ZMod p via shear; p² dim-1 and p-1 dim-p. All three sorry-free."
   },
   {
     "id": "Chapter5/Exercise5.27.3",


### PR DESCRIPTION
Closes #6490

Session: `1d090d21-29ff-41ac-8c22-971cfb8374e8`

b9df3696 feat(Ch5 #6490): prove affine_classification via Theorem 5.27.1 (orbit method)

🤖 Prepared with Claude Code