### PR TITLE
feat(Ch2 #6553-A): K^orderOf central acts as scalar ⇒ K diagonalizable, ≤ orderOf q eigenvalues

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Problem2_16_5.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_16_5.lean
@@ -586,6 +586,103 @@ lemma Kpow_orderOf_mul_f (q : ℂˣ) :
     K q ^ orderOf q * f q = f q * K q ^ orderOf q := by
   rw [Kpow_mul_f, inv_pow, sq_pow_orderOf_eq_one, inv_one, one_smul]
 
+/-- **Centrality of `K ^ orderOf q`.** At a root of unity the element `K ^ orderOf q` is central
+in `U_q(sl₂)`: it commutes with every element. It commutes with all four generators
+(`Kpow_orderOf_mul_e`, `Kpow_orderOf_mul_f`, and trivially with `K` and `L`), and these generate;
+we reduce a general element to the generator cases via the surjection `mk q` and
+`FreeAlgebra.induction`. -/
+lemma Kpow_orderOf_central (q : ℂˣ) (a : Uqsl2 q) :
+    K q ^ orderOf q * a = a * K q ^ orderOf q := by
+  suffices H : ∀ p : FreeAlgebra ℂ Gen,
+      K q ^ orderOf q * mk q p = mk q p * K q ^ orderOf q by
+    obtain ⟨p, rfl⟩ := RingQuot.mkAlgHom_surjective ℂ (Rel q) a
+    exact H p
+  intro p
+  induction p using FreeAlgebra.induction with
+  | grade0 r =>
+      rw [show mk q (algebraMap ℂ (FreeAlgebra ℂ Gen) r) = algebraMap ℂ (Uqsl2 q) r from
+        AlgHom.commutes (mk q) r, Algebra.commutes]
+  | grade1 g =>
+      fin_cases g
+      · change K q ^ orderOf q * e q = e q * K q ^ orderOf q
+        exact Kpow_orderOf_mul_e q
+      · change K q ^ orderOf q * f q = f q * K q ^ orderOf q
+        exact Kpow_orderOf_mul_f q
+      · change K q ^ orderOf q * K q = K q * K q ^ orderOf q
+        rw [← pow_succ, ← pow_succ']
+      · change K q ^ orderOf q * L q = L q * K q ^ orderOf q
+        have hc : Commute (K q) (L q) := by
+          change K q * L q = L q * K q; rw [KL_rel, LK_rel]
+        exact (hc.pow_left (orderOf q)).eq
+  | mul x y hx hy =>
+      rw [map_mul, ← mul_assoc, hx, mul_assoc, hy, ← mul_assoc]
+  | add x y hx hy =>
+      rw [map_add, mul_add, add_mul, hx, hy]
+
+/-- **`K ^ orderOf q` acts as a nonzero scalar.** On a finite dimensional irreducible
+`U_q(sl₂)`-module over `ℂ`, the central element `K ^ orderOf q` acts as a single scalar `α ≠ 0`.
+This is Schur's lemma: `K ^ orderOf q` is central (`Kpow_orderOf_central`), so it acts
+`U_q`-linearly and each of its `ℂ`-eigenspaces is a `U_q`-submodule. Over the algebraically closed
+`ℂ` with `V` finite dimensional the operator has an eigenvalue `α`, and its `α`-eigenspace, being a
+nonzero `U_q`-submodule of the simple module `V`, is all of `V`. `α ≠ 0` because `K ^ orderOf q` is
+a unit (`K · L = 1`). -/
+theorem Kpow_orderOf_isScalar (q : ℂˣ) (hq : IsOfFinOrder q)
+    (V : Type*) [AddCommGroup V] [Module ℂ V] [Module (Uqsl2 q) V]
+    [IsScalarTower ℂ (Uqsl2 q) V] [FiniteDimensional ℂ V] [IsSimpleModule (Uqsl2 q) V] :
+    ∃ α : ℂ, α ≠ 0 ∧ ∀ v : V, K q ^ orderOf q • v = α • v := by
+  haveI : Nontrivial V := IsSimpleModule.nontrivial (Uqsl2 q) V
+  -- `(Kop)^n` applies as `K^n • ·`.
+  have hTapply : ∀ (n : ℕ) (v : V), (Kop q V ^ n) v = K q ^ n • v := by
+    intro n
+    induction n with
+    | zero => intro v; simp
+    | succ n ih =>
+        intro v
+        rw [pow_succ, Module.End.mul_apply, Kop_apply, ih, ← mul_smul, ← pow_succ]
+  -- `α`: an eigenvalue of the endomorphism `Kop ^ orderOf q`.
+  obtain ⟨α, hα⟩ := Module.End.exists_eigenvalue (Kop q V ^ orderOf q)
+  -- The `α`-eigenspace is a `U_q`-submodule (centrality of `K ^ orderOf q`).
+  let W' : Submodule (Uqsl2 q) V :=
+    { carrier := (Module.End.eigenspace (Kop q V ^ orderOf q) α : Set V)
+      add_mem' := fun ha hb => Submodule.add_mem _ ha hb
+      zero_mem' := Submodule.zero_mem _
+      smul_mem' := by
+        intro a x hx
+        rw [SetLike.mem_coe, Module.End.mem_eigenspace_iff, hTapply] at hx
+        rw [SetLike.mem_coe, Module.End.mem_eigenspace_iff, hTapply,
+          ← mul_smul, Kpow_orderOf_central, mul_smul, hx, smul_comm] }
+  -- Nonzero (it contains an eigenvector), so by simplicity it is everything.
+  have hne : W' ≠ ⊥ := by
+    obtain ⟨v, hv, hv0⟩ := hα.exists_hasEigenvector
+    intro hbot
+    apply hv0
+    have hmem : v ∈ W' := hv
+    rw [hbot, Submodule.mem_bot] at hmem
+    exact hmem
+  have htop : W' = ⊤ := (eq_bot_or_eq_top W').resolve_left hne
+  refine ⟨α, ?_, ?_⟩
+  · -- `α ≠ 0` since `K ^ orderOf q` is a unit (inverse `L ^ orderOf q`).
+    obtain ⟨v, hv, hv0⟩ := hα.exists_hasEigenvector
+    intro hα0
+    apply hv0
+    have hKv : K q ^ orderOf q • v = 0 := by
+      have hmem := Module.End.mem_eigenspace_iff.mp hv
+      rw [hTapply, hα0, zero_smul] at hmem
+      exact hmem
+    have hLK : L q ^ orderOf q * K q ^ orderOf q = 1 := by
+      have hc : Commute (L q) (K q) := by
+        change L q * K q = K q * L q; rw [LK_rel, KL_rel]
+      rw [← hc.mul_pow, LK_rel, one_pow]
+    have h := congrArg (fun x => L q ^ orderOf q • x) hKv
+    simp only [smul_zero] at h
+    rw [← mul_smul, hLK, one_smul] at h
+    exact h
+  · intro v
+    have hv_mem : v ∈ W' := by rw [htop]; exact Submodule.mem_top
+    have hmem : v ∈ Module.End.eigenspace (Kop q V ^ orderOf q) α := hv_mem
+    rw [Module.End.mem_eigenspace_iff, hTapply] at hmem
+    exact hmem
+
 /-- **Root-of-unity case.** When `q` is a root of unity, the dimensions of the finite
 dimensional irreducible representations are bounded (by `orderOf q`): they no longer occur in
 every dimension, in contrast to the non-root-of-unity case. -/

--- a/EtingofRepresentationTheory/Chapter2/Problem2_16_5.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_16_5.lean
@@ -619,6 +619,14 @@ lemma Kpow_orderOf_central (q : ℂˣ) (a : Uqsl2 q) :
   | add x y hx hy =>
       rw [map_add, mul_add, add_mul, hx, hy]
 
+/-- The `n`-th power of the `K`-endomorphism `Kop` applies as `K^n • ·`. -/
+lemma Kop_pow_apply (q : ℂˣ) (V : Type*) [AddCommGroup V] [Module ℂ V] [Module (Uqsl2 q) V]
+    [IsScalarTower ℂ (Uqsl2 q) V] [FiniteDimensional ℂ V] (n : ℕ) (v : V) :
+    (Kop q V ^ n) v = K q ^ n • v := by
+  induction n generalizing v with
+  | zero => simp
+  | succ n ih => rw [pow_succ, Module.End.mul_apply, Kop_apply, ih, ← mul_smul, ← pow_succ]
+
 /-- **`K ^ orderOf q` acts as a nonzero scalar.** On a finite dimensional irreducible
 `U_q(sl₂)`-module over `ℂ`, the central element `K ^ orderOf q` acts as a single scalar `α ≠ 0`.
 This is Schur's lemma: `K ^ orderOf q` is central (`Kpow_orderOf_central`), so it acts
@@ -626,19 +634,11 @@ This is Schur's lemma: `K ^ orderOf q` is central (`Kpow_orderOf_central`), so i
 `ℂ` with `V` finite dimensional the operator has an eigenvalue `α`, and its `α`-eigenspace, being a
 nonzero `U_q`-submodule of the simple module `V`, is all of `V`. `α ≠ 0` because `K ^ orderOf q` is
 a unit (`K · L = 1`). -/
-theorem Kpow_orderOf_isScalar (q : ℂˣ) (hq : IsOfFinOrder q)
+theorem Kpow_orderOf_isScalar (q : ℂˣ) (_hq : IsOfFinOrder q)
     (V : Type*) [AddCommGroup V] [Module ℂ V] [Module (Uqsl2 q) V]
     [IsScalarTower ℂ (Uqsl2 q) V] [FiniteDimensional ℂ V] [IsSimpleModule (Uqsl2 q) V] :
     ∃ α : ℂ, α ≠ 0 ∧ ∀ v : V, K q ^ orderOf q • v = α • v := by
   haveI : Nontrivial V := IsSimpleModule.nontrivial (Uqsl2 q) V
-  -- `(Kop)^n` applies as `K^n • ·`.
-  have hTapply : ∀ (n : ℕ) (v : V), (Kop q V ^ n) v = K q ^ n • v := by
-    intro n
-    induction n with
-    | zero => intro v; simp
-    | succ n ih =>
-        intro v
-        rw [pow_succ, Module.End.mul_apply, Kop_apply, ih, ← mul_smul, ← pow_succ]
   -- `α`: an eigenvalue of the endomorphism `Kop ^ orderOf q`.
   obtain ⟨α, hα⟩ := Module.End.exists_eigenvalue (Kop q V ^ orderOf q)
   -- The `α`-eigenspace is a `U_q`-submodule (centrality of `K ^ orderOf q`).
@@ -648,8 +648,8 @@ theorem Kpow_orderOf_isScalar (q : ℂˣ) (hq : IsOfFinOrder q)
       zero_mem' := Submodule.zero_mem _
       smul_mem' := by
         intro a x hx
-        rw [SetLike.mem_coe, Module.End.mem_eigenspace_iff, hTapply] at hx
-        rw [SetLike.mem_coe, Module.End.mem_eigenspace_iff, hTapply,
+        rw [SetLike.mem_coe, Module.End.mem_eigenspace_iff, Kop_pow_apply] at hx
+        rw [SetLike.mem_coe, Module.End.mem_eigenspace_iff, Kop_pow_apply,
           ← mul_smul, Kpow_orderOf_central, mul_smul, hx, smul_comm] }
   -- Nonzero (it contains an eigenvector), so by simplicity it is everything.
   have hne : W' ≠ ⊥ := by
@@ -667,7 +667,7 @@ theorem Kpow_orderOf_isScalar (q : ℂˣ) (hq : IsOfFinOrder q)
     apply hv0
     have hKv : K q ^ orderOf q • v = 0 := by
       have hmem := Module.End.mem_eigenspace_iff.mp hv
-      rw [hTapply, hα0, zero_smul] at hmem
+      rw [Kop_pow_apply, hα0, zero_smul] at hmem
       exact hmem
     have hLK : L q ^ orderOf q * K q ^ orderOf q = 1 := by
       have hc : Commute (L q) (K q) := by
@@ -680,8 +680,48 @@ theorem Kpow_orderOf_isScalar (q : ℂˣ) (hq : IsOfFinOrder q)
   · intro v
     have hv_mem : v ∈ W' := by rw [htop]; exact Submodule.mem_top
     have hmem : v ∈ Module.End.eigenspace (Kop q V ^ orderOf q) α := hv_mem
-    rw [Module.End.mem_eigenspace_iff, hTapply] at hmem
+    rw [Module.End.mem_eigenspace_iff, Kop_pow_apply] at hmem
     exact hmem
+
+/-- **`K` is diagonalizable at a root of unity.** On a finite dimensional irreducible
+`U_q(sl₂)`-module over `ℂ`, the `K`-endomorphism `Kop` is a semisimple operator: it satisfies the
+separable annihilating polynomial `X ^ orderOf q - C α` (where `α` is the scalar from
+`Kpow_orderOf_isScalar`, nonzero, so the polynomial is squarefree in characteristic zero), hence its
+eigenspaces span `V`, and every `K`-eigenvalue is an `orderOf q`-th root of `α` (so there are at
+most `orderOf q` distinct `K`-eigenvalues). -/
+theorem Kop_isSemisimple_and_eigenvalues (q : ℂˣ) (hq : IsOfFinOrder q)
+    (V : Type*) [AddCommGroup V] [Module ℂ V] [Module (Uqsl2 q) V]
+    [IsScalarTower ℂ (Uqsl2 q) V] [FiniteDimensional ℂ V] [IsSimpleModule (Uqsl2 q) V] :
+    (Kop q V).IsSemisimple ∧
+      (⨆ μ : ℂ, Module.End.eigenspace (Kop q V) μ) = ⊤ ∧
+      ∃ α : ℂ, α ≠ 0 ∧ ∀ μ : ℂ, (Kop q V).HasEigenvalue μ → μ ^ orderOf q = α := by
+  obtain ⟨α, hα0, hα⟩ := Kpow_orderOf_isScalar q hq V
+  have hℓ : 0 < orderOf q := hq.orderOf_pos
+  -- `Kop` satisfies `Kop ^ orderOf q = α • 1`.
+  have hpow : Kop q V ^ orderOf q = α • (1 : Module.End ℂ V) := by
+    ext v; rw [Kop_pow_apply, hα v, LinearMap.smul_apply, Module.End.one_apply]
+  -- so it is a root of the separable (hence squarefree) polynomial `X ^ orderOf q - C α`.
+  have hss : (Kop q V).IsSemisimple := by
+    have hsqf : Squarefree (Polynomial.X ^ orderOf q - Polynomial.C α : Polynomial ℂ) :=
+      (Polynomial.separable_X_pow_sub_C α (Nat.cast_ne_zero.mpr hℓ.ne') hα0).squarefree
+    have haeval : Polynomial.aeval (Kop q V) (Polynomial.X ^ orderOf q - Polynomial.C α) = 0 := by
+      rw [map_sub, map_pow, Polynomial.aeval_X, Polynomial.aeval_C, hpow,
+        Algebra.algebraMap_eq_smul_one, sub_self]
+    exact Module.End.isSemisimple_of_squarefree_aeval_eq_zero hsqf haeval
+  refine ⟨hss, hss.iSup_eigenspace_eq_top, α, hα0, ?_⟩
+  intro μ hμ
+  obtain ⟨v, hv, hv0⟩ := hμ.exists_hasEigenvector
+  have hve : Kop q V v = μ • v := Module.End.mem_eigenspace_iff.mp hv
+  -- On the eigenvector `v`, `Kop ^ n` acts by `μ ^ n`; specialise at `orderOf q`, compare to `α`.
+  have hpm : ∀ n : ℕ, (Kop q V ^ n) v = μ ^ n • v := by
+    intro n
+    induction n with
+    | zero => simp
+    | succ n ih => rw [pow_succ, Module.End.mul_apply, hve, map_smul, ih, smul_smul, ← pow_succ']
+  have h1 : μ ^ orderOf q • v = α • v := by
+    rw [← hpm, hpow, LinearMap.smul_apply, Module.End.one_apply]
+  have h2 : (μ ^ orderOf q - α) • v = 0 := by rw [sub_smul, h1, sub_self]
+  exact (smul_eq_zero.mp h2).resolve_right hv0 |> sub_eq_zero.mp
 
 /-- **Root-of-unity case.** When `q` is a root of unity, the dimensions of the finite
 dimensional irreducible representations are bounded (by `orderOf q`): they no longer occur in

--- a/progress/2026-07-14T10-45-33Z_a7c07fea.md
+++ b/progress/2026-07-14T10-45-33Z_a7c07fea.md
@@ -1,0 +1,44 @@
+## Accomplished
+
+Session type: feature (`/work` → `/feature` on issue #6558).
+
+Discharged both deliverables of #6558 (Ch2 #6553-A, root-of-unity regime) sorry-free in
+`EtingofRepresentationTheory/Chapter2/Problem2_16_5.lean`:
+
+1. **`Kpow_orderOf_central`** — `K ^ orderOf q` commutes with every element of `U_q(sl₂)`.
+   Reduces a general element to the four generator cases (`Kpow_orderOf_mul_e/f`, plus trivial `K`
+   and `L` via `Commute.pow_left`) through the surjection `mk q` and `FreeAlgebra.induction`.
+2. **`Kpow_orderOf_isScalar`** — on a finite dimensional irreducible module over `ℂ`,
+   `K ^ orderOf q` acts as a single scalar `α ≠ 0`. Schur's lemma: centrality makes the
+   `α`-eigenspace of `Kop ^ orderOf q` a `U_q`-submodule, which (nonzero, in a simple module) is
+   all of `V`; `α ≠ 0` because `K ^ orderOf q` is a unit with inverse `L ^ orderOf q`.
+3. **`Kop_isSemisimple_and_eigenvalues`** (deliverable 2, diagonalizability) — `Kop` satisfies the
+   separable (hence squarefree, char 0, `α ≠ 0`) annihilating polynomial `X ^ orderOf q - C α`, so
+   it `IsSemisimple`, its eigenspaces span `V` (`⨆ μ, eigenspace = ⊤`), and every `K`-eigenvalue is
+   an `orderOf q`-th root of `α` (≤ `orderOf q` distinct eigenvalues).
+
+Also extracted the reusable helper **`Kop_pow_apply`** (`(Kop ^ n) v = K ^ n • v`).
+
+## Current frontier
+
+`Problem2_16_5.lean` builds with a single remaining sorry: `finrank_irreducible_le_of_isOfFinOrder`
+(the actual dimension bound `finrank ≤ orderOf q`), which is the target of the separate blocked
+issue #6559.
+
+## Overall project progress
+
+Phase 3 formalization ongoing across chapters. Ch2 Problem 2.16.5: non-root-of-unity classification
+landed earlier; root-of-unity infrastructure now has centrality + scalar action + diagonalizability
+of `K`. The final finrank bound remains.
+
+## Next step
+
+Pick up #6559 (now effectively unblocked by this work): use `Kop_isSemisimple_and_eigenvalues` plus
+1-dimensionality of the `K`-eigenspaces (from highest-weight uniqueness) to prove
+`finrank_irreducible_le_of_isOfFinOrder`. The eigenvalue-count fact `μ ^ orderOf q = α` and
+`⨆ μ, eigenspace = ⊤` are the pieces a counting argument needs.
+
+## Blockers
+
+None. Key Mathlib lemmas used: `Module.End.isSemisimple_of_squarefree_aeval_eq_zero`,
+`Module.End.IsSemisimple.iSup_eigenspace_eq_top`, `Polynomial.separable_X_pow_sub_C`.


### PR DESCRIPTION
This PR discharges both deliverables of #6558 (Ch2 #6553-A, the root-of-unity regime of Problem 2.16.5) sorry-free.

It proves `Kpow_orderOf_central`: the element `K ^ orderOf q` commutes with every element of `U_q(sl₂)`, reducing a general element to the four generator cases via the surjection `mk q` and `FreeAlgebra.induction`. It then proves `Kpow_orderOf_isScalar`: on a finite dimensional irreducible module over `ℂ`, this central element acts as a single scalar `α ≠ 0` (Schur's lemma — its `α`-eigenspace is a nonzero `U_q`-submodule of a simple module, hence all of `V`; `α ≠ 0` because `K ^ orderOf q` is a unit with inverse `L ^ orderOf q`). Finally it proves `Kop_isSemisimple_and_eigenvalues`: `Kop` satisfies the separable annihilating polynomial `X ^ orderOf q - C α`, so it is a semisimple (diagonalizable) operator whose eigenspaces span `V`, and every `K`-eigenvalue is an `orderOf q`-th root of `α` (at most `orderOf q` distinct eigenvalues). A reusable helper `Kop_pow_apply` is extracted.

The remaining `sorry` in the file (`finrank_irreducible_le_of_isOfFinOrder`, the dimension bound) is the target of the separate blocked issue #6559, which this work effectively unblocks.

Closes #6558

🤖 Prepared with Claude Code
