### PR TITLE
feat(Ch2 #6559): add f_eigenvalue_shift; plan step 2 is false, needs replan

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Problem2_16_5.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_16_5.lean
@@ -128,6 +128,16 @@ lemma e_eigenvalue_shift (μ : ℂ) (w : V) (hw : Kop q V w = μ • w) :
   rw [h1, Ke_rel, smul_assoc, mul_smul, hw, smul_comm (e q) μ w, smul_smul]
 
 omit [FiniteDimensional ℂ V] in
+/-- If `w` is a `K`-eigenvector with eigenvalue `μ`, then `f • w` is `0` or a `K`-eigenvector
+with eigenvalue `q⁻²·μ` (from the relation `K f = q⁻²·(f K)`). Dual to `e_eigenvalue_shift`; it
+is the `f`-direction of the weight ladder used in the root-of-unity dimension bound. -/
+lemma f_eigenvalue_shift (μ : ℂ) (w : V) (hw : Kop q V w = μ • w) :
+    Kop q V (f q • w) = (((q : ℂ) ^ 2)⁻¹ * μ) • (f q • w) := by
+  simp only [Kop_apply] at hw ⊢
+  have h1 : K q • (f q • w) = (K q * f q) • w := by rw [mul_smul]
+  rw [h1, Kf_rel, smul_assoc, mul_smul, hw, smul_comm (f q) μ w, smul_smul]
+
+omit [FiniteDimensional ℂ V] in
 /-- `K` acts invertibly (`K·L = 1`), so `0` is not an eigenvalue of `Kop`. -/
 lemma eigenvalue_ne_zero (μ : ℂ) (hμ : (Kop q V).HasEigenvalue μ) : μ ≠ 0 := by
   rintro rfl

--- a/progress/2026-07-14T13-51-29Z_3ba3d57f.md
+++ b/progress/2026-07-14T13-51-29Z_3ba3d57f.md
@@ -1,0 +1,75 @@
+## Accomplished
+
+Worked on #6559 (Ch2 #6553-B: `finrank ℂ V ≤ orderOf q` for irreducible
+`U_q(sl₂)`-modules at a root of unity). Landed the `f`-direction of the weight
+ladder:
+
+- **`f_eigenvalue_shift`** (sorry-free): `f` maps the `μ`-eigenspace of `K` into
+  the `q⁻²·μ`-eigenspace, from `Kf_rel` (`K f = q⁻²(f K)`). Dual to the already
+  landed `e_eigenvalue_shift`. Needed by any correct proof of the bound.
+
+`lake build EtingofRepresentationTheory.Chapter2.Problem2_16_5` succeeds; the only
+remaining `sorry` is the main theorem `finrank_irreducible_le_of_isOfFinOrder`.
+
+## Key finding: the issue's proof plan (step 2) is mathematically FALSE
+
+The issue's step 2 asserts **"each `K`-eigenspace is 1-dimensional"** and step 3
+concludes `finrank = Σ_μ dim(eigenspace) ≤ #eigenvalues · 1 ≤ orderOf q`. Step 2
+is false whenever `orderOf q` is even.
+
+Counterexample: `q = i`, so `orderOf q = 4` and `q² = -1` has order `2`. There is
+a simple 4-dimensional module (the Steinberg / a generic De Concini–Kac cyclic
+module) on which `K` has weights `λ·(q⁻²)^j = λ, -λ, λ, -λ` for `j = 0,1,2,3`.
+So there are only `ord(q²) = 2` distinct eigenvalues, each with a **2-dimensional**
+eigenspace, while `dim = 4 = orderOf q`. Hence eigenspaces are not 1-dimensional,
+yet the bound is tight. Two independent constructions confirm this: the
+highest-weight Steinberg module `L(ℓ-1)` and the generic cyclic module.
+
+Consequence: the `≤ #eigenvalues · 1` step cannot work. The distinct eigenvalues
+number `ord(q²) = orderOf(q)/gcd(2, orderOf q)`, which for even order is
+`orderOf(q)/2`, and the eigenspaces have average multiplicity `2`.
+
+## Corrected approach (for the replan)
+
+Note the eigenvalue COUNT bound is already free: `Kop_isSemisimple_and_eigenvalues`
+proves every eigenvalue `μ` satisfies `μ^(orderOf q) = α` for a fixed `α ≠ 0`, so
+there are at most `orderOf q` distinct eigenvalues (roots of `X^ℓ - α`). Step 1's
+`q²`-orbit refinement is not needed for the count.
+
+The genuine content (the crux) is the dimension bound with multiplicities, which
+is the De Concini–Kac structure theory:
+
+1. `e^ℓ` and `f^ℓ` are central in `U_q(sl₂)` at a root of unity (quantum
+   Frobenius): `K e^ℓ = q^{2ℓ} e^ℓ K = e^ℓ K` since `q^{2ℓ} = 1`, and likewise
+   they commute with `e`, `f`. By Schur they act as scalars on the simple `V`.
+2. The nonzero eigenspaces form a single `q²`-orbit cycle `E_0,…,E_{s-1}`
+   (`s = ord(q²)`) with `e : E_j → E_{j+1}`, `f : E_j → E_{j-1}` (mod `s`), spanning
+   an invariant subspace `= V` by simplicity.
+3. The closed-string relations (`e^ℓ`, `f^ℓ` scalar) bound the total length of the
+   `e`/`f`-string through any eigenvector, giving `dim V ≤ ℓ`.
+
+This is substantial (centrality of `e^ℓ`/`f^ℓ` plus the string-closure bound) and
+should be decomposed into at least two sub-issues. **Do not re-file the
+"1-dim eigenspaces" plan.**
+
+## Current frontier
+
+`f_eigenvalue_shift` landed; main theorem still `sorry`. Partial PR opened on
+#6559; issue marked `replan` with the corrected-approach comment above.
+
+## Overall project progress
+
+Phase 3 formalization, Chapter 2 quantum-`sl₂` classification. Non-root-of-unity
+case fully proved in this file; root-of-unity dimension bound is the last
+`sorry` here, now correctly scoped.
+
+## Next step
+
+Planner: re-scope #6559 to the corrected De Concini–Kac approach (centrality of
+`e^ℓ`, `f^ℓ` → scalars; closed-string dimension bound). Discard the false
+"1-dim eigenspace" plan.
+
+## Blockers
+
+None mechanical. The remaining crux is genuinely research-level (multi-session)
+and the original plan was mathematically incorrect; re-scoping needed.


### PR DESCRIPTION
Partial progress on #6559

Session: `3ba3d57f-5af9-407a-a330-6b531c26ea50`

91e04289 docs(#6559): progress note — f_eigenvalue_shift landed, plan step 2 is false
696e6f58 feat(Ch2 #6559): add f_eigenvalue_shift (K-weight ladder, f-direction)

🤖 Prepared with Claude Code