### PR TITLE
feat(Ch8 #6589): mirror right-exactness of M ⊗_A - and degree-0 balancing

### DIFF
--- a/EtingofRepresentationTheory/Chapter8/Definition8_2_3_LeftExact.lean
+++ b/EtingofRepresentationTheory/Chapter8/Definition8_2_3_LeftExact.lean
@@ -1,0 +1,159 @@
+import EtingofRepresentationTheory.Chapter8.Problem8_2_6_Core
+import EtingofRepresentationTheory.Chapter8.Definition8_2_3_RightExact
+import Mathlib.CategoryTheory.Adjunction.Limits
+
+/-!
+# Right-exactness of `M ⊗_A -`
+
+The functor `Etingof.tensorLeftFunctor A M : ModuleCat A ⥤ AddCommGrpCat` (Problem 8.2.6 core),
+sending a left `A`-module `N` to `M ⊗_A N`, is a **left adjoint**: its right adjoint sends an
+abelian group `B` to the left `A`-module `M →+ B`, with action `(a • f) m = f (aᵒᵖ • m)`. This is
+the tensor–hom adjunction
+
+  `Hom_ℤ(M ⊗_A N, B) ≃ Hom_A(N, M →+ B)`
+
+on the *second* tensor factor (mirroring `Definition8_2_3_RightExact.lean`, which treats the first
+factor). Consequently `M ⊗_A -` preserves all colimits, in particular finite colimits. This is the
+`PreservesFiniteColimits` input that `Functor.leftDerivedZeroIsoSelf` needs to identify the zeroth
+left derived functor of `M ⊗_A -` with `M ⊗_A -` itself — the base case of the balancing theorem
+Problem 8.2.6(iv).
+-/
+
+open CategoryTheory Limits TensorProduct MulOpposite
+
+namespace Etingof
+
+universe u
+
+variable (A : Type u) [Ring A]
+variable (M : ModuleCat.{u} Aᵐᵒᵖ)
+
+section HomModule
+
+variable (B : Type u) [AddCommGroup B]
+
+/-- The left `A`-action on `M →+ B` used as the value of the right adjoint of `M ⊗_A -`:
+`(a • f) m = f (aᵒᵖ • m)`, using the right `A`-action `aᵒᵖ • m` on the right module `M`. -/
+instance homLSMul : SMul A (M →+ B) where
+  smul a f := f.comp (DistribSMul.toAddMonoidHom M (MulOpposite.op a))
+
+@[simp] lemma homLSMul_apply (a : A) (f : M →+ B) (m : M) :
+    (a • f) m = f (MulOpposite.op a • m) := rfl
+
+/-- `M →+ B` is a left `A`-module. -/
+instance homLModule : Module A (M →+ B) where
+  one_smul f := by ext m; simp
+  mul_smul a b f := by ext m; simp only [homLSMul_apply, MulOpposite.op_mul, mul_smul]
+  smul_zero a := by ext m; simp
+  smul_add a f g := by ext m; simp
+  add_smul a b f := by ext m; simp only [homLSMul_apply, MulOpposite.op_add, add_smul, map_add,
+    AddMonoidHom.add_apply]
+  zero_smul f := by ext m; simp
+
+end HomModule
+
+variable {A M}
+variable {N : Type u} [AddCommGroup N] [Module A N]
+
+/-- Forward direction of the tensor–hom adjunction (second factor): an additive map
+`φ : M ⊗_A N →+ B` curries to the left-`A`-linear map `n ↦ (m ↦ φ (m ⊗ n))`. -/
+def homEquivToFunL {B : Type u} [AddCommGroup B] (φ : tensorOver A N M →+ B) :
+    N →ₗ[A] (M →+ B) where
+  toFun n := φ.comp ((QuotientAddGroup.mk' _).comp ((TensorProduct.mk ℤ M N).flip n).toAddMonoidHom)
+  map_add' n n' := by
+    ext m
+    simp only [AddMonoidHom.coe_comp, Function.comp_apply, LinearMap.toAddMonoidHom_coe,
+      LinearMap.flip_apply, TensorProduct.mk_apply, AddMonoidHom.add_apply]
+    rw [tmul_add, map_add, map_add]
+  map_smul' a n := by
+    ext m
+    simp only [AddMonoidHom.coe_comp, Function.comp_apply, LinearMap.toAddMonoidHom_coe,
+      LinearMap.flip_apply, TensorProduct.mk_apply, QuotientAddGroup.mk'_apply, RingHom.id_apply,
+      homLSMul_apply]
+    rw [mk_smul_tmul (MulOpposite.op a), MulOpposite.unop_op]
+
+@[simp] lemma homEquivToFunL_apply {B : Type u} [AddCommGroup B] (φ : tensorOver A N M →+ B)
+    (n : N) (m : M) :
+    homEquivToFunL φ n m = φ (m ⊗ₜ[ℤ] n : TensorProduct ℤ M N) := rfl
+
+/-- Inverse direction of the tensor–hom adjunction (second factor): a left-`A`-linear map
+`Ψ : N →ₗ[A] (M →+ B)` uncurries to the additive map `M ⊗_A N →+ B`, `m ⊗ n ↦ Ψ n m`. -/
+noncomputable def homEquivInvFunL {B : Type u} [AddCommGroup B] (Ψ : N →ₗ[A] (M →+ B)) :
+    tensorOver A N M →+ B :=
+  QuotientAddGroup.lift (balancedSubgroup A N M)
+    (TensorProduct.liftAddHom (AddMonoidHom.flip Ψ.toAddMonoidHom) (fun r m n => by
+      simp only [AddMonoidHom.flip_apply, LinearMap.toAddMonoidHom_coe, map_zsmul,
+        AddMonoidHom.smul_apply]))
+    (by
+      refine AddSubgroup.closure_le _ |>.mpr ?_
+      rintro _ ⟨a, m, n, rfl⟩
+      simp only [SetLike.mem_coe, AddMonoidHom.mem_ker, map_sub, TensorProduct.liftAddHom_tmul,
+        AddMonoidHom.flip_apply, LinearMap.toAddMonoidHom_coe]
+      rw [show Ψ (a • n) = a • Ψ n from map_smul Ψ a n, homLSMul_apply, sub_self])
+
+@[simp] lemma homEquivInvFunL_mk {B : Type u} [AddCommGroup B] (Ψ : N →ₗ[A] (M →+ B))
+    (m : M) (n : N) :
+    homEquivInvFunL Ψ (m ⊗ₜ[ℤ] n : TensorProduct ℤ M N) = Ψ n m :=
+  rfl
+
+variable (A M)
+
+/-- The right adjoint `B ↦ (M →+ B)` of `M ⊗_A -`, as a functor from abelian groups to left
+`A`-modules. -/
+noncomputable def homFunctorL : AddCommGrpCat.{u} ⥤ ModuleCat.{u} A where
+  obj B := ModuleCat.of A (M →+ B)
+  map {B B'} g := ModuleCat.ofHom
+    { toFun f := g.hom.comp f
+      map_add' f f' := by ext m; simp
+      map_smul' a f := by ext m; simp }
+  map_id B := by
+    apply ModuleCat.hom_ext
+    apply LinearMap.ext
+    intro f
+    ext m
+    simp
+  map_comp {B B' B''} g h := by
+    apply ModuleCat.hom_ext
+    apply LinearMap.ext
+    intro f
+    ext m
+    simp
+
+/-- The tensor–hom adjunction `(M ⊗_A -) ⊣ (M →+ -)`. -/
+noncomputable def tensorHomAdjunctionL : tensorLeftFunctor A M ⊣ homFunctorL A M :=
+  Adjunction.mkOfHomEquiv
+    { homEquiv := fun N B =>
+        { toFun := fun φ => ModuleCat.ofHom (homEquivToFunL φ.hom)
+          invFun := fun Ψ => AddCommGrpCat.ofHom (homEquivInvFunL Ψ.hom)
+          left_inv := fun φ => by
+            apply AddCommGrpCat.hom_ext
+            apply tensorOver_hom_ext
+            intro m n
+            simp
+          right_inv := fun Ψ => by
+            apply ModuleCat.hom_ext
+            apply LinearMap.ext
+            intro n
+            refine AddMonoidHom.ext fun m => ?_
+            simp }
+      homEquiv_naturality_left_symm := fun {N' N B} f g => by
+        apply AddCommGrpCat.hom_ext
+        apply tensorOver_hom_ext
+        intro m n
+        rfl
+      homEquiv_naturality_right := fun {N B B'} f g => by
+        apply ModuleCat.hom_ext
+        apply LinearMap.ext
+        intro n
+        refine AddMonoidHom.ext fun m => ?_
+        rfl }
+
+/-- `M ⊗_A -` is a left adjoint, hence preserves finite colimits (it is right exact). This is the
+input `Functor.leftDerivedZeroIsoSelf` needs for the balancing theorem's degree-0 base case. -/
+noncomputable instance tensorLeftFunctor_preservesFiniteColimits :
+    PreservesFiniteColimits (tensorLeftFunctor A M) := by
+  haveI : PreservesColimitsOfSize.{u, u} (tensorLeftFunctor A M) :=
+    (tensorHomAdjunctionL A M).leftAdjoint_preservesColimits
+  exact PreservesColimitsOfSize.preservesFiniteColimits _
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_6.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_6.lean
@@ -1,5 +1,6 @@
 import EtingofRepresentationTheory.Chapter8.Definition8_2_3
 import EtingofRepresentationTheory.Chapter8.Definition8_2_3_RightExact
+import EtingofRepresentationTheory.Chapter8.Definition8_2_3_LeftExact
 import EtingofRepresentationTheory.Chapter8.Problem8_2_6_Core
 import EtingofRepresentationTheory.Chapter8.TensorProjectiveExact
 import EtingofRepresentationTheory.Chapter8.LeftDerivedSequence
@@ -158,6 +159,20 @@ theorem Problem_8_2_6_iii_tor
     (fun Y _ => tensorLeftFunctor_map_shortExact A Y hS) M n₀ n₁ h
 
 /-! ### Part (iv): the balancing theorem -/
+
+/-- **Balancing in degree 0** (the base case of the dimension-shift proof of Problem 8.2.6(iv)).
+Both `Tor₀ᴬ(M, N)` and the zeroth left derived functor of `M ⊗_A -` evaluated at `N` are
+canonically the group `M ⊗_A N`: `Etingof.Tor A N M 0 = (leftDerived (tensorRightFunctor A N) 0).obj M`
+and `(leftDerived (tensorLeftFunctor A M) 0).obj N` both reduce, via `leftDerivedZeroIsoSelf`, to the
+common object `AddCommGrpCat.of (tensorOver A N M) = M ⊗_A N`. Composing the two zeroth-derived
+identifications gives the balancing isomorphism in degree `0`. -/
+noncomputable def balancingIsoZero
+    (A : Type u) [Ring A] (N : Type u) [AddCommGroup N] [Module A N]
+    (M : ModuleCat.{u} Aᵐᵒᵖ) :
+    Etingof.Tor A N M 0 ≅
+      (Functor.leftDerived (tensorLeftFunctor A M) 0).obj (ModuleCat.of A N) :=
+  ((tensorRightFunctor A N).leftDerivedZeroIsoSelf.app M) ≪≫
+    ((tensorLeftFunctor A M).leftDerivedZeroIsoSelf.app (ModuleCat.of A N)).symm
 
 /-- **Problem 8.2.6(iv), balancing.** `Torₙᴬ(M, N)` may be computed from a projective resolution
 of `N` tensored with `M`: the `n`-th left derived functor of `- ⊗_A N` evaluated at `M`

--- a/progress/2026-07-14T18-03-45Z_5075611b.md
+++ b/progress/2026-07-14T18-03-45Z_5075611b.md
@@ -1,0 +1,34 @@
+## Accomplished
+Partial progress on the balancing theorem for `Tor` (Problem 8.2.6(iv), issue #6589). Landed two
+foundational, sorry-free bricks on the critical path:
+- `EtingofRepresentationTheory/Chapter8/Definition8_2_3_LeftExact.lean` (new): the tensor–hom
+  adjunction `(M ⊗_A -) ⊣ (M →+ -)` on the *second* tensor factor (mirror of
+  `Definition8_2_3_RightExact.lean`), yielding the instance
+  `PreservesFiniteColimits (tensorLeftFunctor A M)`. This is the right-exactness input
+  `Functor.leftDerivedZeroIsoSelf` needs on the balancing side.
+- `Etingof.balancingIsoZero` in `Problem8_2_6.lean`: the degree-0 base case
+  `Tor A N M 0 ≅ (leftDerived (tensorLeftFunctor A M) 0).obj (of A N)`, via the two
+  `leftDerivedZeroIsoSelf` identifications onto the common object `M ⊗_A N`.
+
+Discovered and adopted the **elementary dimension-shifting** proof route (avoids the
+double-complex / spectral-sequence machinery the original issue suggested). Verified the key
+enabling fact: `tensorLeftFunctor A M` obj N and `tensorRightFunctor A N` obj M are the *same*
+object `AddCommGrpCat.of (tensorOver A N M)`, so degree-0 balancing is just the two right-derived-zero
+identifications.
+
+## Current frontier
+`Problem_8_2_6_iv` remains `sorry` (only sorry in `Problem8_2_6.lean`, line ~182). Decomposed the
+remaining work into #6608 (A), #6609 (B), #6610 (C), #6611 (D) — see the breadcrumb on #6589.
+
+## Overall project progress
+Stage 3 formalization. Problem 8.2.6 parts (i),(ii),(iii),(v) are done; (iv) is the last piece,
+now scaffolded with base case + right-exactness landed and a 4-issue plan for the rest.
+
+## Next step
+Work #6608 (mirror first-argument flatness `tensorRightFunctor_map_shortExact`) — it now has all its
+helper infrastructure (`Definition8_2_3_LeftExact.lean` landed) and unblocks #6609. Then #6610, then
+assemble in #6611 using `balancingIsoZero` as the base case.
+
+## Blockers
+None. #6608 is ready once this PR merges (it uses `Definition8_2_3_LeftExact.lean`). #6609/#6611
+are dependency-gated on #6608/#6610 via `depends-on`.


### PR DESCRIPTION
This PR lands the foundational bricks for the balancing theorem for `Tor` (Problem 8.2.6(iv), #6589), taking the elementary **dimension-shifting** route rather than the double-complex/spectral-sequence machinery the original issue suggested. It adds `Definition8_2_3_LeftExact.lean`, which establishes the tensor–hom adjunction `(M ⊗_A -) ⊣ (M →+ -)` on the second tensor factor (mirror of `Definition8_2_3_RightExact.lean`) and hence the instance `PreservesFiniteColimits (tensorLeftFunctor A M)`; and it proves `Etingof.balancingIsoZero`, the degree-0 base case `Tor A N M 0 ≅ (leftDerived (tensorLeftFunctor A M) 0).obj (of A N)` via the two `leftDerivedZeroIsoSelf` identifications onto the common object `M ⊗_A N`.

Both additions are sorry-free; `Problem_8_2_6_iv` itself remains `sorry`. The remaining work is decomposed into #6608 (mirror first-argument flatness), #6609 (balancing-side six-term long exact sequence), #6610 (balancing-side vanishing on projectives), and #6611 (the dimension-shift assembly), with ordering dependencies wired.

Partial completion of #6589 (marked `replan`).

🤖 Prepared with Claude Code