### PR TITLE
feat(Ch8 #6589-C): balancing-side Tor vanishes on projective right modules

### DIFF
--- a/EtingofRepresentationTheory/Chapter8/TensorProjectiveExact.lean
+++ b/EtingofRepresentationTheory/Chapter8/TensorProjectiveExact.lean
@@ -5,6 +5,8 @@ import Mathlib.Algebra.Category.ModuleCat.Adjunctions
 import Mathlib.Algebra.Category.Grp.EpiMono
 import Mathlib.Algebra.Homology.ShortComplex.Retract
 import Mathlib.Algebra.Homology.ShortComplex.Ab
+import Mathlib.Algebra.Homology.ShortComplex.ExactFunctor
+import Mathlib.CategoryTheory.Abelian.LeftDerived
 import Mathlib.LinearAlgebra.Finsupp.LSum
 import Mathlib.Algebra.BigOperators.Finsupp.Basic
 
@@ -398,5 +400,31 @@ theorem tensorLeftFunctor_map_shortExact (P : ModuleCat.{u} Aᵐᵒᵖ) [Project
       r := ε
       retract := Projective.factorThru_comp (𝟙 P) ε }
   exact shortExact_of_retract (mapRetract A h) (free_map_shortExact A _ hS)
+
+/-- **Higher `Tor` (balancing side) vanishes on projective right modules.** The `(n+1)`-st left
+derived functor of `P ⊗_A -` (`tensorLeftFunctor A P`) vanishes at every left `A`-module `N` when
+the right module `P` is projective. Since `P ⊗_A -` is exact (`tensorLeftFunctor_map_shortExact`),
+applying it to a projective resolution of `N` keeps the resolution exact in positive degrees, so its
+homology — the derived functor — vanishes above degree `0`. This is the balancing-side vanishing
+input to the balancing theorem (Problem 8.2.6(iv)), matching the `Etingof.Tor`-side vanishing
+`Functor.isZero_leftDerived_obj_projective_succ`. -/
+lemma isZero_tensorLeftFunctor_leftDerived_succ
+    (P : ModuleCat.{u} Aᵐᵒᵖ) [Projective P]
+    (N : Type u) [AddCommGroup N] [Module A N] (n : ℕ) :
+    IsZero ((Functor.leftDerived (tensorLeftFunctor A P) (n + 1)).obj (ModuleCat.of A N)) := by
+  -- `P ⊗_A -` is exact, hence preserves homology.
+  haveI : (tensorLeftFunctor A P).PreservesHomology :=
+    ((Functor.exact_tfae (tensorLeftFunctor A P)).out 0 2).mp
+      (fun _ hS => tensorLeftFunctor_map_shortExact A P hS)
+  -- Compute the derived functor from a projective resolution of `N`.
+  let R : ProjectiveResolution (ModuleCat.of A N) := ProjectiveResolution.of _
+  refine IsZero.of_iso ?_ (R.isoLeftDerivedObj (tensorLeftFunctor A P) (n + 1))
+  rw [HomologicalComplex.homologyFunctor_obj, ← HomologicalComplex.exactAt_iff_isZero_homology,
+    HomologicalComplex.exactAt_iff]
+  -- The resolution is exact in positive degrees; an exact functor preserves that exactness.
+  have hex : (R.complex.sc (n + 1)).Exact := by
+    have := R.complex_exactAt_succ n
+    rwa [HomologicalComplex.exactAt_iff] at this
+  exact hex.map (tensorLeftFunctor A P)
 
 end Etingof

--- a/progress/2026-07-14T18-30-00Z_4026e223.md
+++ b/progress/2026-07-14T18-30-00Z_4026e223.md
@@ -1,0 +1,54 @@
+## Accomplished
+
+Worked issue #6610 (Ch8, balancing-side `Tor` vanishing on projective right modules). Added the
+lemma `Etingof.isZero_tensorLeftFunctor_leftDerived_succ` to
+`EtingofRepresentationTheory/Chapter8/TensorProjectiveExact.lean`, sorry-free and axiom-clean
+(only `propext`, `Classical.choice`, `Quot.sound`):
+
+```lean
+lemma isZero_tensorLeftFunctor_leftDerived_succ
+    (P : ModuleCat.{u} Aᵐᵒᵖ) [Projective P]
+    (N : Type u) [AddCommGroup N] [Module A N] (n : ℕ) :
+    IsZero ((Functor.leftDerived (tensorLeftFunctor A P) (n + 1)).obj (ModuleCat.of A N))
+```
+
+Proof route (as planned in the issue):
+- `tensorLeftFunctor A P` (= `P ⊗_A -`) sends short exact sequences to short exact sequences by the
+  existing `tensorLeftFunctor_map_shortExact` (#6587). Via `Functor.exact_tfae` (Mathlib) this gives
+  `PreservesHomology` for the functor.
+- Compute the derived functor from a projective resolution `R := ProjectiveResolution.of (of A N)`
+  using `ProjectiveResolution.isoLeftDerivedObj`; reduce `IsZero` of the homology to
+  `ExactAt (n+1)` of the image complex via `homologyFunctor_obj` + `exactAt_iff_isZero_homology`.
+- `R.complex` is exact in positive degrees (`complex_exactAt_succ`); an exact functor preserves that
+  exactness. `ShortComplex.Exact.map` applied to `R.complex.sc (n+1)` closes the goal (the mapped
+  `sc` is definitionally the image short complex, so `hex.map _` typechecks directly).
+
+Two imports added to the file: `Mathlib.Algebra.Homology.ShortComplex.ExactFunctor` (for
+`exact_tfae`) and `Mathlib.CategoryTheory.Abelian.LeftDerived` (for `leftDerived` /
+`isoLeftDerivedObj`).
+
+## Current frontier
+
+`isZero_tensorLeftFunctor_leftDerived_succ` is landed. It is the balancing-side counterpart to the
+`Etingof.Tor`-side vanishing `Functor.isZero_leftDerived_obj_projective_succ`; both are now available
+to collapse the two six-term long exact sequences in the balancing theorem `Problem_8_2_6_iv`
+(`Chapter8/Problem8_2_6.lean`), which is still `sorry`.
+
+## Overall project progress
+
+Phase 3 formalization ongoing. Chapter 8 Tor/Ext infrastructure continues to fill in: parts (i),
+(ii), (iii)-Ext/Tor, (v)-Ext/Tor are done; (iv) the balancing theorem remains `sorry` but both of
+its projective-vanishing inputs now exist.
+
+## Next step
+
+Assemble `Problem_8_2_6_iv` (the balancing isomorphism) using dimension shifting: both derived
+functors vanish on projectives (`Functor.isZero_leftDerived_obj_projective_succ` for the `Tor` side,
+`isZero_tensorLeftFunctor_leftDerived_succ` for the balancing side). Likely needs its own issue given
+the size of the double-complex / dimension-shifting argument.
+
+## Blockers
+
+None.
+</content>
+</invoke>


### PR DESCRIPTION
Closes #6610

Session: `4026e223-f791-415f-b63a-a8feab7ab7cf`

ab0fd140 docs: progress for #6610 (balancing-side Tor vanishing)
71e946c8 feat(Ch8 #6610): balancing-side Tor vanishes on projective right modules

🤖 Prepared with Claude Code