### PR TITLE
feat(Ch5 #Problem5.11.1-c): decompose A₅ representations induced from ℤ₅ (indZ5_triv, indZ5_nontriv)

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -903,6 +903,22 @@ has two traps that each cost several build cycles:
   independent members of any nonzero invariant `U` (a nonzero `f` and a well-chosen `ρ(g) f`, via
   a `2×2` coordinate determinant `≠ 0`), then `Submodule.eq_of_le_of_finrank_le`.
 
+### `rw [← h]` on an order/cardinality numeral that equals the `Fin n` size corrupts the motive (#6639, Ch5 A₅)
+
+Working in `A5 = ↥(alternatingGroup (Fin 5))`, an order-`5` element `a` has `orderOf a = 5` — the
+same numeral `5` as in `Fin 5`, which is baked into `a`'s *type*. So `rw [← horda]` (rewriting
+`5 ↦ orderOf a` in a goal like `a ^ 5 = 1`) or `rw [ha_def, ← horda₀]` (in `orderOf a = 5`)
+tries to generalize *every* `5`, including the one inside `Fin 5`, and fails with
+`motive is not type correct` plus a spurious `Fintype (ToType {len := 4})` mismatch. The
+identical proof shape for order-`3`/order-`2` elements works precisely because `3`/`2 ≠ 5`.
+**Fix:** never rewrite the numeral. Rewrite the `orderOf`/order term instead:
+- `have horda : orderOf a = 5 := by rw [ha_def]; exact (orderOf_injective H.subtype (Subgroup.subtype_injective H) a₀).trans horda₀` (compose, don't `← horda₀`).
+- `have ha5 : a ^ 5 = 1 := by have h := pow_orderOf_eq_one a; rwa [horda] at h` (rewrite `orderOf a ↦ 5`, forward, not the numeral).
+
+Same trap bites `Real.sqrt 5` vector literals: `![12, 0, 0, (-1 + Real.sqrt 5)/2, …]` compared to a
+`: ℂ` character elaborates the vector as `Fin 5 → ℝ` and inserts a `↑(…)` coercion, so it won't
+`rfl`-match a `ℂ`-side value with `↑√5`. Force `ℂ` by writing `(Real.sqrt 5 : ℂ)` inside the entries.
+
 ### Plugging a concrete `Type 0` group (`ZMod`, `Fin`, …) into a `∀ Q : Type u` hypothesis → `ULift` (#6101)
 
 A theorem like `Exercise_8_2_9_i_finAb` quantifies its lifting hypothesis over `Q₁ Q₂ : Type u`

--- a/EtingofRepresentationTheory/Chapter5/Problem5_11_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_11_1.lean
@@ -974,6 +974,318 @@ theorem indZ5_triv (H : Subgroup A5) (hH : Nat.card H = 5)
   funext g
   rw [indZ5_triv_char_all H hH σ htriv g, indZ5_triv_target_char_all g]
 
+/-! ### Nontrivial characters of `ℤ₅`
+
+Unlike the `3`-cycle class, the two `5`-cycle classes `5a`/`5b` are distinct, and the four
+nontrivial elements `a, a², a³, a⁴` of `H = ⟨a⟩` split as `{a, a⁴} ⊂ 5x`, `{a², a³} ⊂ 5y`
+(inverse pairs), with `{5x, 5y} = {5a, 5b}` depending on the class of the generator. The
+induced character therefore takes values `z + z⁴` and `z² + z³` (`z = χ(a)` a primitive `5`th
+root of unity) on the two `5`-cycle classes, in one order or the other. Both are roots of
+`t² + t − 1`, i.e. `(−1 ± √5)/2`, matching the golden-ratio character values of `3`/`3'`. -/
+
+set_option maxRecDepth 8000 in
+-- honest `decide` over the 60 elements: which `5`-cycle class each power of an order-`5`
+-- element lands in (`{s, s⁴}` share a class, `{s², s³}` the other).
+set_option maxHeartbeats 4000000 in
+/-- For an order-`5` element `s`, the powers split as `{s, s⁴}` in one `5`-cycle class and
+`{s², s³}` in the other (`3 = 5a`, `4 = 5b`). -/
+lemma classIdxA5_pow5 (s : A5) (h5 : s ^ 5 = 1) (hne : s ≠ 1) :
+    (classIdxA5 s = 3 ∧ classIdxA5 (s ^ 2) = 4 ∧ classIdxA5 (s ^ 3) = 4 ∧ classIdxA5 (s ^ 4) = 3)
+    ∨ (classIdxA5 s = 4 ∧ classIdxA5 (s ^ 2) = 3 ∧ classIdxA5 (s ^ 3) = 3 ∧
+        classIdxA5 (s ^ 4) = 4) := by
+  revert s; decide
+
+set_option maxRecDepth 8000 in
+-- `decide` evaluates the conjugator equality over all 60 elements of `A₅`.
+set_option maxHeartbeats 4000000 in
+/-- The count `#{x : x·(classRepA5 j)·x⁻¹ = classRepA5 3}`: `5` (the centralizer order) on the
+`5a` class, `0` elsewhere. -/
+lemma cr3Count (j : Fin 5) :
+    (univ.filter (fun x : A5 => x * classRepA5 j * x⁻¹ = classRepA5 3)).card
+      = ![0, 0, 0, 5, 0] j := by
+  fin_cases j <;> decide
+
+set_option maxRecDepth 8000 in
+-- `decide` evaluates the conjugator equality over all 60 elements of `A₅`.
+set_option maxHeartbeats 4000000 in
+/-- The count `#{x : x·(classRepA5 j)·x⁻¹ = classRepA5 4}`: `5` (the centralizer order) on the
+`5b` class, `0` elsewhere. -/
+lemma cr4Count (j : Fin 5) :
+    (univ.filter (fun x : A5 => x * classRepA5 j * x⁻¹ = classRepA5 4)).card
+      = ![0, 0, 0, 0, 5] j := by
+  fin_cases j <;> decide
+
+/-- **Target character (`3 ⊕ 4 ⊕ 5`), class-rep values.** `(3, 4, 5)` sum to
+`(12, 0, 0, (−1+√5)/2, (−1−√5)/2)` on the five class reps. -/
+lemma indZ5_target1_value (j : Fin 5) :
+    (repC3plus ⊞ repC4 ⊞ repC5).character (classRepA5 j)
+      = ![12, 0, 0, (-1 + (Real.sqrt 5 : ℂ)) / 2, (-1 - (Real.sqrt 5 : ℂ)) / 2] j := by
+  simp only [character_biprod, repC3plus_character, repC4_character, repC5_character]
+  have hs := sqrt5_sq
+  fin_cases j <;>
+    norm_num [Q5toC, chiA5, tblA5, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+      Matrix.cons_val_three, Matrix.cons_val_four, Matrix.head_cons, Matrix.tail_cons,
+      Q5.mk_re, Q5.mk_im, Q5.ofNat_re, Q5.ofNat_im, Q5.neg_re, Q5.neg_im, Q5.one_re, Q5.one_im,
+      Q5.zero_re, Q5.zero_im] <;>
+    ring
+
+/-- **Target character (`3' ⊕ 4 ⊕ 5`), class-rep values.** `(3', 4, 5)` sum to
+`(12, 0, 0, (−1−√5)/2, (−1+√5)/2)` on the five class reps (the two `5`-cycle values swapped). -/
+lemma indZ5_target2_value (j : Fin 5) :
+    (repC3minus ⊞ repC4 ⊞ repC5).character (classRepA5 j)
+      = ![12, 0, 0, (-1 - (Real.sqrt 5 : ℂ)) / 2, (-1 + (Real.sqrt 5 : ℂ)) / 2] j := by
+  simp only [character_biprod, repC3minus_character, repC4_character, repC5_character]
+  have hs := sqrt5_sq
+  fin_cases j <;>
+    norm_num [Q5toC, chiA5, tblA5, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+      Matrix.cons_val_three, Matrix.cons_val_four, Matrix.head_cons, Matrix.tail_cons,
+      Q5.mk_re, Q5.mk_im, Q5.ofNat_re, Q5.ofNat_im, Q5.neg_re, Q5.neg_im, Q5.one_re, Q5.one_im,
+      Q5.zero_re, Q5.zero_im] <;>
+    ring
+
+/-- **Nontrivial character, class-rep values.** For an order-`5` `H` and a simple nontrivial `σ`
+with `z = σ.character` of a generator, `(ind σ).character` takes the values
+`(12, 0, 0, A, B)` on the five class reps, where `{A, B} = {z + z⁴, z² + z³}` (in one order or the
+other, per the class of the generator), `A + B = -1`, and `A² + A − 1 = 0`. -/
+lemma indZ5_nontriv_value (H : Subgroup A5) [DecidablePred (· ∈ H)] (hH : Nat.card H = 5)
+    (σ : FDRep ℂ ↥H) [Simple σ] (hntriv : ∃ h : ↥H, σ.character h ≠ 1) :
+    ∃ A B : ℂ, A + B = -1 ∧ A ^ 2 + A - 1 = 0 ∧
+      ∀ j, (ind σ).character (classRepA5 j) = ![12, 0, 0, A, B] j := by
+  classical
+  haveI : Fact (Nat.Prime 5) := ⟨by norm_num⟩
+  haveI hcyc : IsCyclic ↥H := isCyclic_of_prime_card hH
+  letI cg : CommGroup ↥H := IsCyclic.commGroup
+  haveI hsm : IsSimpleModule (MonoidAlgebra ℂ ↥H) (Representation.asModule σ.ρ) :=
+    Etingof.isSimpleModule_asModule_of_simple σ
+  have hdim : Module.finrank ℂ (σ : Type) = 1 := Etingof.Example4_3_FiniteAbelianGroups σ.ρ
+  have hscalar : ∀ g : ↥H, σ.ρ g = (σ.character g : ℂ) • LinearMap.id := by
+    intro g
+    obtain ⟨c, hc, -⟩ := LinearMap.existsUnique_eq_smul_id_of_finrank_eq_one hdim (σ.ρ g)
+    have hcc : σ.character g = c := by
+      change LinearMap.trace ℂ _ (σ.ρ g) = c
+      rw [hc, map_smul, LinearMap.trace_id, hdim]; simp
+    rw [hcc]; exact hc
+  have hone : σ.character 1 = 1 := by rw [FDRep.char_one, hdim, Nat.cast_one]
+  have hmul : ∀ g h : ↥H, σ.character (g * h) = σ.character g * σ.character h := by
+    intro g h
+    have key : (σ.character (g * h) : ℂ) • (LinearMap.id : (σ : Type) →ₗ[ℂ] (σ : Type))
+             = (σ.character g * σ.character h : ℂ) • LinearMap.id := by
+      rw [← hscalar (g * h), map_mul, hscalar g, hscalar h]
+      ext x
+      simp only [Module.End.mul_apply, LinearMap.smul_apply, LinearMap.id_coe, id_eq, smul_smul]
+    have htr := congrArg (LinearMap.trace ℂ (σ : Type)) key
+    rwa [map_smul, map_smul, LinearMap.trace_id, hdim, Nat.cast_one, smul_eq_mul, smul_eq_mul,
+      mul_one, mul_one] at htr
+  set χ : ↥H →* ℂ := { toFun := σ.character, map_one' := hone, map_mul' := hmul } with hχ
+  have hχa : ∀ g : ↥H, χ g = σ.character g := fun _ => rfl
+  obtain ⟨a₀, ha₀⟩ := hcyc.exists_generator
+  have horda₀ : orderOf a₀ = 5 := by rw [orderOf_eq_card_of_forall_mem_zpowers ha₀]; exact hH
+  set a : A5 := (a₀ : A5) with ha_def
+  -- Avoid rewriting the numeral `5` (it collides with the `5` in `Fin 5`, a₀'s type).
+  have horda : orderOf a = 5 := by
+    rw [ha_def]
+    exact (orderOf_injective H.subtype (Subgroup.subtype_injective H) a₀).trans horda₀
+  have ha5 : a ^ 5 = 1 := by have h := pow_orderOf_eq_one a; rwa [horda] at h
+  have ha_ne1 : a ≠ 1 := by
+    intro h; rw [h, orderOf_one] at horda; exact absurd horda (by norm_num)
+  obtain ⟨z, hz_def⟩ : ∃ z : ℂ, z = σ.character a₀ := ⟨σ.character a₀, rfl⟩
+  have ha₀5 : a₀ ^ 5 = 1 := by have h := pow_orderOf_eq_one a₀; rwa [horda₀] at h
+  have hz5 : z ^ 5 = 1 := by
+    have h := map_pow χ a₀ 5
+    rw [ha₀5, map_one, hχa, ← hz_def] at h; exact h.symm
+  have hchar_pow : ∀ k : ℕ, σ.character (a₀ ^ k) = z ^ k := by
+    intro k
+    have h := map_pow χ a₀ k
+    rw [hχa, hχa, ← hz_def] at h; exact h
+  -- Enumerate `H = {1, a, a², a³, a⁴}`.
+  have hgen_top : Subgroup.zpowers a₀ = ⊤ := by rw [eq_top_iff]; intro x _; exact ha₀ x
+  have hHzp : Subgroup.zpowers a = H := by
+    have h1 : (Subgroup.zpowers a₀).map H.subtype = Subgroup.zpowers a :=
+      MonoidHom.map_zpowers H.subtype a₀
+    rw [hgen_top, ← MonoidHom.range_eq_map, Subgroup.range_subtype] at h1
+    exact h1.symm
+  have ha2coe : a ^ 2 = ((a₀ ^ 2 : ↥H) : A5) := by rw [ha_def]; push_cast; ring
+  have ha3coe : a ^ 3 = ((a₀ ^ 3 : ↥H) : A5) := by rw [ha_def]; push_cast; ring
+  have ha4coe : a ^ 4 = ((a₀ ^ 4 : ↥H) : A5) := by rw [ha_def]; push_cast; ring
+  have henum : ∀ y : A5, y ∈ H → y = 1 ∨ y = a ∨ y = a ^ 2 ∨ y = a ^ 3 ∨ y = a ^ 4 := by
+    intro y hy
+    rw [← hHzp, Etingof.Problem4_12_5.mem_zpowers_range a 5 horda] at hy
+    simp only [Finset.mem_image, Finset.mem_range] at hy
+    obtain ⟨k, hk, hky⟩ := hy
+    interval_cases k
+    · left; rw [← hky]; simp
+    · right; left; rw [← hky, pow_one]
+    · right; right; left; rw [← hky]
+    · right; right; right; left; rw [← hky]
+    · right; right; right; right; rw [← hky]
+  have ha_mem : a ∈ H := by rw [ha_def]; exact SetLike.coe_mem a₀
+  have ha2_mem : a ^ 2 ∈ H := by rw [ha2coe]; exact SetLike.coe_mem _
+  have ha3_mem : a ^ 3 ∈ H := by rw [ha3coe]; exact SetLike.coe_mem _
+  have ha4_mem : a ^ 4 ∈ H := by rw [ha4coe]; exact SetLike.coe_mem _
+  -- Distinctness of the powers `a⁰,…,a⁴`.
+  have hne : ∀ i j : ℕ, i < 5 → j < 5 → i ≠ j → a ^ i ≠ a ^ j := by
+    intro i j hi hj hij h
+    wlog hlt : i < j generalizing i j
+    · exact this j i hj hi (Ne.symm hij) h.symm (by omega)
+    have hd : a ^ (j - i) = 1 := by
+      have hcancel : a ^ i * a ^ (j - i) = a ^ i * 1 := by
+        rw [mul_one, ← pow_add, Nat.add_sub_cancel' (le_of_lt hlt)]; exact h.symm
+      exact mul_left_cancel hcancel
+    have hle := orderOf_le_of_pow_eq_one (n := j - i) (by omega) hd
+    rw [horda] at hle; omega
+  have e01 : (1 : A5) ≠ a := by
+    have := hne 0 1 (by norm_num) (by norm_num) (by norm_num); rwa [pow_zero, pow_one] at this
+  have e02 : (1 : A5) ≠ a ^ 2 := by
+    have := hne 0 2 (by norm_num) (by norm_num) (by norm_num); rwa [pow_zero] at this
+  have e03 : (1 : A5) ≠ a ^ 3 := by
+    have := hne 0 3 (by norm_num) (by norm_num) (by norm_num); rwa [pow_zero] at this
+  have e04 : (1 : A5) ≠ a ^ 4 := by
+    have := hne 0 4 (by norm_num) (by norm_num) (by norm_num); rwa [pow_zero] at this
+  have e12 : a ≠ a ^ 2 := by
+    have := hne 1 2 (by norm_num) (by norm_num) (by norm_num); rwa [pow_one] at this
+  have e13 : a ≠ a ^ 3 := by
+    have := hne 1 3 (by norm_num) (by norm_num) (by norm_num); rwa [pow_one] at this
+  have e14 : a ≠ a ^ 4 := by
+    have := hne 1 4 (by norm_num) (by norm_num) (by norm_num); rwa [pow_one] at this
+  have e23 : a ^ 2 ≠ a ^ 3 := hne 2 3 (by norm_num) (by norm_num) (by norm_num)
+  have e24 : a ^ 2 ≠ a ^ 4 := hne 2 4 (by norm_num) (by norm_num) (by norm_num)
+  have e34 : a ^ 3 ≠ a ^ 4 := hne 3 4 (by norm_num) (by norm_num) (by norm_num)
+  -- `z ≠ 1` and `z + z² + z³ + z⁴ = -1`.
+  have hz_ne : z ≠ 1 := by
+    obtain ⟨h0, hh0⟩ := hntriv
+    rcases henum (h0 : A5) (SetLike.coe_mem h0) with he | he | he | he | he
+    · exact absurd (by rw [show h0 = 1 from Subtype.ext he]; exact hone) hh0
+    · intro hz1; apply hh0
+      rw [show h0 = a₀ from Subtype.ext (he.trans ha_def), ← hz_def]; exact hz1
+    · intro hz1; apply hh0
+      rw [show h0 = a₀ ^ 2 from Subtype.ext (he.trans ha2coe), hchar_pow 2, hz1]; ring
+    · intro hz1; apply hh0
+      rw [show h0 = a₀ ^ 3 from Subtype.ext (he.trans ha3coe), hchar_pow 3, hz1]; ring
+    · intro hz1; apply hh0
+      rw [show h0 = a₀ ^ 4 from Subtype.ext (he.trans ha4coe), hchar_pow 4, hz1]; ring
+  have hz_sum4 : z + z ^ 2 + z ^ 3 + z ^ 4 = -1 := by
+    have hfac : (z - 1) * (z ^ 4 + z ^ 3 + z ^ 2 + z + 1) = 0 := by linear_combination hz5
+    rcases mul_eq_zero.mp hfac with h | h
+    · exact absurd (by linear_combination h : z = 1) hz_ne
+    · linear_combination h
+  have hcardℂ : (Fintype.card ↥H : ℂ) = 5 := by rw [← Nat.card_eq_fintype_card, hH]; norm_num
+  -- The `hterm` decomposition, shared by both class cases.
+  have hterm : ∀ (j : Fin 5) (x : A5),
+      (if h : x * classRepA5 j * x⁻¹ ∈ H then σ.character ⟨x * classRepA5 j * x⁻¹, h⟩ else 0)
+        = (1 : ℂ) * (if x * classRepA5 j * x⁻¹ = 1 then 1 else 0)
+          + z * (if x * classRepA5 j * x⁻¹ = a then 1 else 0)
+          + z ^ 2 * (if x * classRepA5 j * x⁻¹ = a ^ 2 then 1 else 0)
+          + z ^ 3 * (if x * classRepA5 j * x⁻¹ = a ^ 3 then 1 else 0)
+          + z ^ 4 * (if x * classRepA5 j * x⁻¹ = a ^ 4 then 1 else 0) := by
+    intro j x
+    set y := x * classRepA5 j * x⁻¹ with hy
+    by_cases hmem : y ∈ H
+    · rcases henum y hmem with h1 | hA | hA2 | hA3 | hA4
+      · rw [dif_pos hmem, show (⟨y, hmem⟩ : ↥H) = 1 from Subtype.ext h1, hone,
+          if_pos h1, if_neg (by rw [h1]; exact e01), if_neg (by rw [h1]; exact e02),
+          if_neg (by rw [h1]; exact e03), if_neg (by rw [h1]; exact e04)]
+        ring
+      · rw [dif_pos hmem, show (⟨y, hmem⟩ : ↥H) = a₀ from Subtype.ext (hA.trans ha_def), ← hz_def,
+          if_neg (by rw [hA]; exact e01.symm), if_pos hA, if_neg (by rw [hA]; exact e12),
+          if_neg (by rw [hA]; exact e13), if_neg (by rw [hA]; exact e14)]
+        ring
+      · rw [dif_pos hmem, show (⟨y, hmem⟩ : ↥H) = a₀ ^ 2 from Subtype.ext (hA2.trans ha2coe),
+          hchar_pow 2, if_neg (by rw [hA2]; exact e02.symm), if_neg (by rw [hA2]; exact e12.symm),
+          if_pos hA2, if_neg (by rw [hA2]; exact e23), if_neg (by rw [hA2]; exact e24)]
+        ring
+      · rw [dif_pos hmem, show (⟨y, hmem⟩ : ↥H) = a₀ ^ 3 from Subtype.ext (hA3.trans ha3coe),
+          hchar_pow 3, if_neg (by rw [hA3]; exact e03.symm), if_neg (by rw [hA3]; exact e13.symm),
+          if_neg (by rw [hA3]; exact e23.symm), if_pos hA3, if_neg (by rw [hA3]; exact e34)]
+        ring
+      · rw [dif_pos hmem, show (⟨y, hmem⟩ : ↥H) = a₀ ^ 4 from Subtype.ext (hA4.trans ha4coe),
+          hchar_pow 4, if_neg (by rw [hA4]; exact e04.symm), if_neg (by rw [hA4]; exact e14.symm),
+          if_neg (by rw [hA4]; exact e24.symm), if_neg (by rw [hA4]; exact e34.symm), if_pos hA4]
+        ring
+    · rw [dif_neg hmem,
+        if_neg (fun h => hmem (by rw [h]; exact H.one_mem)),
+        if_neg (fun h => hmem (by rw [h]; exact ha_mem)),
+        if_neg (fun h => hmem (by rw [h]; exact ha2_mem)),
+        if_neg (fun h => hmem (by rw [h]; exact ha3_mem)),
+        if_neg (fun h => hmem (by rw [h]; exact ha4_mem))]
+      ring
+  -- Reduce the induced character on class reps to conjugator counts, shared form.
+  have hraw : ∀ j : Fin 5, (ind σ).character (classRepA5 j)
+      = (5 : ℂ)⁻¹ * ((1 : ℂ) * ((univ.filter (fun x : A5 => x * classRepA5 j * x⁻¹ = 1)).card : ℂ)
+          + z * ((univ.filter (fun x : A5 => x * classRepA5 j * x⁻¹ = a)).card : ℂ)
+          + z ^ 2 * ((univ.filter (fun x : A5 => x * classRepA5 j * x⁻¹ = a ^ 2)).card : ℂ)
+          + z ^ 3 * ((univ.filter (fun x : A5 => x * classRepA5 j * x⁻¹ = a ^ 3)).card : ℂ)
+          + z ^ 4 * ((univ.filter (fun x : A5 => x * classRepA5 j * x⁻¹ = a ^ 4)).card : ℂ)) := by
+    intro j
+    rw [ind_character_eq, hcardℂ, Finset.sum_congr rfl (fun x _ => hterm j x),
+      Finset.sum_add_distrib, Finset.sum_add_distrib, Finset.sum_add_distrib,
+      Finset.sum_add_distrib, ← Finset.mul_sum, ← Finset.mul_sum, ← Finset.mul_sum,
+      ← Finset.mul_sum, ← Finset.mul_sum, Finset.sum_boole, Finset.sum_boole, Finset.sum_boole,
+      Finset.sum_boole, Finset.sum_boole]
+  -- Split on the class of the generator.
+  rcases classIdxA5_pow5 a ha5 ha_ne1 with ⟨h1, h2, h3, h4⟩ | ⟨h1, h2, h3, h4⟩
+  · -- `a ∈ 5a`: `A = z + z⁴`, `B = z² + z³`.
+    refine ⟨z + z ^ 4, z ^ 2 + z ^ 3, by linear_combination hz_sum4,
+      by linear_combination (z ^ 3 + 2) * hz5 + hz_sum4, ?_⟩
+    intro j
+    have hca : ∃ c : A5, c * classRepA5 3 * c⁻¹ = a := by
+      obtain ⟨c, hc⟩ := classIdxA5_spec a; rw [h1] at hc; exact ⟨c, hc⟩
+    have hca2 : ∃ c : A5, c * classRepA5 4 * c⁻¹ = a ^ 2 := by
+      obtain ⟨c, hc⟩ := classIdxA5_spec (a ^ 2); rw [h2] at hc; exact ⟨c, hc⟩
+    have hca3 : ∃ c : A5, c * classRepA5 4 * c⁻¹ = a ^ 3 := by
+      obtain ⟨c, hc⟩ := classIdxA5_spec (a ^ 3); rw [h3] at hc; exact ⟨c, hc⟩
+    have hca4 : ∃ c : A5, c * classRepA5 3 * c⁻¹ = a ^ 4 := by
+      obtain ⟨c, hc⟩ := classIdxA5_spec (a ^ 4); rw [h4] at hc; exact ⟨c, hc⟩
+    rw [hraw j, oneCount, conjCount_shift (classRepA5 j) (classRepA5 3) a hca,
+      conjCount_shift (classRepA5 j) (classRepA5 4) (a ^ 2) hca2,
+      conjCount_shift (classRepA5 j) (classRepA5 4) (a ^ 3) hca3,
+      conjCount_shift (classRepA5 j) (classRepA5 3) (a ^ 4) hca4, cr3Count, cr4Count]
+    fin_cases j <;> norm_num <;> ring
+  · -- `a ∈ 5b`: `A = z² + z³`, `B = z + z⁴`.
+    refine ⟨z ^ 2 + z ^ 3, z + z ^ 4, by linear_combination hz_sum4,
+      by linear_combination (z + 2) * hz5 + hz_sum4, ?_⟩
+    intro j
+    have hca : ∃ c : A5, c * classRepA5 4 * c⁻¹ = a := by
+      obtain ⟨c, hc⟩ := classIdxA5_spec a; rw [h1] at hc; exact ⟨c, hc⟩
+    have hca2 : ∃ c : A5, c * classRepA5 3 * c⁻¹ = a ^ 2 := by
+      obtain ⟨c, hc⟩ := classIdxA5_spec (a ^ 2); rw [h2] at hc; exact ⟨c, hc⟩
+    have hca3 : ∃ c : A5, c * classRepA5 3 * c⁻¹ = a ^ 3 := by
+      obtain ⟨c, hc⟩ := classIdxA5_spec (a ^ 3); rw [h3] at hc; exact ⟨c, hc⟩
+    have hca4 : ∃ c : A5, c * classRepA5 4 * c⁻¹ = a ^ 4 := by
+      obtain ⟨c, hc⟩ := classIdxA5_spec (a ^ 4); rw [h4] at hc; exact ⟨c, hc⟩
+    rw [hraw j, oneCount, conjCount_shift (classRepA5 j) (classRepA5 4) a hca,
+      conjCount_shift (classRepA5 j) (classRepA5 3) (a ^ 2) hca2,
+      conjCount_shift (classRepA5 j) (classRepA5 3) (a ^ 3) hca3,
+      conjCount_shift (classRepA5 j) (classRepA5 4) (a ^ 4) hca4, cr3Count, cr4Count]
+    fin_cases j <;> norm_num <;> ring
+
+/-- Arbitrary-`g` nontrivial-character values, from a class-rep value vector. -/
+lemma indZ5_nontriv_char_all (H : Subgroup A5) [DecidablePred (· ∈ H)] (hH : Nat.card H = 5)
+    (σ : FDRep ℂ ↥H) [Simple σ] {A B : ℂ}
+    (hval : ∀ j, (ind σ).character (classRepA5 j) = ![12, 0, 0, A, B] j) (g : A5) :
+    (ind σ).character g = ![12, 0, 0, A, B] (classIdxA5 g) := by
+  obtain ⟨c, hc⟩ := classIdxA5_spec g
+  conv_lhs => rw [← hc]
+  rw [FDRep.char_conj]
+  exact hval (classIdxA5 g)
+
+/-- Arbitrary-`g` target character values for `3 ⊕ 4 ⊕ 5`, via the class-function property. -/
+lemma indZ5_target1_char_all (g : A5) :
+    (repC3plus ⊞ repC4 ⊞ repC5).character g
+      = ![12, 0, 0, (-1 + (Real.sqrt 5 : ℂ)) / 2, (-1 - (Real.sqrt 5 : ℂ)) / 2] (classIdxA5 g) := by
+  obtain ⟨c, hc⟩ := classIdxA5_spec g
+  conv_lhs => rw [← hc]
+  rw [FDRep.char_conj]
+  exact indZ5_target1_value (classIdxA5 g)
+
+/-- Arbitrary-`g` target character values for `3' ⊕ 4 ⊕ 5`, via the class-function property. -/
+lemma indZ5_target2_char_all (g : A5) :
+    (repC3minus ⊞ repC4 ⊞ repC5).character g
+      = ![12, 0, 0, (-1 - (Real.sqrt 5 : ℂ)) / 2, (-1 + (Real.sqrt 5 : ℂ)) / 2] (classIdxA5 g) := by
+  obtain ⟨c, hc⟩ := classIdxA5_spec g
+  conv_lhs => rw [← hc]
+  rw [FDRep.char_conj]
+  exact indZ5_target2_value (classIdxA5 g)
+
 /-- **(c) nontrivial character.** For any of the four nontrivial characters `ζ^k` (`k ≠ 0`),
 `Ind_{ℤ₅}^{A₅} ζ^k` is `3 ⊕ 4 ⊕ 5` or `3' ⊕ 4 ⊕ 5` (dimension `12`); the pair `{ζ, ζ⁴}` picks
 one `3`-dimensional and `{ζ², ζ³}` the other. -/
@@ -981,7 +1293,27 @@ theorem indZ5_nontriv (H : Subgroup A5) (hH : Nat.card H = 5)
     (σ : FDRep ℂ ↥H) [Simple σ] (hntriv : ∃ h : ↥H, σ.character h ≠ 1) :
     Nonempty (ind σ ≅ repC3plus ⊞ repC4 ⊞ repC5) ∨
       Nonempty (ind σ ≅ repC3minus ⊞ repC4 ⊞ repC5) := by
-  sorry
+  classical
+  obtain ⟨A, B, hAB, hAq, hval⟩ := indZ5_nontriv_value H hH σ hntriv
+  -- `A` is a root of `t² + t − 1`, hence `(−1 ± √5)/2`.
+  have hs : (Real.sqrt 5 : ℂ) ^ 2 = 5 := sqrt5_sq
+  have hfac : (A - (-1 + (Real.sqrt 5 : ℂ)) / 2) * (A - (-1 - (Real.sqrt 5 : ℂ)) / 2) = 0 := by
+    linear_combination hAq - (1 / 4 : ℂ) * hs
+  rcases mul_eq_zero.mp hfac with hA | hA
+  · -- `A = (−1+√5)/2`, `B = (−1−√5)/2`: matches `3 ⊕ 4 ⊕ 5`.
+    left
+    apply Etingof.charEq_iso
+    funext g
+    rw [indZ5_nontriv_char_all H hH σ hval g, indZ5_target1_char_all g,
+      show A = (-1 + (Real.sqrt 5 : ℂ)) / 2 by linear_combination hA,
+      show B = (-1 - (Real.sqrt 5 : ℂ)) / 2 by linear_combination hAB - hA]
+  · -- `A = (−1−√5)/2`, `B = (−1+√5)/2`: matches `3' ⊕ 4 ⊕ 5`.
+    right
+    apply Etingof.charEq_iso
+    funext g
+    rw [indZ5_nontriv_char_all H hH σ hval g, indZ5_target2_char_all g,
+      show A = (-1 - (Real.sqrt 5 : ℂ)) / 2 by linear_combination hA,
+      show B = (-1 + (Real.sqrt 5 : ℂ)) / 2 by linear_combination hAB - hA]
 
 /-! ## (d) Induction from `A₄` -/
 

--- a/EtingofRepresentationTheory/Chapter5/Problem5_11_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_11_1.lean
@@ -849,7 +849,119 @@ theorem indZ3_nontriv (H : Subgroup A5) (hH : Nat.card H = 3)
   funext g
   rw [indZ3_nontriv_char_all H hH σ hntriv g, indZ3_nontriv_target_char_all g]
 
-/-! ## (c) Induction from `ℤ₅` -/
+/-! ## (c) Induction from `ℤ₅`
+
+For an order-`5` subgroup `H` the twisted counts reduce, by conjugacy of `H` with the concrete
+Sylow `5`-subgroup `⟨classRepA5 3⟩` (all Sylow `5`-subgroups are conjugate), to `decide`-evaluable
+computations over `A₅`. -/
+
+set_option maxRecDepth 8000 in
+-- `decide` evaluates the twisted membership over all 60 elements of `A₅`, needing raised limits.
+set_option maxHeartbeats 4000000 in
+/-- The twisted counts `#{x : x·(classRepA5 j)·x⁻¹ ∈ ⟨classRepA5 3⟩}` on the five classes:
+`60` at the identity, `10` at each of the two `5`-cycle classes (`⟨classRepA5 3⟩` contains two
+elements of each `5`-cycle class), `0` on `3a`/`2a`. -/
+lemma twisted_p5' (j : Fin 5) :
+    (univ.filter
+        (fun x : A5 => x * classRepA5 j * x⁻¹ ∈ Subgroup.zpowers (classRepA5 3))).card
+      = ![60, 0, 0, 10, 10] j := by
+  rw [twisted_filter_eq' (classRepA5 3) (classRepA5 j) 5 Etingof.Problem4_12_5.ord_cr3]
+  fin_cases j <;> decide
+
+/-- An order-`5` subgroup of `A₅` is conjugate to `⟨classRepA5 3⟩`: there is `d` with
+`y ∈ H ↔ d y d⁻¹ ∈ ⟨classRepA5 3⟩` (Sylow's second theorem — all Sylow `5`-subgroups are
+conjugate). -/
+lemma exists_conj_H5 (H : Subgroup A5) (hH : Nat.card H = 5) :
+    ∃ d : A5, ∀ y : A5, y ∈ H ↔ d * y * d⁻¹ ∈ Subgroup.zpowers (classRepA5 3) := by
+  haveI : Fact (Nat.Prime 5) := ⟨by norm_num⟩
+  let P : Sylow 5 A5 := Sylow.ofCard H (by rw [hH, Etingof.Problem4_12_5.fact5, pow_one])
+  have hQc : Nat.card (Subgroup.zpowers (classRepA5 3)) = 5 := by
+    rw [Nat.card_zpowers, Etingof.Problem4_12_5.ord_cr3]
+  let Q : Sylow 5 A5 := Sylow.ofCard (Subgroup.zpowers (classRepA5 3))
+    (by rw [hQc, Etingof.Problem4_12_5.fact5, pow_one])
+  obtain ⟨cc, hcc⟩ := MulAction.exists_smul_eq A5 P Q
+  have hPc : (P : Subgroup A5) = H := Sylow.coe_ofCard _ _
+  have hQcoe : (Q : Subgroup A5) = Subgroup.zpowers (classRepA5 3) := Sylow.coe_ofCard _ _
+  have hco : (Q : Subgroup A5) = MulAut.conj cc • (P : Subgroup A5) := by rw [← hcc]; rfl
+  have hzeq : Subgroup.zpowers (classRepA5 3) = MulAut.conj cc • H := by
+    rw [← hQcoe, ← hPc]; exact hco
+  refine ⟨cc, fun y => ?_⟩
+  rw [hzeq, Subgroup.mem_pointwise_smul_iff_inv_smul_mem]
+  simp only [MulAut.smul_def, MulAut.conj_inv_apply]
+  constructor
+  · intro hy; rw [show cc⁻¹ * (cc * y * cc⁻¹) * cc = y by group]; exact hy
+  · intro hy; rw [show cc⁻¹ * (cc * y * cc⁻¹) * cc = y by group] at hy; exact hy
+
+/-- The count of conjugators landing in an order-`5` `H` matches that for `⟨classRepA5 3⟩`. -/
+lemma countH_eq5 (H : Subgroup A5) [DecidablePred (· ∈ H)] (hH : Nat.card H = 5) (g : A5) :
+    (univ.filter (fun x : A5 => x * g * x⁻¹ ∈ H)).card
+      = (univ.filter
+          (fun x : A5 => x * g * x⁻¹ ∈ Subgroup.zpowers (classRepA5 3))).card := by
+  obtain ⟨d, hd⟩ := exists_conj_H5 H hH
+  apply Finset.card_bij' (fun x _ => d * x) (fun x _ => d⁻¹ * x)
+  · intro x hx
+    simp only [mem_filter, mem_univ, true_and] at hx ⊢
+    rw [hd] at hx
+    rw [show d * x * g * (d * x)⁻¹ = d * (x * g * x⁻¹) * d⁻¹ by group]
+    exact hx
+  · intro x hx
+    simp only [mem_filter, mem_univ, true_and] at hx ⊢
+    rw [hd]
+    rw [show d * (d⁻¹ * x * g * (d⁻¹ * x)⁻¹) * d⁻¹ = x * g * x⁻¹ by group]
+    exact hx
+  · intro x hx; group
+  · intro x hx; group
+
+/-- **Trivial character, class-rep values.** For an order-`5` `H` and the trivial character `σ`,
+`(ind σ).character` on the five class reps is `(12, 0, 0, 2, 2)`. -/
+lemma indZ5_triv_value (H : Subgroup A5) [DecidablePred (· ∈ H)] (hH : Nat.card H = 5)
+    (σ : FDRep ℂ ↥H) (htriv : ∀ h : ↥H, σ.character h = 1) (j : Fin 5) :
+    (ind σ).character (classRepA5 j) = ![12, 0, 0, 2, 2] j := by
+  rw [ind_character_eq]
+  have hcard : (Fintype.card ↥H : ℂ) = 5 := by
+    rw [← Nat.card_eq_fintype_card, hH]; norm_num
+  have hsum : (∑ x : A5, if h : x * classRepA5 j * x⁻¹ ∈ H then σ.character ⟨_, h⟩ else 0)
+      = ((univ.filter (fun x : A5 => x * classRepA5 j * x⁻¹ ∈ H)).card : ℂ) := by
+    rw [← Finset.sum_boole]
+    apply Finset.sum_congr rfl
+    intro x _
+    by_cases hx : x * classRepA5 j * x⁻¹ ∈ H
+    · rw [dif_pos hx, if_pos hx, htriv]
+    · rw [dif_neg hx, if_neg hx]
+  rw [hsum, countH_eq5 H hH, twisted_p5', hcard]
+  fin_cases j <;> norm_num
+
+/-- Arbitrary-`g` trivial-character values, via the class-function property. -/
+lemma indZ5_triv_char_all (H : Subgroup A5) [DecidablePred (· ∈ H)] (hH : Nat.card H = 5)
+    (σ : FDRep ℂ ↥H) (htriv : ∀ h : ↥H, σ.character h = 1) (g : A5) :
+    (ind σ).character g = ![12, 0, 0, 2, 2] (classIdxA5 g) := by
+  obtain ⟨c, hc⟩ := classIdxA5_spec g
+  conv_lhs => rw [← hc]
+  rw [FDRep.char_conj]
+  exact indZ5_triv_value H hH σ htriv (classIdxA5 g)
+
+/-- **Target character, class-rep values** for the trivial-character decomposition. -/
+lemma indZ5_triv_target_value (j : Fin 5) :
+    (repTriv ⊞ repC3plus ⊞ repC3minus ⊞ repC5).character (classRepA5 j)
+      = ![12, 0, 0, 2, 2] j := by
+  simp only [character_biprod, repTriv_character, repC3plus_character, repC3minus_character,
+    repC5_character]
+  have hs := sqrt5_sq
+  fin_cases j <;>
+    norm_num [Q5toC, chiA5, tblA5, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+      Matrix.cons_val_three, Matrix.cons_val_four, Matrix.head_cons, Matrix.tail_cons,
+      Q5.mk_re, Q5.mk_im, Q5.ofNat_re, Q5.ofNat_im, Q5.neg_re, Q5.neg_im, Q5.one_re, Q5.one_im,
+      Q5.zero_re, Q5.zero_im] <;>
+    ring
+
+/-- Arbitrary-`g` target character values, via the class-function property. -/
+lemma indZ5_triv_target_char_all (g : A5) :
+    (repTriv ⊞ repC3plus ⊞ repC3minus ⊞ repC5).character g
+      = ![12, 0, 0, 2, 2] (classIdxA5 g) := by
+  obtain ⟨c, hc⟩ := classIdxA5_spec g
+  conv_lhs => rw [← hc]
+  rw [FDRep.char_conj]
+  exact indZ5_triv_target_value (classIdxA5 g)
 
 /-- **(c) trivial character.** `Ind_{ℤ₅}^{A₅} 1 ≅ 1 ⊕ 3 ⊕ 3' ⊕ 5` (dimension `12`), the
 permutation representation on the `12` cosets. Multiplicities `(χ_W(1a) + 2·χ_W(5a) +
@@ -857,7 +969,10 @@ permutation representation on the `12` cosets. Multiplicities `(χ_W(1a) + 2·χ
 theorem indZ5_triv (H : Subgroup A5) (hH : Nat.card H = 5)
     (σ : FDRep ℂ ↥H) [Simple σ] (htriv : ∀ h : ↥H, σ.character h = 1) :
     Nonempty (ind σ ≅ repTriv ⊞ repC3plus ⊞ repC3minus ⊞ repC5) := by
-  sorry
+  classical
+  apply Etingof.charEq_iso
+  funext g
+  rw [indZ5_triv_char_all H hH σ htriv g, indZ5_triv_target_char_all g]
 
 /-- **(c) nontrivial character.** For any of the four nontrivial characters `ζ^k` (`k ≠ 0`),
 `Ind_{ℤ₅}^{A₅} ζ^k` is `3 ⊕ 4 ⊕ 5` or `3' ⊕ 4 ⊕ 5` (dimension `12`); the pair `{ζ, ζ⁴}` picks

--- a/progress/2026-07-15T04-59-34Z_3ea6fe3a.md
+++ b/progress/2026-07-15T04-59-34Z_3ea6fe3a.md
@@ -1,0 +1,30 @@
+## Accomplished
+Proved Problem 5.11.1(c) — induction of `A₅` representations from `ℤ₅` — sorry-free
+(#6639), both the trivial and nontrivial characters, in
+`EtingofRepresentationTheory/Chapter5/Problem5_11_1.lean`:
+
+- `indZ5_triv`: `Ind_{ℤ₅}^{A₅} 1 ≅ 1 ⊕ 3 ⊕ 3' ⊕ 5`. Mirrors the `ℤ₂`/`ℤ₃` route:
+  reduce the order-5 twisted conjugator counts to the concrete Sylow 5-subgroup
+  `⟨classRepA5 3⟩` via Sylow conjugacy (`exists_conj_H5`, `twisted_p5'`, `countH_eq5`).
+- `indZ5_nontriv`: `Ind_{ℤ₅}^{A₅} ζ^k ≅ 3 ⊕ 4 ⊕ 5` or `3' ⊕ 4 ⊕ 5` (disjunction).
+  The two 5-cycle classes 5a/5b split the nontrivial powers `{a,a⁴}`/`{a²,a³}`
+  (`classIdxA5_pow5`, an honest `decide`); the induced character takes values
+  `z+z⁴`, `z²+z³` on the two 5-classes. Both are roots of `t²+t−1`, i.e. `(−1±√5)/2`,
+  matching the golden-ratio values of `3`/`3'`; the quadratic split selects which
+  3-dimensional appears.
+
+`#print axioms` on both shows only `[propext, Classical.choice, Quot.sound]`.
+
+## Current frontier
+Parts (d) `A₄` and (e) `ℤ₂×ℤ₂` of Problem 5.11.1 remain `sorry` (separate future
+issues, explicitly out of scope for #6639).
+
+## Overall project progress
+Stage 3 formalization ongoing. Problem 5.11.1 parts (a),(b),(c) now complete;
+(d),(e) stubbed.
+
+## Next step
+Pick up (d)/(e) of Problem 5.11.1 when planned, or any other open feature issue.
+
+## Blockers
+None.


### PR DESCRIPTION
Closes #6639

Session: `3ea6fe3a-f5ad-401d-b44a-07ca29aae2f1`

4300c37c feat(Ch5 #Problem5.11.1-c): prove indZ5_nontriv sorry-free (#6639)
42a7bd11 feat(Ch5 #Problem5.11.1-c): prove indZ5_triv sorry-free (#6639)

🤖 Prepared with Claude Code