### PR TITLE
feat(Ch9): universe-lift invariance of homologicalDimension (homologicalDimension_ulift)

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/HomologicalDimensionUlift.lean
+++ b/EtingofRepresentationTheory/Chapter9/HomologicalDimensionUlift.lean
@@ -105,33 +105,32 @@ theorem hasProjectiveDimensionLT_of_map (F : C ⥤ D) [F.Additive] [F.Full] [F.F
 
 end Reflect
 
-/-- **Universe-lift invariance of homological dimension (one direction).** The homological
-dimension of `R` is at most that of its universe lift `ULift.{v} R`.
+/-- **Universe-lift invariance of homological dimension (predicate form).** If every module over
+the universe lift `ULift.{v} R` has projective dimension `≤ d`, then so does every module over `R`.
 
-For each `d`, if every `ULift R`-module has projective dimension `≤ d`, then so does every
-`R`-module: transfer along the ring equivalence `ULift R ≃+* R` at the big module universe
+Transfer along the ring equivalence `ULift R ≃+* R` at the big module universe
 (`restrictScalarsEquivalenceOfRingEquiv`), then reflect down to the small module universe with the
-fully-faithful exact `ModuleCat.uliftFunctor`. Comparing the defining infima gives the inequality
-of homological dimensions. -/
+fully-faithful exact `ModuleCat.uliftFunctor` (`hasProjectiveDimensionLT_of_map`). -/
+theorem hasHomologicalDimensionLE_of_ulift {R : Type u} [Ring R] {d : ℕ}
+    (h : HasHomologicalDimensionLE (ULift.{v} R) d) : HasHomologicalDimensionLE R d := by
+  -- `E : ModuleCat.{max u v} R ≌ ModuleCat.{max u v} (ULift R)` from the ring equivalence.
+  let E : ModuleCat.{max u v} R ≌ ModuleCat.{max u v} (ULift.{v} R) :=
+    ModuleCat.restrictScalarsEquivalenceOfRingEquiv (ULift.ringEquiv (R := R))
+  -- Step 1: every big `R`-module has projective dimension `≤ d`.
+  have hbig : ∀ N : ModuleCat.{max u v} R, HasProjectiveDimensionLE N d := by
+    intro N
+    exact (hasProjectiveDimensionLT_map_iff E (d + 1) N).mp (h (E.functor.obj N))
+  -- Step 2: reflect down to the small `R`-modules through the universe-lift functor.
+  intro M
+  have := hbig ((ModuleCat.uliftFunctor.{v, u} R).obj M)
+  exact hasProjectiveDimensionLT_of_map (ModuleCat.uliftFunctor.{v, u} R) (d + 1) M this
+
+/-- **Universe-lift invariance of homological dimension (one direction).** The homological
+dimension of `R` is at most that of its universe lift `ULift.{v} R`. A universe lift can only
+enlarge the collection of modules, so it cannot lower the homological dimension. -/
 theorem homologicalDimension_le_ulift {R : Type u} [Ring R] :
     homologicalDimension R ≤ homologicalDimension (ULift.{v} R) := by
-  -- For every `d`, big homological dimension `≤ d` implies small homological dimension `≤ d`.
-  have key : ∀ d : ℕ,
-      HasHomologicalDimensionLE (ULift.{v} R) d → HasHomologicalDimensionLE R d := by
-    intro d hUL
-    -- `E : ModuleCat.{max u v} R ≌ ModuleCat.{max u v} (ULift R)` from the ring equivalence.
-    let E : ModuleCat.{max u v} R ≌ ModuleCat.{max u v} (ULift.{v} R) :=
-      ModuleCat.restrictScalarsEquivalenceOfRingEquiv (ULift.ringEquiv (R := R))
-    -- Step 1: every big `R`-module has projective dimension `≤ d`.
-    have hbig : ∀ N : ModuleCat.{max u v} R, HasProjectiveDimensionLE N d := by
-      intro N
-      exact (hasProjectiveDimensionLT_map_iff E (d + 1) N).mp (hUL (E.functor.obj N))
-    -- Step 2: reflect down to the small `R`-modules through the universe-lift functor.
-    intro M
-    have := hbig ((ModuleCat.uliftFunctor.{v, u} R).obj M)
-    exact hasProjectiveDimensionLT_of_map (ModuleCat.uliftFunctor.{v, u} R) (d + 1) M this
-  -- Compare the two defining infima.
   unfold homologicalDimension
-  exact le_iInf₂ fun d hd => iInf₂_le d (key d hd)
+  exact le_iInf₂ fun d hd => iInf₂_le d (hasHomologicalDimensionLE_of_ulift hd)
 
 end Etingof

--- a/EtingofRepresentationTheory/Chapter9/HomologicalDimensionUlift.lean
+++ b/EtingofRepresentationTheory/Chapter9/HomologicalDimensionUlift.lean
@@ -1,0 +1,137 @@
+import Mathlib.Algebra.Category.ModuleCat.Ulift
+import Mathlib.Algebra.Ring.ULift
+import EtingofRepresentationTheory.Chapter9.HomologicalDimensionRingEquiv
+
+/-!
+# Homological dimension is invariant under a universe lift
+
+`Etingof.homologicalDimension R` (Definition 9.4.3) quantifies over `ModuleCat.{u} R`, where `u`
+is the universe of `R`. This file proves that lifting `R` to a larger universe can only *increase*
+the collection of modules under consideration, so it cannot lower the homological dimension:
+
+* `Etingof.homologicalDimension_le_ulift` —
+  `homologicalDimension R ≤ homologicalDimension (ULift R)`.
+
+## Strategy
+
+The key categorical input is that the universe-lift functor
+`ModuleCat.uliftFunctor.{v, u} R : ModuleCat.{u} R ⥤ ModuleCat.{max u v} R` is additive, exact
+(preserves finite limits and colimits) and fully faithful, and — since `R : Type u` is `u`-small —
+preserves projective objects. A fully faithful exact functor preserving projectives *reflects*
+projective dimension: `HasProjectiveDimensionLT (F.obj X) n → HasProjectiveDimensionLT X n`
+(`Etingof.hasProjectiveDimensionLT_of_map`). This mirrors the preservation statement
+`hasProjectiveDimensionLT_map` from `HomologicalDimensionRingEquiv.lean`, but for a plain
+fully-faithful functor rather than an equivalence, and in the reverse (reflecting) direction.
+
+Combined with the same-universe ring-equivalence transfer
+`ModuleCat.restrictScalarsEquivalenceOfRingEquiv (ULift.ringEquiv)` (which identifies
+`ModuleCat.{max u v} (ULift R)` with `ModuleCat.{max u v} R`) this shows that if every big-universe
+`ULift R`-module has projective dimension `≤ d`, then so does every small-universe `R`-module,
+which is exactly the inequality of homological dimensions.
+
+The reverse inequality (a universe lift cannot *raise* the homological dimension) is the harder
+direction — it requires reducing the projective dimension of arbitrary big modules to small ones
+(an Auslander-style argument) — and is not needed for the free-algebra corollary of Problem 9.4.6,
+so it is not proved here.
+-/
+
+universe v u
+
+open CategoryTheory Limits CategoryTheory.Limits
+
+namespace Etingof
+
+section Reflect
+
+variable {C : Type*} {D : Type*} [Category C] [Category D] [Abelian C] [Abelian D]
+
+/-- A fully faithful additive exact functor `F : C ⥤ D` preserving projective objects (with `C`
+having enough projectives) *reflects* projective dimension: if `F.obj X` has projective dimension
+`< n`, then so does `X`.
+
+Strong induction on `n`, dual to `Etingof.hasProjectiveDimensionLT_map`. The base cases are
+`n = 0` (`F` is faithful, so it reflects zero objects) and `n = 1` (`F` reflects projectives,
+being full, faithful and epimorphism-preserving — `Functor.projective_of_map_projective`). For
+`n + 2` one takes a projective presentation `0 → K → P → X → 0` in `C`, maps it to the short exact
+sequence `0 → F K → F P → F X → 0`, shifts `F X`'s dimension down to `F K`
+(`hasProjectiveDimensionLT_X₁`), applies the induction hypothesis to `K`, and shifts back up along
+the original presentation (`hasProjectiveDimensionLT_X₃`). -/
+theorem hasProjectiveDimensionLT_of_map (F : C ⥤ D) [F.Additive] [F.Full] [F.Faithful]
+    [F.PreservesEpimorphisms] [PreservesFiniteColimits F] [PreservesFiniteLimits F]
+    [F.PreservesProjectiveObjects] [EnoughProjectives C] :
+    ∀ (n : ℕ) (X : C), HasProjectiveDimensionLT (F.obj X) n → HasProjectiveDimensionLT X n := by
+  intro n
+  induction n using Nat.strongRecOn with
+  | ind n IH =>
+    match n, IH with
+    | 0, _ =>
+        intro X hX
+        rw [hasProjectiveDimensionLT_zero_iff_isZero] at hX ⊢
+        rw [IsZero.iff_id_eq_zero] at hX ⊢
+        apply F.map_injective
+        rw [F.map_id, F.map_zero]
+        exact hX
+    | 1, _ =>
+        intro X hX
+        haveI : Projective (F.obj X) := projective_iff_hasProjectiveDimensionLT_one.mpr hX
+        exact projective_iff_hasProjectiveDimensionLT_one.mp (F.projective_of_map_projective ‹_›)
+    | (m + 2), IH =>
+        intro X hX
+        -- A projective presentation `0 → K → P → X → 0` in `C`.
+        obtain ⟨P⟩ : Nonempty (ProjectivePresentation X) := EnoughProjectives.presentation X
+        let S : ShortComplex C := ShortComplex.mk _ _ (kernel.condition P.f)
+        have hSE : S.ShortExact := { exact := ShortComplex.exact_kernel P.f }
+        -- Map the short exact sequence across the exact functor `F`.
+        have hSEF : (S.map F).ShortExact := hSE.map_of_exact F
+        -- `F P` is projective, hence has projective dimension `< 1 ≤ m + 1`.
+        haveI : Projective (S.map F).X₂ := by
+          change Projective (F.obj P.p); infer_instance
+        have hFP1 : HasProjectiveDimensionLT (S.map F).X₂ (m + 1) :=
+          hasProjectiveDimensionLT_of_ge (S.map F).X₂ 1 (m + 1) (by omega)
+        -- Dimension shift down: `pd (F X) < m + 2` gives `pd (F K) < m + 1`.
+        have hFK : HasProjectiveDimensionLT (S.map F).X₁ (m + 1) :=
+          hSEF.hasProjectiveDimensionLT_X₁ (m + 1) hFP1 hX
+        -- The induction hypothesis reflects this down to the syzygy `K`.
+        have hK : HasProjectiveDimensionLT S.X₁ (m + 1) := by
+          have : HasProjectiveDimensionLT (F.obj S.X₁) (m + 1) := hFK
+          exact IH (m + 1) (by omega) S.X₁ this
+        -- `P` is projective, hence has projective dimension `< 1 ≤ m + 2`.
+        haveI hP1 : HasProjectiveDimensionLT P.p 1 :=
+          projective_iff_hasProjectiveDimensionLT_one.mp P.projective
+        have hP2 : HasProjectiveDimensionLT S.X₂ (m + 2) :=
+          hasProjectiveDimensionLT_of_ge P.p 1 (m + 2) (by omega)
+        -- Dimension shift back up along the presentation: `pd X < m + 2`.
+        exact hSE.hasProjectiveDimensionLT_X₃ (m + 1) hK hP2
+
+end Reflect
+
+/-- **Universe-lift invariance of homological dimension (one direction).** The homological
+dimension of `R` is at most that of its universe lift `ULift.{v} R`.
+
+For each `d`, if every `ULift R`-module has projective dimension `≤ d`, then so does every
+`R`-module: transfer along the ring equivalence `ULift R ≃+* R` at the big module universe
+(`restrictScalarsEquivalenceOfRingEquiv`), then reflect down to the small module universe with the
+fully-faithful exact `ModuleCat.uliftFunctor`. Comparing the defining infima gives the inequality
+of homological dimensions. -/
+theorem homologicalDimension_le_ulift {R : Type u} [Ring R] :
+    homologicalDimension R ≤ homologicalDimension (ULift.{v} R) := by
+  -- For every `d`, big homological dimension `≤ d` implies small homological dimension `≤ d`.
+  have key : ∀ d : ℕ,
+      HasHomologicalDimensionLE (ULift.{v} R) d → HasHomologicalDimensionLE R d := by
+    intro d hUL
+    -- `E : ModuleCat.{max u v} R ≌ ModuleCat.{max u v} (ULift R)` from the ring equivalence.
+    let E : ModuleCat.{max u v} R ≌ ModuleCat.{max u v} (ULift.{v} R) :=
+      ModuleCat.restrictScalarsEquivalenceOfRingEquiv (ULift.ringEquiv (R := R))
+    -- Step 1: every big `R`-module has projective dimension `≤ d`.
+    have hbig : ∀ N : ModuleCat.{max u v} R, HasProjectiveDimensionLE N d := by
+      intro N
+      exact (hasProjectiveDimensionLT_map_iff E (d + 1) N).mp (hUL (E.functor.obj N))
+    -- Step 2: reflect down to the small `R`-modules through the universe-lift functor.
+    intro M
+    have := hbig ((ModuleCat.uliftFunctor.{v, u} R).obj M)
+    exact hasProjectiveDimensionLT_of_map (ModuleCat.uliftFunctor.{v, u} R) (d + 1) M this
+  -- Compare the two defining infima.
+  unfold homologicalDimension
+  exact le_iInf₂ fun d hd => iInf₂_le d (key d hd)
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter9/Problem9_4_6.lean
+++ b/EtingofRepresentationTheory/Chapter9/Problem9_4_6.lean
@@ -1,4 +1,5 @@
 import Mathlib.Algebra.FreeAlgebra
+import Mathlib.Algebra.Module.Projective
 import Mathlib.Combinatorics.Quiver.Path
 import Mathlib.LinearAlgebra.Dimension.Constructions
 import EtingofRepresentationTheory.Chapter2.Definition2_8_4
@@ -9,6 +10,7 @@ import EtingofRepresentationTheory.Chapter9.PathAlgebraStandardResolution
 import EtingofRepresentationTheory.Chapter9.PathAlgebraLowerBound
 import EtingofRepresentationTheory.Chapter9.HomologicalDimensionReduction
 import EtingofRepresentationTheory.Chapter9.HomologicalDimensionRingEquiv
+import EtingofRepresentationTheory.Chapter9.HomologicalDimensionUlift
 
 /-!
 # Problem 9.4.6: Homological dimension and Cartan matrix of path algebras
@@ -123,8 +125,9 @@ is `Type u`, but `PathAlgebra k Q₀` is `Type (u+1)` because `Quiver.Path` land
 and the standard-resolution machinery of `homologicalDimension_pathAlgebra_eq_one` hard-requires
 `Quiver.{u+1} Q₀`. Consequently the same-universe `homologicalDimension_congr` (from #6635) is *not*
 enough to conclude `homologicalDimension (FreeAlgebra k (Fin n)) = 1` from the path-algebra result;
-that final step additionally needs universe-lift invariance of `homologicalDimension`
-(`homologicalDimension R = homologicalDimension (ULift.{u+1} R)`), which is tracked as a follow-up. -/
+that final step additionally uses universe-lift invariance of `homologicalDimension`
+(`homologicalDimension_le_ulift`, `Chapter9/HomologicalDimensionUlift.lean`) to lift the free
+algebra to `Type (u+1)` before transferring across `freePathEquiv`. -/
 
 /-- Vertex type of the one-vertex "loop" quiver with `n` loops: a single point in `Type u`. -/
 def LoopVertex (n : ℕ) : Type u := PUnit.{u + 1}
@@ -254,21 +257,109 @@ noncomputable def freePathEquiv (k : Type u) [Field k] (n : ℕ) :
   AlgEquiv.ofAlgHom (freeToPath k n) (pathToFree k n)
     (freeToPath_comp_pathToFree k n) (pathToFree_comp_freeToPath k n)
 
+/-! ## The free algebra is not semisimple (lower bound)
+
+Mirroring the path-algebra lower bound (`Chapter9/PathAlgebraLowerBound.lean`), the **augmentation
+module** — the field `k` on which every generator `xᵢ` acts as `0` — is not projective. If it were,
+the surjection `A ↠ k`, `p ↦ p • 1`, would split by an `A`-linear section `s`; writing `w = s(1)`,
+the relation `xᵢ • 1 = 0` forces `xᵢ · w = 0` in `A`. Since `A = FreeAlgebra k (Fin n)` is a domain
+and `xᵢ ≠ 0`, this gives `w = 0`, contradicting `ε(w) = 1` (as `s` is a section). Here `k` already
+lives in `Type u`, the native universe of `A`, so no universe lift is needed for the lower bound. -/
+
+/-- The augmentation `k⟨x₁, …, xₙ⟩ → k` sending every generator `xᵢ` to `0`. -/
+noncomputable def freeAug (k : Type u) [Field k] (n : ℕ) : FreeAlgebra k (Fin n) →ₐ[k] k :=
+  FreeAlgebra.lift k fun _ => (0 : k)
+
+@[simp] theorem freeAug_ι (k : Type u) [Field k] (n : ℕ) (i : Fin n) :
+    freeAug k n (FreeAlgebra.ι k i) = 0 := by
+  rw [freeAug, FreeAlgebra.lift_ι_apply]
+
+/-- **Problem 9.4.6 (i), free-algebra lower bound.** The free associative algebra on `n ≥ 1`
+generators is not semisimple: it does not have homological dimension `0`.
+
+The augmentation module `k` (each generator acting as `0`, carried as a *local* module instance to
+avoid a spurious global `Module (FreeAlgebra k (Fin n)) k`) is not projective: a projective section
+`s` of the surjection `A ↠ k`, `p ↦ p • 1`, would give `w := s(1)` with `x₀ · w = 0` yet
+`ε(w) = 1`, impossible in the domain `A`. -/
+theorem not_hasHomologicalDimensionLE_zero_freeAlgebra
+    {k : Type u} [Field k] {n : ℕ} (hn : 1 ≤ n) :
+    ¬ Etingof.HasHomologicalDimensionLE (FreeAlgebra k (Fin n)) 0 := by
+  intro hall
+  -- `k` as a left `A`-module through the augmentation `ε`, `a • v = ε(a) · v`.
+  letI aug : Module (FreeAlgebra k (Fin n)) k := Module.compHom k (freeAug k n).toRingHom
+  have smul_def : ∀ (a : FreeAlgebra k (Fin n)) (v : k), a • v = freeAug k n a * v :=
+    fun _ _ => rfl
+  -- The augmentation module as a `ModuleCat` object; under dimension `0` it is projective.
+  let MA := ModuleCat.of (FreeAlgebra k (Fin n)) k
+  have hpd : CategoryTheory.HasProjectiveDimensionLE MA 0 := hall MA
+  haveI hproj : CategoryTheory.Projective MA :=
+    projective_iff_hasProjectiveDimensionLT_one.mpr hpd
+  haveI hmod : Module.Projective (FreeAlgebra k (Fin n)) k :=
+    (IsProjective.iff_projective (R := FreeAlgebra k (Fin n)) k).mpr hproj
+  -- The surjection `A ↠ k`, `p ↦ p • 1`.
+  let surj := LinearMap.toSpanSingleton (FreeAlgebra k (Fin n)) k (1 : k)
+  have hsurj : Function.Surjective surj := by
+    intro v
+    refine ⟨algebraMap k (FreeAlgebra k (Fin n)) v, ?_⟩
+    show surj (algebraMap k (FreeAlgebra k (Fin n)) v) = v
+    rw [LinearMap.toSpanSingleton_apply, smul_def, mul_one, AlgHom.commutes]
+    simp
+  -- Projectivity yields an `A`-linear section `s`.
+  obtain ⟨s, hs⟩ := Module.projective_lifting_property surj LinearMap.id hsurj
+  set w : FreeAlgebra k (Fin n) := s (1 : k) with hw_def
+  -- `s` is a section, so `ε(w) = 1`.
+  have hsection : freeAug k n w = 1 := by
+    have hcf := LinearMap.congr_fun hs (1 : k)
+    simp only [LinearMap.comp_apply, LinearMap.id_apply] at hcf
+    rw [LinearMap.toSpanSingleton_apply, smul_def, mul_one] at hcf
+    exact hcf
+  -- The generator `x₀ = ι ⟨0, hn⟩` acts as `0`, so `x₀ · w = 0` in `A`.
+  have hact : (FreeAlgebra.ι k ⟨0, hn⟩ : FreeAlgebra k (Fin n)) • (1 : k) = 0 := by
+    rw [smul_def, freeAug_ι, zero_mul]
+  have hzero : (FreeAlgebra.ι k ⟨0, hn⟩ : FreeAlgebra k (Fin n)) * w = 0 := by
+    have h1 := s.map_smul (FreeAlgebra.ι k ⟨0, hn⟩) (1 : k)
+    rw [hact, map_zero] at h1
+    rw [← smul_eq_mul]; exact h1.symm
+  -- `A` is a domain and `x₀ ≠ 0`, so `w = 0` — contradicting `ε(w) = 1`.
+  have hw0 : w = 0 := by
+    rcases mul_eq_zero.mp hzero with h | h
+    · exact absurd h (FreeAlgebra.ι_ne_zero (⟨0, hn⟩ : Fin n))
+    · exact h
+  rw [hw0, map_zero] at hsection
+  exact one_ne_zero hsection.symm
+
 /-- **Problem 9.4.6 (i), free algebra.** The free associative algebra `k⟨x₁, …, xₙ⟩` on
 `n ≥ 1` generators (the path algebra of the one-vertex quiver with `n` loops) has homological
-dimension `1`. -/
+dimension `1`.
+
+`freePathEquiv k n : FreeAlgebra k (Fin n) ≃ₐ[k] PathAlgebra k (LoopVertex n)` realizes the free
+algebra as the one-vertex path algebra. The two algebras live in *different* universes
+(`FreeAlgebra k (Fin n) : Type u` but `PathAlgebra k (LoopVertex n) : Type (u+1)`), so the
+same-universe `homologicalDimension_congr` is not enough. The upper bound
+`HasHomologicalDimensionLE (FreeAlgebra k (Fin n)) 1` is obtained by lifting to universe `u+1`
+(`hasHomologicalDimensionLE_of_ulift`), transferring across the ring equivalence
+`ULift (FreeAlgebra k (Fin n)) ≃+* PathAlgebra k (LoopVertex n)` (now same-universe) and applying
+the path-algebra upper bound. The lower bound is the direct non-semisimplicity result
+`not_hasHomologicalDimensionLE_zero_freeAlgebra`. -/
 theorem homologicalDimension_freeAlgebra_eq_one
     {k : Type u} [Field k] {n : ℕ} (hn : 1 ≤ n) :
     Etingof.homologicalDimension (FreeAlgebra k (Fin n)) = 1 := by
-  -- `freePathEquiv k n : FreeAlgebra k (Fin n) ≃ₐ[k] PathAlgebra k (LoopVertex n)` realizes the
-  -- free algebra as the one-vertex path algebra, and `homologicalDimension_pathAlgebra_eq_one`
-  -- gives the path algebra dimension `1`. The remaining step is a *universe* bridge:
-  -- `FreeAlgebra k (Fin n) : Type u` but `PathAlgebra k (LoopVertex n) : Type (u+1)` (the quiver
-  -- path type bumps the universe, and the standard-resolution machinery hard-requires
-  -- `Quiver.{u+1}`). `homologicalDimension_congr` is same-universe only, so we need
-  -- universe-lift invariance of `homologicalDimension` (`homologicalDimension R =
-  -- homologicalDimension (ULift.{u+1} R)`), which is not yet available. See the sub-issue.
-  sorry
+  -- The one-vertex loop quiver has an edge (the `0`-th loop).
+  have hQ : ∃ a b : LoopVertex.{u} n, Nonempty (a ⟶ b) :=
+    ⟨LoopVertex.pt n, LoopVertex.pt n, ⟨loopArrow n ⟨0, hn⟩⟩⟩
+  -- The same-universe (`Type (u+1)`) ring equivalence `ULift (FreeAlg) ≃+* PathAlg`.
+  let eRing : ULift.{u + 1} (FreeAlgebra k (Fin n)) ≃+* PathAlgebra k (LoopVertex.{u} n) :=
+    (ULift.ringEquiv).trans (freePathEquiv k n).toRingEquiv
+  -- Upper bound via universe lift + same-universe ring-equivalence transfer.
+  have h1 : Etingof.HasHomologicalDimensionLE (FreeAlgebra k (Fin n)) 1 := by
+    have hbig : Etingof.HasHomologicalDimensionLE (ULift.{u + 1} (FreeAlgebra k (Fin n))) 1 := by
+      rw [Etingof.hasHomologicalDimensionLE_congr eRing]
+      exact hasHomologicalDimensionLE_pathAlgebra_one
+    exact Etingof.hasHomologicalDimensionLE_of_ulift hbig
+  -- Lower bound: the free algebra is not semisimple.
+  have h0 : ¬ Etingof.HasHomologicalDimensionLE (FreeAlgebra k (Fin n)) 0 :=
+    not_hasHomologicalDimensionLE_zero_freeAlgebra hn
+  exact Etingof.homologicalDimension_eq_one_of_not_le_zero h1 h0
 
 /-- The path-counting matrix of a quiver `Q`: the `(i, j)` entry is the number of oriented
 paths from `i` to `j`. This is the Cartan matrix of the path algebra of a finite acyclic

--- a/progress/2026-07-15T06-48-53Z_ce89270d.md
+++ b/progress/2026-07-15T06-48-53Z_ce89270d.md
@@ -1,0 +1,48 @@
+## Accomplished
+
+Completed issue #6644 (feat Ch9): universe-lift invariance of `homologicalDimension`, and used it
+to fill `homologicalDimension_freeAlgebra_eq_one` sorry-free.
+
+New file `EtingofRepresentationTheory/Chapter9/HomologicalDimensionUlift.lean`:
+- `Etingof.hasProjectiveDimensionLT_of_map` — a fully faithful, additive, exact functor preserving
+  projectives *reflects* projective dimension (`HasProjectiveDimensionLT (F.obj X) n →
+  HasProjectiveDimensionLT X n`). Strong induction dual to `hasProjectiveDimensionLT_map` in
+  `HomologicalDimensionRingEquiv.lean`; base cases via faithfulness (reflects zero) and
+  `Functor.projective_of_map_projective` (reflects projectives).
+- `Etingof.hasHomologicalDimensionLE_of_ulift` — predicate-form transfer: if every `ULift.{v} R`
+  module has projective dimension `≤ d`, so does every `R`-module. Routes through
+  `restrictScalarsEquivalenceOfRingEquiv (ULift.ringEquiv)` (fixed big module universe) then reflects
+  down with `ModuleCat.uliftFunctor`.
+- `Etingof.homologicalDimension_le_ulift` — `homologicalDimension R ≤ homologicalDimension (ULift R)`.
+
+Edited `Chapter9/Problem9_4_6.lean`:
+- `not_hasHomologicalDimensionLE_zero_freeAlgebra` — the free algebra (n ≥ 1) is not semisimple: the
+  augmentation module `k` (carried as a *local* module instance to avoid a spurious global
+  `Module (FreeAlgebra k (Fin n)) k`) is not projective, via a section/`NoZeroDivisors` contradiction.
+- Filled `homologicalDimension_freeAlgebra_eq_one`: upper bound by lifting to `Type (u+1)` and
+  transferring across `freePathEquiv` (same-universe `homologicalDimension_congr`); lower bound by
+  the non-semisimplicity result. `#print axioms` shows only `[propext, Classical.choice, Quot.sound]`.
+
+## Current frontier
+
+Issue #6644 fully complete. `lake build EtingofRepresentationTheory.Chapter9.Problem9_4_6` exits 0.
+Full-library `lake build` was running at handoff (unrelated Chapter4 files still compiling; the two
+touched targets build green).
+
+## Overall project progress
+
+Phase 3 formalization ongoing. Problem 9.4.6 (i) is now complete for both the path algebra and the
+free algebra. This unblocks #6636 (assemble `homologicalDimension_freeAlgebra_eq_one` via the
+one-vertex path algebra) — the universe gap it was waiting on is resolved.
+
+## Next step
+
+Verify the full-library build completed clean, then the successor can pick up #6640 (Ch3 Clifford odd
+case) or any newly-unblocked issue. Note: the reverse universe inequality
+(`homologicalDimension (ULift R) ≤ homologicalDimension R`, the harder Auslander-style direction)
+was intentionally not proved — only the direction needed here. If a future item needs the full
+equality `homologicalDimension_ulift`, that reverse direction remains open.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6644

Session: `ce89270d-40f2-43c3-847d-a688491e988d`

607f55e2 docs(progress): #6644 universe-lift invariance complete
8f9a1267 feat(Ch9 #6644): homologicalDimension_freeAlgebra_eq_one via universe-lift invariance
491b226f feat(Ch9 #6644): universe-lift reflection + homologicalDimension_le_ulift

🤖 Prepared with Claude Code