### PR TITLE
feat(Ch5 #6658): indA4_triv (Ind 1 ≅ 1⊕4) + order-12 conjugacy scaffold

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Problem5_11_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_11_1.lean
@@ -1315,7 +1315,120 @@ theorem indZ5_nontriv (H : Subgroup A5) (hH : Nat.card H = 5)
       show A = (-1 - (Real.sqrt 5 : ℂ)) / 2 by linear_combination hA,
       show B = (-1 + (Real.sqrt 5 : ℂ)) / 2 by linear_combination hAB - hA]
 
-/-! ## (d) Induction from `A₄` -/
+/-! ## (d) Induction from `A₄`
+
+The order-`12` subgroups of `A₅` are the (conjugate) point stabilizers `A₄` — not Sylow
+subgroups — so the cyclic-case route (`exists_conj_H5` via Sylow's theorem) does not apply.
+We fix the concrete `A₄` as the stabilizer of `0` under the natural action `natHom` and reduce
+an arbitrary order-`12` subgroup to it. The induced-character counts then reduce, exactly as in
+the cyclic cases, to `decide`-evaluable computations over the `60` elements of `A₅`. -/
+
+/-- The natural action of `A₅` on `Fin 5`, as a `MonoidHom`. -/
+def natHom : A5 →* Equiv.Perm (Fin 5) := (alternatingGroup (Fin 5)).subtype
+
+/-- The concrete order-`12` subgroup `A₄ ≤ A₅`: the point stabilizer of `0`. -/
+abbrev A4std : Subgroup A5 := Etingof.Problem4_12_5.stabSub natHom 0
+
+/-- Membership in the concrete `A₄` is fixing the point `0`. -/
+lemma mem_A4std (a : A5) : a ∈ A4std ↔ natHom a 0 = 0 := Iff.rfl
+
+instance : DecidablePred (· ∈ A4std) := fun a => decidable_of_iff _ (mem_A4std a).symm
+
+set_option maxRecDepth 12000 in
+-- `decide` counts the `12` even permutations of `Fin 5` fixing `0`.
+set_option maxHeartbeats 4000000 in
+/-- The concrete `A₄` has order `12`. -/
+lemma card_A4std : Nat.card A4std = 12 := by
+  rw [Nat.card_eq_fintype_card, Fintype.card_subtype]
+  decide
+
+/-- **Order-`12` conjugacy reduction.** Every order-`12` subgroup `H ≤ A₅` is conjugate to the
+concrete point-stabilizer `A₄`: there is `d` with `y ∈ H ↔ d y d⁻¹ ∈ A4std`.
+
+The order-`12` subgroups of `A₅` are not Sylow subgroups, so this is proved via the Sylow-`2`
+normalizer: a Sylow-`2` subgroup `P` of `H` (order `4`) is a Sylow-`2` of `A₅`; it is normal in
+`H` (`n₂(H)=1`, ruling out `n₃(H)=1` since `|N_{A₅}(order-3)| ∈ {6,15}` is not a multiple of
+`12`), so `H = N_{A₅}(P)`; and `P` is conjugate to the Sylow-`2` of `A4std` (Sylow II), whence
+`H = c · A4std · c⁻¹`. -/
+lemma exists_conj_H12 (H : Subgroup A5) (hH : Nat.card H = 12) :
+    ∃ d : A5, ∀ y : A5, y ∈ H ↔ d * y * d⁻¹ ∈ A4std := by
+  sorry
+
+/-- The count of conjugators landing in an order-`12` `H` matches that for the concrete `A₄`. -/
+lemma countH_eq12 (H : Subgroup A5) [DecidablePred (· ∈ H)] (hH : Nat.card H = 12) (g : A5) :
+    (univ.filter (fun x : A5 => x * g * x⁻¹ ∈ H)).card
+      = (univ.filter (fun x : A5 => x * g * x⁻¹ ∈ A4std)).card := by
+  obtain ⟨d, hd⟩ := exists_conj_H12 H hH
+  apply Finset.card_bij' (fun x _ => d * x) (fun x _ => d⁻¹ * x)
+  · intro x hx
+    simp only [mem_filter, mem_univ, true_and] at hx ⊢
+    rw [hd] at hx
+    rw [show d * x * g * (d * x)⁻¹ = d * (x * g * x⁻¹) * d⁻¹ by group]
+    exact hx
+  · intro x hx
+    simp only [mem_filter, mem_univ, true_and] at hx ⊢
+    rw [hd]
+    rw [show d * (d⁻¹ * x * g * (d⁻¹ * x)⁻¹) * d⁻¹ = x * g * x⁻¹ by group]
+    exact hx
+  · intro x hx; group
+  · intro x hx; group
+
+set_option maxRecDepth 12000 in
+-- `decide` evaluates the twisted membership (fixing `0`) over all `60` elements of `A₅`.
+set_option maxHeartbeats 4000000 in
+/-- **Twisted counts in the concrete `A₄`.** `#{x : x·(classRepA5 j)·x⁻¹ ∈ A₄}` on the five
+class reps is `(60, 24, 12, 0, 0)` — that is `12 ·` the fixed-point count `(5,2,1,0,0)`. -/
+lemma twisted_A4std (j : Fin 5) :
+    (univ.filter (fun x : A5 => x * classRepA5 j * x⁻¹ ∈ A4std)).card
+      = ![60, 24, 12, 0, 0] j := by
+  have h : (univ.filter (fun x : A5 => x * classRepA5 j * x⁻¹ ∈ A4std))
+      = (univ.filter (fun x : A5 => natHom (x * classRepA5 j * x⁻¹) 0 = 0)) := by
+    apply Finset.filter_congr; intro x _; simp only [mem_A4std]
+  rw [h]; fin_cases j <;> decide
+
+/-- **Trivial character, class-rep values.** For an order-`12` `H` and the trivial character `σ`,
+`(ind σ).character` on the five class reps is `(5, 2, 1, 0, 0)`. -/
+lemma indA4_triv_value (H : Subgroup A5) [DecidablePred (· ∈ H)] (hH : Nat.card H = 12)
+    (σ : FDRep ℂ ↥H) (htriv : ∀ h : ↥H, σ.character h = 1) (j : Fin 5) :
+    (ind σ).character (classRepA5 j) = ![5, 2, 1, 0, 0] j := by
+  rw [ind_character_eq]
+  have hcard : (Fintype.card ↥H : ℂ) = 12 := by
+    rw [← Nat.card_eq_fintype_card, hH]; norm_num
+  have hsum : (∑ x : A5, if h : x * classRepA5 j * x⁻¹ ∈ H then σ.character ⟨_, h⟩ else 0)
+      = ((univ.filter (fun x : A5 => x * classRepA5 j * x⁻¹ ∈ H)).card : ℂ) := by
+    rw [← Finset.sum_boole]
+    apply Finset.sum_congr rfl
+    intro x _
+    by_cases hx : x * classRepA5 j * x⁻¹ ∈ H
+    · rw [dif_pos hx, if_pos hx, htriv]
+    · rw [dif_neg hx, if_neg hx]
+  rw [hsum, countH_eq12 H hH, twisted_A4std, hcard]
+  fin_cases j <;> norm_num
+
+/-- Arbitrary-`g` trivial-character values, via the class-function property. -/
+lemma indA4_triv_char_all (H : Subgroup A5) [DecidablePred (· ∈ H)] (hH : Nat.card H = 12)
+    (σ : FDRep ℂ ↥H) (htriv : ∀ h : ↥H, σ.character h = 1) (g : A5) :
+    (ind σ).character g = ![5, 2, 1, 0, 0] (classIdxA5 g) := by
+  obtain ⟨c, hc⟩ := classIdxA5_spec g
+  conv_lhs => rw [← hc]
+  rw [FDRep.char_conj]
+  exact indA4_triv_value H hH σ htriv (classIdxA5 g)
+
+/-- **Target character, class-rep values** for `1 ⊕ 4`: `(5, 2, 1, 0, 0)`. -/
+lemma indA4_triv_target_value (j : Fin 5) :
+    (repTriv ⊞ repC4).character (classRepA5 j) = ![5, 2, 1, 0, 0] j := by
+  simp only [character_biprod, repTriv_character, repC4_character]
+  fin_cases j <;>
+    norm_num [tblA5, Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.cons_val_two,
+      Matrix.cons_val_three, Matrix.cons_val_four, Matrix.head_cons, Matrix.tail_cons]
+
+/-- Arbitrary-`g` target character values, via the class-function property. -/
+lemma indA4_triv_target_char_all (g : A5) :
+    (repTriv ⊞ repC4).character g = ![5, 2, 1, 0, 0] (classIdxA5 g) := by
+  obtain ⟨c, hc⟩ := classIdxA5_spec g
+  conv_lhs => rw [← hc]
+  rw [FDRep.char_conj]
+  exact indA4_triv_target_value (classIdxA5 g)
 
 /-- **(d) trivial character.** `Ind_{A₄}^{A₅} 1 ≅ 1 ⊕ 4` (dimension `5`), the permutation
 representation on the `5` cosets. -/
@@ -1323,7 +1436,10 @@ theorem indA4_triv (H : Subgroup A5) (hH : Nat.card H = 12)
     (σ : FDRep ℂ ↥H) [Simple σ] (hdim : Module.finrank ℂ σ = 1)
     (htriv : ∀ h : ↥H, σ.character h = 1) :
     Nonempty (ind σ ≅ repTriv ⊞ repC4) := by
-  sorry
+  classical
+  apply Etingof.charEq_iso
+  funext g
+  rw [indA4_triv_char_all H hH σ htriv g, indA4_triv_target_char_all g]
 
 /-- **(d) nontrivial linear character.** For either nontrivial one-dimensional character
 `ω, ω²` of `A₄`, `Ind_{A₄}^{A₅} ω ≅ 5` (dimension `5`). -/

--- a/progress/2026-07-15T08-06-44Z_e2e43078.md
+++ b/progress/2026-07-15T08-06-44Z_e2e43078.md
@@ -1,0 +1,49 @@
+## Accomplished
+
+Worked issue #6648 (Problem 5.11.1 part (d), induction from `A₄`). Determined it bundles three
+distinct character theorems plus substantial new shared infrastructure (all order-12 subgroups
+of `A₅` are conjugate — a non-Sylow reduction not covered by the existing `exists_conj_stab_sylow`
+machinery). **Decomposed** #6648 into three well-scoped sub-issues with complete, feasibility-
+validated proof strategies:
+
+- **#6658** — order-12 conjugacy infra (`exists_conj_H12`) + `indA4_triv` (Ind 1 ≅ 1⊕4)
+- **#6659** — `indA4_nontriv_linear` (Ind ω ≅ 5), depends on #6658
+- **#6660** — `indA4_threeDim` (Ind 3 ≅ 3⊕3'⊕4⊕5), depends on #6658
+
+Claimed #6658 and landed a **partial PR**: `indA4_triv` is proven end-to-end modulo the single
+group-theory lemma `exists_conj_H12`. Added to `Chapter5/Problem5_11_1.lean`:
+- `natHom` (natural `A₅ → Perm (Fin 5)`), `A4std` (concrete order-12 point stabilizer of `0`),
+  `mem_A4std`, a computable `DecidablePred` instance, `card_A4std = 12` (decide).
+- `exists_conj_H12` — stated with full Sylow-2-normalizer strategy in its docstring, single sorry.
+- `countH_eq12` (proven from `exists_conj_H12`, mirrors `countH_eq5`).
+- `twisted_A4std` — decide count `(60,24,12,0,0)` of conjugators landing in `A4std`.
+- `indA4_triv_value/char_all`, `indA4_triv_target_value/char_all`, and `indA4_triv` — all proven.
+
+Validated (scratch, against the built olean) all load-bearing `decide` facts: stabilizer order
+12; order-3 normalizer count 6; twisted count `(60,24,12,0,0)`. File builds clean (exit 0).
+
+## Current frontier
+
+`exists_conj_H12` (line ~1353) is the only remaining sorry in the part-(d) trivial case, and the
+shared blocker for #6659/#6660. Its proof (Sylow-2 normalizer route) is fully documented in the
+lemma docstring and in #6658's body: `P = Sylow-2 of H` (order 4) is a Sylow-2 of `A₅`; it is
+normal in `H` (`n₂(H)=1`, ruling out `n₃(H)=1` via `|N_{A₅}(order-3)| ∈ {6,15}`, not a multiple
+of 12); so `H = N_{A₅}(P)`; and `P` conj the Sylow-2 of `A4std` (Sylow II) gives `H = c·A4std·c⁻¹`.
+
+## Overall project progress
+
+Phase 3 formalization ongoing. Problem 5.11.1 parts (a)/(b)/(c) sorry-free; part (d) trivial
+character now proven modulo `exists_conj_H12`; parts (d)-nontrivial/3dim and (e) remain stubbed.
+
+## Next step
+
+A dedicated session should prove `exists_conj_H12` (the order-12 conjugacy reduction). This is
+~150+ lines of Sylow group theory but the computational foundation (concrete `A4std`, all decide
+counts, `countH_eq12`) is already in place. Once it lands, #6658 closes sorry-free and #6659/#6660
+unblock. Useful mathlib: `Sylow.card_eq_multiplicity`, `Sylow.ofCard`, `card_eq_index_normalizer`,
+`card_sylow_modEq_one`, `MulAction.exists_smul_eq`, `alternatingGroup.isSimpleGroup_five`.
+
+## Blockers
+
+None hard. `exists_conj_H12` is a substantial but well-scoped group-theory lemma with a validated
+computational foundation; landed as `--partial` so the planner routes the residual.


### PR DESCRIPTION
Partial progress on #6658.

This PR proves `indA4_triv` (`Ind_{A₄}^{A₅} 1 ≅ 1 ⊕ 4`, the 5-point permutation representation)
for Problem 5.11.1 part (d), together with the reusable order-12 scaffold, leaving only the
group-theory conjugacy reduction `exists_conj_H12` as a single well-scoped sorry.

Added to `Chapter5/Problem5_11_1.lean`:
- `natHom` (natural `A₅ → Perm (Fin 5)`), `A4std` (concrete order-12 point stabilizer of `0`),
  `mem_A4std`, a computable `DecidablePred` instance, and `card_A4std = 12`.
- `exists_conj_H12` — every order-12 subgroup of `A₅` is conjugate to `A4std`, stated with its
  full Sylow-2-normalizer proof strategy in the docstring (the single remaining sorry).
- `countH_eq12` (proven from `exists_conj_H12`) and `twisted_A4std` (decide count `(60,24,12,0,0)`).
- `indA4_triv_value` / `_char_all`, `indA4_triv_target_value` / `_char_all`, and `indA4_triv`
  itself — all proven.

`indA4_triv` is verified end-to-end modulo `exists_conj_H12`. Because the order-12 subgroups of
`A₅` are point stabilizers `A₄` rather than Sylow subgroups, the cyclic-case route
(`exists_conj_H5` via Sylow's theorem) does not apply, so the reduction is left for a focused
follow-up (see #6658 body / the lemma docstring for the Sylow-2-normalizer plan). The remaining
part-(d) theorems are tracked by #6659 (nontrivial linear) and #6660 (3-dimensional), which
depend on `exists_conj_H12`.

`lake build EtingofRepresentationTheory.Chapter5.Problem5_11_1` exits 0.

🤖 Prepared with Claude Code
