### PR TITLE
feat(Ch7 #Problem8.2.8-Tor): milestone (a) — degreewise iso tensorExtendXIso for tensor∘extend (extend C ⊗ extend D).X j' ≅ (extend (C⊗D)).X j'

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -5235,3 +5235,44 @@ and reintroduces the ill-typed sub):
 
 `using 3` descends `0 ≤ · ⬝ᵥ (M.mulVec x)` down to the matrix equality `M = Matrix.of …`;
 `ext a b` then gives a well-typed entry goal because `M` came from the goal, not from you.
+
+## `HomologicalComplex.mapBifunctor`/`tensorObj` degreewise iso proofs (`extend`/Künneth, #6693)
+
+Building a degreewise iso between `(tensorObj K₁ K₂).X j` objects (e.g. the crux
+`extend C ⊗ extend D ≅ extend (C ⊗ D)`) fights three recurring traps. Working recipe:
+
+1. **Reduce along summands with `mapBifunctor.hom_ext` + `ι_mapBifunctorDesc`, never manual
+   `Category.assoc`.** `(tensorObj K₁ K₂).X j` unfolds to `GradedObject.mapBifunctor … .obj K.X`,
+   which is *not type-correct at `instances` transparency* (`K.X : ι → C` vs `GradedObject ι C`).
+   So `rw [Category.assoc]`, `simp only [Category.assoc]`, `slice_lhs`, and even `conv_lhs => rw
+   [Category.assoc]` all fail with "motive is not type correct" / "not type-correct under the
+   instances transparency level" whenever the composite's middle object is a `.X` of a tensor.
+   `←Category.assoc` on a *clean* `hom_ext` goal (`ι ≫ (f ≫ g)`) works; the forward direction on
+   an unfolded body does not.
+
+2. **The fix that unblocks everything:** put
+   `set_option backward.isDefEq.respectTransparency false in`
+   on the lemma. This is exactly what `Mathlib/…/Embedding/Extend.lean` uses. With it, the
+   standalone composite-reduction lemmas (`phiInv ≫ fwdNeg = ι`, proved by `rw [phiInv,
+   Category.assoc, ι…desc, …]`) go through. Structure the round-trips so the painful step lives in
+   such a standalone lemma (clean starting goal, no prior unfolds polluting it), then the
+   `hom_ext` proof is just `rw […, ι…_desc]; exact that_lemma`.
+
+3. **Match your own `ι` spelling to `hom_ext`'s.** `hom_ext`/`ι_mapBifunctorDesc` produce/expect
+   `HomologicalComplex.ιMapBifunctor …`, but `ιTensorObj` (a reducible abbrev) does *not* rw-match
+   it. Define your summand maps with `ιMapBifunctor` directly (wrap in a local `abbrev ιN`/`ιZ`
+   fixing `curriedTensor _` and the shape) — do **not** `simp only [ιTensorObj]` to convert, since
+   that unfolds into the ill-typed `GradedObject` form and re-triggers trap 1.
+
+**Match-with-binder defs reduce via `split`, not `simp`.** For a per-summand map defined
+`match ha : e.r a, hb : e.r b with | some p, some q => … | _,_ => 0`, prove its reduction lemma
+with `rw [phiFwd]; split; next p' q' hh1 hh2 => obtain rfl := Option.some.inj (hh1 ▸ ha); …;
+next hh => exact (hh p q ha hb).elim`. `simp only [phiFwd, ha, hb]` will *not* fire (the match
+binds its own scrutinees); a `dite`-on-`isSome` reformulation reduces cleanly but then `.get`
+sits in dependent positions and `rw`/`simp` cannot rewrite `(e.r a).get → p` (motive). Prefer the
+match+`split`.
+
+**Transport a `-n`-indexed iso to a variable `j'` via a `match hj : e.r j'` def**, `some n` branch
+`eqToIso (congrArg (…).X (j' = -n)) ≪≫ isoNegExt … ≪≫ eqToIso (…)`. Prove `foo_neg : foo (-n) =
+isoNegExt n` by `rw [foo]; split; next m hm => obtain rfl := …; apply Iso.ext; simp`. Do **not**
+use `.get` for `n` (dependent-position `get` is unrewritable); the match binder gives a real `n`.

--- a/EtingofRepresentationTheory/Chapter7/KunnethChainComplexNat.lean
+++ b/EtingofRepresentationTheory/Chapter7/KunnethChainComplexNat.lean
@@ -80,6 +80,266 @@ theorem homology_extend_isZero (C : ChainComplex (ModuleCat.{u} k) ℕ) (j' : �
   simp only [ComplexShape.embeddingDownNat_f]
   omega
 
+namespace TensorExtend
+
+/-!
+## Milestone (a): the degreewise object isomorphism
+
+This section constructs, for every `j' : ℤ`, the degreewise isomorphism
+`(extend C ⊗ extend D).X j' ≅ (extend (C ⊗ D)).X j'` (`tensorExtendXIso`), the object-level half
+of the crux `nonempty_tensorObj_extend_iso`. The nonzero degrees are `j' = -n`, where both sides
+identify with `⨁_{p+q=n} C_p ⊗ D_q`; positive degrees are zero on both sides.
+
+The forward/inverse maps are assembled out of `mapBifunctorDesc` over the summand maps `phiFwd`
+(nonzero summands `(a,b) = (-p,-q)`) and `phiInv`, and packaged as `isoNeg`. The two summand
+compatibility lemmas `tensorExtendXIso_hom_extendXIso` and `extendXIso_inv_tensorExtendXIso_inv`
+are what milestone (b) consumes to check differential compatibility.
+-/
+
+/-- The reindexing embedding `n ↦ -n`. -/
+noncomputable abbrev e : ComplexShape.Embedding (ComplexShape.down ℕ) (ComplexShape.up ℤ) :=
+  ComplexShape.embeddingDownNat
+
+/-- If the left factor is zero, the tensor is zero. -/
+lemma isZero_tensorObj_left {C : Type*} [Category C] [MonoidalCategory C] [Preadditive C]
+    [MonoidalPreadditive C] {X Y : C} (hX : IsZero X) : IsZero (X ⊗ Y) := by
+  rw [IsZero.iff_id_eq_zero, ← MonoidalCategory.id_tensorHom_id, hX.eq_of_src (𝟙 X) 0]
+  simp
+
+/-- If the right factor is zero, the tensor is zero. -/
+lemma isZero_tensorObj_right {C : Type*} [Category C] [MonoidalCategory C] [Preadditive C]
+    [MonoidalPreadditive C] {X Y : C} (hY : IsZero Y) : IsZero (X ⊗ Y) := by
+  rw [IsZero.iff_id_eq_zero, ← MonoidalCategory.id_tensorHom_id, hY.eq_of_src (𝟙 Y) 0]
+  simp
+
+variable (C D : ChainComplex (ModuleCat.{u} k) ℕ)
+
+/-- Summand inclusion into `(tensorObj C D).X n`, spelled as `ιMapBifunctor`. -/
+noncomputable abbrev ιN (p q n : ℕ)
+    (h : (ComplexShape.down ℕ).π (ComplexShape.down ℕ) (ComplexShape.down ℕ) (p, q) = n) :
+    ((curriedTensor (ModuleCat.{u} k)).obj (C.X p)).obj (D.X q) ⟶
+      (HomologicalComplex.tensorObj C D).X n :=
+  HomologicalComplex.ιMapBifunctor C D (curriedTensor (ModuleCat.{u} k)) (ComplexShape.down ℕ)
+    p q n h
+
+/-- Summand inclusion into `(tensorObj (extend C) (extend D)).X j`, spelled as `ιMapBifunctor`. -/
+noncomputable abbrev ιZ (a b j : ℤ)
+    (h : (ComplexShape.up ℤ).π (ComplexShape.up ℤ) (ComplexShape.up ℤ) (a, b) = j) :
+    ((curriedTensor (ModuleCat.{u} k)).obj ((C.extend e).X a)).obj ((D.extend e).X b) ⟶
+      (HomologicalComplex.tensorObj (C.extend e) (D.extend e)).X j :=
+  HomologicalComplex.ιMapBifunctor (C.extend e) (D.extend e) (curriedTensor (ModuleCat.{u} k))
+    (ComplexShape.up ℤ) a b j h
+
+/-- Forward per-summand map for the degree `-n` iso. -/
+noncomputable def phiFwd (n : ℕ) (a b : ℤ) (h : a + b = -(n : ℤ)) :
+    (C.extend e).X a ⊗ (D.extend e).X b ⟶ (HomologicalComplex.tensorObj C D).X n :=
+  match ha : e.r a, hb : e.r b with
+  | some p, some q =>
+      ((C.extendXIso e (e.f_eq_of_r_eq_some ha)).hom ⊗ₘ
+        (D.extendXIso e (e.f_eq_of_r_eq_some hb)).hom) ≫
+        ιN C D p q n (by
+          have hp := e.f_eq_of_r_eq_some ha
+          have hq := e.f_eq_of_r_eq_some hb
+          simp only [ComplexShape.embeddingDownNat_f] at hp hq
+          have : p + q = n := by omega
+          simpa using this)
+  | _, _ => 0
+
+/-- Reduction of `phiFwd` on the nonzero (some/some) summands. -/
+lemma phiFwd_some (n : ℕ) {a b : ℤ} (h : a + b = -(n : ℤ)) {p q : ℕ}
+    (ha : e.r a = some p) (hb : e.r b = some q)
+    (hpq : (ComplexShape.down ℕ).π (ComplexShape.down ℕ) (ComplexShape.down ℕ) (p, q) = n) :
+    phiFwd C D n a b h =
+      ((C.extendXIso e (show e.f p = a from e.f_eq_of_r_eq_some ha)).hom ⊗ₘ
+        (D.extendXIso e (show e.f q = b from e.f_eq_of_r_eq_some hb)).hom) ≫ ιN C D p q n hpq := by
+  rw [phiFwd]
+  split
+  next p' q' hh1 hh2 =>
+    obtain rfl : p' = p := Option.some.inj (hh1 ▸ ha)
+    obtain rfl : q' = q := Option.some.inj (hh2 ▸ hb)
+    rfl
+  next hh => exact (hh p q ha hb).elim
+
+/-- Inverse per-summand map for the degree `-n` iso. -/
+noncomputable def phiInv (n : ℕ) (p q : ℕ)
+    (h : (ComplexShape.down ℕ).π (ComplexShape.down ℕ) (ComplexShape.down ℕ) (p, q) = n) :
+    C.X p ⊗ D.X q ⟶ (HomologicalComplex.tensorObj (C.extend e) (D.extend e)).X (-(n : ℤ)) :=
+  ((C.extendXIso e (show e.f p = -(p : ℤ) by simp)).inv ⊗ₘ
+    (D.extendXIso e (show e.f q = -(q : ℤ) by simp)).inv) ≫
+    ιZ C D (-(p : ℤ)) (-(q : ℤ)) (-(n : ℤ)) (by
+      have hpq : p + q = n := by simpa using h
+      have : (p : ℤ) + q = n := by exact_mod_cast hpq
+      simpa using by omega)
+
+/-- Forward map for the degree `-n` iso. -/
+noncomputable def fwdNeg (n : ℕ) :
+    (HomologicalComplex.tensorObj (C.extend e) (D.extend e)).X (-(n : ℤ)) ⟶
+      (HomologicalComplex.tensorObj C D).X n :=
+  HomologicalComplex.mapBifunctorDesc (fun a b h => phiFwd C D n a b h)
+
+/-- Inverse map for the degree `-n` iso. -/
+noncomputable def invNeg (n : ℕ) :
+    (HomologicalComplex.tensorObj C D).X n ⟶
+      (HomologicalComplex.tensorObj (C.extend e) (D.extend e)).X (-(n : ℤ)) :=
+  HomologicalComplex.mapBifunctorDesc (fun p q h => phiInv C D n p q h)
+
+/-- `e.r (-p) = some p`. -/
+lemma r_negNat (p : ℕ) : e.r (-(p : ℤ)) = some p :=
+  e.r_eq_some (show e.f p = -(p : ℤ) by simp)
+
+/-- Reduction of `fwdNeg` on a summand inclusion. -/
+lemma ιZ_fwdNeg (n : ℕ) (a b : ℤ)
+    (h : (ComplexShape.up ℤ).π (ComplexShape.up ℤ) (ComplexShape.up ℤ) (a, b) = -(n : ℤ)) :
+    ιZ C D a b (-(n : ℤ)) h ≫ fwdNeg C D n = phiFwd C D n a b h := by
+  simp only [ιZ, fwdNeg, ι_mapBifunctorDesc]
+
+/-- Reduction of `invNeg` on a summand inclusion. -/
+lemma ιN_invNeg (n : ℕ) (p q : ℕ)
+    (h : (ComplexShape.down ℕ).π (ComplexShape.down ℕ) (ComplexShape.down ℕ) (p, q) = n) :
+    ιN C D p q n h ≫ invNeg C D n = phiInv C D n p q h := by
+  simp only [ιN, invNeg, ι_mapBifunctorDesc]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- `phiInv` followed by `fwdNeg` is the summand inclusion. -/
+lemma phiInv_comp_fwdNeg (n p q : ℕ)
+    (h : (ComplexShape.down ℕ).π (ComplexShape.down ℕ) (ComplexShape.down ℕ) (p, q) = n) :
+    phiInv C D n p q h ≫ fwdNeg C D n = ιN C D p q n h := by
+  rw [phiInv, Category.assoc, ιZ_fwdNeg, phiFwd_some C D n _ (r_negNat p) (r_negNat q) h]
+  simp
+
+set_option backward.isDefEq.respectTransparency false in
+/-- `phiFwd` on a nonzero summand followed by `invNeg` is the summand inclusion. -/
+lemma phiFwd_comp_invNeg (n : ℕ) (a b : ℤ) (h : a + b = -(n : ℤ)) {p q : ℕ}
+    (ha : e.r a = some p) (hb : e.r b = some q)
+    (hpq : (ComplexShape.down ℕ).π (ComplexShape.down ℕ) (ComplexShape.down ℕ) (p, q) = n) :
+    phiFwd C D n a b h ≫ invNeg C D n = ιZ C D a b (-(n : ℤ)) h := by
+  obtain rfl : a = -(p : ℤ) := by have := e.f_eq_of_r_eq_some ha; simpa using this.symm
+  obtain rfl : b = -(q : ℤ) := by have := e.f_eq_of_r_eq_some hb; simpa using this.symm
+  rw [phiFwd_some C D n _ (r_negNat p) (r_negNat q) hpq, Category.assoc, ιN_invNeg, phiInv]
+  simp
+
+/-- The degree `-n` component isomorphism `(extend C ⊗ extend D).X (-n) ≅ (C ⊗ D).X n`. -/
+noncomputable def isoNeg (n : ℕ) :
+    (HomologicalComplex.tensorObj (C.extend e) (D.extend e)).X (-(n : ℤ)) ≅
+      (HomologicalComplex.tensorObj C D).X n where
+  hom := fwdNeg C D n
+  inv := invNeg C D n
+  inv_hom_id := by
+    apply HomologicalComplex.mapBifunctor.hom_ext
+    intro p q h'
+    rw [Category.comp_id, ← Category.assoc,
+      show HomologicalComplex.ιMapBifunctor C D _ _ p q n h' = ιN C D p q n h' from rfl,
+      ιN_invNeg]
+    exact phiInv_comp_fwdNeg C D n p q h'
+  hom_inv_id := by
+    apply HomologicalComplex.mapBifunctor.hom_ext
+    intro a b h'
+    rcases ha : e.r a with _ | p
+    · exact (isZero_tensorObj_left (C.isZero_extend_X' e a ha)).eq_of_src _ _
+    rcases hb : e.r b with _ | q
+    · exact (isZero_tensorObj_right (D.isZero_extend_X' e b hb)).eq_of_src _ _
+    have hpq : (ComplexShape.down ℕ).π (ComplexShape.down ℕ) (ComplexShape.down ℕ) (p, q) = n := by
+      have hpa := e.f_eq_of_r_eq_some ha
+      have hqb := e.f_eq_of_r_eq_some hb
+      simp only [ComplexShape.embeddingDownNat_f] at hpa hqb
+      have h2 : a + b = -(n : ℤ) := h'
+      have : p + q = n := by omega
+      simpa using this
+    rw [Category.comp_id, ← Category.assoc,
+      show HomologicalComplex.ιMapBifunctor (C.extend e) (D.extend e) _ _ a b (-(n : ℤ)) h'
+        = ιZ C D a b (-(n : ℤ)) h' from rfl,
+      ιZ_fwdNeg]
+    exact phiFwd_comp_invNeg C D n a b h' ha hb hpq
+
+/-- The `ℤ`-tensor of the extensions vanishes in positive degrees. -/
+lemma isZero_tensorObj_extend_X_of_pos (j' : ℤ) (hj' : 0 < j') :
+    IsZero ((HomologicalComplex.tensorObj (C.extend e) (D.extend e)).X j') := by
+  rw [IsZero.iff_id_eq_zero]
+  apply HomologicalComplex.mapBifunctor.hom_ext
+  intro a b hab
+  have hab' : a + b = j' := hab
+  rw [Category.comp_id, comp_zero]
+  refine (?_ : IsZero _).eq_of_src _ _
+  by_cases ha : a ≤ 0
+  · have hb : 0 < b := by omega
+    exact isZero_tensorObj_right
+      (D.isZero_extend_X e b (fun i => by simp only [ComplexShape.embeddingDownNat_f]; omega))
+  · exact isZero_tensorObj_left
+      (C.isZero_extend_X e a (fun i => by simp only [ComplexShape.embeddingDownNat_f]; omega))
+
+/-- `e.f n = -n` as a stored equality. -/
+lemma ef_eq_neg (n : ℕ) : e.f n = -(n : ℤ) := by simp
+
+/-- The degree `-n` component iso, landing directly in the extension of `C ⊗ D`. -/
+noncomputable def isoNegExt (n : ℕ) :
+    (HomologicalComplex.tensorObj (C.extend e) (D.extend e)).X (-(n : ℤ)) ≅
+      ((HomologicalComplex.tensorObj C D).extend e).X (-(n : ℤ)) :=
+  isoNeg C D n ≪≫
+    (HomologicalComplex.extendXIso (HomologicalComplex.tensorObj C D) e (ef_eq_neg n)).symm
+
+/-- **Milestone (a): the degreewise object iso.** For every `j' : ℤ`,
+`(extend C ⊗ extend D).X j' ≅ (extend (C ⊗ D)).X j'`. On the nonzero degrees `j' = -n` it is
+`isoNegExt`; on positive degrees both sides vanish. -/
+noncomputable def tensorExtendXIso (j' : ℤ) :
+    (HomologicalComplex.tensorObj (C.extend e) (D.extend e)).X j' ≅
+      ((HomologicalComplex.tensorObj C D).extend e).X j' :=
+  match hj : e.r j' with
+  | some n =>
+      eqToIso (congrArg (HomologicalComplex.tensorObj (C.extend e) (D.extend e)).X
+        (show j' = -(n : ℤ) by
+          have := e.f_eq_of_r_eq_some hj
+          simp only [ComplexShape.embeddingDownNat_f] at this; omega)) ≪≫
+      isoNegExt C D n ≪≫
+      eqToIso (congrArg ((HomologicalComplex.tensorObj C D).extend e).X
+        (show -(n : ℤ) = j' by
+          have := e.f_eq_of_r_eq_some hj
+          simp only [ComplexShape.embeddingDownNat_f] at this; omega))
+  | none =>
+      IsZero.iso
+        (isZero_tensorObj_extend_X_of_pos C D j' (by
+          by_contra hle
+          have hr : e.r j' = some ((-j').toNat) :=
+            e.r_eq_some (by simp only [ComplexShape.embeddingDownNat_f]; omega)
+          rw [hr] at hj
+          simp at hj))
+        (HomologicalComplex.isZero_extend_X' _ e j' hj)
+
+/-- `tensorExtendXIso` at `-n` is `isoNegExt`. -/
+lemma tensorExtendXIso_neg (n : ℕ) :
+    tensorExtendXIso C D (-(n : ℤ)) = isoNegExt C D n := by
+  rw [tensorExtendXIso]
+  split
+  next m hm =>
+    obtain rfl : m = n := (Option.some.inj ((r_negNat n).symm.trans hm)).symm
+    apply Iso.ext
+    simp
+  next hm => rw [r_negNat] at hm; simp at hm
+
+set_option backward.isDefEq.respectTransparency false in
+/-- **Milestone (a) simp lemma (`.hom`).** Composing the iso with the extend transport recovers
+the coproduct forward map `fwdNeg` (whose action on summand inclusions is `ιZ_fwdNeg`). -/
+@[simp]
+lemma tensorExtendXIso_hom_extendXIso (n : ℕ) :
+    (tensorExtendXIso C D (-(n : ℤ))).hom ≫
+        (HomologicalComplex.extendXIso (HomologicalComplex.tensorObj C D) e (ef_eq_neg n)).hom =
+      fwdNeg C D n := by
+  rw [tensorExtendXIso_neg, isoNegExt]
+  simp only [Iso.trans_hom, Iso.symm_hom, Category.assoc, Iso.inv_hom_id, Category.comp_id]
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+/-- **Milestone (a) simp lemma (`.inv`).** Composing the extend transport with the iso's inverse
+recovers the coproduct inverse map `invNeg` (whose action on summand inclusions is `ιN_invNeg`). -/
+@[simp]
+lemma extendXIso_inv_tensorExtendXIso_inv (n : ℕ) :
+    (HomologicalComplex.extendXIso (HomologicalComplex.tensorObj C D) e (ef_eq_neg n)).inv ≫
+        (tensorExtendXIso C D (-(n : ℤ))).inv = invNeg C D n := by
+  rw [tensorExtendXIso_neg, isoNegExt]
+  simp only [Iso.trans_inv, Iso.symm_inv, Iso.inv_hom_id_assoc]
+  rfl
+
+end TensorExtend
+
 /-- **Crux (tensor ∘ extend compatibility).** The `ℤ`-tensor of the extensions is the extension
 of the `ℕ`-tensor:
 `extend e C ⊗ extend e D ≅ extend e (C ⊗ D)`, `e = embeddingDownNat`.

--- a/progress/2026-07-15T18-11-00Z_a4acf0f0.md
+++ b/progress/2026-07-15T18-11-00Z_a4acf0f0.md
@@ -1,0 +1,47 @@
+## Accomplished
+
+Formalized issue #6693 (Ch7 Künneth milestone (a)): the degreewise object iso
+`tensorExtendXIso` for `tensor ∘ extend`, in
+`EtingofRepresentationTheory/Chapter7/KunnethChainComplexNat.lean` (new
+`Etingof.TensorExtend` namespace, 260 lines, sorry-free).
+
+Deliverables (all axioms `[propext, Classical.choice, Quot.sound]`):
+- `tensorExtendXIso C D j' : (extend C ⊗ extend D).X j' ≅ (extend (C ⊗ D)).X j'`
+  for every `j' : ℤ` (nonzero at `j' = -n`, both sides zero for `j' > 0`).
+- Two `@[simp]` summand-compatibility lemmas milestone (b) consumes:
+  `tensorExtendXIso_hom_extendXIso` (`.hom ≫ extendXIso.hom = fwdNeg`) and
+  `extendXIso_inv_tensorExtendXIso_inv` (`extendXIso.inv ≫ .inv = invNeg`).
+
+Supporting API: `phiFwd`/`phiInv` (per-summand maps), `fwdNeg`/`invNeg`
+(`mapBifunctorDesc` assemblies), `isoNeg` (the `-n` component iso with both
+round-trips proved), `ιZ_fwdNeg`/`ιN_invNeg` (desc reductions),
+`phiInv_comp_fwdNeg`/`phiFwd_comp_invNeg` (composite reductions),
+`isZero_tensorObj_extend_X_of_pos` (positive-degree vanishing).
+
+## Current frontier
+
+Milestone (a) of the crux `nonempty_tensorObj_extend_iso` (#6677) is done at the
+object level. The crux itself (complex iso with Koszul-signed differential
+compatibility) and `kunnethChainComplexNat` remain `sorry` — that is milestone
+(b) and the #6678 assembly.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. Ch7 `KunnethChainComplexNat` scaffold now has its
+degreewise object iso; two `sorry`s remain in the file (the crux and the main
+Künneth statement), both downstream of this piece.
+
+## Next step
+
+Milestone (b): upgrade `tensorExtendXIso` to a complex isomorphism
+`extend C ⊗ extend D ≅ extend (C ⊗ D)` by checking differential compatibility
+(`d = d₁ ⊗ 1 + (-1)ʲ 1 ⊗ d₂`) using the two new simp lemmas, then discharge
+`nonempty_tensorObj_extend_iso`. After that, #6678 assembles
+`kunnethChainComplexNat`.
+
+## Blockers
+
+None. Note: several proofs need
+`set_option backward.isDefEq.respectTransparency false` because `(tensorObj _ _).X`
+is not type-correct at `instances` transparency after unfolding (a known Mathlib
+`mapBifunctor.X` friction); milestone (b) will likely need the same option.


### PR DESCRIPTION
Closes #6693

Session: `a4acf0f0-8297-41fb-8a0b-53ecf535e819`

63297eef docs(skill): mapBifunctor/tensorObj degreewise-iso gotchas (from #6693)
7883c3ee feat(Ch7 #6693): tensorExtendXIso — degreewise object iso for tensor∘extend (milestone a)

🤖 Prepared with Claude Code