### PR TITLE
feat(Ch6 #Problem6.1.3-c): prove cycle_cartan_mulVec_one_eq_zero + cycle_cartan_det_zero

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -3432,6 +3432,26 @@ If the concrete example fails, the statement has a convention bug. Fix the state
 
 Direct `rw` on dependent types is a recurring friction point. These patterns work:
 
+### `omega` cannot do variable-modulus `% n` or unfold `if-then-else`
+`omega` supports `%`/`/` only by **numeral** divisors. For a *variable* modulus
+`n` (e.g. cyclic adjacency `(i+1) % n = j`, `Fin n` rotation), `omega` treats
+`(m+1) % n` as an opaque atom and fails even on trivial facts like
+`(i+1) % n = i+1` given `i+1 < n`. It also does **not** case-split on
+`if c then _ else _`. Recipe (used for `cycle_cartan_*`, #6745,
+`Chapter6/Problem6_1_3_continued_E7_E8.lean`): first rewrite every mod into an
+`if`-branch form with an explicit helper —
+`have hmod : ∀ m, m < n → (m+1) % n = if m+1 = n then 0 else m+1 := fun m hm => by
+  by_cases h : m+1 = n; · rw [if_pos h, h]; exact Nat.mod_self n;
+  · rw [if_neg h]; exact Nat.mod_eq_of_lt (by omega)` — then `rw [hmod …]` at each
+occurrence and finish with `split_ifs <;> omega` (now pure linear + `ite`
+eliminated). To count the two cyclic neighbours as a `Finset`, show
+`univ.filter P = {⟨(i+1)%n, _⟩, ⟨if i=0 then n-1 else i-1, _⟩}` (predecessor
+written *without* an outer mod so its `.val` stays a raw natural), then
+`Finset.sum_boole` + `Finset.card_pair hab`. Reuse `Fin.val_mk` in the `simp only`
+so `(⟨x,h⟩ : Fin n).val` reduces to `x` before `omega`/`split_ifs`. A nonzero
+kernel vector ⇒ `det = 0` is `Matrix.exists_mulVec_eq_zero_iff` (holds over any
+`[CommRing] [IsDomain]`, so ℤ directly — no need to map through ℚ).
+
 ### Pattern 1: `congrArg` with `Fin.ext` (for Fin-indexed access)
 When you need to rewrite a `Fin` value inside a dependent context (e.g., cycle access, list indexing):
 ```lean

--- a/EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_E7_E8.lean
+++ b/EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_E7_E8.lean
@@ -134,13 +134,57 @@ each row of `2·Id - R` sums to `0` because every vertex of a cycle has degree `
 ("the sum of rows is `0`"). -/
 theorem cycle_cartan_mulVec_one_eq_zero (n : ℕ) (hn : 3 ≤ n) :
     (2 • (1 : Matrix (Fin n) (Fin n) ℤ) - cycleAdj n).mulVec (fun _ => 1) = 0 := by
-  sorry
+  have hn0 : 0 < n := by omega
+  funext i
+  -- Every vertex of the `n`-cycle has exactly two neighbours (`i+1` and `i-1`,
+  -- distinct for `n ≥ 3`), so its degree — the row sum of `R` — is `2`.
+  have hdeg : ∑ j : Fin n, cycleAdj n i j = (2 : ℤ) := by
+    -- `omega` cannot reason about `% n` for a variable modulus, so first rewrite
+    -- each `(m+1) % n` (with `m < n`) into the elementary `if`-branch form.
+    have hmod : ∀ m : ℕ, m < n → (m + 1) % n = if m + 1 = n then 0 else m + 1 := by
+      intro m hm
+      by_cases h : m + 1 = n
+      · rw [if_pos h, h]; exact Nat.mod_self n
+      · rw [if_neg h]; exact Nat.mod_eq_of_lt (by omega)
+    have hlt1 : (i.val + 1) % n < n := Nat.mod_lt _ hn0
+    have hlt2 : (if i.val = 0 then n - 1 else i.val - 1) < n := by split <;> omega
+    have hfil : (Finset.univ.filter
+          (fun j : Fin n => (i.val + 1) % n = j.val ∨ (j.val + 1) % n = i.val))
+        = {(⟨(i.val + 1) % n, hlt1⟩ : Fin n),
+            ⟨if i.val = 0 then n - 1 else i.val - 1, hlt2⟩} := by
+      ext j
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_insert,
+        Finset.mem_singleton, Fin.ext_iff, Fin.val_mk]
+      rw [hmod i.val i.isLt, hmod j.val j.isLt]
+      split_ifs <;> omega
+    have hab : (⟨(i.val + 1) % n, hlt1⟩ : Fin n)
+        ≠ ⟨if i.val = 0 then n - 1 else i.val - 1, hlt2⟩ := by
+      simp only [ne_eq, Fin.mk.injEq]
+      rw [hmod i.val i.isLt]
+      split_ifs <;> omega
+    have hsum : ∑ j : Fin n, cycleAdj n i j
+        = ∑ j : Fin n,
+            if (i.val + 1) % n = j.val ∨ (j.val + 1) % n = i.val then (1 : ℤ) else 0 := by
+      simp only [cycleAdj]
+    rw [hsum, Finset.sum_boole, hfil, Finset.card_pair hab]
+    norm_num
+  -- The all-ones row sum of `2·Id - R` is `2 - deg = 0`.
+  have h1 : ∑ j : Fin n, (2 • (1 : Matrix (Fin n) (Fin n) ℤ)) i j = (2 : ℤ) := by
+    simp [Matrix.smul_apply, Matrix.one_apply, Finset.sum_ite_eq]
+  simp only [mulVec, dotProduct, mul_one, Matrix.sub_apply, Pi.zero_apply]
+  rw [Finset.sum_sub_distrib, h1, hdeg]
+  norm_num
 
 /-- **(c)** Consequently the Cartan matrix of a cycle is singular: `det A = 0`,
 so a cycle is never a Dynkin diagram. -/
 theorem cycle_cartan_det_zero (n : ℕ) (hn : 3 ≤ n) :
     (2 • (1 : Matrix (Fin n) (Fin n) ℤ) - cycleAdj n).det = 0 := by
-  sorry
+  have hn0 : 0 < n := by omega
+  rw [← Matrix.exists_mulVec_eq_zero_iff]
+  refine ⟨fun _ => 1, ?_, cycle_cartan_mulVec_one_eq_zero n hn⟩
+  intro h
+  have := congrFun h ⟨0, hn0⟩
+  simp at this
 
 /-- **(c)** A Dynkin diagram is a **tree**: being connected (part of
 `IsDynkinDiagram`) and positive definite forces the number of edges to be

--- a/progress/2026-07-16T05-51-07Z_276a005a.md
+++ b/progress/2026-07-16T05-51-07Z_276a005a.md
@@ -1,0 +1,42 @@
+## Accomplished
+
+Closed the two `sorry`s of Problem 6.1.3 (continued) **part (c)** in
+`EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_E7_E8.lean`
+(issue #6745):
+
+- `cycle_cartan_mulVec_one_eq_zero` — the all-ones vector is in the kernel of
+  the cycle's Cartan matrix `2·Id - R`. Proved that each vertex of the `n`-cycle
+  has degree exactly `2` (its two neighbours `i+1` and `i-1 (mod n)` are distinct
+  for `n ≥ 3`) by showing `filter P univ = {succ, pred}` and using
+  `Finset.sum_boole` + `Finset.card_pair`; then the row sum is `2 - 2 = 0`.
+- `cycle_cartan_det_zero` — det `= 0`, via `Matrix.exists_mulVec_eq_zero_iff`
+  (valid over the integral domain `ℤ`, no need to pass through `ℚ`), fed the
+  nonzero all-ones kernel vector.
+
+Both `#print axioms` are `[propext, Classical.choice, Quot.sound]` (sorry-free).
+
+## Current frontier
+
+`lake build EtingofRepresentationTheory.Chapter6.Problem6_1_3_continued_E7_E8`
+exits 0. The remaining `sorry`s in the file are the ones #6745 explicitly left
+alone: parts (a)/(b) determinant recursions, `isDynkinDiagram_isTree`, and part
+(d) `isDynkinDiagram_degree_le_three` / `isDynkinDiagram_unique_degree_three`.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. This closes part (c) of Problem 6.1.3-continued;
+item `Chapter6/Problem6.1.3_continued_E7_E8` stays `statement_formalized`
+(other parts still sorry). Coverage note updated in `progress/items.json`.
+
+## Next step
+
+Key lesson for successors on this file: **`omega` cannot reason about `% n` for
+a variable modulus `n`, and does not unfold `if-then-else`**. Rewrite each
+`(m+1) % n` (with `m < n`) into `if m+1 = n then 0 else m+1` via
+`Nat.mod_self` / `Nat.mod_eq_of_lt`, then `split_ifs <;> omega`. The harder
+open lemmas here (parts a/b determinant recursions, the tree edge-count, degree
+bounds) are genuinely more involved and warrant their own issues.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -5342,7 +5342,7 @@
     "start_line": 1,
     "end_line": 43,
     "status": "statement_formalized",
-    "coverage_note": "Faithful statements in Chapter6/Problem6_1_3_continued_E7_E8.lean, parts (a)-(d): det A for An/Dn/E6-8, Dynkin diagram claims, cycle det=0 (tree), degree bounds; sorry proofs. Part (e) extended-diagram det=0 lives in the tildeE file."
+    "coverage_note": "Faithful statements in Chapter6/Problem6_1_3_continued_E7_E8.lean, parts (a)-(d): det A for An/Dn/E6-8, Dynkin diagram claims, cycle det=0 (tree), degree bounds. Part (c) cycle lemmas cycle_cartan_mulVec_one_eq_zero and cycle_cartan_det_zero are proved (#6745); parts (a),(b),(d) and isDynkinDiagram_isTree remain sorry. Part (e) extended-diagram det=0 lives in the tildeE file."
   },
   {
     "id": "Chapter6/Problem6.1.3_continued_tildeE",


### PR DESCRIPTION
Closes #6745

Session: `276a005a-db6c-45d1-8ca1-303fa0bea632`

52019e0c chore(skill): note omega's variable-modulus/ite limits and the cyclic-degree recipe (#6745)
e7a774cb feat(Ch6 #Problem6.1.3-c): prove cycle_cartan_mulVec_one_eq_zero + cycle_cartan_det_zero (#6745)

🤖 Prepared with Claude Code