### PR TITLE
feat(Ch8 #6742): bifunctors + component iso + bridge for rearrangeBifunctorNatIso (partial)

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -84,6 +84,22 @@ apply Sigma.hom_ext; intro b; rw [Sigma.ι_desc_assoc]; exact Projective.factorT
 lesson: when a Mathlib instance/lemma quietly uses full transparency, bypass it with an explicit
 term rather than fighting heartbeats.
 
+**The Chapter 8 `Tor` rearrangement stack carries a *second* `Module k` action on the same
+carrier — restriction-through-`Aᵐᵒᵖ` vs `TensorProduct`-diagonal — that is defeq-*false*.** Hit in
+#6742 (`Chapter8/RearrangeBifunctorNatIso.lean`). `tensorRightFunctorₖ.obj` equips `tensorOver A N M`
+with the `k`-action *restricted through* `algebraMap k Aᵐᵒᵖ` (its file's `instModuleKObj`), whereas
+`rearrangeBidegree`/`TensorOverModule` use the `TensorProduct`-diagonal `k`-action on `M`. On simple
+tensors both give `c • ⟦(x⊗y)⊗n⟧ = ⟦(c•x)⊗y⊗n⟧`, so they agree **propositionally but not
+definitionally** — `ModuleCat.of k (tensorOver …)` built the two ways are *not* `rfl`-equal, so
+`(…).toModuleIso` will not typecheck against `(F.obj X).obj Y`. Note the `(A₁⊗A₂)ᵐᵒᵖ`-*module* half
+of the diamond **is** dissolvable by defining your local `Module (A₁⊗A₂)ᵐᵒᵖ (X⊗Y)` as
+`inferInstanceAs (Module _ (extTensorFunctorObj … X Y))` (reuse the very instance the functor object
+carries); only the `k`-action still differs, and only on the `(A₁⊗A₂)` side (the `Aᵢ` factor sides
+match because `rearrangeBidegree` takes `Module k (Pᵢ)` from those same restriction instances).
+**Fix:** reconcile the one remaining `k`-action by proving the two `Module k` structures equal
+(`Module.ext` / smul-agreement over `QuotientAddGroup.mk_surjective` + `TensorProduct.induction_on`
+generators) and cross with `eqToIso`, rather than hunting for a `rfl`.
+
 **Reading background-build results: grep the teed log for `error:`, do not trust a
 wrapper's exit code or `tail`.** `lake build` prints Lean errors *before* the final
 `Build completed` / `✖` summary, so `... | tee log | tail -40` can hide them, and a

--- a/EtingofRepresentationTheory/Chapter8.lean
+++ b/EtingofRepresentationTheory/Chapter8.lean
@@ -30,6 +30,7 @@ import EtingofRepresentationTheory.Chapter8.Problem8_2_8
 import EtingofRepresentationTheory.Chapter8.RearrangeBidegree
 import EtingofRepresentationTheory.Chapter8.RearrangeBidegreeNat
 import EtingofRepresentationTheory.Chapter8.TensorRightFunctorK
+import EtingofRepresentationTheory.Chapter8.RearrangeBifunctorNatIso
 import EtingofRepresentationTheory.Chapter8.Exercise8_2_9
 import EtingofRepresentationTheory.Chapter8.BarResolution
 

--- a/EtingofRepresentationTheory/Chapter8/RearrangeBifunctorNatIso.lean
+++ b/EtingofRepresentationTheory/Chapter8/RearrangeBifunctorNatIso.lean
@@ -1,0 +1,88 @@
+import EtingofRepresentationTheory.Chapter8.RearrangeBidegreeNat
+import EtingofRepresentationTheory.Chapter8.TensorRightFunctorK
+import EtingofRepresentationTheory.Chapter8.ExternalTensorFunctor
+import Mathlib.Algebra.Category.ModuleCat.Monoidal.Basic
+
+/-!
+# The bifunctor natural isomorphism for the `Tor` Künneth rearrangement
+
+Route **step 2** of milestone (c) of the four-fold rearrangement (Problem 8.2.8 `Tor`). Milestones
+(a) `Etingof.rearrangeBidegree` (`RearrangeBidegree.lean`) and (b)
+`Etingof.rearrangeBidegree_naturality` (`RearrangeBidegreeNat.lean`) provide, for each pair of right
+modules `(X, Y)`, a `k`-linear isomorphism
+
+  `tensorOver (A₁⊗A₂) (N₁⊗ₖN₂) (X⊗ₖY) ≃ₗ[k] (tensorOver A₁ N₁ X) ⊗ₖ (tensorOver A₂ N₂ Y)`
+
+natural in `X` and `Y`. This file packages that data as a **natural isomorphism of bifunctors**
+
+  `rearrangeBifunctorNatIso :`
+  `extTensorFunctor ⋙ tensorRightₖ(N₁⊗ₖN₂)  ≅  (tensorRightₖ N₁ · ) ⊗ (tensorRightₖ N₂ · )`
+
+of type `ModuleCat A₁ᵐᵒᵖ ⥤ ModuleCat A₂ᵐᵒᵖ ⥤ ModuleCat k`. The left bifunctor is a post-composition
+of the external tensor bifunctor with `Etingof.tensorRightFunctorₖ k (A₁⊗A₂) (N₁⊗ₖN₂)`; the right is
+`(X, Y) ↦ (X ⊗_{A₁} N₁) ⊗ₖ (Y ⊗_{A₂} N₂)`, assembled from the two factor functors and the monoidal
+tensor on `ModuleCat k`.
+
+Downstream (route step 3, the final assembly of the `ChainComplex (ModuleCat k) ℕ` rearrangement
+iso) transports this natural iso through `HomologicalComplex.mapBifunctor`.
+-/
+
+open CategoryTheory MonoidalCategory TensorProduct MulOpposite
+
+namespace Etingof
+
+universe u
+
+variable (k : Type u) [Field k]
+variable (A₁ A₂ : Type u) [Ring A₁] [Ring A₂] [Algebra k A₁] [Algebra k A₂]
+variable (N₁ N₂ : Type u)
+  [AddCommGroup N₁] [Module k N₁] [Module A₁ N₁] [IsScalarTower k A₁ N₁]
+  [AddCommGroup N₂] [Module k N₂] [Module A₂ N₂] [IsScalarTower k A₂ N₂]
+variable [instN : Module (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)]
+variable
+  (hN : ∀ (a₁ : A₁) (a₂ : A₂) (n₁ : N₁) (n₂ : N₂),
+    (a₁ ⊗ₜ[k] a₂ : A₁ ⊗[k] A₂) • (n₁ ⊗ₜ[k] n₂ : N₁ ⊗[k] N₂)
+      = (a₁ • n₁) ⊗ₜ[k] (a₂ • n₂))
+
+/-! ### Restriction-of-scalars instances on the `ModuleCat` carriers
+
+The same `local instance`s as `ExternalTensorFunctor.lean` / `TensorRightFunctorK.lean`, brought
+into scope so that `(tensorRightFunctorₖ k (A₁⊗A₂) (N₁⊗ₖN₂)).obj (extTensorFunctorObj X Y)` is the
+`ModuleCat k` on `tensorOver (A₁⊗A₂) (N₁⊗ₖN₂) (X⊗ₖY)` with the external action expected by
+`rearrangeBidegree`. -/
+
+noncomputable local instance instModuleK₁ (X : ModuleCat.{u} A₁ᵐᵒᵖ) : Module k X :=
+  Module.compHom X (algebraMap k A₁ᵐᵒᵖ)
+
+noncomputable local instance instModuleK₂ (Y : ModuleCat.{u} A₂ᵐᵒᵖ) : Module k Y :=
+  Module.compHom Y (algebraMap k A₂ᵐᵒᵖ)
+
+local instance instTower₁ (X : ModuleCat.{u} A₁ᵐᵒᵖ) : IsScalarTower k A₁ᵐᵒᵖ X :=
+  { smul_assoc := fun a b x => by rw [Algebra.smul_def]; exact mul_smul _ _ _ }
+
+local instance instTower₂ (Y : ModuleCat.{u} A₂ᵐᵒᵖ) : IsScalarTower k A₂ᵐᵒᵖ Y :=
+  { smul_assoc := fun a b x => by rw [Algebra.smul_def]; exact mul_smul _ _ _ }
+
+local instance instComm₁ (X : ModuleCat.{u} A₁ᵐᵒᵖ) : SMulCommClass k A₁ᵐᵒᵖ X where
+  smul_comm c a m := by
+    change (algebraMap k A₁ᵐᵒᵖ c) • (a • m) = a • ((algebraMap k A₁ᵐᵒᵖ c) • m)
+    rw [← mul_smul, ← mul_smul, Algebra.commutes]
+
+local instance instComm₂ (Y : ModuleCat.{u} A₂ᵐᵒᵖ) : SMulCommClass k A₂ᵐᵒᵖ Y where
+  smul_comm c a m := by
+    change (algebraMap k A₂ᵐᵒᵖ c) • (a • m) = a • ((algebraMap k A₂ᵐᵒᵖ c) • m)
+    rw [← mul_smul, ← mul_smul, Algebra.commutes]
+
+/-- The external `(A₁ ⊗[k] A₂)ᵐᵒᵖ`-action on `X ⊗[k] Y`, matching `ExternalTensorFunctor.lean`. -/
+noncomputable local instance instExtModule (X : ModuleCat.{u} A₁ᵐᵒᵖ) (Y : ModuleCat.{u} A₂ᵐᵒᵖ) :
+    Module (A₁ ⊗[k] A₂)ᵐᵒᵖ (X ⊗[k] Y) := extTensorModule k A₁ A₂ X Y
+
+/-- `k` commutes with the external `(A₁ ⊗[k] A₂)ᵐᵒᵖ`-action, because the action is realised by a
+`k`-algebra map into `Module.End k (X ⊗[k] Y)`, whose values are `k`-linear endomorphisms. -/
+local instance instCommExt (X : ModuleCat.{u} A₁ᵐᵒᵖ) (Y : ModuleCat.{u} A₂ᵐᵒᵖ) :
+    SMulCommClass k (A₁ ⊗[k] A₂)ᵐᵒᵖ (X ⊗[k] Y) where
+  smul_comm c r m := by
+    change c • (extTensorRep k A₁ A₂ X Y r m) = extTensorRep k A₁ A₂ X Y r (c • m)
+    rw [map_smul]
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter8/RearrangeBifunctorNatIso.lean
+++ b/EtingofRepresentationTheory/Chapter8/RearrangeBifunctorNatIso.lean
@@ -25,6 +25,18 @@ tensor on `ModuleCat k`.
 
 Downstream (route step 3, the final assembly of the `ChainComplex (ModuleCat k) ℕ` rearrangement
 iso) transports this natural iso through `HomologicalComplex.mapBifunctor`.
+
+## Status (partial — see #6742)
+
+This file lands the reusable scaffolding: the restriction-of-scalars `local instance`s on the
+`ModuleCat` carriers, the two bifunctors `extTensorRightFunctor` / `factorTensorFunctor`, the bridge
+lemma `tensorRightMapₖ_eq_tensorOverMapₖ`, and the component iso `rearrangeComponentIso` (milestone
+(a) as a `ModuleCat k` iso). The remaining glue to the full bifunctor `NatIso` is a `Module k`
+instance diamond on the `tensorOver` carriers: `tensorRightFunctorₖ` uses the `k`-action restricted
+through `(A₁⊗A₂)ᵐᵒᵖ`, while `rearrangeBidegree` uses the `TensorProduct`-diagonal `k`-action. These
+agree propositionally but not definitionally; reconciling them (only the `(A₁⊗A₂)`-side differs, the
+factor sides already match) and then discharging naturality from `rearrangeBidegree_naturality` via
+`tensorRightMapₖ_eq_tensorOverMapₖ` completes `rearrangeBifunctorNatIso`.
 -/
 
 open CategoryTheory MonoidalCategory TensorProduct MulOpposite
@@ -49,33 +61,31 @@ variable
 The same `local instance`s as `ExternalTensorFunctor.lean` / `TensorRightFunctorK.lean`, brought
 into scope so that `(tensorRightFunctorₖ k (A₁⊗A₂) (N₁⊗ₖN₂)).obj (extTensorFunctorObj X Y)` is the
 `ModuleCat k` on `tensorOver (A₁⊗A₂) (N₁⊗ₖN₂) (X⊗ₖY)` with the external action expected by
-`rearrangeBidegree`. -/
+`rearrangeBidegree`. Stated generically in a `k`-algebra `B` so they cover `A₁`, `A₂` and
+`A₁ ⊗[k] A₂` at once. -/
 
-noncomputable local instance instModuleK₁ (X : ModuleCat.{u} A₁ᵐᵒᵖ) : Module k X :=
-  Module.compHom X (algebraMap k A₁ᵐᵒᵖ)
+noncomputable local instance instModuleK {B : Type u} [Ring B] [Algebra k B]
+    (X : ModuleCat.{u} Bᵐᵒᵖ) : Module k X :=
+  Module.compHom X (algebraMap k Bᵐᵒᵖ)
 
-noncomputable local instance instModuleK₂ (Y : ModuleCat.{u} A₂ᵐᵒᵖ) : Module k Y :=
-  Module.compHom Y (algebraMap k A₂ᵐᵒᵖ)
-
-local instance instTower₁ (X : ModuleCat.{u} A₁ᵐᵒᵖ) : IsScalarTower k A₁ᵐᵒᵖ X :=
+local instance instTower {B : Type u} [Ring B] [Algebra k B] (X : ModuleCat.{u} Bᵐᵒᵖ) :
+    IsScalarTower k Bᵐᵒᵖ X :=
   { smul_assoc := fun a b x => by rw [Algebra.smul_def]; exact mul_smul _ _ _ }
 
-local instance instTower₂ (Y : ModuleCat.{u} A₂ᵐᵒᵖ) : IsScalarTower k A₂ᵐᵒᵖ Y :=
-  { smul_assoc := fun a b x => by rw [Algebra.smul_def]; exact mul_smul _ _ _ }
-
-local instance instComm₁ (X : ModuleCat.{u} A₁ᵐᵒᵖ) : SMulCommClass k A₁ᵐᵒᵖ X where
+local instance instComm {B : Type u} [Ring B] [Algebra k B] (X : ModuleCat.{u} Bᵐᵒᵖ) :
+    SMulCommClass k Bᵐᵒᵖ X where
   smul_comm c a m := by
-    change (algebraMap k A₁ᵐᵒᵖ c) • (a • m) = a • ((algebraMap k A₁ᵐᵒᵖ c) • m)
+    change (algebraMap k Bᵐᵒᵖ c) • (a • m) = a • ((algebraMap k Bᵐᵒᵖ c) • m)
     rw [← mul_smul, ← mul_smul, Algebra.commutes]
 
-local instance instComm₂ (Y : ModuleCat.{u} A₂ᵐᵒᵖ) : SMulCommClass k A₂ᵐᵒᵖ Y where
-  smul_comm c a m := by
-    change (algebraMap k A₂ᵐᵒᵖ c) • (a • m) = a • ((algebraMap k A₂ᵐᵒᵖ c) • m)
-    rw [← mul_smul, ← mul_smul, Algebra.commutes]
-
-/-- The external `(A₁ ⊗[k] A₂)ᵐᵒᵖ`-action on `X ⊗[k] Y`, matching `ExternalTensorFunctor.lean`. -/
+/-- The external `(A₁ ⊗[k] A₂)ᵐᵒᵖ`-action on `X ⊗[k] Y`. Defined as *the very instance*
+`extTensorFunctorObj` carries (its carrier is defeq to `X ⊗[k] Y`), so that
+`(tensorRightFunctorₖ …).obj (extTensorFunctorObj X Y)` and
+`tensorOver (A₁⊗A₂) (N₁⊗ₖN₂) (X ⊗[k] Y)` share the `(A₁⊗A₂)ᵐᵒᵖ`-action definitionally, dissolving
+that half of the `Module`-instance diamond. -/
 noncomputable local instance instExtModule (X : ModuleCat.{u} A₁ᵐᵒᵖ) (Y : ModuleCat.{u} A₂ᵐᵒᵖ) :
-    Module (A₁ ⊗[k] A₂)ᵐᵒᵖ (X ⊗[k] Y) := extTensorModule k A₁ A₂ X Y
+    Module (A₁ ⊗[k] A₂)ᵐᵒᵖ (X ⊗[k] Y) :=
+  inferInstanceAs (Module (A₁ ⊗[k] A₂)ᵐᵒᵖ (extTensorFunctorObj k A₁ A₂ X Y))
 
 /-- `k` commutes with the external `(A₁ ⊗[k] A₂)ᵐᵒᵖ`-action, because the action is realised by a
 `k`-algebra map into `Module.End k (X ⊗[k] Y)`, whose values are `k`-linear endomorphisms. -/
@@ -84,5 +94,61 @@ local instance instCommExt (X : ModuleCat.{u} A₁ᵐᵒᵖ) (Y : ModuleCat.{u} 
   smul_comm c r m := by
     change c • (extTensorRep k A₁ A₂ X Y r m) = extTensorRep k A₁ A₂ X Y r (c • m)
     rw [map_smul]
+
+/-! ### Bridging `tensorRightMapₖ` with `tensorOverMapₖ ∘ restrictK`
+
+`Etingof.tensorRightFunctorₖ.map f` (for a `ModuleCat Bᵐᵒᵖ`-morphism `f`) and the `k`-linear
+functoriality `Etingof.tensorOverMapₖ` used to state milestone (b) both send `⟦m ⊗ n⟧ ↦ ⟦f m ⊗ n⟧`.
+This identifies them, letting the NatIso's naturality reduce to `rearrangeBidegree_naturality`. -/
+
+theorem tensorRightMapₖ_eq_tensorOverMapₖ {B : Type u} [Ring B] [Algebra k B]
+    (N : Type u) [AddCommGroup N] [Module B N] {M M' : ModuleCat.{u} Bᵐᵒᵖ} (f : M ⟶ M') :
+    tensorRightMapₖ k B N f
+      = tensorOverMapₖ k B M M' N (restrictK k B M M' f.hom)
+          (restrictK_op_smul k B M M' f.hom) := by
+  apply LinearMap.ext
+  intro z
+  obtain ⟨y, rfl⟩ := QuotientAddGroup.mk_surjective z
+  induction y with
+  | zero => simp
+  | tmul m n => rw [tensorRightMapₖ_mk, tensorOverMapₖ_mk, restrictK_apply]
+  | add a b ha hb => rw [QuotientAddGroup.mk_add, map_add, map_add, ha, hb]
+
+/-! ### The two bifunctors -/
+
+/-- The left bifunctor `(X, Y) ↦ (X ⊗ₖ Y) ⊗_{A₁⊗A₂} (N₁ ⊗ₖ N₂)`: the external tensor bifunctor
+post-composed with `tensorRightFunctorₖ k (A₁⊗A₂) (N₁⊗ₖN₂)`. -/
+noncomputable def extTensorRightFunctor :
+    ModuleCat.{u} A₁ᵐᵒᵖ ⥤ ModuleCat.{u} A₂ᵐᵒᵖ ⥤ ModuleCat.{u} k :=
+  extTensorFunctor k A₁ A₂ ⋙
+    (Functor.whiskeringRight (ModuleCat.{u} A₂ᵐᵒᵖ) (ModuleCat.{u} (A₁ ⊗[k] A₂)ᵐᵒᵖ)
+      (ModuleCat.{u} k)).obj (tensorRightFunctorₖ k (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂))
+
+/-- The right bifunctor `(X, Y) ↦ (X ⊗_{A₁} N₁) ⊗ₖ (Y ⊗_{A₂} N₂)`: the two factor functors
+`tensorRightFunctorₖ` combined through the monoidal tensor of `ModuleCat k`. -/
+noncomputable def factorTensorFunctor :
+    ModuleCat.{u} A₁ᵐᵒᵖ ⥤ ModuleCat.{u} A₂ᵐᵒᵖ ⥤ ModuleCat.{u} k :=
+  (tensorRightFunctorₖ k A₁ N₁ ⋙ curriedTensor (ModuleCat.{u} k)) ⋙
+    (Functor.whiskeringLeft (ModuleCat.{u} A₂ᵐᵒᵖ) (ModuleCat.{u} k) (ModuleCat.{u} k)).obj
+      (tensorRightFunctorₖ k A₂ N₂)
+
+/-! ### The component isomorphism -/
+
+include hN in
+/-- The component of the natural iso at `(X, Y)`: milestone (a) `rearrangeBidegree`, packaged as an
+iso in `ModuleCat k` between the concrete carriers.
+
+The two bifunctor objects `((extTensorRightFunctor …).obj X).obj Y` and
+`((factorTensorFunctor …).obj X).obj Y` reduce (by `rfl` at the `Functor.obj` level) to these two
+`ModuleCat.of k (tensorOver …)`, **except** that `tensorRightFunctorₖ` equips its `tensorOver` with
+the `k`-action restricted through `(A₁⊗A₂)ᵐᵒᵖ` (resp. `Aᵢᵐᵒᵖ`), whereas `rearrangeBidegree` uses the
+`TensorProduct`-diagonal `k`-action. These agree propositionally but not definitionally; reconciling
+them (an `IsScalarTower` uniqueness / `eqToIso` argument) and then assembling the full bifunctor
+`NatIso` with naturality from `rearrangeBidegree_naturality` is the remaining work of #6742. -/
+noncomputable def rearrangeComponentIso (X : ModuleCat.{u} A₁ᵐᵒᵖ) (Y : ModuleCat.{u} A₂ᵐᵒᵖ) :
+    ModuleCat.of k (tensorOver (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂) (X ⊗[k] Y))
+      ≅ ModuleCat.of k (tensorOver A₁ N₁ X ⊗[k] tensorOver A₂ N₂ Y) :=
+  (rearrangeBidegree k A₁ A₂ X Y N₁ N₂
+    (extTensorFunctor_op_smul_tmul k A₁ A₂ X Y) hN).toModuleIso
 
 end Etingof

--- a/progress/2026-07-16T05-52-43Z_e437ed2b.md
+++ b/progress/2026-07-16T05-52-43Z_e437ed2b.md
@@ -1,0 +1,55 @@
+## Accomplished
+
+Claimed #6727 (Problem 8.2.8 `Tor`, rearrangement milestone (c) — assemble the bidegree isos into
+an iso of `ChainComplex (ModuleCat k) ℕ`). After orienting through the merged milestones (a)
+`rearrangeBidegree`, (b) `rearrangeBidegree_naturality`, `tensorRightFunctorₖ` (#6726),
+`extTensorFunctor`, `extTensorComplex`, and the Künneth `tensorObj` API, judged milestone (c) too
+large for one session (its own issue lays it out as three independent route steps, each a
+full-session construction with real total-complex / instance-diamond risk).
+
+**Decomposed #6727** into three self-contained sub-issues (breadcrumb left, parent `skip`ped to
+`replan`):
+- #6742 — step 2: `rearrangeBifunctorNatIso` (NatIso of bifunctors packaging (a)+(b))
+- #6743 — step 1: `mapBifunctorPostcompIso` (additive functor commutes with `mapBifunctor (down ℕ)`)
+- #6744 — step 3: `rearrangeComplex` final assembly (`depends-on: #6742, #6743`, auto-`blocked`)
+
+Then claimed #6742 and landed a **partial** (new file `Chapter8/RearrangeBifunctorNatIso.lean`,
+compiles clean, no sorries):
+- the restriction-of-scalars `local instance`s on the `ModuleCat` carriers, generic in a `k`-algebra
+  `B` (covers `A₁`, `A₂`, `A₁⊗A₂`), including `SMulCommClass k (A₁⊗A₂)ᵐᵒᵖ (X⊗Y)` via the `End k`
+  algebra map;
+- the two bifunctors `extTensorRightFunctor` (= `extTensorFunctor ⋙ tensorRightₖ`) and
+  `factorTensorFunctor` (= `(tensorRightₖ ·) ⊗ (tensorRightₖ ·)`), both pure functor compositions;
+- `tensorRightMapₖ_eq_tensorOverMapₖ` (bridge for the future naturality proof);
+- `rearrangeComponentIso` — milestone (a) as a `ModuleCat k` iso between the concrete carriers.
+
+## Current frontier
+
+`rearrangeBifunctorNatIso` (#6742) is not yet assembled. Two probed `rfl`s confirm the bifunctor
+objects reduce to `tensorRightFunctorₖ.obj (extTensorFunctorObj X Y)` and `tensorObj (…) (…)`. The
+remaining obstacle is a **`Module k` instance diamond** on the `tensorOver` carriers:
+`tensorRightFunctorₖ` equips `tensorOver` with the `k`-action *restricted through* `(A₁⊗A₂)ᵐᵒᵖ`
+(resp. `Aᵢᵐᵒᵖ`), whereas `rearrangeBidegree` uses the `TensorProduct`-diagonal `k`-action. The
+`(A₁⊗A₂)ᵐᵒᵖ`-action half was dissolved by defining `instExtModule` via `inferInstanceAs` on
+`extTensorFunctorObj`; the factor (`Aᵢ`) sides already match; only the source `(A₁⊗A₂)` `k`-action
+still differs (agree propositionally, not definitionally).
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. Problem 8.2.8 `Tor` route: milestones (a),(b) merged;
+`tensorRightFunctorₖ` (#6726) merged; milestone (c) now decomposed into #6742/#6743/#6744.
+
+## Next step
+
+Finish #6742: reconcile the source `Module k` diamond (only the `(A₁⊗A₂)`-side; prove the two
+`k`-actions equal by `Module.ext` over generators + `eqToIso`, or align instances), retype
+`rearrangeComponentIso` to `((extTensorRightFunctor …).obj X).obj Y ≅ ((factorTensorFunctor …).obj
+X).obj Y`, then build the bifunctor `NatIso` via nested `NatIso.ofComponents`, discharging both
+naturality squares from `rearrangeBidegree_naturality` + `tensorRightMapₖ_eq_tensorOverMapₖ`
+(specialise `f₂ = 𝟙` for the outer square, `f₁ = 𝟙` for the inner). #6743 and #6744 are independent
+and ready to claim.
+
+## Blockers
+
+None hard. #6742 residual (the `Module k` diamond + naturality) is well-scoped and documented in the
+file's `## Status` section; #6744 is correctly `blocked` on #6742 + #6743.


### PR DESCRIPTION
This PR lands the reusable scaffolding for route step 2 of Problem 8.2.8 `Tor` milestone (c)
(#6742), in the new file `EtingofRepresentationTheory/Chapter8/RearrangeBifunctorNatIso.lean`
(compiles clean, no sorries):

- the restriction-of-scalars `local instance`s on the `ModuleCat` carriers, generic in a `k`-algebra
  `B` so they cover `A₁`, `A₂` and `A₁ ⊗[k] A₂` at once, including `SMulCommClass k (A₁⊗A₂)ᵐᵒᵖ (X⊗Y)`
  via the `End k` algebra map;
- the two bifunctors `extTensorRightFunctor` (`extTensorFunctor ⋙ tensorRightₖ(N₁⊗ₖN₂)`) and
  `factorTensorFunctor` (`(· ⊗_{A₁} N₁) ⊗ₖ (· ⊗_{A₂} N₂)`), both pure functor compositions;
- `tensorRightMapₖ_eq_tensorOverMapₖ`, identifying `tensorRightFunctorₖ.map f` with
  `tensorOverMapₖ (restrictK f.hom)` (the bridge the eventual naturality proof needs);
- `rearrangeComponentIso`, milestone (a) `rearrangeBidegree` as a `ModuleCat k` iso.

Remaining work (documented in the file's `## Status` section; #6742 is marked `replan` for the
planner to narrow): assembling the full bifunctor `NatIso` is blocked by a `Module k` instance
diamond on the `tensorOver` carriers — `tensorRightFunctorₖ` uses the `k`-action restricted through
`(A₁⊗A₂)ᵐᵒᵖ` while `rearrangeBidegree` uses the `TensorProduct`-diagonal action. The `(A₁⊗A₂)ᵐᵒᵖ`
half is already dissolved and the factor (`Aᵢ`) sides match; only the source `(A₁⊗A₂)` `k`-action
still differs (equal propositionally, not definitionally). Reconciling it (e.g. `Module.ext` over
generators + `eqToIso`) then lets `rearrangeComponentIso` be retyped to the functor objects and the
`NatIso` assembled with naturality from `rearrangeBidegree_naturality`.

Part of the #6727 decomposition (#6742 step 2, #6743 step 1, #6744 step 3).

🤖 Prepared with Claude Code