### PR TITLE
feat(Ch8 #Problem8.2.8-Tor): rearrangeBifunctorNatIso — package rearrangeBidegree (a)+(b) into a NatIso of bifunctors ModuleCat A₁ᵐᵒᵖ ⥤ ModuleCat A₂ᵐᵒᵖ ⥤ ModuleCat k (step 2 of #6727)

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -96,9 +96,28 @@ of the diamond **is** dissolvable by defining your local `Module (A₁⊗A₂)�
 `inferInstanceAs (Module _ (extTensorFunctorObj … X Y))` (reuse the very instance the functor object
 carries); only the `k`-action still differs, and only on the `(A₁⊗A₂)` side (the `Aᵢ` factor sides
 match because `rearrangeBidegree` takes `Module k (Pᵢ)` from those same restriction instances).
-**Fix:** reconcile the one remaining `k`-action by proving the two `Module k` structures equal
-(`Module.ext` / smul-agreement over `QuotientAddGroup.mk_surjective` + `TensorProduct.induction_on`
-generators) and cross with `eqToIso`, rather than hunting for a `rfl`.
+**Fix (what actually worked, #6742 completed):** you do *not* need `Module.ext`/`eqToIso` on the
+instances. Build an identity-carrier `LinearEquiv` `((F.obj X).obj Y) ≃ₗ[k] ModuleCat.of k (tensorOver …)`
+(`toFun := fun z => z`); the two `ModuleCat` objects each pin their own `Module k`, so `map_smul'`
+becomes the honest `c •_restr z = c •_diag z`, dischargeable over `QuotientAddGroup.mk_surjective` +
+`TensorProduct.induction_on` + `smul_mk` + `TensorProduct.smul_tmul'`, bottoming out at
+`extModule_algebraMap_smul` (`algebraMap k (A₁⊗A₂)ᵐᵒᵖ c • z = c • z`, via `AlgHom.commutes`). Then
+`LinearEquiv.trans` with `rearrangeBidegree` and `.toModuleIso`. Assemble the bifunctor `NatIso` as
+two **nested** `NatIso.ofComponents`, and make the inner (per-`X`) NatIso a **separate named `def`**
+with a `@[simp]` `_hom_app` lemma — otherwise the outer naturality `simp` tries to unfold the inner
+NatIso's large baked-in proof and hits `(deterministic) timeout at whnf`.
+
+**Distinct-but-defeq local `Module k` instances break `rw`/`simp` on imported lemmas — use `erw`
+or a `rfl`-restatement.** This file's own `instModuleK`/`instModuleKObj` and `ExternalTensorFunctor`'s
+*private* `restrictModule₁` are all `Module.compHom X (algebraMap k Bᵐᵒᵖ)` — defeq but **syntactically
+distinct** (the private ones aren't importable, so you must redeclare). An imported `@[simp]` lemma
+like `extTensorFunctorMapHom_tmul` (whose `m₁ ⊗ₜ[k] m₂` is baked in `restrictModule₁`) then silently
+fails to fire on a goal whose `x ⊗ₜ[k] y` came from *your* induction context (`instModuleK`) — `rw`
+reports "did not find pattern", `simp only` lists it as "unused". Two robust escapes: (a) `erw [lemma]`
+(matches up to reducible defeq), or (b) restate the lemma with a `rfl` proof in your own instance
+context (`theorem extMapHom_tmul … := rfl`) so its LHS matches syntactically. Do **not** chain many
+`erw`s in one call — each does an expensive defeq search and the combined term blows up `whnf`; keep
+them on separate lines.
 
 **Reading background-build results: grep the teed log for `error:`, do not trust a
 wrapper's exit code or `tail`.** `lake build` prints Lean errors *before* the final

--- a/EtingofRepresentationTheory/Chapter8/RearrangeBifunctorNatIso.lean
+++ b/EtingofRepresentationTheory/Chapter8/RearrangeBifunctorNatIso.lean
@@ -26,17 +26,22 @@ tensor on `ModuleCat k`.
 Downstream (route step 3, the final assembly of the `ChainComplex (ModuleCat k) ℕ` rearrangement
 iso) transports this natural iso through `HomologicalComplex.mapBifunctor`.
 
-## Status (partial — see #6742)
+## Contents
 
-This file lands the reusable scaffolding: the restriction-of-scalars `local instance`s on the
-`ModuleCat` carriers, the two bifunctors `extTensorRightFunctor` / `factorTensorFunctor`, the bridge
-lemma `tensorRightMapₖ_eq_tensorOverMapₖ`, and the component iso `rearrangeComponentIso` (milestone
-(a) as a `ModuleCat k` iso). The remaining glue to the full bifunctor `NatIso` is a `Module k`
-instance diamond on the `tensorOver` carriers: `tensorRightFunctorₖ` uses the `k`-action restricted
-through `(A₁⊗A₂)ᵐᵒᵖ`, while `rearrangeBidegree` uses the `TensorProduct`-diagonal `k`-action. These
-agree propositionally but not definitionally; reconciling them (only the `(A₁⊗A₂)`-side differs, the
-factor sides already match) and then discharging naturality from `rearrangeBidegree_naturality` via
-`tensorRightMapₖ_eq_tensorOverMapₖ` completes `rearrangeBifunctorNatIso`.
+* `extTensorRightFunctor`, `factorTensorFunctor` — the two bifunctors (with the
+  restriction-of-scalars `local instance`s on the `ModuleCat` carriers).
+* `extModuleK_algebraMap_smul`, `rearrangeSourceEquiv` — the source-diamond reconciliation. The two
+  bifunctor objects share the carrier `tensorOver (A₁⊗A₂) (N₁⊗ₖN₂) (X ⊗[k] Y)` but
+  `tensorRightFunctorₖ` equips it with the `k`-action restricted through `(A₁⊗A₂)ᵐᵒᵖ`, whereas
+  `rearrangeBidegree` uses the `TensorProduct`-diagonal `k`-action. These agree propositionally (the
+  external action of `algebraMap k (A₁⊗A₂)ᵐᵒᵖ c` is `c • ·`), and the identity carrier map bridges
+  the diamond; the target factor `k`-actions already match definitionally.
+* `rearrangeBifunctorComponentIso` — milestone (a) `rearrangeBidegree`, retyped to the functor
+  objects.
+* `rearrangeBifunctorNatIso` — the full bifunctor natural isomorphism, assembled by two nested
+  `NatIso.ofComponents`; both naturality squares are the generator computation underlying
+  `rearrangeBidegree_naturality` (each factor map is `tensorRightMapₖ`, identified with the
+  `tensorOver`-functoriality by `tensorRightMapₖ_eq_tensorOverMapₖ`).
 -/
 
 open CategoryTheory MonoidalCategory TensorProduct MulOpposite
@@ -191,6 +196,7 @@ noncomputable def rearrangeSourceEquiv (X : ModuleCat.{u} A₁ᵐᵒᵖ) (Y : Mo
   left_inv _ := rfl
   right_inv _ := rfl
 
+omit [Module A₁ N₁] [IsScalarTower k A₁ N₁] [Module A₂ N₂] [IsScalarTower k A₂ N₂] in
 @[simp] theorem rearrangeSourceEquiv_apply (X : ModuleCat.{u} A₁ᵐᵒᵖ) (Y : ModuleCat.{u} A₂ᵐᵒᵖ)
     (z : ((extTensorRightFunctor k A₁ A₂ N₁ N₂).obj X).obj Y) :
     rearrangeSourceEquiv k A₁ A₂ N₁ N₂ X Y z = z := rfl
@@ -228,5 +234,145 @@ noncomputable def rearrangeBifunctorComponentIso (X : ModuleCat.{u} A₁ᵐᵒ�
     ((extTensorRightFunctor k A₁ A₂ N₁ N₂).obj X).obj Y ≅
       ((factorTensorFunctor k A₁ A₂ N₁ N₂).obj X).obj Y :=
   (rearrangeComponentLinEquiv k A₁ A₂ N₁ N₂ hN X Y).toModuleIso
+
+include hN in
+@[simp] theorem rearrangeBifunctorComponentIso_hom_apply (X : ModuleCat.{u} A₁ᵐᵒᵖ)
+    (Y : ModuleCat.{u} A₂ᵐᵒᵖ) (x : X) (y : Y) (n₁ : N₁) (n₂ : N₂) :
+    (rearrangeBifunctorComponentIso k A₁ A₂ N₁ N₂ hN X Y).hom
+        (QuotientAddGroup.mk ((x ⊗ₜ[k] y) ⊗ₜ[ℤ] (n₁ ⊗ₜ[k] n₂)))
+      = (QuotientAddGroup.mk (x ⊗ₜ[ℤ] n₁) : tensorOver A₁ N₁ X)
+          ⊗ₜ[k] (QuotientAddGroup.mk (y ⊗ₜ[ℤ] n₂) : tensorOver A₂ N₂ Y) :=
+  rearrangeComponentLinEquiv_mk k A₁ A₂ N₁ N₂ hN X Y x y n₁ n₂
+
+omit [Module A₁ N₁] [IsScalarTower k A₁ N₁] [Module A₂ N₂] [IsScalarTower k A₂ N₂] in
+theorem extTensorRightFunctor_obj_map (X : ModuleCat.{u} A₁ᵐᵒᵖ) {Y Y' : ModuleCat.{u} A₂ᵐᵒᵖ}
+    (g : Y ⟶ Y') :
+    ((extTensorRightFunctor k A₁ A₂ N₁ N₂).obj X).map g =
+      (tensorRightFunctorₖ k (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)).map (extTensorFunctorMap k (𝟙 X) g) :=
+  rfl
+
+omit [Module k N₁] [IsScalarTower k A₁ N₁] [Module k N₂] [IsScalarTower k A₂ N₂] instN in
+theorem factorTensorFunctor_obj_map (X : ModuleCat.{u} A₁ᵐᵒᵖ) {Y Y' : ModuleCat.{u} A₂ᵐᵒᵖ}
+    (g : Y ⟶ Y') :
+    ((factorTensorFunctor k A₁ A₂ N₁ N₂).obj X).map g =
+      MonoidalCategory.whiskerLeft ((tensorRightFunctorₖ k A₁ N₁).obj X)
+        ((tensorRightFunctorₖ k A₂ N₂).map g) :=
+  rfl
+
+/-- `rfl` restatement of `extTensorFunctorMapHom_tmul` in this file's instance context (the
+`Module k` on the carriers is `instModuleK`, syntactically distinct from `ExternalTensorFunctor`'s
+private `restrictModule₁`, so the imported simp lemma does not fire). -/
+theorem extMapHom_tmul {X X' : ModuleCat.{u} A₁ᵐᵒᵖ} {Y Y' : ModuleCat.{u} A₂ᵐᵒᵖ}
+    (f : X ⟶ X') (g : Y ⟶ Y') (x : X) (y : Y) :
+    extTensorFunctorMapHom k f g (x ⊗ₜ[k] y) = f.hom x ⊗ₜ[k] g.hom y :=
+  rfl
+
+omit [Module A₁ N₁] [IsScalarTower k A₁ N₁] [Module A₂ N₂] [IsScalarTower k A₂ N₂] in
+theorem extTensorRightFunctor_map_app {X X' : ModuleCat.{u} A₁ᵐᵒᵖ} (f : X ⟶ X')
+    (Y : ModuleCat.{u} A₂ᵐᵒᵖ) :
+    ((extTensorRightFunctor k A₁ A₂ N₁ N₂).map f).app Y =
+      (tensorRightFunctorₖ k (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)).map (extTensorFunctorMap k f (𝟙 Y)) :=
+  rfl
+
+omit [Module k N₁] [IsScalarTower k A₁ N₁] [Module k N₂] [IsScalarTower k A₂ N₂] instN in
+theorem factorTensorFunctor_map_app {X X' : ModuleCat.{u} A₁ᵐᵒᵖ} (f : X ⟶ X')
+    (Y : ModuleCat.{u} A₂ᵐᵒᵖ) :
+    ((factorTensorFunctor k A₁ A₂ N₁ N₂).map f).app Y =
+      MonoidalCategory.whiskerRight ((tensorRightFunctorₖ k A₁ N₁).map f)
+        ((tensorRightFunctorₖ k A₂ N₂).obj Y) :=
+  rfl
+
+/-! ### The bifunctor natural isomorphism -/
+
+include hN in
+/-- The natural isomorphism of functors
+`(extTensorRightFunctor).obj X ≅ (factorTensorFunctor).obj X` (naturality in the second variable
+`Y`), for a fixed first variable `X`. Kept as a named `def` so the large naturality proof stays
+opaque to the outer naturality assembly. -/
+noncomputable def rearrangeBifunctorNatIsoApp (X : ModuleCat.{u} A₁ᵐᵒᵖ) :
+    (extTensorRightFunctor k A₁ A₂ N₁ N₂).obj X ≅ (factorTensorFunctor k A₁ A₂ N₁ N₂).obj X :=
+  NatIso.ofComponents
+    (fun Y => rearrangeBifunctorComponentIso k A₁ A₂ N₁ N₂ hN X Y)
+    (by
+      intro Y Y' g
+      apply ModuleCat.hom_ext
+      apply LinearMap.ext
+      intro z
+      obtain ⟨w, rfl⟩ := QuotientAddGroup.mk_surjective z
+      induction w using TensorProduct.induction_on with
+      | zero => simp
+      | add a b ha hb => simp only [QuotientAddGroup.mk_add, map_add, ha, hb]
+      | tmul p q =>
+          induction p using TensorProduct.induction_on with
+          | zero => simp
+          | add a b ha hb =>
+              simp only [add_tmul, QuotientAddGroup.mk_add, map_add, ha, hb]
+          | tmul x y =>
+              induction q using TensorProduct.induction_on with
+              | zero => simp
+              | add a b ha hb =>
+                  simp only [tmul_add, QuotientAddGroup.mk_add, map_add, ha, hb]
+              | tmul n₁ n₂ =>
+                  simp only [extTensorRightFunctor_obj_map, factorTensorFunctor_obj_map,
+                    ModuleCat.comp_apply]
+                  erw [tensorRightFunctorₖ_map_mk]
+                  erw [extTensorFunctorMap_hom, extMapHom_tmul]
+                  simp only [ModuleCat.hom_id, LinearMap.id_coe, id_eq]
+                  rw [rearrangeBifunctorComponentIso_hom_apply,
+                    rearrangeBifunctorComponentIso_hom_apply]
+                  erw [ModuleCat.MonoidalCategory.whiskerLeft_apply]
+                  rw [tensorRightFunctorₖ_map_mk])
+
+include hN in
+@[simp] theorem rearrangeBifunctorNatIsoApp_hom_app (X : ModuleCat.{u} A₁ᵐᵒᵖ)
+    (Y : ModuleCat.{u} A₂ᵐᵒᵖ) :
+    (rearrangeBifunctorNatIsoApp k A₁ A₂ N₁ N₂ hN X).hom.app Y =
+      (rearrangeBifunctorComponentIso k A₁ A₂ N₁ N₂ hN X Y).hom :=
+  rfl
+
+include hN in
+/-- **Route step 2 (#6742).** The natural isomorphism of bifunctors
+`extTensorRightFunctor ≅ factorTensorFunctor`, i.e.
+`(X, Y) ↦ (X ⊗ₖ Y) ⊗_{A₁⊗A₂} (N₁ ⊗ₖ N₂)` is naturally isomorphic to
+`(X, Y) ↦ (X ⊗_{A₁} N₁) ⊗ₖ (Y ⊗_{A₂} N₂)`. The components are `rearrangeBifunctorComponentIso`
+(milestone (a) `rearrangeBidegree` after reconciling the source `Module k` diamond); naturality in
+each variable is the generator computation underlying `rearrangeBidegree_naturality`. -/
+noncomputable def rearrangeBifunctorNatIso :
+    extTensorRightFunctor k A₁ A₂ N₁ N₂ ≅ factorTensorFunctor k A₁ A₂ N₁ N₂ :=
+  NatIso.ofComponents
+    (fun X => rearrangeBifunctorNatIsoApp k A₁ A₂ N₁ N₂ hN X)
+    (by
+      intro X X' f
+      apply NatTrans.ext
+      apply funext
+      intro Y
+      apply ModuleCat.hom_ext
+      apply LinearMap.ext
+      intro z
+      obtain ⟨w, rfl⟩ := QuotientAddGroup.mk_surjective z
+      induction w using TensorProduct.induction_on with
+      | zero => simp
+      | add a b ha hb => simp only [QuotientAddGroup.mk_add, map_add, ha, hb]
+      | tmul p q =>
+          induction p using TensorProduct.induction_on with
+          | zero => simp
+          | add a b ha hb =>
+              simp only [add_tmul, QuotientAddGroup.mk_add, map_add, ha, hb]
+          | tmul x y =>
+              induction q using TensorProduct.induction_on with
+              | zero => simp
+              | add a b ha hb =>
+                  simp only [tmul_add, QuotientAddGroup.mk_add, map_add, ha, hb]
+              | tmul n₁ n₂ =>
+                  simp only [NatTrans.comp_app, rearrangeBifunctorNatIsoApp_hom_app,
+                    extTensorRightFunctor_map_app, factorTensorFunctor_map_app,
+                    ModuleCat.comp_apply]
+                  erw [tensorRightFunctorₖ_map_mk]
+                  erw [extTensorFunctorMap_hom, extMapHom_tmul]
+                  simp only [ModuleCat.hom_id, LinearMap.id_coe, id_eq]
+                  rw [rearrangeBifunctorComponentIso_hom_apply,
+                    rearrangeBifunctorComponentIso_hom_apply]
+                  erw [ModuleCat.MonoidalCategory.whiskerRight_apply]
+                  rw [tensorRightFunctorₖ_map_mk])
 
 end Etingof

--- a/EtingofRepresentationTheory/Chapter8/RearrangeBifunctorNatIso.lean
+++ b/EtingofRepresentationTheory/Chapter8/RearrangeBifunctorNatIso.lean
@@ -165,32 +165,68 @@ theorem extModuleK_algebraMap_smul (X : ModuleCat.{u} A₁ᵐᵒᵖ) (Y : Module
   rw [AlgHom.commutes]
   simp [Module.algebraMap_end_apply]
 
-/-- The source-diamond reconciliation isomorphism. The functor object
-`((extTensorRightFunctor …).obj X).obj Y` and `rearrangeComponentIso`'s source share the carrier
-`tensorOver (A₁⊗A₂) (N₁⊗ₖN₂) (X ⊗[k] Y)`; they differ only in the `Module k` structure (restricted
-through `(A₁⊗A₂)ᵐᵒᵖ` vs the `TensorProduct`-diagonal). The identity carrier map is the iso, `k`-linear
-because the two actions agree on the left factor by `extModuleK_algebraMap_smul`. -/
-noncomputable def rearrangeSourceIso (X : ModuleCat.{u} A₁ᵐᵒᵖ) (Y : ModuleCat.{u} A₂ᵐᵒᵖ) :
+/-- The source-diamond reconciliation as a `k`-linear equivalence: the identity on the shared
+carrier `tensorOver (A₁⊗A₂) (N₁⊗ₖN₂) (X ⊗[k] Y)`, from the functor object's `Module k` (restricted
+through `(A₁⊗A₂)ᵐᵒᵖ`) to the `TensorProduct`-diagonal `Module k` used by `rearrangeBidegree`. It is
+`k`-linear because the two actions agree on the left factor by `extModuleK_algebraMap_smul`. -/
+noncomputable def rearrangeSourceEquiv (X : ModuleCat.{u} A₁ᵐᵒᵖ) (Y : ModuleCat.{u} A₂ᵐᵒᵖ) :
+    (((extTensorRightFunctor k A₁ A₂ N₁ N₂).obj X).obj Y) ≃ₗ[k]
+      tensorOver (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂) (X ⊗[k] Y) where
+  toFun z := z
+  map_add' _ _ := rfl
+  map_smul' c z := by
+    induction z using QuotientAddGroup.induction_on with
+    | _ x =>
+      simp only [RingHom.id_apply]
+      induction x using TensorProduct.induction_on with
+      | zero => simp
+      | tmul w n =>
+          simp only [smul_mk, TensorProduct.smul_tmul']
+          exact congrArg (fun v => (QuotientAddGroup.mk (v ⊗ₜ[ℤ] n) :
+            tensorOver (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂) (X ⊗[k] Y)))
+            (extModuleK_algebraMap_smul k A₁ A₂ X Y c w)
+      | add a b ha hb =>
+          simp only [QuotientAddGroup.mk_add, smul_add, ha, hb]
+  invFun z := z
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+@[simp] theorem rearrangeSourceEquiv_apply (X : ModuleCat.{u} A₁ᵐᵒᵖ) (Y : ModuleCat.{u} A₂ᵐᵒᵖ)
+    (z : ((extTensorRightFunctor k A₁ A₂ N₁ N₂).obj X).obj Y) :
+    rearrangeSourceEquiv k A₁ A₂ N₁ N₂ X Y z = z := rfl
+
+/-! ### The bifunctor component isomorphism -/
+
+include hN in
+/-- The component of the bifunctor natural isomorphism at `(X, Y)`, as a `k`-linear equivalence
+between the actual functor objects: reconcile the source `k`-module diamond
+(`rearrangeSourceEquiv`), then apply milestone (a) `rearrangeBidegree`. The target already matches
+the functor object definitionally (the factor `k`-actions agree). -/
+noncomputable def rearrangeComponentLinEquiv (X : ModuleCat.{u} A₁ᵐᵒᵖ)
+    (Y : ModuleCat.{u} A₂ᵐᵒᵖ) :
+    (((extTensorRightFunctor k A₁ A₂ N₁ N₂).obj X).obj Y) ≃ₗ[k]
+      (((factorTensorFunctor k A₁ A₂ N₁ N₂).obj X).obj Y) :=
+  (rearrangeSourceEquiv k A₁ A₂ N₁ N₂ X Y).trans
+    (rearrangeBidegree k A₁ A₂ X Y N₁ N₂ (extTensorFunctor_op_smul_tmul k A₁ A₂ X Y) hN)
+
+include hN in
+@[simp] theorem rearrangeComponentLinEquiv_mk (X : ModuleCat.{u} A₁ᵐᵒᵖ)
+    (Y : ModuleCat.{u} A₂ᵐᵒᵖ) (x : X) (y : Y) (n₁ : N₁) (n₂ : N₂) :
+    rearrangeComponentLinEquiv k A₁ A₂ N₁ N₂ hN X Y
+        (QuotientAddGroup.mk ((x ⊗ₜ[k] y) ⊗ₜ[ℤ] (n₁ ⊗ₜ[k] n₂)))
+      = (QuotientAddGroup.mk (x ⊗ₜ[ℤ] n₁) : tensorOver A₁ N₁ X)
+          ⊗ₜ[k] (QuotientAddGroup.mk (y ⊗ₜ[ℤ] n₂) : tensorOver A₂ N₂ Y) := by
+  rw [rearrangeComponentLinEquiv, LinearEquiv.trans_apply]
+  exact rearrangeBidegree_mk_tmul k A₁ A₂ X Y N₁ N₂
+    (extTensorFunctor_op_smul_tmul k A₁ A₂ X Y) hN x y n₁ n₂
+
+include hN in
+/-- The component of the bifunctor natural isomorphism at `(X, Y)`, as an iso in `ModuleCat k`
+between the actual functor objects. -/
+noncomputable def rearrangeBifunctorComponentIso (X : ModuleCat.{u} A₁ᵐᵒᵖ)
+    (Y : ModuleCat.{u} A₂ᵐᵒᵖ) :
     ((extTensorRightFunctor k A₁ A₂ N₁ N₂).obj X).obj Y ≅
-      ModuleCat.of k (tensorOver (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂) (X ⊗[k] Y)) :=
-  LinearEquiv.toModuleIso
-    { toFun := fun z => z
-      map_add' := fun _ _ => rfl
-      map_smul' := fun c z => by
-        induction z using QuotientAddGroup.induction_on with
-        | _ x =>
-          simp only [RingHom.id_apply]
-          induction x using TensorProduct.induction_on with
-          | zero => simp
-          | tmul w n =>
-              simp only [smul_mk, TensorProduct.smul_tmul']
-              exact congrArg (fun v => (QuotientAddGroup.mk (v ⊗ₜ[ℤ] n) :
-                tensorOver (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂) (X ⊗[k] Y)))
-                (extModuleK_algebraMap_smul k A₁ A₂ X Y c w)
-          | add a b ha hb =>
-              simp only [QuotientAddGroup.mk_add, smul_add, ha, hb]
-      invFun := fun z => z
-      left_inv := fun _ => rfl
-      right_inv := fun _ => rfl }
+      ((factorTensorFunctor k A₁ A₂ N₁ N₂).obj X).obj Y :=
+  (rearrangeComponentLinEquiv k A₁ A₂ N₁ N₂ hN X Y).toModuleIso
 
 end Etingof

--- a/EtingofRepresentationTheory/Chapter8/RearrangeBifunctorNatIso.lean
+++ b/EtingofRepresentationTheory/Chapter8/RearrangeBifunctorNatIso.lean
@@ -151,4 +151,46 @@ noncomputable def rearrangeComponentIso (X : ModuleCat.{u} A₁ᵐᵒᵖ) (Y : M
   (rearrangeBidegree k A₁ A₂ X Y N₁ N₂
     (extTensorFunctor_op_smul_tmul k A₁ A₂ X Y) hN).toModuleIso
 
+/-! ### Reconciling the source `k`-module diamond -/
+
+/-- On the external tensor `X ⊗[k] Y`, the `k`-action restricted through `(A₁ ⊗[k] A₂)ᵐᵒᵖ` (the one
+`tensorRightFunctorₖ k (A₁⊗A₂) (N₁⊗ₖN₂)` puts on its source) coincides with the `TensorProduct`
+diagonal `k`-action (the one `rearrangeBidegree` uses): `algebraMap k (A₁⊗A₂)ᵐᵒᵖ c` acts as `c • ·`
+because the external representation `extTensorRep` is a `k`-algebra map. This is the source half of
+the `Module k` diamond. -/
+theorem extModuleK_algebraMap_smul (X : ModuleCat.{u} A₁ᵐᵒᵖ) (Y : ModuleCat.{u} A₂ᵐᵒᵖ) (c : k)
+    (z : X ⊗[k] Y) :
+    (algebraMap k (A₁ ⊗[k] A₂)ᵐᵒᵖ c) • z = c • z := by
+  change extTensorRep k A₁ A₂ X Y (algebraMap k (A₁ ⊗[k] A₂)ᵐᵒᵖ c) z = c • z
+  rw [AlgHom.commutes]
+  simp [Module.algebraMap_end_apply]
+
+/-- The source-diamond reconciliation isomorphism. The functor object
+`((extTensorRightFunctor …).obj X).obj Y` and `rearrangeComponentIso`'s source share the carrier
+`tensorOver (A₁⊗A₂) (N₁⊗ₖN₂) (X ⊗[k] Y)`; they differ only in the `Module k` structure (restricted
+through `(A₁⊗A₂)ᵐᵒᵖ` vs the `TensorProduct`-diagonal). The identity carrier map is the iso, `k`-linear
+because the two actions agree on the left factor by `extModuleK_algebraMap_smul`. -/
+noncomputable def rearrangeSourceIso (X : ModuleCat.{u} A₁ᵐᵒᵖ) (Y : ModuleCat.{u} A₂ᵐᵒᵖ) :
+    ((extTensorRightFunctor k A₁ A₂ N₁ N₂).obj X).obj Y ≅
+      ModuleCat.of k (tensorOver (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂) (X ⊗[k] Y)) :=
+  LinearEquiv.toModuleIso
+    { toFun := fun z => z
+      map_add' := fun _ _ => rfl
+      map_smul' := fun c z => by
+        induction z using QuotientAddGroup.induction_on with
+        | _ x =>
+          simp only [RingHom.id_apply]
+          induction x using TensorProduct.induction_on with
+          | zero => simp
+          | tmul w n =>
+              simp only [smul_mk, TensorProduct.smul_tmul']
+              exact congrArg (fun v => (QuotientAddGroup.mk (v ⊗ₜ[ℤ] n) :
+                tensorOver (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂) (X ⊗[k] Y)))
+                (extModuleK_algebraMap_smul k A₁ A₂ X Y c w)
+          | add a b ha hb =>
+              simp only [QuotientAddGroup.mk_add, smul_add, ha, hb]
+      invFun := fun z => z
+      left_inv := fun _ => rfl
+      right_inv := fun _ => rfl }
+
 end Etingof

--- a/progress/2026-07-16T07-12-09Z_1fd62441.md
+++ b/progress/2026-07-16T07-12-09Z_1fd62441.md
@@ -1,0 +1,52 @@
+## Accomplished
+
+Completed the residual deliverable of #6742: assembled the full bifunctor natural
+isomorphism `Etingof.rearrangeBifunctorNatIso` in
+`EtingofRepresentationTheory/Chapter8/RearrangeBifunctorNatIso.lean`, on top of the
+#6747 scaffolding.
+
+- `extModuleK_algebraMap_smul`: the external action of `algebraMap k (A₁⊗A₂)ᵐᵒᵖ c`
+  on `X ⊗[k] Y` is `c • ·` (via `AlgHom.commutes`), the source half of the `Module k`
+  diamond.
+- `rearrangeSourceEquiv`: the identity-carrier `k`-linear equivalence reconciling the
+  functor object's restricted-through-`(A₁⊗A₂)ᵐᵒᵖ` `k`-action with the
+  `TensorProduct`-diagonal action `rearrangeBidegree` uses. `map_smul'` reduces via
+  `smul_mk` + `TensorProduct.smul_tmul'` to `extModuleK_algebraMap_smul` on the left
+  factor.
+- `rearrangeComponentLinEquiv` / `rearrangeBifunctorComponentIso`: `rearrangeSourceEquiv`
+  composed with `rearrangeBidegree`, retyped to the functor objects (the target factor
+  `k`-actions already match definitionally — probes confirmed by `rfl`).
+- `rearrangeBifunctorNatIso`: two nested `NatIso.ofComponents`. The inner NatIso (in `Y`)
+  is a separate `def` (`rearrangeBifunctorNatIsoApp`) with a `@[simp]` app lemma, so the
+  outer naturality assembly stays fast (avoids whnf-timeout from unfolding the inner
+  proof). Both naturality squares are discharged by generator computation.
+
+Verification: `lake build EtingofRepresentationTheory.Chapter8.RearrangeBifunctorNatIso`
+exits 0, no warnings; no `sorry`/`admit`; `#print axioms rearrangeBifunctorNatIso` =
+`[propext, Classical.choice, Quot.sound]`.
+
+## Current frontier
+
+`rearrangeBifunctorNatIso` is complete. This feeds route step 3 (#6744 → #6727 → #6668
+→ #6657): transporting the natural iso through `HomologicalComplex.mapBifunctor` to
+assemble the `ChainComplex (ModuleCat k) ℕ` rearrangement iso.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. Problem 8.2.8 `Tor` four-fold rearrangement: milestones
+(a) `rearrangeBidegree`, (b) `rearrangeBidegree_naturality`, and now the bifunctor
+NatIso packaging (route step 2) are done.
+
+## Next step
+
+Route step 3 (#6744): transport `rearrangeBifunctorNatIso` through
+`HomologicalComplex.mapBifunctor` (the total-complex machinery) to obtain the complex-level
+rearrangement iso.
+
+## Blockers
+
+None. Note: the two syntactically-distinct restriction-of-scalars `Module k` local
+instances (`instModuleK` here vs `ExternalTensorFunctor`'s private `restrictModule₁`) are
+defeq but not syntactically equal, so a few imported `@[simp]` lemmas needed `erw` (or the
+`rfl`-restatement `extMapHom_tmul`) rather than `rw`/`simp`. Worth keeping in mind for
+downstream files mixing these instances.


### PR DESCRIPTION
Closes #6742

Session: `1fd62441-80b0-4bdf-8a6b-2ac4ed800eaf`

acb8d71f feat(Ch8 #6742): assemble rearrangeBifunctorNatIso (route step 2)
de29c3b3 feat(Ch8 #6742): WIP bifunctor component iso (rearrangeComponentLinEquiv + rearrangeBifunctorComponentIso)
1790aab7 feat(Ch8 #6742): WIP source-diamond reconciliation (extModuleK_algebraMap_smul + rearrangeSourceIso)

🤖 Prepared with Claude Code