### PR TITLE
feat(Ch6 #Problem6.1.3-e): prove marks_pos + cartan_mulVec_marks_eq_zero + cartan_det_zero (affine Cartan matrices are singular via the marks kernel vector)

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_tildeE.lean
+++ b/EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_tildeE.lean
@@ -145,7 +145,8 @@ private theorem dtilde_key (m : ℕ) (hn : 4 ≤ m + 6) (i : Fin (AffineType.Dti
   have adj_val : ∀ (a b : Fin (AffineType.Dtilde (m+6) hn).rank),
       (AffineType.Dtilde (m+6) hn).adj a b
         = if min a.val b.val = 0 ∧ max a.val b.val = 2 ∨ min a.val b.val = 1 ∧ max a.val b.val = 2 ∨
-             2 ≤ min a.val b.val ∧ max a.val b.val ≤ (m+6)-2 ∧ min a.val b.val + 1 = max a.val b.val ∨
+             2 ≤ min a.val b.val ∧ max a.val b.val ≤ (m+6)-2
+               ∧ min a.val b.val + 1 = max a.val b.val ∨
              min a.val b.val = (m+6)-2 ∧ max a.val b.val = (m+6)-1 ∨
              min a.val b.val = (m+6)-2 ∧ max a.val b.val = (m+6) then 1 else 0 := fun _ _ => rfl
   have mval : ∀ (j : Fin (AffineType.Dtilde (m+6) hn).rank),
@@ -160,9 +161,12 @@ private theorem dtilde_key (m : ℕ) (hn : 4 ≤ m + 6) (i : Fin (AffineType.Dti
         (fun x _ hx => by rw [adj_val, if_neg]; · ring
                           · simp only [mem_singleton, Fin.ext_iff] at hx; omega),
         Finset.sum_singleton]
-    rw [show (AffineType.Dtilde (m+6) hn).adj i ⟨2,h2⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).marks ⟨2,h2⟩ = 2 from by rw [mval, if_neg]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).marks i = 1 from by rw [mval, if_pos]; (try dsimp only []); omega]
+    rw [show (AffineType.Dtilde (m+6) hn).adj i ⟨2,h2⟩ = 1 from by
+        rw [adj_val, if_pos]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).marks ⟨2,h2⟩ = 2 from by
+            rw [mval, if_neg]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).marks i = 1 from by
+            rw [mval, if_pos]; omega]
     norm_num
   · -- v = 1 : nbr {2}
     have h2 : (2:ℕ) < (AffineType.Dtilde (m+6) hn).rank := by omega
@@ -170,9 +174,12 @@ private theorem dtilde_key (m : ℕ) (hn : 4 ≤ m + 6) (i : Fin (AffineType.Dti
         (fun x _ hx => by rw [adj_val, if_neg]; · ring
                           · simp only [mem_singleton, Fin.ext_iff] at hx; omega),
         Finset.sum_singleton]
-    rw [show (AffineType.Dtilde (m+6) hn).adj i ⟨2,h2⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).marks ⟨2,h2⟩ = 2 from by rw [mval, if_neg]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).marks i = 1 from by rw [mval, if_pos]; (try dsimp only []); omega]
+    rw [show (AffineType.Dtilde (m+6) hn).adj i ⟨2,h2⟩ = 1 from by
+        rw [adj_val, if_pos]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).marks ⟨2,h2⟩ = 2 from by
+            rw [mval, if_neg]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).marks i = 1 from by
+            rw [mval, if_pos]; omega]
     norm_num
   · -- v = 2 : nbrs {0,1,3}
     have h0 : (0:ℕ) < (AffineType.Dtilde (m+6) hn).rank := by omega
@@ -184,13 +191,20 @@ private theorem dtilde_key (m : ℕ) (hn : 4 ≤ m + 6) (i : Fin (AffineType.Dti
                           · simp only [mem_insert, mem_singleton, Fin.ext_iff] at hx; omega),
         Finset.sum_insert (by simp only [mem_insert, mem_singleton, Fin.ext_iff]; omega),
         Finset.sum_insert (by simp only [mem_singleton, Fin.ext_iff]; omega), Finset.sum_singleton]
-    rw [show (AffineType.Dtilde (m+6) hn).adj i ⟨0,h0⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).adj i ⟨1,h1⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).adj i ⟨3,h3⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).marks ⟨0,h0⟩ = 1 from by rw [mval, if_pos]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).marks ⟨1,h1⟩ = 1 from by rw [mval, if_pos]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).marks ⟨3,h3⟩ = 2 from by rw [mval, if_neg]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).marks i = 2 from by rw [mval, if_neg]; (try dsimp only []); omega]
+    rw [show (AffineType.Dtilde (m+6) hn).adj i ⟨0,h0⟩ = 1 from by
+        rw [adj_val, if_pos]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).adj i ⟨1,h1⟩ = 1 from by
+            rw [adj_val, if_pos]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).adj i ⟨3,h3⟩ = 1 from by
+            rw [adj_val, if_pos]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).marks ⟨0,h0⟩ = 1 from by
+            rw [mval, if_pos]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).marks ⟨1,h1⟩ = 1 from by
+            rw [mval, if_pos]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).marks ⟨3,h3⟩ = 2 from by
+            rw [mval, if_neg]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).marks i = 2 from by
+            rw [mval, if_neg]; omega]
     norm_num
   · -- interior : 3 ≤ v ≤ m+3, nbrs {v-1, v+1}
     have hp : (i.val - 1 : ℕ) < (AffineType.Dtilde (m+6) hn).rank := by omega
@@ -199,11 +213,16 @@ private theorem dtilde_key (m : ℕ) (hn : 4 ≤ m + 6) (i : Fin (AffineType.Dti
         (fun x _ hx => by rw [adj_val, if_neg]; · ring
                           · simp only [mem_insert, mem_singleton, Fin.ext_iff] at hx; omega),
         Finset.sum_insert (by simp only [mem_singleton, Fin.ext_iff]; omega), Finset.sum_singleton]
-    rw [show (AffineType.Dtilde (m+6) hn).adj i ⟨i.val-1,hp⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).adj i ⟨i.val+1,hs⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).marks ⟨i.val-1,hp⟩ = 2 from by rw [mval, if_neg]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).marks ⟨i.val+1,hs⟩ = 2 from by rw [mval, if_neg]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).marks i = 2 from by rw [mval, if_neg]; (try dsimp only []); omega]
+    rw [show (AffineType.Dtilde (m+6) hn).adj i ⟨i.val-1,hp⟩ = 1 from by
+        rw [adj_val, if_pos]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).adj i ⟨i.val+1,hs⟩ = 1 from by
+            rw [adj_val, if_pos]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).marks ⟨i.val-1,hp⟩ = 2 from by
+            rw [mval, if_neg]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).marks ⟨i.val+1,hs⟩ = 2 from by
+            rw [mval, if_neg]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).marks i = 2 from by
+            rw [mval, if_neg]; omega]
     norm_num
   · -- v = m+4 : nbrs {m+3, m+5, m+6}
     have h3 : (m+3 : ℕ) < (AffineType.Dtilde (m+6) hn).rank := by omega
@@ -215,13 +234,20 @@ private theorem dtilde_key (m : ℕ) (hn : 4 ≤ m + 6) (i : Fin (AffineType.Dti
                           · simp only [mem_insert, mem_singleton, Fin.ext_iff] at hx; omega),
         Finset.sum_insert (by simp only [mem_insert, mem_singleton, Fin.ext_iff]; omega),
         Finset.sum_insert (by simp only [mem_singleton, Fin.ext_iff]; omega), Finset.sum_singleton]
-    rw [show (AffineType.Dtilde (m+6) hn).adj i ⟨m+3,h3⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).adj i ⟨m+5,h5⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).adj i ⟨m+6,h6⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).marks ⟨m+3,h3⟩ = 2 from by rw [mval, if_neg]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).marks ⟨m+5,h5⟩ = 1 from by rw [mval, if_pos]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).marks ⟨m+6,h6⟩ = 1 from by rw [mval, if_pos]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).marks i = 2 from by rw [mval, if_neg]; (try dsimp only []); omega]
+    rw [show (AffineType.Dtilde (m+6) hn).adj i ⟨m+3,h3⟩ = 1 from by
+        rw [adj_val, if_pos]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).adj i ⟨m+5,h5⟩ = 1 from by
+            rw [adj_val, if_pos]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).adj i ⟨m+6,h6⟩ = 1 from by
+            rw [adj_val, if_pos]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).marks ⟨m+3,h3⟩ = 2 from by
+            rw [mval, if_neg]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).marks ⟨m+5,h5⟩ = 1 from by
+            rw [mval, if_pos]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).marks ⟨m+6,h6⟩ = 1 from by
+            rw [mval, if_pos]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).marks i = 2 from by
+            rw [mval, if_neg]; omega]
     norm_num
   · -- v = m+5 : nbr {m+4}
     have h4 : (m+4 : ℕ) < (AffineType.Dtilde (m+6) hn).rank := by omega
@@ -229,9 +255,12 @@ private theorem dtilde_key (m : ℕ) (hn : 4 ≤ m + 6) (i : Fin (AffineType.Dti
         (fun x _ hx => by rw [adj_val, if_neg]; · ring
                           · simp only [mem_singleton, Fin.ext_iff] at hx; omega),
         Finset.sum_singleton]
-    rw [show (AffineType.Dtilde (m+6) hn).adj i ⟨m+4,h4⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).marks ⟨m+4,h4⟩ = 2 from by rw [mval, if_neg]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).marks i = 1 from by rw [mval, if_pos]; (try dsimp only []); omega]
+    rw [show (AffineType.Dtilde (m+6) hn).adj i ⟨m+4,h4⟩ = 1 from by
+        rw [adj_val, if_pos]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).marks ⟨m+4,h4⟩ = 2 from by
+            rw [mval, if_neg]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).marks i = 1 from by
+            rw [mval, if_pos]; omega]
     norm_num
   · -- v = m+6 : nbr {m+4}
     have h4 : (m+4 : ℕ) < (AffineType.Dtilde (m+6) hn).rank := by omega
@@ -239,9 +268,12 @@ private theorem dtilde_key (m : ℕ) (hn : 4 ≤ m + 6) (i : Fin (AffineType.Dti
         (fun x _ hx => by rw [adj_val, if_neg]; · ring
                           · simp only [mem_singleton, Fin.ext_iff] at hx; omega),
         Finset.sum_singleton]
-    rw [show (AffineType.Dtilde (m+6) hn).adj i ⟨m+4,h4⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).marks ⟨m+4,h4⟩ = 2 from by rw [mval, if_neg]; (try dsimp only []); omega,
-        show (AffineType.Dtilde (m+6) hn).marks i = 1 from by rw [mval, if_pos]; (try dsimp only []); omega]
+    rw [show (AffineType.Dtilde (m+6) hn).adj i ⟨m+4,h4⟩ = 1 from by
+        rw [adj_val, if_pos]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).marks ⟨m+4,h4⟩ = 2 from by
+            rw [mval, if_neg]; first | omega | (dsimp only []; omega),
+        show (AffineType.Dtilde (m+6) hn).marks i = 1 from by
+            rw [mval, if_pos]; omega]
     norm_num
 
 /-- **(e)** The marks span the kernel of the Cartan matrix: `(2·Id - R)·marks = 0`
@@ -266,10 +298,12 @@ theorem cartan_mulVec_marks_eq_zero (t : AffineType) :
       | (m + 6), hn =>
           funext i
           have hrow : ((2 • (1 : Matrix (Fin (AffineType.Dtilde (m+6) hn).rank)
-                (Fin (AffineType.Dtilde (m+6) hn).rank) ℤ) - (AffineType.Dtilde (m+6) hn).adj).mulVec
+                (Fin (AffineType.Dtilde (m+6) hn).rank) ℤ)
+                - (AffineType.Dtilde (m+6) hn).adj).mulVec
               (AffineType.Dtilde (m+6) hn).marks) i
               = 2 * (AffineType.Dtilde (m+6) hn).marks i
-                - ∑ j, (AffineType.Dtilde (m+6) hn).adj i j * (AffineType.Dtilde (m+6) hn).marks j := by
+                - ∑ j, (AffineType.Dtilde (m+6) hn).adj i j
+                    * (AffineType.Dtilde (m+6) hn).marks j := by
             rw [sub_mulVec, smul_mulVec, Matrix.one_mulVec, Pi.sub_apply, Pi.smul_apply]
             simp only [Matrix.mulVec, dotProduct, two_smul, two_mul]
           rw [Pi.zero_apply, hrow, dtilde_key m hn i, sub_self]

--- a/EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_tildeE.lean
+++ b/EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_tildeE.lean
@@ -131,6 +131,119 @@ theorem marks_pos (t : AffineType) (i : Fin t.rank) : 0 < t.marks i := by
   | E7tilde => fin_cases i <;> simp [AffineType.marks]
   | E8tilde => fin_cases i <;> simp [AffineType.marks]
 
+/-- The neighbour-sum identity `∑ⱼ adj i j · marks j = 2 · marks i` for the affine
+`D̃ₙ` type at `n = m + 6` (rank `m + 7`), where the two forks are well separated
+(`n ≥ 6`), so the vertex classes — the four leaves, the two forks, and the interior
+chain — are handled uniformly. This is the crux of `cartan_mulVec_marks_eq_zero` for
+`D̃ₙ`; the small cases `n = 4, 5` (where the forks coincide or are adjacent) are
+dispatched by `decide`. -/
+private theorem dtilde_key (m : ℕ) (hn : 4 ≤ m + 6) (i : Fin (AffineType.Dtilde (m+6) hn).rank) :
+    ∑ j, (AffineType.Dtilde (m+6) hn).adj i j * (AffineType.Dtilde (m+6) hn).marks j
+      = 2 * (AffineType.Dtilde (m+6) hn).marks i := by
+  have hrank : (AffineType.Dtilde (m+6) hn).rank = m + 7 := by simp [AffineType.rank]
+  have hlt : i.val < m + 7 := hrank ▸ i.isLt
+  have adj_val : ∀ (a b : Fin (AffineType.Dtilde (m+6) hn).rank),
+      (AffineType.Dtilde (m+6) hn).adj a b
+        = if min a.val b.val = 0 ∧ max a.val b.val = 2 ∨ min a.val b.val = 1 ∧ max a.val b.val = 2 ∨
+             2 ≤ min a.val b.val ∧ max a.val b.val ≤ (m+6)-2 ∧ min a.val b.val + 1 = max a.val b.val ∨
+             min a.val b.val = (m+6)-2 ∧ max a.val b.val = (m+6)-1 ∨
+             min a.val b.val = (m+6)-2 ∧ max a.val b.val = (m+6) then 1 else 0 := fun _ _ => rfl
+  have mval : ∀ (j : Fin (AffineType.Dtilde (m+6) hn).rank),
+      (AffineType.Dtilde (m+6) hn).marks j
+        = if j.val = 0 ∨ j.val = 1 ∨ j.val = m+5 ∨ j.val = m+6 then 1 else 2 := fun _ => rfl
+  have hclass : i.val = 0 ∨ i.val = 1 ∨ i.val = 2 ∨ (3 ≤ i.val ∧ i.val ≤ m+3) ∨
+      i.val = m+4 ∨ i.val = m+5 ∨ i.val = m+6 := by omega
+  rcases hclass with hi | hi | hi | ⟨hlo, hhi⟩ | hi | hi | hi
+  · -- v = 0 : nbr {2}
+    have h2 : (2:ℕ) < (AffineType.Dtilde (m+6) hn).rank := by omega
+    rw [← Finset.sum_subset (Finset.subset_univ {(⟨2,h2⟩ : Fin _)})
+        (fun x _ hx => by rw [adj_val, if_neg]; · ring
+                          · simp only [mem_singleton, Fin.ext_iff] at hx; omega),
+        Finset.sum_singleton]
+    rw [show (AffineType.Dtilde (m+6) hn).adj i ⟨2,h2⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).marks ⟨2,h2⟩ = 2 from by rw [mval, if_neg]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).marks i = 1 from by rw [mval, if_pos]; (try dsimp only []); omega]
+    norm_num
+  · -- v = 1 : nbr {2}
+    have h2 : (2:ℕ) < (AffineType.Dtilde (m+6) hn).rank := by omega
+    rw [← Finset.sum_subset (Finset.subset_univ {(⟨2,h2⟩ : Fin _)})
+        (fun x _ hx => by rw [adj_val, if_neg]; · ring
+                          · simp only [mem_singleton, Fin.ext_iff] at hx; omega),
+        Finset.sum_singleton]
+    rw [show (AffineType.Dtilde (m+6) hn).adj i ⟨2,h2⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).marks ⟨2,h2⟩ = 2 from by rw [mval, if_neg]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).marks i = 1 from by rw [mval, if_pos]; (try dsimp only []); omega]
+    norm_num
+  · -- v = 2 : nbrs {0,1,3}
+    have h0 : (0:ℕ) < (AffineType.Dtilde (m+6) hn).rank := by omega
+    have h1 : (1:ℕ) < (AffineType.Dtilde (m+6) hn).rank := by omega
+    have h3 : (3:ℕ) < (AffineType.Dtilde (m+6) hn).rank := by omega
+    rw [← Finset.sum_subset (Finset.subset_univ
+          {(⟨0,h0⟩ : Fin _), ⟨1,h1⟩, ⟨3,h3⟩})
+        (fun x _ hx => by rw [adj_val, if_neg]; · ring
+                          · simp only [mem_insert, mem_singleton, Fin.ext_iff] at hx; omega),
+        Finset.sum_insert (by simp only [mem_insert, mem_singleton, Fin.ext_iff]; omega),
+        Finset.sum_insert (by simp only [mem_singleton, Fin.ext_iff]; omega), Finset.sum_singleton]
+    rw [show (AffineType.Dtilde (m+6) hn).adj i ⟨0,h0⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).adj i ⟨1,h1⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).adj i ⟨3,h3⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).marks ⟨0,h0⟩ = 1 from by rw [mval, if_pos]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).marks ⟨1,h1⟩ = 1 from by rw [mval, if_pos]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).marks ⟨3,h3⟩ = 2 from by rw [mval, if_neg]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).marks i = 2 from by rw [mval, if_neg]; (try dsimp only []); omega]
+    norm_num
+  · -- interior : 3 ≤ v ≤ m+3, nbrs {v-1, v+1}
+    have hp : (i.val - 1 : ℕ) < (AffineType.Dtilde (m+6) hn).rank := by omega
+    have hs : (i.val + 1 : ℕ) < (AffineType.Dtilde (m+6) hn).rank := by omega
+    rw [← Finset.sum_subset (Finset.subset_univ {(⟨i.val-1,hp⟩ : Fin _), ⟨i.val+1,hs⟩})
+        (fun x _ hx => by rw [adj_val, if_neg]; · ring
+                          · simp only [mem_insert, mem_singleton, Fin.ext_iff] at hx; omega),
+        Finset.sum_insert (by simp only [mem_singleton, Fin.ext_iff]; omega), Finset.sum_singleton]
+    rw [show (AffineType.Dtilde (m+6) hn).adj i ⟨i.val-1,hp⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).adj i ⟨i.val+1,hs⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).marks ⟨i.val-1,hp⟩ = 2 from by rw [mval, if_neg]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).marks ⟨i.val+1,hs⟩ = 2 from by rw [mval, if_neg]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).marks i = 2 from by rw [mval, if_neg]; (try dsimp only []); omega]
+    norm_num
+  · -- v = m+4 : nbrs {m+3, m+5, m+6}
+    have h3 : (m+3 : ℕ) < (AffineType.Dtilde (m+6) hn).rank := by omega
+    have h5 : (m+5 : ℕ) < (AffineType.Dtilde (m+6) hn).rank := by omega
+    have h6 : (m+6 : ℕ) < (AffineType.Dtilde (m+6) hn).rank := by omega
+    rw [← Finset.sum_subset (Finset.subset_univ
+          {(⟨m+3,h3⟩ : Fin _), ⟨m+5,h5⟩, ⟨m+6,h6⟩})
+        (fun x _ hx => by rw [adj_val, if_neg]; · ring
+                          · simp only [mem_insert, mem_singleton, Fin.ext_iff] at hx; omega),
+        Finset.sum_insert (by simp only [mem_insert, mem_singleton, Fin.ext_iff]; omega),
+        Finset.sum_insert (by simp only [mem_singleton, Fin.ext_iff]; omega), Finset.sum_singleton]
+    rw [show (AffineType.Dtilde (m+6) hn).adj i ⟨m+3,h3⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).adj i ⟨m+5,h5⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).adj i ⟨m+6,h6⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).marks ⟨m+3,h3⟩ = 2 from by rw [mval, if_neg]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).marks ⟨m+5,h5⟩ = 1 from by rw [mval, if_pos]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).marks ⟨m+6,h6⟩ = 1 from by rw [mval, if_pos]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).marks i = 2 from by rw [mval, if_neg]; (try dsimp only []); omega]
+    norm_num
+  · -- v = m+5 : nbr {m+4}
+    have h4 : (m+4 : ℕ) < (AffineType.Dtilde (m+6) hn).rank := by omega
+    rw [← Finset.sum_subset (Finset.subset_univ {(⟨m+4,h4⟩ : Fin _)})
+        (fun x _ hx => by rw [adj_val, if_neg]; · ring
+                          · simp only [mem_singleton, Fin.ext_iff] at hx; omega),
+        Finset.sum_singleton]
+    rw [show (AffineType.Dtilde (m+6) hn).adj i ⟨m+4,h4⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).marks ⟨m+4,h4⟩ = 2 from by rw [mval, if_neg]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).marks i = 1 from by rw [mval, if_pos]; (try dsimp only []); omega]
+    norm_num
+  · -- v = m+6 : nbr {m+4}
+    have h4 : (m+4 : ℕ) < (AffineType.Dtilde (m+6) hn).rank := by omega
+    rw [← Finset.sum_subset (Finset.subset_univ {(⟨m+4,h4⟩ : Fin _)})
+        (fun x _ hx => by rw [adj_val, if_neg]; · ring
+                          · simp only [mem_singleton, Fin.ext_iff] at hx; omega),
+        Finset.sum_singleton]
+    rw [show (AffineType.Dtilde (m+6) hn).adj i ⟨m+4,h4⟩ = 1 from by rw [adj_val, if_pos]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).marks ⟨m+4,h4⟩ = 2 from by rw [mval, if_neg]; (try dsimp only []); omega,
+        show (AffineType.Dtilde (m+6) hn).marks i = 1 from by rw [mval, if_pos]; (try dsimp only []); omega]
+    norm_num
+
 /-- **(e)** The marks span the kernel of the Cartan matrix: `(2·Id - R)·marks = 0`
 ("the numbers labeling the vertices are the null vector"). -/
 theorem cartan_mulVec_marks_eq_zero (t : AffineType) :
@@ -138,7 +251,28 @@ theorem cartan_mulVec_marks_eq_zero (t : AffineType) :
   cases t with
   | Atilde n hn =>
       exact Etingof.Problem6_1_3_E7E8.cycle_cartan_mulVec_one_eq_zero n hn
-  | Dtilde n hn => sorry
+  | Dtilde n hn =>
+      match n, hn with
+      | 4, _ =>
+          funext i
+          fin_cases i <;>
+            simp only [AffineType.adj, AffineType.marks, AffineType.rank, Pi.zero_apply] <;>
+            decide +revert
+      | 5, _ =>
+          funext i
+          fin_cases i <;>
+            simp only [AffineType.adj, AffineType.marks, AffineType.rank, Pi.zero_apply] <;>
+            decide +revert
+      | (m + 6), hn =>
+          funext i
+          have hrow : ((2 • (1 : Matrix (Fin (AffineType.Dtilde (m+6) hn).rank)
+                (Fin (AffineType.Dtilde (m+6) hn).rank) ℤ) - (AffineType.Dtilde (m+6) hn).adj).mulVec
+              (AffineType.Dtilde (m+6) hn).marks) i
+              = 2 * (AffineType.Dtilde (m+6) hn).marks i
+                - ∑ j, (AffineType.Dtilde (m+6) hn).adj i j * (AffineType.Dtilde (m+6) hn).marks j := by
+            rw [sub_mulVec, smul_mulVec, Matrix.one_mulVec, Pi.sub_apply, Pi.smul_apply]
+            simp only [Matrix.mulVec, dotProduct, two_smul, two_mul]
+          rw [Pi.zero_apply, hrow, dtilde_key m hn i, sub_self]
   | E6tilde => decide
   | E7tilde => decide
   | E8tilde => decide

--- a/EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_tildeE.lean
+++ b/EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_tildeE.lean
@@ -122,18 +122,39 @@ def AffineType.marks : (t : AffineType) → (Fin t.rank → ℤ)
 
 /-- The marks are (strictly) positive. -/
 theorem marks_pos (t : AffineType) (i : Fin t.rank) : 0 < t.marks i := by
-  sorry
+  cases t with
+  | Atilde n hn => simp [AffineType.marks]
+  | Dtilde n hn =>
+      simp only [AffineType.marks]
+      split <;> norm_num
+  | E6tilde => fin_cases i <;> simp [AffineType.marks]
+  | E7tilde => fin_cases i <;> simp [AffineType.marks]
+  | E8tilde => fin_cases i <;> simp [AffineType.marks]
 
 /-- **(e)** The marks span the kernel of the Cartan matrix: `(2·Id - R)·marks = 0`
 ("the numbers labeling the vertices are the null vector"). -/
 theorem cartan_mulVec_marks_eq_zero (t : AffineType) :
     (2 • (1 : Matrix (Fin t.rank) (Fin t.rank) ℤ) - t.adj).mulVec t.marks = 0 := by
-  sorry
+  cases t with
+  | Atilde n hn =>
+      exact Etingof.Problem6_1_3_E7E8.cycle_cartan_mulVec_one_eq_zero n hn
+  | Dtilde n hn => sorry
+  | E6tilde => decide
+  | E7tilde => decide
+  | E8tilde => decide
 
 /-- **(e)** Consequently `det A = 0` for every extended diagram. -/
 theorem cartan_det_zero (t : AffineType) :
     (2 • (1 : Matrix (Fin t.rank) (Fin t.rank) ℤ) - t.adj).det = 0 := by
-  sorry
+  have hr : 0 < t.rank := by cases t <;> simp only [AffineType.rank] <;> omega
+  rw [← Matrix.exists_mulVec_eq_zero_iff]
+  refine ⟨t.marks, ?_, cartan_mulVec_marks_eq_zero t⟩
+  intro h
+  have h0 := congrFun h ⟨0, hr⟩
+  have hp := marks_pos t ⟨0, hr⟩
+  simp only [Pi.zero_apply] at h0
+  rw [h0] at hp
+  exact lt_irrefl 0 hp
 
 /-- **(g, one direction)** Each extended diagram really is an affine Dynkin
 diagram (its Cartan form is positive semidefinite but degenerate). -/

--- a/progress/2026-07-16T07-17-47Z_dc37e2ab.md
+++ b/progress/2026-07-16T07-17-47Z_dc37e2ab.md
@@ -1,0 +1,56 @@
+## Accomplished
+
+Closed the affine part-(e) cluster of Problem 6.1.3 (issue #6754) in
+`EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_tildeE.lean`.
+The three previously-`sorry` lemmas are now sorry-free:
+
+- `marks_pos` — positivity of the marks vector (case split per affine type;
+  `fin_cases`/`decide` for the exceptional `![...]` vectors).
+- `cartan_mulVec_marks_eq_zero` — `(2·Id − R)·marks = 0` for all five affine
+  types. `Ãₙ` reuses `cycle_cartan_mulVec_one_eq_zero`; `Ẽ₆/Ẽ₇/Ẽ₈` by `decide`;
+  `D̃ₙ` via a new private lemma `dtilde_key`.
+- `cartan_det_zero` — `det = 0` from the kernel vector via
+  `Matrix.exists_mulVec_eq_zero_iff` (marks nonzero from `marks_pos`).
+
+`dtilde_key` proves the neighbour-sum identity `∑ⱼ adj i j · marks j = 2·marks i`
+for `D̃ₙ` at `n = m + 6` (rank `m + 7`), splitting the vertices into seven
+classes (four leaves, two forks, interior chain) — well separated because
+`n ≥ 6`. The Dtilde branch of `cartan_mulVec_marks_eq_zero` dispatches the small
+cases `n = 4, 5` (coincident/adjacent forks) by `decide +revert` and reduces the
+general case to `dtilde_key` after a `sub_mulVec`/`one_mulVec` row expansion.
+
+`#print axioms` on all three shows only `[propext, Classical.choice, Quot.sound]`.
+`lake build EtingofRepresentationTheory.Chapter6.Problem6_1_3_continued_tildeE`
+exits 0. Sorry count in the file dropped from 5 to 2.
+
+## Current frontier
+
+The two remaining `sorry`s in the file are the out-of-scope
+`isAffineDynkinDiagram_of_type` (positive-semidefiniteness) and
+`affine_dynkin_classification`, exactly as the issue instructed.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. This turn cleared one issue's three-lemma cluster;
+the affine part (e) "marks are the kernel vector, det = 0" is fully formalized.
+
+## Next step
+
+Pick up the remaining unclaimed Ch6 issues (#6755 general-family Cartan
+determinants det_cartan_A/D via cofactor recursion; #6754's affine
+positive-semidefinite witness `isAffineDynkinDiagram_of_type` is a natural
+follow-on that can now consume `cartan_mulVec_marks_eq_zero`).
+
+## Blockers
+
+None.
+
+## Key patterns discovered
+
+- `omega` refutes a disjunction as a *goal* (via `if_neg`) but does NOT case-split
+  a disjunction *hypothesis* well — so evaluate each `if` value with
+  `rw [lem, if_pos/if_neg]; omega` rather than `split_ifs <;> omega`.
+- `↑⟨k, h⟩` (Fin.val of an anonymous constructor) is not reduced by `omega` nor by
+  `simp [Fin.val_mk]`; use `dsimp only []` to iota-reduce it before `omega`.
+- `decide` on a goal mentioning a free hypothesis (`Dtilde 4 hn`) fails with
+  "free variables"; either unfold the def away or use `decide +revert`.


### PR DESCRIPTION
Closes #6754

Session: `dc37e2ab-20e7-4947-ad65-5ccfd42b9872`

5b852135 docs(#6754): progress entry for affine part-(e) cluster
3afa2dfc style(Ch6 #6754): wrap long lines and tidy value-proof tactics
f909d7d5 feat(Ch6 #6754): prove Dtilde case of cartan_mulVec_marks_eq_zero via dtilde_key
a3a1d4ef feat(Ch6 #6754): marks_pos + cartan_det_zero + mulVec (Atilde/E6/E7/E8); WIP Dtilde

🤖 Prepared with Claude Code