### PR TITLE
feat(Ch8 #Problem8.2.8-Tor): rearrangeComplex — final assembly of the ChainComplex(ModuleCat k) ℕ rearrangement iso from NatIso + total-complex postcomp (step 3 of #6727)

### DIFF
--- a/EtingofRepresentationTheory/Chapter8/RearrangeComplex.lean
+++ b/EtingofRepresentationTheory/Chapter8/RearrangeComplex.lean
@@ -125,4 +125,33 @@ noncomputable def rearrangeComplex :
     HomologicalComplex₂.total.mapIso (rearrangeComplexBicomplexIso k A₁ A₂ N₁ N₂ hN P₁ P₂)
       (ComplexShape.down ℕ)
 
+/-- The rearrangement iso pinned on a summand: postcomposing the `G`-image of the `(i₁, i₂)` summand
+inclusion of the external tensor complex with `rearrangeComplex` lands, via milestone (a)
+`rearrangeBifunctorComponentIso`, on the corresponding `(i₁, i₂)` summand of the target tensor
+complex `tensorObj C₁ C₂`. This is the rewrite the Künneth `Tor` assembler (#6657) uses. -/
+@[reassoc]
+theorem rearrangeComplex_hom_f_ιMapBifunctor (i₁ i₂ j : ℕ)
+    (h : ComplexShape.π (ComplexShape.down ℕ) (ComplexShape.down ℕ) (ComplexShape.down ℕ)
+      (i₁, i₂) = j) :
+    (tensorRightFunctorₖ k (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)).map
+          (HomologicalComplex.ιMapBifunctor P₁.complex P₂.complex (extTensorFunctor k A₁ A₂)
+            (ComplexShape.down ℕ) i₁ i₂ j h) ≫
+        (rearrangeComplex k A₁ A₂ N₁ N₂ hN P₁ P₂).hom.f j =
+      (rearrangeBifunctorComponentIso k A₁ A₂ N₁ N₂ hN
+            (P₁.complex.X i₁) (P₂.complex.X i₂)).hom ≫
+        HomologicalComplex.ιMapBifunctor
+          (((tensorRightFunctorₖ k A₁ N₁).mapHomologicalComplex (ComplexShape.down ℕ)).obj
+            P₁.complex)
+          (((tensorRightFunctorₖ k A₂ N₂).mapHomologicalComplex (ComplexShape.down ℕ)).obj
+            P₂.complex)
+          (curriedTensor (ModuleCat.{u} k)) (ComplexShape.down ℕ) i₁ i₂ j h := by
+  rw [rearrangeComplex, Iso.trans_hom, HomologicalComplex.comp_f, ← Category.assoc]
+  rw [show (mapBifunctorPostcompIso P₁.complex P₂.complex (extTensorFunctor k A₁ A₂)
+        (tensorRightFunctorₖ k (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂))).hom.f j =
+      (postcompX P₁.complex P₂.complex (extTensorFunctor k A₁ A₂)
+        (tensorRightFunctorₖ k (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)) j).hom from rfl,
+    ιMapBifunctor_comp_postcompX_hom, HomologicalComplex₂.total.mapIso_hom,
+    HomologicalComplex₂.ιTotal_map]
+  rfl
+
 end Etingof

--- a/EtingofRepresentationTheory/Chapter8/RearrangeComplex.lean
+++ b/EtingofRepresentationTheory/Chapter8/RearrangeComplex.lean
@@ -1,0 +1,128 @@
+import EtingofRepresentationTheory.Chapter8.RearrangeBifunctorNatIso
+import EtingofRepresentationTheory.Chapter8.MapBifunctorPostcomp
+import Mathlib.Algebra.Homology.Monoidal
+
+/-!
+# The complex-level rearrangement isomorphism for the `Tor` Künneth formula
+
+Route **step 3** (final assembly) of milestone (c) of the four-fold rearrangement of Problem 8.2.8
+(`Tor`, parent #6727). Combining the two prior milestones,
+
+* `Etingof.mapBifunctorPostcompIso` (#6743, `MapBifunctorPostcomp.lean`): an additive functor `G`
+  commutes with the total complex `mapBifunctor`, so
+  `(G.mapHomologicalComplex).obj (mapBifunctor K₁ K₂ F) ≅ mapBifunctor K₁ K₂ (F ⋙ G)`;
+* `Etingof.rearrangeBifunctorNatIso` (#6742, `RearrangeBifunctorNatIso.lean`): the natural iso of
+  bifunctors `extTensorRightFunctor ≅ factorTensorFunctor`, i.e.
+  `(X, Y) ↦ (X ⊗ₖ Y) ⊗_{A₁⊗A₂} (N₁⊗ₖN₂)  ≅  (X ⊗_{A₁} N₁) ⊗ₖ (Y ⊗_{A₂} N₂)`,
+
+this file assembles the isomorphism of `ChainComplex (ModuleCat k) ℕ`
+
+```
+rearrangeComplex :
+  (tensorRightFunctorₖ(N₁⊗ₖN₂)).mapHC.obj (extTensorComplex P₁ P₂)
+    ≅ HomologicalComplex.tensorObj
+        ((tensorRightFunctorₖ N₁).mapHC.obj P₁.complex)
+        ((tensorRightFunctorₖ N₂).mapHC.obj P₂.complex)
+```
+
+feeding the Künneth `Tor` result #6657.
+
+## Route
+
+The left-hand side is `(G.mapHC).obj (mapBifunctor P₁.complex P₂.complex (extTensorFunctor))` with
+`G = tensorRightFunctorₖ (A₁⊗A₂) (N₁⊗ₖN₂)`.
+
+1. `mapBifunctorPostcompIso` rewrites it to `mapBifunctor P₁.complex P₂.complex
+   (extTensorFunctor ⋙ G) = (bicomplex of `postcompBifunctor extTensorFunctor G`).total`.
+2. `rearrangeComplexBicomplexIso` is an isomorphism of the underlying **bicomplexes**, from the
+   `postcompBifunctor extTensorFunctor G`-bicomplex on `(P₁, P₂)` to the `curriedTensor`-bicomplex
+   on the two mapped factors `Cᵢ = (tensorRightFunctorₖ Nᵢ).mapHC.obj Pᵢ.complex`. Its bidegree
+   `(i₁, i₂)` component is `rearrangeBifunctorComponentIso` (milestone (a) `rearrangeBidegree`); its
+   two differential-commutation squares are exactly the two naturality squares of the bifunctor
+   natural iso (`rearrangeBifunctorNatIsoApp` in the second variable, `rearrangeBifunctorNatIso` in
+   the first). `HomologicalComplex₂.total.mapIso` promotes this bicomplex iso to the total complex
+   iso, discharging the Koszul-signed differential automatically.
+
+Steps 2–3 of the issue's route (apply the NatIso, then identify with `tensorObj`) fuse here into the
+single bicomplex iso `rearrangeComplexBicomplexIso`, because the target bifunctor
+`factorTensorFunctor` agrees **definitionally** with `curriedTensor` post-composed on each factor by
+`tensorRightFunctorₖ`
+(the `rfl`-lemmas `factorTensorFunctor_obj_map` / `factorTensorFunctor_map_app` of the NatIso file),
+so the `factorTensorFunctor`-bicomplex on `(P₁, P₂)` and the `curriedTensor`-bicomplex on `(C₁, C₂)`
+are the same object.
+-/
+
+open CategoryTheory Limits MonoidalCategory TensorProduct HomologicalComplex
+
+namespace Etingof
+
+universe u
+
+variable (k : Type u) [Field k]
+variable (A₁ A₂ : Type u) [Ring A₁] [Ring A₂] [Algebra k A₁] [Algebra k A₂]
+variable (N₁ N₂ : Type u)
+  [AddCommGroup N₁] [Module k N₁] [Module A₁ N₁] [IsScalarTower k A₁ N₁]
+  [AddCommGroup N₂] [Module k N₂] [Module A₂ N₂] [IsScalarTower k A₂ N₂]
+variable [instN : Module (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)]
+variable
+  (hN : ∀ (a₁ : A₁) (a₂ : A₂) (n₁ : N₁) (n₂ : N₂),
+    (a₁ ⊗ₜ[k] a₂ : A₁ ⊗[k] A₂) • (n₁ ⊗ₜ[k] n₂ : N₁ ⊗[k] N₂)
+      = (a₁ • n₁) ⊗ₜ[k] (a₂ • n₂))
+variable {M₁ : ModuleCat.{u} A₁ᵐᵒᵖ} {M₂ : ModuleCat.{u} A₂ᵐᵒᵖ}
+variable (P₁ : ProjectiveResolution M₁) (P₂ : ProjectiveResolution M₂)
+
+/-- The bicomplex-level rearrangement isomorphism. Source: the bicomplex of
+`postcompBifunctor (extTensorFunctor) (tensorRightFunctorₖ (A₁⊗A₂) (N₁⊗ₖN₂))` on the resolutions
+`(P₁, P₂)`. Target: the `curriedTensor (ModuleCat k)`-bicomplex on the two mapped factors
+`Cᵢ = (tensorRightFunctorₖ Nᵢ).mapHC.obj Pᵢ.complex`. The bidegree `(i₁, i₂)` component is
+`rearrangeBifunctorComponentIso`; the two differential-commutation squares are the two naturality
+squares of the bifunctor natural iso. -/
+noncomputable def rearrangeComplexBicomplexIso :
+    (((postcompBifunctor (extTensorFunctor k A₁ A₂)
+          (tensorRightFunctorₖ k (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂))).mapBifunctorHomologicalComplex
+          (ComplexShape.down ℕ) (ComplexShape.down ℕ)).obj P₁.complex).obj P₂.complex ≅
+      (((curriedTensor (ModuleCat.{u} k)).mapBifunctorHomologicalComplex
+          (ComplexShape.down ℕ) (ComplexShape.down ℕ)).obj
+          (((tensorRightFunctorₖ k A₁ N₁).mapHomologicalComplex (ComplexShape.down ℕ)).obj
+            P₁.complex)).obj
+        (((tensorRightFunctorₖ k A₂ N₂).mapHomologicalComplex (ComplexShape.down ℕ)).obj
+          P₂.complex) :=
+  HomologicalComplex.Hom.isoOfComponents
+    (fun i₁ => HomologicalComplex.Hom.isoOfComponents
+      (fun i₂ => rearrangeBifunctorComponentIso k A₁ A₂ N₁ N₂ hN
+        (P₁.complex.X i₁) (P₂.complex.X i₂))
+      (fun i₂ i₂' _ =>
+        ((rearrangeBifunctorNatIsoApp k A₁ A₂ N₁ N₂ hN (P₁.complex.X i₁)).hom.naturality
+          (P₂.complex.d i₂ i₂')).symm))
+    (fun i₁ i₁' _ => by
+      apply HomologicalComplex.hom_ext
+      intro i₂
+      exact NatTrans.congr_app
+        ((rearrangeBifunctorNatIso k A₁ A₂ N₁ N₂ hN).hom.naturality (P₁.complex.d i₁ i₁')).symm
+        (P₂.complex.X i₂))
+
+/-- **Route step 3 (#6744).** The complex-level rearrangement isomorphism of
+`ChainComplex (ModuleCat k) ℕ`:
+
+```
+(tensorRightFunctorₖ (N₁⊗ₖN₂)).mapHC.obj (extTensorComplex P₁ P₂)
+  ≅ HomologicalComplex.tensorObj
+      ((tensorRightFunctorₖ N₁).mapHC.obj P₁.complex)
+      ((tensorRightFunctorₖ N₂).mapHC.obj P₂.complex)
+```
+
+built by post-composing `mapBifunctorPostcompIso` (an additive functor commutes with the total
+complex) with `total.mapIso` of the bicomplex rearrangement `rearrangeComplexBicomplexIso`. -/
+noncomputable def rearrangeComplex :
+    ((tensorRightFunctorₖ k (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)).mapHomologicalComplex
+        (ComplexShape.down ℕ)).obj (extTensorComplex P₁ P₂) ≅
+      HomologicalComplex.tensorObj
+        (((tensorRightFunctorₖ k A₁ N₁).mapHomologicalComplex (ComplexShape.down ℕ)).obj P₁.complex)
+        (((tensorRightFunctorₖ k A₂ N₂).mapHomologicalComplex (ComplexShape.down ℕ)).obj
+          P₂.complex) :=
+  mapBifunctorPostcompIso P₁.complex P₂.complex (extTensorFunctor k A₁ A₂)
+      (tensorRightFunctorₖ k (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)) ≪≫
+    HomologicalComplex₂.total.mapIso (rearrangeComplexBicomplexIso k A₁ A₂ N₁ N₂ hN P₁ P₂)
+      (ComplexShape.down ℕ)
+
+end Etingof

--- a/progress/2026-07-16T07-42-03Z_e0d5d0ad.md
+++ b/progress/2026-07-16T07-42-03Z_e0d5d0ad.md
@@ -1,0 +1,60 @@
+## Accomplished
+
+Closed issue #6744 (feature): route step 3 / final assembly of milestone (c) of the four-fold
+rearrangement for Problem 8.2.8 (`Tor`). New file
+`EtingofRepresentationTheory/Chapter8/RearrangeComplex.lean` with:
+
+* `Etingof.rearrangeComplexBicomplexIso` — the bicomplex-level rearrangement iso, from the
+  `postcompBifunctor (extTensorFunctor) (tensorRightFunctorₖ (A₁⊗A₂) (N₁⊗ₖN₂))`-bicomplex on the
+  resolutions `(P₁, P₂)` to the `curriedTensor (ModuleCat k)`-bicomplex on the two mapped factors
+  `Cᵢ = (tensorRightFunctorₖ Nᵢ).mapHC.obj Pᵢ.complex`. Bidegree component is
+  `rearrangeBifunctorComponentIso` (#6742 milestone (a)); the two differential-commutation squares
+  are the two naturality squares of the bifunctor natural iso.
+* `Etingof.rearrangeComplex` — the complex-level `ChainComplex (ModuleCat k) ℕ` iso
+  `(tensorRightFunctorₖ (N₁⊗ₖN₂)).mapHC.obj (extTensorComplex P₁ P₂) ≅ tensorObj C₁ C₂`, built by
+  `mapBifunctorPostcompIso` (#6743) ≪≫ `HomologicalComplex₂.total.mapIso` of the bicomplex iso.
+* `Etingof.rearrangeComplex_hom_f_ιMapBifunctor` — the `@[reassoc]` summand-pinning lemma the
+  Künneth `Tor` assembler (#6657) rewrites against.
+
+Sorry-free; `#print axioms` for both `rearrangeComplex` and the summand lemma limited to
+`propext, Classical.choice, Quot.sound`. `lake build …Chapter8.RearrangeComplex` exits 0 with no
+warnings from the new file.
+
+## Key patterns / decisions
+
+* `HomologicalComplex₂.total.mapIso` is the lever: it promotes a **bicomplex** iso to a total-complex
+  iso, discharging the Koszul-signed differential commutation automatically. So the only real content
+  is the bicomplex iso, whose two differential squares are literally the bifunctor natural-iso's
+  naturality squares (`rearrangeBifunctorNatIsoApp` in the second variable, `rearrangeBifunctorNatIso`
+  in the first).
+* Route steps 2 and 3 fuse: `factorTensorFunctor` agrees **definitionally** with `curriedTensor`
+  post-composed on each factor by `tensorRightFunctorₖ` (the `rfl`-lemmas
+  `factorTensorFunctor_obj_map` / `_map_app` of the NatIso file), so the `factorTensorFunctor`-bicomplex
+  on `(P₁, P₂)` and the `curriedTensor`-bicomplex on `(C₁, C₂)` are the same object — no separate
+  identification iso needed.
+* Working against `postcompBifunctor extTensorFunctor G` (not the named `extTensorRightFunctor` def)
+  keeps the `PreservesZeroMorphisms` instances from `MapBifunctorPostcomp.lean` visible to typeclass
+  search.
+
+## Current frontier
+
+`rearrangeComplex` (the rearrangement half of Problem 8.2.8 `Tor`) is complete. #6657 (Künneth for
+`Tor` over `A₁ ⊗ A₂`) was `blocked on #6744`; it should unblock once this PR merges.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing across chapters. Problem 8.2.8 `Tor` thread: milestones (a)
+`rearrangeBidegree`, (b) `rearrangeBidegree_naturality`, step 1 `mapBifunctorPostcompIso` (#6743),
+step 2 `rearrangeBifunctorNatIso` (#6742), and now step 3 `rearrangeComplex` (#6744) are all landed.
+Remaining: #6657 Künneth assembly (tensor-of-resolutions + algebraic Künneth over the field).
+
+## Next step
+
+A worker should claim #6657 (now unblockable): combine `rearrangeComplex` with
+`Chapter7/KunnethChainComplexNat.lean` and the tensor-of-resolutions `ProjectiveResolution` (#6683)
+to derive the Künneth formula for `Tor` over `A₁ ⊗ A₂`. The summand lemma
+`rearrangeComplex_hom_f_ιMapBifunctor` is provided for that rewrite.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6744

Session: `e0d5d0ad-38df-436d-9fba-a1e5bf65f4e5`

065d46a3 docs: progress entry for #6744 rearrangeComplex (step 3 assembly)
d1749e0e feat(Ch8 #6744): rearrangeComplex_hom_f_ιMapBifunctor summand simp lemma
a8511b0e feat(Ch8 #6744): rearrangeComplex — complex-level Tor Künneth rearrangement iso (step 3)

🤖 Prepared with Claude Code