### PR TITLE
feat(Ch8 #6756): reduce quasiIso to a single degree-0 goal — restriction-of-scalars reduction, iso transport, and positive-degree acyclicity (degree 0 remains)

### DIFF
--- a/EtingofRepresentationTheory/Chapter8/ExternalTensorResolution.lean
+++ b/EtingofRepresentationTheory/Chapter8/ExternalTensorResolution.lean
@@ -166,17 +166,44 @@ theorem homology_tensorObj_res_isZero_succ
 /-- The **external tensor product of two projective resolutions** `P•₁ ⊗_k P•₂` is a projective
 resolution of `M₁ ⊗[k] M₂` over `(A₁ ⊗[k] A₂)ᵐᵒᵖ`. The complex and augmentation are the total
 complex `extTensorComplex P₁ P₂` and its augmentation `extTensorπ P₁ P₂`; degreewise projectivity is
-`extTensorComplex_projective`. The `quasiIso` obligation (exactness of the resolution) is currently
-`sorry` — see the module docstring for the route. -/
+`extTensorComplex_projective`.
+
+Exactness of the resolution (`quasiIso`): restriction of scalars to `k` reflects `QuasiIso` (it
+preserves homology, `restrictScalars_preservesHomology`, and reflects isomorphisms), so it suffices
+to check the restricted map, which `extTensorComplex_restrictIso` (#6738) identifies with the
+augmentation of the `k`-tensor total complex `res₁Complex P₁ ⊗ res₂Complex P₂ → res₁ M₁ ⊗ res₂ M₂`.
+That is a quasi-isomorphism degreewise: positive degrees by the acyclicity
+`homology_tensorObj_res_isZero_succ`, and degree `0` by the tensor-cokernel isomorphism. -/
 noncomputable def extTensorProjectiveResolution
     (P₁ : ProjectiveResolution M₁) (P₂ : ProjectiveResolution M₂) :
     ProjectiveResolution (ModuleCat.of (A₁ ⊗[k] A₂)ᵐᵒᵖ (M₁ ⊗[k] M₂)) where
   complex := extTensorComplex P₁ P₂
   projective := extTensorComplex_projective P₁ P₂
   π := extTensorπ P₁ P₂
-  -- Remaining: assemble `QuasiIso` from `homology_tensorObj_res_isZero_succ` (positive degrees)
-  -- and the degree-`0` augmentation isomorphism, transported by `extTensorComplex_restrictIso`
-  -- (#6738). Positive-degree acyclicity is proved above; see the module docstring for the route.
-  quasiIso := sorry
+  quasiIso := by
+    haveI : (resExt k A₁ A₂).PreservesHomology :=
+      restrictScalars_preservesHomology (algebraMap k (A₁ ⊗[k] A₂)ᵐᵒᵖ)
+    rw [← HomologicalComplex.quasiIso_map_iff_of_preservesHomology (extTensorπ P₁ P₂)
+      (resExt k A₁ A₂)]
+    set sIso := extTensorComplex_restrictIso (k := k) P₁ P₂ with hsIso
+    set tIso := (HomologicalComplex.singleMapHomologicalComplex (resExt k A₁ A₂)
+        (ComplexShape.down ℕ) 0).app (extTensorFunctorObj k A₁ A₂ M₁ M₂) ≪≫
+      (ChainComplex.single₀ (ModuleCat.{u} k)).mapIso
+        (extRestrictObjIso (k := k) M₁ M₂) with htIso
+    set Φ := sIso.inv ≫ ((resExt k A₁ A₂).mapHomologicalComplex (ComplexShape.down ℕ)).map
+      (extTensorπ P₁ P₂) ≫ tIso.hom with hΦ
+    suffices hQ : QuasiIso Φ by
+      have heq : ((resExt k A₁ A₂).mapHomologicalComplex (ComplexShape.down ℕ)).map
+          (extTensorπ P₁ P₂) = sIso.hom ≫ Φ ≫ tIso.inv := by
+        rw [hΦ]; simp
+      rw [heq]; infer_instance
+    rw [quasiIso_iff]
+    rintro (_ | n)
+    · -- degree `0`: the tensor-cokernel augmentation isomorphism.
+      sorry
+    · -- positive degrees: source is acyclic, target is `single₀`.
+      rw [quasiIsoAt_iff_exactAt' _ _ (ChainComplex.exactAt_succ_single_obj _ _),
+        HomologicalComplex.exactAt_iff_isZero_homology]
+      exact homology_tensorObj_res_isZero_succ P₁ P₂ n
 
 end Etingof

--- a/progress/2026-07-16T07-42-16Z_2b4bf6ba.md
+++ b/progress/2026-07-16T07-42-16Z_2b4bf6ba.md
@@ -1,0 +1,83 @@
+## Accomplished
+
+Feature session on #6756 (`fill extTensorProjectiveResolution.quasiIso`). Landed the
+**reduction scaffolding + positive-degree half** of the `quasiIso` obligation in
+`EtingofRepresentationTheory/Chapter8/ExternalTensorResolution.lean`. The `quasiIso` field now:
+
+1. **Reduces to `ModuleCat k`** — `HomologicalComplex.quasiIso_map_iff_of_preservesHomology
+   (extTensorπ P₁ P₂) (resExt k A₁ A₂)`, with `(resExt k A₁ A₂).PreservesHomology` supplied by
+   `restrictScalars_preservesHomology (algebraMap k (A₁ ⊗[k] A₂)ᵐᵒᵖ)` (`.Additive`,
+   `.ReflectsIsomorphisms` are Mathlib instances).
+2. **Transports source/target along isos** — `sIso := extTensorComplex_restrictIso (k := k) P₁ P₂`
+   and `tIso := (singleMapHomologicalComplex (resExt …) (down ℕ) 0).app _ ≪≫
+   (single₀ (ModuleCat k)).mapIso (extRestrictObjIso (k := k) M₁ M₂)`, conjugating to
+   `Φ := sIso.inv ≫ (resExt …).mapHomologicalComplex _ |>.map (extTensorπ P₁ P₂) ≫ tIso.hom`. Since
+   `sIso.hom`/`tIso.inv` are (quasi-)isos, `QuasiIso (resExt.map extTensorπ) ⟺ QuasiIso Φ`.
+3. **Degreewise split** (`rw [quasiIso_iff]; rintro (_ | n)`): the **positive-degree** case `n + 1`
+   is closed via `quasiIsoAt_iff_exactAt' _ _ (ChainComplex.exactAt_succ_single_obj _ _)` then
+   `HomologicalComplex.exactAt_iff_isZero_homology` and the predecessor's
+   `homology_tensorObj_res_isZero_succ P₁ P₂ n`.
+
+`lake build EtingofRepresentationTheory.Chapter8.ExternalTensorResolution` exits 0 with exactly one
+`sorry` (degree 0, line ~191). Positive degrees, reduction, and transport all compile.
+
+Key gotcha resolved: the `{k}` implicit of `extTensorComplex_restrictIso` / `extRestrictObjIso` is
+**not** determined by `P₁ P₂` (their types don't mention `k`), so it must be passed as `(k := k)` or
+elaboration gets a stuck `Algebra ?m A₂`. Also the standalone-theorem statement
+`QuasiIso (extTensorπ P₁ P₂)` fails to elaborate outside the structure field (same instance stuck),
+so the proof lives inline in `quasiIso := by …`.
+
+## Current frontier
+
+The single remaining `sorry` is the **degree-0 augmentation isomorphism**:
+`QuasiIsoAt Φ 0` where `Φ : tensorObj (res₁Complex P₁) (res₂Complex P₂) ⟶ single₀ (res₁ M₁ ⊗ res₂ M₂)`.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing; Chapter 8 Problem 8.2.8 `Tor` line. This issue is the last glue for
+`extTensorProjectiveResolution` (#6729); its `quasiIso` is now reduced to one clean degree-0 goal.
+
+## Next step
+
+Prove `QuasiIsoAt Φ 0` (degree-0 branch, currently `sorry`). Route (all in `ModuleCat k`, so no
+instance-stuck issues once inside the goal):
+
+1. `rw [quasiIsoAt_iff_isIso_homologyMap]` → `IsIso (homologyMap Φ 0)`. For a chain complex,
+   `homologyι 0` is iso, so `homologyMap Φ 0` is conjugate (via `isoHomologyι₀` +
+   `isoHomologyι₀_inv_naturality`, `Algebra/Homology/ShortComplex/HomologicalComplex.lean`) to
+   `opcyclesMap Φ 0`. Reduce to `IsIso (opcyclesMap Φ 0)`.
+2. **Bridge (i): identify `Φ.f 0 = p₁ ⊗ p₂`** where `p₁ = (res₁ k A₁).map ((toSingle₀Equiv P₁.complex
+   M₁) P₁.π).1 : C₁.X 0 → res₁ M₁`, `p₂` similarly. Purpose-built API:
+   `Etingof.ι_extRestrictComplexXIso_aug₀` (`Chapter8/ExternalTensorRestriction.lean`) gives exactly
+   this square. `(extTensorπ P₁ P₂).f 0 = extTensorAug₀ P₁ P₂` by
+   `ChainComplex.toSingle₀Equiv_symm_apply_f_zero`. At degree 0 there is a single Künneth summand
+   `(0,0)`, so `ιMapBifunctor … 0 0 0` is iso — use `ι_extRestrictComplexXIso_hom/inv` and
+   `HomologicalComplex.singleMapHomologicalComplex_hom_app_self` to push `sIso.inv.f 0` / `tIso.hom.f 0`
+   through.
+3. **Bridge (ii): `Φ.f 0` is a cokernel of `Φ.source.d 1 0`.** Two equivalent options:
+   * *Categorical:* `MonoidalClosed (ModuleCat k)` ⟹ `PreservesColimits (tensorLeft A)` /
+     `tensorRight` (`CategoryTheory/Monoidal/Closed/Basic.lean:134`). `p₁ ⊗ p₂ = (p₁ ▷ C₂.X0) ≫
+     (res₁M₁ ◁ p₂)`; each factor is a cokernel (of `C₁.d 1 0 ▷ …` resp. `… ◁ C₂.d 1 0`) via
+     `isColimitOfPreserves` applied to `P₁.isColimitCokernelCofork` / `P₂.…`
+     (`Preadditive/Projective/Resolution.lean:108`). Compose to a cokernel of `d 1 0` (unfold with
+     `HomologicalComplex.mapBifunctor.d_eq` for `curriedTensor (ModuleCat k)`; signs are units,
+     irrelevant to range/cokernel). Then `ShortComplex.Exact.gIsCokernel`
+     (`ShortComplex/Exact.lean:764`).
+   * *Concrete module-level:* `ShortComplex` exactness in `ModuleCat k` = `range (d 1 0) = ker
+     (p₁ ⊗ p₂)` + surjectivity. `TensorProduct.map_surjective`, `rTensor_exact`/`lTensor_exact`
+     (`LinearAlgebra/TensorProduct/RightExactness.lean`), and
+     `TensorProduct.quotientTensorQuotientEquiv` (`…/TensorProduct/Quotient.lean`) give the identity
+     `ker(p₁⊗p₂) = range(ker p₁ ⊗ 1) + range(1 ⊗ ker p₂) = range(d₁⊗1)+range(1⊗d₂)`. `range(dᵢ) =
+     ker(pᵢ)` is the degree-0 exactness of the resolution (`P.isColimitCokernelCofork` ⟹ epi + exact).
+4. Given `Φ.f 0` cokernel: `opcyclesMap Φ 0 = K.descOpcycles (Φ.f 0) … ≫ L.pOpcycles 0`, both iso
+   (`K.opcyclesIsCokernel` + comparison of colimit coforks for the first; `single₀` cokernel-of-zero
+   for the second). Conclude `IsIso (homologyMap Φ 0)`.
+
+Estimated ~150-250 lines; consider a standalone helper lemma
+`quasiIsoAt_zero_of_isColimit_cokernelCofork` (reverse of `ProjectiveResolution.isColimitCokernelCofork`)
+to isolate step 4 from the tensor-specific steps 2-3.
+
+## Blockers
+
+None. All dependencies (#6738, #6735) merged. Remaining work is a single well-scoped degree-0 goal
+atop a compiling scaffold.


### PR DESCRIPTION
Partial progress on #6756

Session: `2b4bf6ba-f937-4c83-9fc2-d130e44272d6`

42fd2383 progress(#6756): degree-0 handoff — scaffolding + positive degrees done, degree-0 route documented
02f331e2 feat(Ch8 #6756): WIP quasiIso scaffolding — reduce to ModuleCat k, transport isos, positive degrees done (degree 0 sorry)

🤖 Prepared with Claude Code