### PR TITLE
feat(Ch6 #Problem6.1.3-a): isDynkinDiagram_A + isDynkinDiagram_D — the Aₙ/Dₙ families are Dynkin diagrams (close the last two part-(a) sorries via isDynkinDiagram_of_type, mirroring isDynkinDiagram_E)

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_E7_E8.lean
+++ b/EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_E7_E8.lean
@@ -299,16 +299,20 @@ theorem det_cartan_D (n : ℕ) (hn : 4 ≤ n) :
   obtain ⟨m, rfl⟩ : ∃ m, n = m + 4 := ⟨n - 4, by omega⟩
   rw [cartan_D_eq_dCartan (m + 4) hn, det_dCartan m]
 
-/-- **(a)** `Aₙ` is a Dynkin diagram (its Cartan form is positive definite),
-deduced from `det > 0` of all leading minors via Sylvester's criterion. -/
+/-- **(a)** `Aₙ` is a Dynkin diagram (its Cartan form is positive definite).
+Sylvester's criterion reads the positivity off the leading principal minors,
+whose values are the `det_cartan_A (= n+1)` computation; the underlying
+positive-definiteness is packaged in `isDynkinDiagram_of_type`. -/
 theorem isDynkinDiagram_A (n : ℕ) (hn : 1 ≤ n) :
-    IsDynkinDiagram (DynkinType.A n hn).rank (DynkinType.A n hn).adj := by
-  sorry
+    IsDynkinDiagram (DynkinType.A n hn).rank (DynkinType.A n hn).adj :=
+  isDynkinDiagram_of_type (.A n hn)
 
-/-- **(a)** `Dₙ` is a Dynkin diagram. -/
+/-- **(a)** `Dₙ` is a Dynkin diagram. Sylvester's criterion reads the positivity
+off the leading principal minors (`det_cartan_D (= 4)` being the top minor); the
+positive-definiteness is supplied by `isDynkinDiagram_of_type`. -/
 theorem isDynkinDiagram_D (n : ℕ) (hn : 4 ≤ n) :
-    IsDynkinDiagram (DynkinType.D n hn).rank (DynkinType.D n hn).adj := by
-  sorry
+    IsDynkinDiagram (DynkinType.D n hn).rank (DynkinType.D n hn).adj :=
+  isDynkinDiagram_of_type (.D n hn)
 
 /-! ## Part (b): determinants of `E₆, E₇, E₈`, and they are Dynkin diagrams -/
 

--- a/progress/2026-07-16T08-16-14Z_81b8253e.md
+++ b/progress/2026-07-16T08-16-14Z_81b8253e.md
@@ -1,0 +1,26 @@
+## Accomplished
+Closed the two remaining part-(a) sorries of Problem 6.1.3(continued) in
+`EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_E7_E8.lean`
+(issue #6769):
+- `isDynkinDiagram_A (n) (hn : 1 ≤ n)` — now `isDynkinDiagram_of_type (.A n hn)`
+- `isDynkinDiagram_D (n) (hn : 4 ≤ n)` — now `isDynkinDiagram_of_type (.D n hn)`
+
+Both mirror the sibling `isDynkinDiagram_E`, delegating positive-definiteness to
+`isDynkinDiagram_of_type` from `DynkinTypes.lean`. Doc comments connect the
+`det_cartan_A`/`det_cartan_D` leading-minor determinants to the Sylvester-criterion
+reading in the book; the `det_cartan_*` lemmas are untouched.
+
+## Current frontier
+Part-(a) block (lines 302-311) is sorry-free. `lake build` of the module exits 0.
+`#print axioms` for both theorems shows only `[propext, Classical.choice, Quot.sound]`.
+
+## Overall project progress
+Stage 3 formalization ongoing. Problem 6.1.3: parts (a)/(b) Dynkin-diagram
+statements now complete; remaining sorries in the file are part (c)
+(`isDynkinDiagram_isTree`, #6765) and part (d) degree restrictions (#6768/#6760).
+
+## Next step
+Pick up another unclaimed feature issue (e.g. #6765 part-c tree, or #6732 Ch2).
+
+## Blockers
+None.


### PR DESCRIPTION
Closes #6769

Session: `81b8253e-3b44-40e6-a3f8-c6655b97c581`

ee87c7f7 feat(Ch6 #Problem6.1.3-a): prove isDynkinDiagram_A + isDynkinDiagram_D

🤖 Prepared with Claude Code