### PR TITLE
feat(Ch6 #Problem6.1.3-c): isDynkinDiagram_isTree — a Dynkin diagram is a tree (acyclicity from positive-definiteness via singular cycle sub-Cartan, then connected+acyclic ⟹ 2(n-1) edges)

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_E7_E8.lean
+++ b/EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_E7_E8.lean
@@ -412,11 +412,101 @@ theorem cycle_cartan_det_zero (n : ℕ) (hn : 3 ≤ n) :
 /-- **(c)** A Dynkin diagram is a **tree**: being connected (part of
 `IsDynkinDiagram`) and positive definite forces the number of edges to be
 `n - 1` (equivalently, `Γ` has no cycle). We record the tree condition as
-"the total number of ordered adjacent pairs is `2·(n-1)`". -/
+"the total number of ordered adjacent pairs is `2·(n-1)`".
+
+The proof splits the tree edge-count `e = n - 1` into two inequalities.
+
+* **Upper bound `e ≤ n - 1` (no cycles).** Testing positive definiteness against
+  the all-ones vector `x = (1, …, 1)` gives `0 < xᵀ A x = 2n - ∑ᵢ∑ⱼ adjᵢⱼ`, i.e.
+  `∑ᵢ∑ⱼ adjᵢⱼ = 2e < 2n`, so `e < n`. (A connected graph with a cycle would have
+  `e ≥ n`, so this is exactly the book's "`Γ` has no cycle".)
+* **Lower bound `e ≥ n - 1` (connectivity).** The connectivity clause of
+  `IsDynkinDiagram` makes the associated `SimpleGraph` connected, and a connected
+  graph on `n` vertices has at least `n - 1` edges
+  (`SimpleGraph.Connected.card_vert_le_card_edgeSet_add_one`).
+
+The `1 ≤ n` hypothesis is essential: at `n = 0` the RHS is `-2` while the empty
+diagram vacuously satisfies `IsDynkinDiagram`, so the statement is false there
+(the all-ones test vector degenerates to `0`, and a tree needs at least one
+vertex for the `n - 1` edge count to make sense). -/
 theorem isDynkinDiagram_isTree {n : ℕ} {adj : Matrix (Fin n) (Fin n) ℤ}
-    (hD : IsDynkinDiagram n adj) :
+    (hn : 1 ≤ n) (hD : IsDynkinDiagram n adj) :
     (∑ i, ∑ j, adj i j) = 2 * ((n : ℤ) - 1) := by
-  sorry
+  classical
+  obtain ⟨hsymm, hdiag, h01, hconn, hpos⟩ := hD
+  have hsymm' : ∀ a b, adj a b = adj b a := fun a b => by
+    have h := congrFun (congrFun hsymm b) a
+    rw [Matrix.transpose_apply] at h; exact h
+  -- The simple graph of the diagram: `i — j` iff `adjᵢⱼ = 1`.
+  let G : SimpleGraph (Fin n) :=
+    { Adj := fun i j => adj i j = 1
+      symm := ⟨fun i j h => by rw [hsymm' j i]; exact h⟩
+      loopless := ⟨fun i h => by rw [hdiag i] at h; exact absurd h (by norm_num)⟩ }
+  have hGadj : ∀ a b, adj a b = 1 → G.Adj a b := fun _ _ h => h
+  haveI hNe : Nonempty (Fin n) := ⟨⟨0, by omega⟩⟩
+  -- Connectivity: transport the `List`-path clause into `SimpleGraph.Connected`.
+  have hpre : G.Preconnected := by
+    intro i j
+    obtain ⟨p, hhead, hlast, hpath⟩ := hconn i j
+    have hne : p ≠ [] := by rintro rfl; simp at hhead
+    have hchain : List.IsChain (fun a b => adj a b = 1) p := by
+      rw [List.isChain_iff_getElem]; intro k hk; exact hpath k hk
+    have hi : p.head hne = i :=
+      Option.some_inj.mp ((List.head?_eq_some_head hne).symm.trans hhead)
+    have hj : p.getLast hne = j := by
+      have := (List.getLast?_eq_getLast_of_ne_nil hne).symm.trans hlast
+      exact Option.some_inj.mp this
+    have hrtg := List.relationReflTransGen_of_exists_isChain p hchain hne
+    rw [hi, hj] at hrtg
+    exact (SimpleGraph.reachable_iff_reflTransGen i j).mpr
+      (Relation.ReflTransGen.mono (fun a b h => hGadj a b h) hrtg)
+  have hconn' : G.Connected := ⟨hpre⟩
+  -- Edge-count translation: `∑ᵢ∑ⱼ adjᵢⱼ = 2 · #edges`.
+  have hcount : (∑ i, ∑ j, adj i j) = 2 * (#G.edgeFinset : ℤ) := by
+    have hterm : ∀ p : Fin n × Fin n,
+        adj p.1 p.2 = (if adj p.1 p.2 = 1 then (1 : ℤ) else 0) := by
+      intro p; rcases h01 p.1 p.2 with h | h <;> simp [h]
+    calc (∑ i, ∑ j, adj i j)
+        = ∑ p : Fin n × Fin n, adj p.1 p.2 := (Fintype.sum_prod_type' adj).symm
+      _ = ∑ p : Fin n × Fin n, (if adj p.1 p.2 = 1 then (1 : ℤ) else 0) :=
+            Finset.sum_congr rfl (fun p _ => hterm p)
+      _ = ((univ.filter fun p : Fin n × Fin n => adj p.1 p.2 = 1).card : ℤ) := by
+            rw [Finset.sum_boole]
+      _ = ((2 * #G.edgeFinset : ℕ) : ℤ) := by rw [G.two_mul_card_edgeFinset]
+      _ = 2 * (#G.edgeFinset : ℤ) := by push_cast; ring
+  -- Lower bound: a connected graph has at least `n - 1` edges.
+  have hlb : n ≤ #G.edgeFinset + 1 := by
+    have h := hconn'.card_vert_le_card_edgeSet_add_one
+    rwa [Nat.card_fin, Nat.card_eq_fintype_card, ← SimpleGraph.edgeFinset_card] at h
+  -- Upper bound: positive definiteness against the all-ones vector.
+  have hub : (∑ i, ∑ j, adj i j) < 2 * (n : ℤ) := by
+    have hxne : (fun _ : Fin n => (1 : ℤ)) ≠ 0 := by
+      intro h; have := congrFun h ⟨0, by omega⟩; simp at this
+    have hp := hpos (fun _ => 1) hxne
+    have hone : ∀ i j : Fin n,
+        (2 • (1 : Matrix (Fin n) (Fin n) ℤ)) i j = if i = j then 2 else 0 := by
+      intro i j; simp only [Matrix.smul_apply, Matrix.one_apply, two_nsmul]
+      split_ifs <;> norm_num
+    have hrow : ∀ i : Fin n,
+        ((2 • (1 : Matrix (Fin n) (Fin n) ℤ) - adj).mulVec (fun _ => 1)) i
+          = 2 - ∑ j, adj i j := by
+      intro i
+      simp only [Matrix.mulVec, dotProduct, Matrix.sub_apply, hone, mul_one,
+        Finset.sum_sub_distrib]
+      rw [Finset.sum_ite_eq univ i (fun _ => (2 : ℤ))]; simp
+    have hval : dotProduct (fun _ : Fin n => (1 : ℤ))
+        ((2 • (1 : Matrix (Fin n) (Fin n) ℤ) - adj).mulVec (fun _ => 1))
+        = 2 * (n : ℤ) - ∑ i, ∑ j, adj i j := by
+      simp only [dotProduct, hrow, one_mul, Finset.sum_sub_distrib]
+      rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+      ring
+    rw [hval] at hp; linarith
+  -- Combine: `e = n - 1`, hence `∑ᵢ∑ⱼ adjᵢⱼ = 2(n - 1)`.
+  have hcard_ub : #G.edgeFinset < n := by
+    have : 2 * (#G.edgeFinset : ℤ) < 2 * (n : ℤ) := by rw [← hcount]; exact hub
+    exact_mod_cast (by linarith : (#G.edgeFinset : ℤ) < (n : ℤ))
+  have hcard_eq : #G.edgeFinset = n - 1 := by omega
+  rw [hcount, hcard_eq, Nat.cast_sub hn]; push_cast; ring
 
 /-! ## Part (d): degree restrictions on a Dynkin diagram -/
 

--- a/progress/2026-07-16T08-35-56Z_daddba1c.md
+++ b/progress/2026-07-16T08-35-56Z_daddba1c.md
@@ -1,0 +1,56 @@
+## Accomplished
+
+Proved `isDynkinDiagram_isTree` (Problem 6.1.3 part (c), issue #6765) sorry-free in
+`EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_E7_E8.lean`.
+
+A Dynkin diagram is a tree, recorded as `∑ᵢ∑ⱼ adjᵢⱼ = 2(n-1)`. Instead of the
+issue's suggested cycle-submatrix acyclicity crux (Deliverable 1), I used a
+cleaner two-bound argument:
+
+* **Upper bound `e ≤ n-1` (no cycles).** Positive-definiteness tested against the
+  all-ones vector gives `0 < xᵀ A x = 2n - ∑ᵢ∑ⱼ adjᵢⱼ`, so `2e < 2n`, `e < n`.
+  This is exactly the book's "a cycle makes `det A = 0`, so `Γ` has no cycle": a
+  connected graph with a cycle would have `e ≥ n`.
+* **Lower bound `e ≥ n-1` (connectivity).** The `List`-path connectivity clause is
+  transported into `SimpleGraph.Connected` (via `List.IsChain` →
+  `relationReflTransGen_of_exists_isChain` → `reachable_iff_reflTransGen`), and
+  `SimpleGraph.Connected.card_vert_le_card_edgeSet_add_one` gives `n ≤ e + 1`.
+
+The `∑ᵢ∑ⱼ adjᵢⱼ = 2·#edges` translation uses `SimpleGraph.two_mul_card_edgeFinset`.
+
+`#print axioms isDynkinDiagram_isTree` = `[propext, Classical.choice, Quot.sound]`.
+`lake build` exits 0; no new warnings introduced by this change.
+
+### Statement change (important)
+
+Added a `(hn : 1 ≤ n)` hypothesis. The original statement is **false at `n = 0`**:
+`IsDynkinDiagram 0 adj` is vacuously satisfiable (all five clauses are vacuous over
+`Fin 0`, including positive-definiteness since the only `x : Fin 0 → ℤ` is `0`),
+but the conclusion becomes `∑ = 0 = 2·((0:ℤ)-1) = -2`. The all-ones test vector
+also degenerates to `0` at `n = 0`, so no contradiction is available. `1 ≤ n` is
+the mathematically correct spec (a tree needs at least one vertex for the `n-1`
+edge count). This is the minimal change; no other file references the theorem.
+Posted an explanatory comment on issue #6765.
+
+## Current frontier
+
+Part (c) of Problem 6.1.3 is complete. The file still has out-of-scope sorries:
+part-(a) `isDynkinDiagram_A` / `isDynkinDiagram_D` (lines ~314/319), and part-(d)
+`isDynkinDiagram_unique_degree_three` (line ~617, issue #6768).
+
+## Overall project progress
+
+Chapter 6 Problem 6.1.3 classification push: parts (a) determinants, (b)
+E-determinants + `isDynkinDiagram_E`, (c) tree (this PR), (d) `degree_le_three`
+all landed/landing. Remaining in this file: part-(a) A/D positive-definiteness,
+part-(d) unique degree-three (#6768).
+
+## Next step
+
+A planner may want to note the `1 ≤ n` spec correction if any downstream
+classification theorem consumes `isDynkinDiagram_isTree`. Next unclaimed Ch6 work:
+#6768 (unique degree-three branch point).
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR proves `isDynkinDiagram_isTree` (Problem 6.1.3 part (c)) sorry-free: a Dynkin diagram is a tree, recorded as `∑ᵢ∑ⱼ adjᵢⱼ = 2(n-1)`. The proof avoids the cycle-submatrix acyclicity crux via two bounds — positive-definiteness against the all-ones vector gives `e < n` (no cycles), and the connectivity clause makes the associated `SimpleGraph` connected so `e ≥ n-1` (`SimpleGraph.Connected.card_vert_le_card_edgeSet_add_one`); the `∑ᵢ∑ⱼ adjᵢⱼ = 2·#edges` translation uses `two_mul_card_edgeFinset`.

**Note for review:** this adds a `(hn : 1 ≤ n)` hypothesis. The original statement is false at `n = 0` — `IsDynkinDiagram 0 adj` is vacuously satisfiable (positive-definiteness never fires since the only `Fin 0 → ℤ` is `0`) but the conclusion becomes `0 = -2`. `1 ≤ n` is the correct spec (a tree needs at least one vertex). No other file references the theorem. See the comment on #6765.

`#print axioms isDynkinDiagram_isTree` = `[propext, Classical.choice, Quot.sound]`.

Closes #6765

🤖 Prepared with Claude Code