### PR TITLE
feat(Ch8 #Problem8.2.8-Tor): fill extTensorProjectiveResolution.quasiIso degree-0 goal — tensor-cokernel augmentation iso H₀(C₁⊗C₂) ≅ res₁M₁⊗res₂M₂ (residual of #6756, atop scaffold #6764)

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -84,6 +84,23 @@ apply Sigma.hom_ext; intro b; rw [Sigma.ι_desc_assoc]; exact Projective.factorT
 lesson: when a Mathlib instance/lemma quietly uses full transparency, bypass it with an explicit
 term rather than fighting heartbeats.
 
+**When an inline proof over huge *concrete* terms times out heartbeats, lift the heavy structural
+argument into a standalone helper `def`/lemma whose hypotheses are the *abstract* objects.** Hit in
+#6767 (`Chapter8/ExternalTensorResolution.lean`): the degree-0 `quasiIso` goal assembled a cokernel
+of `(tensorObj (res₁Complex P₁) (res₂Complex P₂)).d 1 0` via `Cofork.IsColimit.mk` +
+`mapBifunctor.hom_ext` + `Cofork.IsColimit.π_desc`; inline these tactics run their `isDefEq`/`whnf`
+on the enormous restricted-external-tensor complexes and blow 200k heartbeats. **Fix:** extract
+`isColimitCokernelCofork_tensorObj_augmentation {C₁ C₂ : ChainComplex (ModuleCat k) ℕ} … : IsColimit
+(CokernelCofork.ofπ q _)` taking `C₁ C₂ q p₁ p₂` and the cofork/`ιTensorObj`-identity hypotheses as
+*variables* — the colimit bookkeeping now elaborates on symbols (fast), and the concrete call site
+is a single `exact`. (`IsColimit` is `Type`, not `Prop`, so the helper is a `noncomputable def`, not
+a `theorem`.) Two `Cofork` gotchas from that proof: `CokernelCofork.tensor c₁ c₂` is *definitionally*
+a `CokernelCofork.ofπ`, so a bare `rw [CokernelCofork.π_ofπ]` will collapse `Cofork.π (tensor …)` —
+rewrite it via your own `hππ : Cofork.π (tensor …) = p₁ ⊗ₘ p₂` *before* any `π_ofπ` fires; and
+`s.condition` on a `CokernelCofork s` resolves to the general `Cofork.condition` (`f ≫ π = 0 ≫ π`,
+leaving a `0 ≫ π`), so use `CokernelCofork.condition s` (`f ≫ π = 0`) instead. For a functor-category
+iso `α : F ≅ G`, the simp lemma for `(α.app X).hom` is `Iso.app_hom` (not `NatIso.app_hom`).
+
 **The Chapter 8 `Tor` rearrangement stack carries a *second* `Module k` action on the same
 carrier — restriction-through-`Aᵐᵒᵖ` vs `TensorProduct`-diagonal — that is defeq-*false*.** Hit in
 #6742 (`Chapter8/RearrangeBifunctorNatIso.lean`). `tensorRightFunctorₖ.obj` equips `tensorOver A N M`

--- a/EtingofRepresentationTheory/Chapter8/ExternalTensorResolution.lean
+++ b/EtingofRepresentationTheory/Chapter8/ExternalTensorResolution.lean
@@ -163,6 +163,44 @@ theorem homology_tensorObj_res_isZero_succ
   · exact TensorExtend.isZero_tensorObj_left
       (homology_mapHomologicalComplex_projective_isZero_succ P₁ (res₁ k A₁) p')
 
+/-- **Reverse of `ProjectiveResolution.isColimitCokernelCofork`.** If a chain map
+`φ : K ⟶ single₀ N` (over an abelian category) has its degree-`0` component `φ.f 0` exhibiting `N`
+as the cokernel of `K.d 1 0`, then `φ` is a quasi-isomorphism at degree `0`. The homology at `0`
+of a chain complex is its degree-`0` opcycles (`isoHomologyι₀`), and both `K.pOpcycles 0` and
+`φ.f 0` are cokernels of `K.d 1 0`, so the comparison of the two cokernels shows `opcyclesMap φ 0`
+is an isomorphism. -/
+theorem quasiIsoAt_zero_of_isColimitCokernelCofork {V : Type*} [Category V] [Abelian V]
+    {K : ChainComplex V ℕ} {N : V} (φ : K ⟶ (ChainComplex.single₀ V).obj N)
+    (hc : IsColimit (CokernelCofork.ofπ (φ.f 0)
+      (show K.d 1 0 ≫ φ.f 0 = 0 by
+        rw [← φ.comm 1 0, HomologicalComplex.single_obj_d, comp_zero]))) :
+    QuasiIsoAt φ 0 := by
+  rw [quasiIsoAt_iff_isIso_homologyMap]
+  -- The comparison isomorphism between the two cokernels of `K.d 1 0`.
+  have hcompare : K.pOpcycles 0 ≫
+      (IsColimit.coconePointUniqueUpToIso (K.opcyclesIsCokernel 1 0 (by simp)) hc).hom = φ.f 0 := by
+    have := IsColimit.comp_coconePointUniqueUpToIso_hom
+      (K.opcyclesIsCokernel 1 0 (by simp)) hc WalkingParallelPair.one
+    simpa only [Cofork.app_one_eq_π, CokernelCofork.π_ofπ] using this
+  -- `L.pOpcycles 0` is an isomorphism since `L = single₀ N` has `L.d 1 0 = 0`.
+  haveI : IsIso (((ChainComplex.single₀ V).obj N).pOpcycles 0) :=
+    ((ChainComplex.single₀ V).obj N).isIso_pOpcycles 1 0 (by simp)
+      (by rw [HomologicalComplex.single_obj_d])
+  -- Hence `opcyclesMap φ 0 = e.hom ≫ L.pOpcycles 0` is an isomorphism.
+  haveI : IsIso (HomologicalComplex.opcyclesMap φ 0) := by
+    have hmap : HomologicalComplex.opcyclesMap φ 0 =
+        (IsColimit.coconePointUniqueUpToIso (K.opcyclesIsCokernel 1 0 (by simp)) hc).hom ≫
+          ((ChainComplex.single₀ V).obj N).pOpcycles 0 := by
+      rw [← cancel_epi (K.pOpcycles 0), HomologicalComplex.p_opcyclesMap, ← Category.assoc,
+        hcompare]
+    rw [hmap]; infer_instance
+  -- Transport back to `homologyMap` via `isoHomologyι₀`.
+  have key : HomologicalComplex.homologyMap φ 0 =
+      K.isoHomologyι₀.hom ≫ HomologicalComplex.opcyclesMap φ 0 ≫
+        ((ChainComplex.single₀ V).obj N).isoHomologyι₀.inv := by
+    rw [← ChainComplex.isoHomologyι₀_inv_naturality, Iso.hom_inv_id_assoc]
+  rw [key]; infer_instance
+
 /-- The **external tensor product of two projective resolutions** `P•₁ ⊗_k P•₂` is a projective
 resolution of `M₁ ⊗[k] M₂` over `(A₁ ⊗[k] A₂)ᵐᵒᵖ`. The complex and augmentation are the total
 complex `extTensorComplex P₁ P₂` and its augmentation `extTensorπ P₁ P₂`; degreewise projectivity is

--- a/EtingofRepresentationTheory/Chapter8/ExternalTensorResolution.lean
+++ b/EtingofRepresentationTheory/Chapter8/ExternalTensorResolution.lean
@@ -31,26 +31,24 @@ Over a field every module is flat, so the obstruction vanishes. Accordingly the 
 `[Field k]`; nothing downstream consumes the (over-general, previously `[CommRing k]`) resolution
 yet, so tightening the hypothesis is safe.
 
-## Status of `quasiIso`
+## The `quasiIso` obligation
 
-The positive-degree half is proved here: `homology_tensorObj_res_isZero_succ` shows the `k`-tensor
-of the two restricted resolutions is exact in every degree `n + 1`, via the Chapter 7 Künneth
-formula `kunnethChainComplexNat` (`H_{n+1}(C₁ ⊗ C₂) ≅ ⨁_{p+q=n+1} H_p(C₁) ⊗ H_q(C₂)`, every summand
-zero
-since one index is positive and the restricted resolutions are acyclic in positive degrees).
+Exactness of the resolution is proved in full (sorry-free). Restriction of scalars to `k` reflects
+`QuasiIso` (it preserves homology, `restrictScalars_preservesHomology`, and reflects isomorphisms),
+so it suffices to check the restricted augmentation, which `extTensorComplex_restrictIso` (#6738)
+identifies with the augmentation `Φ` of the `k`-tensor total complex
+`res₁Complex P₁ ⊗ res₂Complex P₂ → res₁ M₁ ⊗ res₂ M₂`. That map is a quasi-isomorphism degreewise:
 
-The `quasiIso` field itself is still a `sorry` (a proof obligation *within* the definition; the
-resolution data is real). What remains is the degree-`0` half — that the augmentation induces an
-isomorphism on `H_0`, i.e. `H_0(C₁ ⊗ C₂) ≅ res M₁ ⊗ res M₂` compatibly with the map — together with
-the final assembly. The route (tracked as a follow-up work item) is:
-
-1. Restriction of scalars `ModuleCat (A₁ ⊗ A₂)ᵐᵒᵖ ⥤ ModuleCat k` is exact and conservative, hence
-   reflects `QuasiIso` (`quasiIso_map_iff_of_preservesHomology`).
-2. It carries `extTensorComplex P₁ P₂` to the total `k`-tensor complex of the underlying
-   `k`-complexes of `P•₁`, `P•₂`, via `extTensorComplex_restrictIso` (#6738).
-3. That `k`-tensor augmentation is a quasi-isomorphism: positive degrees by
-   `homology_tensorObj_res_isZero_succ` above, and degree `0` by right-exactness of `⊗` over a field
-   with the map-level `i = 0` square `ι_extRestrictComplexXIso_aug₀` (#6738).
+* **positive degrees** by `homology_tensorObj_res_isZero_succ`: the `k`-tensor of the two restricted
+  resolutions is exact in every degree `n + 1`, via the Chapter 7 Künneth formula
+  `kunnethChainComplexNat` (`H_{n+1}(C₁ ⊗ C₂) ≅ ⨁_{p+q=n+1} H_p(C₁) ⊗ H_q(C₂)`, every summand zero
+  since one index is positive and the restricted resolutions are acyclic in positive degrees);
+* **degree `0`** by `quasiIsoAt_zero_of_isColimitCokernelCofork` together with
+  `isColimitCokernelCofork_tensorObj_augmentation`: `Φ.f 0` is a cokernel of the total-complex
+  differential `d 1 0`. Its degree-`0` component is `res₁ (P₁.π)₀ ⊗ res₂ (P₂.π)₀` (the map-level
+  `i = 0` square `ι_extRestrictComplexXIso_aug₀`, #6738), and the tensor of two cokernels is a
+  cokernel (right-exactness of `⊗`, `CokernelCofork.isColimitTensor`), so it induces an isomorphism
+  on `H_0`.
 -/
 
 open CategoryTheory Limits MonoidalCategory HomologicalComplex TensorProduct MulOpposite
@@ -201,6 +199,79 @@ theorem quasiIsoAt_zero_of_isColimitCokernelCofork {V : Type*} [Category V] [Abe
     rw [← ChainComplex.isoHomologyι₀_inv_naturality, Iso.hom_inv_id_assoc]
   rw [key]; infer_instance
 
+/-- **Tensor of two degree-`0` cokernels is a cokernel of the total-complex differential.** If
+`p₁` (resp. `p₂`) exhibits `N₁` (resp. `N₂`) as the cokernel of `C₁.d 1 0` (resp. `C₂.d 1 0`), then
+any `q : (C₁ ⊗ C₂).X 0 ⟶ N₁ ⊗ N₂` whose restriction to the single degree-`0` summand is
+`p₁ ⊗ p₂` exhibits `N₁ ⊗ N₂` as the cokernel of `(C₁ ⊗ C₂).d 1 0`. This is the categorical
+right-exactness of `⊗` (`CokernelCofork.isColimitTensor`) transported through the identification of
+the total-complex degree-`1 → 0` differential with `coprod.desc (d₁ ▷ ·) (· ◁ d₂)`. Extracted as a
+standalone lemma so the heavy colimit bookkeeping is checked over abstract complexes. -/
+noncomputable def isColimitCokernelCofork_tensorObj_augmentation
+    {C₁ C₂ : ChainComplex (ModuleCat.{u} k) ℕ} [HomologicalComplex.HasTensor C₁ C₂]
+    {N₁ N₂ : ModuleCat.{u} k} {p₁ : C₁.X 0 ⟶ N₁} {p₂ : C₂.X 0 ⟶ N₂}
+    (hp₁comm : C₁.d 1 0 ≫ p₁ = 0) (hp₂comm : C₂.d 1 0 ≫ p₂ = 0)
+    (hc₁ : IsColimit (CokernelCofork.ofπ p₁ hp₁comm))
+    (hc₂ : IsColimit (CokernelCofork.ofπ p₂ hp₂comm))
+    {q : (HomologicalComplex.tensorObj C₁ C₂).X 0 ⟶ N₁ ⊗ N₂}
+    (hqcomm : (HomologicalComplex.tensorObj C₁ C₂).d 1 0 ≫ q = 0)
+    (hq : HomologicalComplex.ιTensorObj C₁ C₂ 0 0 0 rfl ≫ q = MonoidalCategory.tensorHom p₁ p₂) :
+    IsColimit (CokernelCofork.ofπ q hqcomm) := by
+  have htensor := CokernelCofork.isColimitTensor hc₁ hc₂
+  have hππ : Cofork.π (CokernelCofork.tensor (CokernelCofork.ofπ p₁ hp₁comm)
+      (CokernelCofork.ofπ p₂ hp₂comm)) = MonoidalCategory.tensorHom p₁ p₂ := by
+    rw [CokernelCofork.π_ofπ, CokernelCofork.π_ofπ, CokernelCofork.π_ofπ]
+  have hrel1 : HomologicalComplex.ιTensorObj C₁ C₂ 1 0 1 rfl ≫
+      (HomologicalComplex.tensorObj C₁ C₂).d 1 0
+      = (C₁.d 1 0 ▷ C₂.X 0) ≫ HomologicalComplex.ιTensorObj C₁ C₂ 0 0 0 rfl := by
+    rw [HomologicalComplex.mapBifunctor.d_eq, Preadditive.comp_add,
+      HomologicalComplex.mapBifunctor.ι_D₁, HomologicalComplex.mapBifunctor.ι_D₂,
+      HomologicalComplex.mapBifunctor.d₂_eq_zero (K₁ := C₁) (K₂ := C₂)
+        (F := curriedTensor (ModuleCat.{u} k)) (c := ComplexShape.down ℕ)
+        (i₁ := 1) (i₂ := 0) (j := 0) (by rw [ChainComplex.next_nat_zero]; simp [ComplexShape.down_Rel]),
+      HomologicalComplex.mapBifunctor.d₁_eq (K₁ := C₁) (K₂ := C₂)
+        (F := curriedTensor (ModuleCat.{u} k)) (c := ComplexShape.down ℕ)
+        (i₁ := 1) (i₁' := 0) (i₂ := 0) (j := 0) (by simp [ComplexShape.down_Rel])
+        (by simp [ComplexShape.down_Rel]),
+      show ComplexShape.ε₁ (ComplexShape.down ℕ) (ComplexShape.down ℕ)
+        (ComplexShape.down ℕ) (1, 0) = 1 from rfl, one_smul, add_zero]
+    rfl
+  have hrel2 : HomologicalComplex.ιTensorObj C₁ C₂ 0 1 1 rfl ≫
+      (HomologicalComplex.tensorObj C₁ C₂).d 1 0
+      = (C₁.X 0 ◁ C₂.d 1 0) ≫ HomologicalComplex.ιTensorObj C₁ C₂ 0 0 0 rfl := by
+    rw [HomologicalComplex.mapBifunctor.d_eq, Preadditive.comp_add,
+      HomologicalComplex.mapBifunctor.ι_D₁, HomologicalComplex.mapBifunctor.ι_D₂,
+      HomologicalComplex.mapBifunctor.d₁_eq_zero (K₁ := C₁) (K₂ := C₂)
+        (F := curriedTensor (ModuleCat.{u} k)) (c := ComplexShape.down ℕ)
+        (i₁ := 0) (i₂ := 1) (j := 0) (by rw [ChainComplex.next_nat_zero]; simp [ComplexShape.down_Rel]),
+      HomologicalComplex.mapBifunctor.d₂_eq (K₁ := C₁) (K₂ := C₂)
+        (F := curriedTensor (ModuleCat.{u} k)) (c := ComplexShape.down ℕ)
+        (i₁ := 0) (i₂ := 1) (i₂' := 0) (j := 0) (by simp [ComplexShape.down_Rel])
+        (by simp [ComplexShape.down_Rel]),
+      show ComplexShape.ε₂ (ComplexShape.down ℕ) (ComplexShape.down ℕ)
+        (ComplexShape.down ℕ) (0, 1) = 1 from by simp [ComplexShape.ε₂, ComplexShape.ε],
+      one_smul, zero_add]
+    rfl
+  refine Cofork.IsColimit.mk _
+    (fun s => htensor.desc (CokernelCofork.ofπ
+      (HomologicalComplex.ιTensorObj C₁ C₂ 0 0 0 rfl ≫ Cofork.π s) ?_)) ?_ ?_
+  · apply Limits.coprod.hom_ext
+    · rw [Limits.coprod.inl_desc_assoc, comp_zero, ← Category.assoc, ← hrel1, Category.assoc,
+        CokernelCofork.condition s, comp_zero]
+    · rw [Limits.coprod.inr_desc_assoc, comp_zero, ← Category.assoc, ← hrel2, Category.assoc,
+        CokernelCofork.condition s, comp_zero]
+  · intro s
+    apply HomologicalComplex.mapBifunctor.hom_ext
+    intro i₁ i₂ h
+    obtain ⟨rfl, rfl⟩ : i₁ = 0 ∧ i₂ = 0 := by
+      have : i₁ + i₂ = 0 := h
+      omega
+    rw [← Category.assoc, CokernelCofork.π_ofπ, hq, ← hππ, Cofork.IsColimit.π_desc,
+      CokernelCofork.π_ofπ]
+  · intro s m hm
+    rw [CokernelCofork.π_ofπ] at hm
+    apply Cofork.IsColimit.hom_ext htensor
+    rw [Cofork.IsColimit.π_desc, hππ, CokernelCofork.π_ofπ, ← hq, Category.assoc, hm]
+
 /-- The **external tensor product of two projective resolutions** `P•₁ ⊗_k P•₂` is a projective
 resolution of `M₁ ⊗[k] M₂` over `(A₁ ⊗[k] A₂)ᵐᵒᵖ`. The complex and augmentation are the total
 complex `extTensorComplex P₁ P₂` and its augmentation `extTensorπ P₁ P₂`; degreewise projectivity is
@@ -238,7 +309,55 @@ noncomputable def extTensorProjectiveResolution
     rw [quasiIso_iff]
     rintro (_ | n)
     · -- degree `0`: the tensor-cokernel augmentation isomorphism.
-      sorry
+      refine quasiIsoAt_zero_of_isColimitCokernelCofork Φ ?_
+      -- The two degree-`0` augmentations of the restricted resolutions.
+      set p₁ : (res₁Complex P₁).X 0 ⟶ (res₁ k A₁).obj M₁ :=
+        (res₁ k A₁).map ((ChainComplex.toSingle₀Equiv P₁.complex M₁) P₁.π).1 with hp₁def
+      set p₂ : (res₂Complex P₂).X 0 ⟶ (res₂ k A₂).obj M₂ :=
+        (res₂ k A₂).map ((ChainComplex.toSingle₀Equiv P₂.complex M₂) P₂.π).1 with hp₂def
+      -- Restriction of scalars preserves the degree-`0` cokernel, so `pᵢ` is a cokernel of `Cᵢ.d 1 0`.
+      haveI : Limits.PreservesColimits (res₁ k A₁) :=
+        (ModuleCat.restrictCoextendScalarsAdj (algebraMap k A₁ᵐᵒᵖ)).leftAdjoint_preservesColimits
+      haveI : Limits.PreservesColimits (res₂ k A₂) :=
+        (ModuleCat.restrictCoextendScalarsAdj (algebraMap k A₂ᵐᵒᵖ)).leftAdjoint_preservesColimits
+      have hp₁comm : (res₁Complex P₁).d 1 0 ≫ p₁ = 0 := by
+        have h : (res₁Complex P₁).d 1 0 ≫ p₁ = (res₁ k A₁).map (P₁.complex.d 1 0 ≫ P₁.π.f 0) := by
+          rw [Functor.map_comp]; rfl
+        rw [h, ProjectiveResolution.complex_d_comp_π_f_zero, Functor.map_zero]
+      have hp₂comm : (res₂Complex P₂).d 1 0 ≫ p₂ = 0 := by
+        have h : (res₂Complex P₂).d 1 0 ≫ p₂ = (res₂ k A₂).map (P₂.complex.d 1 0 ≫ P₂.π.f 0) := by
+          rw [Functor.map_comp]; rfl
+        rw [h, ProjectiveResolution.complex_d_comp_π_f_zero, Functor.map_zero]
+      have hc₁ : IsColimit (CokernelCofork.ofπ p₁ hp₁comm) :=
+        P₁.cokernelCofork.mapIsColimit P₁.isColimitCokernelCofork (res₁ k A₁)
+      have hc₂ : IsColimit (CokernelCofork.ofπ p₂ hp₂comm) :=
+        P₂.cokernelCofork.mapIsColimit P₂.isColimitCokernelCofork (res₂ k A₂)
+      -- **Gap (A): identify `ι₀₀ ≫ Φ.f 0` with `p₁ ⊗ₘ p₂`.**
+      have h₀ : ComplexShape.π (ComplexShape.down ℕ) (ComplexShape.down ℕ)
+          (ComplexShape.down ℕ) (0, 0) = 0 := rfl
+      have hgapA : HomologicalComplex.ιTensorObj (res₁Complex P₁) (res₂Complex P₂) 0 0 0 rfl ≫
+          Φ.f 0 = MonoidalCategory.tensorHom p₁ p₂ := by
+        have hs0 : sIso.inv.f 0 = (extRestrictComplexXIso P₁ P₂ 0).inv := by rw [hsIso]; rfl
+        have hmid0 : (((resExt k A₁ A₂).mapHomologicalComplex (ComplexShape.down ℕ)).map
+            (extTensorπ P₁ P₂)).f 0 = (resExt k A₁ A₂).map (extTensorAug₀ P₁ P₂) := by
+          show (resExt k A₁ A₂).map ((extTensorπ P₁ P₂).f 0) = _
+          congr 1
+        have ht0 : tIso.hom.f 0 = (extRestrictObjIso M₁ M₂).hom := by
+          rw [htIso, Iso.trans_hom, HomologicalComplex.comp_f, Iso.app_hom,
+            HomologicalComplex.singleMapHomologicalComplex_hom_app_self]
+          simp only [ChainComplex.single₀ObjXSelf, Iso.refl_hom, CategoryTheory.Functor.map_id,
+            Iso.refl_inv, Category.comp_id, Category.id_comp,
+            CategoryTheory.Functor.mapIso_hom, ChainComplex.single₀_map_f_zero]
+          exact Category.id_comp _
+        rw [hΦ]
+        simp only [HomologicalComplex.comp_f]
+        rw [hs0, hmid0, ht0, ← Category.assoc,
+          ι_extRestrictComplexXIso_inv (k := k) P₁ P₂ 0 0 0 h₀, Category.assoc,
+          ι_extRestrictComplexXIso_aug₀ (k := k) P₁ P₂ h₀, Iso.inv_hom_id_assoc]
+      -- **Assemble** the cokernel of `K.d 1 0` from the tensor cokernel (right-exactness of `⊗`).
+      exact isColimitCokernelCofork_tensorObj_augmentation hp₁comm hp₂comm hc₁ hc₂
+        (show (HomologicalComplex.tensorObj (res₁Complex P₁) (res₂Complex P₂)).d 1 0 ≫ Φ.f 0 = 0 by
+          rw [← Φ.comm 1 0, HomologicalComplex.single_obj_d, comp_zero]) hgapA
     · -- positive degrees: source is acyclic, target is `single₀`.
       rw [quasiIsoAt_iff_exactAt' _ _ (ChainComplex.exactAt_succ_single_obj _ _),
         HomologicalComplex.exactAt_iff_isZero_homology]

--- a/progress/2026-07-16T09-05-00Z_ecf66527.md
+++ b/progress/2026-07-16T09-05-00Z_ecf66527.md
@@ -1,0 +1,60 @@
+## Accomplished
+
+Feature session on **#6767** (`fill extTensorProjectiveResolution.quasiIso degree-0 goal`).
+Closed the last `sorry` of `extTensorProjectiveResolution` in
+`EtingofRepresentationTheory/Chapter8/ExternalTensorResolution.lean`. `#print axioms
+Etingof.extTensorProjectiveResolution` is now clean (`propext, Classical.choice, Quot.sound` — no
+`sorryAx`).
+
+Two new lemmas were added:
+
+1. `quasiIsoAt_zero_of_isColimitCokernelCofork` — reverse of
+   `ProjectiveResolution.isColimitCokernelCofork`. For a chain map `φ : K ⟶ single₀ N` over an
+   abelian category whose degree-0 component `φ.f 0` is a cokernel of `K.d 1 0`, `φ` is a
+   quasi-iso at `0`. Proof: `homologyMap φ 0` is conjugate to `opcyclesMap φ 0` via `isoHomologyι₀`;
+   `opcyclesMap φ 0 = e.hom ≫ L.pOpcycles 0` where `e` compares the two cokernels of `K.d 1 0`
+   (`K.opcyclesIsCokernel` vs `hc`) and `L.pOpcycles 0` is iso for `single₀`.
+
+2. `isColimitCokernelCofork_tensorObj_augmentation` — the tensor-of-cokernels fact, extracted as a
+   standalone `def` over *abstract* `C₁ C₂ : ChainComplex (ModuleCat k) ℕ` (this was necessary: the
+   full inline proof blew the 200k-heartbeat budget on the huge concrete complexes). Uses Mathlib's
+   `CokernelCofork.isColimitTensor` (right-exactness of `⊗`) and identifies the total-complex
+   differential `d 1 0` with `coprod.desc (d₁ ▷ ·) (· ◁ d₂)` via `mapBifunctor.d_eq`/`d₁_eq`/`d₂_eq`.
+
+The degree-0 branch of `quasiIso` then: builds the two restricted-resolution cokernel coforks
+(`CokernelCofork.mapIsColimit` + `restrictScalars` preserves colimits), proves the gap-(A)
+identity `ι₀₀ ≫ Φ.f 0 = res₁ (P₁.π)₀ ⊗ res₂ (P₂.π)₀` from `ι_extRestrictComplexXIso_inv` +
+`ι_extRestrictComplexXIso_aug₀`, and applies the two helpers.
+
+## Current frontier
+
+`extTensorProjectiveResolution` (#6729/#6727 line) is complete and sorry-free. The
+`ExternalTensorResolution.lean` file builds clean.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing; Chapter 8 Problem 8.2.8 `Tor` line. The external-tensor projective
+resolution is now fully constructed, unblocking `extTensorProjectiveResolution`-dependent work
+(the Künneth-for-Tor capstone #6657).
+
+## Next step
+
+Downstream: the Tor Künneth formula #6657 (`Tor over A₁⊗A₂ = tensor-of-resolutions + algebraic
+Künneth over a field`) can now consume the completed `extTensorProjectiveResolution`. Ch6 Dynkin
+classification pieces (#6765, #6768, #6769) remain unclaimed.
+
+## Blockers
+
+None.
+
+## Key patterns discovered
+
+- **`Iso.app_hom`** (not `NatIso.app_hom`) is the simp lemma for `(α.app X).hom = α.hom.app X` on a
+  functor-category iso.
+- Extracting a heavy colimit-bookkeeping proof into a standalone `def` over abstract complexes keeps
+  each declaration under the heartbeat budget; the concrete instantiation is then a single `exact`.
+- `CokernelCofork.tensor c₁ c₂` is *definitionally* a `CokernelCofork.ofπ`, so `rw
+  [CokernelCofork.π_ofπ]` will collapse `Cofork.π (tensor ...)` — order `π_ofπ`/`hππ` rewrites
+  carefully (use `hππ` to name it before `π_ofπ` fires).
+- `s.condition` on a `CokernelCofork s` resolves to the general `Cofork.condition` (`f ≫ π = 0 ≫ π`);
+  use `CokernelCofork.condition s` for `f ≫ π = 0`.


### PR DESCRIPTION
Closes #6767

Session: `ecf66527-34e1-4170-9380-114f5eb3ac2a`

9d74ea9a chore(#6767): progress file + lean-formalization skill note on extracting heavy colimit proofs
71a97e48 feat(Ch8 #6767): fill extTensorProjectiveResolution.quasiIso degree-0 goal — tensor-cokernel augmentation iso
47555d29 feat(Ch8 #6767): add quasiIsoAt_zero_of_isColimitCokernelCofork helper (reverse of ProjectiveResolution.isColimitCokernelCofork)

🤖 Prepared with Claude Code