### PR TITLE
feat(Ch5 #Problem5.24.2): endTensorEval GL-equivariance — conjAlgHom g intertwines diagonal-operator conjugation g^⊗n on End(V^⊗n)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Problem5_24_2_Bridge.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_24_2_Bridge.lean
@@ -113,6 +113,153 @@ theorem endTensorEval_apply (slot : Fin n → Fin k)
           * genericTensorMatrix k N n slot g f := by
   rfl
 
+/-- `endTensorEval` is `evalMatrix` applied to the matrix of `M` in the standard tensor basis. -/
+theorem endTensorEval_eq_evalMatrix (slot : Fin n → Fin k)
+    (M : Module.End ℂ (TensorPower ℂ (BridgeV N) n)) :
+    endTensorEval k N n slot M
+      = evalMatrix k N n slot (LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) M) :=
+  rfl
+
+/-! ## GL-equivariance of the evaluation pairing
+
+The evaluation pairing intertwines conjugation of an endomorphism `M` of `V^{⊗n}` by the diagonal
+operator `g^{⊗n}` with the simultaneous-conjugation automorphism `conjAlgHom g` of the coordinate
+ring. This is book step of the Schur–Weyl argument: `endTensorEval slot` is `GL(V)`-equivariant.
+-/
+
+/-- `evalMatrix` written as a matrix trace: contracting `A` completely against the generic tensor is
+the trace of `(A.map C) · genericTensorMatrix slot`. -/
+theorem evalMatrix_eq_trace (slot : Fin n → Fin k)
+    (A : Matrix (Fin n → Fin N) (Fin n → Fin N) ℂ) :
+    evalMatrix k N n slot A
+      = Matrix.trace ((A.map (algebraMap ℂ (MatrixTupleRing k N)))
+          * genericTensorMatrix k N n slot) := by
+  change (∑ f : Fin n → Fin N, ∑ g : Fin n → Fin N,
+      algebraMap ℂ (MatrixTupleRing k N) (A f g) * genericTensorMatrix k N n slot g f) = _
+  rw [Matrix.trace]
+  refine Finset.sum_congr rfl fun f _ => ?_
+  rw [Matrix.diag_apply, Matrix.mul_apply]
+  refine Finset.sum_congr rfl fun g _ => ?_
+  rw [Matrix.map_apply]
+
+/-- The matrix, in the standard tensor basis, of the diagonal tensor-power operator
+`PiTensorProduct.map (fun _ => mulVecLin h) = h^{⊗n}` on `V^{⊗n}`: its `(p, q)` entry is the product
+over slots of the matrix entries `h (p j) (q j)`. -/
+theorem toMatrix_piTensorMap_mulVecLin (h : Matrix (Fin N) (Fin N) ℂ) (p q : Fin n → Fin N) :
+    LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n)
+        (PiTensorProduct.map (fun _ : Fin n => Matrix.mulVecLin h)) p q
+      = ∏ j : Fin n, h (p j) (q j) := by
+  rw [LinearMap.toMatrix_apply, tensorBasis, Basis.piTensorProduct_apply,
+    PiTensorProduct.map_tprod, Basis.piTensorProduct_repr_tprod_apply]
+  refine Finset.prod_congr rfl fun j _ => ?_
+  rw [← LinearMap.toMatrix_apply (Pi.basisFun ℂ (Fin N)) (Pi.basisFun ℂ (Fin N))
+        (Matrix.mulVecLin h) (p j) (q j), LinearMap.toMatrix_eq_toMatrix',
+      ← Matrix.toLin'_apply', LinearMap.toMatrix'_toLin']
+
+/-- Conjugation acts on a single coordinate variable by expanding the matrix conjugation
+`X (i, r, c) ↦ (g · Xᵢ · g⁻¹)_{r,c}` into a double sum over the intermediate indices. -/
+theorem conjAlgHom_X_sum (g : (Matrix (Fin N) (Fin N) ℂ)ˣ) (i : Fin k) (r c : Fin N) :
+    conjAlgHom k N g (MvPolynomial.X (i, r, c))
+      = ∑ s : Fin N, ∑ t : Fin N,
+          algebraMap ℂ (MatrixTupleRing k N) ((↑g : Matrix (Fin N) (Fin N) ℂ) r s)
+            * MvPolynomial.X (i, s, t)
+            * algebraMap ℂ (MatrixTupleRing k N) ((↑g⁻¹ : Matrix (Fin N) (Fin N) ℂ) t c) := by
+  rw [conjAlgHom, MvPolynomial.aeval_X]
+  simp only [Matrix.mul_apply, Matrix.map_apply, genericMatrix, Finset.sum_mul]
+  rw [Finset.sum_comm]
+
+/-- **Entrywise conjugation of the generic tensor matrix.** Applying `conjAlgHom g` entrywise to the
+generic tensor matrix conjugates it by the tensor-power matrices of `g` and `g⁻¹`:
+`(genericTensorMatrix slot).map (conjAlgHom g) = (g^{⊗n}) · genericTensorMatrix slot · (g⁻¹)^{⊗n}`
+(all as matrices over the coordinate ring). This is the matrix form of the substitution
+`X (i, r, c) ↦ (g Xᵢ g⁻¹)_{r,c}` propagated across the tensor slots. -/
+theorem genericTensorMatrix_map_conjAlgHom (slot : Fin n → Fin k)
+    (g : (Matrix (Fin N) (Fin N) ℂ)ˣ) :
+    (genericTensorMatrix k N n slot).map (conjAlgHom k N g)
+      = (LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n)
+            (PiTensorProduct.map (fun _ : Fin n =>
+              Matrix.mulVecLin (↑g : Matrix (Fin N) (Fin N) ℂ)))).map
+              (algebraMap ℂ (MatrixTupleRing k N))
+        * genericTensorMatrix k N n slot
+        * (LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n)
+            (PiTensorProduct.map (fun _ : Fin n =>
+              Matrix.mulVecLin (↑g⁻¹ : Matrix (Fin N) (Fin N) ℂ)))).map
+              (algebraMap ℂ (MatrixTupleRing k N)) := by
+  classical
+  refine Matrix.ext fun e f => ?_
+  -- Left side: apply `conjAlgHom` to the monomial `∏ⱼ X (slot j, e j, f j)`, expand each factor as
+  -- a double sum, and collect the product of sums into a double sum over intermediate index
+  -- functions `a, b : Fin n → Fin N` (one application of `prod_univ_sum` per matrix index).
+  rw [Matrix.map_apply]
+  change conjAlgHom k N g (∏ j : Fin n, MvPolynomial.X (slot j, e j, f j)) = _
+  rw [map_prod]
+  simp_rw [conjAlgHom_X_sum]
+  rw [Finset.prod_univ_sum, Fintype.piFinset_univ]
+  simp_rw [Finset.prod_univ_sum, Fintype.piFinset_univ]
+  -- Right side: expand the two matrix products into a `∑ b ∑ a` and swap to `∑ a ∑ b`.
+  rw [Matrix.mul_apply]
+  simp_rw [Matrix.mul_apply, Finset.sum_mul]
+  rw [Finset.sum_comm]
+  refine Finset.sum_congr rfl fun a _ => Finset.sum_congr rfl fun b _ => ?_
+  -- Match a single `(a, b)` term.
+  simp only [Matrix.map_apply, toMatrix_piTensorMap_mulVecLin, genericTensorMatrix]
+  rw [Finset.prod_mul_distrib, Finset.prod_mul_distrib, ← map_prod, ← map_prod]
+
+/-- **GL-equivariance of the evaluation pairing.** The pairing `endTensorEval slot` intertwines
+conjugation of an endomorphism `M` of `V^{⊗n}` by the diagonal operator `g^{⊗n}` with the
+simultaneous-conjugation automorphism `conjAlgHom g` of the coordinate ring:
+`endTensorEval slot ((g^{⊗n})⁻¹ · M · g^{⊗n}) = conjAlgHom g (endTensorEval slot M)`.
+
+Here `g^{⊗n} = PiTensorProduct.map (fun _ => mulVecLin g)` is the diagonal `GL(V)`-action on
+`V^{⊗n}`, and `(g^{⊗n})⁻¹` is the corresponding operator for `g⁻¹`. This is the equivariance glue
+that lets the range identification transport `GL(V)`-invariance of tensors to conjugation-invariance
+of polynomials. -/
+theorem endTensorEval_conj (slot : Fin n → Fin k) (g : (Matrix (Fin N) (Fin N) ℂ)ˣ)
+    (M : Module.End ℂ (TensorPower ℂ (BridgeV N) n)) :
+    endTensorEval k N n slot
+        (PiTensorProduct.map (fun _ : Fin n => Matrix.mulVecLin (↑g⁻¹ : Matrix (Fin N) (Fin N) ℂ))
+          * M
+          * PiTensorProduct.map (fun _ : Fin n => Matrix.mulVecLin (↑g : Matrix (Fin N) (Fin N) ℂ)))
+      = conjAlgHom k N g (endTensorEval k N n slot M) := by
+  set G : Matrix (Fin n → Fin N) (Fin n → Fin N) ℂ :=
+    LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n)
+      (PiTensorProduct.map (fun _ : Fin n => Matrix.mulVecLin (↑g : Matrix (Fin N) (Fin N) ℂ)))
+    with hG
+  set G' : Matrix (Fin n → Fin N) (Fin n → Fin N) ℂ :=
+    LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n)
+      (PiTensorProduct.map (fun _ : Fin n => Matrix.mulVecLin (↑g⁻¹ : Matrix (Fin N) (Fin N) ℂ)))
+    with hG'
+  set A : Matrix (Fin n → Fin N) (Fin n → Fin N) ℂ :=
+    LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) M with hA
+  -- Left side: the matrix of the conjugated endomorphism is `G' · A · G`; evaluate as a trace.
+  have hlhs : endTensorEval k N n slot
+      (PiTensorProduct.map (fun _ : Fin n => Matrix.mulVecLin (↑g⁻¹ : Matrix (Fin N) (Fin N) ℂ))
+        * M
+        * PiTensorProduct.map (fun _ : Fin n => Matrix.mulVecLin (↑g : Matrix (Fin N) (Fin N) ℂ)))
+      = Matrix.trace ((G'.map (algebraMap ℂ (MatrixTupleRing k N))
+            * A.map (algebraMap ℂ (MatrixTupleRing k N))
+            * G.map (algebraMap ℂ (MatrixTupleRing k N))) * genericTensorMatrix k N n slot) := by
+    rw [endTensorEval_eq_evalMatrix, LinearMap.toMatrix_mul, LinearMap.toMatrix_mul,
+      evalMatrix_eq_trace, ← hG, ← hG', ← hA, Matrix.map_mul, Matrix.map_mul]
+  -- Right side: push `conjAlgHom` through the trace, fixing scalar entries and conjugating the
+  -- generic tensor matrix.
+  have hrhs : conjAlgHom k N g (endTensorEval k N n slot M)
+      = Matrix.trace ((G'.map (algebraMap ℂ (MatrixTupleRing k N))
+            * A.map (algebraMap ℂ (MatrixTupleRing k N))
+            * G.map (algebraMap ℂ (MatrixTupleRing k N))) * genericTensorMatrix k N n slot) := by
+    rw [endTensorEval_eq_evalMatrix, ← hA, evalMatrix_eq_trace,
+      AddMonoidHom.map_trace (conjAlgHom k N g), Matrix.map_mul,
+      genericTensorMatrix_map_conjAlgHom, ← hG, ← hG']
+    -- `(A.map C).map (conjAlgHom g) = A.map C` since `conjAlgHom` fixes scalars.
+    have hAfix : (A.map (algebraMap ℂ (MatrixTupleRing k N))).map (conjAlgHom k N g)
+        = A.map (algebraMap ℂ (MatrixTupleRing k N)) := by
+      rw [Matrix.map_map]
+      refine Matrix.ext fun i j => ?_
+      simp only [Matrix.map_apply, Function.comp_apply, AlgHom.commutes]
+    rw [hAfix, ← Matrix.mul_assoc, ← Matrix.mul_assoc, Matrix.trace_mul_comm,
+      ← Matrix.mul_assoc, ← Matrix.mul_assoc]
+  rw [hlhs, hrhs]
+
 /-- **Range identification (statement).** Every fixed-multidegree conjugation-invariant polynomial
 lies in the image, under the evaluation pairing `endTensorEval slot`, of the `GL(V)`-invariant part
 of `End(V)^{⊗n}` — namely `symGroupImage ℂ V n`, the `ℂ`-span of the permutation operators.

--- a/progress/2026-07-16T10-32-36Z_93a64acf.md
+++ b/progress/2026-07-16T10-32-36Z_93a64acf.md
@@ -1,0 +1,47 @@
+## Accomplished
+
+Formalized issue #6787 — GL-equivariance of the coordinate ↔ tensor evaluation pairing
+(`endTensorEval_conj`) in `Chapter5/Problem5_24_2_Bridge.lean`. Added, all sorry-free:
+
+- `evalMatrix_eq_trace` — `evalMatrix` as `trace ((A.map C) * genericTensorMatrix slot)`.
+- `endTensorEval_eq_evalMatrix` — the `rfl` unfolding `endTensorEval slot M = evalMatrix slot (toMatrix M)`.
+- `toMatrix_piTensorMap_mulVecLin` — the tensor-basis matrix of `PiTensorProduct.map (mulVecLin h)`
+  is `∏ⱼ h (p j) (q j)` (via `Basis.piTensorProduct_apply` / `map_tprod` /
+  `piTensorProduct_repr_tprod_apply`, then `LinearMap.toMatrix' (mulVecLin h) = h`).
+- `conjAlgHom_X_sum` — `conjAlgHom g (X (i,r,c))` expanded as the double sum
+  `∑ₛ∑ₜ C(gᵣₛ) · X(i,s,t) · C(g⁻¹ₜc)`.
+- `genericTensorMatrix_map_conjAlgHom` (the crux) — entrywise conjugation of the generic tensor
+  matrix equals conjugation by the tensor-power matrices of `g` and `g⁻¹`. Proved by expanding
+  `conjAlgHom` on the monomial `∏ⱼ X(slot j, e j, f j)` and applying `Finset.prod_univ_sum` once
+  per matrix index (no pair/arrow reindexing needed).
+- `endTensorEval_conj` — the deliverable:
+  `endTensorEval slot ((g^{⊗n})⁻¹ · M · g^{⊗n}) = conjAlgHom g (endTensorEval slot M)`.
+  Assembled via the trace form: LHS matrix is `G'·A·G` (`LinearMap.toMatrix_mul`); RHS pushes
+  `conjAlgHom` through the trace (`AddMonoidHom.map_trace`), fixes the scalar matrix
+  (`AlgHom.commutes`), conjugates the generic tensor matrix, then cycles with `trace_mul_comm`.
+
+The direction stated in the issue is confirmed correct: it is `(g^{⊗n})⁻¹ · M · g^{⊗n}` that
+`endTensorEval` maps to `conjAlgHom g` of the value.
+
+`#print axioms endTensorEval_conj` = `[propext, Classical.choice, Quot.sound]`.
+
+## Current frontier
+
+`Problem5_24_2_Bridge.lean` builds; downstream `Problem5_24_2.lean` builds. The only remaining
+`sorry` in the file is the pre-existing FFT statement
+`weightedHomogeneous_invariant_mem_range_endTensorEval` (unchanged; separate work item).
+
+## Overall project progress
+
+Phase 3 formalization ongoing. This lands the GL-equivariance glue identified as missing
+infrastructure for the Schur–Weyl FFT range-identification (`endTensorEval`).
+
+## Next step
+
+The FFT range-identification sorry (`weightedHomogeneous_invariant_mem_range_endTensorEval`) can
+now use `endTensorEval_conj` to transport `GL(V)`-invariance of tensors to conjugation-invariance
+of polynomials.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6787

Session: `93a64acf-f228-42a5-a83e-7ee54f6cd655`

b44cacde feat(Ch5 #Problem5.24.2): endTensorEval_conj — GL-equivariance of the coordinate ↔ tensor pairing (#6787)

🤖 Prepared with Claude Code