### PR TITLE
feat(Ch8 #Problem8.2.8-Tor): fix Problem_8_2_8_tor RHS to the k-linear tensor ⊗_k (not ⊗_ℤ) and prove it via tensor-of-resolutions + Künneth over the field

### DIFF
--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_8.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_8.lean
@@ -1,9 +1,13 @@
-import EtingofRepresentationTheory.Chapter8.Definition8_2_3
 import EtingofRepresentationTheory.Chapter8.Definition8_2_4
+import EtingofRepresentationTheory.Chapter8.RearrangeComplex
+import EtingofRepresentationTheory.Chapter8.ExternalTensorResolution
+import EtingofRepresentationTheory.Chapter8.TensorRightFunctorK
+import EtingofRepresentationTheory.Chapter7.KunnethChainComplexNat
 import Mathlib.RingTheory.TensorProduct.Basic
 import Mathlib.LinearAlgebra.TensorProduct.Opposite
 import Mathlib.Algebra.DirectSum.Basic
 import Mathlib.Algebra.Category.ModuleCat.Ext.HasExt
+import Mathlib.Algebra.Category.ModuleCat.Algebra
 import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 
 /-!
@@ -11,13 +15,18 @@ import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 
 If `A₁, A₂` are algebras over a field `k`, and `Mᵢ, Nᵢ` are `Aᵢ`-modules, then
 
-* `Torᵢ^{A₁ ⊗ A₂}(M₁ ⊗ M₂, N₁ ⊗ N₂) = ⨁_{j+m=i} Torⱼ^{A₁}(M₁, N₁) ⊗ Torₘ^{A₂}(M₂, N₂)`,
-* `Extⁱ_{A₁ ⊗ A₂}(M₁ ⊗ M₂, N₁ ⊗ N₂) = ⨁_{j+m=i} Extʲ_{A₁}(M₁, N₁) ⊗ Extᵐ_{A₂}(M₂, N₂)`
+* `Torᵢ^{A₁ ⊗ A₂}(M₁ ⊗ M₂, N₁ ⊗ N₂) = ⨁_{j+m=i} Torⱼ^{A₁}(M₁, N₁) ⊗ₖ Torₘ^{A₂}(M₂, N₂)`,
+* `Extⁱ_{A₁ ⊗ A₂}(M₁ ⊗ M₂, N₁ ⊗ N₂) = ⨁_{j+m=i} Extʲ_{A₁}(M₁, N₁) ⊗ₖ Extᵐ_{A₂}(M₂, N₂)`
   when the `Nᵢ` are finite dimensional.
+
+All tensor products of the factor `Tor`/`Ext` on the right-hand side are over the **field `k`**, as
+in the book: the objects are `k`-vector spaces and the Künneth summands are their `k`-linear tensor
+products, not the (much larger) group-level `⊗_ℤ`.
 
 ## What is formalized here
 
-Both statements are stated below (spec-first, `sorry` proofs).
+The `Tor` statement is proved sorry-free below; the `Ext` statement is stated (spec-first, `sorry`
+proof).
 
 ### The external tensor product module structures
 
@@ -29,25 +38,28 @@ The theorem's content lives in three tensor products of `k`-vector spaces: `A₁
   `(m₁ ⊗ m₂) · (a₁ ⊗ a₂) = (m₁ · a₁) ⊗ (m₂ · a₂)`;
 * for `Ext`, `M₁ ⊗ₖ M₂` is a **left** `A₁ ⊗ₖ A₂`-module, componentwise as for `N`.
 
-Mathlib provides `TensorProduct.Algebra.module` (a `Module (A ⊗ B) M` from commuting `A`- and
-`B`-actions on a *single* `M`), but the *external* tensor product module — where `A₁` acts on the
-first factor and `A₂` on the second — is not a defeq-safe instance in the noncommutative setting
-(the right-factor action is not a default instance, and one must transport along
-`Algebra.TensorProduct.opAlgEquiv : (A₁ ⊗ A₂)ᵐᵒᵖ ≃ₐ A₁ᵐᵒᵖ ⊗ A₂ᵐᵒᵖ` on the `Tor` side). We
-therefore take the module structures as parameters, **pinned** by their action on simple tensors
-(`hN` / `hM` below). Because simple tensors generate the tensor product and the action is additive,
-these hypotheses determine the structures uniquely: they are exactly the canonical external tensor
-products. This is faithful and avoids the (statement-irrelevant) instance plumbing.
+For the `Tor` statement, the right external module on `M₁ ⊗ₖ M₂` is realised by the actual
+construction `Etingof.extTensorFunctorObj` (from `Etingof.extTensorModule`), whose componentwise
+action is `Etingof.extTensorModule_op_smul_tmul`. The left external module on `N₁ ⊗ₖ N₂` is taken as
+a parameter `instN` pinned to act componentwise on simple tensors by `hN`; because simple tensors
+generate the tensor product and the action is additive, this determines it uniquely as the canonical
+external tensor product, and it is the structure the rearrangement machinery
+(`Etingof.rearrangeComplex`) consumes.
 
 ### The right-hand side
 
-`Torⱼ^{A₁}(M₁, N₁)` is `Etingof.Tor A₁ N₁ M₁ j`, an `AddCommGrpCat`; the summands
-`Torⱼ^{A₁}(M₁, N₁) ⊗ Torₘ^{A₂}(M₂, N₂)` are tensor products of abelian groups (over `ℤ`, the
-group-level shadow of the book's `⊗ₖ`; the current `Tor`/`Ext` API forgets the `k`-linear
-structure), and `⨁_{j+m=i}` is a `DirectSum` over `{p : ℕ × ℕ // p.1 + p.2 = i}`.
+`Torⱼ^{A₁}(M₁, N₁)` as a `k`-vector space is `Etingof.Torₖ k A₁ N₁ M₁ j : ModuleCat k` (the
+`k`-linear left derived functor of `- ⊗_{A₁} N₁`, refining the `AddCommGrpCat`-valued
+`Etingof.Tor`). The Künneth summands `Torⱼ^{A₁}(M₁, N₁) ⊗ₖ Torₘ^{A₂}(M₂, N₂)` are their monoidal
+tensor products in
+`ModuleCat k`, and `⨁_{j+m=i}` is the coproduct `∐` over `{p : ℕ × ℕ // p.1 + p.2 = i}` in
+`ModuleCat k`. For `Ext`, whose values carry no such `k`-linear derived-functor refinement here, the
+summands are the `k`-linear tensor products `TensorProduct k` of the underlying `Ext` groups, which
+are `k`-modules through the `Linear k (ModuleCat A)` structure of a module category over a
+`k`-algebra.
 -/
 
-open CategoryTheory TensorProduct DirectSum
+open CategoryTheory Limits MonoidalCategory TensorProduct DirectSum
 
 namespace Etingof
 
@@ -57,40 +69,57 @@ section Tor
 
 variable (k : Type u) [Field k]
 variable (A₁ A₂ : Type u) [Ring A₁] [Ring A₂] [Algebra k A₁] [Algebra k A₂]
--- right `Aᵢ`-modules `Mᵢ` (`Module Aᵢᵐᵒᵖ`), also `k`-vector spaces so `M₁ ⊗ₖ M₂` makes sense
-variable (M₁ M₂ : Type u)
-  [AddCommGroup M₁] [Module k M₁] [Module A₁ᵐᵒᵖ M₁]
-  [AddCommGroup M₂] [Module k M₂] [Module A₂ᵐᵒᵖ M₂]
--- left `Aᵢ`-modules `Nᵢ`
+-- right `Aᵢ`-modules `Mᵢ` (`ModuleCat Aᵢᵐᵒᵖ`)
+variable (M₁ : ModuleCat.{u} A₁ᵐᵒᵖ) (M₂ : ModuleCat.{u} A₂ᵐᵒᵖ)
+-- left `Aᵢ`-modules `Nᵢ`, `k`-linearly (`IsScalarTower k Aᵢ Nᵢ`)
 variable (N₁ N₂ : Type u)
-  [AddCommGroup N₁] [Module k N₁] [Module A₁ N₁]
-  [AddCommGroup N₂] [Module k N₂] [Module A₂ N₂]
+  [AddCommGroup N₁] [Module k N₁] [Module A₁ N₁] [IsScalarTower k A₁ N₁]
+  [AddCommGroup N₂] [Module k N₂] [Module A₂ N₂] [IsScalarTower k A₂ N₂]
+variable [instN : Module (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)]
 
 /-- **Problem 8.2.8, `Tor`.** For `k`-algebras `A₁, A₂`, right modules `M₁, M₂` and left modules
-`N₁, N₂`, the `Tor` of the external tensor products decomposes as a Künneth direct sum:
-`Torᵢ^{A₁ ⊗ A₂}(M₁ ⊗ M₂, N₁ ⊗ N₂) ≅ ⨁_{j+m=i} Torⱼ^{A₁}(M₁, N₁) ⊗ Torₘ^{A₂}(M₂, N₂)`.
+`N₁, N₂`, the `Tor` of the external tensor products decomposes as a Künneth direct sum over the
+field `k`:
+`Torᵢ^{A₁ ⊗ A₂}(M₁ ⊗ M₂, N₁ ⊗ N₂) ≅ ⨁_{j+m=i} Torⱼ^{A₁}(M₁, N₁) ⊗ₖ Torₘ^{A₂}(M₂, N₂)`.
 
-`instN` / `instM` are the external tensor product module structures on `N₁ ⊗ₖ N₂` (left) and
-`M₁ ⊗ₖ M₂` (right); `hN` / `hM` pin them to act componentwise on simple tensors, which determines
-them uniquely. -/
+The right external `(A₁ ⊗ A₂)ᵐᵒᵖ`-module on `M₁ ⊗ₖ M₂` is `Etingof.extTensorFunctorObj`; the left
+external `A₁ ⊗ A₂`-module on `N₁ ⊗ₖ N₂` is `instN`, pinned by `hN` to act componentwise on simple
+tensors.
+
+The proof is the four-step book route: a tensor of projective resolutions
+(`extTensorProjectiveResolution`), the complex-level rearrangement `rearrangeComplex`, and the
+algebraic Künneth theorem over the field `kunnethChainComplexNat`, with the factor homologies
+identified as `Torₖ` through `torIsoHomologyTensorRightₖ`. -/
 theorem Problem_8_2_8_tor (i : ℕ)
-    [instN : Module (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)]
-    [instM : Module (A₁ ⊗[k] A₂)ᵐᵒᵖ (M₁ ⊗[k] M₂)]
     (hN : ∀ (a₁ : A₁) (a₂ : A₂) (n₁ : N₁) (n₂ : N₂),
       (a₁ ⊗ₜ[k] a₂ : A₁ ⊗[k] A₂) • (n₁ ⊗ₜ[k] n₂ : N₁ ⊗[k] N₂)
-        = (a₁ • n₁) ⊗ₜ[k] (a₂ • n₂))
-    (hM : ∀ (a₁ : A₁) (a₂ : A₂) (m₁ : M₁) (m₂ : M₂),
-      (MulOpposite.op (a₁ ⊗ₜ[k] a₂ : A₁ ⊗[k] A₂)) • (m₁ ⊗ₜ[k] m₂ : M₁ ⊗[k] M₂)
-        = (MulOpposite.op a₁ • m₁) ⊗ₜ[k] (MulOpposite.op a₂ • m₂)) :
+        = (a₁ • n₁) ⊗ₜ[k] (a₂ • n₂)) :
     Nonempty
-      (Etingof.Tor (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)
-          (ModuleCat.of (A₁ ⊗[k] A₂)ᵐᵒᵖ (M₁ ⊗[k] M₂)) i
-        ≅ AddCommGrpCat.of
-            (⨁ p : {p : ℕ × ℕ // p.1 + p.2 = i},
-              TensorProduct ℤ
-                (Etingof.Tor A₁ N₁ (ModuleCat.of A₁ᵐᵒᵖ M₁) p.1.1)
-                (Etingof.Tor A₂ N₂ (ModuleCat.of A₂ᵐᵒᵖ M₂) p.1.2))) := by
-  sorry
+      (Torₖ k (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂) (extTensorFunctorObj k A₁ A₂ M₁ M₂) i
+        ≅ ∐ fun p : {p : ℕ × ℕ // p.1 + p.2 = i} =>
+            Torₖ k A₁ N₁ M₁ p.1.1 ⊗ Torₖ k A₂ N₂ M₂ p.1.2) := by
+  -- Chosen projective resolutions of the two right modules, and of their external tensor.
+  let P₁ : ProjectiveResolution M₁ := ProjectiveResolution.of M₁
+  let P₂ : ProjectiveResolution M₂ := ProjectiveResolution.of M₂
+  let Q : ProjectiveResolution (extTensorFunctorObj k A₁ A₂ M₁ M₂) :=
+    extTensorProjectiveResolution P₁ P₂
+  -- The two `k`-linear factor complexes `Cᵢ = P•ᵢ ⊗_{Aᵢ} Nᵢ`.
+  refine ⟨
+    -- Step 1: `Torᵢ` of the external tensor = `Hᵢ` of `(P•₁ ⊗_k P•₂) ⊗_{A₁⊗A₂} (N₁⊗ₖN₂)`.
+    torIsoHomologyTensorRightₖ k (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)
+        (extTensorFunctorObj k A₁ A₂ M₁ M₂) Q i ≪≫
+    -- Step 2 & 3: rearrange the complex to `(P•₁ ⊗_{A₁} N₁) ⊗_k (P•₂ ⊗_{A₂} N₂)`, then take `Hᵢ`.
+    (HomologicalComplex.homologyFunctor (ModuleCat.{u} k) (ComplexShape.down ℕ) i).mapIso
+        (rearrangeComplex k A₁ A₂ N₁ N₂ hN P₁ P₂) ≪≫
+    -- Step 4a: algebraic Künneth over the field for the tensor of the two factor complexes.
+    (kunnethChainComplexNat
+        (((tensorRightFunctorₖ k A₁ N₁).mapHomologicalComplex (ComplexShape.down ℕ)).obj P₁.complex)
+        (((tensorRightFunctorₖ k A₂ N₂).mapHomologicalComplex (ComplexShape.down ℕ)).obj P₂.complex)
+        i).some ≪≫
+    -- Step 4b: identify the factor homologies as `Torⱼ^{A₁}` / `Torₘ^{A₂}`.
+    Sigma.mapIso (fun p => tensorIso
+      (torIsoHomologyTensorRightₖ k A₁ N₁ M₁ P₁ p.1.1).symm
+      (torIsoHomologyTensorRightₖ k A₂ N₂ M₂ P₂ p.1.2).symm)⟩
 
 end Tor
 
@@ -108,11 +137,12 @@ variable (N₁ N₂ : Type u)
 
 /-- **Problem 8.2.8, `Ext`.** For `k`-algebras `A₁, A₂`, left modules `M₁, M₂` and finite
 dimensional left modules `N₁, N₂`, the `Ext` of the external tensor products decomposes as a
-Künneth direct sum:
-`Extⁱ_{A₁ ⊗ A₂}(M₁ ⊗ M₂, N₁ ⊗ N₂) ≅ ⨁_{j+m=i} Extʲ_{A₁}(M₁, N₁) ⊗ Extᵐ_{A₂}(M₂, N₂)`.
+Künneth direct sum over the field `k`:
+`Extⁱ_{A₁ ⊗ A₂}(M₁ ⊗ M₂, N₁ ⊗ N₂) ≅ ⨁_{j+m=i} Extʲ_{A₁}(M₁, N₁) ⊗ₖ Extᵐ_{A₂}(M₂, N₂)`.
 
 `instM` / `instN` are the left external tensor product module structures on `M₁ ⊗ₖ M₂` and
-`N₁ ⊗ₖ N₂`; `hM` / `hN` pin them to act componentwise on simple tensors. -/
+`N₁ ⊗ₖ N₂`; `hM` / `hN` pin them to act componentwise on simple tensors. The summands are `k`-linear
+tensor products of the factor `Ext` groups, which are `k`-modules via `Linear k (ModuleCat Aᵢ)`. -/
 theorem Problem_8_2_8_ext (i : ℕ)
     [instM : Module (A₁ ⊗[k] A₂) (M₁ ⊗[k] M₂)]
     [instN : Module (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)]
@@ -126,7 +156,7 @@ theorem Problem_8_2_8_ext (i : ℕ)
       (Etingof.Ext (ModuleCat.of (A₁ ⊗[k] A₂) (M₁ ⊗[k] M₂))
           (ModuleCat.of (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)) i
         ≃+ (⨁ p : {p : ℕ × ℕ // p.1 + p.2 = i},
-              TensorProduct ℤ
+              TensorProduct k
                 (Etingof.Ext (ModuleCat.of A₁ M₁) (ModuleCat.of A₁ N₁) p.1.1)
                 (Etingof.Ext (ModuleCat.of A₂ M₂) (ModuleCat.of A₂ N₂) p.1.2))) := by
   sorry

--- a/EtingofRepresentationTheory/Chapter8/TensorRightFunctorK.lean
+++ b/EtingofRepresentationTheory/Chapter8/TensorRightFunctorK.lean
@@ -144,4 +144,28 @@ noncomputable def tensorRightFunctorₖ_forget₂ :
     simp only [Functor.comp_map, Iso.refl_hom, Category.comp_id, Category.id_comp]
     rfl)
 
+/-- The `k`-linear `n`-th `Tor` functor `Torₙᴬ(-, N) : (right A-modules) ⥤ ModuleCat k`, the `n`-th
+left derived functor of the `k`-linear `- ⊗_A N`. It refines `Etingof.TorFunctor A N n` (whose
+values are the underlying abelian groups, via `tensorRightFunctorₖ_forget₂`). -/
+noncomputable def TorFunctorₖ (n : ℕ) : ModuleCat.{u} Aᵐᵒᵖ ⥤ ModuleCat.{u} k :=
+  Functor.leftDerived (tensorRightFunctorₖ k A N) n
+
+/-- `Torₙᴬ(M, N)` as a `k`-vector space: the `n`-th left derived functor of the `k`-linear
+`- ⊗_A N` evaluated at the right `A`-module `M`. Its underlying abelian group is `Etingof.Tor A N M
+n` (via `tensorRightFunctorₖ_forget₂`), so this is the `k`-linear refinement of `Tor` used by the
+Künneth formula of Problem 8.2.8, which tensors the factor `Tor`s over the field `k`. -/
+noncomputable def Torₖ (M : ModuleCat.{u} Aᵐᵒᵖ) (n : ℕ) : ModuleCat.{u} k :=
+  (TorFunctorₖ k A N n).obj M
+
+/-- **`Torₖ` from a chosen projective resolution.** For any projective resolution `P•` of the right
+`A`-module `M`, `Torₙᴬ(M, N)` (as a `k`-vector space) is canonically isomorphic to the `n`-th
+homology of the `k`-linear complex `P• ⊗_A N`. The `k`-linear analogue of
+`Etingof.torIsoHomologyTensorRight`, obtained from `ProjectiveResolution.isoLeftDerivedObj`. -/
+noncomputable def torIsoHomologyTensorRightₖ (M : ModuleCat.{u} Aᵐᵒᵖ)
+    (P : ProjectiveResolution M) (n : ℕ) :
+    Torₖ k A N M n ≅
+      (HomologicalComplex.homologyFunctor (ModuleCat.{u} k) (ComplexShape.down ℕ) n).obj
+        (((tensorRightFunctorₖ k A N).mapHomologicalComplex _).obj P.complex) :=
+  P.isoLeftDerivedObj (tensorRightFunctorₖ k A N) n
+
 end Etingof

--- a/progress/2026-07-16T10-47-38Z_718bf9a6.md
+++ b/progress/2026-07-16T10-47-38Z_718bf9a6.md
@@ -1,0 +1,49 @@
+## Accomplished
+
+Feature session for issue #6796 — fix and prove `Problem_8_2_8_tor` (Künneth for `Tor` over a
+tensor product of algebras), which the #6657 assembler had discovered was stated over the **false**
+group-level tensor `⊗_ℤ`.
+
+- **New `k`-linear `Tor` API** in `Chapter8/TensorRightFunctorK.lean`:
+  `Etingof.TorFunctorₖ` / `Etingof.Torₖ` (the `ModuleCat k`-valued left derived functor of the
+  `k`-linear `- ⊗_A N`) and `Etingof.torIsoHomologyTensorRightₖ` (the `ₖ`-analogue of
+  `torIsoHomologyTensorRight`, from `ProjectiveResolution.isoLeftDerivedObj`). These are the objects
+  the book tensors over the field.
+- **Corrected `Problem_8_2_8_tor` statement**: RHS is now the `ModuleCat k` coproduct
+  `∐_{j+m=i} Torₖ_j(M₁,N₁) ⊗ Torₖ_m(M₂,N₂)` (monoidal `⊗` in `ModuleCat k`), replacing the invalid
+  `⨁ TensorProduct ℤ ...`. Restated `M₁, M₂` as `ModuleCat Aᵢᵐᵒᵖ` objects and used the concrete
+  external module `extTensorFunctorObj` (realised by `extTensorModule`), so the LHS matches the
+  resolution infrastructure exactly; `N₁, N₂` stay raw types with the pinned left external module
+  `instN` + `hN` that `rearrangeComplex` consumes (added the needed `IsScalarTower k Aᵢ Nᵢ`).
+- **Proved it sorry-free** by the four-step book route as a four-iso `≪≫` chain:
+  `torIsoHomologyTensorRightₖ` (Tor = homology of `(P•₁⊗P•₂) ⊗ (N₁⊗N₂)`) ≫
+  `homologyFunctor.mapIso (rearrangeComplex …)` ≫ `(kunnethChainComplexNat …).some` ≫
+  `Sigma.mapIso (tensorIso (torIso…).symm (torIso…).symm)`. `#print axioms` shows only
+  `propext, Classical.choice, Quot.sound`.
+- **Corrected `Problem_8_2_8_ext` statement** RHS `TensorProduct ℤ → TensorProduct k` for spec
+  consistency (the factor `Ext` groups are `k`-modules via `Linear k (ModuleCat Aᵢ)`); its proof
+  stays `sorry` (out of scope, as the issue specifies).
+
+## Current frontier
+
+`Problem_8_2_8_ext` is the only remaining `sorry` in `Chapter8/Problem8_2_8.lean`. The whole
+Chapter 8 `Problem8_2_8` file builds; the new `Torₖ` API in `TensorRightFunctorK.lean` builds.
+
+## Overall project progress
+
+Problem 8.2.8 `Tor` capstone is complete and axiom-clean, closing out the `#6657` subtree
+(`extTensorProjectiveResolution`, `rearrangeComplex`, `kunnethChainComplexNat`,
+`torIsoHomologyTensorRight`) which is now all consumed by a real, non-vacuous theorem. `items.json`
+status for `Chapter8/Problem8.2.8` kept at `statement_formalized` (Ext half still sorried); note
+updated.
+
+## Next step
+
+Prove `Problem_8_2_8_ext` — the `Ext` Künneth (needs the finite-dimensional `N` hypothesis and the
+`Ext`/`Hom`-dual analogue of the `Tor` route). Consider building an `Extₖ` (`ModuleCat k`-valued)
+refinement mirroring `Torₖ` so the RHS `⊗_k` lands directly, rather than relying on the ambient
+`Module k (Abelian.Ext …)`.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -7063,7 +7063,7 @@
     "start_line": 27,
     "end_line": 40,
     "status": "statement_formalized",
-    "coverage_note": "No Lean formalization on origin/main (re-derived 2026-07-02; prior 'sorry_free' was vacuous)."
+    "coverage_note": "Tor half (`Problem_8_2_8_tor`) proved sorry-free and axiom-clean over ⊗_k (#6796, 2026-07-16), via tensor-of-resolutions + rearrangeComplex + kunnethChainComplexNat; RHS corrected from the false ⊗_ℤ to the k-linear ⊗_k. Ext half (`Problem_8_2_8_ext`) statement RHS likewise corrected to ⊗_k, proof still `sorry`."
   },
   {
     "id": "Chapter8/Discussion_after_Problem8.2.8",


### PR DESCRIPTION
Closes #6796

This PR corrects the false group-level `⊗_ℤ` right-hand side of `Etingof.Problem_8_2_8_tor` to the book's `k`-linear `⊗_k` and proves the theorem sorry-free: `Torᵢ^{A₁⊗A₂}(M₁⊗M₂, N₁⊗N₂) ≅ ∐_{j+m=i} Torⱼ^{A₁}(M₁,N₁) ⊗_k Torₘ^{A₂}(M₂,N₂)`. It adds the `ModuleCat k`-valued `Torₖ` / `TorFunctorₖ` / `torIsoHomologyTensorRightₖ` API to `TensorRightFunctorK.lean` (the `k`-linear refinement of `Tor` that the Künneth summands tensor over the field), and assembles the proof from the four-step book route: a tensor of projective resolutions (`extTensorProjectiveResolution`), the complex-level rearrangement (`rearrangeComplex`), and the algebraic Künneth theorem over the field (`kunnethChainComplexNat`), identifying the factor homologies as `Torₖ` via `torIsoHomologyTensorRightₖ`. The `Problem_8_2_8_ext` statement RHS is likewise corrected to `TensorProduct k` for spec consistency, with its proof left as `sorry` (out of scope).

The `Tor` statement is restated over `ModuleCat Aᵢᵐᵒᵖ` objects using the concrete external module `extTensorFunctorObj`, so the left-hand side matches the resolution infrastructure directly; `N₁, N₂` keep the pinned left external module `instN` + `hN` that `rearrangeComplex` consumes, with the required `IsScalarTower k Aᵢ Nᵢ` added.

`#print axioms Etingof.Problem_8_2_8_tor` reports only `propext, Classical.choice, Quot.sound`.

Corrected one `progress/items.json` coverage note (no status change: the item stays `statement_formalized` because the `Ext` half remains sorried).

🤖 Prepared with Claude Code