### PR TITLE
feat(Ch8 #Problem8.2.8-Ext): cochain Künneth over k — kunnethCochainComplexNat, the up ℕ cochain twin of kunnethChainComplexNat via embeddingUpNat (deliverable 2 of #6817)

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -5463,6 +5463,27 @@ match+`split`.
 isoNegExt n` by `rw [foo]; split; next m hm => obtain rfl := …; apply Iso.ext; simp`. Do **not**
 use `.get` for `n` (dependent-position `get` is unrewritable); the match binder gives a real `n`.
 
+**Mirroring the chain (`down ℕ`) Künneth to the cochain (`up ℕ`) case (`embeddingUpNat`, #6825,
+`Chapter7/KunnethCochainComplexNat.lean`).** Two extra traps the `-n` chain version dodges:
+- Mathlib ships `TensorSigns (up ℤ)` and `TensorSigns (down ℕ)` but **not** `TensorSigns (up ℕ)`;
+  `HomologicalComplex.tensorObj` won't elaborate on `up ℕ` until you add it (`ε n = (-1)^n`, copy
+  the `down ℕ` instance, flip only the `Rel` direction: `rel_add`/`add_rel` by
+  `simp only [ComplexShape.up_Rel]; omega`, `ε'_succ` by `change (-1:ℤˣ)^(p+1) = -(-1:ℤˣ)^p`).
+- **Cast-spelling war `↑(n+1)` vs `↑n+1`.** The upward differential targets degree `n+1`, and
+  `fwdNat (n+1)` / `r_nat (n+1)` are locked to `↑(n+1)`, but a plain **`dsimp` silently rewrites
+  `↑(n+1)` to `↑n+1`**, after which `rw [ιZ_fwdNat …]` / `phiFwd_some` fail "did not find pattern".
+  The chain case never hits this (its downward differential targets `-↑n`, no `+1`). Fixes: (1)
+  never let `dsimp` touch the goal here — reduce the Koszul signs with explicit rewrites instead,
+  `show ComplexShape.ε₁ (up ℕ) (up ℕ) (up ℕ) (p,q) = (1:ℤˣ) from rfl` (then `one_smul`) and
+  `show ComplexShape.ε₂ … (p,q) = Int.negOnePow ↑p from (negOnePow_natCast p).symm` (then `congr 1`);
+  (2) spell every shifted index as `((p+1 : ℕ) : ℤ)` (not `(p:ℤ)+1`) in the `mapBifunctor.d₁_eq`/
+  `d₂_eq` `Rel` proofs, `extend_d_eq` via `ef_eq (p+1)`, and the `ιZ_fwdNat`/`r_nat` calls, so all
+  four agree. Sign lemma is the simpler `negOnePow_natCast` (`Int.negOnePow ↑n = (-1)^n`); the
+  up-differential `C.d p (p+1)` never vanishes, so there are **no** `p=0`/`q=0` boundary sub-cases.
+- Importing the chain twin to reuse `sigmaIsoOfInjOfIsZeroCompl` also pulls its `Etingof.`-namespaced
+  `homology_extend_iso`/`homology_extend_isZero` into scope — rename your parallel helpers
+  (`…_up`) or you get "already declared".
+
 ## `omega` proves atoms, not `∨`/`∧` *goals*; matrix-entry `split_ifs <;> omega` traps (#6755)
 
 Computing entries / cofactor recursions of concrete matrices (e.g. tridiagonal Cartan

--- a/EtingofRepresentationTheory/Chapter7.lean
+++ b/EtingofRepresentationTheory/Chapter7.lean
@@ -39,6 +39,7 @@ import EtingofRepresentationTheory.Chapter7.Exercise7_9_8
 import EtingofRepresentationTheory.Chapter7.TensorComplexBiprod
 import EtingofRepresentationTheory.Chapter7.Problem7_8_7
 import EtingofRepresentationTheory.Chapter7.KunnethChainComplexNat
+import EtingofRepresentationTheory.Chapter7.KunnethCochainComplexNat
 
 /-!
 # Chapter 7: Introduction to Categories

--- a/EtingofRepresentationTheory/Chapter7/KunnethCochainComplexNat.lean
+++ b/EtingofRepresentationTheory/Chapter7/KunnethCochainComplexNat.lean
@@ -1,0 +1,540 @@
+import Mathlib
+import EtingofRepresentationTheory.Chapter7.Problem7_8_7
+import EtingofRepresentationTheory.Chapter7.KunnethChainComplexNat
+
+/-!
+# Künneth for `ℕ`-indexed cochain complexes: the `ℕ`/`ℤ` reindex bridge (cochain case)
+
+Chapter 7's Künneth formula (`Etingof.Problem7_8_7_iv`) is stated for cohomologically indexed
+`CochainComplex (ModuleCat k) ℤ`. The `Ext` assembly of Problem 8.2.8, however, works with the Hom
+cochain complexes `Hom_A(P•, N)`, which are `ℕ`-indexed **cochain** complexes
+`CochainComplex (ModuleCat.{u} k) ℕ` (`= HomologicalComplex _ (ComplexShape.up ℕ)`). This file
+provides the bridge: a Künneth isomorphism for `ℕ`-indexed cochain complexes, obtained by
+**reindexing** the `ℤ` result rather than reproving it.
+
+This is the exact mirror of `Etingof.kunnethChainComplexNat`
+(`EtingofRepresentationTheory/Chapter7/KunnethChainComplexNat.lean`, the `down ℕ` chain case) along
+the embedding `ComplexShape.embeddingUpNat : Embedding (up ℕ) (up ℤ)` (`n ↦ n`, support `ℤ≥0`)
+instead of `embeddingDownNat` (`n ↦ -n`, support `ℤ≤0`). The `CoproductSupport` API
+(`sigmaIsoOfInjOfIsZeroCompl`, `sigmaSupport{Hom,Inv}`) is embedding-agnostic and reused directly
+from that file.
+
+## The reindexing embedding
+
+Mathlib's `ComplexShape.embeddingUpNat : Embedding (up ℕ) (up ℤ)` sends `n ↦ n`
+(`Mathlib/Algebra/Homology/Embedding/Basic.lean`), with the needed `IsRelIff`/`IsTruncGE`
+instances. `HomologicalComplex.extend embeddingUpNat` sends a `CochainComplex ℕ` to a
+`CochainComplex ℤ` supported on `ℤ≥0` (the image of `n ↦ n`), zero elsewhere.
+
+Homology transport is Mathlib's `HomologicalComplex.extendHomologyIso`:
+`Hⁱ(extend C) ≅ Hⁿ(C)` at `i = n` in the image, and `extend_exactAt` gives vanishing outside the
+image. These two facts are proved here as `homology_extend_iso_up` and `homology_extend_isZero_up`.
+
+## The `up ℕ` tensor sign
+
+Mathlib ships `TensorSigns (ComplexShape.up ℤ)` and `TensorSigns (ComplexShape.down ℕ)` but not
+`TensorSigns (ComplexShape.up ℕ)`; without it `HomologicalComplex.tensorObj` does not elaborate on
+`up ℕ` complexes. We supply the missing instance here (`ε n = (-1)^n`, identical data to the
+`down ℕ` instance, only the `Rel` direction differs).
+
+## The crux: tensor ∘ extend compatibility
+
+`extend e C ⊗ extend e D ≅ extend e (C ⊗ D)`  (in the `up ℤ` monoidal structure).
+
+Degreewise both sides are `⨁_{p+q=n} C_p ⊗ D_q` at `+n` and zero at negative degrees; the content
+is matching the `ιTensorObj` injections and the Koszul-signed total differential. The only
+non-mechanical step is the sign match, here `negOnePow_natCast` (`Int.negOnePow (n : ℤ) = (-1)^n`),
+simpler than the chain case (no `negOnePow_neg`). This is `nonempty_tensorObj_extend_iso` below,
+constructed via `TensorExtend.tensorObjExtendIso`.
+
+## The payoff
+
+`Hᵢ(C ⊗ D)` (`ℕ`) `≅ Hᵢ(extend (C ⊗ D))` `≅ Hᵢ(extend C ⊗ extend D)` (crux)
+`≅ ⨁_{a+b=i} H_a(extend C) ⊗ H_b(extend D)` (Chapter 7 Künneth at universe `u`, degree `i`)
+`≅ ⨁_{p+q=i} H_p(C) ⊗ H_q(D)` (reindex `a = p`, `b = q`; the `a < 0` / `b < 0` summands are zero by
+`homology_extend_isZero_up`).
+
+The main deliverable `kunnethCochainComplexNat` is stated below (Prop-valued `Nonempty`), pinning
+the API that the Problem 8.2.8 `Ext` assembler consumes.
+-/
+
+open CategoryTheory Limits MonoidalCategory HomologicalComplex
+
+namespace Etingof
+
+universe u
+
+variable {k : Type u} [Field k]
+
+/-- The `TensorSigns` structure on `ComplexShape.up ℕ`, missing from Mathlib (which ships only
+`down ℕ` and `up ℤ`). The vertical sign is `ε n = (-1)^n`, the same data as the `down ℕ` instance;
+only the `Rel` direction (`n + 1 = m` vs `m + 1 = n`) differs. -/
+instance : (ComplexShape.up ℕ).TensorSigns where
+  ε' := MonoidHom.mk' (fun (i : ℕ) => (-1 : ℤˣ) ^ i) (pow_add (-1 : ℤˣ))
+  rel_add p q r (hpq : p + 1 = q) := by simp only [ComplexShape.up_Rel]; omega
+  add_rel p q r (hpq : p + 1 = q) := by simp only [ComplexShape.up_Rel]; omega
+  ε'_succ := by
+    rintro p _ rfl
+    change (-1 : ℤˣ) ^ (p + 1) = -(-1 : ℤˣ) ^ p
+    rw [pow_add, pow_one, mul_neg, mul_one]
+
+@[simp]
+lemma ε_up_ℕ (n : ℕ) : (ComplexShape.up ℕ).ε n = (-1 : ℤˣ) ^ n := rfl
+
+/-- Homology of `extend e C` at the embedded degree `n` recovers `Hⁿ(C)`. Direct instance of
+Mathlib's `extendHomologyIso` for `embeddingUpNat` (`e.f n = n`). -/
+noncomputable def homology_extend_iso_up (C : CochainComplex (ModuleCat.{u} k) ℕ) (n : ℕ) :
+    (C.extend ComplexShape.embeddingUpNat).homology (n : ℤ) ≅ C.homology n :=
+  C.extendHomologyIso ComplexShape.embeddingUpNat (by simp)
+
+/-- Homology of `extend e C` vanishes at negative degrees `j' < 0`, which lie outside the image
+`{n : n : ℕ} = ℤ≥0` of `embeddingUpNat`. -/
+theorem homology_extend_isZero_up (C : CochainComplex (ModuleCat.{u} k) ℕ) (j' : ℤ) (hj' : j' < 0) :
+    IsZero ((C.extend ComplexShape.embeddingUpNat).homology j') := by
+  rw [← HomologicalComplex.exactAt_iff_isZero_homology]
+  refine HomologicalComplex.extend_exactAt _ _ j' (fun j => ?_)
+  simp only [ComplexShape.embeddingUpNat_f]
+  omega
+
+namespace TensorExtendUp
+
+/-!
+## Milestone (a): the degreewise object isomorphism
+
+This section constructs, for every `j' : ℤ`, the degreewise isomorphism
+`(extend C ⊗ extend D).X j' ≅ (extend (C ⊗ D)).X j'` (`tensorExtendXIso`). The nonzero degrees are
+`j' = n`, where both sides identify with `⨁_{p+q=n} C_p ⊗ D_q`; negative degrees are zero on both
+sides. Mirror of `KunnethChainComplexNat.TensorExtend`, degrees `+n` in place of `-n`.
+-/
+
+/-- The reindexing embedding `n ↦ n`. -/
+noncomputable abbrev e : ComplexShape.Embedding (ComplexShape.up ℕ) (ComplexShape.up ℤ) :=
+  ComplexShape.embeddingUpNat
+
+/-- If the left factor is zero, the tensor is zero. -/
+lemma isZero_tensorObj_left {C : Type*} [Category C] [MonoidalCategory C] [Preadditive C]
+    [MonoidalPreadditive C] {X Y : C} (hX : IsZero X) : IsZero (X ⊗ Y) := by
+  rw [IsZero.iff_id_eq_zero, ← MonoidalCategory.id_tensorHom_id, hX.eq_of_src (𝟙 X) 0]
+  simp
+
+/-- If the right factor is zero, the tensor is zero. -/
+lemma isZero_tensorObj_right {C : Type*} [Category C] [MonoidalCategory C] [Preadditive C]
+    [MonoidalPreadditive C] {X Y : C} (hY : IsZero Y) : IsZero (X ⊗ Y) := by
+  rw [IsZero.iff_id_eq_zero, ← MonoidalCategory.id_tensorHom_id, hY.eq_of_src (𝟙 Y) 0]
+  simp
+
+variable (C D : CochainComplex (ModuleCat.{u} k) ℕ)
+
+/-- Summand inclusion into `(tensorObj C D).X n`, spelled as `ιMapBifunctor`. -/
+noncomputable abbrev ιN (p q n : ℕ)
+    (h : (ComplexShape.up ℕ).π (ComplexShape.up ℕ) (ComplexShape.up ℕ) (p, q) = n) :
+    ((curriedTensor (ModuleCat.{u} k)).obj (C.X p)).obj (D.X q) ⟶
+      (HomologicalComplex.tensorObj C D).X n :=
+  HomologicalComplex.ιMapBifunctor C D (curriedTensor (ModuleCat.{u} k)) (ComplexShape.up ℕ)
+    p q n h
+
+/-- Summand inclusion into `(tensorObj (extend C) (extend D)).X j`, spelled as `ιMapBifunctor`. -/
+noncomputable abbrev ιZ (a b j : ℤ)
+    (h : (ComplexShape.up ℤ).π (ComplexShape.up ℤ) (ComplexShape.up ℤ) (a, b) = j) :
+    ((curriedTensor (ModuleCat.{u} k)).obj ((C.extend e).X a)).obj ((D.extend e).X b) ⟶
+      (HomologicalComplex.tensorObj (C.extend e) (D.extend e)).X j :=
+  HomologicalComplex.ιMapBifunctor (C.extend e) (D.extend e) (curriedTensor (ModuleCat.{u} k))
+    (ComplexShape.up ℤ) a b j h
+
+/-- Forward per-summand map for the degree `n` iso. -/
+noncomputable def phiFwd (n : ℕ) (a b : ℤ) (h : a + b = (n : ℤ)) :
+    (C.extend e).X a ⊗ (D.extend e).X b ⟶ (HomologicalComplex.tensorObj C D).X n :=
+  match ha : e.r a, hb : e.r b with
+  | some p, some q =>
+      ((C.extendXIso e (e.f_eq_of_r_eq_some ha)).hom ⊗ₘ
+        (D.extendXIso e (e.f_eq_of_r_eq_some hb)).hom) ≫
+        ιN C D p q n (by
+          have hp := e.f_eq_of_r_eq_some ha
+          have hq := e.f_eq_of_r_eq_some hb
+          simp only [ComplexShape.embeddingUpNat_f] at hp hq
+          have : p + q = n := by omega
+          simpa using this)
+  | _, _ => 0
+
+/-- Reduction of `phiFwd` on the nonzero (some/some) summands. -/
+lemma phiFwd_some (n : ℕ) {a b : ℤ} (h : a + b = (n : ℤ)) {p q : ℕ}
+    (ha : e.r a = some p) (hb : e.r b = some q)
+    (hpq : (ComplexShape.up ℕ).π (ComplexShape.up ℕ) (ComplexShape.up ℕ) (p, q) = n) :
+    phiFwd C D n a b h =
+      ((C.extendXIso e (show e.f p = a from e.f_eq_of_r_eq_some ha)).hom ⊗ₘ
+        (D.extendXIso e (show e.f q = b from e.f_eq_of_r_eq_some hb)).hom) ≫ ιN C D p q n hpq := by
+  rw [phiFwd]
+  split
+  next p' q' hh1 hh2 =>
+    obtain rfl : p' = p := Option.some.inj (hh1 ▸ ha)
+    obtain rfl : q' = q := Option.some.inj (hh2 ▸ hb)
+    rfl
+  next hh => exact (hh p q ha hb).elim
+
+/-- Inverse per-summand map for the degree `n` iso. -/
+noncomputable def phiInv (n : ℕ) (p q : ℕ)
+    (h : (ComplexShape.up ℕ).π (ComplexShape.up ℕ) (ComplexShape.up ℕ) (p, q) = n) :
+    C.X p ⊗ D.X q ⟶ (HomologicalComplex.tensorObj (C.extend e) (D.extend e)).X (n : ℤ) :=
+  ((C.extendXIso e (show e.f p = (p : ℤ) by simp)).inv ⊗ₘ
+    (D.extendXIso e (show e.f q = (q : ℤ) by simp)).inv) ≫
+    ιZ C D (p : ℤ) (q : ℤ) (n : ℤ) (by
+      have hpq : p + q = n := by simpa using h
+      have : (p : ℤ) + q = n := by exact_mod_cast hpq
+      simpa using this)
+
+/-- Forward map for the degree `n` iso. -/
+noncomputable def fwdNat (n : ℕ) :
+    (HomologicalComplex.tensorObj (C.extend e) (D.extend e)).X (n : ℤ) ⟶
+      (HomologicalComplex.tensorObj C D).X n :=
+  HomologicalComplex.mapBifunctorDesc (fun a b h => phiFwd C D n a b h)
+
+/-- Inverse map for the degree `n` iso. -/
+noncomputable def invNat (n : ℕ) :
+    (HomologicalComplex.tensorObj C D).X n ⟶
+      (HomologicalComplex.tensorObj (C.extend e) (D.extend e)).X (n : ℤ) :=
+  HomologicalComplex.mapBifunctorDesc (fun p q h => phiInv C D n p q h)
+
+/-- `e.r p = some p`. -/
+lemma r_nat (p : ℕ) : e.r (p : ℤ) = some p :=
+  e.r_eq_some (show e.f p = (p : ℤ) by simp)
+
+/-- Reduction of `fwdNat` on a summand inclusion. -/
+lemma ιZ_fwdNat (n : ℕ) (a b : ℤ)
+    (h : (ComplexShape.up ℤ).π (ComplexShape.up ℤ) (ComplexShape.up ℤ) (a, b) = (n : ℤ)) :
+    ιZ C D a b (n : ℤ) h ≫ fwdNat C D n = phiFwd C D n a b h := by
+  simp only [ιZ, fwdNat, ι_mapBifunctorDesc]
+
+/-- Reduction of `invNat` on a summand inclusion. -/
+lemma ιN_invNat (n : ℕ) (p q : ℕ)
+    (h : (ComplexShape.up ℕ).π (ComplexShape.up ℕ) (ComplexShape.up ℕ) (p, q) = n) :
+    ιN C D p q n h ≫ invNat C D n = phiInv C D n p q h := by
+  simp only [ιN, invNat, ι_mapBifunctorDesc]
+
+set_option backward.isDefEq.respectTransparency false in
+/-- `phiInv` followed by `fwdNat` is the summand inclusion. -/
+lemma phiInv_comp_fwdNat (n p q : ℕ)
+    (h : (ComplexShape.up ℕ).π (ComplexShape.up ℕ) (ComplexShape.up ℕ) (p, q) = n) :
+    phiInv C D n p q h ≫ fwdNat C D n = ιN C D p q n h := by
+  rw [phiInv, Category.assoc, ιZ_fwdNat, phiFwd_some C D n _ (r_nat p) (r_nat q) h]
+  simp
+
+set_option backward.isDefEq.respectTransparency false in
+/-- `phiFwd` on a nonzero summand followed by `invNat` is the summand inclusion. -/
+lemma phiFwd_comp_invNat (n : ℕ) (a b : ℤ) (h : a + b = (n : ℤ)) {p q : ℕ}
+    (ha : e.r a = some p) (hb : e.r b = some q)
+    (hpq : (ComplexShape.up ℕ).π (ComplexShape.up ℕ) (ComplexShape.up ℕ) (p, q) = n) :
+    phiFwd C D n a b h ≫ invNat C D n = ιZ C D a b (n : ℤ) h := by
+  obtain rfl : a = (p : ℤ) := by have := e.f_eq_of_r_eq_some ha; simpa using this.symm
+  obtain rfl : b = (q : ℤ) := by have := e.f_eq_of_r_eq_some hb; simpa using this.symm
+  rw [phiFwd_some C D n _ (r_nat p) (r_nat q) hpq, Category.assoc, ιN_invNat, phiInv]
+  simp
+
+/-- The degree `n` component isomorphism `(extend C ⊗ extend D).X n ≅ (C ⊗ D).X n`. -/
+noncomputable def isoNat (n : ℕ) :
+    (HomologicalComplex.tensorObj (C.extend e) (D.extend e)).X (n : ℤ) ≅
+      (HomologicalComplex.tensorObj C D).X n where
+  hom := fwdNat C D n
+  inv := invNat C D n
+  inv_hom_id := by
+    apply HomologicalComplex.mapBifunctor.hom_ext
+    intro p q h'
+    rw [Category.comp_id, ← Category.assoc,
+      show HomologicalComplex.ιMapBifunctor C D _ _ p q n h' = ιN C D p q n h' from rfl,
+      ιN_invNat]
+    exact phiInv_comp_fwdNat C D n p q h'
+  hom_inv_id := by
+    apply HomologicalComplex.mapBifunctor.hom_ext
+    intro a b h'
+    rcases ha : e.r a with _ | p
+    · exact (isZero_tensorObj_left (C.isZero_extend_X' e a ha)).eq_of_src _ _
+    rcases hb : e.r b with _ | q
+    · exact (isZero_tensorObj_right (D.isZero_extend_X' e b hb)).eq_of_src _ _
+    have hpq : (ComplexShape.up ℕ).π (ComplexShape.up ℕ) (ComplexShape.up ℕ) (p, q) = n := by
+      have hpa := e.f_eq_of_r_eq_some ha
+      have hqb := e.f_eq_of_r_eq_some hb
+      simp only [ComplexShape.embeddingUpNat_f] at hpa hqb
+      have h2 : a + b = (n : ℤ) := h'
+      have : p + q = n := by omega
+      simpa using this
+    rw [Category.comp_id, ← Category.assoc,
+      show HomologicalComplex.ιMapBifunctor (C.extend e) (D.extend e) _ _ a b (n : ℤ) h'
+        = ιZ C D a b (n : ℤ) h' from rfl,
+      ιZ_fwdNat]
+    exact phiFwd_comp_invNat C D n a b h' ha hb hpq
+
+/-- The `ℤ`-tensor of the extensions vanishes in negative degrees. -/
+lemma isZero_tensorObj_extend_X_of_neg (j' : ℤ) (hj' : j' < 0) :
+    IsZero ((HomologicalComplex.tensorObj (C.extend e) (D.extend e)).X j') := by
+  rw [IsZero.iff_id_eq_zero]
+  apply HomologicalComplex.mapBifunctor.hom_ext
+  intro a b hab
+  have hab' : a + b = j' := hab
+  rw [Category.comp_id, comp_zero]
+  refine (?_ : IsZero _).eq_of_src _ _
+  by_cases ha : 0 ≤ a
+  · have hb : b < 0 := by omega
+    exact isZero_tensorObj_right
+      (D.isZero_extend_X e b (fun i => by simp only [ComplexShape.embeddingUpNat_f]; omega))
+  · exact isZero_tensorObj_left
+      (C.isZero_extend_X e a (fun i => by simp only [ComplexShape.embeddingUpNat_f]; omega))
+
+/-- `e.f n = n` as a stored equality. -/
+lemma ef_eq (n : ℕ) : e.f n = (n : ℤ) := by simp
+
+/-- The degree `n` component iso, landing directly in the extension of `C ⊗ D`. -/
+noncomputable def isoNatExt (n : ℕ) :
+    (HomologicalComplex.tensorObj (C.extend e) (D.extend e)).X (n : ℤ) ≅
+      ((HomologicalComplex.tensorObj C D).extend e).X (n : ℤ) :=
+  isoNat C D n ≪≫
+    (HomologicalComplex.extendXIso (HomologicalComplex.tensorObj C D) e (ef_eq n)).symm
+
+/-- **Milestone (a): the degreewise object iso.** For every `j' : ℤ`,
+`(extend C ⊗ extend D).X j' ≅ (extend (C ⊗ D)).X j'`. On the nonzero degrees `j' = n` it is
+`isoNatExt`; on negative degrees both sides vanish. -/
+noncomputable def tensorExtendXIso (j' : ℤ) :
+    (HomologicalComplex.tensorObj (C.extend e) (D.extend e)).X j' ≅
+      ((HomologicalComplex.tensorObj C D).extend e).X j' :=
+  match hj : e.r j' with
+  | some n =>
+      eqToIso (congrArg (HomologicalComplex.tensorObj (C.extend e) (D.extend e)).X
+        (show j' = (n : ℤ) by
+          have := e.f_eq_of_r_eq_some hj
+          simp only [ComplexShape.embeddingUpNat_f] at this; omega)) ≪≫
+      isoNatExt C D n ≪≫
+      eqToIso (congrArg ((HomologicalComplex.tensorObj C D).extend e).X
+        (show (n : ℤ) = j' by
+          have := e.f_eq_of_r_eq_some hj
+          simp only [ComplexShape.embeddingUpNat_f] at this; omega))
+  | none =>
+      IsZero.iso
+        (isZero_tensorObj_extend_X_of_neg C D j' (by
+          by_contra hle
+          have hr : e.r j' = some (j'.toNat) :=
+            e.r_eq_some (by simp only [ComplexShape.embeddingUpNat_f]; omega)
+          rw [hr] at hj
+          simp at hj))
+        (HomologicalComplex.isZero_extend_X' _ e j' hj)
+
+/-- `tensorExtendXIso` at `n` is `isoNatExt`. -/
+lemma tensorExtendXIso_nat (n : ℕ) :
+    tensorExtendXIso C D (n : ℤ) = isoNatExt C D n := by
+  rw [tensorExtendXIso]
+  split
+  next m hm =>
+    obtain rfl : m = n := (Option.some.inj ((r_nat n).symm.trans hm)).symm
+    apply Iso.ext
+    simp
+  next hm => rw [r_nat] at hm; simp at hm
+
+set_option backward.isDefEq.respectTransparency false in
+/-- **Milestone (a) simp lemma (`.hom`).** Composing the iso with the extend transport recovers
+the coproduct forward map `fwdNat`. -/
+@[simp]
+lemma tensorExtendXIso_hom_extendXIso (n : ℕ) :
+    (tensorExtendXIso C D (n : ℤ)).hom ≫
+        (HomologicalComplex.extendXIso (HomologicalComplex.tensorObj C D) e (ef_eq n)).hom =
+      fwdNat C D n := by
+  rw [tensorExtendXIso_nat, isoNatExt]
+  simp only [Iso.trans_hom, Iso.symm_hom, Category.assoc, Iso.inv_hom_id, Category.comp_id]
+  rfl
+
+set_option backward.isDefEq.respectTransparency false in
+/-- **Milestone (a) simp lemma (`.inv`).** Composing the extend transport with the iso's inverse
+recovers the coproduct inverse map `invNat`. -/
+@[simp]
+lemma extendXIso_inv_tensorExtendXIso_inv (n : ℕ) :
+    (HomologicalComplex.extendXIso (HomologicalComplex.tensorObj C D) e (ef_eq n)).inv ≫
+        (tensorExtendXIso C D (n : ℤ)).inv = invNat C D n := by
+  rw [tensorExtendXIso_nat, isoNatExt]
+  simp only [Iso.trans_inv, Iso.symm_inv, Iso.inv_hom_id_assoc]
+  rfl
+
+/-!
+## Milestone (b): differential compatibility
+
+The degreewise isos `tensorExtendXIso` are packaged, via `fwdNat_comm`, into an honest isomorphism
+of cochain complexes `tensorObjExtendIso`. The only non-mechanical step is the Koszul sign match
+`negOnePow_natCast`. In the `up` case the factor differentials `C.d p (p+1)` never vanish (unlike
+the `down` case's `C.d p (p-1)` at `p = 0`), so there are no boundary sub-cases.
+-/
+
+/-- **Koszul sign identity.** The `up ℤ` vertical sign `(n : ℤ).negOnePow` agrees with the `up ℕ`
+vertical sign `(-1)^n`. -/
+lemma negOnePow_natCast (p : ℕ) : Int.negOnePow (p : ℤ) = (-1 : ℤˣ) ^ p := by
+  simp [Int.negOnePow, zpow_natCast]
+
+/-- **Milestone (b): differential compatibility of the coproduct forward maps.** The degree-`n`
+isos `fwdNat` commute with the (Koszul-signed) total differentials: `fwdNat n` followed by the
+`up ℕ` differential of `C ⊗ D` equals the `up ℤ` differential of `extend C ⊗ extend D` followed by
+`fwdNat (n+1)`. Proved summand-by-summand via `mapBifunctor.hom_ext`; the `d₁` summands carry sign
+`1` on both sides, and the `d₂` summands match through `negOnePow_natCast`. -/
+@[reassoc]
+lemma fwdNat_comm (n : ℕ) :
+    fwdNat C D n ≫ (HomologicalComplex.tensorObj C D).d n (n + 1) =
+      (HomologicalComplex.tensorObj (C.extend e) (D.extend e)).d (n : ℤ) ((n + 1 : ℕ) : ℤ) ≫
+        fwdNat C D (n + 1) := by
+  apply HomologicalComplex.mapBifunctor.hom_ext
+  intro a b hab
+  rcases ha : e.r a with _ | p
+  · exact (isZero_tensorObj_left (C.isZero_extend_X' e a ha)).eq_of_src _ _
+  rcases hb : e.r b with _ | q
+  · exact (isZero_tensorObj_right (D.isZero_extend_X' e b hb)).eq_of_src _ _
+  obtain rfl : a = (p : ℤ) := by
+    have := e.f_eq_of_r_eq_some ha
+    simp only [ComplexShape.embeddingUpNat_f] at this; omega
+  obtain rfl : b = (q : ℤ) := by
+    have := e.f_eq_of_r_eq_some hb
+    simp only [ComplexShape.embeddingUpNat_f] at this; omega
+  have hpq : p + q = n := by
+    have h2 : (p : ℤ) + (q : ℤ) = (n : ℤ) := hab
+    omega
+  rw [← Category.assoc, ιZ_fwdNat C D n (p : ℤ) (q : ℤ) hab,
+      phiFwd_some C D n hab (r_nat p) (r_nat q) hpq, Category.assoc]
+  simp only [mapBifunctor.d_eq, Preadditive.comp_add, Preadditive.add_comp,
+    mapBifunctor.ι_D₁, mapBifunctor.ι_D₂, mapBifunctor.ι_D₁_assoc, mapBifunctor.ι_D₂_assoc]
+  refine congr_arg₂ (· + ·) ?_ ?_
+  · -- d₁ part (factor 1 differential): C.d p (p+1); sign ε₁ = 1
+    have hpn : (p + 1) + q = n + 1 := by omega
+    rw [mapBifunctor.d₁_eq C D _ (ComplexShape.up ℕ)
+          (show (ComplexShape.up ℕ).Rel p (p + 1) by rw [ComplexShape.up_Rel]) q (n + 1) hpn,
+        mapBifunctor.d₁_eq (C.extend e) (D.extend e) _ (ComplexShape.up ℤ)
+          (show (ComplexShape.up ℤ).Rel (p : ℤ) ((p + 1 : ℕ) : ℤ) by
+            rw [ComplexShape.up_Rel]; push_cast; ring) (q : ℤ) ((n + 1 : ℕ) : ℤ)
+          (by push_cast; omega : ((p + 1 : ℕ) : ℤ) + (q : ℤ) = ((n + 1 : ℕ) : ℤ)),
+        extend_d_eq C e (ef_eq p) (ef_eq (p + 1)),
+        show ComplexShape.ε₁ (ComplexShape.up ℕ) (ComplexShape.up ℕ) (ComplexShape.up ℕ) (p, q)
+          = (1 : ℤˣ) from rfl,
+        show ComplexShape.ε₁ (ComplexShape.up ℤ) (ComplexShape.up ℤ) (ComplexShape.up ℤ)
+              ((p : ℤ), (q : ℤ)) = (1 : ℤˣ) from rfl]
+    simp only [one_smul, Category.assoc]
+    rw [ιZ_fwdNat C D (n + 1) ((p + 1 : ℕ) : ℤ) (q : ℤ)
+          (by push_cast; omega : ((p + 1 : ℕ) : ℤ) + (q : ℤ) = ((n + 1 : ℕ) : ℤ)),
+        phiFwd_some C D (n + 1) _ (r_nat (p + 1)) (r_nat q) (by simpa using hpn)]
+    simp only [Functor.map_comp, NatTrans.comp_app, curriedTensor_map_app,
+      Category.assoc, MonoidalCategory.tensorHom_def, whisker_exchange_assoc,
+      ← MonoidalCategory.comp_whiskerRight_assoc, Iso.inv_hom_id,
+      MonoidalCategory.id_whiskerRight, Category.id_comp]
+  · -- d₂ part (factor 2 differential): D.d q (q+1); sign ε₂ = (-1)^p
+    have hpn : p + (q + 1) = n + 1 := by omega
+    rw [mapBifunctor.d₂_eq C D _ (ComplexShape.up ℕ) p
+          (show (ComplexShape.up ℕ).Rel q (q + 1) by rw [ComplexShape.up_Rel]) (n + 1) hpn,
+        mapBifunctor.d₂_eq (C.extend e) (D.extend e) _ (ComplexShape.up ℤ) (p : ℤ)
+          (show (ComplexShape.up ℤ).Rel (q : ℤ) ((q + 1 : ℕ) : ℤ) by
+            rw [ComplexShape.up_Rel]; push_cast; ring) ((n + 1 : ℕ) : ℤ)
+          (by push_cast; omega : (p : ℤ) + ((q + 1 : ℕ) : ℤ) = ((n + 1 : ℕ) : ℤ)),
+        extend_d_eq D e (ef_eq q) (ef_eq (q + 1)),
+        show ComplexShape.ε₂ (ComplexShape.up ℕ) (ComplexShape.up ℕ) (ComplexShape.up ℕ) (p, q)
+          = Int.negOnePow (p : ℤ) from (negOnePow_natCast p).symm,
+        show ComplexShape.ε₂ (ComplexShape.up ℤ) (ComplexShape.up ℤ) (ComplexShape.up ℤ)
+              ((p : ℤ), (q : ℤ)) = Int.negOnePow (p : ℤ) from rfl]
+    simp only [Linear.units_smul_comp, Linear.comp_units_smul, Category.assoc]
+    rw [ιZ_fwdNat C D (n + 1) (p : ℤ) ((q + 1 : ℕ) : ℤ)
+          (by push_cast; omega : (p : ℤ) + ((q + 1 : ℕ) : ℤ) = ((n + 1 : ℕ) : ℤ)),
+        phiFwd_some C D (n + 1) _ (r_nat p) (r_nat (q + 1)) (by simpa using hpn)]
+    congr 1
+    simp only [curriedTensor_obj_map, Category.assoc,
+      MonoidalCategory.tensorHom_def, ← whisker_exchange_assoc,
+      ← MonoidalCategory.whiskerLeft_comp_assoc, Iso.inv_hom_id, Category.comp_id]
+
+/-- **Milestone (c): the complex isomorphism.** Assemble the degreewise isos `tensorExtendXIso`
+into an isomorphism of `ℤ`-cochain complexes `extend C ⊗ extend D ≅ extend (C ⊗ D)`, using
+`fwdNat_comm` for differential compatibility on the nonzero degrees `j = n` and vanishing of the
+source on negative degrees. -/
+noncomputable def tensorObjExtendIso :
+    HomologicalComplex.tensorObj (C.extend e) (D.extend e) ≅
+      (HomologicalComplex.tensorObj C D).extend e :=
+  HomologicalComplex.Hom.isoOfComponents (fun j' => tensorExtendXIso C D j') (by
+    intro i j hij
+    by_cases hi : i < 0
+    · exact (isZero_tensorObj_extend_X_of_neg C D i hi).eq_of_src _ _
+    · rw [not_lt] at hi
+      obtain ⟨n, rfl⟩ : ∃ n : ℕ, i = (n : ℤ) := ⟨i.toNat, by omega⟩
+      obtain rfl : j = ((n + 1 : ℕ) : ℤ) := by
+        have : (n : ℤ) + 1 = j := hij
+        push_cast; omega
+      rw [HomologicalComplex.extend_d_eq (HomologicalComplex.tensorObj C D) e
+            (ef_eq n) (ef_eq (n + 1)),
+          ← Category.assoc, tensorExtendXIso_hom_extendXIso C D n,
+          fwdNat_comm_assoc C D n]
+      congr 1
+      rw [← tensorExtendXIso_hom_extendXIso C D (n + 1), Category.assoc, Iso.hom_inv_id,
+        Category.comp_id])
+
+end TensorExtendUp
+
+/-- **Crux (tensor ∘ extend compatibility, cochain case).** The `ℤ`-tensor of the extensions is the
+extension of the `ℕ`-tensor:
+`extend e C ⊗ extend e D ≅ extend e (C ⊗ D)`, `e = embeddingUpNat`.
+
+Degreewise both sides are `⨁_{p+q=n} C_p ⊗ D_q` at `+n` and zero at negative degrees; the content
+is matching the `ιTensorObj` injections and the Koszul-signed total differential. Universe-general
+and independent of Chapter 7. Constructed via `TensorExtendUp.tensorObjExtendIso`. -/
+theorem nonempty_tensorObj_extend_iso_up (C D : CochainComplex (ModuleCat.{u} k) ℕ) :
+    Nonempty (HomologicalComplex.tensorObj (C.extend ComplexShape.embeddingUpNat)
+        (D.extend ComplexShape.embeddingUpNat) ≅
+      (HomologicalComplex.tensorObj C D).extend ComplexShape.embeddingUpNat) :=
+  ⟨TensorExtendUp.tensorObjExtendIso C D⟩
+
+/-- **Künneth for `ℕ`-indexed cochain complexes.** For cochain complexes `C, D` of `k`-vector
+spaces indexed over `ℕ`, the homology of the tensor product decomposes as a direct sum:
+`Hⁱ(C ⊗ D) ≅ ⨁_{p+q=i} Hᵖ(C) ⊗ Hᵍ(D)`.
+
+Reindexes Chapter 7's `Problem7_8_7_iv` along `embeddingUpNat`; the exact mirror of
+`kunnethChainComplexNat`. Consumed by the Problem 8.2.8 `Ext` assembler on the Hom cochain
+complexes `Hom_A(P•, N)`. -/
+theorem kunnethCochainComplexNat (C D : CochainComplex (ModuleCat.{u} k) ℕ) (i : ℕ) :
+    Nonempty ((HomologicalComplex.tensorObj C D).homology i ≅
+      ∐ fun (p : {p : ℕ × ℕ // p.1 + p.2 = i}) =>
+        C.homology p.1.1 ⊗ D.homology p.1.2) := by
+  classical
+  let e := ComplexShape.embeddingUpNat
+  -- Step 1: `Hⁱ(C ⊗ D) ≅ Hⁱ(extend (C ⊗ D))`.
+  let α₁ : (HomologicalComplex.tensorObj C D).homology i ≅
+      ((HomologicalComplex.tensorObj C D).extend e).homology (i : ℤ) :=
+    (homology_extend_iso_up (HomologicalComplex.tensorObj C D) i).symm
+  -- Step 2: apply `Hⁱ` to the crux iso `extend (C ⊗ D) ≅ extend C ⊗ extend D`.
+  let φ : (HomologicalComplex.tensorObj C D).extend e ≅
+      HomologicalComplex.tensorObj (C.extend e) (D.extend e) :=
+    (nonempty_tensorObj_extend_iso_up C D).some.symm
+  let α₂ := (HomologicalComplex.homologyFunctor (ModuleCat.{u} k) (ComplexShape.up ℤ)
+    (i : ℤ)).mapIso φ
+  -- Step 3: Chapter 7's universe-general Künneth at degree `i`.
+  let α₃ := (Problem7_8_7_iv (C.extend e) (D.extend e) (i : ℤ)).some
+  -- Step 4: reindex the `ℤ`-coproduct `⨁_{a+b=i}` onto the `ℕ`-antidiagonal `⨁_{p+q=i}`;
+  -- the summands with `a < 0` or `b < 0` vanish by `homology_extend_isZero_up`.
+  let ι : {p : ℕ × ℕ // p.1 + p.2 = i} → {p : ℤ × ℤ // p.1 + p.2 = (i : ℤ)} :=
+    fun p => ⟨((p.1.1 : ℤ), (p.1.2 : ℤ)), by
+      have h2 : (p.1.1 : ℤ) + (p.1.2 : ℤ) = (i : ℤ) := by exact_mod_cast p.2
+      exact h2⟩
+  have hι : Function.Injective ι := by
+    intro p p' hpp
+    apply Subtype.ext
+    have hv : (ι p).1 = (ι p').1 := congrArg Subtype.val hpp
+    have h1 : (p.1.1 : ℤ) = (p'.1.1 : ℤ) := congrArg Prod.fst hv
+    have h2 : (p.1.2 : ℤ) = (p'.1.2 : ℤ) := congrArg Prod.snd hv
+    exact Prod.ext (by exact_mod_cast h1) (by exact_mod_cast h2)
+  let α₄ : (∐ fun (p : {p : ℤ × ℤ // p.1 + p.2 = (i : ℤ)}) =>
+        (C.extend e).homology p.1.1 ⊗ (D.extend e).homology p.1.2) ≅
+      (∐ fun (p : {p : ℕ × ℕ // p.1 + p.2 = i}) => C.homology p.1.1 ⊗ D.homology p.1.2) :=
+    sigmaIsoOfInjOfIsZeroCompl ι hι
+      (fun a => tensorIso (homology_extend_iso_up C a.1.1) (homology_extend_iso_up D a.1.2))
+      (by
+        rintro ⟨⟨a, b⟩, hab⟩ hj
+        by_cases ha : a < 0
+        · exact TensorExtendUp.isZero_tensorObj_left (homology_extend_isZero_up C a ha)
+        by_cases hb : b < 0
+        · exact TensorExtendUp.isZero_tensorObj_right (homology_extend_isZero_up D b hb)
+        rw [not_lt] at ha hb
+        exfalso
+        have hp : ((a.toNat) : ℤ) = a := Int.toNat_of_nonneg ha
+        have hq : ((b.toNat) : ℤ) = b := Int.toNat_of_nonneg hb
+        have hpq : a.toNat + b.toNat = i := by
+          have : ((a.toNat) : ℤ) + ((b.toNat) : ℤ) = (i : ℤ) := by rw [hp, hq]; exact hab
+          exact_mod_cast this
+        refine hj ⟨(a.toNat, b.toNat), hpq⟩ (Subtype.ext ?_)
+        change (((a.toNat : ℕ) : ℤ), ((b.toNat : ℕ) : ℤ)) = (a, b)
+        rw [Prod.mk.injEq]
+        exact ⟨hp, hq⟩)
+  exact ⟨α₁ ≪≫ α₂ ≪≫ α₃ ≪≫ α₄⟩
+
+end Etingof

--- a/progress/2026-07-16T12-36-20Z_9ab70b1c.md
+++ b/progress/2026-07-16T12-36-20Z_9ab70b1c.md
@@ -1,0 +1,60 @@
+## Accomplished
+
+Formalized issue #6825 (deliverable 2 of #6817): the **cochain** Künneth over the field `k`.
+New file `EtingofRepresentationTheory/Chapter7/KunnethCochainComplexNat.lean` proves
+
+```
+Etingof.kunnethCochainComplexNat (C D : CochainComplex (ModuleCat.{u} k) ℕ) (i : ℕ) :
+  Nonempty ((HomologicalComplex.tensorObj C D).homology i ≅
+    ∐ fun (p : {p : ℕ × ℕ // p.1 + p.2 = i}) => C.homology p.1.1 ⊗ D.homology p.1.2)
+```
+
+sorry-free, the `up ℕ` cochain twin of `Etingof.kunnethChainComplexNat` (`down ℕ`), obtained by
+reindexing Chapter 7's `Problem7_8_7_iv` along `ComplexShape.embeddingUpNat` (`n ↦ n`, support ℤ≥0).
+
+Route (direct mirror of `KunnethChainComplexNat.lean`, degrees `+n` instead of `-n`):
+- `homology_extend_iso_up` / `homology_extend_isZero_up`: homology transport + vanishing below the
+  image (`j' < 0`).
+- `TensorExtendUp` namespace: degreewise object iso `tensorExtendXIso`, differential compatibility
+  `fwdNat_comm`, complex iso `tensorObjExtendIso`; crux `nonempty_tensorObj_extend_iso_up`.
+- Reused the embedding-agnostic `sigmaIsoOfInjOfIsZeroCompl` / `sigmaSupport{Hom,Inv}` API directly
+  from `KunnethChainComplexNat.lean` (imported).
+
+Key differences from the chain case worth recording:
+1. **Missing Mathlib instance**: Mathlib ships `TensorSigns (up ℤ)` and `TensorSigns (down ℕ)` but
+   NOT `TensorSigns (up ℕ)`; without it `HomologicalComplex.tensorObj` does not elaborate on `up ℕ`
+   complexes. Added the instance (`ε n = (-1)^n`, same data as `down ℕ`, only `Rel` direction
+   differs). This is prerequisite infrastructure the Ext assembler on `Hom_A(P•,N)` needs.
+2. **Cast-spelling war** (`↑(n+1)` vs `↑n+1`): the upward differential targets degree `n+1`, and a
+   plain `dsimp` normalizes `↑(n+1)` to `↑n+1`, which then fails to match `fwdNat (n+1)` /
+   `r_nat (n+1)` (locked to `↑(n+1)`). The chain case dodges this (its downward differential targets
+   `-↑n`, no `+1`). Fix: never let `dsimp` touch casts — reduce the Koszul signs via explicit
+   `show … = 1 from rfl` / `show … = Int.negOnePow ↑p from (negOnePow_natCast p).symm` rewrites, and
+   spell every shifted index as `((p+1 : ℕ) : ℤ)` so it matches `r_nat`.
+3. Sign lemma is `negOnePow_natCast` (`Int.negOnePow ↑n = (-1)^n`), simpler than the chain's
+   `negOnePow_neg_natCast` (no `negOnePow_neg`). d₁ never vanishes (up-differential `C.d p (p+1)`
+   always exists), so no `p = 0` boundary sub-cases.
+
+`lake build EtingofRepresentationTheory.Chapter7.KunnethCochainComplexNat` succeeds (8584 jobs),
+no sorries, no warnings. Added the import to `EtingofRepresentationTheory/Chapter7.lean`.
+
+## Current frontier
+
+Issue #6825 complete. The Problem 8.2.8 `Ext` cohomological Künneth (parent #6817/#6814) now has
+both deliverables landed once this merges (deliverable 1 `ExtCohomologyHomK.lean` already merged).
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. Active cluster: Problem 8.2.8 `Ext` half (#6815 left-module stack,
+#6816 Hom-tensor iso, #6817 cohomological Künneth, #6818 assembly). This PR clears the cochain
+Künneth piece feeding #6818.
+
+## Next step
+
+`kunnethCochainComplexNat` is now available for the Problem 8.2.8 `Ext` assembler (#6818, blocked on
+#6822). A downstream worker on #6818 consumes it on the Hom cochain complexes
+`Hom_A(P•, N) = P.complex.linearYonedaObj k N`.
+
+## Blockers
+
+None for this item.


### PR DESCRIPTION
Closes #6825

Session: `9ab70b1c-ae47-49fe-98de-e5a5dea58feb`

7b67a3d9 docs(lean-formalization): record cochain-mirror cast trap and TensorSigns (up ℕ) gap (#6825)
7ed0c2cf feat(Ch7 #Problem8.2.8-Ext): cochain Künneth over k (kunnethCochainComplexNat)

🤖 Prepared with Claude Code