### PR TITLE
feat(Ch5 #Problem5.24.2): prove reynolds_injective — endTensorEval is injective on block-symmetric endomorphisms (last sorry in Problem5_24_2_Bridge, FFT reductivity heart)

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -1090,6 +1090,29 @@ Same trap bites `Real.sqrt 5` vector literals: `![12, 0, 0, (-1 + Real.sqrt 5)/2
 `: ℂ` character elaborates the vector as `Fin 5 → ℝ` and inserts a `↑(…)` coercion, so it won't
 `rfl`-match a `ℂ`-side value with `↑√5`. Force `ℂ` by writing `(Real.sqrt 5 : ℂ)` inside the entries.
 
+### Three cheap `rw`/`congr` traps when averaging/reindexing over `Fin n → Fin N` (#6829, Ch5 `Problem5_24_2_Bridge.lean`)
+
+Proving `reynolds_injective` (block-symmetrization Reynolds operator on `End(V^{⊗n})`) surfaced three
+recurring, easily-fixed pitfalls:
+
+- **`congr 1` on `c • (big sum) = c • (big sum)` blows 200k heartbeats.** Stripping the scalar off a
+  `((…).card : ℂ)⁻¹ • ∑ τ ∈ blockPerms, toMatrix M (a∘τ) (b∘τ)` equality via `congr 1` runs
+  `isDefEq` on the full sums (index type `Fin n → Fin N`) and times out — *nondeterministically*, so
+  it may pass one build and fail the next. **Fix:** prove the inner `∑ = ∑` as its own `have hsum`
+  (e.g. by `Finset.sum_nbij'` reindexing) and finish with `rw [toMatrix_reynolds, toMatrix_reynolds,
+  hsum]`. Never `congr 1` across a large `Finset.sum`.
+- **`rw [← h]` with `h : BIG = 0` rewrites the *first* `0`, usually an inner `else 0`.** In a goal
+  `∑ f, ∑ g, (if P then W f₀ g₀ else 0) = 0`, `rw [← h]` (meaning to expand the RHS `0`) instead
+  hits the `else 0` inside the summand and corrupts the term. **Fix:** never `rw [← h]` to touch a
+  bare `0`; rewrite *forward* with an explicit `rw [show LHS = LHS' from Finset.sum_congr …]` then
+  `exact h`.
+- **`congrFun hσ j` on `hσ : f ∘ g = f` yields `(f ∘ g) j`, which won't `rw` into a goal written as
+  `f (g j)`.** `rw [congrFun hσ.2 j]` fails with "did not find `(slot ∘ ⇑σ) j`" against a target
+  `slot (σ j) = slot j` (defeq but not syntactic). **Fix:** bind an explicitly-typed intermediate
+  `have h2 : slot (σ j) = slot j := congrFun hσ.2 j` (defeq-tolerant `:=`), then `rw [h2]`. Same for
+  `ρ (ρ⁻¹ j) = j`: use `Equiv.apply_symm_apply ρ j` (there is no `Equiv.Perm.apply_inv_self`; `ρ⁻¹`
+  is defeq `ρ.symm`).
+
 ### Graph connectivity ("∃ edge-path" clauses) via `Relation.ReflTransGen`, and Fin-bound `omega` gotchas (#6762, Ch6 affine Dynkin `Problem6_1_3_continued_tildeE.lean`)
 
 Connectivity clauses of the shape `∀ i j, ∃ path : List (Fin n), path.head? = some i ∧ path.getLast? = some j ∧ ∀ k (h : k+1 < path.length), adj (path.get ⟨k,_⟩) (path.get ⟨k+1,h⟩) = 1` are painful to build as raw lists. **Recipe:** work with `Relation.ReflTransGen (fun a b => adj a b = 1)` (built-in `.refl`/`.single`/`.head`/`.tail`/`.trans`), and convert *once* with a helper: `obtain ⟨l, hne, hchain, hhead, hlast⟩ := List.exists_isChain_ne_nil_of_relationReflTransGen h; refine ⟨l, ?_, ?_, ?_⟩` closing head/last by `rw [List.head?_eq_some_head hne, hhead]` / `List.getLast?_eq_some_getLast`, and the `get`-condition by `simpa [List.get_eq_getElem] using List.isChain_iff_getElem.mp hchain k hk`. Reduce full connectivity to reach-from-a-base: `symm` of `ReflTransGen` holds when `adj.IsSymm` (induct, flipping each edge via `hsymm.apply`), so `(reach i).symm.trans (reach j)`. For variable-rank families (cycle `Ãₙ`, chain `D̃ₙ`) prove `reach` by `induction` on the vertex index; for finite exceptional diagrams enumerate with `fin_cases`.

--- a/EtingofRepresentationTheory/Chapter5/Problem5_24_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_24_2.lean
@@ -52,30 +52,6 @@ variable (k N : ℕ)
 
 /-! ## Tensor-trace ↔ trace-word: the value on a permutation operator -/
 
-/-- The matrix of the permutation operator `symGroupAction σ` in the standard tensor basis is the
-`{0,1}`-permutation matrix `f = g ∘ σ⁻¹`: `reindex σ` sends the basis vector `⨂ᵢ eᵢ` indexed by
-`g` to the one indexed by `g ∘ σ⁻¹`. -/
-theorem toMatrix_symGroupAction (n : ℕ) (σ : Equiv.Perm (Fin n))
-    (f g : Fin n → Fin N) :
-    LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n)
-        (symGroupAction ℂ (BridgeV N) n σ).toLinearMap f g
-      = if f = g ∘ σ.symm then 1 else 0 := by
-  rw [LinearMap.toMatrix_apply]
-  -- The permutation operator sends the basis vector indexed by `g` to the one indexed by `g ∘ σ⁻¹`.
-  have hval : (symGroupAction ℂ (BridgeV N) n σ).toLinearMap (tensorBasis N n g)
-      = tensorBasis N n (g ∘ σ.symm) := by
-    have h1 : tensorBasis N n g = ⨂ₜ[ℂ] i, (Pi.basisFun ℂ (Fin N)) (g i) :=
-      Basis.piTensorProduct_apply _ g
-    have h2 : tensorBasis N n (g ∘ σ.symm)
-        = ⨂ₜ[ℂ] i, (Pi.basisFun ℂ (Fin N)) ((g ∘ σ.symm) i) :=
-      Basis.piTensorProduct_apply _ (g ∘ σ.symm)
-    rw [h1, h2]
-    show symGroupAction ℂ (BridgeV N) n σ (⨂ₜ[ℂ] i, (Pi.basisFun ℂ (Fin N)) (g i)) = _
-    rw [symGroupAction, PiTensorProduct.reindex_tprod]
-    rfl
-  rw [hval, Basis.repr_self, Finsupp.single_apply]
-  exact if_congr eq_comm rfl rfl
-
 /-- The per-orbit factor `trace (matrixCycleProd σ (X_{letter ·}) r)` of the cycle-trace identity is
 a trace-of-word function: the ordered matrix product around the orbit of `r`,
 `X_{letter r} · X_{letter (σ⁻¹ r)} · …`, is the word product `w = [letter r, letter (σ⁻¹ r), …]`
@@ -120,7 +96,8 @@ theorem endTensorEval_symGroupAction_mem_adjoin (n : ℕ) (slot : Fin n → Fin 
               * genericTensorMatrix k N n slot g f
             = if f = g ∘ σ.symm then genericTensorMatrix k N n slot g f else 0 := by
         intro f
-        rw [toMatrix_symGroupAction, apply_ite (algebraMap ℂ (MatrixTupleRing k N)),
+        rw [toMatrix_symGroupAction, Equiv.Perm.inv_def,
+          apply_ite (algebraMap ℂ (MatrixTupleRing k N)),
           map_one, map_zero, ite_mul, one_mul, zero_mul]
       simp_rw [hterm]
       rw [Finset.sum_ite_eq' Finset.univ (g ∘ σ.symm)

--- a/EtingofRepresentationTheory/Chapter5/Problem5_24_2_Bridge.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_24_2_Bridge.lean
@@ -679,6 +679,349 @@ theorem reynolds_conj (slot : Fin n → Fin k) (g : (Matrix (Fin N) (Fin N) ℂ)
   rw [show P * Pτ' = Pτ' * P from hcP'.symm.eq, ← mul_assoc Pτ Q,
     show Pτ * Q = Q * Pτ from hcQ.eq, mul_assoc Q Pτ]
 
+/-- `reynolds` is `ℂ`-linear, so it commutes with subtraction. -/
+private theorem reynolds_sub (slot : Fin n → Fin k)
+    (M M' : Module.End ℂ (TensorPower ℂ (BridgeV N) n)) :
+    reynolds k N n slot (M - M') = reynolds k N n slot M - reynolds k N n slot M' := by
+  classical
+  rw [reynolds, reynolds, reynolds, ← smul_sub, ← Finset.sum_sub_distrib]
+  congr 1
+  refine Finset.sum_congr rfl fun τ _ => ?_
+  rw [mul_sub, sub_mul]
+
+/-- **Matrix of a Reynolds summand.** Conjugating `M` by the permutation operators of `τ` and `τ⁻¹`
+reindexes its matrix by `τ`: the `(a, b)` entry of `P_τ · M · P_{τ⁻¹}` is `M_{a∘τ, b∘τ}`. -/
+private theorem toMatrix_reynolds_summand (slot : Fin n → Fin k)
+    (M : Module.End ℂ (TensorPower ℂ (BridgeV N) n)) (τ : Equiv.Perm (Fin n))
+    (a b : Fin n → Fin N) :
+    LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n)
+        ((symGroupAction ℂ (BridgeV N) n τ).toLinearMap * M
+          * (symGroupAction ℂ (BridgeV N) n τ⁻¹).toLinearMap) a b
+      = LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) M (a ∘ τ) (b ∘ τ) := by
+  classical
+  rw [LinearMap.toMatrix_mul, LinearMap.toMatrix_mul]
+  set A := LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) M with hA
+  have hPLval : ∀ p : Fin n → Fin N,
+      LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n)
+          (symGroupAction ℂ (BridgeV N) n τ).toLinearMap a p
+        = if a = p ∘ (τ⁻¹ : Equiv.Perm (Fin n)) then (1 : ℂ) else 0 := by
+    intro p; rw [toMatrix_symGroupAction]
+  have hPRval : ∀ q : Fin n → Fin N,
+      LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n)
+          (symGroupAction ℂ (BridgeV N) n τ⁻¹).toLinearMap q b
+        = if q = b ∘ (τ : Equiv.Perm (Fin n)) then (1 : ℂ) else 0 := by
+    intro q; rw [toMatrix_symGroupAction, inv_inv]
+  rw [Matrix.mul_apply, Finset.sum_eq_single (b ∘ (τ : Equiv.Perm (Fin n)))]
+  · rw [hPRval, if_pos rfl, mul_one, Matrix.mul_apply,
+      Finset.sum_eq_single (a ∘ (τ : Equiv.Perm (Fin n)))]
+    · rw [hPLval, if_pos (show a = (a ∘ (τ : Equiv.Perm (Fin n))) ∘ (τ⁻¹ : Equiv.Perm (Fin n)) by
+          funext j; simp), one_mul]
+    · intro p _ hp
+      rw [hPLval, if_neg (fun he => hp (by
+        funext j; have := congrFun he ((τ : Equiv.Perm (Fin n)) j); simpa using this.symm)),
+        zero_mul]
+    · intro h; exact absurd (Finset.mem_univ _) h
+  · intro q _ hq
+    rw [hPRval, if_neg hq, mul_zero]
+  · intro h; exact absurd (Finset.mem_univ _) h
+
+/-- **Matrix of the Reynolds operator.** Its `(a, b)` entry is the block average of the reindexed
+entries `M_{a∘τ, b∘τ}` of `M` over the block symmetric group. -/
+private theorem toMatrix_reynolds (slot : Fin n → Fin k)
+    (M : Module.End ℂ (TensorPower ℂ (BridgeV N) n)) (a b : Fin n → Fin N) :
+    LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) (reynolds k N n slot M) a b
+      = ((blockPerms k n slot).card : ℂ)⁻¹
+        • ∑ τ ∈ blockPerms k n slot,
+            LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) M (a ∘ τ) (b ∘ τ) := by
+  classical
+  rw [reynolds, map_smul, map_sum, Matrix.smul_apply, Matrix.sum_apply]
+  congr 1
+  refine Finset.sum_congr rfl fun τ _ => ?_
+  exact toMatrix_reynolds_summand k N n slot M τ a b
+
+/-- **Block symmetry of the Reynolds operator.** Its matrix is invariant under reindexing rows and
+columns by a block permutation `ρ` (`ρ ∈ blockPerms slot`): the block average absorbs the extra
+translation. -/
+private theorem reynolds_block_symmetric (slot : Fin n → Fin k)
+    (M : Module.End ℂ (TensorPower ℂ (BridgeV N) n)) {ρ : Equiv.Perm (Fin n)}
+    (hρ : ρ ∈ blockPerms k n slot) (a b : Fin n → Fin N) :
+    LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) (reynolds k N n slot M)
+        (a ∘ ρ) (b ∘ ρ)
+      = LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) (reynolds k N n slot M) a b := by
+  classical
+  have hslotρ : slot ∘ ρ = slot := by rw [blockPerms, Finset.mem_filter] at hρ; exact hρ.2
+  have hmem : ∀ σ : Equiv.Perm (Fin n), σ ∈ blockPerms k n slot →
+      ρ * σ ∈ blockPerms k n slot := by
+    intro σ hσ
+    rw [blockPerms, Finset.mem_filter] at hσ ⊢
+    refine ⟨Finset.mem_univ _, ?_⟩
+    funext j
+    show slot (ρ (σ j)) = slot j
+    have h1 : slot (ρ (σ j)) = slot (σ j) := congrFun hslotρ (σ j)
+    have h2 : slot (σ j) = slot j := congrFun hσ.2 j
+    rw [h1, h2]
+  have hslotρinv : slot ∘ (ρ⁻¹ : Equiv.Perm (Fin n)) = slot := by
+    funext j
+    have h1 : slot (ρ (ρ⁻¹ j)) = slot (ρ⁻¹ j) := congrFun hslotρ (ρ⁻¹ j)
+    have hρρ : ρ (ρ⁻¹ j) = j := Equiv.apply_symm_apply ρ j
+    rw [hρρ] at h1
+    exact h1.symm
+  have hmemInv : ∀ σ : Equiv.Perm (Fin n), σ ∈ blockPerms k n slot →
+      ρ⁻¹ * σ ∈ blockPerms k n slot := by
+    intro σ hσ
+    rw [blockPerms, Finset.mem_filter] at hσ ⊢
+    refine ⟨Finset.mem_univ _, ?_⟩
+    funext j
+    show slot (ρ⁻¹ (σ j)) = slot j
+    have h1 : slot (ρ⁻¹ (σ j)) = slot (σ j) := congrFun hslotρinv (σ j)
+    have h2 : slot (σ j) = slot j := congrFun hσ.2 j
+    rw [h1, h2]
+  have hsum : (∑ τ ∈ blockPerms k n slot,
+        LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) M ((a ∘ ρ) ∘ τ) ((b ∘ ρ) ∘ τ))
+      = ∑ τ ∈ blockPerms k n slot,
+        LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) M (a ∘ τ) (b ∘ τ) := by
+    refine Finset.sum_nbij' (fun τ => ρ * τ) (fun τ => ρ⁻¹ * τ) ?_ ?_ ?_ ?_ ?_
+    · intro σ hσ; exact hmem σ hσ
+    · intro σ hσ; exact hmemInv σ hσ
+    · intro σ _; rw [← mul_assoc, inv_mul_cancel, one_mul]
+    · intro σ _; rw [← mul_assoc, mul_inv_cancel, one_mul]
+    · intro σ _
+      congr 1 <;>
+        · funext j; simp only [Function.comp_apply, Equiv.Perm.mul_apply]
+  rw [toMatrix_reynolds, toMatrix_reynolds, hsum]
+
+/-- The generic tensor matrix entry `(g, f)` is the monomial of the exponent vector realized by the
+slot assignment `(f, g)`. -/
+private theorem genericTensorMatrix_eq_monomial (slot : Fin n → Fin k) (g f : Fin n → Fin N) :
+    genericTensorMatrix k N n slot g f
+      = MvPolynomial.monomial (∑ j : Fin n, Finsupp.single (slot j, g j, f j) 1) (1 : ℂ) := by
+  classical
+  rw [genericTensorMatrix]
+  have hX : ∀ j : Fin n, (MvPolynomial.X (slot j, g j, f j) : MatrixTupleRing k N)
+      = MvPolynomial.monomial (Finsupp.single (slot j, g j, f j) 1) 1 := fun j => by
+    rw [← MvPolynomial.X_pow_eq_monomial, pow_one]
+  simp_rw [hX]
+  rw [prod_monomial_single]
+
+/-- Given two sequences `f g : Fin m → α` with equal underlying multiset, an explicit permutation
+`σ` matching them (`g = f ∘ σ`). Peel the head of `g` and match it against an element of `f`'s
+domain. -/
+private noncomputable def matchingPerm {α : Type*} [DecidableEq α] :
+    ∀ {m : ℕ} (f g : Fin m → α),
+      Multiset.map f (Finset.univ : Finset (Fin m)).val =
+        Multiset.map g (Finset.univ : Finset (Fin m)).val →
+      {σ : Equiv.Perm (Fin m) // g = f ∘ σ}
+  | 0, _, g, _ => ⟨Equiv.refl _, funext fun i => i.elim0⟩
+  | m + 1, f, g, h =>
+      let hg0_mem : g 0 ∈ Multiset.map f (Finset.univ : Finset (Fin (m+1))).val := by
+        rw [h]; exact Multiset.mem_map.mpr ⟨0, Finset.mem_univ_val _, rfl⟩
+      let l₀ : Fin (m+1) := Classical.choose (Multiset.mem_map.mp hg0_mem)
+      let l₀_spec :
+        l₀ ∈ (Finset.univ : Finset (Fin (m+1))).val ∧ f l₀ = g 0 :=
+        Classical.choose_spec (Multiset.mem_map.mp hg0_mem)
+      let hl₀ : f l₀ = g 0 := l₀_spec.2
+      let f' : Fin m → α := f ∘ l₀.succAbove
+      let g' : Fin m → α := g ∘ Fin.succ
+      let hpeel_f : Multiset.map f (Finset.univ : Finset (Fin (m+1))).val =
+          f l₀ ::ₘ Multiset.map f' (Finset.univ : Finset (Fin m)).val := by
+        conv_lhs => rw [Fin.univ_succAbove m l₀]
+        simp only [Finset.cons_val, Multiset.map_cons, Finset.map_val,
+          Multiset.map_map, Fin.coe_succAboveEmb]
+        rfl
+      let hpeel_g : Multiset.map g (Finset.univ : Finset (Fin (m+1))).val =
+          g 0 ::ₘ Multiset.map g' (Finset.univ : Finset (Fin m)).val := by
+        conv_lhs => rw [Fin.univ_succAbove m 0]
+        simp only [Finset.cons_val, Multiset.map_cons, Finset.map_val,
+          Multiset.map_map, Fin.coe_succAboveEmb, Fin.succAbove_zero]
+        rfl
+      let hms : Multiset.map f' (Finset.univ : Finset (Fin m)).val =
+          Multiset.map g' (Finset.univ : Finset (Fin m)).val := by
+        have hh : f l₀ ::ₘ Multiset.map f' (Finset.univ : Finset (Fin m)).val =
+            f l₀ ::ₘ Multiset.map g' (Finset.univ : Finset (Fin m)).val := by
+          rw [← hpeel_f, h, hpeel_g, hl₀]
+        exact (Multiset.cons_inj_right _).mp hh
+      let σ'_pkg := matchingPerm f' g' hms
+      let σ' : Equiv.Perm (Fin m) := σ'_pkg.1
+      let hσ' : g' = f' ∘ σ' := σ'_pkg.2
+      let σ_fn : Fin (m+1) → Fin (m+1) :=
+        Fin.cases l₀ (fun j => l₀.succAbove (σ' j))
+      let hinj : Function.Injective σ_fn := by
+        intro i j hij
+        induction i using Fin.cases with
+        | zero =>
+          induction j using Fin.cases with
+          | zero => rfl
+          | succ b =>
+            exfalso
+            change l₀ = l₀.succAbove (σ' b) at hij
+            exact (Fin.succAbove_ne l₀ (σ' b)) hij.symm
+        | succ a =>
+          induction j using Fin.cases with
+          | zero =>
+            exfalso
+            change l₀.succAbove (σ' a) = l₀ at hij
+            exact (Fin.succAbove_ne l₀ (σ' a)) hij
+          | succ b =>
+            change l₀.succAbove (σ' a) = l₀.succAbove (σ' b) at hij
+            have h1 : σ' a = σ' b := l₀.succAbove_right_injective hij
+            have h2 : a = b := σ'.injective h1
+            exact congrArg Fin.succ h2
+      let hbij : Function.Bijective σ_fn :=
+        Finite.injective_iff_bijective.mp hinj
+      ⟨Equiv.ofBijective σ_fn hbij, by
+        funext i
+        induction i using Fin.cases with
+        | zero =>
+          show g 0 = f (σ_fn 0)
+          change g 0 = f l₀
+          exact hl₀.symm
+        | succ j =>
+          show g (Fin.succ j) = f (σ_fn (Fin.succ j))
+          change g (Fin.succ j) = f (l₀.succAbove (σ' j))
+          have := congrFun hσ' j
+          show g' j = f' (σ' j)
+          exact this⟩
+
+/-- For any sequence `g : Fin n → α`, the multiset of values equals
+`Finsupp.toMultiset (∑ l, single (g l) 1)`. -/
+private theorem toMultiset_sum_single_fn {α : Type*} [DecidableEq α] (g : Fin n → α) :
+    Finsupp.toMultiset (∑ l : Fin n, Finsupp.single (g l) (1 : ℕ)) =
+      Multiset.map g (Finset.univ : Finset (Fin n)).val := by
+  classical
+  rw [Finsupp.toMultiset_sum]
+  simp only [Finsupp.toMultiset_single, one_smul]
+  induction (Finset.univ : Finset (Fin n)) using Finset.induction_on with
+  | empty => simp
+  | insert a s ha ih =>
+    rw [Finset.sum_insert ha, ih, Finset.insert_val, Multiset.ndinsert_of_notMem ha,
+      Multiset.map_cons, Multiset.singleton_add]
+
+/-- **Single-orbit realizability.** If a slot-assignment pair `(f, g)` realizes the same exponent
+vector as `(f₀, g₀)`, then it is obtained from `(f₀, g₀)` by a block permutation `σ`: matching the
+common multiset of triples `(slot j, · j, · j)` produces a slot-preserving `σ` with `f = f₀ ∘ σ`,
+`g = g₀ ∘ σ`. -/
+private theorem exists_blockPerm_of_sum_single_eq (slot : Fin n → Fin k)
+    (f g f₀ g₀ : Fin n → Fin N)
+    (h : ∑ j : Fin n, Finsupp.single (slot j, g j, f j) (1 : ℕ)
+        = ∑ j : Fin n, Finsupp.single (slot j, g₀ j, f₀ j) (1 : ℕ)) :
+    ∃ σ ∈ blockPerms k n slot, f = f₀ ∘ σ ∧ g = g₀ ∘ σ := by
+  classical
+  have hmulti : Multiset.map (fun j => ((slot j, g₀ j, f₀ j) : Fin k × Fin N × Fin N))
+        (Finset.univ : Finset (Fin n)).val
+      = Multiset.map (fun j => ((slot j, g j, f j) : Fin k × Fin N × Fin N))
+        (Finset.univ : Finset (Fin n)).val := by
+    rw [← toMultiset_sum_single_fn, ← toMultiset_sum_single_fn, h]
+  obtain ⟨σ, hσ⟩ := matchingPerm
+    (fun j => ((slot j, g₀ j, f₀ j) : Fin k × Fin N × Fin N))
+    (fun j => ((slot j, g j, f j) : Fin k × Fin N × Fin N)) hmulti
+  refine ⟨σ, ?_, ?_, ?_⟩
+  · rw [blockPerms, Finset.mem_filter]
+    refine ⟨Finset.mem_univ _, ?_⟩
+    funext j
+    have hj := congrFun hσ j
+    simp only [Function.comp_apply, Prod.mk.injEq] at hj
+    show slot (σ j) = slot j
+    exact hj.1.symm
+  · funext j
+    have hj := congrFun hσ j
+    simp only [Function.comp_apply, Prod.mk.injEq] at hj
+    exact hj.2.2
+  · funext j
+    have hj := congrFun hσ j
+    simp only [Function.comp_apply, Prod.mk.injEq] at hj
+    exact hj.2.1
+
+/-- **Injectivity core.** A block-symmetric endomorphism (in the image of `reynolds`) whose
+evaluation vanishes is zero: reading off the coefficient of each monomial, the block symmetry makes
+the matrix constant on each single realizability orbit, and the positive orbit count over `ℂ` forces
+every matrix entry to zero. -/
+private theorem reynolds_eq_zero_of_endTensorEval_zero (slot : Fin n → Fin k)
+    (W₀ : Module.End ℂ (TensorPower ℂ (BridgeV N) n))
+    (hW : endTensorEval k N n slot (reynolds k N n slot W₀) = 0) :
+    reynolds k N n slot W₀ = 0 := by
+  classical
+  set W := reynolds k N n slot W₀ with hWdef
+  suffices hzero : ∀ f g : Fin n → Fin N,
+      LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) W f g = 0 by
+    have hmat : LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) W = 0 := by
+      ext f g; exact hzero f g
+    have hsymm : (LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n)).symm
+          (LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) W)
+        = (LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n)).symm 0 := by rw [hmat]
+    rwa [LinearEquiv.symm_apply_apply, map_zero] at hsymm
+  intro f₀ g₀
+  set u₀ : (Fin k × Fin N × Fin N) →₀ ℕ :=
+    ∑ j : Fin n, Finsupp.single (slot j, g₀ j, f₀ j) 1 with hu₀
+  -- `endTensorEval W` is a sum of monomials, one per pair `(f, g)`.
+  have hEval : endTensorEval k N n slot W
+      = ∑ f : Fin n → Fin N, ∑ g : Fin n → Fin N,
+          MvPolynomial.monomial (∑ j : Fin n, Finsupp.single (slot j, g j, f j) 1)
+            (LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) W f g) := by
+    rw [endTensorEval_apply]
+    refine Finset.sum_congr rfl fun f _ => Finset.sum_congr rfl fun g _ => ?_
+    rw [genericTensorMatrix_eq_monomial, MvPolynomial.algebraMap_eq, MvPolynomial.C_mul_monomial,
+      mul_one]
+  -- The coefficient of `monomial u₀` vanishes.
+  have hcoeff : (∑ f : Fin n → Fin N, ∑ g : Fin n → Fin N,
+      (if (∑ j : Fin n, Finsupp.single (slot j, g j, f j) 1) = u₀ then
+          LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) W f g else 0)) = 0 := by
+    have hc : MvPolynomial.coeff u₀ (endTensorEval k N n slot W) = 0 := by
+      rw [hW, MvPolynomial.coeff_zero]
+    rw [hEval] at hc
+    simp_rw [MvPolynomial.coeff_sum, MvPolynomial.coeff_monomial] at hc
+    exact hc
+  -- Block symmetry makes the surviving entries all equal to the `(f₀, g₀)` entry.
+  have hconst : ∀ f g : Fin n → Fin N,
+      (if (∑ j : Fin n, Finsupp.single (slot j, g j, f j) 1) = u₀ then
+          LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) W f g else 0)
+        = (if (∑ j : Fin n, Finsupp.single (slot j, g j, f j) 1) = u₀ then
+          LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) W f₀ g₀ else 0) := by
+    intro f g
+    by_cases hfg : (∑ j : Fin n, Finsupp.single (slot j, g j, f j) 1) = u₀
+    · rw [if_pos hfg, if_pos hfg]
+      obtain ⟨σ, hσbp, hfσ, hgσ⟩ :=
+        exists_blockPerm_of_sum_single_eq k N n slot f g f₀ g₀ (by rw [hfg, hu₀])
+      have hbs := reynolds_block_symmetric k N n slot W₀ hσbp f₀ g₀
+      rw [← hWdef] at hbs
+      rw [hfσ, hgσ]
+      exact hbs
+    · rw [if_neg hfg, if_neg hfg]
+  have hcoeff2 : (∑ f : Fin n → Fin N, ∑ g : Fin n → Fin N,
+      (if (∑ j : Fin n, Finsupp.single (slot j, g j, f j) 1) = u₀ then
+          LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) W f₀ g₀ else 0)) = 0 := by
+    rw [show (∑ f : Fin n → Fin N, ∑ g : Fin n → Fin N,
+          (if (∑ j : Fin n, Finsupp.single (slot j, g j, f j) 1) = u₀ then
+            LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) W f₀ g₀ else 0))
+        = ∑ f : Fin n → Fin N, ∑ g : Fin n → Fin N,
+          (if (∑ j : Fin n, Finsupp.single (slot j, g j, f j) 1) = u₀ then
+            LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) W f g else 0) from
+      Finset.sum_congr rfl fun f _ =>
+        Finset.sum_congr rfl fun g _ => (hconst f g).symm]
+    exact hcoeff
+  -- Fold the double sum into a cardinality times the `(f₀, g₀)` entry.
+  have hcombine : (∑ p : (Fin n → Fin N) × (Fin n → Fin N),
+        (if (∑ j : Fin n, Finsupp.single (slot j, p.2 j, p.1 j) 1) = u₀ then
+          LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) W f₀ g₀ else 0))
+      = ∑ f : Fin n → Fin N, ∑ g : Fin n → Fin N,
+          (if (∑ j : Fin n, Finsupp.single (slot j, g j, f j) 1) = u₀ then
+            LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) W f₀ g₀ else 0) :=
+    Fintype.sum_prod_type _
+  have hpc : (∑ p : (Fin n → Fin N) × (Fin n → Fin N),
+        (if (∑ j : Fin n, Finsupp.single (slot j, p.2 j, p.1 j) 1) = u₀ then
+          LinearMap.toMatrix (tensorBasis N n) (tensorBasis N n) W f₀ g₀ else 0)) = 0 := by
+    rw [hcombine]; exact hcoeff2
+  rw [← Finset.sum_filter, Finset.sum_const, nsmul_eq_mul] at hpc
+  have hmemfilter : (f₀, g₀) ∈
+      (Finset.univ.filter fun p : (Fin n → Fin N) × (Fin n → Fin N) =>
+        (∑ j : Fin n, Finsupp.single (slot j, p.2 j, p.1 j) 1) = u₀) := by
+    rw [Finset.mem_filter]
+    exact ⟨Finset.mem_univ _, hu₀.symm⟩
+  have hcard_ne : ((Finset.univ.filter fun p : (Fin n → Fin N) × (Fin n → Fin N) =>
+        (∑ j : Fin n, Finsupp.single (slot j, p.2 j, p.1 j) 1) = u₀).card : ℂ) ≠ 0 := by
+    rw [Ne, Nat.cast_eq_zero, Finset.card_eq_zero]
+    exact Finset.nonempty_iff_ne_empty.mp ⟨(f₀, g₀), hmemfilter⟩
+  exact (mul_eq_zero.mp hpc).resolve_left hcard_ne
+
 /-- **Injectivity of the evaluation pairing on block-symmetric endomorphisms.** Two endomorphisms in
 the image of the Reynolds operator with the same evaluation are equal: the block-symmetric
 endomorphisms are exactly the span of the uniform averages of matrix units over the fibres of
@@ -700,7 +1043,13 @@ theorem reynolds_injective (slot : Fin n → Fin k)
   --       `PolynomialTensorBridge.matchingPerm`). Block-symmetry makes `W` constant on that orbit,
   --       so the coefficient is `(orbit card) • W_{a,b}`; `endTensorEval W = 0` forces every
   --       coefficient to vanish (monomials are linearly independent), hence every `W_{a,b} = 0`.
-  sorry
+  classical
+  have hz : endTensorEval k N n slot (reynolds k N n slot (M - M')) = 0 := by
+    rw [reynolds_sub, map_sub, h, sub_self]
+  have hzero : reynolds k N n slot (M - M') = 0 :=
+    reynolds_eq_zero_of_endTensorEval_zero k N n slot (M - M') hz
+  rw [reynolds_sub, sub_eq_zero] at hzero
+  exact hzero
 
 /-- **Conjugation preserves multidegree.** The simultaneous-conjugation automorphism `conjAlgHom g`
 of the coordinate ring preserves the `matrixWeight`-multidegree: it substitutes each variable

--- a/progress/2026-07-16T13-33-05Z_1fcc42bc.md
+++ b/progress/2026-07-16T13-33-05Z_1fcc42bc.md
@@ -1,0 +1,52 @@
+## Accomplished
+
+Proved `reynolds_injective` sorry-free in
+`EtingofRepresentationTheory/Chapter5/Problem5_24_2_Bridge.lean` (issue #6829), the last `sorry`
+in the FFT reductivity heart. This makes `exists_endTensorEval_equivariant_section` and
+`weightedHomogeneous_invariant_mem_range_endTensorEval` fully sorry-free.
+
+The proof follows the roadmap in the file. New private helper lemmas added before
+`reynolds_injective`:
+
+- `reynolds_sub` — `reynolds` commutes with subtraction (it is `ℂ`-linear).
+- `toMatrix_reynolds_summand` — the `(a,b)` matrix entry of `P_τ · M · P_{τ⁻¹}` is `M_{a∘τ, b∘τ}`.
+- `toMatrix_reynolds` — matrix of `reynolds M` is the block average of reindexed entries.
+- `reynolds_block_symmetric` — that matrix is invariant under reindexing rows/columns by a block
+  permutation (proved by reindexing the block-average sum via `Finset.sum_nbij'`, using that
+  `blockPerms` is closed under left multiplication).
+- `genericTensorMatrix_eq_monomial` — the generic tensor matrix entry is the monomial of the
+  realized exponent vector.
+- `matchingPerm` / `toMultiset_sum_single_fn` — reproved locally (the originals in
+  `PolynomialTensorBridge` are `private` and not imported): equal multisets of `Fin m → α` give an
+  explicit matching permutation.
+- `exists_blockPerm_of_sum_single_eq` — two slot-assignment pairs realizing the same exponent
+  vector differ by a block permutation (multiset-matching / single-orbit).
+- `reynolds_eq_zero_of_endTensorEval_zero` — the injectivity core: a block-symmetric endomorphism
+  with vanishing evaluation is zero (coefficient extraction + block symmetry makes the matrix
+  constant on each single realizability orbit; positive orbit count over `ℂ` forces every entry to
+  zero).
+
+`reynolds_injective` itself reduces to the core via `reynolds_sub` and linearity of
+`endTensorEval`.
+
+## Current frontier
+
+`Problem5_24_2_Bridge.lean` builds sorry-free (`lake build` of the module: 8587 jobs, success).
+Signature of `reynolds_injective` unchanged, as required by the issue.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. This turn closed the FFT reductivity heart for Problem 5.24.2 step 2
+(range identification). Note: the doc comment near the top of the Bridge file still references a
+`sorry` in the sibling file `Problem5_24_2.lean` (`weightedHomogeneous_invariant_mem_adjoin`), which
+is the downstream consumer — not touched here.
+
+## Next step
+
+The assembly `weightedHomogeneous_invariant_mem_adjoin` in `Problem5_24_2.lean` can now consume the
+sorry-free `weightedHomogeneous_invariant_mem_range_endTensorEval`. A follow-up worker can discharge
+that `sorry` using the now-complete range identification.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6829

Session: `1fcc42bc-3806-4f07-aaf3-3b0cd089d096`

e8c33418 feat(Ch5 #Problem5.24.2): prove reynolds_injective sorry-free

🤖 Prepared with Claude Code