### PR TITLE
doc(plan): add twin/dualise scoping check for planners

### DIFF
--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -110,6 +110,15 @@ Each issue body MUST be **self-contained**:
 **Sizing**: max 3 deliverables, ~2 files, ~200 lines. Over 300 lines → split.
 When in doubt, split. Each issue must have a single logical concern.
 
+**"Twin/dualise" issues**: when an issue mirrors an existing multi-file stack on a
+parallel side (e.g. the `Ext` twin of a `Tor` construction, a left-module twin of a
+right-module one), do **not** assume "just wire up the final assembly". Check that each
+intermediate layer of the analogue actually exists on the new side, not only the
+endpoints. If the source stack was, say, bidegree iso → bifunctor natural iso → complex
+assembly, the new side usually needs every layer rebuilt — a single "assembly" issue that
+names only the degreewise piece will be underscoped and get decomposed by the worker.
+Plan one issue per missing layer (in dependency order) instead.
+
 **Stage granularity**: If the project roadmap has "stages" or "phases", **never
 create an issue that spans multiple stages**. Each issue belongs to exactly one
 stage.

--- a/progress/2026-07-16T15-00-39Z_93d957d8.md
+++ b/progress/2026-07-16T15-00-39Z_93d957d8.md
@@ -1,0 +1,59 @@
+## Accomplished
+
+Claimed **#6823** (feat Ch8 #Problem8.2.8-Ext: cohomological rearrange iso — twin of
+`rearrangeComplex` for the Hom cochain complex) and, after orientation, **decomposed** it: the issue
+was framed as "just the complex assembly, degreewise iso already provided by #6816", but comparison
+with the `Tor` stack showed a whole categorical layer is missing.
+
+- On the `Tor` side, `Etingof.rearrangeComplex` (`RearrangeComplex.lean`, #6744) is built from the
+  **natural** bifunctor iso `rearrangeBifunctorNatIso` (`RearrangeBifunctorNatIso.lean`, #6742),
+  whose naturality squares are exactly what discharge the differential-commutation squares of the
+  complex iso (`rearrangeComplexBicomplexIso` derives its two `d`-squares from
+  `rearrangeBifunctorNatIso.hom.naturality`).
+- On the `Ext` side, only the raw `k`-linear degreewise iso
+  `Etingof.HomTensorFGProj.homTensorHomEquiv` (`HomTensorFGProjective.lean`, #6816) exists — the
+  twin of `rearrangeBidegree`, not of the categorical natural-iso layer. That layer does not exist,
+  so #6823 as written had no route to prove commutation.
+
+Created two self-contained successor issues (mirroring the `Tor` stack):
+- **#6843** — cohomological bidegree bifunctor natural iso (twin of `rearrangeBifunctorNatIso`):
+  package `homTensorHomEquiv` as a `ModuleCat k` natural iso of the two contravariant bifunctors,
+  with the two naturality squares proved sorry-free. `depends-on: #6816`.
+- **#6844** — cochain complex assembly `rearrangeHomComplex` (residual of #6823, twin of
+  `rearrangeComplex`): assemble the `CochainComplex (ModuleCat k) ℕ` iso
+  `Hom_{A₁⊗A₂}(P•₁⊗P•₂, N₁⊗N₂) ≅ Hom(P•₁,N₁) ⊗ Hom(P•₂,N₂)`, using #6843's naturality for the
+  codifferential-commutation squares. `depends-on: #6816, #6843` (blocked on #6843).
+
+Left the `Decomposed into #6843, #6844` breadcrumb on #6823 and `coordination skip`ped it (→ replan).
+
+Also (`/reflect`): added a "Twin/dualise issues" note to `.claude/commands/plan.md` — when planning
+the twin of an existing multi-file stack, verify each intermediate layer exists on the new side, not
+just the endpoints; plan one issue per missing layer. This mis-scoping has now recurred twice
+(#6823 here; the #6833–#6835 "scaffold assumed but never committed" pattern in earlier progress
+notes).
+
+## Current frontier
+
+Ch8 Problem 8.2.8 `Ext` half. The `Ext` Künneth rearrangement now has a correctly-layered issue
+chain: #6816 (done) → **#6843** (unblocked, ready) → **#6844** (blocked on #6843) → #6818
+(`Problem_8_2_8_ext` assembler, consumes #6844).
+
+No Lean code was written this session (decomposition + planning-guidance only). The worktree has no
+`.lake` build environment set up; a worker picking up #6843 should `lake exe cache get` before the
+first build.
+
+## Overall project progress
+
+Phase 3 formalization, ongoing. This session was scoping/triage: one oversized issue split into a
+correct two-layer dependency chain, plus a planner-guidance improvement to prevent the recurrence.
+
+## Next step
+
+Claim **#6843** (cohomological bidegree bifunctor natural iso). It is unblocked, self-contained, and
+~400-600 lines by analogy with `RearrangeBifunctorNatIso.lean`/`RearrangeBidegreeNat.lean` — budget
+a full session. Template: dualise `Chapter8/RearrangeBifunctorNatIso.lean` through `Hom`, wrapping
+`homTensorHomEquiv` (#6816). Once it lands, #6844 auto-unblocks.
+
+## Blockers
+
+None. #6844 is intentionally blocked on #6843; #6818 waits on #6844.


### PR DESCRIPTION
This PR adds a planner-guidance note to `.claude/commands/plan.md`: when an issue mirrors an existing multi-file stack on a parallel side (the `Ext` twin of a `Tor` construction, a left-module twin of a right-module one), verify that each intermediate layer of the analogue actually exists on the new side rather than assuming only the final assembly remains, and plan one issue per missing layer in dependency order.

The gap surfaced while triaging #6823 (Ext cohomological rearrange iso), which was framed as "just the complex assembly using the #6816 degreewise iso" but in fact needed the whole categorical bidegree/bifunctor-natural-iso layer that the `Tor` side has across `RearrangeBidegreeNat.lean`/`RearrangeBifunctorNatIso.lean` (#6742) and that the complex assembly's differential-commutation squares depend on. It was decomposed into #6843 (the missing natural-iso layer) and #6844 (the residual assembly). The same mis-scoping recurred earlier with the #6833–#6835 scaffold.

Includes the session progress file.

🤖 Prepared with Claude Code