### PR TITLE
feat(Ch8 #6867): summandIso — per-summand Hom bridge for the Ext Künneth degreewise iso

### DIFF
--- a/EtingofRepresentationTheory/Chapter8/RearrangeHomComplexX.lean
+++ b/EtingofRepresentationTheory/Chapter8/RearrangeHomComplexX.lean
@@ -1,0 +1,77 @@
+import EtingofRepresentationTheory.Chapter8.RearrangeHomBifunctorNatIso
+import EtingofRepresentationTheory.Chapter8.ExternalTensorComplexLeft
+import EtingofRepresentationTheory.Chapter8.ExtCohomologyHomK
+import EtingofRepresentationTheory.Chapter7.KunnethCochainComplexNat
+
+/-!
+# The degreewise object iso for the `Ext` Künneth cochain assembly
+
+Substep of #6844 (the `Ext` half of Problem 8.2.8). This file constructs, for each degree `i`, the
+`ModuleCat k` isomorphism
+
+    Hom_{A₁⊗A₂}(⊕_{j+m=i} extTensorFunctorLeftObj (P₁ⱼ) (P₂ₘ), N₁⊗N₂)
+      ≅ ⊕_{j+m=i} Hom_{A₁}(P₁ⱼ, N₁) ⊗ₖ Hom_{A₂}(P₂ₘ, N₂),
+
+identifying the degree-`i` object of the source cochain complex
+`(extTensorComplexLeft P₁ P₂).linearYonedaObj k (N₁⊗N₂)` with that of the target
+`HomologicalComplex.tensorObj (P₁.complex.linearYonedaObj k N₁) (P₂.complex.linearYonedaObj k N₂)`.
+
+Because the source is `Hom(mapBifunctor …, N)` — a **product** over the finite fiber via the op/unop
+`linearYonedaObj`, not a `mapBifunctor` bicomplex — the `Tor`-side `total.mapIso` shortcut is
+unavailable, and the complex iso (#6868) has to be assembled degreewise from this object iso.
+
+## The per-summand bridge
+
+The essential ingredient is `summandIso`: on a single summand `(j, m)`,
+`Hom(extTensorFunctorLeftObj (P₁ⱼ)(P₂ₘ), N₁⊗N₂) ≅ Hom(P₁ⱼ,N₁) ⊗ₖ Hom(P₂ₘ,N₂)`, obtained by
+bridging the categorical `Hom`s (`ModuleCat.homLinearEquiv`) to `→ₗ`-maps and applying the
+component iso `Etingof.rearrangeHomComponentIso` (#6843).
+-/
+
+open CategoryTheory Limits MonoidalCategory TensorProduct HomologicalComplex
+
+namespace Etingof
+
+universe u
+
+variable (k : Type u) [Field k]
+variable (A₁ A₂ : Type u) [Ring A₁] [Ring A₂] [Algebra k A₁] [Algebra k A₂]
+variable (N₁ N₂ : Type u)
+  [AddCommGroup N₁] [Module k N₁] [Module A₁ N₁] [IsScalarTower k A₁ N₁]
+  [AddCommGroup N₂] [Module k N₂] [Module A₂ N₂] [IsScalarTower k A₂ N₂]
+variable [instN : Module (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)]
+  [IsScalarTower k (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)]
+variable
+  (hN : ∀ (a₁ : A₁) (a₂ : A₂) (n₁ : N₁) (n₂ : N₂),
+    (a₁ ⊗ₜ[k] a₂ : A₁ ⊗[k] A₂) • (n₁ ⊗ₜ[k] n₂ : N₁ ⊗[k] N₂)
+      = (a₁ • n₁) ⊗ₜ[k] (a₂ • n₂))
+
+/-- The `A₁ ⊗ A₂`-module `N₁ ⊗ₖ N₂` as an object of `ModuleCat (A₁ ⊗ A₂)`. -/
+noncomputable abbrev NNobj : ModuleCat.{u} (A₁ ⊗[k] A₂) := ModuleCat.of (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)
+
+attribute [local instance] restrictModule₁L restrictModule₂L tower₁L tower₂L extModuleL
+
+section Summand
+
+variable {A₁ A₂}
+
+include hN in
+/-- The per-summand bridge iso: on the `(X₁, X₂)` summand,
+`Hom_{A₁⊗A₂}(extTensorFunctorLeftObj X₁ X₂, N₁⊗N₂) ≅ Hom_{A₁}(X₁, N₁) ⊗ₖ Hom_{A₂}(X₂, N₂)`, phrased
+between the categorical `Hom` objects (as they appear in `linearYonedaObj`/`tensorObj`). Bridges the
+categorical `Hom`s to `→ₗ`-maps via `ModuleCat.homLinearEquiv` and applies the component iso
+`rearrangeHomComponentIso` (#6843). -/
+noncomputable def summandIso (X₁ : ModuleCat.{u} A₁) (X₂ : ModuleCat.{u} A₂)
+    [Module.Finite A₁ X₁] [Module.Projective A₁ X₁]
+    [Module.Finite A₂ X₂] [Module.Projective A₂ X₂] :
+    ModuleCat.of k (extTensorFunctorLeftObj k A₁ A₂ X₁ X₂ ⟶ NNobj k A₁ A₂ N₁ N₂) ≅
+      (ModuleCat.of k (X₁ ⟶ ModuleCat.of A₁ N₁)) ⊗ (ModuleCat.of k (X₂ ⟶ ModuleCat.of A₂ N₂)) :=
+  ModuleCat.homLinearEquiv.toModuleIso ≪≫
+    rearrangeHomComponentIso k N₁ N₂ hN X₁ X₂ ≪≫
+    (tensorIso
+      (ModuleCat.homLinearEquiv (M := X₁) (N := ModuleCat.of A₁ N₁) (S := k)).toModuleIso
+      (ModuleCat.homLinearEquiv (M := X₂) (N := ModuleCat.of A₂ N₂) (S := k)).toModuleIso).symm
+
+end Summand
+
+end Etingof

--- a/progress/2026-07-16T18-57-46Z_201bf754.md
+++ b/progress/2026-07-16T18-57-46Z_201bf754.md
@@ -1,0 +1,60 @@
+## Accomplished
+
+Worker session (`/work` → `/feature`) on the Ch8 `Ext`-Künneth cochain assembly.
+
+1. **Decomposed #6844** (full `Ext` Künneth cochain-complex iso `Hom(P•₁⊗P•₂, N₁⊗N₂) ≅
+   Hom(P•₁,N₁)⊗Hom(P•₂,N₂)`) into two self-contained sub-issues, mirroring the Tor side's
+   milestone split (#6742/#6743/#6744):
+   - **#6867** — the degreewise object iso (the mathematical heart), and
+   - **#6868** — the `isoOfComponents` complex assembly + differential squares (depends on #6867).
+   Skipped #6844 (`replan`) with a `Decomposed into #6867, #6868` breadcrumb capturing the full
+   analysis (why `total.mapIso` is unavailable here: the source is `Hom(mapBifunctor …, N)`, a
+   *product* via op/unop `linearYonedaObj`, not a `mapBifunctor` bicomplex).
+
+2. **Started #6867**: new file `EtingofRepresentationTheory/Chapter8/RearrangeHomComplexX.lean`
+   with `Etingof.summandIso` proved sorry-free — the reusable per-summand bridge
+   `Hom(extTensorFunctorLeftObj X₁ X₂, N₁⊗N₂) ≅ Hom(X₁,N₁) ⊗ Hom(X₂,N₂)`, built by bridging the
+   categorical `Hom`s to `→ₗ`-maps (`ModuleCat.homLinearEquiv`) and applying
+   `rearrangeHomComponentIso` (#6843). This is the essential ingredient the degreewise iso and the
+   assembler both consume.
+
+## Current frontier
+
+`RearrangeHomComplexX.lean` builds clean, no `sorry`. `summandIso` done. The **degreewise iso**
+`rearrangeHomComplexXIso i : source.X i ≅ target.X i` is NOT yet built — that is the residual of
+#6867.
+
+## Overall project progress
+
+Ch8 Problem 8.2.8 `Ext` half: the categorical bidegree layer (#6843) and f.g.-projective Hom-tensor
+iso (#6816) are merged. The cochain assembly #6844 is now split into #6867 (degreewise iso, partly
+done here) and #6868 (complex assembly, blocked on #6867). Downstream: #6818 (`Problem_8_2_8_ext`
+final assembler) waits on #6868.
+
+## Next step
+
+Finish #6867's degreewise iso. Confirmed structural facts (all in this session's PR/issue bodies):
+- `source.X i = Hom((extTensorComplexLeft P₁ P₂).X i, N₁⊗N₂)` via `ChainComplex.linearYonedaObj_X`
+  (`((linearYoneda k _).obj Y).obj (op (X.X i))`, defeq `ModuleCat.of k (X.X i ⟶ Y)`).
+- `(extTensorComplexLeft P₁ P₂).X i` and `target.X i` are both `mapBifunctor` coproducts over the
+  finite fiber `{(j,m):j+m=i}` (source on `down ℕ`, target on `up ℕ`; `TensorSigns (up ℕ)` from
+  `Chapter7/KunnethCochainComplexNat.lean`). Inclusions `ιMapBifunctor`, desc `mapBifunctorDesc`,
+  ext `mapBifunctor.hom_ext`.
+- **The remaining work** is the coproduct↔product↔biproduct assembly:
+  `fwd : Hom(⊕Sⱼₘ,N) ⟶ ⊕Tⱼₘ := Σ_{fiber} lcompₖ(ιS) ≫ summandIso.hom ≫ ιT` (finite sum into the
+  target biproduct); `inv := mapBifunctorDesc (fun j m h => summandIso.inv ≫ lcompₖ(πS))`;
+  `hom_inv_id`/`inv_hom_id` by `mapBifunctor.hom_ext` (both sides) using biproduct `ι ≫ π = δ`.
+  Needs the **source-coproduct projections** `πS` matching `ιMapBifunctor` — no ready API; construct
+  from `GradedObject.cofanMapObj`/`isColimitCofanMapObj` + ModuleCat `HasFiniteBiproducts`, or an
+  additive-`Hom(-,N)`-preserves-biproduct argument. `Chapter7/KunnethCochainComplexNat.lean`
+  (`isoNat`, `phiFwd`/`phiInv`, `ιN_invNat`/`ιZ_fwdNat`) is the closest style template.
+  `lcompₖ` (`Chapter8/HomTensorFGProjective.lean`) is the precomposition building block.
+- Carry f.g.-projective hypotheses `[Module.Finite/Projective]` on `P₁.complex.X j`, `P₂.complex.X m`
+  (needed by `rearrangeHomComponentIso`).
+
+Then #6868 assembles the cochain iso via `isoOfComponents` + the two `homTensorHom_comp_lcompₖ_*`
+naturality lemmas (#6843) + Koszul signs (template: `fwdNat_comm`).
+
+## Blockers
+
+None. #6867 residual is well-scoped; #6868 blocked on #6867 (expected).


### PR DESCRIPTION
This PR lands `Etingof.summandIso` (new file `EtingofRepresentationTheory/Chapter8/RearrangeHomComplexX.lean`), the reusable per-summand bridge for the `Ext` Künneth degreewise iso: `Hom(extTensorFunctorLeftObj X₁ X₂, N₁⊗N₂) ≅ Hom(X₁,N₁) ⊗ Hom(X₂,N₂)`, built by bridging the categorical `Hom`s to `→ₗ`-maps via `ModuleCat.homLinearEquiv` and applying `rearrangeHomComponentIso` (#6843). Sorry-free.

Partial toward #6867. **Residual** (kept in #6867, marked `replan`): the full degreewise iso `source.X i ≅ target.X i` — the finite-fiber coproduct↔biproduct assembly wrapping `summandIso` (needs source-coproduct projections matching `ιMapBifunctor`, via `cofanMapObj`/`isColimitCofanMapObj` + ModuleCat finite biproducts). Full analysis and the confirmed structural facts are in the progress file `progress/2026-07-16T18-57-46Z_201bf754.md` and the #6867 body.

🤖 Prepared with Claude Code