### PR TITLE
feat(Ch4 #Problem4.12.8-a-iv): dihedral recognition lemma (algebraic core)

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Problem4_12_8.lean
+++ b/EtingofRepresentationTheory/Chapter4/Problem4_12_8.lean
@@ -1080,6 +1080,105 @@ theorem pole_order_data (G : Subgroup (specialOrthogonalGroup (Fin 3) ℝ)) [Fin
 
 end PoleCounting
 
+/-!
+## Dihedral recognition
+
+Algebraic core of the dihedral disjunct of `so3_classification_aux`. In the `{2, 2, k}`
+pole-order family the group has order `n = 2k`, a rotation `ρ` of order `k` about the
+principal axis (a generator of the order-`k` pole stabilizer), and an order-`2` element `s`
+(a `π`-rotation swapping the two principal poles) that inverts `ρ`, with `s` not itself a
+rotation about the principal axis (`s ∉ ⟨ρ⟩`). These relations determine `G ≃* DihedralGroup k`.
+
+The lemma is pure group theory — it takes the generators and their relations as hypotheses,
+so the geometric extraction of `ρ` and `s` from the pole data can feed it separately. -/
+theorem mulEquiv_dihedralGroup_of_conj_inv
+    {G : Type*} [Group G] [Finite G] (k : ℕ) [NeZero k]
+    (ρ s : G) (hρ : orderOf ρ = k) (hs : orderOf s = 2)
+    (hconj : s * ρ * s⁻¹ = ρ⁻¹) (hsnotin : s ∉ Subgroup.zpowers ρ)
+    (hcard : Nat.card G = 2 * k) :
+    Nonempty (G ≃* DihedralGroup k) := by
+  classical
+  -- `ρz i := ρ ^ i.val` realises the rotation part `ℤ/kℤ ≅ ⟨ρ⟩`.
+  set ρz : ZMod k → G := fun i => ρ ^ i.val with hρz
+  have hρz_add : ∀ i j : ZMod k, ρz (i + j) = ρz i * ρz j := by
+    intro i j
+    show ρ ^ (i + j).val = ρ ^ i.val * ρ ^ j.val
+    rw [← pow_add]
+    apply pow_eq_pow_iff_modEq.mpr
+    rw [hρ, ZMod.val_add]
+    exact Nat.mod_modEq _ _
+  have hρz_zero : ρz 0 = 1 := by
+    show ρ ^ (0 : ZMod k).val = 1
+    rw [ZMod.val_zero, pow_zero]
+  have hρz_neg : ∀ i : ZMod k, ρz (-i) = (ρz i)⁻¹ := by
+    intro i
+    rw [eq_inv_iff_mul_eq_one, ← hρz_add, neg_add_cancel, hρz_zero]
+  -- `s` is an involution inverting every power of `ρ`.
+  have hs2 : s * s = 1 := by
+    have h : s ^ 2 = 1 := by rw [← hs]; exact pow_orderOf_eq_one s
+    rwa [pow_two] at h
+  have hsinv : s⁻¹ = s := inv_eq_of_mul_eq_one_right hs2
+  have hconj_pow : ∀ i : ZMod k, s * ρz i * s⁻¹ = (ρz i)⁻¹ := by
+    intro i
+    show s * ρ ^ i.val * s⁻¹ = (ρ ^ i.val)⁻¹
+    have hsc : SemiconjBy s ρ ρ⁻¹ := by
+      show s * ρ = ρ⁻¹ * s
+      rw [← hconj, mul_assoc, inv_mul_cancel, mul_one]
+    have hp := hsc.pow_right i.val
+    rw [SemiconjBy, inv_pow] at hp
+    rw [hp, mul_assoc, mul_inv_cancel, mul_one]
+  -- Consequently `ρz i` slides past `s`, turning into its inverse.
+  have hcomm : ∀ i : ZMod k, ρz i * s = s * (ρz i)⁻¹ := by
+    intro i
+    have h := hconj_pow i
+    rw [hsinv] at h
+    calc ρz i * s = s * (s * ρz i * s) := by
+            rw [← mul_assoc, ← mul_assoc, hs2, one_mul]
+      _ = s * (ρz i)⁻¹ := by rw [h]
+  -- The realisation map `DihedralGroup k → G`, and its multiplicativity.
+  let F : DihedralGroup k → G := fun x =>
+    match x with
+    | DihedralGroup.r i => ρz i
+    | DihedralGroup.sr i => s * ρz i
+  have hmul : ∀ a b : DihedralGroup k, F (a * b) = F a * F b := by
+    rintro (i | i) (j | j)
+    · show ρz (i + j) = ρz i * ρz j
+      exact hρz_add i j
+    · show s * ρz (j - i) = ρz i * (s * ρz j)
+      have e1 : ρz i * (s * ρz j) = ρz i * s * ρz j := by group
+      rw [e1, hcomm i]
+      have e2 : s * (ρz i)⁻¹ * ρz j = s * ((ρz i)⁻¹ * ρz j) := by group
+      rw [e2, ← hρz_neg, ← hρz_add, neg_add_eq_sub]
+    · show s * ρz (i + j) = s * ρz i * ρz j
+      rw [hρz_add, mul_assoc]
+    · show ρz (j - i) = s * ρz i * (s * ρz j)
+      have e1 : s * ρz i * (s * ρz j) = s * (ρz i * s) * ρz j := by group
+      rw [e1, hcomm i]
+      have e2 : s * (s * (ρz i)⁻¹) * ρz j = (s * s) * ((ρz i)⁻¹ * ρz j) := by group
+      rw [e2, hs2, one_mul, ← hρz_neg, ← hρz_add, neg_add_eq_sub]
+  let φ : DihedralGroup k →* G := MonoidHom.mk' F hmul
+  -- `φ` is injective: rotations land in `⟨ρ⟩`, reflections would force `s ∈ ⟨ρ⟩`.
+  have hinj : Function.Injective φ := by
+    rw [injective_iff_map_eq_one]
+    rintro (i | i) hi
+    · have hpow : ρ ^ i.val = 1 := hi
+      have hdvd : orderOf ρ ∣ i.val := orderOf_dvd_of_pow_eq_one hpow
+      rw [hρ] at hdvd
+      have hval : i.val = 0 := Nat.eq_zero_of_dvd_of_lt hdvd (ZMod.val_lt i)
+      rw [show (DihedralGroup.r i : DihedralGroup k) = DihedralGroup.r 0 by
+        rw [(ZMod.val_eq_zero i).mp hval], DihedralGroup.r_zero]
+    · exfalso
+      have hsval : s * ρ ^ i.val = 1 := hi
+      have hs_eq : s = (ρ ^ i.val)⁻¹ := eq_inv_iff_mul_eq_one.mpr hsval
+      exact hsnotin (by
+        rw [hs_eq]; exact inv_mem (Subgroup.npow_mem_zpowers ρ i.val))
+  -- Injective + matching order `2k` gives the isomorphism.
+  haveI : Fintype G := Fintype.ofFinite G
+  have hcardeq : Fintype.card (DihedralGroup k) = Fintype.card G := by
+    rw [DihedralGroup.card, ← Nat.card_eq_fintype_card, hcard]
+  exact ⟨(MulEquiv.ofBijective φ
+    ((Fintype.bijective_iff_injective_and_card φ).mpr ⟨hinj, hcardeq⟩)).symm⟩
+
 /-- The substantive content of part (a): the Burnside counting that turns the geometry
 (milestones (i), (ii)) into the pole-order multiset, the application of milestone (iii), and
 the five `MulEquiv` constructions realizing each solution family as `ℤ/nℤ`, `Dₙ`, `A₄`, `S₄`,

--- a/progress/2026-07-16T21-17-09Z_4c278725.md
+++ b/progress/2026-07-16T21-17-09Z_4c278725.md
@@ -1,0 +1,53 @@
+## Accomplished
+
+Feature session on **#6863** (Ch4 #Problem4.12.8-a-iv), landed as a **partial** PR.
+Added to `EtingofRepresentationTheory/Chapter4/Problem4_12_8.lean` (sorry-free,
+axioms = `propext, Classical.choice, Quot.sound`):
+
+- `mulEquiv_dihedralGroup_of_conj_inv` — the **algebraic core** of the dihedral
+  disjunct of `so3_classification_aux`, stated as reusable, geometry-free group
+  theory: for a finite group `G` with a rotation `ρ` of order `k`, an order-2
+  element `s` with `s·ρ·s⁻¹ = ρ⁻¹` and `s ∉ ⟨ρ⟩`, and `Nat.card G = 2k`, then
+  `Nonempty (G ≃* DihedralGroup k)`.
+
+Proof: the map `DihedralGroup k → G`, `r i ↦ ρ^i.val`, `sr i ↦ s·ρ^i.val`, is a
+homomorphism (four `map_mul` cases discharged via `ρ^i.val` well-defined mod
+`orderOf ρ = k` using `pow_eq_pow_iff_modEq`, the `SemiconjBy` conjugation
+`s·ρ^m·s⁻¹ = (ρ^m)⁻¹`, and the slide `ρ^m·s = s·ρ^{-m}`). Injective (`r i` in the
+kernel forces `k ∣ i.val < k`, so `i = 0`; `sr i` in the kernel forces
+`s = (ρ^i.val)⁻¹ ∈ ⟨ρ⟩`, contra `hsnotin`). Injective + equal finite cardinality
+`2k` gives bijectivity (`Fintype.bijective_iff_injective_and_card`), then
+`MulEquiv.ofBijective … |>.symm`.
+
+## Current frontier
+
+The **cyclic** disjunct is already served by the existing
+`isCyclic_of_common_fixed_vector`. What remains for #6863's full scope is the
+**geometric extraction** feeding both lemmas from the pole data, plus wiring into
+`so3_classification_aux`.
+
+Key blocker discovered: `pole_order_data` returns only the multiset of stabilizer
+orders and the 5-way arithmetic classification — it discards the orbit
+representatives / stabilizer generators / antipodal-pole geometry, so the group
+realization cannot be reconstructed from its output. The pole analysis must be
+enriched into an intermediate theorem exposing that geometry. Filed as **#6877**
+(depends-on #6863), with a suggested decomposition.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. Ch4 SO(3) classification: geometry milestones
+(i)-(iii), the Burnside reduction (`pole_order_data`), and now the dihedral
+recognition algebraic core are sorry-free. Remaining Ch4 work: geometric
+extraction (#6877) and the exceptional families `A₄`/`S₄`/`A₅`, all feeding the
+single remaining `sorry` in `so3_classification_aux`.
+
+## Next step
+
+Pick up **#6877**: enrich the pole analysis to expose orbit reps + stabilizer
+generators + stabilizer cyclicity, then prove `so3_cyclic_of_poleData` (via
+`isCyclic_of_common_fixed_vector`) and `so3_dihedral_of_poleData` (via
+`mulEquiv_dihedralGroup_of_conj_inv`). Consider decomposing per the issue body.
+
+## Blockers
+
+None for this PR. The residual geometric extraction is tracked in #6877.


### PR DESCRIPTION
This PR proves `mulEquiv_dihedralGroup_of_conj_inv`, the geometry-free algebraic core of the dihedral disjunct of `so3_classification_aux` (Problem 4.12.8-a-iv): a finite group `G` carrying a rotation `ρ` of order `k`, an order-2 element `s` inverting it (`s·ρ·s⁻¹ = ρ⁻¹`) with `s ∉ ⟨ρ⟩`, and total order `2k`, is isomorphic to `DihedralGroup k`. The isomorphism is built from the explicit map `r i ↦ ρ^i.val`, `sr i ↦ s·ρ^i.val`, shown multiplicative from the dihedral relations, injective, hence bijective by equal cardinality. Sorry-free; axioms limited to `propext, Classical.choice, Quot.sound`.

This is a partial completion of #6863. The cyclic disjunct is already served by the existing `isCyclic_of_common_fixed_vector`. The residual geometric extraction — enriching the pole analysis to expose orbit representatives and stabilizer generators, then feeding both recognition lemmas and wiring `so3_classification_aux` — is tracked in #6877, since `pole_order_data` currently returns only the stabilizer-order multiset and discards the geometry needed to reconstruct the group.

Closes #6863

🤖 Prepared with Claude Code