### PR TITLE
feat(Ch6 #Problem6.1.3-g): prove affine_tree_branch_count sorry-free

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_tildeE.lean
+++ b/EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_tildeE.lean
@@ -2289,9 +2289,163 @@ lemma affine_tree_branch_count {n : ℕ} (adj : Matrix (Fin n) (Fin n) ℤ)
         Etingof.Problem6_1_3_E7E8.vertexDegree adj v = 3 ∧
         Etingof.Problem6_1_3_E7E8.vertexDegree adj w = 3 ∧
         ∀ u, Etingof.Problem6_1_3_E7E8.vertexDegree adj u = 3 → u = v ∨ u = w) := by
-  -- Sub-issue: tree + max-degree-3 ⟹ #leaves = #branches + 2; degeneracy ⟹ ≥ 1 branch;
-  -- minimality (`affine_properInduced_finiteDynkin` + `dynkin_unique_degree_three`) ⟹ ≤ 2.
-  sorry
+  classical
+  -- The two `vertexDegree` definitions are definitionally equal; work with `Etingof.vertexDegree`.
+  have hVD : ∀ (m : ℕ) (M : Matrix (Fin m) (Fin m) ℤ) (v : Fin m),
+      Etingof.Problem6_1_3_E7E8.vertexDegree M v = Etingof.vertexDegree M v := fun _ _ _ => rfl
+  simp only [hVD] at hdeg3 ⊢
+  have hsymm := hD.1
+  have hdiag := hD.2.1
+  have h01 := hD.2.2.1
+  have hconn := hD.2.2.2.1
+  have hsymm' : ∀ a b, adj a b = adj b a := fun a b => by
+    have h := congrFun (congrFun hsymm b) a
+    rw [Matrix.transpose_apply] at h; exact h
+  -- Reindex `n = k + 1` for the leaf-deletion machinery.
+  obtain ⟨k, rfl⟩ : ∃ k, n = k + 1 := ⟨n - 1, by omega⟩
+  -- The branch set.
+  set S : Finset (Fin (k + 1)) :=
+    Finset.univ.filter (fun v => Etingof.vertexDegree adj v = 3) with hS_def
+  have hmemS : ∀ v, v ∈ S ↔ Etingof.vertexDegree adj v = 3 := fun v => by
+    simp only [hS_def, Finset.mem_filter, Finset.mem_univ, true_and]
+  -- **At least one branch.**
+  obtain ⟨vbr, hvbr⟩ := affine_tree_exists_branch adj (by omega) hD hacyc hdeg3
+  have hlo : 1 ≤ S.card := Finset.card_pos.mpr ⟨vbr, (hmemS vbr).mpr hvbr⟩
+  -- **A leaf `u` (degree 1) exists**, via the tree structure.
+  obtain ⟨u, hu_deg⟩ : ∃ u, Etingof.vertexDegree adj u = 1 := by
+    let G : SimpleGraph (Fin (k + 1)) :=
+      { Adj := fun i j => adj i j = 1
+        symm := ⟨fun i j (h : adj i j = 1) => by rw [hsymm' j i]; exact h⟩
+        loopless := ⟨fun i (h : adj i i = 1) => by
+          rw [hdiag i] at h; exact absurd h (by norm_num)⟩ }
+    haveI : DecidableRel G.Adj := fun i j => decEq (adj i j) 1
+    haveI : Nonempty (Fin (k + 1)) := ⟨⟨0, by omega⟩⟩
+    have hG_conn : G.Connected := ⟨fun a b => by
+      obtain ⟨path, hhead, hlast, hedges⟩ := hconn a b
+      exact list_path_reachable G path a b hhead hlast (fun m hm => hedges m hm)⟩
+    have hcount : (∑ i, ∑ j, adj i j) = 2 * (#G.edgeFinset : ℤ) := by
+      have hterm : ∀ p : Fin (k + 1) × Fin (k + 1),
+          adj p.1 p.2 = (if adj p.1 p.2 = 1 then (1 : ℤ) else 0) := by
+        intro p; rcases h01 p.1 p.2 with h | h <;> simp [h]
+      calc (∑ i, ∑ j, adj i j)
+          = ∑ p : Fin (k + 1) × Fin (k + 1), adj p.1 p.2 := (Fintype.sum_prod_type' adj).symm
+        _ = ∑ p : Fin (k + 1) × Fin (k + 1), (if adj p.1 p.2 = 1 then (1 : ℤ) else 0) :=
+              Finset.sum_congr rfl (fun p _ => hterm p)
+        _ = ((univ.filter fun p : Fin (k + 1) × Fin (k + 1) => adj p.1 p.2 = 1).card : ℤ) := by
+              rw [Finset.sum_boole]
+        _ = ((2 * #G.edgeFinset : ℕ) : ℤ) := by rw [G.two_mul_card_edgeFinset]
+        _ = 2 * (#G.edgeFinset : ℤ) := by push_cast; ring
+    have hlb : k + 1 ≤ #G.edgeFinset + 1 := by
+      have h := hG_conn.card_vert_le_card_edgeSet_add_one
+      rwa [Nat.card_fin, Nat.card_eq_fintype_card, ← SimpleGraph.edgeFinset_card] at h
+    have hub : (#G.edgeFinset : ℤ) < (k + 1 : ℤ) := by
+      have h2 : 2 * (#G.edgeFinset : ℤ) < 2 * ((k + 1 : ℕ) : ℤ) := by
+        rw [← hcount]; exact hacyc
+      push_cast at h2; linarith
+    have hub' : #G.edgeFinset < k + 1 := by exact_mod_cast hub
+    have hedge_eq : #G.edgeFinset = k := by omega
+    have hTree : G.IsTree := by
+      rw [SimpleGraph.isTree_iff_connected_and_card]
+      refine ⟨hG_conn, ?_⟩
+      have hNatEdge : Nat.card G.edgeSet = k := by
+        rw [Nat.card_eq_fintype_card, ← SimpleGraph.edgeFinset_card, hedge_eq]
+      rw [hNatEdge, Nat.card_fin]
+    -- ≥ 4 vertices, so `Fin (k+1)` is nontrivial.
+    have hk3 : 3 ≤ k := by
+      have hcnt : Etingof.vertexDegree adj vbr ≤ (Finset.univ.erase vbr).card := by
+        unfold Etingof.vertexDegree
+        apply Finset.card_le_card
+        intro x hx
+        simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hx
+        refine Finset.mem_erase.mpr ⟨fun h' => ?_, Finset.mem_univ _⟩
+        subst h'; rw [hdiag x] at hx; exact absurd hx (by norm_num)
+      rw [Finset.card_erase_of_mem (Finset.mem_univ vbr), Finset.card_univ,
+        Fintype.card_fin] at hcnt
+      rw [hvbr] at hcnt; omega
+    haveI : Nontrivial (Fin (k + 1)) := Fin.nontrivial_iff_two_le.mpr (by omega)
+    obtain ⟨u, hu⟩ := hTree.exists_vert_degree_one_of_nontrivial
+    refine ⟨u, ?_⟩
+    have hdegeq : G.degree u = Etingof.vertexDegree adj u := by
+      rw [SimpleGraph.degree]
+      unfold Etingof.vertexDegree
+      congr 1
+      ext j
+      simp only [SimpleGraph.mem_neighborFinset, Finset.mem_filter, Finset.mem_univ, true_and]
+      exact Iff.rfl
+    rw [hdegeq] at hu; exact hu
+  -- Delete the leaf: a finite Dynkin diagram on the survivors.
+  have hDsub : IsDynkinDiagram k (adj.submatrix u.succAbove u.succAbove) :=
+    affine_delete_leaf_isDynkin adj hD u hu_deg
+  -- **At most two branches.**
+  have hhi : S.card ≤ 2 := by
+    have hpart := Finset.card_filter_add_card_filter_not (s := S) (p := fun v => adj u v = 1)
+    have hA : (S.filter (fun v => adj u v = 1)).card ≤ 1 := by
+      have hsub : S.filter (fun v => adj u v = 1) ⊆
+          Finset.univ.filter (fun j => adj u j = 1) := by
+        intro v hv
+        simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hv ⊢
+        exact hv.2
+      have hc := Finset.card_le_card hsub
+      have hdegu : (Finset.univ.filter (fun j => adj u j = 1)).card = 1 := hu_deg
+      omega
+    -- A branch vertex not adjacent to `u` keeps degree 3 in the subdiagram.
+    have hsubdeg : ∀ (x : Fin (k + 1)) (x' : Fin k), u.succAbove x' = x →
+        Etingof.vertexDegree adj x = 3 → ¬ adj u x = 1 →
+        Etingof.vertexDegree (adj.submatrix u.succAbove u.succAbove) x' = 3 := by
+      intro x x' hx hx3 hxu
+      have himg : (Finset.univ.filter
+            (fun j : Fin k => (adj.submatrix u.succAbove u.succAbove) x' j = 1)).image u.succAbove
+          = Finset.univ.filter (fun c => adj x c = 1) := by
+        ext c
+        simp only [Finset.mem_image, Finset.mem_filter, Finset.mem_univ, true_and,
+          Matrix.submatrix_apply, hx]
+        constructor
+        · rintro ⟨j, hj, rfl⟩; exact hj
+        · intro hc
+          have hcu : c ≠ u := by
+            intro hcu_eq; rw [hcu_eq, hsymm' x u] at hc; exact hxu hc
+          obtain ⟨j, hj⟩ := Fin.exists_succAbove_eq hcu
+          exact ⟨j, by rw [hj]; exact hc, hj⟩
+      have hcardN : (Finset.univ.filter (fun c => adj x c = 1)).card = 3 := hx3
+      change (Finset.univ.filter
+        (fun j : Fin k => (adj.submatrix u.succAbove u.succAbove) x' j = 1)).card = 3
+      rw [← Finset.card_image_of_injective _ Fin.succAbove_right_injective, himg, hcardN]
+    have hB : (S.filter (fun v => ¬ adj u v = 1)).card ≤ 1 := by
+      rw [Finset.card_le_one]
+      intro a ha b hb
+      simp only [Finset.mem_filter] at ha hb
+      obtain ⟨haS, haU⟩ := ha
+      obtain ⟨hbS, hbU⟩ := hb
+      have ha3 : Etingof.vertexDegree adj a = 3 := (hmemS a).mp haS
+      have hb3 : Etingof.vertexDegree adj b = 3 := (hmemS b).mp hbS
+      have hau : a ≠ u := by rintro rfl; rw [hu_deg] at ha3; omega
+      have hbu : b ≠ u := by rintro rfl; rw [hu_deg] at hb3; omega
+      obtain ⟨a', ha'⟩ := Fin.exists_succAbove_eq hau
+      obtain ⟨b', hb'⟩ := Fin.exists_succAbove_eq hbu
+      have hda' := hsubdeg a a' ha' ha3 haU
+      have hdb' := hsubdeg b b' hb' hb3 hbU
+      have hab' : a' = b' := dynkin_unique_degree_three hDsub a' b' hda' hdb'
+      rw [← ha', ← hb', hab']
+    omega
+  -- **Assemble** the disjunction from `S.card ∈ {1, 2}`.
+  rcases Nat.lt_or_ge S.card 2 with hcard | hcard
+  · have hc1 : S.card = 1 := by omega
+    obtain ⟨a, haS⟩ := Finset.card_eq_one.mp hc1
+    left
+    refine ⟨a, (hmemS a).mp (by rw [haS]; exact Finset.mem_singleton_self a), ?_⟩
+    intro w hw
+    have hwmem : w ∈ S := (hmemS w).mpr hw
+    rw [haS, Finset.mem_singleton] at hwmem; exact hwmem
+  · have hc2 : S.card = 2 := by omega
+    obtain ⟨a, b, hab, hSab⟩ := Finset.card_eq_two.mp hc2
+    right
+    refine ⟨a, b, hab,
+      (hmemS a).mp (by rw [hSab]; exact Finset.mem_insert_self a _),
+      (hmemS b).mp (by rw [hSab]; exact Finset.mem_insert_of_mem (Finset.mem_singleton_self b)),
+      ?_⟩
+    intro w hw
+    have hwmem : w ∈ S := (hmemS w).mpr hw
+    rw [hSab, Finset.mem_insert, Finset.mem_singleton] at hwmem; exact hwmem
 
 /-- **Two branch vertices ⟹ D̃ₙ.** A connected acyclic affine Dynkin diagram with all degrees `≤ 3`
 and exactly two branch (degree-3) vertices is graph-isomorphic to `AffineType.Dtilde n` for some

--- a/EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_tildeE.lean
+++ b/EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_tildeE.lean
@@ -2078,6 +2078,199 @@ The main lemma `affine_tree_degree_le_three_iso` dispatches on the branch count.
 below are each substantial (the finite `branch_classification` alone is ~700 lines) and are tracked
 as separate sub-issues; their statements are fixed here so downstream work has stable interfaces. -/
 
+/-- **Affine degree balance.** For an affine Dynkin diagram there is a strictly positive vector
+`w` (the marks) with `∑ⱼ (deg j − 2)·wⱼ = 0`. Sum the null equation `(2·Id − adj)·ᵥw = 0` over all
+rows and use `∑ₐ adjₐⱼ = deg j`. This is the affine analogue of the finite handshake identity and
+is the source of both the "at least one branch" and "leaf exists" facts below. -/
+lemma affine_degree_balance {n : ℕ} (adj : Matrix (Fin n) (Fin n) ℤ) (hn : 1 ≤ n)
+    (hD : IsAffineDynkinDiagram n adj) :
+    ∃ w : Fin n → ℤ, (∀ i, 0 < w i) ∧
+      ∑ j, ((Etingof.vertexDegree adj j : ℤ) - 2) * w j = 0 := by
+  classical
+  have hsymm := hD.1
+  have h01 := hD.2.2.1
+  have hsymm' : ∀ a b, adj a b = adj b a := fun a b => by
+    have h := congrFun (congrFun hsymm b) a
+    rw [Matrix.transpose_apply] at h; exact h
+  obtain ⟨w, hw_pos, hMw⟩ := affineNullVector_pos adj hn hD
+  refine ⟨w, hw_pos, ?_⟩
+  have mulVec_eq : ∀ a, ((2 • (1 : Matrix _ _ ℤ) - adj).mulVec w) a =
+      2 * w a - ∑ b, adj a b * w b := by
+    intro a; simp only [mulVec, dotProduct]
+    rw [show ∑ b, (2 • (1 : Matrix (Fin n) (Fin n) ℤ) - adj) a b * w b =
+        ∑ b, (2 * (1 : Matrix _ _ ℤ) a b * w b - adj a b * w b) from
+      Finset.sum_congr rfl (fun b _ => by
+        simp only [Matrix.sub_apply, Matrix.smul_apply, smul_eq_mul]; ring)]
+    rw [Finset.sum_sub_distrib]
+    congr 1
+    rw [show ∑ b, 2 * (1 : Matrix (Fin n) (Fin n) ℤ) a b * w b =
+        ∑ b, if a = b then 2 * w b else 0 from
+      Finset.sum_congr rfl (fun b _ => by
+        simp only [Matrix.one_apply]; split_ifs <;> simp <;> ring)]
+    simp [Finset.sum_ite_eq']
+  have hrow0 : ∀ a, 2 * w a - ∑ b, adj a b * w b = 0 := by
+    intro a; rw [← mulVec_eq a]; simpa using congrFun hMw a
+  have hsum : ∑ a, (2 * w a - ∑ b, adj a b * w b) = 0 :=
+    Finset.sum_eq_zero (fun a _ => hrow0 a)
+  have e1 : ∑ a, (2 * w a - ∑ b, adj a b * w b)
+      = 2 * (∑ a, w a) - ∑ a, ∑ b, adj a b * w b := by
+    rw [Finset.sum_sub_distrib, Finset.mul_sum]
+  have e2 : ∑ a, ∑ b, adj a b * w b = ∑ b, (Etingof.vertexDegree adj b : ℤ) * w b := by
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl (fun b _ => ?_)
+    rw [← Finset.sum_mul]
+    congr 1
+    rw [show (∑ a, adj a b) = ∑ a, adj b a from Finset.sum_congr rfl (fun a _ => hsymm' a b)]
+    exact adj_sum_eq_degree h01 b
+  rw [e1, e2] at hsum
+  rw [show (∑ j, ((Etingof.vertexDegree adj j : ℤ) - 2) * w j)
+      = (∑ j, (Etingof.vertexDegree adj j : ℤ) * w j) - 2 * ∑ j, w j from by
+        rw [Finset.mul_sum, ← Finset.sum_sub_distrib]
+        exact Finset.sum_congr rfl (fun j _ => by ring)]
+  linarith
+
+/-- **Deleting a leaf leaves a finite Dynkin diagram.** Removing a degree-1 vertex `u` (indexing
+the survivors by `u.succAbove`) from an affine Dynkin diagram gives a proper connected induced
+subgraph, which is finite Dynkin by `affine_properInduced_isDynkin`. Connectivity is preserved
+because `u` is a leaf (`SimpleGraph.Connected.induce_compl_singleton_of_degree_eq_one`). -/
+lemma affine_delete_leaf_isDynkin {k : ℕ} (adj : Matrix (Fin (k + 1)) (Fin (k + 1)) ℤ)
+    (hD : IsAffineDynkinDiagram (k + 1) adj) (u : Fin (k + 1))
+    (hu_deg : Etingof.vertexDegree adj u = 1) :
+    IsDynkinDiagram k (adj.submatrix u.succAbove u.succAbove) := by
+  classical
+  have hsymm := hD.1
+  have hdiag := hD.2.1
+  have h01 := hD.2.2.1
+  have hconn := hD.2.2.2.1
+  have hsymm' : ∀ a b, adj a b = adj b a := fun a b => by
+    have h := congrFun (congrFun hsymm b) a
+    rw [Matrix.transpose_apply] at h; exact h
+  let G : SimpleGraph (Fin (k + 1)) :=
+    { Adj := fun i j => adj i j = 1
+      symm := ⟨fun i j (h : adj i j = 1) => by change adj j i = 1; rw [hsymm' j i]; exact h⟩
+      loopless := ⟨fun i (h : adj i i = 1) => by rw [hdiag i] at h; exact absurd h (by norm_num)⟩ }
+  haveI : DecidableRel G.Adj := fun i j => decEq (adj i j) 1
+  haveI : Nonempty (Fin (k + 1)) := ⟨u⟩
+  have hG_conn : G.Connected := ⟨fun a b => by
+    obtain ⟨path, hhead, hlast, hedges⟩ := hconn a b
+    exact list_path_reachable G path a b hhead hlast (fun m hm => hedges m hm)⟩
+  have hG_deg : G.degree u = 1 := by
+    have hdegeq : G.degree u = Etingof.vertexDegree adj u := by
+      rw [SimpleGraph.degree]
+      unfold Etingof.vertexDegree
+      congr 1
+      ext j
+      simp only [SimpleGraph.mem_neighborFinset, Finset.mem_filter, Finset.mem_univ, true_and]
+      exact Iff.rfl
+    rw [hdegeq]; exact hu_deg
+  have hG' := hG_conn.induce_compl_singleton_of_degree_eq_one hG_deg
+  refine affine_properInduced_isDynkin adj (by omega) hD u.succAbove
+    Fin.succAbove_right_injective (fun i => Fin.succAbove_ne u i) ?_
+  intro a b
+  have ha_ne : u.succAbove a ≠ u := Fin.succAbove_ne u a
+  have hb_ne : u.succAbove b ≠ u := Fin.succAbove_ne u b
+  have ha_mem : u.succAbove a ∈ ({u}ᶜ : Set (Fin (k + 1))) :=
+    Set.mem_compl_singleton_iff.mpr ha_ne
+  have hb_mem : u.succAbove b ∈ ({u}ᶜ : Set (Fin (k + 1))) :=
+    Set.mem_compl_singleton_iff.mpr hb_ne
+  obtain ⟨walk⟩ := hG'.preconnected ⟨u.succAbove a, ha_mem⟩ ⟨u.succAbove b, hb_mem⟩
+  let toFink : ↥({u}ᶜ : Set (Fin (k + 1))) → Fin k :=
+    fun ⟨x, hx⟩ => (Fin.exists_succAbove_eq (Set.mem_compl_singleton_iff.mp hx)).choose
+  have htoFink_spec : ∀ (x : ↥({u}ᶜ : Set (Fin (k + 1)))),
+      u.succAbove (toFink x) = x.val :=
+    fun ⟨x, hx⟩ => (Fin.exists_succAbove_eq (Set.mem_compl_singleton_iff.mp hx)).choose_spec
+  have htoFink_adj : ∀ (x y : ↥({u}ᶜ : Set (Fin (k + 1)))),
+      (G.induce ({u}ᶜ : Set _)).Adj x y →
+      (adj.submatrix u.succAbove u.succAbove) (toFink x) (toFink y) = 1 := by
+    intro x y hadj_xy
+    simp only [Matrix.submatrix_apply, SimpleGraph.induce_adj] at hadj_xy ⊢
+    rw [htoFink_spec x, htoFink_spec y]; exact hadj_xy
+  suffices h_walk : ∀ (a b : ↥({u}ᶜ : Set (Fin (k + 1))))
+      (w' : (G.induce ({u}ᶜ : Set _)).Walk a b),
+      ∃ path : List (Fin k),
+        path.head? = some (toFink a) ∧
+        path.getLast? = some (toFink b) ∧
+        ∀ m, (hm : m + 1 < path.length) →
+          (adj.submatrix u.succAbove u.succAbove)
+            (path.get ⟨m, by omega⟩) (path.get ⟨m + 1, hm⟩) = 1 by
+    obtain ⟨path, hhead, hlast, hedges⟩ := h_walk _ _ walk
+    refine ⟨path, ?_, ?_, hedges⟩
+    · convert hhead using 2
+      exact (Fin.succAbove_right_injective
+        (htoFink_spec ⟨u.succAbove a, ha_mem⟩)).symm
+    · convert hlast using 2
+      exact (Fin.succAbove_right_injective
+        (htoFink_spec ⟨u.succAbove b, hb_mem⟩)).symm
+  intro a b w'
+  induction w' with
+  | nil =>
+    exact ⟨[toFink _], rfl, rfl, fun m hm => absurd hm (by simp)⟩
+  | @cons c d _ hadj_edge rest ih =>
+    obtain ⟨path_rest, hhead_rest, hlast_rest, hedges_rest⟩ := ih
+    refine ⟨toFink c :: path_rest, by simp, ?_, ?_⟩
+    · cases path_rest with
+      | nil => simp at hhead_rest hlast_rest ⊢
+      | cons y ys => simp only [List.getLast?_cons_cons]; exact hlast_rest
+    · intro m hm
+      match m with
+      | 0 =>
+        simp only [List.get_eq_getElem, List.getElem_cons_zero, List.getElem_cons_succ]
+        have h0 : 0 < path_rest.length := by
+          simp only [List.length_cons] at hm; omega
+        have hd_eq : path_rest[0] = toFink d := by
+          cases path_rest with
+          | nil => simp at h0
+          | cons y ys =>
+            simp only [List.head?, Option.some.injEq] at hhead_rest
+            simp only [List.getElem_cons_zero]; exact hhead_rest
+        rw [hd_eq]; exact htoFink_adj c d hadj_edge
+      | m' + 1 =>
+        simp only [List.get_eq_getElem, List.getElem_cons_succ]
+        exact hedges_rest m' (by simp only [List.length_cons] at hm; omega)
+
+/-- **At least one branch.** An affine Dynkin diagram whose Cartan form is acyclic
+(`∑∑adj < 2n`) and has every degree `≤ 3` must contain a degree-3 vertex: otherwise the balance
+`∑ⱼ(deg j − 2)wⱼ = 0` with `wⱼ > 0` and every `deg j ≤ 2` forces all degrees `= 2`, whence
+`∑∑adj = 2n`, contradicting acyclicity. -/
+lemma affine_tree_exists_branch {n : ℕ} (adj : Matrix (Fin n) (Fin n) ℤ) (hn : 1 ≤ n)
+    (hD : IsAffineDynkinDiagram n adj)
+    (hacyc : (∑ i, ∑ j, adj i j) < 2 * (n : ℤ))
+    (hdeg3 : ∀ v, Etingof.vertexDegree adj v ≤ 3) :
+    ∃ v, Etingof.vertexDegree adj v = 3 := by
+  classical
+  have h01 := hD.2.2.1
+  obtain ⟨w, hw_pos, hbal⟩ := affine_degree_balance adj hn hD
+  by_contra hno
+  push_neg at hno
+  have hle2 : ∀ v, Etingof.vertexDegree adj v ≤ 2 := fun v => by
+    have h1 := hdeg3 v; have h2 := hno v; omega
+  have hterm_nonpos : ∀ v, ((Etingof.vertexDegree adj v : ℤ) - 2) * w v ≤ 0 := by
+    intro v
+    have hd2 : (Etingof.vertexDegree adj v : ℤ) ≤ 2 := by exact_mod_cast hle2 v
+    nlinarith [hw_pos v]
+  have hall2 : ∀ v, Etingof.vertexDegree adj v = 2 := by
+    intro v
+    have hz : ((Etingof.vertexDegree adj v : ℤ) - 2) * w v = 0 := by
+      by_contra hne
+      have hlt : ((Etingof.vertexDegree adj v : ℤ) - 2) * w v < 0 :=
+        lt_of_le_of_ne (hterm_nonpos v) hne
+      have hsum_lt : ∑ j, ((Etingof.vertexDegree adj j : ℤ) - 2) * w j
+          < ∑ _j : Fin n, (0 : ℤ) :=
+        Finset.sum_lt_sum (fun j _ => hterm_nonpos j) ⟨v, Finset.mem_univ v, by simpa using hlt⟩
+      rw [Finset.sum_const_zero] at hsum_lt
+      linarith [hbal]
+    have hwv := hw_pos v
+    rcases mul_eq_zero.mp hz with h | h
+    · have : (Etingof.vertexDegree adj v : ℤ) = 2 := by linarith
+      exact_mod_cast this
+    · exact absurd h (ne_of_gt hwv)
+  have hsumadj : (∑ i, ∑ j, adj i j) = 2 * (n : ℤ) := by
+    have hstep : (∑ i, ∑ j, adj i j) = ∑ _i : Fin n, (2 : ℤ) := by
+      refine Finset.sum_congr rfl (fun i _ => ?_)
+      rw [adj_sum_eq_degree h01 i, hall2 i]; norm_num
+    rw [hstep, Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]; ring
+  linarith [hacyc, hsumadj]
+
 /-- **Branch count.** A connected acyclic affine Dynkin diagram with every vertex of degree `≤ 3`
 has exactly one or two degree-3 (branch) vertices.
 

--- a/EtingofRepresentationTheory/Chapter6/Theorem_Dynkin_classification.lean
+++ b/EtingofRepresentationTheory/Chapter6/Theorem_Dynkin_classification.lean
@@ -10,7 +10,7 @@ open Matrix Finset
     Proof: if v ≠ w both have degree 3, define x on Fin n by putting 2 on all vertices
     of the unique v-to-w path and 1 on the extra neighbors of v and w (not on the path).
     Then B(x,x) = 0, contradicting positive definiteness. -/
-private lemma dynkin_unique_degree_three {n : ℕ} {adj : Matrix (Fin n) (Fin n) ℤ}
+lemma dynkin_unique_degree_three {n : ℕ} {adj : Matrix (Fin n) (Fin n) ℤ}
     (hD : IsDynkinDiagram n adj) (v w : Fin n)
     (hv : vertexDegree adj v = 3) (hw : vertexDegree adj w = 3) : v = w := by
   obtain ⟨hsymm, hdiag, h01, hconn, hpos⟩ := hD

--- a/progress/2026-07-16T22-08-26Z_c2464877.md
+++ b/progress/2026-07-16T22-08-26Z_c2464877.md
@@ -1,0 +1,60 @@
+## Accomplished
+
+Feature session, issue #6880 (Ch6 #Problem6.1.3-g, `affine_tree_branch_count` — the branch-count
+dispatcher for the affine tree case).
+
+Proved **sorry-free** `affine_tree_branch_count` in
+`EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_tildeE.lean`: a connected acyclic
+affine Dynkin diagram with every vertex of degree ≤ 3 has exactly one or two degree-3 (branch)
+vertices. `#print axioms` → `[propext, Classical.choice, Quot.sound]`. `lake build` of the file
+succeeds.
+
+Added three supporting lemmas (all sorry-free):
+
+- `affine_degree_balance`: the affine handshake identity `∑ⱼ (deg j − 2)·wⱼ = 0` for a
+  strictly-positive kernel vector `w` (summing the null equation `(2·Id − adj)·ᵥw = 0` over rows).
+- `affine_delete_leaf_isDynkin`: deleting a degree-1 vertex `u` (reindex survivors by `u.succAbove`)
+  leaves a finite Dynkin diagram, via `affine_properInduced_isDynkin` +
+  `SimpleGraph.Connected.induce_compl_singleton_of_degree_eq_one`.
+- `affine_tree_exists_branch`: at least one degree-3 vertex (else the balance forces all degrees `= 2`,
+  so `∑∑adj = 2n`, contradicting acyclicity).
+
+De-privatised `dynkin_unique_degree_three` in `Theorem_Dynkin_classification.lean` (was `private`) so
+the ≤2 argument can reuse it cross-file.
+
+## Key decisions / patterns
+
+- **No Steiner tree needed for the ≤2 bound.** The route hint suggested a proper induced subgraph
+  containing three branch vertices. Instead I delete a *single leaf* `u`: only `u`'s unique neighbour
+  loses a degree, so every branch vertex not adjacent to `u` keeps degree 3 in the subdiagram. Two
+  such would violate `dynkin_unique_degree_three` (finite Dynkin has ≤1 degree-3 vertex). Partition
+  the branch set `S` by adjacency to `u`: `|S ∩ N(u)| ≤ deg u = 1` and `|S \ N(u)| ≤ 1`, so `|S| ≤ 2`.
+- **≥1 branch via the balance identity, not path-recognition.** `∑ⱼ(deg j − 2)wⱼ = 0` with `wⱼ > 0`:
+  if no degree-3 vertex, all terms are ≤ 0, forcing every `deg = 2`, hence `∑∑adj = 2n`, contradicting
+  `hacyc`. Avoids ordering the path / transporting to `Aₙ`.
+- **Leaf existence via Mathlib trees.** `hacyc` + connectivity ⇒ `#edges = n − 1` ⇒ `G.IsTree`
+  (`SimpleGraph.isTree_iff_connected_and_card`), then
+  `IsTree.exists_vert_degree_one_of_nontrivial` gives `G.degree u = 1`.
+- **Gotchas.** Two definitionally-equal `vertexDegree`s coexist (`Etingof.vertexDegree` and
+  `Etingof.Problem6_1_3_E7E8.vertexDegree`); bridge with a `rfl` lemma + `simp only`. Under
+  `classical`, an explicitly-written `Finset.univ.filter (adj v · = 1)` picks a different
+  `DecidablePred` instance than `vertexDegree`'s, so `exact hu_deg` fails — route through `ext`/`unfold`
+  or `Finset.card_le_card` on the goal's own filter rather than a hand-written one. `rintro rfl` on
+  `c = u` can eliminate the outer `u`; use `intro h; rw [h]` instead.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. Ch6 Problem 6.1.3(g) affine classification: the cyclic case and the
+degree-4 dichotomy were already done; now the tree-case dispatcher `affine_tree_branch_count` (#6880)
+is proven, so `affine_tree_degree_le_three_iso` compiles (its own proof is sorry-free, pending its two
+callees). Remaining sorries in the file: `affine_tree_two_branch_iso` (#6881),
+`affine_tree_one_branch_iso` (#6882), and the top-level `affine_dynkin_classification` (⟹ direction).
+
+## Next step
+
+- #6881 (two branch vertices ⟹ D̃ₙ) and #6882 (one branch vertex ⟹ Ẽ₆/₇/₈), now both unblocked by
+  the branch count. The `affine_delete_leaf_isDynkin` helper landed here may also help those.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6880

Session: `c2464877-68f2-4e35-9289-ca253e60870e`

9c04a169 feat(Ch6 #Problem6.1.3-g): prove affine_tree_branch_count sorry-free (progress 2026-07-16T22-08-26Z)
13e78316 feat(Ch6 #Problem6.1.3-g): balance identity, leaf-deletion Dynkin, branch-existence helpers for affine_tree_branch_count

🤖 Prepared with Claude Code