### PR TITLE
feat(Ch8 #Problem8.2.8-Ext): summandIso_inv_hom_apply crux + naturality scaffold (partial #6888)

### DIFF
--- a/EtingofRepresentationTheory/Chapter8/RearrangeHomComplex.lean
+++ b/EtingofRepresentationTheory/Chapter8/RearrangeHomComplex.lean
@@ -62,6 +62,93 @@ variable (P₁ : ProjectiveResolution M₁) (P₂ : ProjectiveResolution M₂)
 variable [∀ j, Module.Finite A₁ (P₁.complex.X j)] [∀ j, Module.Projective A₁ (P₁.complex.X j)]
 variable [∀ m, Module.Finite A₂ (P₂.complex.X m)] [∀ m, Module.Projective A₂ (P₂.complex.X m)]
 
+/-- Applying a `ModuleCat k` `eqToHom` to an element is a `cast` along the carrier equality. -/
+private lemma eqToHom_moduleCat_apply {X Y : ModuleCat.{u} k} (h : X = Y) (x : X) :
+    (eqToHom h) x = cast (congrArg (fun o : ModuleCat.{u} k => (o : Type u)) h) x := by
+  subst h; rfl
+
+/-- The underlying linear map of a `ModuleCat k` `eqToHom`, applied to an element, is a `cast`. -/
+private lemma hom_eqToHom_apply {X Y : ModuleCat.{u} k} (h : X = Y) (x : X) :
+    ModuleCat.Hom.hom (eqToHom h) x = cast (congrArg (fun o : ModuleCat.{u} k => (o : Type u)) h) x := by
+  subst h; rfl
+
+include hN in
+/-- Pointwise action of `summandIso.inv` on a simple tensor of categorical homs. -/
+theorem summandIso_inv_hom_apply (X₁ : ModuleCat.{u} A₁) (X₂ : ModuleCat.{u} A₂)
+    [Module.Finite A₁ X₁] [Module.Projective A₁ X₁]
+    [Module.Finite A₂ X₂] [Module.Projective A₂ X₂]
+    (ψ₁ : X₁ ⟶ ModuleCat.of A₁ N₁) (ψ₂ : X₂ ⟶ ModuleCat.of A₂ N₂) (x₁ : X₁) (x₂ : X₂) :
+    ModuleCat.Hom.hom ((summandIso k N₁ N₂ hN X₁ X₂).inv (ψ₁ ⊗ₜ[k] ψ₂)) (x₁ ⊗ₜ[k] x₂)
+      = (ModuleCat.Hom.hom ψ₁) x₁ ⊗ₜ[k] (ModuleCat.Hom.hom ψ₂) x₂ := by
+  simp only [summandIso, rearrangeHomComponentIso, rearrangeHomComponentEquiv,
+    HomTensorFGProj.homTensorHomEquiv, Iso.trans_inv, Iso.symm_inv, tensorIso,
+    LinearEquiv.toModuleIso_inv, LinearEquiv.toModuleIso_hom, LinearEquiv.symm_symm,
+    extTensorFunctorLeftObj, ModuleCat.hom_comp, LinearMap.comp_apply, ModuleCat.hom_tensorHom,
+    ModuleCat.hom_ofHom, TensorProduct.map_tmul, ModuleCat.homLinearEquiv_apply,
+    ModuleCat.homLinearEquiv_symm_apply, LinearEquiv.ofBijective_apply,
+    HomTensorFGProj.homTensorHom_tmul_tmul]
+  erw [TensorProduct.map_tmul]
+  simp only [LinearEquiv.coe_coe, LinearMap.restrictScalars_apply]
+  rfl
+
+include hN in
+/-- Pointwise action of the inverse per-summand iso on a simple tensor: on `φ₁ ⊗ₜ φ₂` it is the
+`homTensorHom` comparison map, evaluated at `x₁ ⊗ₜ x₂` it returns `φ₁ x₁ ⊗ₜ φ₂ x₂`. This isolates
+all the `eqToHom` carrier-transport bookkeeping of `fullSummandIso`.
+
+The core reduction to `homTensorHom` is `summandIso_inv_hom_apply` (proved above, sorry-free). What
+remains here is purely the `eqToHom` carrier-transport bookkeeping between the two `k`-module
+spellings of the same hom-space (the `srcSummandEq`/`linYonedaXEq` bridges of `fullSummandIso`).
+These transports are *propositional*, not definitional: `eqToHom h` between `ModuleCat k` objects
+with defeq-but-not-syntactically-equal carriers is a stuck `Eq.rec`, so neither `rfl` nor a single
+`Eq.trans` against `summandIso_inv_hom_apply` closes the goal — both the source (`fullSummandIso.inv`
+composite) and target (`φᵢ` vs `eqToHom (linYonedaXEq …) φᵢ`) differ by such a transport. Closing it
+needs a nested `HEq` bridge (`cast_heq`/`eqRec_heq`) threaded through `summandIso.inv` on both sides.
+Tracked as the residual of #6888. -/
+theorem fullSummandIso_inv_tmul_hom_apply (j m : ℕ)
+    (φ₁ : (P₁.complex.linearYonedaObj k (ModuleCat.of A₁ N₁)).X j)
+    (φ₂ : (P₂.complex.linearYonedaObj k (ModuleCat.of A₂ N₂)).X m)
+    (x₁ : P₁.complex.X j) (x₂ : P₂.complex.X m) :
+    ModuleCat.Hom.hom ((fullSummandIso k N₁ N₂ hN P₁ P₂ j m).inv (φ₁ ⊗ₜ[k] φ₂))
+        (x₁ ⊗ₜ[k] x₂)
+      = (ModuleCat.Hom.hom φ₁) x₁ ⊗ₜ[k] (ModuleCat.Hom.hom φ₂) x₂ := by
+  -- Reduces to `summandIso_inv_hom_apply` modulo the two `eqToHom` carrier-transports; see docstring.
+  sorry
+
+include hN in
+/-- **Naturality in the first variable, inverse form.** Precomposition by the source chain
+differential on the first factor commutes past `fullSummandIso.inv`. Reduces (elementwise) to the
+#6843 naturality lemma `homTensorHom_comp_lcompₖ_left`. -/
+theorem fullSummandIso_inv_natLeft (p q : ℕ) :
+    ((curriedTensor (ModuleCat.{u} k)).map
+          ((P₁.complex.linearYonedaObj k (ModuleCat.of A₁ N₁)).d p (p + 1))).app
+        ((P₂.complex.linearYonedaObj k (ModuleCat.of A₂ N₂)).X q) ≫
+        (fullSummandIso k N₁ N₂ hN P₁ P₂ (p + 1) q).inv =
+      (fullSummandIso k N₁ N₂ hN P₁ P₂ p q).inv ≫
+        (homYoneda k N₁ N₂).map
+          (extTensorFunctorLeftMap k (P₁.complex.d (p + 1) p) (𝟙 (P₂.complex.X q))).op := by
+  apply ModuleCat.hom_ext
+  refine TensorProduct.ext' fun φ₁ φ₂ => ?_
+  -- Both sides evaluate, via `fullSummandIso_inv_tmul_hom_apply`, to `homTensorHom` composed with
+  -- precomposition by the source differential; matching them is `homTensorHom_comp_lcompₖ_left`.
+  sorry
+
+include hN in
+/-- **Naturality in the second variable, inverse form.** Mirror of `fullSummandIso_inv_natLeft`,
+reducing to `homTensorHom_comp_lcompₖ_right`. -/
+theorem fullSummandIso_inv_natRight (p q : ℕ) :
+    ((curriedTensor (ModuleCat.{u} k)).obj
+          ((P₁.complex.linearYonedaObj k (ModuleCat.of A₁ N₁)).X p)).map
+        ((P₂.complex.linearYonedaObj k (ModuleCat.of A₂ N₂)).d q (q + 1)) ≫
+        (fullSummandIso k N₁ N₂ hN P₁ P₂ p (q + 1)).inv =
+      (fullSummandIso k N₁ N₂ hN P₁ P₂ p q).inv ≫
+        (homYoneda k N₁ N₂).map
+          (extTensorFunctorLeftMap k (𝟙 (P₁.complex.X p)) (P₂.complex.d (q + 1) q)).op := by
+  apply ModuleCat.hom_ext
+  refine TensorProduct.ext' fun φ₁ φ₂ => ?_
+  -- Mirror of `fullSummandIso_inv_natLeft`; matches via `homTensorHom_comp_lcompₖ_right`.
+  sorry
+
 include hN in
 /-- **The differential-commutation square, inverse form.** Composing the target differential with
 the inverse degreewise iso equals the inverse degreewise iso followed by the source differential.

--- a/progress/2026-07-17T01-27-22Z.md
+++ b/progress/2026-07-17T01-27-22Z.md
@@ -1,0 +1,57 @@
+## Accomplished
+
+Worked on GitHub issue #6888 (Ch8 #Problem8.2.8-Ext: the two per-summand naturality lemmas
+`fullSummandIso_inv_natLeft/natRight`), in `Chapter8/RearrangeHomComplex.lean`.
+
+- **Proved sorry-free** `Etingof.summandIso_inv_hom_apply` — the pointwise action of `summandIso.inv`
+  on a simple tensor of categorical homs:
+  `(summandIso.inv (ψ₁ ⊗ₜ ψ₂)).hom (x₁ ⊗ₜ x₂) = ψ₁.hom x₁ ⊗ₜ ψ₂.hom x₂`. This is the mathematical
+  crux — it reduces `summandIso.inv` (i.e. `homTensorHomEquiv`/`homTensorHom`) to a raw tensor
+  evaluation. The proof unfolds `summandIso`/`rearrangeHomComponentIso`/`homTensorHomEquiv` via a
+  `.hom`-level `simp only`, then cracks the `TensorProduct.map` with an `erw [TensorProduct.map_tmul]`
+  (needed because the `homLinearEquiv.symm`/`homTensorHom` boundary is only defeq up to the
+  `extTensorFunctorLeftObj = X₁ ⊗ X₂` spelling, so `simp`'s `instances`-transparency matcher stalls).
+- Added two reusable helper lemmas: `eqToHom_moduleCat_apply` (an `eqToHom` on a `ModuleCat k` element
+  is a `cast` along the carrier equality) and `hom_eqToHom_apply` (its `.hom`-projection form).
+- Wrote the exact statements of the two deliverables `fullSummandIso_inv_natLeft` /
+  `fullSummandIso_inv_natRight` (verbatim from the issue; they typecheck) and the helper
+  `fullSummandIso_inv_tmul_hom_apply`, each with a `sorry` and a docstring recording the route.
+
+`lake build EtingofRepresentationTheory.Chapter8.RearrangeHomComplex` succeeds (4 sorries: the three
+above plus the pre-existing `rearrangeHomComplexXIso_inv_comm` from the sibling issue).
+
+## Current frontier
+
+`fullSummandIso_inv_tmul_hom_apply` is the last blocker. It should follow from the proven
+`summandIso_inv_hom_apply` by peeling the `eqToIso(srcSummandEq)` / `tensorIso(eqToIso(linYonedaXEq))`
+bridges of `fullSummandIso`. The reduction is fully worked out
+(`fullSummandIso.inv = tensorIso.inv ≫ summandIso.inv ≫ eqToHom srcSummandEq.symm`, applied via
+`ModuleCat.comp_apply` + `tensorHom_tmul`), but the residual `eqToHom` carrier-transports are
+**propositional, not definitional**: an `eqToHom h` between `ModuleCat k` objects whose carriers are
+defeq but not syntactically equal is a *stuck* `Eq.rec`, so `rfl` / a single `Eq.trans` against
+`summandIso_inv_hom_apply` do not close it (both the source composite and the `φᵢ` vs
+`eqToHom (linYonedaXEq …) φᵢ` targets differ by such a transport). Closing it needs a nested `HEq`
+bridge (`cast_heq` / `eqRec_heq`) threaded through `summandIso.inv` on both sides. This is exactly the
+"one obstacle" #6888 flagged — but it turned out harder than the issue anticipated (the issue expected
+`h ▸ x` to be defeq to `x`; it is not, across non-syntactic carrier equalities).
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. This turn added one sorry-free crux lemma toward #6888; the two
+naturality deliverables and one bridging helper remain sorried with the route documented.
+
+## Next step
+
+Discharge `fullSummandIso_inv_tmul_hom_apply` via the nested-`HEq` bridge (recommended shape:
+`refine Eq.trans ?_ (summandIso_inv_hom_apply … φ₁ φ₂ …)` then prove
+`.hom (fullSummandIso.inv (φ₁⊗φ₂)) w = .hom (summandIso.inv (φ₁⊗φ₂)) w` by `HEq`-congruence of
+`ModuleCat.Hom.hom` across the `srcSummandEq`/`linYonedaXEq` transports, using `cast_heq`). Then both
+`fullSummandIso_inv_natLeft/natRight` reduce, via `fullSummandIso_inv_tmul_hom_apply` and the source
+differential `ChainComplex.linearYonedaObj_d`, to `homTensorHom_comp_lcompₖ_left/right` (the #6843
+naturality lemmas) — the route is in the issue and the natLeft/natRight docstrings.
+
+## Blockers
+
+GitHub had a partial outage for the first part of the session (REST 503s while GraphQL stayed up),
+which delayed claiming; it recovered. No blockers now beyond the transport-bridge proof engineering
+above.


### PR DESCRIPTION
This PR adds, toward https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/issues/6888 (the two per-summand naturality lemmas `fullSummandIso_inv_natLeft/natRight`), the sorry-free crux lemma `Etingof.summandIso_inv_hom_apply` together with two reusable `eqToHom`-transport helpers, and states the two deliverables plus a bridging helper with documented `sorry`s.

It does **not** close #6888: `fullSummandIso_inv_natLeft`, `fullSummandIso_inv_natRight`, and the helper `fullSummandIso_inv_tmul_hom_apply` remain `sorry` pending the `eqToHom` carrier-transport bridge described below.

`summandIso_inv_hom_apply` proves `(summandIso.inv (ψ₁ ⊗ₜ ψ₂)).hom (x₁ ⊗ₜ x₂) = ψ₁.hom x₁ ⊗ₜ ψ₂.hom x₂`, i.e. it reduces `summandIso.inv` (which repackages `homTensorHomEquiv`/`homTensorHom`) to a raw tensor evaluation. This is the mathematical core the naturality lemmas rest on.

The remaining obstacle is the exact one #6888 flagged, but it is harder than anticipated: an `eqToHom h` between `ModuleCat k` objects whose carriers are defeq but not syntactically equal is a **stuck** `Eq.rec`, so the `srcSummandEq`/`linYonedaXEq` bridges of `fullSummandIso` are propositional, not definitional. Neither `rfl` nor a single `Eq.trans` against `summandIso_inv_hom_apply` closes `fullSummandIso_inv_tmul_hom_apply`; a nested `HEq` bridge (`cast_heq`/`eqRec_heq`) threaded through `summandIso.inv` on both sides is required. Once that helper lands, both naturality lemmas reduce (via it and `ChainComplex.linearYonedaObj_d`) to the #6843 lemmas `homTensorHom_comp_lcompₖ_left/right`, as recorded in their docstrings.

`lake build EtingofRepresentationTheory.Chapter8.RearrangeHomComplex` succeeds.

🤖 Prepared with Claude Code