### PR TITLE
feat(Ch8 #Problem8.2.8-Ext): fullSummandIso_inv_natLeft/natRight — the two homTensorHom-bridge per-summand naturality lemmas (crux of #6884)

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -222,6 +222,21 @@ context (`theorem extMapHom_tmul … := rfl`) so its LHS matches syntactically. 
 `erw`s in one call — each does an expensive defeq search and the combined term blows up `whnf`; keep
 them on separate lines.
 
+**When `erw` *itself* times out (`whnf` heartbeat blow-up on a big `ModuleCat`/iso term), close by
+explicit-term `refine`, not a rewrite.** For a two-sided goal `LHS = RHS` where a pointwise helper
+`h : … = …` applies to each side but `rw`/`simp` "did not find pattern" and `erw` blows `whnf` even
+at `maxHeartbeats 1000000`: apply the helper as a *fully-applied term* (all section args explicit,
+no metavars) inside `refine (h_left …).trans (Eq.trans ?_ (h_right …).symm)` and let `refine`'s
+defeq unification match each side; discharge the residual middle goal (the two helpers' RHS, equal
+by definitional differential/whisker reductions) with `rfl`. This sidesteps both syntactic `rw`
+matching and `erw`'s runaway `whnf`. Pointwise `ModuleCat` helpers also need the *inner*
+application spelled in the same coercion form as the goal (state the LHS as
+`ModuleCat.Hom.hom (ModuleCat.Hom.hom f.inv (a ⊗ₜ b)) (y ⊗ₜ z)`, not the bare-coe
+`f.inv (a ⊗ₜ b)`, which elaborates to `ConcreteCategory.hom` and won't match a `hom_comp`-reduced
+goal). The `eqToHom`-on-elements bridge between same-carrier `ModuleCat` objects (different
+`Module k` instance) is `HEq (ModuleCat.Hom.hom (eqToHom h) w) w := by subst h; rfl`, upgraded per
+site with `eq_of_heq`.
+
 **Reading background-build results: grep the teed log for `error:`, do not trust a
 wrapper's exit code or `tail`.** `lake build` prints Lean errors *before* the final
 `Build completed` / `✖` summary, so `... | tee log | tail -40` can hide them, and a

--- a/EtingofRepresentationTheory/Chapter8/RearrangeHomComplex.lean
+++ b/EtingofRepresentationTheory/Chapter8/RearrangeHomComplex.lean
@@ -40,6 +40,8 @@ open CategoryTheory Limits MonoidalCategory TensorProduct HomologicalComplex
 
 namespace Etingof
 
+open HomTensorFGProj
+
 universe u
 
 variable (k : Type u) [Field k]
@@ -61,6 +63,85 @@ variable {M₁ : ModuleCat.{u} A₁} {M₂ : ModuleCat.{u} A₂}
 variable (P₁ : ProjectiveResolution M₁) (P₂ : ProjectiveResolution M₂)
 variable [∀ j, Module.Finite A₁ (P₁.complex.X j)] [∀ j, Module.Projective A₁ (P₁.complex.X j)]
 variable [∀ m, Module.Finite A₂ (P₂.complex.X m)] [∀ m, Module.Projective A₂ (P₂.complex.X m)]
+
+/-- Applying a `ModuleCat k` `eqToHom` to an element is the `▸` transport of the element. Since the
+`eqToHom` object equalities appearing in `fullSummandIso` (`srcSummandEq`, `linYonedaXEq`) are
+between `ModuleCat.of k T` objects sharing the *same carrier* `T`, the resulting `h ▸ x` is defeq to
+`x`. -/
+private lemma eqToHom_moduleCat_apply {X Y : ModuleCat.{u} k} (h : X = Y) (x : X) :
+    (eqToHom h) x = h ▸ x := by cases h; rfl
+
+/-- Applying a `ModuleCat k` `eqToHom` to an element yields a heterogeneously-equal element. When the
+two objects share a carrier (the `srcSummandEq`/`linYonedaXEq` bridges of `fullSummandIso`), this
+upgrades to an honest equation via `eq_of_heq`. -/
+private lemma eqToHom_hom_apply_heq {X Y : ModuleCat.{u} k} (h : X = Y) (w : X) :
+    HEq (ModuleCat.Hom.hom (eqToHom h) w) w := by subst h; rfl
+
+include hN in
+/-- Closed form of `summandIso.inv` on a simple tensor `a₁ ⊗ₜ a₂` (genuine morphisms, no `eqToHom`
+bridging), evaluated at `y₁ ⊗ₜ y₂`: it is `a₁ y₁ ⊗ₜ a₂ y₂`. The `eqToHom`-free core of
+`fullSummandIso_inv_tmul_apply`. -/
+private lemma summandIso_inv_tmul_apply (X₁ : ModuleCat.{u} A₁) (X₂ : ModuleCat.{u} A₂)
+    [Module.Finite A₁ X₁] [Module.Projective A₁ X₁]
+    [Module.Finite A₂ X₂] [Module.Projective A₂ X₂]
+    (a₁ : X₁ ⟶ ModuleCat.of A₁ N₁) (a₂ : X₂ ⟶ ModuleCat.of A₂ N₂) (y₁ : X₁) (y₂ : X₂) :
+    (ModuleCat.Hom.hom ((summandIso k N₁ N₂ hN X₁ X₂).inv (a₁ ⊗ₜ[k] a₂))) (y₁ ⊗ₜ[k] y₂)
+      = a₁.hom y₁ ⊗ₜ[k] a₂.hom y₂ := by
+  simp only [summandIso, rearrangeHomComponentIso, Iso.trans_inv, Iso.symm_inv,
+    LinearEquiv.toModuleIso_inv, ModuleCat.hom_comp, LinearMap.comp_apply]
+  rfl
+
+set_option maxHeartbeats 1000000 in
+include hN in
+/-- Closed form of `fullSummandIso.inv` on a simple tensor `ψ₁ ⊗ₜ ψ₂`, evaluated at a simple tensor
+`y₁ ⊗ₜ y₂`: it is `ψ₁ y₁ ⊗ₜ ψ₂ y₂` (`homTensorHom`). This is the pointwise reduction that both
+naturality lemmas share; the `eqToHom` bridges in `fullSummandIso` act as the identity on the shared
+underlying `↦` map, discharged by `eqToHom_moduleCat_apply`. -/
+private lemma fullSummandIso_inv_tmul_apply (j m : ℕ)
+    (ψ₁ : ↥((P₁.complex.linearYonedaObj k (ModuleCat.of A₁ N₁)).X j))
+    (ψ₂ : ↥((P₂.complex.linearYonedaObj k (ModuleCat.of A₂ N₂)).X m))
+    (y₁ : P₁.complex.X j) (y₂ : P₂.complex.X m) :
+    (ModuleCat.Hom.hom ((fullSummandIso k N₁ N₂ hN P₁ P₂ j m).inv (ψ₁ ⊗ₜ[k] ψ₂)))
+        (y₁ ⊗ₜ[k] y₂) = ψ₁.hom y₁ ⊗ₜ[k] ψ₂.hom y₂ := by
+  have e0 := fun w => eq_of_heq (eqToHom_hom_apply_heq k (srcSummandEq k N₁ N₂ hN P₁ P₂ j m).symm w)
+  have e1 := fun w => eq_of_heq (eqToHom_hom_apply_heq k (linYonedaXEq k A₁ N₁ P₁.complex j) w)
+  have e2 := fun w => eq_of_heq (eqToHom_hom_apply_heq k (linYonedaXEq k A₂ N₂ P₂.complex m) w)
+  simp only [fullSummandIso, Iso.trans_inv, tensorIso_inv, eqToIso.inv, ModuleCat.hom_comp,
+    LinearMap.comp_apply, ModuleCat.hom_tensorHom, e0]
+  erw [TensorProduct.map_tmul]
+  rw [e1, e2]
+  simp only [summandIso, rearrangeHomComponentIso, Iso.trans_inv, Iso.symm_inv,
+    LinearEquiv.toModuleIso_inv, ModuleCat.hom_comp, LinearMap.comp_apply]
+  rfl
+
+include hN in
+/-- **Naturality of `fullSummandIso.inv` in the first (contravariant) variable.** Composing the
+degree-`p → p+1` source differential of the first `Hom` cochain factor (via `curriedTensor`) with the
+per-summand inverse iso equals the per-summand inverse iso followed by precomposition by the
+external-tensor map of the chain differential `P₁.d (p+1) p`. Bridges `fullSummandIso.inv` to the
+#6843 naturality lemma `homTensorHom_comp_lcompₖ_left`. -/
+theorem fullSummandIso_inv_natLeft (p q : ℕ) :
+    ((curriedTensor (ModuleCat.{u} k)).map
+          ((P₁.complex.linearYonedaObj k (ModuleCat.of A₁ N₁)).d p (p + 1))).app
+        ((P₂.complex.linearYonedaObj k (ModuleCat.of A₂ N₂)).X q) ≫
+        (fullSummandIso k N₁ N₂ hN P₁ P₂ (p + 1) q).inv =
+      (fullSummandIso k N₁ N₂ hN P₁ P₂ p q).inv ≫
+        (homYoneda k N₁ N₂).map
+          (extTensorFunctorLeftMap k (P₁.complex.d (p + 1) p) (𝟙 (P₂.complex.X q))).op := by
+  sorry
+
+include hN in
+/-- **Naturality of `fullSummandIso.inv` in the second (contravariant) variable.** The mirror of
+`fullSummandIso_inv_natLeft`, bridging to `homTensorHom_comp_lcompₖ_right`. -/
+theorem fullSummandIso_inv_natRight (p q : ℕ) :
+    ((curriedTensor (ModuleCat.{u} k)).obj
+          ((P₁.complex.linearYonedaObj k (ModuleCat.of A₁ N₁)).X p)).map
+        ((P₂.complex.linearYonedaObj k (ModuleCat.of A₂ N₂)).d q (q + 1)) ≫
+        (fullSummandIso k N₁ N₂ hN P₁ P₂ p (q + 1)).inv =
+      (fullSummandIso k N₁ N₂ hN P₁ P₂ p q).inv ≫
+        (homYoneda k N₁ N₂).map
+          (extTensorFunctorLeftMap k (𝟙 (P₁.complex.X p)) (P₂.complex.d (q + 1) q)).op := by
+  sorry
 
 include hN in
 /-- **The differential-commutation square, inverse form.** Composing the target differential with

--- a/EtingofRepresentationTheory/Chapter8/RearrangeHomComplex.lean
+++ b/EtingofRepresentationTheory/Chapter8/RearrangeHomComplex.lean
@@ -56,7 +56,7 @@ variable
     (a₁ ⊗ₜ[k] a₂ : A₁ ⊗[k] A₂) • (n₁ ⊗ₜ[k] n₂ : N₁ ⊗[k] N₂)
       = (a₁ • n₁) ⊗ₜ[k] (a₂ • n₂))
 
-attribute [local instance] restrictModule₁L restrictModule₂L tower₁L tower₂L extModuleL
+attribute [local instance] restrictModule₁L restrictModule₂L tower₁L tower₂L extModuleL towerExtL
 
 variable {A₁ A₂}
 variable {M₁ : ModuleCat.{u} A₁} {M₂ : ModuleCat.{u} A₂}
@@ -101,7 +101,7 @@ private lemma fullSummandIso_inv_tmul_apply (j m : ℕ)
     (ψ₁ : ↥((P₁.complex.linearYonedaObj k (ModuleCat.of A₁ N₁)).X j))
     (ψ₂ : ↥((P₂.complex.linearYonedaObj k (ModuleCat.of A₂ N₂)).X m))
     (y₁ : P₁.complex.X j) (y₂ : P₂.complex.X m) :
-    (ModuleCat.Hom.hom ((fullSummandIso k N₁ N₂ hN P₁ P₂ j m).inv (ψ₁ ⊗ₜ[k] ψ₂)))
+    (ModuleCat.Hom.hom (ModuleCat.Hom.hom (fullSummandIso k N₁ N₂ hN P₁ P₂ j m).inv (ψ₁ ⊗ₜ[k] ψ₂)))
         (y₁ ⊗ₜ[k] y₂) = ψ₁.hom y₁ ⊗ₜ[k] ψ₂.hom y₂ := by
   have e0 := fun w => eq_of_heq (eqToHom_hom_apply_heq k (srcSummandEq k N₁ N₂ hN P₁ P₂ j m).symm w)
   have e1 := fun w => eq_of_heq (eqToHom_hom_apply_heq k (linYonedaXEq k A₁ N₁ P₁.complex j) w)
@@ -114,6 +114,7 @@ private lemma fullSummandIso_inv_tmul_apply (j m : ℕ)
     LinearEquiv.toModuleIso_inv, ModuleCat.hom_comp, LinearMap.comp_apply]
   rfl
 
+set_option maxHeartbeats 1000000 in
 include hN in
 /-- **Naturality of `fullSummandIso.inv` in the first (contravariant) variable.** Composing the
 degree-`p → p+1` source differential of the first `Hom` cochain factor (via `curriedTensor`) with the
@@ -128,7 +129,19 @@ theorem fullSummandIso_inv_natLeft (p q : ℕ) :
       (fullSummandIso k N₁ N₂ hN P₁ P₂ p q).inv ≫
         (homYoneda k N₁ N₂).map
           (extTensorFunctorLeftMap k (P₁.complex.d (p + 1) p) (𝟙 (P₂.complex.X q))).op := by
-  sorry
+  apply ModuleCat.hom_ext
+  refine TensorProduct.ext' fun φ₁ φ₂ => ?_
+  simp only [ModuleCat.hom_comp, LinearMap.comp_apply, curriedTensor_map_app,
+    ChainComplex.linearYonedaObj_d, ModuleCat.hom_whiskerRight, ModuleCat.hom_ofHom,
+    linearYoneda_obj_map]
+  erw [LinearMap.rTensor_tmul]
+  apply ModuleCat.hom_ext
+  refine HomTensorFGProj.hom_ext k A₁ A₂ _ _ N₁ N₂ (fun x₁ x₂ => ?_)
+  refine (fullSummandIso_inv_tmul_apply k N₁ N₂ hN P₁ P₂ (p + 1) q
+      (Linear.leftComp k (ModuleCat.of A₁ N₁) (P₁.complex.d (p + 1) p) φ₁) φ₂ x₁ x₂).trans
+    (Eq.trans ?_ (fullSummandIso_inv_tmul_apply k N₁ N₂ hN P₁ P₂ p q φ₁ φ₂
+      ((P₁.complex.d (p + 1) p).hom x₁) x₂).symm)
+  rfl
 
 include hN in
 /-- **Naturality of `fullSummandIso.inv` in the second (contravariant) variable.** The mirror of

--- a/EtingofRepresentationTheory/Chapter8/RearrangeHomComplex.lean
+++ b/EtingofRepresentationTheory/Chapter8/RearrangeHomComplex.lean
@@ -71,9 +71,9 @@ between `ModuleCat.of k T` objects sharing the *same carrier* `T`, the resulting
 private lemma eqToHom_moduleCat_apply {X Y : ModuleCat.{u} k} (h : X = Y) (x : X) :
     (eqToHom h) x = h ▸ x := by cases h; rfl
 
-/-- Applying a `ModuleCat k` `eqToHom` to an element yields a heterogeneously-equal element. When the
-two objects share a carrier (the `srcSummandEq`/`linYonedaXEq` bridges of `fullSummandIso`), this
-upgrades to an honest equation via `eq_of_heq`. -/
+/-- Applying a `ModuleCat k` `eqToHom` to an element yields a heterogeneously-equal element. When
+the two objects share a carrier (the `srcSummandEq`/`linYonedaXEq` bridges of `fullSummandIso`),
+this upgrades to an honest equation via `eq_of_heq`. -/
 private lemma eqToHom_hom_apply_heq {X Y : ModuleCat.{u} k} (h : X = Y) (w : X) :
     HEq (ModuleCat.Hom.hom (eqToHom h) w) w := by subst h; rfl
 
@@ -110,17 +110,15 @@ private lemma fullSummandIso_inv_tmul_apply (j m : ℕ)
     LinearMap.comp_apply, ModuleCat.hom_tensorHom, e0]
   erw [TensorProduct.map_tmul]
   rw [e1, e2]
-  simp only [summandIso, rearrangeHomComponentIso, Iso.trans_inv, Iso.symm_inv,
-    LinearEquiv.toModuleIso_inv, ModuleCat.hom_comp, LinearMap.comp_apply]
   rfl
 
 set_option maxHeartbeats 1000000 in
 include hN in
 /-- **Naturality of `fullSummandIso.inv` in the first (contravariant) variable.** Composing the
-degree-`p → p+1` source differential of the first `Hom` cochain factor (via `curriedTensor`) with the
-per-summand inverse iso equals the per-summand inverse iso followed by precomposition by the
-external-tensor map of the chain differential `P₁.d (p+1) p`. Bridges `fullSummandIso.inv` to the
-#6843 naturality lemma `homTensorHom_comp_lcompₖ_left`. -/
+degree-`p → p+1` source differential of the first `Hom` cochain factor (via `curriedTensor`) with
+the per-summand inverse iso equals the per-summand inverse iso followed by precomposition by the
+external-tensor map of the chain differential `P₁.d (p+1) p`. Reduces pointwise through
+`fullSummandIso_inv_tmul_apply` to `homTensorHom_comp_lcompₖ_left` (#6843). -/
 theorem fullSummandIso_inv_natLeft (p q : ℕ) :
     ((curriedTensor (ModuleCat.{u} k)).map
           ((P₁.complex.linearYonedaObj k (ModuleCat.of A₁ N₁)).d p (p + 1))).app
@@ -154,7 +152,19 @@ theorem fullSummandIso_inv_natRight (p q : ℕ) :
       (fullSummandIso k N₁ N₂ hN P₁ P₂ p q).inv ≫
         (homYoneda k N₁ N₂).map
           (extTensorFunctorLeftMap k (𝟙 (P₁.complex.X p)) (P₂.complex.d (q + 1) q)).op := by
-  sorry
+  apply ModuleCat.hom_ext
+  refine TensorProduct.ext' fun φ₁ φ₂ => ?_
+  simp only [ModuleCat.hom_comp, LinearMap.comp_apply, curriedTensor_obj_map,
+    ChainComplex.linearYonedaObj_d, ModuleCat.hom_whiskerLeft, ModuleCat.hom_ofHom,
+    linearYoneda_obj_map]
+  erw [LinearMap.lTensor_tmul]
+  apply ModuleCat.hom_ext
+  refine HomTensorFGProj.hom_ext k A₁ A₂ _ _ N₁ N₂ (fun x₁ x₂ => ?_)
+  refine (fullSummandIso_inv_tmul_apply k N₁ N₂ hN P₁ P₂ p (q + 1)
+      φ₁ (Linear.leftComp k (ModuleCat.of A₂ N₂) (P₂.complex.d (q + 1) q) φ₂) x₁ x₂).trans
+    (Eq.trans ?_ (fullSummandIso_inv_tmul_apply k N₁ N₂ hN P₁ P₂ p q φ₁ φ₂
+      x₁ ((P₂.complex.d (q + 1) q).hom x₂)).symm)
+  rfl
 
 include hN in
 /-- **The differential-commutation square, inverse form.** Composing the target differential with

--- a/progress/2026-07-17T04-14-00Z_9d4e788a.md
+++ b/progress/2026-07-17T04-14-00Z_9d4e788a.md
@@ -1,0 +1,66 @@
+## Accomplished
+
+Delivered issue #6888: the two per-summand naturality lemmas for the `Ext` Künneth cochain
+assembly, both **sorry-free** in `Chapter8/RearrangeHomComplex.lean`:
+
+- `Etingof.fullSummandIso_inv_natLeft`
+- `Etingof.fullSummandIso_inv_natRight`
+
+To get there I introduced a small tower of supporting lemmas (all sorry-free):
+
+- `eqToHom_moduleCat_apply` / `eqToHom_hom_apply_heq` — the `eqToHom`-on-elements bridge. The
+  `fullSummandIso` `eqToHom` transports go between `ModuleCat k` objects that share a carrier but
+  differ in `Module k` instance (through the scalar tower), so they are propositional, not
+  definitional, identities. `eqToHom_hom_apply_heq` records `HEq (Hom.hom (eqToHom h) w) w`,
+  provable by `subst h; rfl` with free type variables, and upgrades to an honest `Eq` via
+  `eq_of_heq` wherever the carriers are defeq.
+- `summandIso_inv_tmul_apply` — closed form of `summandIso.inv` on a simple tensor of genuine
+  morphisms (no `eqToHom`); proved by unfolding + `rfl`.
+- `fullSummandIso_inv_tmul_apply` — the pointwise reduction shared by both naturality lemmas:
+  `fullSummandIso.inv (ψ₁ ⊗ₜ ψ₂)` evaluated at `y₁ ⊗ₜ y₂` is `ψ₁ y₁ ⊗ₜ ψ₂ y₂`. Proof unfolds the
+  iso composite, reduces the whisker via `ModuleCat.hom_tensorHom` + `TensorProduct.map_tmul`,
+  discharges the three `eqToHom` transports via the `eq_of_heq` bridge lemmas, then `rfl` through
+  `summandIso.inv`.
+
+The two naturality lemmas then reduce mechanically: `ModuleCat.hom_ext` + `TensorProduct.ext'`
+(over `k`) to fix the two `Hom`-factor arguments, differential reductions
+(`curriedTensor_map_app`/`curriedTensor_obj_map`, `linearYonedaObj_d`,
+`hom_whiskerRight`/`hom_whiskerLeft` + `rTensor_tmul`/`lTensor_tmul`), then `ModuleCat.hom_ext` +
+`HomTensorFGProj.hom_ext` (for the `A₁⊗A₂`-linear map out of `X⊗[k]Y`), closing by applying
+`fullSummandIso_inv_tmul_apply` to each side through a `refine (…).trans (Eq.trans ?_ (…).symm)`
+with `rfl`.
+
+## Current frontier
+
+`Chapter8/RearrangeHomComplex.lean` builds (`lake build …RearrangeHomComplex` exits 0). The single
+remaining `sorry` in the file is `rearrangeHomComplexXIso_inv_comm` — that is the **sibling** issue
+#6889 (the assembly consuming these two lemmas), not part of #6888.
+
+## Overall project progress
+
+Stage 3 (formalization) of the `Ext` half of Problem 8.2.8. #6888 is closed; its sibling #6889
+(assemble `rearrangeHomComplexXIso_inv_comm` from these two lemmas + `srcProj_comm`) is now
+unblocked.
+
+## Next step
+
+Pick up #6889: it consumes `fullSummandIso_inv_natLeft` / `fullSummandIso_inv_natRight` (now
+available, sorry-free) plus the source-complex identity to discharge the `sorry` at
+`rearrangeHomComplexXIso_inv_comm`.
+
+## Blockers
+
+None.
+
+## Notes / patterns discovered
+
+- The recurring friction was **coercion form** (`ModuleCat.Hom.hom` vs `ConcreteCategory.hom`,
+  defeq but not syntactic) and **instance-level tmul mismatches**. `rw` is purely syntactic and
+  failed repeatedly on visually-identical goals; `erw` matched but its `whnf` blew the heartbeat
+  budget on the `fullSummandIso` term. The robust closer was to apply the pointwise helper as an
+  explicit fully-applied term inside `refine (…).trans (Eq.trans ?_ (…).symm)` and let `refine`'s
+  defeq unification bridge the gap, with `rfl` for the middle.
+- `fullSummandIso_inv_tmul_apply` needs `set_option maxHeartbeats 1000000` (the `eq_of_heq` casts +
+  `summandIso` unfold make the final kernel `rfl` expensive).
+- Re-activating the file-local `towerExtL` (`attribute [local instance] … towerExtL`) is required
+  for `HomTensorFGProj.hom_ext`.


### PR DESCRIPTION
Closes #6888

Session: `9d4e788a-9c5a-4fd6-8a5c-887545da3536`

66f04023 chore(#6888): progress file for fullSummandIso naturality lemmas
cb340e53 feat(Ch8 #Problem8.2.8-Ext): prove fullSummandIso_inv_natRight + cleanup (closes #6888 deliverables)
1e702b98 feat(Ch8 #Problem8.2.8-Ext): prove fullSummandIso_inv_natLeft (WIP #6888)
9baa128c feat(Ch8 #Problem8.2.8-Ext): prove fullSummandIso_inv_tmul_apply pointwise helper + eqToHom bridge lemmas (WIP #6888; natLeft/natRight remain)

🤖 Prepared with Claude Code