### PR TITLE
feat(Ch6 #Problem6.1.3-g): prove the ⟹ direction of affine_dynkin_classification — connected degenerate positive-semidefinite Cartan form ⟹ graph-iso to Ãₙ/D̃ₙ/Ẽ₆/Ẽ₇/Ẽ₈ (residual of #6779; backward dir in PR #6781)

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_tildeE.lean
+++ b/EtingofRepresentationTheory/Chapter6/Problem6_1_3_continued_tildeE.lean
@@ -2991,8 +2991,17 @@ theorem affine_dynkin_classification (n : ℕ) (adj : Matrix (Fin n) (Fin n) ℤ
   constructor
   · -- (⟹) The classification proper: a positive-semidefinite-but-degenerate
     -- connected simply-laced graph is graph-isomorphic to one of the five
-    -- extended types. This is the deep content (see the sub-issue).
-    sorry
+    -- extended types. Case split on whether the diagram contains a cycle,
+    -- measured by the edge count `∑ᵢ∑ⱼ adjᵢⱼ`: a connected graph is a tree
+    -- (acyclic) exactly when it has `n − 1` edges (`∑ᵢ∑ⱼ adjᵢⱼ = 2(n−1)`),
+    -- so `2n ≤ ∑ᵢ∑ⱼ adjᵢⱼ` is the "contains a cycle" branch.
+    intro hD
+    rcases le_or_gt (2 * (n : ℤ)) (∑ i, ∑ j, adj i j) with hcyc | hacyc
+    · -- Cyclic branch: graph-iso to the cycle `Ãₙ` (#6792).
+      obtain ⟨h3, σ, hσ⟩ := affine_cyclic_case adj hn hD hcyc
+      exact ⟨AffineType.Atilde n h3, σ, hσ⟩
+    · -- Tree branch: graph-iso to `D̃ₙ/Ẽ₆/Ẽ₇/Ẽ₈` (#6793).
+      exact affine_tree_case adj hn hD hacyc
   · -- (⟸) Each extended type is an affine Dynkin diagram (`isAffineDynkinDiagram_of_type`),
     -- transported along the graph isomorphism `σ`.
     rintro ⟨t, σ, hσ⟩

--- a/progress/2026-07-17T17-42-26Z_2c23fca8.md
+++ b/progress/2026-07-17T17-42-26Z_2c23fca8.md
@@ -1,0 +1,48 @@
+## Accomplished
+
+Closed the residual scope of issue #6785 (step 5, final assembly): the ⟹ direction of
+`Etingof.Problem6_1_3_tildeE.affine_dynkin_classification`
+(`Chapter6/Problem6_1_3_continued_tildeE.lean`) is now proved — the `sorry` at the forward
+branch is gone. The assembly is a single case split on the edge count `∑ᵢ∑ⱼ adjᵢⱼ`:
+
+- `2n ≤ ∑ᵢ∑ⱼ adjᵢⱼ` (contains a cycle) → `affine_cyclic_case` (#6792) gives graph-iso to `Ãₙ`.
+- `∑ᵢ∑ⱼ adjᵢⱼ < 2n` (tree) → `affine_tree_case` (#6793) gives graph-iso to `D̃ₙ/Ẽ₆/Ẽ₇/Ẽ₈`.
+
+Both feed the existential `∃ t : AffineType, ∃ σ, ∀ i j, adj (σ i) (σ j) = t.adj i j`. The
+cyclic branch repackages `affine_cyclic_case`'s `⟨h3, σ, hσ⟩` as `⟨AffineType.Atilde n h3, σ, hσ⟩`;
+the tree branch returns `affine_tree_case` directly.
+
+`lake build EtingofRepresentationTheory.Chapter6.Problem6_1_3` completes (8581 jobs). The
+assembly itself is sorry-free.
+
+## Current frontier
+
+`affine_dynkin_classification` (both directions) is fully assembled. The ⟸ direction was already
+done via `isAffineDynkinDiagram_of_graph_iso`.
+
+## Overall project progress
+
+Stage 3, Chapter 6 Problem 6.1.3 (g). The affine Dynkin classification iff is now structurally
+complete. Two sorries remain in the file, both inherited from still-open sub-issues (NOT introduced
+by this work):
+
+- `affine_tree_two_branch_iso` (line ~2590) — the D̃ₙ two-branch case.
+- the harmonic-arm linearity lemma (line ~2654) feeding the one-branch Ẽ₆/Ẽ₇/Ẽ₈ layout, tied to
+  the `affine_one_branch_arm_layout` residual (#6913).
+
+## Next step
+
+Discharge the two remaining tree-case sorries: #6913 (`affine_one_branch_arm_layout`, pure graph
+combinatorics for the one-branch layout) and the `affine_tree_two_branch_iso` D̃ₙ case. Once those
+land, `#print axioms affine_dynkin_classification` will be clean.
+
+## Blockers
+
+None. Note main advanced during the session (PR #6914 merged into the same file); rebased cleanly
+onto origin/main with no conflicts.
+
+## Notes / patterns discovered
+
+- `le_or_lt` is not the current name in this Mathlib pin; use `le_or_gt` (as elsewhere in the file).
+  `le_or_gt (2*n) (∑∑adj)` yields `2n ≤ ∑∑ ∨ ∑∑ < 2n` directly (the `>` reduces defeq to the `<`
+  hypothesis the tree lemma wants).


### PR DESCRIPTION
Closes #6785

Session: `2c23fca8-5f5d-4b15-b786-778be72a99f0`

67cacf4b docs: progress for #6785 assembly (2026-07-17T17-42-26Z)
60be6ae9 feat(Ch6 #Problem6.1.3-g): assemble ⟹ direction of affine_dynkin_classification via cyclic/tree case split (residual step 5 of #6785)

🤖 Prepared with Claude Code