### PR TITLE
feat(Ch4 #Problem4.12.8-a-iv): so3_cyclic_of_poleData — cyclic disjunct of so3_classification_aux from the {n,n} pole family via isCyclic_of_common_fixed_vector (residual of #6877)

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Problem4_12_8.lean
+++ b/EtingofRepresentationTheory/Chapter4/Problem4_12_8.lean
@@ -1212,6 +1212,21 @@ theorem mulEquiv_dihedralGroup_of_conj_inv
   exact ⟨(MulEquiv.ofBijective φ
     ((Fintype.bijective_iff_injective_and_card φ).mpr ⟨hinj, hcardeq⟩)).symm⟩
 
+/-- **Cyclic disjunct — geometric bridge.** A finite `G ≤ SO(3)` possessing a pole `b` fixed by
+*every* element of `G` is cyclic: all of `G` then shares the common axis `ℝ·b.1`, so
+`isCyclic_of_common_fixed_vector` applies. This is the content of the `{n, n}` (cyclic) family of
+`so3_classification_aux`, once the family is shown to contain a `G`-fixed pole. -/
+theorem so3_cyclic_of_globally_fixed_pole
+    (G : Subgroup (specialOrthogonalGroup (Fin 3) ℝ)) [Finite G]
+    (b : ↥(poleSet G)) (hb : ∀ g : ↥G, g • b = b) :
+    IsCyclic G := by
+  have hunit : (b : ↥(poleSet G)).1 ⬝ᵥ (b : ↥(poleSet G)).1 = 1 := b.2.1
+  have hv0 : (b : ↥(poleSet G)).1 ≠ 0 := by
+    intro h; rw [h] at hunit; simp at hunit
+  refine isCyclic_of_common_fixed_vector G (b : ↥(poleSet G)).1 hv0 (fun g => ?_)
+  have hg := congrArg (fun P : ↥(poleSet G) => (P : Fin 3 → ℝ)) (hb g)
+  rwa [poleSet_coe_smul] at hg
+
 /-- The substantive content of part (a): the Burnside counting that turns the geometry
 (milestones (i), (ii)) into the pole-order multiset, the application of milestone (iii), and
 the five `MulEquiv` constructions realizing each solution family as `ℤ/nℤ`, `Dₙ`, `A₄`, `S₄`,

--- a/EtingofRepresentationTheory/Chapter4/Problem4_12_8.lean
+++ b/EtingofRepresentationTheory/Chapter4/Problem4_12_8.lean
@@ -1227,6 +1227,18 @@ theorem so3_cyclic_of_globally_fixed_pole
   have hg := congrArg (fun P : ↥(poleSet G) => (P : Fin 3 → ℝ)) (hb g)
   rwa [poleSet_coe_smul] at hg
 
+/-- **Cyclic disjunct — full-stabilizer extraction.** If some pole `b` has stabilizer of order the
+full group order `Nat.card G`, then that stabilizer is all of `G`, so `b` is fixed by every element
+of `G` and `so3_cyclic_of_globally_fixed_pole` gives `IsCyclic G`. In the `{n, n}` pole family the
+two principal poles are exactly such fixed poles (orbit size `1`, stabilizer order `n`). -/
+theorem so3_cyclic_of_full_stabilizer_pole
+    (G : Subgroup (specialOrthogonalGroup (Fin 3) ℝ)) [Finite G]
+    (b : ↥(poleSet G)) (hb : Nat.card (MulAction.stabilizer (↥G) b) = Nat.card (↥G)) :
+    IsCyclic G := by
+  have htop : MulAction.stabilizer (↥G) b = ⊤ := Subgroup.eq_top_of_card_eq _ hb
+  refine so3_cyclic_of_globally_fixed_pole G b (fun g => ?_)
+  exact (MulAction.mem_stabilizer_iff).mp (htop ▸ Subgroup.mem_top g)
+
 /-- The substantive content of part (a): the Burnside counting that turns the geometry
 (milestones (i), (ii)) into the pole-order multiset, the application of milestone (iii), and
 the five `MulEquiv` constructions realizing each solution family as `ℤ/nℤ`, `Dₙ`, `A₄`, `S₄`,

--- a/EtingofRepresentationTheory/Chapter4/Problem4_12_8.lean
+++ b/EtingofRepresentationTheory/Chapter4/Problem4_12_8.lean
@@ -915,7 +915,8 @@ theorem pole_order_data (G : Subgroup (specialOrthogonalGroup (Fin 3) ℝ)) [Fin
       2 * (1 - (Nat.card G : ℚ)⁻¹) = (m.map (fun x => 1 - (x : ℚ)⁻¹)).sum ∧
       (m = {Nat.card G, Nat.card G} ∨
        (∃ k, Nat.card G = 2 * k ∧ m = {2, 2, k}) ∨
-       m = {2, 3, 3} ∨ m = {2, 3, 4} ∨ m = {2, 3, 5}) := by
+       m = {2, 3, 3} ∨ m = {2, 3, 4} ∨ m = {2, 3, 5}) ∧
+      (∀ x ∈ m, ∃ b : ↥(poleSet G), Nat.card (stabilizer (↥G) b) = x) := by
   classical
   haveI : Finite ↥(poleSet G) := (finite_poleSet G).to_subtype
   haveI hFG : Fintype ↥G := Fintype.ofFinite _
@@ -1058,7 +1059,7 @@ theorem pole_order_data (G : Subgroup (specialOrthogonalGroup (Fin 3) ℝ)) [Fin
           field_simp
           ring
   -- Build the multiset and apply the arithmetic classification.
-  refine ⟨(Finset.univ : Finset Ω).val.map mω, ?_, ?_, ?_, ?_⟩
+  refine ⟨(Finset.univ : Finset Ω).val.map mω, ?_, ?_, ?_, ?_, ?_⟩
   · intro x hx
     rw [Multiset.mem_map] at hx
     obtain ⟨ω, _, rfl⟩ := hx
@@ -1077,6 +1078,11 @@ theorem pole_order_data (G : Subgroup (specialOrthogonalGroup (Fin 3) ℝ)) [Fin
       (by
         simp only [bind_pure_comp, Multiset.fmap_def, Multiset.map_map, Function.comp_def]
         exact hsum.symm)
+  · -- Each stabilizer-order in the multiset is realized by the orbit representative `ω.out`.
+    intro x hx
+    rw [Multiset.mem_map] at hx
+    obtain ⟨ω, _, rfl⟩ := hx
+    exact ⟨ω.out, by rw [Nat.card_eq_fintype_card, hmω]⟩
 
 /-- **Milestone (ii): pole stabilizers are cyclic.** For a finite subgroup `G ≤ SO(3)` and a
 pole `b`, every element of the stabilizer of `b` fixes the underlying unit vector `b.1 ≠ 0`, so
@@ -1238,6 +1244,19 @@ theorem so3_cyclic_of_full_stabilizer_pole
   have htop : MulAction.stabilizer (↥G) b = ⊤ := Subgroup.eq_top_of_card_eq _ hb
   refine so3_cyclic_of_globally_fixed_pole G b (fun g => ?_)
   exact (MulAction.mem_stabilizer_iff).mp (htop ▸ Subgroup.mem_top g)
+
+/-- **Cyclic disjunct of `so3_classification_aux`.** From the cyclic pole family `m = {n, n}`
+(`n = Nat.card G`) together with the pole-realization data of `pole_order_data` (each stabilizer
+order in `m` is achieved by an actual pole), extract the principal pole `b` with
+`Nat.card (stabilizer G b) = n` and conclude `IsCyclic G`. This is the first disjunct;
+`m` and `hpole` are supplied verbatim by `pole_order_data`. -/
+theorem so3_cyclic_of_poleData
+    (G : Subgroup (specialOrthogonalGroup (Fin 3) ℝ)) [Finite G] (m : Multiset ℕ)
+    (hclass : m = {Nat.card (↥G), Nat.card (↥G)})
+    (hpole : ∀ x ∈ m, ∃ b : ↥(poleSet G), Nat.card (MulAction.stabilizer (↥G) b) = x) :
+    IsCyclic G := by
+  obtain ⟨b, hb⟩ := hpole (Nat.card (↥G)) (by rw [hclass]; simp)
+  exact so3_cyclic_of_full_stabilizer_pole G b hb
 
 /-- The substantive content of part (a): the Burnside counting that turns the geometry
 (milestones (i), (ii)) into the pole-order multiset, the application of milestone (iii), and

--- a/progress/2026-07-17T18-12-00Z_04a54fd7.md
+++ b/progress/2026-07-17T18-12-00Z_04a54fd7.md
@@ -1,0 +1,56 @@
+## Accomplished
+
+Session type: `/work` → `/feature`. Landed the **cyclic disjunct** of
+`so3_classification_aux` (Ch4 Problem 4.12.8(a)) sorry-free, and did coordination
+triage on several stale/oversized/blocked issues.
+
+Code (`EtingofRepresentationTheory/Chapter4/Problem4_12_8.lean`, issue #6925):
+- `so3_cyclic_of_globally_fixed_pole` — a finite `G ≤ SO(3)` with a pole fixed by all of `G`
+  is cyclic (specialises `isCyclic_of_common_fixed_vector` to the pole's unit vector).
+- `so3_cyclic_of_full_stabilizer_pole` — a pole whose stabilizer has order `Nat.card G` has
+  full stabilizer (`⊤`) via `Subgroup.eq_top_of_card_eq`, hence is globally fixed → cyclic.
+- Enriched `pole_order_data` with a 5th conjunct:
+  `∀ x ∈ m, ∃ b : ↥(poleSet G), Nat.card (stabilizer ↥G b) = x` — every stabilizer order in the
+  returned multiset is realized by an actual pole (witnessed by the orbit representative `ω.out`;
+  the data was already built internally and was simply surfaced).
+- `so3_cyclic_of_poleData` — from `m = {n, n}` (`n = Nat.card G`) plus that pole-realization data,
+  reads off the `n`-member, obtains a full-stabilizer pole, concludes `IsCyclic G`.
+
+`#print axioms so3_cyclic_of_poleData` = `[propext, Classical.choice, Quot.sound]` (no `sorryAx`).
+`lake build EtingofRepresentationTheory.Chapter4.Problem4_12_8` succeeds (8580 jobs).
+
+Coordination (no code):
+- #6864 (polyhedral A₄/S₄/A₅ + assembly, oversized): added `depends-on: #6877` — its final
+  assembly needs the cyclic/dihedral generators, so it now drops out of the unclaimed queue until
+  those land, rather than luring the next worker into the same wall.
+- #6920 (Ch8 `extAbelianIsoExtₖ.map_smul'`): skipped → replan. Its target file
+  `Chapter8/ExtAbelianComparison.lean` is not on `main` yet (introduced by the still-in-CI shell
+  PR #6921), so the `sorry` is unreachable.
+- #6877 (dihedral+cyclic geometric extraction): decomposed into #6925 (cyclic, done here) and
+  #6924 (dihedral, hard geometry), each with a sharpened self-contained spec; skipped the parent
+  → replan with a `Decomposed into #6925, #6924` breadcrumb.
+
+## Current frontier
+
+`so3_classification_aux` still has its single pre-existing `sorry` (the full 5-way assembly).
+The cyclic disjunct's realization (`so3_cyclic_of_poleData`) is now available to plug in.
+
+## Overall project progress
+
+Stage 3, Chapter 4 Problem 4.12.8(a) (finite subgroups of SO(3)). Milestones (i)/(ii)/(iii),
+`pole_order_data` (now enriched), and the cyclic disjunct are complete and sorry-free. Remaining
+for `so3_classification_aux`: dihedral realization (#6924), the three polyhedral families +
+final assembly (#6864, blocked on #6877's — now #6924's — dihedral geometry).
+
+## Next step
+
+- Claim #6924 (dihedral `so3_dihedral_of_poleData`): the hard geometry — extract `ρ` (order-`k`
+  principal-stabilizer generator) and `s` (order-2 pole-swap), prove `s·ρ·s⁻¹ = ρ⁻¹` and
+  `s ∉ ⟨ρ⟩`, feed `mulEquiv_dihedralGroup_of_conj_inv`. Reuse the enriched `pole_order_data`
+  5th conjunct to get the principal pole.
+- Then #6864's per-family realizations (A₄/S₄/A₅) — still needs its own decomposition.
+
+## Blockers
+
+None for the delivered work. #6864 remains blocked on the dihedral geometry (#6924); #6920 remains
+blocked on PR #6921 landing `Chapter8/ExtAbelianComparison.lean` to `main`.


### PR DESCRIPTION
Closes #6925

Session: `04a54fd7-2f8c-47f3-9fed-e1368f3ef462`

1d9c6436 chore: progress handoff for #6925 cyclic disjunct
b8dde55b feat(Ch4 #Problem4.12.8-a-iv): so3_cyclic_of_poleData — cyclic disjunct sorry-free (#6925)
3a39fb09 feat(Ch4 #Problem4.12.8-a-iv): so3_cyclic_of_full_stabilizer_pole (#6925)
00d9a0f8 feat(Ch4 #Problem4.12.8-a-iv): so3_cyclic_of_globally_fixed_pole bridge lemma (#6925)

🤖 Prepared with Claude Code