### PR TITLE
feat(Ch8 #Problem8.2.8-Ext): HomComplex postcomposition endo + homologyAddEquiv naturality (N-side infra for crux #6951)

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -66,6 +66,20 @@ instead of `rw`. For subalgebra/subtype coercions specifically, the `Subalgebra.
 /`coe_zero` lemmas are `rfl`, so `rw` on them is brittle — prefer `Subtype.ext (R-level eq)` to
 prove a `↥S`-level equation and `congrArg S.val (↥S-level eq)` to prove an `R`-level one.
 
+**Same failure for `AddCommGrpCat`/`ModuleCat` homology goals in `ConcreteCategory.hom` form**
+(cost ~5 iterations in #6952, `Chapter8/HomComplexHomologyK.lean`). After
+`AddCommGrpCat.comp_apply`, terms read `ConcreteCategory.hom f (ConcreteCategory.hom g x)`; the
+element `x` often has type `CohomologyClass …` while a lemma expects `↑(AddCommGrpCat.of …)`. These
+are defeq but `AddCommGrpCat.of`/carrier is not reducible, so `rw [hcancel]` and even
+`simp only [Iso.inv_hom_id_apply]` **silently do not fire** (reported "unused"/"pattern not found").
+Fixes: (a) don't expand-and-cancel isos elementwise — prove the *forward* naturality square via
+`ShortComplex.LeftHomologyMapData.homologyMap_comm` + `ConcreteCategory.congr_hom … y` +
+`AddCommGrpCat.comp_apply`, then close with **`exact h`** (full-transparency defeq bridges the
+`homology n` vs `(sc n).homology` and carrier-coe gaps that `rw` cannot); (b) derive the `.symm`
+form from the forward square by pure `AddEquiv` algebra (`AddEquiv.symm_apply_eq`,
+`apply_symm_apply`) rather than unfolding `homologyAddEquiv` (which retypes to `(sc n).homology`
+and breaks surrounding applications).
+
 **Cast lifted out of a `Multiset`/`Finset` map inside a hypothesis.** A statement summand like
 `(m.map (fun x => 1 - (x : ℚ)⁻¹)).sum` (with `m : Multiset ℕ`) elaborates with the coercion
 lifted OFF the function and ONTO `m`: the hypothesis becomes

--- a/EtingofRepresentationTheory/Chapter8/HomComplexHomologyK.lean
+++ b/EtingofRepresentationTheory/Chapter8/HomComplexHomologyK.lean
@@ -305,4 +305,160 @@ noncomputable def homCochainComplexPostcomp (g : N ⟶ N') :
       z.comp (Cochain.ofHom ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).map g))
         (add_zero i) := rfl
 
+/-!
+## `homologyAddEquiv` naturality under postcomposition
+
+The middle step of the additive tower `e123` (crux of #6951) is
+`(homologyAddEquiv P.cochainComplex N[0] n).symm ∘ CohomologyClass.mk`. We record its naturality
+under the postcomposition chain map `homCochainComplexPostcomp N P g`: on a cocycle representative
+`c` it intertwines `Cocycle.postcomp` (on the class) with `HomologicalComplex.homologyMap` of the
+chain map. The proof builds the `ShortComplex.LeftHomologyMapData` for `homCochainComplexPostcomp`
+between the two `leftHomologyData` presentations of the cohomology (whose `π` is
+`CohomologyClass.mkAddMonoidHom`), with `φK = Cocycle.postcomp` and `φH = ` the descended
+postcomposition on cohomology classes, and applies `LeftHomologyMapData.homologyMap_eq`.
+-/
+
+variable (g : N ⟶ N')
+
+/-- Postcomposition of `n`-cocycles into `N[0]` with `(singleFunctor _ 0).map g`, as an additive
+hom; the cocycle-level restriction of `homCochainComplexPostcomp N P g` (its `φK`). -/
+noncomputable def cocyclePostcompHom (n : ℤ) :
+    Cocycle P.cochainComplex ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).obj N) n →+
+      Cocycle P.cochainComplex ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).obj N') n where
+  toFun z := z.postcomp ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).map g)
+  map_zero' := by
+    apply Cocycle.ext
+    simp only [Cocycle.postcomp, Cocycle.mk_coe, Cocycle.coe_zero, Cochain.zero_comp]
+  map_add' z z' := by
+    apply Cocycle.ext
+    simp only [Cocycle.postcomp, Cocycle.mk_coe, Cocycle.coe_add, Cochain.add_comp]
+
+@[simp] lemma cocyclePostcompHom_apply (n : ℤ)
+    (z : Cocycle P.cochainComplex ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).obj N) n) :
+    cocyclePostcompHom N P g n z =
+      z.postcomp ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).map g) := rfl
+
+/-- Coboundaries land in coboundaries under postcomposition: this is the kernel condition that
+descends `mk ∘ cocyclePostcompHom` to cohomology classes. Postcomposition commutes with `δ`
+(`δ_comp_ofHom`), so the image of a coboundary `δ β` is the coboundary `δ (β.postcomp)`. -/
+lemma coboundaries_le_ker_mk_cocyclePostcomp (n : ℤ) :
+    coboundaries P.cochainComplex ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).obj N) n ≤
+      ((CohomologyClass.mkAddMonoidHom P.cochainComplex
+          ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).obj N') n).comp
+        (cocyclePostcompHom N P g n)).ker := by
+  rintro α ⟨m, hm, β, hβ⟩
+  simp only [AddMonoidHom.mem_ker, AddMonoidHom.coe_comp, Function.comp_apply,
+    cocyclePostcompHom_apply, CohomologyClass.mkAddMonoidHom_apply, CohomologyClass.mk_eq_zero_iff,
+    mem_coboundaries_iff _ m hm]
+  refine ⟨β.comp (Cochain.ofHom ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).map g))
+    (add_zero m), ?_⟩
+  rw [δ_comp_ofHom, hβ]
+  rfl
+
+/-- Postcomposition on cohomology classes with `(singleFunctor _ 0).map g`, the descent of
+`mk ∘ cocyclePostcompHom` (its `φH`). -/
+noncomputable def cohomologyClassPostcompHom (n : ℤ) :
+    CohomologyClass P.cochainComplex ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).obj N) n →+
+      CohomologyClass P.cochainComplex
+        ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).obj N') n :=
+  CohomologyClass.descAddMonoidHom
+    ((CohomologyClass.mkAddMonoidHom P.cochainComplex
+        ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).obj N') n).comp
+      (cocyclePostcompHom N P g n))
+    (coboundaries_le_ker_mk_cocyclePostcomp N P g n)
+
+@[simp] lemma cohomologyClassPostcompHom_mk (n : ℤ)
+    (c : Cocycle P.cochainComplex ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).obj N) n) :
+    cohomologyClassPostcompHom N P g n (CohomologyClass.mk c) =
+      CohomologyClass.mk
+        (c.postcomp ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).map g)) := rfl
+
+/-- The `ShortComplex.LeftHomologyMapData` for the postcomposition chain map
+`homCochainComplexPostcomp N P g`, between the two `leftHomologyData` presentations of the
+degree-`n` cohomology. Its `φK` is `Cocycle.postcomp`; its `φH` is `cohomologyClassPostcompHom`. -/
+noncomputable def leftHomologyMapDataPostcomp (n : ℤ) :
+    ShortComplex.LeftHomologyMapData
+      ((HomologicalComplex.shortComplexFunctor AddCommGrpCat.{u} (ComplexShape.up ℤ) n).map
+        (homCochainComplexPostcomp N P g))
+      (CochainComplex.HomComplex.leftHomologyData P.cochainComplex
+        ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).obj N) n)
+      (CochainComplex.HomComplex.leftHomologyData P.cochainComplex
+        ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).obj N') n) := by
+  set h₂ := CochainComplex.HomComplex.leftHomologyData P.cochainComplex
+    ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).obj N') n with hh₂
+  have hcommi :
+      AddCommGrpCat.ofHom (cocyclePostcompHom N P g n) ≫ h₂.i
+        = (CochainComplex.HomComplex.leftHomologyData P.cochainComplex
+            ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).obj N) n).i
+          ≫ ((HomologicalComplex.shortComplexFunctor AddCommGrpCat.{u} (ComplexShape.up ℤ) n).map
+              (homCochainComplexPostcomp N P g)).τ₂ := by
+    ext c
+    rw [AddCommGrpCat.comp_apply, AddCommGrpCat.comp_apply]
+    rfl
+  haveI : Mono h₂.i := by
+    rw [AddCommGrpCat.mono_iff_injective]
+    exact fun a b hab => Subtype.ext hab
+  exact
+  { φK := AddCommGrpCat.ofHom (cocyclePostcompHom N P g n)
+    φH := AddCommGrpCat.ofHom (cohomologyClassPostcompHom N P g n)
+    commi := hcommi
+    commπ := by
+      ext c
+      rw [AddCommGrpCat.comp_apply, AddCommGrpCat.comp_apply]
+      rfl
+    commf' := by
+      rw [← cancel_mono h₂.i]
+      simp only [Category.assoc, hcommi]
+      rw [h₂.f'_i, ← Category.assoc,
+        (CochainComplex.HomComplex.leftHomologyData P.cochainComplex
+          ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).obj N) n).f'_i]
+      exact (((HomologicalComplex.shortComplexFunctor AddCommGrpCat.{u} (ComplexShape.up ℤ) n).map
+        (homCochainComplexPostcomp N P g)).comm₁₂).symm }
+
+@[simp] lemma leftHomologyMapDataPostcomp_φH (n : ℤ) :
+    (leftHomologyMapDataPostcomp N P g n).φH
+      = AddCommGrpCat.ofHom (cohomologyClassPostcompHom N P g n) := rfl
+
+/-- `homologyAddEquiv` is `homologyIso.hom`, with types stated so downstream rewrites keep the
+`HomologicalComplex.homology` presentation (avoids unfolding the `def` into `(sc n).homology`). -/
+lemma homologyAddEquiv_apply_hom (L : CochainComplex (ModuleCat.{u} A) ℤ) (n : ℤ)
+    (y : (P.cochainComplex.HomComplex L).homology n) :
+    CochainComplex.HomComplex.homologyAddEquiv P.cochainComplex L n y
+      = (CochainComplex.HomComplex.leftHomologyData P.cochainComplex L n).homologyIso.hom y := rfl
+
+/-- **Forward naturality square of `homologyAddEquiv` under postcomposition.** `homologyAddEquiv`
+intertwines `HomologicalComplex.homologyMap (homCochainComplexPostcomp N P g)` with
+`cohomologyClassPostcompHom` (postcomposition on cohomology classes). Proved from
+`LeftHomologyMapData.homologyMap_comm` transported through `homologyIso`. -/
+lemma homologyAddEquiv_homologyMap (n : ℤ)
+    (y : (homCochainComplex N P).homology n) :
+    CochainComplex.HomComplex.homologyAddEquiv P.cochainComplex
+        ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).obj N') n
+        ((HomologicalComplex.homologyMap (homCochainComplexPostcomp N P g) n) y)
+      = cohomologyClassPostcompHom N P g n
+          (CochainComplex.HomComplex.homologyAddEquiv P.cochainComplex
+            ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).obj N) n y) := by
+  have h := ConcreteCategory.congr_hom
+    (leftHomologyMapDataPostcomp N P g n).homologyMap_comm y
+  rw [AddCommGrpCat.comp_apply, AddCommGrpCat.comp_apply] at h
+  exact h
+
+/-- **Naturality of the middle step `homologyAddEquiv.symm ∘ mk` under postcomposition.** For a
+cocycle `c` and `g : N ⟶ N'`, applying `homCochainComplexPostcomp N P g` on homology after
+`homologyAddEquiv.symm (mk c)` equals `homologyAddEquiv.symm (mk (c.postcomp g))`. This is the
+`N`-side naturality feeding the `k`-homogeneity crux of #6951. -/
+lemma homologyAddEquiv_symm_mk_postcomp (n : ℤ)
+    (c : Cocycle P.cochainComplex
+      ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).obj N) n) :
+    (CochainComplex.HomComplex.homologyAddEquiv P.cochainComplex
+        ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).obj N') n).symm
+        (CohomologyClass.mk
+          (c.postcomp ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).map g)))
+      = (HomologicalComplex.homologyMap (homCochainComplexPostcomp N P g) n)
+          ((CochainComplex.HomComplex.homologyAddEquiv P.cochainComplex
+            ((CochainComplex.singleFunctor (ModuleCat.{u} A) 0).obj N) n).symm
+            (CohomologyClass.mk c)) := by
+  rw [AddEquiv.symm_apply_eq, homologyAddEquiv_homologyMap, AddEquiv.apply_symm_apply,
+    cohomologyClassPostcompHom_mk]
+
 end Etingof

--- a/progress/2026-07-18T08-06-54Z_aa7908f3.md
+++ b/progress/2026-07-18T08-06-54Z_aa7908f3.md
@@ -1,0 +1,52 @@
+## Accomplished
+
+Completed issue #6952 (feature) — the `N`-side (`HomComplex`) postcomposition
+naturality of `homologyAddEquiv`, deliverable 2 of the N-side infra for the
+crux of #6951. Deliverable 1 (`homCochainComplexPostcomp`) had already landed
+via #6954, so this turn covers the remaining piece. All additions in
+`Chapter8/HomComplexHomologyK.lean`, sorry-free:
+
+- `cocyclePostcompHom` — `Cocycle.postcomp` with `(singleFunctor _ 0).map g` as
+  an `AddMonoidHom` (the `φK`).
+- `coboundaries_le_ker_mk_cocyclePostcomp` — coboundaries land in coboundaries
+  under postcomposition (via `δ_comp_ofHom`); the descent condition.
+- `cohomologyClassPostcompHom` + `cohomologyClassPostcompHom_mk` — the descended
+  postcomposition on cohomology classes (the `φH`).
+- `leftHomologyMapDataPostcomp` (+ `_φH` simp) — the `ShortComplex.LeftHomologyMapData`
+  for `homCochainComplexPostcomp` between the two `leftHomologyData` presentations.
+- `homologyAddEquiv_apply_hom` / `homologyAddEquiv_homologyMap` — forward
+  naturality square (from `LeftHomologyMapData.homologyMap_comm`).
+- `homologyAddEquiv_symm_mk_postcomp` — the exact deliverable-2 statement, derived
+  from the forward square by `AddEquiv.symm_apply_eq` / `apply_symm_apply`.
+
+`lake build EtingofRepresentationTheory.Chapter8.HomComplexHomologyK` is
+sorry-free; the downstream `ExtAbelianComparison` still builds (its only `sorry`
+is the pre-existing `crux` of #6951, untouched).
+
+## Current frontier
+
+#6952 is fully done. The next N-side consumer is #6951's residual assembly
+(sub-issue #B), which transports `homologyAddEquiv_symm_mk_postcomp` across
+`homComplexHomologyAddEquivₖ` to discharge the `crux` in `extAbelianIsoExtₖ`.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. Ch8 Problem 8.2.8 (Ext half) chain: the
+`Ext ≃ₗ[k] Extₖ` bridge shell landed; `crux`/`hnat` for its `k`-linearity is
+being built from N-side naturality (this issue) plus the middle/top-step
+transport. Two other feature issues remain unclaimed: #6864 (Ch4 polyhedral
+realizations, large) and #6898 (Ch8 final assembly of `Problem_8_2_8_ext`).
+
+## Next step
+
+Plan/claim #6951's residual sub-issue #B: use `homologyAddEquiv_symm_mk_postcomp`
+plus `extMk`-generator surjectivity to show `e123 ∘ extMk` is `k`-homogeneous,
+closing the `crux` sorry at `ExtAbelianComparison.lean:111`.
+
+## Blockers
+
+None. Key Lean lesson recorded: for `ConcreteCategory.hom`-heavy AddCommGrpCat
+goals, `rw`/`simp only` frequently fail to match on the `↑(AddCommGrpCat.of X)`
+vs `X` carrier defeq; `exact` (full-transparency defeq) closes them where `rw`
+cannot. Iso cancellation was best avoided by proving the forward square via
+`LeftHomologyMapData.homologyMap_comm` rather than expanding + cancelling.


### PR DESCRIPTION
Closes #6952

Session: `aa7908f3-6b61-46e9-88d7-0b53fde0d1ac`

5d556887 docs(lean-formalization): capture ConcreteCategory.hom carrier-coe rw-vs-exact lesson from #6952
3eb766e9 feat(Ch8 #6952): homologyAddEquiv naturality under postcomposition (N-side infra for crux #6951)

🤖 Prepared with Claude Code