### PR TITLE
docs(review): close-out steps for report-only review issues + #6966 audit log

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -39,6 +39,20 @@ Rotate through these areas across sessions:
 **Security**:
 - Check for new issues in recent code, verify past fixes
 
+## Completing the Review
+
+Post your report as a comment on the review issue. Then close the issue yourself —
+a review's deliverable is the report, not a code change, so there is usually **no PR**
+to swap `claimed` → `has-pr`, and an unclosed issue would stay stuck in `claimed`:
+
+- **No defect found:** `gh issue close <N> --comment "Review complete — PASS. See report above."`
+- **Defect found:** open a fix PR (`coordination create-pr <N>` — this closes the issue on
+  merge) **or** a follow-up `feature` issue for the fix, then close the review issue with a
+  link to it. Do not leave the review issue open waiting on a human.
+
+Any progress-file commit lives on your branch; there is no need to push or PR it for a
+report-only review.
+
 ## Updating Skills
 
 When you discover a recurring pattern or encounter a situation not covered by

--- a/progress/2026-07-18T14-40-21Z_a59f93aa.md
+++ b/progress/2026-07-18T14-40-21Z_a59f93aa.md
@@ -1,0 +1,32 @@
+## Accomplished
+Review session for issue #6966: audited `so3_tetrahedral_of_poleData`
+(`Chapter4/Problem4_12_8.lean:1622–1720`, the `{2,3,3} → A₄` disjunct) and its
+consumption by `so3_classification_aux`. Verdict: **PASS, no defects**.
+- Soundness: confirmed sorry-free (build emits sorry only for octahedral/icosahedral
+  siblings at 1730/1747, not tetrahedral); `#print axioms` reports only
+  `[propext, Classical.choice, Quot.sound]` — no `sorryAx` leak. `decide` uses are on
+  concrete decidable facts, not `native_decide`. All hypotheses (`hclass`/`heq`/`hpole`)
+  used.
+- Statement fidelity: conclusion matches book (A₄, order 12); hypotheses identical to
+  `pole_order_data`'s output; verified non-vacuous (`{2,3,3}` sum `11/6` consistent with
+  `2(1-1/12)`, forcing `|G|=12`).
+- Dispatch wiring: correct `rcases` branch, correct args, correct `Or` position (3rd
+  disjunct = A₄) matching the public statement.
+Posted full report as a comment on #6966.
+
+## Current frontier
+Tetrahedral realization reviewed and cleared. Octahedral (#6961) and icosahedral (#6962)
+remain as `sorry` and are unclaimed feature work.
+
+## Overall project progress
+Stage 3 (formalization) ongoing. Ch4 Problem 4.12.8(a): cyclic + dihedral + tetrahedral
+disjuncts of `so3_classification_aux` are proved and (now) reviewed; octahedral and
+icosahedral disjuncts still `sorry`.
+
+## Next step
+Pick up #6961 (octahedral `{2,3,4} → S₄`) or #6962 (icosahedral `{2,3,5} → A₅`). The
+tetrahedral proof is a clean template (count → orbit-stabilizer → faithful action via
+`nontrivial_fixed_unit_vectors` → transport to `Fin k` → index/order argument).
+
+## Blockers
+None.


### PR DESCRIPTION
This PR records the review-session output for issue #6966 (audit of \`so3_tetrahedral_of_poleData\`, verdict PASS — no defects; full report posted on the issue) and documents in the \`/review\` command how to close report-only review issues so they don't get stuck in \`claimed\` (a review's deliverable is a report comment, not a code change, so there is usually no PR to swap the label).

No Lean source changes; \`Chapter4/Problem4_12_8.lean\` builds unchanged.

🤖 Prepared with Claude Code