### PR TITLE
feat(Ch4 #6971): reframe icosahedral crux as group theory — prove faithful_perm5_of_simple_index_five

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -4758,6 +4758,29 @@ theorem hard_theorem : conclusion := by
 
 **Evidence:** Problem6_9_1 was decomposed from 1 sorry into 8 sub-goals, 6 proved (#1807). Theorem5_22_1 was decomposed into coefficient extraction + core identity (#1806). BasicAlgebraExistence was split into 2 targeted helpers (#1803). All three patterns created visible, committable progress.
 
+### Reframe a geometric crux algebraically when the deliverable is abstract (SO(3) icosahedral, #6971)
+
+When an issue *describes* a hard geometric construction ("the five inscribed tetrahedra / Kepler
+cubes of the dodecahedron", "the four body diagonals of the cube") but the actual **deliverable
+is an abstract existence statement** (`∃ φ : G →* Equiv.Perm (Fin 5), Function.Injective φ`, or
+`Nonempty (G ≃* …)`), do NOT reach for a coordinate model (golden-ratio matrices, explicit vertex
+sets) first — that path is thousands of lines. Look for a purely group-theoretic reduction that
+delivers the *same abstract object* without the geometry.
+
+Concretely for #6971 (icosahedral, `|G| = 60`): "faithful action on the 5 tetrahedra" reduces to
+**"`G` is simple + has an index-5 subgroup"**, because a finite simple group with an index-5
+subgroup embeds faithfully into `Equiv.Perm (Fin 5)` via the **core-free coset action** —
+`Subgroup.normalCore_eq_ker H` says the kernel of `MulAction.toPermHom G (G ⧸ H)` is
+`H.normalCore`, which simplicity forces to `⊥` (`Subgroup.Normal.eq_bot_or_eq_top`); transport
+`G ⧸ H ≃ Fin 5` (from `H.index = 5`) with `Equiv.permCongrHom`. This dissolves the entire
+"construct the 5-element G-set" difficulty (no icosahedron coordinates), leaving two standard
+group-theory sorries (`G` simple; index-5 subgroup) — see #6982/#6983. Before checking Mathlib for
+"heavy" infrastructure, note Mathlib has NO order-60→A₅ classification and NO Sylow⟶simple lemma,
+but DOES have every Sylow-counting primitive plus `normalCore_eq_ker`, `MonoidHom.ker_eq_bot_iff`,
+`Equiv.Perm.eq_alternatingGroup_of_index_eq_two`. Rule of thumb: **the coset/normalCore embedding
+is the standard way to realize an abstract finite group as a concrete permutation group of a given
+degree** — prefer it over any explicit configuration whenever the target is `Equiv.Perm (Fin n)`.
+
 ## Rewriting Inside Coercion Wrappers (`.ker`, `↥`, `Module.finrank`)
 
 When `rw [h]` fails to find a pattern that is visibly present in the goal — especially inside

--- a/EtingofRepresentationTheory/Chapter4/Problem4_12_8.lean
+++ b/EtingofRepresentationTheory/Chapter4/Problem4_12_8.lean
@@ -1813,6 +1813,78 @@ theorem so3_icosahedral_card
     linarith
   exact_mod_cast hq
 
+/-- **Coset-action embedding.** A finite simple group with a subgroup `H` of index `5` embeds
+faithfully into `Equiv.Perm (Fin 5)`. The permutation action on the `5` cosets `Grp ⧸ H` is a
+homomorphism `ψ : Grp →* Equiv.Perm (Grp ⧸ H)` whose kernel is `H.normalCore`
+(`Subgroup.normalCore_eq_ker`). Being normal, `H.normalCore` is `⊥` or `⊤` by simplicity; it is
+not `⊤` (else `H = ⊤`, of index `1 ≠ 5`), hence `⊥`, so `ψ` is injective. Transporting along an
+equivalence `Grp ⧸ H ≃ Fin 5` (the index is `5`) yields the desired `φ : Grp →* Equiv.Perm (Fin
+5)`. This is the group-theoretic assembly that turns "`G` simple with an index-`5` subgroup" into
+the faithful degree-`5` permutation representation used by the icosahedral disjunct. -/
+theorem faithful_perm5_of_simple_index_five
+    {Grp : Type*} [Group Grp] [Finite Grp] (hsimple : IsSimpleGroup Grp)
+    (H : Subgroup Grp) (hindex : H.index = 5) :
+    ∃ φ : Grp →* Equiv.Perm (Fin 5), Function.Injective φ := by
+  classical
+  haveI := hsimple
+  -- The `5` cosets `Grp ⧸ H` form a type of cardinality `5`.
+  have hcard5 : Nat.card (Grp ⧸ H) = 5 := by rw [← Subgroup.index_eq_card]; exact hindex
+  -- The coset action `ψ : Grp →* Perm (Grp ⧸ H)` has kernel `H.normalCore`.
+  set ψ : Grp →* Equiv.Perm (Grp ⧸ H) := MulAction.toPermHom Grp (Grp ⧸ H) with hψ
+  have hker : ψ.ker = H.normalCore := (Subgroup.normalCore_eq_ker H).symm
+  -- `H.normalCore` is normal, hence `⊥` or `⊤`; it is not `⊤`, else `H = ⊤` has index `1`.
+  have hnc : H.normalCore = ⊥ := by
+    rcases (Subgroup.normalCore_normal H).eq_bot_or_eq_top with h | h
+    · exact h
+    · exact absurd (Subgroup.index_eq_one.mpr (top_le_iff.mp (h ▸ H.normalCore_le)) ▸ hindex)
+        (by norm_num)
+  have hψinj : Function.Injective ψ := by
+    rw [← MonoidHom.ker_eq_bot_iff, hker, hnc]
+  -- Transport along an equivalence `Grp ⧸ H ≃ Fin 5`.
+  haveI : Fintype (Grp ⧸ H) := Fintype.ofFinite _
+  have hfin5 : Fintype.card (Grp ⧸ H) = 5 := by rw [← Nat.card_eq_fintype_card]; exact hcard5
+  let e := Fintype.equivFinOfCardEq hfin5
+  refine ⟨e.permCongrHom.toMonoidHom.comp ψ, fun p q hpq => ?_⟩
+  exact hψinj (e.permCongrHom.injective hpq)
+
+/-- **Index-`5` subgroup of a simple group of order `60`.** Every finite simple group of order
+`60` has a subgroup of index `5` — geometrically the point-stabilizer of the degree-`5` action,
+group-theoretically the normalizer of a Sylow `2`-subgroup (there are exactly `n₂ = 5` of them).
+
+This is pure finite group theory, independent of the `SO(3)` geometry, and is the standard first
+half of "a simple group of order `60` is `A₅`". Route (Sylow counting): `n₅ = 6` (`≡ 1 mod 5`,
+`∣ 12`, `≠ 1` by simplicity) gives `24` elements of order `5`; `n₃ = 10` (`≠ 4`, else a core-free
+action on `4` cosets embeds `G ↪ S₄`, impossible for `|G| = 60`) gives `20` elements of order
+`3`; the remaining `15` non-identity elements are `2`-elements, forcing `n₂ = 5` (`n₂ = 15` would
+need `45` distinct `2`-elements). Then `|normalizer (Sylow 2)| = 60 / 5 = 12`, index `5`. -/
+theorem simpleGroup_card60_exists_index_five
+    {Grp : Type*} [Group Grp] [Finite Grp] (hsimple : IsSimpleGroup Grp)
+    (hcard : Nat.card Grp = 60) :
+    ∃ H : Subgroup Grp, H.index = 5 := by
+  sorry
+
+/-- **Simplicity of the icosahedral group (geometric input).** An order-`60` finite subgroup
+`G ≤ SO(3)` with the icosahedral pole data `{2, 3, 5}` is simple.
+
+The only geometry needed is that `G` has *more than one* Sylow `5`-subgroup: the order-`5` poles
+form a single `G`-orbit of size `12` (`= 60/5` by orbit-stabilizer), i.e. `6` distinct axes; the
+stabilizer of an order-`5` pole is its (cyclic, order-`5`) Sylow `5`-subgroup, and poles on
+distinct axes have distinct stabilizers (a nontrivial rotation fixes only its own axis), so
+`n₅ ≥ 6 > 1`. The rest is the standard finite-group fact that a group of order `60` with more
+than one Sylow `5`-subgroup is simple: any nontrivial proper normal subgroup `N` would have order
+in `{2, 3, 4, 5, 6, 10, 12, 15, 20, 30}`; each case either forces a normal (hence unique) Sylow
+`5`-subgroup or embeds `G` into too small a symmetric group via the core-free action on `G ⧸ N`,
+contradiction. This isolates the *only* place the icosahedral case needs `SO(3)` geometry;
+everything downstream is pure group theory (`simpleGroup_card60_exists_index_five`,
+`faithful_perm5_of_simple_index_five`). -/
+theorem so3_icosahedral_G_simple
+    (G : Subgroup (specialOrthogonalGroup (Fin 3) ℝ)) [Finite G] (m : Multiset ℕ)
+    (hclass : m = {2, 3, 5})
+    (hcard : Nat.card (↥G) = 60)
+    (hpole : ∀ x ∈ m, ∃ b : ↥(poleSet G), Nat.card (MulAction.stabilizer (↥G) b) = x) :
+    IsSimpleGroup (↥G) := by
+  sorry
+
 /-- **Realization crux of the icosahedral disjunct.** An order-`60` finite subgroup `G ≤ SO(3)`
 with the icosahedral pole data acts faithfully on a `5`-element set — geometrically, the five
 inscribed tetrahedra (equivalently the five "Kepler cubes") of the dodecahedron/icosahedron —
@@ -1832,7 +1904,11 @@ theorem so3_icosahedral_exists_faithful_perm5
     (hcard : Nat.card (↥G) = 60)
     (hpole : ∀ x ∈ m, ∃ b : ↥(poleSet G), Nat.card (MulAction.stabilizer (↥G) b) = x) :
     ∃ φ : ↥G →* Equiv.Perm (Fin 5), Function.Injective φ := by
-  sorry
+  -- `G` is simple (the geometric input); a simple group of order `60` has an index-`5`
+  -- subgroup, and the coset action embeds it faithfully into `Equiv.Perm (Fin 5)`.
+  have hsimple : IsSimpleGroup (↥G) := so3_icosahedral_G_simple G m hclass hcard hpole
+  obtain ⟨H, hindex⟩ := simpleGroup_card60_exists_index_five hsimple hcard
+  exact faithful_perm5_of_simple_index_five hsimple H hindex
 
 /-- **Icosahedral disjunct of `so3_classification_aux`.** From the icosahedral pole family
 `m = {2, 3, 5}` (which forces `Nat.card G = 60`) together with the pole-realization data of

--- a/progress/2026-07-18T19-28-51Z_0579744d.md
+++ b/progress/2026-07-18T19-28-51Z_0579744d.md
@@ -1,0 +1,46 @@
+## Accomplished
+
+Reframed the icosahedral realization crux `so3_icosahedral_exists_faithful_perm5`
+(`EtingofRepresentationTheory/Chapter4/Problem4_12_8.lean`, issue #6971) away from the opaque
+geometric "5 inscribed tetrahedra / Kepler cubes" construction — which would require either an
+explicit golden-ratio coordinate model of the icosahedron or the order-60 simple-group
+classification (neither in Mathlib, both large multi-session efforts) — into a clean
+group-theoretic route:
+
+- **`faithful_perm5_of_simple_index_five` (PROVEN, sorry-free):** a finite simple group with an
+  index-5 subgroup embeds faithfully into `Equiv.Perm (Fin 5)` via the core-free coset action
+  (`Subgroup.normalCore_eq_ker` + `IsSimpleGroup` ⟹ `normalCore = ⊥`, then transport
+  `Grp ⧸ H ≃ Fin 5`).
+- **`simpleGroup_card60_exists_index_five` (sorry → #6982):** pure, portable finite group theory —
+  a simple group of order 60 has an index-5 subgroup (Sylow `n₂ = 5` counting).
+- **`so3_icosahedral_G_simple` (sorry → #6983):** the ONLY remaining geometric input — the
+  order-5 poles give `n₅ > 1`, and an order-60 group with `n₅ > 1` is simple.
+
+`so3_icosahedral_exists_faithful_perm5` is now a sorry-free composition of the three. The whole
+"construct the 5-element G-set geometrically" difficulty is dissolved: no coordinate model needed.
+
+Research (via subagent) confirmed Mathlib has NO order-60/A₅ classification and NO Sylow⟶simple
+lemma, but DOES have every Sylow-counting primitive plus `normalCore_eq_ker`, so both remaining
+sorries are standard.
+
+## Current frontier
+
+Two sorried helpers in `Problem4_12_8.lean` (lines ~1860, ~1880): the group-theory index-5 lemma
+(#6982) and the geometric simplicity lemma (#6983). Build is green.
+
+## Overall project progress
+
+Stage 3 formalization, tail. `lake build EtingofRepresentationTheory.Chapter4.Problem4_12_8`
+succeeds. File sorry count went 9 → 10 (the single icosahedral sorry became two better-scoped
+group-theory sorries, plus one new proven lemma). Sibling octahedral crux
+`exists_octahedral_faithful_hom` (#6972) still open.
+
+## Next step
+
+Claim #6982 (pure group theory, no geometry — most self-contained) or #6983. Both feed the proven
+assembly; once both land, `so3_icosahedral_exists_faithful_perm5` and `so3_icosahedral_of_poleData`
+are fully sorry-free.
+
+## Blockers
+
+None. Both remaining pieces are standard finite group theory with full Mathlib API available.


### PR DESCRIPTION
Partial progress on #6971

Session: `0579744d-fd3b-4ccf-af98-557a6b9bed9c`

d3351e0b docs(progress): icosahedral crux reframed to group theory (#6971 → #6982, #6983)
b507ce85 feat(Ch4 #6971): reframe icosahedral crux as group theory — prove faithful_perm5_of_simple_index_five, reduce to G simple + index-5 subgroup

🤖 Prepared with Claude Code