### PR TITLE
feat(Ch4 #6972): prove octahedral_kernel_negates_or_fixes_trivial — faithfulness of the 4-diagonal action (orthogonality argument)

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -24,6 +24,15 @@ vanishes). Re-resolve each time with
 verify signatures against the compiler (`example : <sig> := by exact?` / a scratch `#check`)
 rather than trusting a cached source path.
 
+**Scope that `find` to `<project-root>`, never to `/`.** An unrelated project's checkout on the
+same machine pins a *different* Mathlib revision, so a name-not-found there means nothing and a
+signature found there may be stale. If you do fall back to a foreign checkout, first compare
+`git -C <that>/.lake/packages/mathlib rev-parse HEAD` against this project's; when they differ,
+treat every hit as a hypothesis and let the build adjudicate. Symptom that you are in the wrong
+tree: greps for plausible Mathlib names (`exists_prime_orderOf_dvd_card`,
+`Nat.one_lt_card_iff_nontrivial`) come back empty and you start inventing workarounds for
+lemmas that do exist in your version.
+
 **In this Mathlib version `Basis` lives in the `Module` namespace.** The type is
 `Module.Basis ι R M` and explicit lemma references need the prefix: `Module.Basis.ext`,
 `Module.Basis.constr_basis`, `Module.finBasis` (returns a `Module.Basis`). A bare identifier

--- a/EtingofRepresentationTheory/Chapter4/Problem4_12_8.lean
+++ b/EtingofRepresentationTheory/Chapter4/Problem4_12_8.lean
@@ -1783,6 +1783,76 @@ theorem octahedral_kernel_negates_or_fixes_trivial
   have hg0 : (g : specialOrthogonalGroup (Fin 3) ℝ) ≠ 1 := by
     intro h
     exact hgne (Subtype.ext (h.trans (OneMemClass.coe_one G).symm))
+  -- **Injection key.** No nontrivial `h ∈ SO(3)` can fix all `8` orbit vectors (it fixes only an
+  -- antipodal pair, of size `≤ 2`).
+  have key : ∀ h : specialOrthogonalGroup (Fin 3) ℝ, h ≠ 1 →
+      (∀ w : ↥(MulAction.orbit ↥G b),
+        (h : Matrix (Fin 3) (Fin 3) ℝ) *ᵥ w.1.1 = w.1.1) → False := by
+    intro h hne hfix
+    obtain ⟨v₀, _hv₀, hset⟩ := nontrivial_fixed_unit_vectors h hne
+    have hmem : ∀ w : ↥(MulAction.orbit ↥G b), w.1.1 ∈ fixedUnitVectors h :=
+      fun w => ⟨hunit w, hfix w⟩
+    haveI : Finite ↥(fixedUnitVectors h) := (finite_fixedUnitVectors h hne).to_subtype
+    have hFinj : Function.Injective
+        (fun w : ↥(MulAction.orbit ↥G b) => (⟨w.1.1, hmem w⟩ : ↥(fixedUnitVectors h))) := by
+      intro x y hxy
+      apply Subtype.ext; apply Subtype.ext
+      simpa using hxy
+    have hle : Nat.card (↥(MulAction.orbit ↥G b)) ≤ Nat.card (↥(fixedUnitVectors h)) :=
+      Nat.card_le_card_of_injective _ hFinj
+    have hle2 : Nat.card (↥(fixedUnitVectors h)) ≤ 2 := by
+      rw [hset, Nat.card_coe_set_eq]
+      calc ({v₀, -v₀} : Set (Fin 3 → ℝ)).ncard
+            ≤ ({-v₀} : Set (Fin 3 → ℝ)).ncard + 1 := Set.ncard_insert_le _ _
+        _ = 2 := by rw [Set.ncard_singleton]
+    rw [horbit_card] at hle; omega
+  -- **Step 1.** `g² = 1`: applying `g` twice sends each orbit vector to itself (the `±` cancel).
+  have hsqfix : ∀ w : ↥(MulAction.orbit ↥G b),
+      ((g : specialOrthogonalGroup (Fin 3) ℝ) : Matrix (Fin 3) (Fin 3) ℝ) *ᵥ
+        (((g : specialOrthogonalGroup (Fin 3) ℝ) : Matrix (Fin 3) (Fin 3) ℝ) *ᵥ w.1.1) = w.1.1 := by
+    intro w
+    rcases hpm w with h | h
+    · rw [h, h]
+    · rw [h, mulVec_neg, h, neg_neg]
+  have hg0sq : (g : specialOrthogonalGroup (Fin 3) ℝ) * (g : specialOrthogonalGroup (Fin 3) ℝ)
+      = 1 := by
+    by_contra hne
+    refine key _ hne (fun w => ?_)
+    rw [Submonoid.coe_mul, ← mulVec_mulVec]
+    exact hsqfix w
+  -- Transport to `↥G` and read off `orderOf g = 2`.
+  have hgg : g * g = 1 := by
+    apply Subtype.ext
+    rw [Subgroup.coe_mul, Subgroup.coe_one]
+    exact hg0sq
+  have hord : orderOf g = 2 := by
+    have hdvd : orderOf g ∣ 2 := orderOf_dvd_of_pow_eq_one (by rw [pow_two]; exact hgg)
+    rcases (Nat.dvd_prime Nat.prime_two).mp hdvd with h | h
+    · rw [orderOf_eq_one_iff] at h; exact absurd h hgne
+    · exact h
+  -- **Step 2-3.** `g` negates *every* orbit vector: it cannot fix one (its stabilizer is cyclic of
+  -- order `3`, with no order-`2` element).
+  have hneg : ∀ w : ↥(MulAction.orbit ↥G b),
+      ((g : specialOrthogonalGroup (Fin 3) ℝ) : Matrix (Fin 3) (Fin 3) ℝ) *ᵥ w.1.1 = -(w.1.1) := by
+    intro w
+    rcases hpm w with hfix | hneg
+    · exfalso
+      -- `g` fixes `w.1`, so `g ∈ stabilizer w.1`, whose card is `3` (conjugate to `stabilizer b`).
+      have hgstab : g ∈ MulAction.stabilizer ↥G w.1 := by
+        rw [MulAction.mem_stabilizer_iff]
+        apply Subtype.ext
+        rw [poleSet_coe_smul]; exact hfix
+      -- `stabilizer w.1` is conjugate to `stabilizer b`, hence has card `3`.
+      have hwmem : w.1 ∈ MulAction.orbit ↥G b := w.2
+      obtain ⟨c, hc⟩ := MulAction.mem_orbit_iff.mp hwmem
+      have hcard3 : Nat.card (MulAction.stabilizer ↥G w.1) = 3 := by
+        rw [← Nat.card_congr (MulAction.stabilizerEquivStabilizer (g := c) (a := b)
+          (b := w.1) hc.symm).toEquiv, hb]
+      -- `orderOf g = 2` divides `|stabilizer w.1| = 3`, impossible.
+      have hdvd : orderOf g ∣ Nat.card (MulAction.stabilizer ↥G w.1) :=
+        Subgroup.orderOf_dvd_natCard _ hgstab
+      rw [hord, hcard3] at hdvd; omega
+    · exact hneg
   sorry
 
 end OctahedralFaithful

--- a/EtingofRepresentationTheory/Chapter4/Problem4_12_8.lean
+++ b/EtingofRepresentationTheory/Chapter4/Problem4_12_8.lean
@@ -1723,6 +1723,7 @@ section OctahedralFaithful
 open scoped RealInnerProductSpace
 open Matrix EuclideanSpace Submodule WithLp Module MulAction
 
+set_option maxHeartbeats 400000 in
 /-- **Kernel triviality for the four-diagonal action (octahedral crux, geometric core).**
 Any `g ∈ G` (with `|G| = 24`, `b` an order-`3` pole) that sends every pole `w` in the orbit
 `O = orbit b` to `±w` — i.e. fixes every body diagonal setwise — is the identity. This is the
@@ -1853,7 +1854,205 @@ theorem octahedral_kernel_negates_or_fixes_trivial
         Subgroup.orderOf_dvd_natCard _ hgstab
       rw [hord, hcard3] at hdvd; omega
     · exact hneg
-  sorry
+  -- **Step 4.** The axis `n` of `g` is orthogonal to every orbit vector.
+  obtain ⟨n, hnunit, hnset⟩ :=
+    nontrivial_fixed_unit_vectors (g : specialOrthogonalGroup (Fin 3) ℝ) hg0
+  have hnfix : ((g : specialOrthogonalGroup (Fin 3) ℝ) : Matrix (Fin 3) (Fin 3) ℝ) *ᵥ n = n :=
+    (show n ∈ fixedUnitVectors (g : specialOrthogonalGroup (Fin 3) ℝ) by
+      rw [hnset]; exact Set.mem_insert _ _).2
+  have hperp : ∀ w : ↥(MulAction.orbit ↥G b), w.1.1 ⬝ᵥ n = 0 := by
+    intro w
+    have h := so3_mulVec_dotProduct (g : specialOrthogonalGroup (Fin 3) ℝ) w.1.1 n
+    rw [hneg w, hnfix, neg_dotProduct] at h
+    linarith
+  -- **Step 5.** A nontrivial element `r` of `stabilizer b`: it has order `3` and fixes `b.1`.
+  haveI : Fintype ↥(MulAction.stabilizer ↥G b) := Fintype.ofFinite _
+  haveI : Nontrivial ↥(MulAction.stabilizer ↥G b) := by
+    rw [← Fintype.one_lt_card_iff_nontrivial, ← Nat.card_eq_fintype_card, hb]
+    norm_num
+  obtain ⟨r0, hr0⟩ := exists_ne (1 : ↥(MulAction.stabilizer ↥G b))
+  have hrne : (r0 : ↥G) ≠ 1 := fun h => hr0 (Subtype.ext h)
+  have hrcube : (r0 : ↥G) ^ 3 = 1 := by
+    have hdvd : orderOf (r0 : ↥G) ∣ 3 := by
+      have h := Subgroup.orderOf_dvd_natCard (MulAction.stabilizer ↥G b) r0.2
+      rwa [hb] at h
+    exact orderOf_dvd_iff_pow_eq_one.mp hdvd
+  have hrfixb : (((r0 : ↥G) : specialOrthogonalGroup (Fin 3) ℝ) : Matrix (Fin 3) (Fin 3) ℝ) *ᵥ
+      (b : ↥(poleSet G)).1 = (b : ↥(poleSet G)).1 := by
+    have h := congrArg (fun P : ↥(poleSet G) => P.1) (MulAction.mem_stabilizer_iff.mp r0.2)
+    rwa [poleSet_coe_smul] at h
+  -- The orbit action in vector form, for an arbitrary group element.
+  have haction' : ∀ (c : ↥G) (x : ↥(MulAction.orbit ↥G b)),
+      ((c • x : ↥(MulAction.orbit ↥G b)) : ↥(poleSet G)).1
+        = ((c : specialOrthogonalGroup (Fin 3) ℝ) : Matrix (Fin 3) (Fin 3) ℝ) *ᵥ x.1.1 := by
+    intro c x
+    rw [MulAction.orbit.coe_smul, poleSet_coe_smul]
+  -- `r • n` is orthogonal to every orbit vector too (`r` permutes the orbit).
+  have hperpR : ∀ w : ↥(MulAction.orbit ↥G b),
+      ((((r0 : ↥G) : specialOrthogonalGroup (Fin 3) ℝ) : Matrix (Fin 3) (Fin 3) ℝ) *ᵥ n)
+        ⬝ᵥ w.1.1 = 0 := by
+    intro w
+    have hvec : (((r0 : ↥G) : specialOrthogonalGroup (Fin 3) ℝ) : Matrix (Fin 3) (Fin 3) ℝ) *ᵥ
+        (((r0 : ↥G)⁻¹ • w : ↥(MulAction.orbit ↥G b)) : ↥(poleSet G)).1 = w.1.1 := by
+      rw [← haction' (r0 : ↥G) ((r0 : ↥G)⁻¹ • w), smul_inv_smul]
+    have h := so3_mulVec_dotProduct ((r0 : ↥G) : specialOrthogonalGroup (Fin 3) ℝ) n
+      (((r0 : ↥G)⁻¹ • w : ↥(MulAction.orbit ↥G b)) : ↥(poleSet G)).1
+    rw [hvec] at h
+    rw [h, dotProduct_comm]
+    exact hperp _
+  -- **Step 6.** Pass to Euclidean space: the orbit spans the plane `nᗮ`, forcing `r • n = ±n`.
+  have hNne : (toLp 2 n : EuclideanSpace ℝ (Fin 3)) ≠ 0 := by
+    intro h
+    have h0 : n ⬝ᵥ n = 0 := by rw [← inner_toLp, h, inner_zero_left]
+    rw [hnunit] at h0; norm_num at h0
+  have hBne : (toLp 2 (b : ↥(poleSet G)).1 : EuclideanSpace ℝ (Fin 3)) ≠ 0 := by
+    intro h
+    have h0 : (b : ↥(poleSet G)).1 ⬝ᵥ (b : ↥(poleSet G)).1 = 0 := by
+      rw [← inner_toLp, h, inner_zero_left]
+    rw [b.2.1] at h0; norm_num at h0
+  haveI : Fact (finrank ℝ (EuclideanSpace ℝ (Fin 3)) = 2 + 1) :=
+    ⟨by norm_num [finrank_euclideanSpace_fin]⟩
+  have hTle : Submodule.span ℝ (Set.range (fun w : ↥(MulAction.orbit ↥G b) =>
+      (toLp 2 w.1.1 : EuclideanSpace ℝ (Fin 3)))) ≤ (ℝ ∙ (toLp 2 n : EuclideanSpace ℝ (Fin 3)))ᗮ := by
+    rw [Submodule.span_le]
+    rintro x ⟨w, rfl⟩
+    rw [SetLike.mem_coe, Submodule.mem_orthogonal_singleton_iff_inner_left, inner_toLp]
+    exact hperp w
+  have hPfr : finrank ℝ ((ℝ ∙ (toLp 2 n : EuclideanSpace ℝ (Fin 3)))ᗮ) = 2 :=
+    Submodule.finrank_orthogonal_span_singleton (n := 2) hNne
+  -- The orbit is not contained in a line: otherwise all `8` orbit vectors would be `±b.1`.
+  have hTfr : 2 ≤ finrank ℝ (Submodule.span ℝ (Set.range (fun w : ↥(MulAction.orbit ↥G b) =>
+      (toLp 2 w.1.1 : EuclideanSpace ℝ (Fin 3))))) := by
+    by_contra hlt
+    push_neg at hlt
+    have hspanle : (ℝ ∙ (toLp 2 (b : ↥(poleSet G)).1 : EuclideanSpace ℝ (Fin 3)))
+        ≤ Submodule.span ℝ (Set.range (fun w : ↥(MulAction.orbit ↥G b) =>
+          (toLp 2 w.1.1 : EuclideanSpace ℝ (Fin 3)))) := by
+      rw [Submodule.span_singleton_le_iff_mem]
+      exact Submodule.subset_span ⟨⟨b, MulAction.mem_orbit_self b⟩, rfl⟩
+    have hfr1 : finrank ℝ (ℝ ∙ (toLp 2 (b : ↥(poleSet G)).1 : EuclideanSpace ℝ (Fin 3))) = 1 :=
+      finrank_span_singleton hBne
+    have heq : (ℝ ∙ (toLp 2 (b : ↥(poleSet G)).1 : EuclideanSpace ℝ (Fin 3)))
+        = Submodule.span ℝ (Set.range (fun w : ↥(MulAction.orbit ↥G b) =>
+          (toLp 2 w.1.1 : EuclideanSpace ℝ (Fin 3)))) :=
+      Submodule.eq_of_le_of_finrank_le hspanle (by rw [hfr1]; omega)
+    have hpar : ∀ w : ↥(MulAction.orbit ↥G b),
+        w.1.1 ∈ ({(b : ↥(poleSet G)).1, -(b : ↥(poleSet G)).1} : Set (Fin 3 → ℝ)) := by
+      intro w
+      have hmem : (toLp 2 w.1.1 : EuclideanSpace ℝ (Fin 3))
+          ∈ (ℝ ∙ (toLp 2 (b : ↥(poleSet G)).1 : EuclideanSpace ℝ (Fin 3))) := by
+        rw [heq]; exact Submodule.subset_span ⟨w, rfl⟩
+      rw [Submodule.mem_span_singleton] at hmem
+      obtain ⟨c, hc⟩ := hmem
+      have hcv : c • (b : ↥(poleSet G)).1 = w.1.1 := by
+        have h := congrArg WithLp.ofLp hc
+        simpa using h
+      have hcsq : c * c = 1 := by
+        have h1 : (c • (b : ↥(poleSet G)).1) ⬝ᵥ (c • (b : ↥(poleSet G)).1) = 1 := by
+          rw [hcv]; exact hunit w
+        rw [smul_dotProduct, dotProduct_smul, smul_eq_mul, smul_eq_mul, b.2.1] at h1
+        linarith
+      rcases mul_self_eq_one_iff.mp hcsq with h | h
+      · exact Or.inl (by rw [← hcv, h, one_smul])
+      · refine Or.inr ?_
+        rw [Set.mem_singleton_iff, ← hcv, h, neg_one_smul]
+    have hFinj : Function.Injective (fun w : ↥(MulAction.orbit ↥G b) =>
+        (⟨w.1.1, hpar w⟩ :
+          ↥({(b : ↥(poleSet G)).1, -(b : ↥(poleSet G)).1} : Set (Fin 3 → ℝ)))) := by
+      intro x y hxy
+      apply Subtype.ext; apply Subtype.ext
+      simpa using hxy
+    have hle : Nat.card (↥(MulAction.orbit ↥G b))
+        ≤ Nat.card (↥({(b : ↥(poleSet G)).1, -(b : ↥(poleSet G)).1} : Set (Fin 3 → ℝ))) :=
+      Nat.card_le_card_of_injective _ hFinj
+    have hle2 : Nat.card (↥({(b : ↥(poleSet G)).1, -(b : ↥(poleSet G)).1} : Set (Fin 3 → ℝ)))
+        ≤ 2 := by
+      rw [Nat.card_coe_set_eq]
+      calc ({(b : ↥(poleSet G)).1, -(b : ↥(poleSet G)).1} : Set (Fin 3 → ℝ)).ncard
+            ≤ ({-(b : ↥(poleSet G)).1} : Set (Fin 3 → ℝ)).ncard + 1 := Set.ncard_insert_le _ _
+        _ = 2 := by rw [Set.ncard_singleton]
+    rw [horbit_card] at hle; omega
+  -- So the span *is* the plane `nᗮ`, and `r • n` lies in its orthogonal complement `ℝ ∙ n`.
+  have hTeq : Submodule.span ℝ (Set.range (fun w : ↥(MulAction.orbit ↥G b) =>
+      (toLp 2 w.1.1 : EuclideanSpace ℝ (Fin 3))))
+        = (ℝ ∙ (toLp 2 n : EuclideanSpace ℝ (Fin 3)))ᗮ :=
+    Submodule.eq_of_le_of_finrank_le hTle (by rw [hPfr]; exact hTfr)
+  have hRNmem : (toLp 2 ((((r0 : ↥G) : specialOrthogonalGroup (Fin 3) ℝ) :
+      Matrix (Fin 3) (Fin 3) ℝ) *ᵥ n) : EuclideanSpace ℝ (Fin 3))
+        ∈ (ℝ ∙ (toLp 2 n : EuclideanSpace ℝ (Fin 3))) := by
+    have hTperp : Submodule.span ℝ (Set.range (fun w : ↥(MulAction.orbit ↥G b) =>
+        (toLp 2 w.1.1 : EuclideanSpace ℝ (Fin 3))))
+          ≤ (ℝ ∙ (toLp 2 ((((r0 : ↥G) : specialOrthogonalGroup (Fin 3) ℝ) :
+              Matrix (Fin 3) (Fin 3) ℝ) *ᵥ n) : EuclideanSpace ℝ (Fin 3)))ᗮ := by
+      rw [Submodule.span_le]
+      rintro x ⟨w, rfl⟩
+      rw [SetLike.mem_coe, Submodule.mem_orthogonal_singleton_iff_inner_right, inner_toLp]
+      exact hperpR w
+    have h2 : (Submodule.span ℝ (Set.range (fun w : ↥(MulAction.orbit ↥G b) =>
+        (toLp 2 w.1.1 : EuclideanSpace ℝ (Fin 3)))))ᗮ
+          = (ℝ ∙ (toLp 2 n : EuclideanSpace ℝ (Fin 3))) := by
+      rw [hTeq, Submodule.orthogonal_orthogonal]
+    rw [← h2]
+    exact (le_trans (Submodule.le_orthogonal_orthogonal _) (Submodule.orthogonal_le hTperp))
+      (Submodule.mem_span_singleton_self _)
+  -- Read off `r • n = ±n`, and rule out `-n` using `r³ = 1`.
+  rw [Submodule.mem_span_singleton] at hRNmem
+  obtain ⟨c, hc⟩ := hRNmem
+  have hcv : c • n = (((r0 : ↥G) : specialOrthogonalGroup (Fin 3) ℝ) :
+      Matrix (Fin 3) (Fin 3) ℝ) *ᵥ n := by
+    have h := congrArg WithLp.ofLp hc
+    simpa using h
+  have hcsq : c * c = 1 := by
+    have h1 : (c • n) ⬝ᵥ (c • n) = 1 := by rw [hcv, so3_mulVec_dotProduct]; exact hnunit
+    rw [smul_dotProduct, dotProduct_smul, smul_eq_mul, smul_eq_mul, hnunit] at h1
+    linarith
+  have hrfixn : (((r0 : ↥G) : specialOrthogonalGroup (Fin 3) ℝ) :
+      Matrix (Fin 3) (Fin 3) ℝ) *ᵥ n = n := by
+    rcases mul_self_eq_one_iff.mp hcsq with h | h
+    · rw [← hcv, h, one_smul]
+    · exfalso
+      have hneg1 : (((r0 : ↥G) : specialOrthogonalGroup (Fin 3) ℝ) :
+          Matrix (Fin 3) (Fin 3) ℝ) *ᵥ n = -n := by rw [← hcv, h, neg_one_smul]
+      have hm3 : ((((r0 : ↥G) : specialOrthogonalGroup (Fin 3) ℝ) :
+            Matrix (Fin 3) (Fin 3) ℝ) * (((r0 : ↥G) : specialOrthogonalGroup (Fin 3) ℝ) :
+            Matrix (Fin 3) (Fin 3) ℝ)) * (((r0 : ↥G) : specialOrthogonalGroup (Fin 3) ℝ) :
+            Matrix (Fin 3) (Fin 3) ℝ) = 1 := by
+        have h1 := congrArg (fun x : ↥G =>
+          ((x : specialOrthogonalGroup (Fin 3) ℝ) : Matrix (Fin 3) (Fin 3) ℝ)) hrcube
+        simpa [pow_succ] using h1
+      have hcube : (((r0 : ↥G) : specialOrthogonalGroup (Fin 3) ℝ) :
+          Matrix (Fin 3) (Fin 3) ℝ) *ᵥ ((((r0 : ↥G) : specialOrthogonalGroup (Fin 3) ℝ) :
+            Matrix (Fin 3) (Fin 3) ℝ) *ᵥ ((((r0 : ↥G) : specialOrthogonalGroup (Fin 3) ℝ) :
+            Matrix (Fin 3) (Fin 3) ℝ) *ᵥ n)) = n := by
+        rw [mulVec_mulVec, mulVec_mulVec, hm3, one_mulVec]
+      have e1 : (((r0 : ↥G) : specialOrthogonalGroup (Fin 3) ℝ) :
+          Matrix (Fin 3) (Fin 3) ℝ) *ᵥ ((((r0 : ↥G) : specialOrthogonalGroup (Fin 3) ℝ) :
+            Matrix (Fin 3) (Fin 3) ℝ) *ᵥ n) = n := by
+        rw [hneg1, mulVec_neg, hneg1, neg_neg]
+      rw [e1, hneg1] at hcube
+      have hcontra : (1 : ℝ) = -1 := by
+        calc (1 : ℝ) = n ⬝ᵥ n := hnunit.symm
+          _ = (-n) ⬝ᵥ n := by rw [hcube]
+          _ = -(n ⬝ᵥ n) := neg_dotProduct _ _
+          _ = -1 := by rw [hnunit]
+      norm_num at hcontra
+  -- **Step 7.** `r` fixes the two orthogonal unit vectors `b.1` and `n` — impossible.
+  have hrso : ((r0 : ↥G) : specialOrthogonalGroup (Fin 3) ℝ) ≠ 1 := by
+    intro h
+    exact hrne (Subtype.ext (h.trans (OneMemClass.coe_one G).symm))
+  obtain ⟨v₁, hv₁unit, hv₁set⟩ :=
+    nontrivial_fixed_unit_vectors ((r0 : ↥G) : specialOrthogonalGroup (Fin 3) ℝ) hrso
+  have hnmem : n ∈ fixedUnitVectors ((r0 : ↥G) : specialOrthogonalGroup (Fin 3) ℝ) :=
+    ⟨hnunit, hrfixn⟩
+  have hbmem : (b : ↥(poleSet G)).1
+      ∈ fixedUnitVectors ((r0 : ↥G) : specialOrthogonalGroup (Fin 3) ℝ) := ⟨b.2.1, hrfixb⟩
+  have hbn : (b : ↥(poleSet G)).1 ⬝ᵥ n = 0 := hperp ⟨b, MulAction.mem_orbit_self b⟩
+  rw [hv₁set] at hnmem hbmem
+  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hnmem hbmem
+  rcases hnmem with hn | hn <;> rcases hbmem with hbv | hbv <;>
+    rw [hn, hbv] at hbn <;>
+    simp only [dotProduct_neg, neg_dotProduct, neg_neg, hv₁unit] at hbn <;>
+    norm_num at hbn
 
 end OctahedralFaithful
 

--- a/EtingofRepresentationTheory/Chapter4/Problem4_12_8.lean
+++ b/EtingofRepresentationTheory/Chapter4/Problem4_12_8.lean
@@ -1719,6 +1719,74 @@ theorem so3_tetrahedral_of_poleData
     Equiv.Perm.eq_alternatingGroup_of_index_eq_two hindex
   exact ⟨hGH.trans (MulEquiv.subgroupCongr hHeq)⟩
 
+section OctahedralFaithful
+open scoped RealInnerProductSpace
+open Matrix EuclideanSpace Submodule WithLp Module MulAction
+
+/-- **Kernel triviality for the four-diagonal action (octahedral crux, geometric core).**
+Any `g ∈ G` (with `|G| = 24`, `b` an order-`3` pole) that sends every pole `w` in the orbit
+`O = orbit b` to `±w` — i.e. fixes every body diagonal setwise — is the identity. This is the
+kernel-triviality that makes the action of `G` on the four body diagonals faithful.
+
+Route: `g` sends each `w ∈ O` to `±w`, so `g²` fixes all `8` unit vectors of `O`; since a
+nontrivial rotation fixes only an antipodal pair, `g² = 1`. If `g ≠ 1` it has order `2`; it
+cannot fix any `w ∈ O` (its stabilizer is cyclic of order `3`), so `g` negates *every* `w ∈ O`.
+Then the axis `n` of `g` is orthogonal to all of `O`; an order-`3` generator `r` of
+`stabilizer b` permutes `O`, so `r • n` is also orthogonal to all of `O`, and since `O` spans
+the plane `nᗮ` this forces `r • n = n`. But then `r` fixes the two orthogonal unit vectors `b.1`
+and `n`, contradicting that a nontrivial rotation fixes only an antipodal pair. -/
+theorem octahedral_kernel_negates_or_fixes_trivial
+    (G : Subgroup (specialOrthogonalGroup (Fin 3) ℝ)) [Finite G]
+    (hcard : Nat.card (↥G) = 24)
+    (b : ↥(poleSet G)) (hb : Nat.card (MulAction.stabilizer (↥G) b) = 3)
+    (g : ↥G)
+    (hg : ∀ w : ↥(MulAction.orbit ↥G b),
+      ((g • w : ↥(MulAction.orbit ↥G b)) : ↥(poleSet G)).1
+          = ((w : ↥(MulAction.orbit ↥G b)) : ↥(poleSet G)).1
+      ∨ ((g • w : ↥(MulAction.orbit ↥G b)) : ↥(poleSet G)).1
+          = -(((w : ↥(MulAction.orbit ↥G b)) : ↥(poleSet G)).1)) :
+    g = 1 := by
+  classical
+  -- The `G`-orbit `O` of `b` has `24 / 3 = 8` elements.
+  have horbit_card : Nat.card (↥(MulAction.orbit ↥G b)) = 8 := by
+    have hos : Nat.card (↥(MulAction.orbit ↥G b)) * Nat.card (↥(MulAction.stabilizer ↥G b))
+        = Nat.card (↥G) := by
+      rw [← Nat.card_prod]
+      exact Nat.card_congr (MulAction.orbitProdStabilizerEquivGroup ↥G b)
+    rw [hb, hcard] at hos
+    omega
+  haveI : Finite ↥(MulAction.orbit ↥G b) := (Finite.finite_mulAction_orbit b).to_subtype
+  -- Reformulate `hg` in terms of the matrix action on the underlying unit vectors.
+  have haction : ∀ w : ↥(MulAction.orbit ↥G b),
+      ((g • w : ↥(MulAction.orbit ↥G b)) : ↥(poleSet G)).1
+        = ((g : specialOrthogonalGroup (Fin 3) ℝ) : Matrix (Fin 3) (Fin 3) ℝ) *ᵥ
+            ((w : ↥(MulAction.orbit ↥G b)) : ↥(poleSet G)).1 := by
+    intro w
+    rw [MulAction.orbit.coe_smul, poleSet_coe_smul]
+  -- Every orbit vector is a unit vector.
+  have hunit : ∀ w : ↥(MulAction.orbit ↥G b),
+      ((w : ↥(MulAction.orbit ↥G b)) : ↥(poleSet G)).1
+        ⬝ᵥ ((w : ↥(MulAction.orbit ↥G b)) : ↥(poleSet G)).1 = 1 :=
+    fun w => (w : ↥(poleSet G)).2.1
+  -- The `±` hypothesis on unit vectors.
+  have hpm : ∀ w : ↥(MulAction.orbit ↥G b),
+      ((g : specialOrthogonalGroup (Fin 3) ℝ) : Matrix (Fin 3) (Fin 3) ℝ) *ᵥ
+          ((w : ↥(MulAction.orbit ↥G b)) : ↥(poleSet G)).1
+        = ((w : ↥(MulAction.orbit ↥G b)) : ↥(poleSet G)).1
+      ∨ ((g : specialOrthogonalGroup (Fin 3) ℝ) : Matrix (Fin 3) (Fin 3) ℝ) *ᵥ
+          ((w : ↥(MulAction.orbit ↥G b)) : ↥(poleSet G)).1
+        = -(((w : ↥(MulAction.orbit ↥G b)) : ↥(poleSet G)).1) := by
+    intro w
+    have := hg w
+    rwa [haction w] at this
+  by_contra hgne
+  have hg0 : (g : specialOrthogonalGroup (Fin 3) ℝ) ≠ 1 := by
+    intro h
+    exact hgne (Subtype.ext (h.trans (OneMemClass.coe_one G).symm))
+  sorry
+
+end OctahedralFaithful
+
 /-- **Faithful octahedral action on the four body diagonals (crux).** For the octahedral pole
 family `m = {2, 3, 4}` with `|G| = 24`, `G` acts faithfully on a four-element set, giving an
 injective `φ : G →* S₄`. Combined with `|G| = 24 = |S₄|` in `so3_octahedral_of_poleData`, this

--- a/progress/2026-07-19T07-09-02Z_99574d66.md
+++ b/progress/2026-07-19T07-09-02Z_99574d66.md
@@ -1,0 +1,78 @@
+## Accomplished
+
+Closed issue #6988 (`feat(Ch4 #6972)`): proved
+`octahedral_kernel_negates_or_fixes_trivial` in
+`EtingofRepresentationTheory/Chapter4/Problem4_12_8.lean`, sorry-free
+(`#print axioms` reports only `propext, Classical.choice, Quot.sound`).
+
+The lemma isolates the geometric content of the octahedral disjunct: any `g ∈ G`
+(with `|G| = 24`, `b` an order-`3` pole) sending every pole `w` of the orbit
+`O = orbit b` to `±w` is the identity. This is the kernel-triviality that makes
+the `G`-action on the four body diagonals faithful.
+
+Proof structure (7 steps, in a new `section OctahedralFaithful` placed just
+before `exists_octahedral_faithful_hom`):
+
+1. Orbit-stabilizer gives `|O| = 24 / 3 = 8`.
+2. Injection key: no nontrivial `h ∈ SO(3)` fixes all `8` orbit vectors, since
+   `nontrivial_fixed_unit_vectors` bounds `fixedUnitVectors h` by `2`.
+3. `g² = 1`: the two `±` signs cancel, so `g²` fixes all of `O`; apply the key.
+   Hence `orderOf g = 2` (given `g ≠ 1`).
+4. `g` negates *every* `w ∈ O`: if it fixed one, `g` would be an order-`2`
+   element of `stabilizer w`, whose card is `3` (conjugate to `stabilizer b` via
+   `MulAction.stabilizerEquivStabilizer`); `2 ∤ 3`.
+5. The axis `n` of `g` is orthogonal to all of `O` (`so3_mulVec_dotProduct`),
+   and so is `r • n` for `r` a nontrivial element of `stabilizer b` (which
+   permutes `O`).
+6. In `EuclideanSpace`, `span (range O) = (ℝ ∙ n)ᗮ`: the inclusion is step 5,
+   and `2 ≤ finrank` because otherwise the span would be the line `ℝ ∙ b.1`,
+   forcing all `8` orbit vectors to be `±b.1`. Hence `r • n ∈ (span O)ᗮ = ℝ ∙ n`,
+   so `r • n = ±n`; `r³ = 1` rules out `-n`.
+7. So `r` fixes the two orthogonal unit vectors `b.1` and `n`, contradicting
+   `fixedUnitVectors r = {v₁, -v₁}`.
+
+### Deviation from the issue's suggested route
+
+The issue's step 5 proposed reusing the `so3_swap_induced_plane` /
+`euclideanIso` submodule-map machinery to show `r` maps the plane to itself.
+I used a lighter argument instead: rather than transporting `r` through a
+plane isometry, I show directly that both `n` and `r • n` are orthogonal to
+every orbit vector, then identify `span (range O)` with `(ℝ ∙ n)ᗮ` by a
+`finrank` comparison (`Submodule.eq_of_le_of_finrank_le`). The
+"`2 ≤ finrank`" step is discharged by contradiction: a `≤ 1`-dimensional span
+would equal `ℝ ∙ b.1`, and unit vectors in a line are `±b.1`, giving `|O| ≤ 2`
+against `|O| = 8`. This avoids `Orientation`/`det` reasoning entirely.
+
+The declaration needs `set_option maxHeartbeats 400000 in` (2x default); the
+cost comes from the repeated nested `↥G → SO(3) → Matrix` coercions in the
+statement's terms, not from any single hard tactic. Full file build: ~29s.
+
+## Current frontier
+
+`exists_octahedral_faithful_hom` (`Problem4_12_8.lean:2087`) is still `sorry`.
+Its two decomposed sub-parts are:
+- this lemma (#6988) — **done**;
+- the sibling antipode-closure / four-diagonal-quotient assembly, which is the
+  remaining content of parent #6972 (still open and unclaimed).
+
+## Overall project progress
+
+`Problem4_12_8.lean` now has 3 live sorries (down from 4):
+- `exists_octahedral_faithful_hom` (:2087) — octahedral, needs #6972's assembly
+- `simpleGroup_card60_exists_index_five` (:2197) — icosahedral
+- `so3_icosahedral_G_simple` (:2217) — icosahedral
+
+## Next step
+
+Claim #6972 (parent, octahedral assembly). With
+`octahedral_kernel_negates_or_fixes_trivial` now available, what remains is the
+bookkeeping: build the four-element body-diagonal set (quotient of the `8`
+order-`3` poles by `w ~ -w`, needing antipode closure of the orbit — note that
+closure is now *free*: a kernel element negates every orbit vector, but more
+directly `g • w ∈ O` for any `g ∈ G`), transport to `Equiv.Perm (Fin 4)` as in
+`so3_tetrahedral_of_poleData` Step 4, and feed the kernel hypothesis into this
+lemma.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #6988

Session: `99574d66-f71e-4ef8-9d5c-f20e0f5d493a`

c7e132dc feat(Ch4 #6988): prove octahedral_kernel_negates_or_fixes_trivial sorry-free
b24796e3 feat(Ch4 #6988): WIP prove g²=1, orderOf g=2, g negates every orbit vector (geometric contradiction sorried)
3978e38e feat(Ch4 #6988): scaffold octahedral_kernel_negates_or_fixes_trivial (statement + setup, geometric crux sorried)

🤖 Prepared with Claude Code