### PR TITLE
doc(Ch5 #7004): correct stale sorry-claiming docstrings in Schur-Weyl deep-seam cluster

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/KernelLemmaKPrime.lean
+++ b/EtingofRepresentationTheory/Chapter5/KernelLemmaKPrime.lean
@@ -52,10 +52,11 @@ The mathematics of `kernelLemmaK'` is the `GL×GL`-equivariant **Cauchy
 decomposition** `k[Xᵢⱼ] = ⊕_{ν ∈ ℕ^N dom} V_ν^* ⊠ V_ν` together with the
 highest-weight shift `det · A ≅ A ⊗ χ`: `A/det` keeps exactly the constituents
 with last highest-weight coordinate `ν_N = 0`, so after the `χ⁻ʳ` twist every
-weight has last coordinate `ν_N − r = −r < 0`, i.e. no weight is `≥ 0`. This core
-is a research-level effort tracked as a residual `sorry` here and decomposed in a
-follow-up sub-issue; the present file fixes the precise statement and constructs
-every object it is phrased over.
+weight has last coordinate `ν_N − r = −r < 0`, i.e. no weight is `≥ 0`. This core is
+proved **sorry-free** in `KernelLemmaKPrimeAssembly.lean` (as
+`quotDetTwist_nonzero_subrep_has_neg_weight`, assembled into `kernelLemmaK'_submodule`);
+the present file fixes the precise statement and constructs every object it is phrased
+over.
 -/
 
 namespace Etingof.KernelLemmaKPrime
@@ -182,9 +183,8 @@ research-level core from elementary linear algebra:
   reducibility the subrep contains an irreducible `L` with highest weight `ν`,
   the Cauchy decomposition forces `ν_N = 0` (constituents of `A/det`), and the
   lowest weight of `L` (twisted) realizes the negative coordinate `−r` after the
-  `χ⁻ʳ` shift. It is tracked as a research-level residual `sorry` and decomposed
-  in a follow-up sub-issue; the `det · A ≅ A ⊗ χ` shift half is already
-  sorry-free in `DetShiftIso.lean`.
+  `χ⁻ʳ` shift. It is proved **sorry-free** in `KernelLemmaKPrimeAssembly.lean`; the
+  `det · A ≅ A ⊗ χ` shift half is likewise sorry-free in `DetShiftIso.lean`.
 
 Given both, (K′) is immediate: a nonzero subrep with all weights `≥ 0` would, by
 the core, contain a negative-weight vector, which the glue lemma forbids. -/

--- a/EtingofRepresentationTheory/Chapter5/PolytabloidBasis.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolytabloidBasis.lean
@@ -21,12 +21,19 @@ of the Specht module V_λ = ℂ[S_n] · c_λ.
 ## Main results
 
 * `Etingof.polytabloid_mem_spechtModule` — polytabloids lie in the Specht module
-* `Etingof.polytabloid_linearIndependent` — polytabloids are linearly independent (sorry;
-  proved at tabloid level as `polytabloidTab_linearIndependent` in `TabloidModule.lean`)
-* `Etingof.perm_mul_youngSymmetrizer_mem_span_polytabloids` — straightening lemma (sorry;
-  requires tabloid-level straightening or dimension argument; see issue #2104)
-* `Etingof.polytabloid_span` — polytabloids span the Specht module (from straightening)
-* `Etingof.finrank_spechtModule_eq_card_syt` — dim V_λ = |SYT(λ)| (from independence + span)
+
+The Specht-basis results themselves are established **sorry-free** at the tabloid level
+rather than the group-algebra level; working at the tabloid module level avoids the Garnir
+tautology issue (cf. issue #2104):
+
+* `Etingof.polytabloidTab_linearIndependent` (`TabloidModule.lean`) — linear independence,
+  together with the tabloid-level straightening and spanning proved there;
+* `Etingof.finrank_spechtModule_eq_card_standardYoungTableau` (`Theorem5_17_1.lean`) —
+  the dimension formula `dim V_λ = |SYT(λ)|`.
+
+The earlier group-algebra-level statements (`polytabloid_linearIndependent`,
+`perm_mul_youngSymmetrizer_mem_span_polytabloids`, `polytabloid_span`) were retired in
+favor of that route and no longer appear in the project.
 
 ## References
 
@@ -433,7 +440,8 @@ theorem polytabloid_support (n : ℕ) (la : Nat.Partition n)
   have : σ = τ * (τ⁻¹ * σ) := by group
   rw [this, h_eq, mul_assoc]
 
--- polytabloid_linearIndependent moved to SpechtModuleBasis.lean (proved via dim V_λ = |SYT|)
+-- Linear independence is proved sorry-free at the tabloid level as
+-- `polytabloidTab_linearIndependent` in `TabloidModule.lean` (via dim V_λ = |SYT|).
 
 /-! ### Sorted comparison lemma -/
 
@@ -1233,11 +1241,12 @@ private theorem columnInvCount'_one (n : ℕ) (la : Nat.Partition n) :
   have hb : b.val < la.sortedParts.sum := by omega
   exact Nat.not_lt.mpr (Nat.le_of_lt (lt_of_lt_rowOfPos la.sortedParts a.val b.val hb hrow))
 
--- perm_mul_youngSymmetrizer_mem_span_polytabloids, polytabloid_span, and
--- finrank_spechtModule_eq_card_syt have been moved to SpechtModuleBasis.lean,
--- where they are proved via the tabloid-level straightening theorem.
--- The straightening works at the tabloid module level (not the group algebra level),
--- avoiding the Garnir tautology issue described in the comment above.
+-- The straightening/spanning and the dimension formula `dim V_λ = |SYT(λ)|` are proved
+-- sorry-free at the tabloid module level: `polytabloidTab_linearIndependent` and the
+-- straightening in `TabloidModule.lean`, and
+-- `finrank_spechtModule_eq_card_standardYoungTableau` in `Theorem5_17_1.lean`.
+-- Working at the tabloid module level (not the group algebra level) avoids the Garnir
+-- tautology issue described in the comment above.
 
 end
 

--- a/EtingofRepresentationTheory/Chapter5/SchurWeylFormalCharacterIso.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurWeylFormalCharacterIso.lean
@@ -348,7 +348,8 @@ theorem simpleModule_iso_component_of_embeds
   obtain ⟨c, rfl⟩ := hm
   exact ⟨c, ⟨eTT'.trans (e'.trans (LinearEquiv.ofInjective _ (hlof_inj c)).symm)⟩⟩
 
-/-- **Isotypic matching half of the classification (general `k`, sorry-free modulo #4946).**
+/-- **Isotypic matching half of the classification (general `k`, sorry-free; builds on the
+#4946 simplicity result).**
 
 Given the equivariant decomposition data of `V^{⊗n}` (`V = Fin N → k`, `n ≤ N`),
 there is an *injective* assignment `φ : BoundedPartition N n → ι` such that
@@ -467,8 +468,8 @@ summand of the polynomial representation `V^{⊗n}`, hence both spanning
 **Important — not circular.** The *existing*
 `glTensorRep_schurWeyl_simples_formalCharacter_linearIndependent`
 (`SchurWeylSimplesClassification.lean`) derives the same conclusion, but *through*
-the still-sorried highest-weight classification core; using it here would make the
-classification depend on the very sorry it is meant to discharge. This lemma is
+the highest-weight classification core; using it here would make the classification
+depend circularly on the very result it is meant to establish. This lemma is
 instead proved **directly** from `hLtop`/`hLalg`/`hLsimp`/`hLdist` (character
 independence), independently of the classification.
 
@@ -539,7 +540,7 @@ private theorem glWeightSpace_map_le_of_equivariant
 Each simple summand `L i` of `V^{⊗n}` (`V = Fin N → k`) carrying a nonzero
 multiplicity space (`0 < dim(S i)`) is a *polynomial* representation: its weight
 spaces span. This supplies the `hLtop` hypothesis of
-`schurWeyl_simples_formalCharacter_linearIndependent_complex` at the call site from
+`schurWeyl_simples_formalCharacter_linearIndependent_general` at the call site from
 the equivariant decomposition data.
 
 Proof: pick a basis vector `s = b i0` of `S i` (exists since `dim(S i) > 0`) and the
@@ -679,7 +680,7 @@ algebraic, `glTensorRep_isAlgebraic`), via `x ↦ e⁻¹ (lof i (s ⊗ x))` for 
 `schurWeyl_simple_summand_glWeightSpace_top`. Restricting the algebraic structure to the
 (invariant) image and transporting it back through the embedding gives algebraicity of
 `(L i).ρ`. This supplies the `IsAlgebraicRepresentation` hypothesis of
-`schurWeyl_simples_formalCharacter_linearIndependent_complex`. -/
+`schurWeyl_simples_formalCharacter_linearIndependent_general`. -/
 theorem schurWeyl_simple_summand_isAlgebraic
     (k : Type) [Field k] [IsAlgClosed k] [CharZero k]
     (N n : ℕ)
@@ -772,8 +773,8 @@ The proof routes through the numerical identity
 counting step `|ι| = |P|` (i.e. `φ` surjective, so `lam := φ⁻¹` is total) is
 obtained here sorry-free *as a reduction*: the numerical identity rewrites to a
 vanishing `ℚ`-combination of the characters `char(L i)`, whose linear independence
-(`schurWeyl_simples_formalCharacter_linearIndependent_complex`, the one remaining
-isolated `sorry`) forces every coefficient to vanish; the empty-fibre coefficients
+(`schurWeyl_simples_formalCharacter_linearIndependent_general`, proved sorry-free)
+forces every coefficient to vanish; the empty-fibre coefficients
 are `dim(Sᵢ)`, so the nonzero-multiplicity hypothesis `hSne` (each `S i ≠ 0`,
 supplied by simplicity at the call site) rules out indices outside `im φ`.
 
@@ -817,7 +818,7 @@ theorem schurWeyl_simples_formalCharacter_classification_core_general
   -- Surjectivity of `φ` (the counting equality `|ι| = |P|`) via the numerical
   -- identity and linear independence of the simple characters. With each `L i`
   -- pairwise non-isomorphic and simple, the characters `char(L i)` are
-  -- `ℚ`-independent (`schurWeyl_simples_formalCharacter_linearIndependent_complex`,
+  -- `ℚ`-independent (`schurWeyl_simples_formalCharacter_linearIndependent_general`,
   -- the isolated remaining content). The numerical identity
   -- `∑ᵢ dim(Sᵢ)·char(Lᵢ) = ∑_λ dim(Specht_λ)·schurPoly λ` rewrites, via
   -- `char(L (φ λ)) = schurPoly λ` and the injectivity of `φ`, to a single
@@ -904,8 +905,9 @@ threaded in as the hypothesis `hLtop`, not manufactured from the character: weig
 is *not* determined by `formalCharacter` for non-polynomial simples (e.g. `det⁻¹ ⊗ Sym³(std)`
 at `N = 2` has character `schurPoly 2 (1,0)` but does not saturate), so the would-be ingredient
 (c) `glWeightSpace_top_of_simple_formalCharacter_eq_schurPoly` was false and is retired (#4969).
-The `L_λ`-side saturation is the true `glWeightSpace_schurModule_iSup_eq_top`. The two remaining
-deep ingredients are isolated as the `sorry`s above (#4946 simplicity, #4947 independence).
+The `L_λ`-side saturation is the true `glWeightSpace_schurModule_iSup_eq_top`. The two deep
+ingredients (#4946 simplicity, #4947 independence) are isolated as the lemmas above and are
+now proved sorry-free.
 
 Algebraicity of `L` is likewise threaded in as the hypothesis `hLalg` (the genuine input to
 ingredient (b), which now takes algebraicity rather than the false `hLtop ⟹ regular` bridge;

--- a/progress/2026-07-20T19-54-00Z_3e033470.md
+++ b/progress/2026-07-20T19-54-00Z_3e033470.md
@@ -1,0 +1,66 @@
+## Accomplished
+
+Issue #7004 (feat): corrected stale "residual/isolated `sorry`" docstrings in the
+Chapter 5 Schur-Weyl deep-seam cluster. Docstring/comment-only changes across three files;
+no declaration, signature, proof term, or import touched. `lake build` of all three modules
+succeeds (exit 0, 8664 jobs, 0 errors; only pre-existing linter warnings).
+
+**Verification of staleness (comment-stripped `sorry` scan).** Project-wide there is exactly
+**1** real `sorry` term, in `Chapter2/Problem2_16_3.lean` (owned by #6340). All three target
+files scan to **0** real `sorry`. Every declaration the corrected docstrings referenced is
+proved sorry-free.
+
+**`PolytabloidBasis.lean`** — the "Main results" list claimed `polytabloid_linearIndependent`
+and `perm_mul_youngSymmetrizer_mem_span_polytabloids` were "(sorry; …)". Investigation showed
+these group-algebra-level names (plus `polytabloid_span`, `finrank_spechtModule_eq_card_syt`)
+**no longer exist as declarations anywhere** — they were retired in favor of the tabloid-level
+route. Rewrote the "Main results" block to state this: the Specht-basis results are proved
+sorry-free at the tabloid level (`Etingof.polytabloidTab_linearIndependent`, `TabloidModule.lean`)
+and the dimension formula via `Etingof.finrank_spechtModule_eq_card_standardYoungTableau`
+(`Theorem5_17_1.lean`). Also fixed two in-body comments (lines ~443, ~1236) that pointed the
+moved results at a nonexistent file `SpechtModuleBasis.lean`; repointed them to the real
+locations (`TabloidModule.lean` / `Theorem5_17_1.lean`) for internal consistency.
+
+**`KernelLemmaKPrime.lean`** — "## Status" and the two-facts breakdown described the genuine
+core (`quotDetTwist_nonzero_subrep_has_neg_weight`, assembled into `kernelLemmaK'_submodule`)
+as "tracked as a residual `sorry` … decomposed in a follow-up sub-issue". Those lemmas are now
+proved sorry-free in `KernelLemmaKPrimeAssembly.lean` (verified 0 real `sorry`). Corrected both
+spots (lines ~55, ~185). Left line 20 ("not a `sorry`'d placeholder") unchanged — accurate.
+
+**`SchurWeylFormalCharacterIso.lean`** — fixed four stale claims:
+- ~471: "the still-sorried highest-weight classification core … depend on the very sorry it is
+  meant to discharge" → preserved the genuine **non-circularity** rationale but removed the
+  false sorry claim (the dependency would be circular regardless of sorry status).
+- ~776: "…linearIndependent_complex, the one remaining isolated `sorry`" → "…_general, proved
+  sorry-free". Note the referenced name `…_linearIndependent_complex` has **no declaration**;
+  the real proved lemma is `…_linearIndependent_general` (line ~478, this file). Updated all
+  four `_complex` prose references (lines ~542, ~682, ~776, ~820) to `_general` for consistency.
+- ~351: "sorry-free modulo #4946" → "sorry-free; builds on the #4946 simplicity result"
+  (#4946 is proved, so "modulo" wrongly implied an open sorry).
+- ~908: "isolated as the `sorry`s above (#4946 simplicity, #4947 independence)" → "…isolated as
+  the lemmas above and are now proved sorry-free".
+
+Positive "sorry-free" statements throughout the file were left as-is (they are accurate).
+
+## Current frontier
+
+Issue #7004 complete; PR pending. Diff is comment/docstring-only (git-diff confirmed every
+`+/-` line is inside a docstring or `--` comment).
+
+## Overall project progress
+
+Stage 3 at deep convergence. Exactly one real `sorry` remains project-wide
+(`finrank_g_three`, `Chapter2/Problem2_16_3.lean`, #6340). Remaining work is
+fidelity/hygiene. Queued sibling audits: #7002 (Ch4 SO(3)) and #7003 (Ch9 9.4.6), both
+report-only and non-overlapping with this.
+
+## Next step
+
+Pick up #7002 or #7003 (report-only fidelity audits). Also note: `PolytabloidBasis.lean`
+line ~409 still opens a "proof strategy for `polytabloid_linearIndependent`" section header
+referencing the retired name — left in place as genuine mathematical narrative (not a sorry
+claim), but a future cleanup could reword it.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7004

Session: `3e033470-0316-44f0-91b0-f0d6c82de7f7`

1be88f25 doc(Ch5 #7004): correct stale 'residual/isolated sorry' docstrings in Schur-Weyl deep-seam cluster

🤖 Prepared with Claude Code