### PR TITLE
feat(Ch4 #Problem4.12.8 docstring-fidelity): correct stale 'sorry proofs / ONLY remaining sorry' docstrings now that the SO(3) classification file is fully sorry-free

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Problem4_12_8.lean
+++ b/EtingofRepresentationTheory/Chapter4/Problem4_12_8.lean
@@ -50,9 +50,9 @@ The classification of finite subgroups of `SO(3)` is a large formalization with 
 support in Mathlib (there is no eigenvalue-`1`/rotation-axis theorem for `SO(3)`, no
 `MulAction` of the special orthogonal group on vectors, and none of the five `MulEquiv`
 targets is produced by existing API). Following the book's hint, the argument splits into
-three reusable milestones plus a case analysis. Each milestone is stated here with a faithful,
-self-contained signature; the milestones are tracked by child issues and filled
-independently. The final assembly `so3_finite_subgroup_classification` combines them.
+three reusable milestones plus a case analysis. Each milestone has a faithful, self-contained
+signature and is proved sorry-free; the final assembly `so3_finite_subgroup_classification`
+combines them.
 
 Vectors are modelled as `Fin 3 → ℝ` with the matrix action `M *ᵥ v` (`Matrix.mulVec`); a
 group element `g` acts through its underlying matrix `(g : Matrix (Fin 3) (Fin 3) ℝ)`.
@@ -1455,9 +1455,9 @@ rotation `ρ` about the axis `ℝ·b`, `ρ • b = b`), and the principal poles 
 axis (`s` sends `ℝ·b` to `ℝ·(-b)`, negating the plane orientation), so `s * ρ * s⁻¹ = ρ⁻¹`.
 
 This is the hard geometric extraction (`s` existence + order `2` + the conjugation-inversion
-relation) feeding the algebraic core `mulEquiv_dihedralGroup_of_conj_inv`. It is stated here with
-a faithful signature and tracked by its own child issue; `so3_dihedral_of_poleData` consumes it and
-supplies the remaining (purely group-theoretic) `hsnotin` and assembly. -/
+relation) feeding the algebraic core `mulEquiv_dihedralGroup_of_conj_inv`. It is proved sorry-free
+with a faithful signature; `so3_dihedral_of_poleData` consumes it and supplies the remaining
+(purely group-theoretic) `hsnotin` and assembly. -/
 theorem exists_dihedral_swap
     (G : Subgroup (specialOrthogonalGroup (Fin 3) ℝ)) [Finite G] (k : ℕ) (hk : 2 ≤ k)
     (hcard : Nat.card (↥G) = 2 * k)
@@ -1618,7 +1618,7 @@ poles (the vertices of the tetrahedron); the action lands in `A₄` and is an is
 cardinality argument (`|G| = 12 = |A₄|`). `m`, `heq`, and `hpole` are supplied verbatim by
 `pole_order_data`.
 
-The realization is deferred to its own child sub-issue (the tetrahedral case of #6864). -/
+The four-pole action and its faithfulness are proved sorry-free below. -/
 theorem so3_tetrahedral_of_poleData
     (G : Subgroup (specialOrthogonalGroup (Fin 3) ℝ)) [Finite G] (m : Multiset ℕ)
     (hclass : m = {2, 3, 3})

--- a/progress/2026-07-20T20-27-17Z_ac3de328.md
+++ b/progress/2026-07-20T20-27-17Z_ac3de328.md
@@ -1,0 +1,51 @@
+## Accomplished
+
+Issue #7005 (Ch4 Problem4.12.8 docstring-fidelity, `feature`).
+
+The three docstring blocks explicitly named in the issue (module header
+lines 27-28, `so3_icosahedral_exists_faithful_perm5` at ~3331, and
+`so3_icosahedral_of_poleData` at ~3359) had already been corrected by the
+merged #7006 (the #7002 review pass). Deliverable 1 was therefore a no-op.
+
+Residual work under deliverable 2 (scan for *other* statement-pass-era
+stale prose) and deliverable 3 (items.json) was still outstanding, so the
+issue was not redundant. Fixed:
+
+- **Line 53-55** (Part (a) section header): "Each milestone is stated here
+  with a faithful signature; the milestones are tracked by child issues and
+  filled independently" → "Each milestone has a faithful, self-contained
+  signature and is proved sorry-free".
+- **Line 1458-1460** (`exists_dihedral_swap` docstring): "It is stated here
+  with a faithful signature and tracked by its own child issue" → "It is
+  proved sorry-free with a faithful signature".
+- **Line 1621** (`so3_tetrahedral_of_poleData` docstring): "The realization
+  is deferred to its own child sub-issue (the tetrahedral case of #6864)."
+  → "The four-pole action and its faithfulness are proved sorry-free below."
+  (the theorem directly below is fully proved, so "deferred" was false).
+- **items.json** `Chapter4/Problem4.12.8`: status `statement_formalized` →
+  `sorry_free`; rewrote the coverage_note, which had claimed milestone
+  lemmas "carry sorries, tracked by child issues #6833/#6834/#6835/#6836".
+
+Verified line 2260 ("completing the octahedral disjunct sorry-free") is
+accurate and left it untouched.
+
+## Current frontier
+
+Issue #7005 deliverables complete. Docstring/items.json-only changes; no
+Lean statements or proofs modified.
+
+## Overall project progress
+
+Chapter 4 Problem 4.12.8 (SO(3)/SU(2) finite-subgroup classification) is
+fully sorry-free and its docstrings + items.json now describe that state
+accurately. The one remaining genuine project sorry is `finrank_g_three`
+in Chapter 2 (#6340), unrelated to this file.
+
+## Next step
+
+Standard: merge ready PRs at the start of the next planning cycle, then
+claim the next unclaimed issue.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3102,8 +3102,8 @@
     "end_page": "87",
     "start_line": 5,
     "end_line": 2,
-    "status": "statement_formalized",
-    "coverage_note": "Statement in Problem4_12_8.lean: (a) every finite subgroup of SO(3) is cyclic/dihedral/A4/S4/A5; (b) SU(2) double-cover relation (proved sorry-free). Part (a) decomposed via pole-counting scaffold (#6802): part (a) body sorry-free, delegating to so3_classification_aux; three concretely-typed milestone lemmas exists_fixed_vector, isCyclic_of_common_fixed_vector, pole_order_diophantine plus glue so3_classification_aux carry sorries, tracked by child issues #6833/#6834/#6835/#6836. No Mathlib support (no SO(3) eigenvalue-1, no MulAction on vectors, no MulEquiv targets)."
+    "status": "sorry_free",
+    "coverage_note": "Problem4_12_8.lean is fully sorry-free: (a) so3_finite_subgroup_classification — every finite subgroup of SO(3) is cyclic/dihedral/A4/S4/A5; (b) su2_finite_subgroup_double_cover — SU(2) double-cover relation. Part (a) proved via the pole-counting route (#6802): the milestone lemmas (exists_fixed_vector, isCyclic_of_common_fixed_vector, pole_order_diophantine) and the tetrahedral/octahedral/icosahedral disjuncts (including the icosahedral crux so3_icosahedral_exists_faithful_perm5 via the simple-group / index-5 coset route) are all proved. No Mathlib support (no SO(3) eigenvalue-1, no MulAction on vectors, no MulEquiv targets)."
   },
   {
     "id": "Chapter4/Problem4.12.9",


### PR DESCRIPTION
Closes #7005

Session: `ac3de328-89e0-410e-a310-0d9c879bccce`

40677a1d doc(Ch4 #7005): correct residual statement-pass-era docstrings in Problem4.12.8, mark items.json sorry_free

🤖 Prepared with Claude Code