### PR TITLE
feat(Ch9 docstring-fidelity): correct stale 'still sorry-d clength_* / only sorry' claims in Krull-Schmidt Length + Fitting (both files sorry-free; Fitting contradicts Length:53)

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Fitting.lean
+++ b/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Fitting.lean
@@ -28,9 +28,9 @@ The categorical statement,
 
 needs the descending image chain `im (f^n)` and the ascending kernel chain `ker (f^n)` to
 *stabilise*. That stabilisation is exactly the finite-length input of `KrullSchmidt/Length.lean`:
-the chains are measured by `Etingof.clength`, whose finiteness/monotonicity is the (still `sorry`-d)
-categorical Jordan–Hölder content of link 1/5. The Fitting decomposition `fitting_decomposition`
-is stated here in the convenient block-conjugation form
+the chains are measured by `Etingof.clength`, whose finiteness/monotonicity is the (now proved,
+sorry-free) categorical Jordan–Hölder content of link 1/5. The Fitting decomposition
+`fitting_decomposition` is stated here in the convenient block-conjugation form
 
 ```
 f = e.hom ≫ biprod.map fK fI ≫ e.inv,   IsNilpotent fK,   IsIso fI,
@@ -42,8 +42,8 @@ isomorphism. Given that iso the whole construction is elementary abelian-categor
 `factorThruImage (fⁿ)` becomes a split epi (section `(g')⁻¹ ≫ image.ι (fⁿ)`), its kernel and image
 split `X` as a biproduct, `f` is block-diagonal because it preserves both summands (the kernel
 summand directly, the image summand because `f` maps `im (fⁿ)` into `im (fⁿ⁺¹) ⊆ im (fⁿ)`), and the
-two blocks are read off from `(fK)ⁿ = (fⁿ)|_K = 0` and `(fI)ⁿ = (fⁿ)|_I = g'`. The only `sorry`
-upstream is in the `clength_*` finiteness lemmas that `exists_pow_stabilizes` rests on.
+two blocks are read off from `(fK)ⁿ = (fⁿ)|_K = 0` and `(fI)ⁿ = (fⁿ)|_I = g'`. The upstream
+`clength_*` finiteness lemmas that `exists_pow_stabilizes` rests on are all proved, sorry-free.
 **Everything downstream of `fitting_decomposition` in this file — the nilpotent-or-iso dichotomy and
 the local-ring property — is proved unconditionally from its statement.**
 
@@ -126,8 +126,8 @@ nilpotent and `fI` an isomorphism.
 
 `K` is the kernel `ker (factorThruImage (fⁿ)) = ker (fⁿ)` and `I` the eventual image `im (fⁿ)` for
 the stabilising power `n` supplied by `Etingof.exists_pow_stabilizes` (the finite-length content of
-`KrullSchmidt/Length.lean`, which rests on the still-`sorry`-d `clength_*` lemmas); see the module
-doc for the proof outline. The downstream dichotomy and local-ring results below are proved
+`KrullSchmidt/Length.lean`, which rests on the proved, sorry-free `clength_*` lemmas); see the
+module doc for the proof outline. The downstream dichotomy and local-ring results below are proved
 unconditionally from this statement. -/
 theorem fitting_decomposition {X : C} (f : End X) :
     ∃ (K I : C) (e : X ≅ K ⊞ I) (fK : End K) (fI : End I),

--- a/progress/2026-07-20T20-31-41Z_19ad39e3.md
+++ b/progress/2026-07-20T20-31-41Z_19ad39e3.md
@@ -1,0 +1,43 @@
+## Accomplished
+
+Docstring-fidelity cleanup (issue #7011) on the Chapter 9 Krull–Schmidt length machinery.
+Corrected three stale status claims in
+`EtingofRepresentationTheory/Chapter9/KrullSchmidt/Fitting.lean` that described the `clength_*`
+finiteness/monotonicity lemmas as live/deferred `sorry`s:
+
+- `Fitting.lean:31` — "finiteness/monotonicity is the (still `sorry`-d) categorical Jordan–Hölder
+  content" → "(now proved, sorry-free) …".
+- `Fitting.lean:45` — "The only `sorry` upstream is in the `clength_*` finiteness lemmas …" →
+  "The upstream `clength_*` finiteness lemmas … are all proved, sorry-free."
+- `Fitting.lean:129` (`fitting_decomposition` docstring) — "rests on the still-`sorry`-d
+  `clength_*` lemmas" → "rests on the proved, sorry-free `clength_*` lemmas".
+
+These were contradicted by `Length.lean:53`, which correctly records `clength_additive` as
+"proved, sorry-free". A comment-stripped scan confirms **0** real `sorry` in either file.
+
+`Length.lean` needed no change: swept it for stale-status language; its only remaining hit
+(`Length.lean:44`, "future work in `Mathlib/CategoryTheory/Noetherian.lean`") is a genuine,
+correct statement about Mathlib not yet having categorical Jordan–Hölder, not a false claim about
+our code. The `Length.lean:53` "proved, sorry-free" note was left as-is.
+
+## Current frontier
+
+Issue #7011 complete. Diff is comment-only (three hunks in `Fitting.lean`). `lake build` of both
+`Chapter9.KrullSchmidt.Fitting` and `…Length` succeeds (2156 jobs); all warnings are pre-existing
+linter noise (unused section vars, long lines) in unrelated declarations, not from these edits.
+All edited comment lines are within the 100-char limit.
+
+## Overall project progress
+
+Deep-convergence docstring/audit phase: project is sorry-free except `finrank_g_three` (#6340).
+Remaining sibling docstring-fidelity work: #7013 (Ch9 block-theory cluster). Review #7014
+(Ch5 Remark 5.2.8 axiom/fidelity audit) was claimed by another agent.
+
+## Next step
+
+A worker should pick up #7013 (Ch9 block-theory docstring fidelity: `Theorem9_2_1.lean`,
+`Problem9_5_3.lean`, `Problem9_5_3_S3Char2.lean`), following the same pattern.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7011

Session: `19ad39e3-ca6a-4e78-b5fa-deeb41e47224`

d02996f8 doc(Ch9 #7011): correct stale 'still sorry-d clength_*' claims in Fitting docstrings

🤖 Prepared with Claude Code