### PR TITLE
feat(Ch9 docstring-fidelity): correct stale 'sorry'd / deferred (sorry) / only remaining sorry' claims in block-theory cluster Theorem9_2_1 + Problem9_5_3 + Problem9_5_3_S3Char2 (all sorry-free)

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/Problem9_5_3.lean
+++ b/EtingofRepresentationTheory/Chapter9/Problem9_5_3.lean
@@ -24,8 +24,8 @@ Etingof Problem 9.5.3 relates the block decomposition of a finite abelian catego
   `Hom(M, N) = 0` whenever `M ∈ 𝒞ₖ`, `N ∈ 𝒞ₗ` with `k ≠ l`. Thus `𝒞 = ⊕ₖ 𝒞ₖ`.
 
 * **(iii)** Determine the blocks of the category of left `A`-modules for `A = k[S₃]` with `k`
-  of characteristic `2`. *(Deferred: this concrete modular-representation computation is left
-  to a follow-up statement-pass item.)*
+  of characteristic `2`. *(This concrete modular-representation computation is discharged in
+  `Problem9_5_3_S3Char2.lean`: `k[S₃] ≅ M₂(k) × k[t]/(t²)`, giving exactly two blocks.)*
 
 ## Statement-pass note
 
@@ -36,7 +36,7 @@ Blocks are `Etingof.Block R` and block membership is `Etingof.InBlock R S M` (De
 of two nonzero orthogonal central idempotents).
 "`Hom(M, N) = 0`" is `Subsingleton (M ⟶ N)`, and "indecomposable object" is
 `CategoryTheory.Indecomposable`. Two blocks are distinct exactly when their representative
-simple modules are not `Etingof.AreLinked`. Proofs are deferred (`sorry`).
+simple modules are not `Etingof.AreLinked`. The proofs are complete (sorry-free).
 -/
 
 universe v u
@@ -619,7 +619,7 @@ The proof runs through `centralIdempotent_smul_simple`: each simple module has a
 (which central idempotents act as `1`), linked simples share it
 (`centralCharacter_eq_of_areLinked`), and the primitive central idempotents `eₖ` in the
 decomposition `1 = Σ eₖ` (`exists_completeOrthogonal_isIndecomposableCentral`) are exactly the
-indicators of the blocks. The remaining `sorry` is the *injectivity* direction
+indicators of the blocks. The *injectivity* direction is supplied by
 `areLinked_of_actsAsOne_common` (block connectivity from indecomposability). -/
 theorem blocks_equiv_indecomposableCentralIdempotents
     {k : Type*} [Field k] [Algebra k R] [FiniteDimensional k R] [Small.{v} R] :

--- a/EtingofRepresentationTheory/Chapter9/Problem9_5_3_S3Char2.lean
+++ b/EtingofRepresentationTheory/Chapter9/Problem9_5_3_S3Char2.lean
@@ -41,7 +41,8 @@ count, and the **algebra decomposition** `k[S₃] ≅ M₂(k) × k[t]/(t²)` are
 decomposition is realized as the algebra map `(rhoStd, psi) : k[S₃] → M₂(k) × k[t]/(t²)` — the
 standard representation in coordinates paired with the sign character — shown bijective by a
 `6 = 6` dimension count after surjectivity via the central idempotent `e = (123) + (132)`. The
-only remaining `sorry` is `simple_iff_triv_or_std` (there are exactly these two simples). See the
+classification `simple_iff_triv_or_std` (there are exactly these two simples) is also proved, so
+this file is fully sorry-free. See the
 block framework in `Definition9_5_1.lean` and `Problem9_5_3.lean` for the `Etingof.Block` /
 `Etingof.AreLinked` machinery reused here.
 -/
@@ -120,7 +121,7 @@ noncomputable def stdMod : ModuleCat (MonoidAlgebra k S3) :=
 /-- The local algebra `k[t]/(t²)`, the principal block of `k[S₃]` in characteristic `2`. -/
 abbrev kt2 : Type := Polynomial k ⧸ Ideal.span {(Polynomial.X : Polynomial k) ^ 2}
 
-/-! ## The classification (statement pass; proofs deferred) -/
+/-! ## The classification (proved) -/
 
 omit [CharP k 2] in
 /-- **The trivial module is simple.** In characteristic `2`, `triv = sign`, so the two char-`0`

--- a/EtingofRepresentationTheory/Chapter9/Theorem9_2_1.lean
+++ b/EtingofRepresentationTheory/Chapter9/Theorem9_2_1.lean
@@ -309,7 +309,7 @@ lemma exists_orthogonal_idempotents_for_simples
   haveI : Module.Finite k (A ⧸ Ring.jacobson A) := inferInstance
   obtain ⟨n, d, hd, ⟨WA⟩⟩ :=
     IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed k (A ⧸ Ring.jacobson A)
-  -- Step B: Block-module correspondence (sorry'd)
+  -- Step B: Block-module correspondence (constructed below)
   -- For each simple A-module M_i (with J acting as 0), there is a unique WA block σ(i)
   -- such that the σ(i)-th block acts nontrivially on M_i. Non-isomorphic modules map
   -- to different blocks (σ is injective).
@@ -317,7 +317,7 @@ lemma exists_orthogonal_idempotents_for_simples
   -- with rank δ_{ij} (via the A-action, using J ≤ ann(M_j) so the action factors
   -- through A/J ≅ ∏ Mat(k)).
   --
-  -- This requires infrastructure not currently available:
+  -- This uses the following infrastructure:
   -- (i) Module structure on M_j over A/J (from J ≤ ann(M_j)) — available via
   --     Module.IsTorsionBySet.module from Mathlib
   -- (ii) Module structure over the product ∏ Mat_{dⱼ}(k) via the WA equivalence
@@ -374,7 +374,7 @@ lemma exists_orthogonal_idempotents_for_simples
   -- (C) finrank of E₁₁-image on the standard representation = 1
   --
   -- Sub-arguments (A) and (B) are individually straightforward; (C) needs a concrete
-  -- dimension computation. We decompose into helper sub-sorrys.
+  -- dimension computation. We decompose into helper sub-lemmas.
 
   -- Helper: the action of WA.symm(x) on M_j (via any lift) factors through A/J.
   -- Two lifts give the same action (by hsmulRange_eq).
@@ -383,7 +383,7 @@ lemma exists_orthogonal_idempotents_for_simples
   -- (∏ Mat(k))-action.
 
   -- For each j, define σ(j) as the unique block where the central idempotent acts nontrivially.
-  -- We construct σ by sorry'ing the existence of the unique block.
+  -- We construct σ from the existence of the unique block (established below).
   -- Then we prove injectivity and the rank property.
 
   -- Sub-lemma: block assignment exists
@@ -2356,7 +2356,7 @@ theorem Etingof.Theorem_9_2_1_ii
   -- 4. A = ⊕_p A·e_p ≅ ⊕_p P_{p.1} ≅ ⊕_i (Fin (dim M_i) → P_i).
   haveI : IsArtinianRing A := isArtinian_of_tower k inferInstance
   -- Step 1: Construct complete orthogonal idempotents with the Hom delta property.
-  -- This is the core WA-based construction (sorry'd — see detailed outline above).
+  -- This is the core WA-based construction (established below — see detailed outline above).
   suffices h_coi : ∃ (e : (Σ i : ι, Fin (Module.finrank k (M i))) → A),
       CompleteOrthogonalIdempotents e ∧
       ∀ (p : Σ i : ι, Fin (Module.finrank k (M i))) (j : ι),

--- a/progress/2026-07-20T20-33-15Z_1d582693.md
+++ b/progress/2026-07-20T20-33-15Z_1d582693.md
@@ -1,0 +1,46 @@
+## Accomplished
+
+Docstring-fidelity cleanup for issue #7013 (Ch9 block-theory cluster). Corrected stale
+live/deferred-`sorry` status claims in three now-sorry-free files (comment-only edits, no proof,
+signature, import, or def-body changes):
+
+- `Chapter9/Problem9_5_3.lean`
+  - module docstring: "Proofs are deferred (`sorry`)." → "The proofs are complete (sorry-free)."
+  - `blocks_equiv_indecomposableCentralIdempotents` docstring: "The remaining `sorry` is the
+    *injectivity* direction …" → "The *injectivity* direction is supplied by …" (the lemma
+    `areLinked_of_actsAsOne_common` is proved at :357 and used at :687).
+  - part (iii) module note: "*(Deferred: … left to a follow-up …)*" → now points to
+    `Problem9_5_3_S3Char2.lean` where (iii) is discharged.
+- `Chapter9/Problem9_5_3_S3Char2.lean`
+  - status paragraph: "The only remaining `sorry` is `simple_iff_triv_or_std`" → "… is also
+    proved, so this file is fully sorry-free" (`simple_iff_triv_or_std` proved at :472).
+  - section header "## The classification (statement pass; proofs deferred)" → "## The
+    classification (proved)".
+- `Chapter9/Theorem9_2_1.lean` — corrected four inline `(sorry'd)` / "sub-sorrys" comments in
+  `exists_orthogonal_idempotents_for_simples` and `Etingof.Theorem_9_2_1_ii` to describe the
+  completed construction: "(sorry'd)" → "(constructed below)"; "This requires infrastructure not
+  currently available:" → "This uses the following infrastructure:"; "helper sub-sorrys" →
+  "helper sub-lemmas"; "construct σ by sorry'ing …" → "construct σ from the existence … (established
+  below)"; "core WA-based construction (sorry'd …)" → "(established below …)". Genuine mathematical
+  exposition (the (i)-(v) / (A)-(C) outlines, block-theory prose) preserved verbatim.
+
+## Current frontier
+
+Issue #7013 complete. `lake build` of all three modules succeeds (8592 jobs). `grep -n sorry` on
+the three files now shows only "sorry-free" / "no `sorry`" notes and genuine prose — no false
+live/deferred-`sorry` claim survives. Diff is comment/docstring-only.
+
+## Overall project progress
+
+Deep convergence / docstring-fidelity sweep of Chapter 9. This continues the recently merged
+docstring-fidelity PRs (#7009 Ch5, #7010 Ch4). One sibling item remains: #7011 (Krull-Schmidt
+Length + Fitting).
+
+## Next step
+
+Land #7011 (Fitting/Length `clength_*` stale-sorry docstrings) — note it showed a `claimed` label
+at the time of this turn, so a successor should re-check its claim state.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7013

Session: `1d582693-91fe-4f34-873b-76207abc309c`

ea2e8f2d doc(Ch9 #7013): correct stale sorry'd/deferred docstrings in block-theory cluster

🤖 Prepared with Claude Code