### PR TITLE
feat(Ch6/Infra docstring-fidelity): correct stale 'sorry'd remaining lemma/blocker' claims in Corollary6_8_4 (Gabriel realization) + FrobeniusCharacterBridge (retired bridge lemmas) — with fidelity guardrail

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/Corollary6_8_4.lean
+++ b/EtingofRepresentationTheory/Chapter6/Corollary6_8_4.lean
@@ -40,21 +40,26 @@ reconstruct the representation from the simple one.
 
 ## Current status
 
-### Infrastructure built
-- **Simple representation construction** (`simpleRepresentation`): Constructs the
+**Complete.** `Etingof.Corollary6_8_4` is proved sorry-free (`#print axioms`
+reports only `[propext, Classical.choice, Quot.sound]`), completing Gabriel's
+theorem for Dynkin quivers.
+
+### Proof structure
+- **Simple representation construction** (`simpleRepresentation`): the
   indecomposable representation k₍ₚ₎ at vertex p (1-dim at p, 0 elsewhere, all
   maps zero) for any quiver Q.
-- **Base case proved** (`Corollary6_8_4_simpleRoot`): When α = simpleRoot n p,
-  the simple representation realizes it.
-- **Induction structure**: The main proof reduces via Theorem 6.8.1 to the base
-  case plus a reflection functor chain step (sorry'd).
-
-### Remaining blocker
-- **Reflection functor chain** (`reflectionFunctorChainStep`): Applying F⁻ᵢ to
-  transform a realization on the reversed quiver back to Q. This requires:
-  - Iterated quiver reversal tracking
-  - Proposition 6.6.7 source case (currently sorry'd)
-  - Proposition 6.6.8 source case for dimension vector tracking
+- **Base case** (`Corollary6_8_4_simpleRoot`): when α = simpleRoot n p, the
+  simple representation realizes it.
+- **Induction**: strong recursion on the coordinate sum ∑α. For a positive root
+  with ∑α ≥ 2, a good vertex i with 0 < (Aα)ᵢ ≤ αᵢ is reflected to a positive
+  root α' = sᵢ(α) with strictly smaller sum, and the representation on the
+  reversed quiver Q' is transported back to Q by a reflection functor:
+  - i a source in Q (sink in Q'): apply F⁺ (`reflectionFunctorPlus`);
+  - i a sink in Q (source in Q'): apply F⁻ (`reflectionFunctorMinus`);
+  - i mixed: `exists_prefix_to_simpleRoot` + `backward_construct_rep` walk an
+    admissible ordering in reverse, applying F⁻ at each sink.
+  Indecomposability and the dimension-vector identity are supplied by
+  Propositions 6.6.5, 6.6.7 and 6.6.8 (source and sink cases).
 
 ### Fixed (issue #1094)
 - **Q-adj connection**: Added `IsOrientationOf Q adj` hypothesis linking the
@@ -831,7 +836,8 @@ theorem Etingof.Corollary6_8_4
       ∀ v, (α v : ℤ) = ↑(Module.finrank k (ρ.obj v)) := by
   -- Strong induction on coordinate sum, using exists_good_vertex directly.
   -- For the good vertex i: if i is a source or sink in Q, apply F⁺/F⁻ directly.
-  -- For mixed vertices: sorry (requires admissible ordering backward construction).
+  -- For mixed vertices: use the admissible-ordering backward construction
+  --   (exists_prefix_to_simpleRoot + backward_construct_rep).
   set A := Etingof.cartanMatrix n adj with hA_def
   have hAsymm : A.IsSymm := Etingof.cartanMatrix_isSymm hDynkin.1
   suffices h : ∀ (m : ℕ) (α : Fin n → ℤ) (Q : @Quiver.{0, 0} (Fin n)),
@@ -974,7 +980,7 @@ theorem Etingof.Corollary6_8_4
       -- The attribute [instance] on QuiverRepresentation.instModule makes both
       -- ρ'.instModule and fp.instModule discoverable for the same carrier type
       -- (since fp.obj v = ρ'.obj v for v ≠ i), causing synthesis conflicts.
-      -- Solution: transport fp to Q via hinvol ▸, then sorry sub-proofs.
+      -- Solution: transport fp to Q via hinvol ▸, discharging the sub-proofs below.
       classical
       -- Double reversal: reversedAtVertex(Q', i) = Q
       have hinvol : @Etingof.reversedAtVertex (Fin n) _

--- a/EtingofRepresentationTheory/Infrastructure/FrobeniusCharacterBridge.lean
+++ b/EtingofRepresentationTheory/Infrastructure/FrobeniusCharacterBridge.lean
@@ -16,9 +16,12 @@ with N variables) and `spechtModuleCharacter` (trace definition over ℂ with n 
 
 ## Note
 
-The main theorem `youngSym_charValue_orthogonality` is proved in
-`Theorem5_22_1.lean` using an inlined version of the trace Kronecker identity.
-Two sorry'd bridge lemmas remain:
+This file provides only the alternant-Vandermonde identity and the ℚ → ℂ
+base-change lemma above. The Frobenius character bridge itself is completed in
+`Theorem5_22_1.lean`, where the main theorem `youngSym_charValue_orthogonality`
+is proved using an inlined version of the trace Kronecker identity. The two bridge
+lemmas once slated for this file are now proved (not `sorry`) in
+`Theorem5_22_1.lean`, not declared here:
 - `charValue_eq_spechtModuleCharacter`: Frobenius character formula for N variables
 - `weightToPartition_eq_iff`: antitone partition injectivity
 -/

--- a/progress/2026-07-20T21-05-04Z_c1cb109e.md
+++ b/progress/2026-07-20T21-05-04Z_c1cb109e.md
@@ -1,0 +1,70 @@
+## Accomplished
+
+Resolved issue #7019 (feature, docstring-fidelity with fidelity guardrail):
+corrected stale `sorry`'d-remaining claims in two files.
+
+- **`Infrastructure/FrobeniusCharacterBridge.lean`** — the "## Note" block claimed
+  "Two sorry'd bridge lemmas remain": `charValue_eq_spechtModuleCharacter` and
+  `weightToPartition_eq_iff`. Fidelity check: the issue assumed these names were
+  *absent* project-wide (retired). A `grep` showed they are **present and proved**
+  in `Chapter5/Theorem5_22_1.lean` (public theorem line 3353; private lemma line
+  3404), actively consumed by `Problem5_16_1`, `SchurWeylPolynomialIdentity`, etc.
+  So "retired/no longer present" would itself be false. Wrote the truthful
+  correction instead: this file provides only the alternant-Vandermonde and ℚ→ℂ
+  base-change lemmas; the two bridge lemmas are now proved (not `sorry`) in
+  `Theorem5_22_1.lean`, not declared here. `Theorem5_22_1.lean` is sorry-free
+  (comment-stripped scan = 0).
+
+- **`Chapter6/Corollary6_8_4.lean`** — the "## Current status" block still described
+  a "Remaining blocker" (`reflectionFunctorChainStep` "sorry'd", Prop 6.6.7 source
+  case "sorry'd"). Ran the guardrail: `#print axioms Etingof.Corollary6_8_4` →
+  `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no custom axiom).
+  Verified the statement is faithful to `blobs/Chapter6/Corollary6.8.4.md` (every
+  positive root of a Dynkin quiver realized by an indecomposable rep with matching
+  dimension vector), non-vacuous (constructs a real representation), hypotheses not
+  over-strengthened. Read the full proof: all three cases discharged (source→F⁺,
+  sink→F⁻, mixed→`exists_prefix_to_simpleRoot`+`backward_construct_rep`).
+  `reflectionFunctorChainStep` exists only in the stale docstring. Rewrote the
+  status block to describe the completed construction, and fixed two stale inline
+  "sorry" comments (lines ~834, ~980) that described the retired plan.
+  `Corollary6_8_4` rebuilds clean (exit 0).
+
+All edits are docstring/comment-only: no proof, signature, import, or def-body
+change. Both files remain sorry-free (comment-stripped scan = 0 each).
+
+## Discovered: pre-existing build break (filed #7024)
+
+Verifying FrobeniusCharacterBridge revealed that its dependency
+`Infrastructure/YoungSymTraceKronecker.lean:62` **fails to build** under the pinned
+toolchain — a hard type-mismatch from the `MonoidAlgebra.mapRangeRingHom(_apply)`
+Mathlib deprecation (changed simp normal form). Not caught by CI because
+`.github/workflows/lean.yml` explicitly excludes `YoungSymTraceKronecker` and
+`FrobeniusCharacterBridge` from the module build (>15GB import closure). This is
+unrelated to my docstring edit (a module-comment change cannot affect compilation)
+and pre-existing. Filed as **#7024** (feature). My FrobeniusCharacterBridge
+docstring correction stands regardless — the facts were verified by `grep` +
+reading `Theorem5_22_1.lean`, which builds independently.
+
+## Current frontier
+
+Issue #7019 complete; PR opened. New repair issue #7024 queued for the
+YoungSymTraceKronecker toolchain-drift break.
+
+## Overall project progress
+
+Deep convergence: project is sorry-free except the single genuine `finrank_g_three`
+(`Chapter2/Problem2_16_3.lean`, G₂ case, owned by #6340). Remaining queue is
+docstring-fidelity cleanup + review audits. Note the two CI-excluded infra files
+(`YoungSymTraceKronecker`, `FrobeniusCharacterBridge`) currently do not compile —
+see #7024.
+
+## Next step
+
+Claim #7018 (Ch8 docstring-fidelity: Exercise8_1_4 / 8_2_2 / 8_2_9) — the remaining
+unclaimed docstring-fidelity issue — or pick up #7024 (repair the
+YoungSymTraceKronecker deprecation break).
+
+## Blockers
+
+None for #7019 (complete). #7024 documents a genuine pre-existing build break in a
+CI-excluded infra file.


### PR DESCRIPTION
Closes #7019

Session: `c1cb109e-dea3-4d2f-8d82-c80ee9b0fe49`

bea03ce4 doc(Ch6/Infra #7019): correct stale 'sorry'd blocker/bridge lemma' docstrings in Corollary6_8_4 + FrobeniusCharacterBridge

🤖 Prepared with Claude Code