### PR TITLE
doc(Ch8 #7018): correct stale spec-first/sorry docstrings in Exercise8_1_4, 8_2_2, 8_2_9

### DIFF
--- a/EtingofRepresentationTheory/Chapter8/Exercise8_1_4.lean
+++ b/EtingofRepresentationTheory/Chapter8/Exercise8_1_4.lean
@@ -21,7 +21,8 @@ The direct sum `P₁ ⊕ P₂` is the product module, with inclusions `LinearMap
 * `f ∘ inl = ι ∘ f₁` (the restriction of `f` to `P₁` is `f₁`, viewed inside `M`);
 * `π ∘ (f ∘ inr) = f₂` (the map `P₂ → M → M₂` induced by `f` is `f₂`).
 
-This is a statement-level formalization (spec-first): the proof is deferred (`sorry`).
+The theorem is proved (sorry-free): `P₂` projective lifts `f₂` through the surjection `π`,
+and `f (p₁, p₂) = ι (f₁ p₁) + g₂ p₂` satisfies both conditions.
 -/
 
 namespace Etingof

--- a/EtingofRepresentationTheory/Chapter8/Exercise8_2_2.lean
+++ b/EtingofRepresentationTheory/Chapter8/Exercise8_2_2.lean
@@ -19,7 +19,8 @@ The parenthetical "consisting of free modules" is the standard construction (rep
 module by a free module on its underlying set); Mathlib's `EnoughProjectives (ModuleCat A)`
 instance provides projective covers by free modules, from which the resolution is built.
 
-This is a statement-level formalization (spec-first): the proof is deferred (`sorry`).
+The theorem is proved (sorry-free) via `ProjectiveResolution.of`, which builds the resolution
+from Mathlib's `EnoughProjectives (ModuleCat A)` instance.
 -/
 
 namespace Etingof

--- a/EtingofRepresentationTheory/Chapter8/Exercise8_2_9.lean
+++ b/EtingofRepresentationTheory/Chapter8/Exercise8_2_9.lean
@@ -45,7 +45,7 @@ category abelian via the Hilbert basis theorem (`A` is Noetherian, so submodules
 generated modules are finitely generated); this is what is needed for the categorical notion of
 "enough projectives" to make sense.
 
-These are statement-level formalizations (spec-first): the proofs are deferred (`sorry`).
+All three theorems are proved (sorry-free).
 -/
 
 namespace Etingof

--- a/progress/2026-07-20T21-43-03Z_5a10c717.md
+++ b/progress/2026-07-20T21-43-03Z_5a10c717.md
@@ -1,0 +1,28 @@
+## Accomplished
+Fixed stale "spec-first / proof deferred (`sorry`)" module docstrings in three
+Chapter 8 exercise files (issue #7018), all of which are in fact proved sorry-free:
+- `Chapter8/Exercise8_1_4.lean` (`Exercise_8_1_4`) — lifting maps along a SES.
+- `Chapter8/Exercise8_2_2.lean` (`Exercise_8_2_2`) — every module has a projective resolution.
+- `Chapter8/Exercise8_2_9.lean` (`Exercise_8_2_9_i_finAb`, `_i_polynomial`, `_ii`) —
+  (non)existence of enough projectives.
+
+Before editing each docstring, verified the theorem statement is faithful to its blob
+(`blobs/Chapter8/Exercise8.1.4.md`, `Exercise8.2.2.md`, `Exercise8.2.9.md`) and genuinely
+proved (hypotheses used, conclusion not weakened to `True`/vacuous). No statement was
+weakened to remove a sorry, so no follow-up fidelity issue was needed.
+
+## Current frontier
+Comment/docstring-only edits; no proof, signature, import, or def-body change.
+Comment-stripped scan still reports 0 real `sorry` in each of the three files.
+
+## Overall project progress
+Deep-convergence docstring-fidelity cleanup. One real code `sorry` remains
+project-wide (`Chapter2/Problem2_16_3.lean`, `finrank_g_three`, owned by #6340).
+
+## Next step
+Continue docstring-fidelity sweep on remaining Chapter 8 files not covered here
+(e.g. items flagged by other review issues this cycle), and address the infra
+build-break issue #7024 if still unclaimed.
+
+## Blockers
+None.


### PR DESCRIPTION
Closes #7018

Session: `5a10c717-e348-413c-8147-6ea586f39434`

dda1227c doc(Ch8 #7018): correct stale spec-first/sorry docstrings in Exercise8_1_4, 8_2_2, 8_2_9 (all proved sorry-free)

🤖 Prepared with Claude Code