### PR TITLE
fix(Infra): repair toolchain-drift build break in YoungSymTraceKronecker.lean:62 (mapRangeRingHom_apply deprecation broke simp normal form)

### DIFF
--- a/EtingofRepresentationTheory/Infrastructure/YoungSymTraceKronecker.lean
+++ b/EtingofRepresentationTheory/Infrastructure/YoungSymTraceKronecker.lean
@@ -32,7 +32,7 @@ Both are images of `YoungSymmetrizerZ` (over ℤ) via base change. -/
 private lemma youngSym_coeff_cast (n : ℕ) (la : Nat.Partition n) (σ : Equiv.Perm (Fin n)) :
     (YoungSymmetrizerK ℚ n la σ : ℂ) = YoungSymmetrizer n la σ := by
   rw [YoungSymmetrizerK_eq_mapRange ℚ n la, YoungSymmetrizer_eq_mapRange n la]
-  simp only [MonoidAlgebra.mapRangeRingHom_apply]
+  simp only [MonoidAlgebra.mapRingHom_apply]
   exact_mod_cast rfl
 
 /-- Transfer `c² = α·c` from ℚ to ℂ via the ℤ base change.
@@ -44,8 +44,8 @@ private lemma youngSym_sq_ℂ (n : ℕ) (la : Nat.Partition n)
   -- Key elements
   set cZ := YoungSymmetrizerZ n la
   set β : ℤ := (cZ * cZ) 1
-  set φ_ℚ := MonoidAlgebra.mapRangeRingHom (Equiv.Perm (Fin n)) (Int.castRingHom ℚ)
-  set φ_ℂ := MonoidAlgebra.mapRangeRingHom (Equiv.Perm (Fin n)) (Int.castRingHom ℂ)
+  set φ_ℚ := MonoidAlgebra.mapRingHom (Equiv.Perm (Fin n)) (Int.castRingHom ℚ)
+  set φ_ℂ := MonoidAlgebra.mapRingHom (Equiv.Perm (Fin n)) (Int.castRingHom ℂ)
   -- Relations to base change
   have h_ℚ : YoungSymmetrizerK ℚ n la = φ_ℚ cZ := YoungSymmetrizerK_eq_mapRange ℚ n la
   have h_ℂ : YoungSymmetrizer n la = φ_ℂ cZ := YoungSymmetrizer_eq_mapRange n la
@@ -57,14 +57,14 @@ private lemma youngSym_sq_ℂ (n : ℕ) (la : Nat.Partition n)
   -- Evaluating at 1: α = (β : ℚ)
   have hα_eq : α = (β : ℚ) := by
     have h1 := Finsupp.ext_iff.mp hmul_ℚ 1
-    simp only [MonoidAlgebra.mapRangeRingHom_apply, MonoidAlgebra.smul_apply,
+    simp only [MonoidAlgebra.mapRingHom_apply, MonoidAlgebra.smul_apply,
       smul_eq_mul, hcZ1, map_one, mul_one, φ_ℚ] at h1
     exact h1.symm
   -- Derive cZ * cZ = β • cZ over ℤ (by injectivity of ℤ → ℚ)
   have hZ : cZ * cZ = β • cZ := by
     ext σ
     have h1 := Finsupp.ext_iff.mp hmul_ℚ σ
-    simp only [MonoidAlgebra.mapRangeRingHom_apply, MonoidAlgebra.smul_apply,
+    simp only [MonoidAlgebra.mapRingHom_apply, MonoidAlgebra.smul_apply,
       smul_eq_mul, hα_eq, φ_ℚ] at h1
     have h2 : ((cZ * cZ) σ : ℚ) = ((β * cZ σ : ℤ) : ℚ) := by push_cast; exact h1
     have h3 : (cZ * cZ) σ = β * cZ σ := Int.cast_injective h2
@@ -170,7 +170,7 @@ private lemma mulLeft_youngSym_zero_of_ne (n : ℕ) (la la' : Nat.Partition n) (
 private lemma youngSym_coeff_one (n : ℕ) (la : Nat.Partition n) :
     (YoungSymmetrizer n la : MonoidAlgebra ℂ (Equiv.Perm (Fin n))) 1 = 1 := by
   rw [YoungSymmetrizer_eq_mapRange]
-  simp [MonoidAlgebra.mapRangeRingHom_apply, YoungSymmetrizerZ_apply_one]
+  simp [MonoidAlgebra.mapRingHom_apply, YoungSymmetrizerZ_apply_one]
 
 /-- For any v ∈ V_λ, c * v is proportional to c: c * v = ((c * v)(1)) • c.
 Uses the sandwich property (Lemma5_13_1) and c(1) = 1. -/

--- a/progress/2026-07-20T21-45-29Z_e9afd1fa.md
+++ b/progress/2026-07-20T21-45-29Z_e9afd1fa.md
@@ -1,0 +1,49 @@
+## Accomplished
+
+Fixed the toolchain-drift build break in
+`EtingofRepresentationTheory/Infrastructure/YoungSymTraceKronecker.lean` (issue #7024).
+
+- Root cause: `MonoidAlgebra.mapRangeRingHom` / `MonoidAlgebra.mapRangeRingHom_apply`
+  were deprecated in Mathlib (superseded by `MonoidAlgebra.mapRingHom` /
+  `MonoidAlgebra.mapRingHom_apply`). The deprecation changed the `simp` normal form,
+  so the `simp only [...]` at lines 60-61 no longer reduced `h1` to the shape
+  `Eq.symm h1` needed, producing a hard type mismatch at line 62.
+- Fix: renamed `MonoidAlgebra.mapRangeRingHom` -> `MonoidAlgebra.mapRingHom` throughout
+  (6 occurrences: the two `set φ_ℚ`/`φ_ℂ` bindings and four `simp only`/`simp` lemma
+  references). This matches the already-migrated inlined copy of these lemmas in
+  `Chapter5/Theorem5_22_1.lean` (`youngSym_coeff_cast'`, `youngSym_sq_ℂ'`, etc.),
+  which was the reference for the correct end state.
+- No theorem statements changed; no weakening.
+
+Verification:
+- `lake build EtingofRepresentationTheory.Infrastructure.YoungSymTraceKronecker` — success.
+- `lake build EtingofRepresentationTheory.Infrastructure.FrobeniusCharacterBridge` (sole
+  consumer) — success.
+- `#print axioms Etingof.youngSym_trace_kronecker` (the file's only public result; all
+  else is `private`) reports exactly `[propext, Classical.choice, Quot.sound]`.
+
+Note: a residual `push_neg` deprecation *warning* remains at line 142. It is a warning,
+not an error — the identical `push_neg at hall` in the inlined copy in Theorem5_22_1.lean
+(lines 3218, 3384) builds fine. Left as-is to keep the change minimal and matching the
+reference copy; not part of the build break.
+
+## Current frontier
+
+Issue #7024 complete. These two files remain excluded from CI (they import full Mathlib
++ large chapter environments, >15GB), so they can silently rot again on future toolchain
+bumps. Not addressed here (out of scope) — a CI or scheduled-check change would be a
+separate infra item.
+
+## Overall project progress
+
+Formalization is deep into docstring-fidelity / audit cleanup across chapters. This was a
+pure infrastructure repair (deprecation migration), not new formalization.
+
+## Next step
+
+Remaining unclaimed queue item: #7018 (Ch8 docstring-fidelity — correct stale spec-first
+docstrings in Exercise8_1_4 / Exercise8_2_2 / Exercise8_2_9).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7024

Session: `e9afd1fa-2e6d-4e09-9645-1921b1680d57`

283da36f doc(#7024): progress file for YoungSymTraceKronecker deprecation-migration repair
e22756ed fix(Infra #7024): migrate deprecated MonoidAlgebra.mapRangeRingHom to mapRingHom in YoungSymTraceKronecker

🤖 Prepared with Claude Code