### PR TITLE
feat(Ch5 docstring-fidelity): correct stale 'sole remaining sorry' / 'assembled separately' / #5602 claims in CauchyCharacterRight + Theorem5_23_2_PeterWeyl + TabloidModule (cluster now sorry-free)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/CauchyCharacterRight.lean
+++ b/EtingofRepresentationTheory/Chapter5/CauchyCharacterRight.lean
@@ -52,9 +52,10 @@ right factor. (See #4944 for the history; this corrected a previously false
 The dominant weights `ν ∈ ℕ^N` with `|ν| = d` are exactly the `BoundedPartition N d`
 (`Proposition5_21_1.lean`: an antitone `ν : Fin N → ℕ` with `∑ i, ν i = d`), a
 finite indexing set. The identity is `polyRightDegreeFDRep_formalCharacter`,
-stated here with its proof deferred to the genuine Cauchy/Schur-Weyl core
-(the Cauchy identity + the highest-weight ⟺ `ν ∈ ℕ^N` theory; overlaps
-`iso_of_formalCharacter_eq_schurPoly`, #4699/#4882). An elementary intermediate
+stated and proved (sorry-free) in `CauchyCharacterRightAssembly.lean` via the
+genuine Cauchy/Schur-Weyl core (the Cauchy identity + the highest-weight ⟺
+`ν ∈ ℕ^N` theory; overlaps `iso_of_formalCharacter_eq_schurPoly`,
+#4699/#4882). An elementary intermediate
 form available without Schur-Weyl: the `μ`-weight space of `A_d` has dimension
 `∏_j C(μ_j + N - 1, N - 1)` (monomials with column-degree vector `μ`), so
 `formalCharacter k N (A_d) = ∑_{|μ| = d} (∏_j C(μ_j + N-1, N-1)) · x^μ`; the

--- a/EtingofRepresentationTheory/Chapter5/TabloidModule.lean
+++ b/EtingofRepresentationTheory/Chapter5/TabloidModule.lean
@@ -1153,9 +1153,10 @@ theorem polytabloidTab_linearIndependent :
 
 -- Note: polytabloid_linearIndependent' (group algebra version) was removed because
 -- it depended on the false polytabloid_self_coeff. The correct proof is
--- polytabloidTab_linearIndependent above. The group algebra version
--- (polytabloid_linearIndependent in PolytabloidBasis.lean) remains sorry'd pending
--- a transfer argument from the tabloid module.
+-- polytabloidTab_linearIndependent above. The group-algebra version
+-- (polytabloid_linearIndependent) was likewise retired from the project in favor of
+-- this sorry-free tabloid-level route (see the module docstring of
+-- PolytabloidBasis.lean); no group-algebra transfer argument is needed.
 
 /-! ### Generalized polytabloidTabs
 

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_23_2_PeterWeyl.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_23_2_PeterWeyl.lean
@@ -36,8 +36,9 @@ matrix-coefficient maps `peterWeylSummandMap` (`PeterWeylMatrixCoeff.lean`) via
 is assembled from the per-summand equivariance. This reduces the capstone
 `Theorem5_23_2_ii_equivariant` to a single bijectivity statement
 `peterWeylMap_bijective` (the Cauchy decomposition,
-`PolynomialGLDecomposition.lean` / `CauchyDetQuotient*`), which is the sole remaining
-`sorry` and is being assembled separately.
+`PolynomialGLDecomposition.lean` / `CauchyDetQuotient*`), which is now proved
+sorry-free (as the conjunction of `peterWeylMap_injective` and
+`peterWeylMap_surjective`).
 -/
 
 open scoped TensorProduct
@@ -579,7 +580,8 @@ private theorem aux_detShift_packaging
 Schur module `charTwistRep (det^{-r}) (schurModuleRep k n ν)` (antitone `ν`) is equivariantly
 isomorphic to the irreducible `algIrrepGLRepρ n lam k` for a concrete dominant weight `lam`.
 
-This is the subtle det-shift bookkeeping isolated as a sorry. **Caveat (issue #5602):**
+This is the subtle det-shift bookkeeping, now proved sorry-free below (`aux_detShift_packaging`).
+**Caveat (issue #5602, closed):**
 `DominantWeight.shift` is not free data — `algIrrepGLRepρ n lam k =
 charTwistRep (det^{-lam.shift}) (schurModuleRep k n lam.toNatWeight)` with `lam.toNatWeight =
 lam.val + lam.shift`, and setting `lam.val := ν − r` gives `lam.shift = (r − ν(last)).toNat`, so
@@ -795,9 +797,9 @@ theorem rightHull_le_iSup_range_peterWeylSummandMap
 coefficients of all the irreducibles `L_λ` together span the whole coordinate ring
 `R = k[gᵢⱼ][1/det]`: the ranges of the per-summand maps `peterWeylSummandMap n λ k` have
 supremum `⊤`. Equivalent to `peterWeylMap_surjective` (via `range_toModule_eq_iSup_range`), and
-the sole remaining representation-theoretic obligation of `peterWeylMap_bijective`.
+the key representation-theoretic input to `peterWeylMap_bijective`; now proved sorry-free (below).
 
-**Intended proof route (Etingof §5.23(ii), the Cauchy decomposition of `R`).** This is the
+**Proof route (Etingof §5.23(ii), the Cauchy decomposition of `R`).** This is the
 abstract Peter-Weyl "every regular function is a matrix coefficient" argument:
 
 1. *Finite-dimensional right-translation hull.* Every `φ ∈ R = Localization.Away (detPoly k n)`
@@ -822,13 +824,13 @@ abstract Peter-Weyl "every regular function is a matrix coefficient" argument:
    `peterWeylSummandMap n λ k`; hence the matrix coefficient of `W_φ`, decomposed across the
    `L_λ` summands, lies in `⨆_λ range (peterWeylSummandMap n λ k)`.
 
-The matrix-coefficient correspondence of step 4 is now available
+The matrix-coefficient correspondence of step 4 is available
 (`equivariant_range_le_peterWeylSummandMap`, #5578), and the hull machinery of steps 1–2 is in
 place (`RightTranslationHull.self_mem_rightHull`, `RightTranslationHull.rightHull_isSemisimple`,
-#5577). What remains is the *realization* half of steps 2–4: identifying each simple constituent
+#5577). The *realization* half of steps 2–4 — identifying each simple constituent
 of the semisimple hull with a concrete `L_λ = AlgIrrepGL n λ k` via a `GL_n`-equivariant
-inclusion into `R`. That is isolated as the bridge lemma
-`rightHull_le_iSup_range_peterWeylSummandMap` below. -/
+inclusion into `R` — is the lemma `rightHull_le_iSup_range_peterWeylSummandMap` below, which
+completes the proof. -/
 theorem peterWeylSummandMap_iSup_range_eq_top
     (n : ℕ) (k : Type) [Field k] [IsAlgClosed k] [CharZero k] :
     ⨆ lam, LinearMap.range (peterWeylSummandMap n lam k) = ⊤ := by
@@ -849,10 +851,10 @@ over all dominant weights `λ` of the `L*_λ ⊗ L_λ` isotypic block, i.e. `pet
 element of `R`.
 
 This is the second of the two genuine Cauchy/Peter-Weyl halves of `peterWeylMap_bijective`. The
-Cauchy machinery it consumes (`Cauchy*`, `PolynomialGL*`) is sorry-free; the present obligation is
-its assembly at the level of the localization `R`, i.e. transporting the per-degree polynomial
-decomposition across the determinant localization to the spanning statement for matrix
-coefficients. Tracked as issue #5550. -/
+Cauchy machinery it consumes (`Cauchy*`, `PolynomialGL*`) is sorry-free; this half — its assembly
+at the level of the localization `R`, i.e. transporting the per-degree polynomial decomposition
+across the determinant localization to the spanning statement for matrix coefficients — is now
+proved sorry-free below (issue #5550, closed). -/
 theorem peterWeylMap_surjective (n : ℕ) (k : Type) [Field k] [IsAlgClosed k] [CharZero k] :
     Function.Surjective (peterWeylMap n k) := by
   rw [← LinearMap.range_eq_top]
@@ -895,7 +897,7 @@ theorem Theorem5_23_2_ii_equivariant
       IsEquivariantEquiv (localBiRep k n) (peterWeylRHS n k) e } :=
   -- The equivariant *structure* is assembled here: `peterWeylMap` together with
   -- `peterWeylMap_equivariant` reduce the capstone to `peterWeylMap_bijective`
-  -- (the Cauchy decomposition), the sole remaining sorry.
+  -- (the Cauchy decomposition), now proved sorry-free.
   nonempty_equivariantEquiv_of_bijective n k (peterWeylMap_bijective n k)
 
 end Etingof

--- a/progress/2026-07-20T22-13-21Z_48a810be.md
+++ b/progress/2026-07-20T22-13-21Z_48a810be.md
@@ -1,0 +1,71 @@
+## Accomplished
+
+Feature session on issue #7029 — Ch5 docstring-fidelity sweep of the Cauchy /
+Schur-Weyl / Peter-Weyl realization cluster (comment/docstring-only, no
+signature/def/proof-term changes). Corrected every stale "proof deferred / sole
+remaining sorry / being assembled separately / isolated as a sorry" claim across
+three files, each rewrite grounded in a verified now-proved declaration:
+
+- `Chapter5/CauchyCharacterRight.lean` line 55: the identity
+  `polyRightDegreeFDRep_formalCharacter` was described as "stated here with its
+  proof deferred". It is in fact stated and proved sorry-free in
+  `CauchyCharacterRightAssembly.lean` (verified: theorem at line 92, 0 live
+  sorries). Rewrote to cite the proved location.
+- `Chapter5/Theorem5_23_2_PeterWeyl.lean`: four stale spots fixed —
+  - module docstring (line ~39): `peterWeylMap_bijective` "sole remaining sorry
+    / being assembled separately" → "now proved sorry-free (conjunction of
+    `peterWeylMap_injective` and `peterWeylMap_surjective`)";
+  - the `peterWeylSummandMap_iSup_range_eq_top` docstring (line ~800): "sole
+    remaining representation-theoretic obligation" + "Intended proof route" +
+    "What remains is the realization half ... isolated as the bridge lemma" →
+    reworded to present tense (proved), preserving the step 1–4 exposition and
+    dropping the banned word "bridge";
+  - `peterWeylMap_surjective` docstring (line ~855): "the present obligation is
+    its assembly ... Tracked as issue #5550" → "now proved sorry-free below
+    (issue #5550, closed)";
+  - `exists_dominantWeight_algIrrepGL_iso_detTwistNeg_schurModule` docstring
+    (line ~582): "isolated as a sorry. Caveat (issue #5602)" → "now proved
+    sorry-free below (`aux_detShift_packaging`). Caveat (issue #5602, closed)",
+    preserving the det-shift mathematical exposition.
+- `Chapter5/TabloidModule.lean` line ~1157: comment claimed the group-algebra
+  `polytabloid_linearIndependent` in `PolytabloidBasis.lean` "remains sorry'd
+  pending a transfer argument". Verified against PolytabloidBasis.lean module
+  docstring: that declaration was *retired* from the project (no longer exists),
+  in favor of the sorry-free tabloid-level `polytabloidTab_linearIndependent`.
+  Rewrote to say so.
+
+Verification:
+- issue-spec grep (`remaining sorry|sole remaining|being assembled
+  separately|proof deferred|remains sorry'?d|isolated as a sorry`) returns no
+  stale claim in any of the three files.
+- live-sorry count 0 in all three files (and in the cross-referenced
+  `CauchyCharacterRightAssembly.lean` and `PolytabloidBasis.lean`).
+- referenced issues #5550 and #5602 confirmed CLOSED.
+- `#print axioms` on `polyRightDegreeFDRep_formalCharacter`,
+  `Theorem5_23_2_ii_equivariant`, `peterWeylMap_bijective`,
+  `polytabloidTab_linearIndependent` — all `[propext, Classical.choice,
+  Quot.sound]`, no `sorryAx`.
+- `lake build` of all three modules succeeds (8691 jobs). No new linter
+  warnings introduced (shortened one rewritten line to stay under the 100-char
+  limit; remaining longLine/maxHeartbeats warnings are pre-existing).
+- `git diff` shows only comment/docstring lines changed in the three files.
+
+## Current frontier
+
+Issue #7029 deliverables complete. Ready for PR.
+
+## Overall project progress
+
+Project remains sorry-free everywhere except `finrank_g_three`
+(`Chapter2/Problem2_16_3.lean`, #6340, still claimed). This continues the
+docstring-fidelity sweep (#7009/#7010/#7016/#7017). Two sibling Ch2
+docstring-fidelity issues (#7027, #7028) remain unclaimed.
+
+## Next step
+
+Pick up #7027 or #7028 (Ch2 docstring fidelity) — same comment-only pattern,
+simpler (single-file, no cross-file / historical-issue references).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7029

Session: `48a810be-ca02-4141-9115-35674812422c`

332f9860 doc(Ch5 #7029): correct stale sorry'd/deferred docstrings in Cauchy/Peter-Weyl realization cluster

🤖 Prepared with Claude Code