### PR TITLE
feat(Ch6 docstring-fidelity): correct stale '## Remaining sorry' recovery-lemma block in Corollary6_8_3 (file sorry-free; mirrors #7019 Corollary6_8_4 fix)

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/Corollary6_8_3.lean
+++ b/EtingofRepresentationTheory/Chapter6/Corollary6_8_3.lean
@@ -24,12 +24,17 @@ Since both reps have the same dimension vector, they make the same choice. In th
 case, `simpleAt_iso` gives the isomorphism. In the surjective case, we apply F⁺ and
 recurse on the reversed quiver.
 
-## Remaining sorry
+## Recovery lemma
 
 The **recovery lemma** (F⁺(ρ₁) ≅ F⁺(ρ₂) → ρ₁ ≅ ρ₂ when both have surjective sink maps)
-requires:
-1. F⁻ functoriality: constructing F⁻(iso) from an iso between F⁺ outputs
-2. Composition with Proposition 6.6.6 round-trip: ρ ≅ F⁻(F⁺(ρ))
+is fully proved in `parallel_reduce_and_recover`. It combines:
+1. F⁻ functoriality (`reflectionFunctorMinus_map_iso`): building F⁻(iso) from an iso
+   between F⁺ outputs;
+2. the Proposition 6.6.6 round-trip `ρ ≅ F⁻(F⁺(ρ))` (`Proposition6_6_6_sink`),
+   transported across `reversedAtVertex_twice` and composed on both sides.
+
+This file is sorry-free (`#print axioms Etingof.Corollary6_8_3` reports only
+`[propext, Classical.choice, Quot.sound]`).
 -/
 
 open scoped Matrix
@@ -163,8 +168,8 @@ Since both representations have the same dimension vector, they make the same
 **Inductive step**: both are surjective at the sink → apply F⁺ → recurse on
 reversed quiver → recover isomorphism via Prop 6.6.6 (round-trip theorem).
 
-**Key sorry**: The recovery lemma (F⁺(ρ₁) ≅ F⁺(ρ₂) → ρ₁ ≅ ρ₂) requires
-F⁻ functoriality + composing with the round-trip theorem. -/
+**Recovery lemma**: The recovery step (F⁺(ρ₁) ≅ F⁺(ρ₂) → ρ₁ ≅ ρ₂) is proved in the
+inductive step below by F⁻ functoriality composed with the Prop 6.6.6 round-trip. -/
 private lemma Etingof.parallel_reduce_and_recover
     {n : ℕ} {adj : Matrix (Fin n) (Fin n) ℤ}
     (hDynkin : Etingof.IsDynkinDiagram n adj)

--- a/progress/2026-07-20T23-12-51Z_c81176dc.md
+++ b/progress/2026-07-20T23-12-51Z_c81176dc.md
@@ -1,0 +1,41 @@
+## Accomplished
+
+Closed issue #7032 (Ch6 docstring-fidelity): corrected the stale `## Remaining sorry`
+block in `EtingofRepresentationTheory/Chapter6/Corollary6_8_3.lean`.
+
+- Verified the file is genuinely complete: `#print axioms Etingof.Corollary6_8_3`
+  reports exactly `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no custom
+  axioms. Comment-stripped `sorry` count is 0 (the only remaining `sorry` tokens were
+  the stale docstring/comment prose corrected here).
+- Rewrote the module-level `## Remaining sorry` section (lines 27-33) into a
+  `## Recovery lemma` section that truthfully states the recovery lemma
+  (F⁺(ρ₁) ≅ F⁺(ρ₂) → ρ₁ ≅ ρ₂) is fully proved in `parallel_reduce_and_recover`
+  via F⁻ functoriality (`reflectionFunctorMinus_map_iso`) composed with the
+  Prop 6.6.6 round-trip (`Proposition6_6_6_sink`), transported across
+  `reversedAtVertex_twice`.
+- Fixed the inline `**Key sorry**` comment in the `parallel_reduce_and_recover`
+  docstring to describe the completed recovery step.
+- Confirmed statement fidelity against `blobs/Chapter6/Corollary6.8.3.md` (unchanged;
+  no proof/signature/import/def-body touched).
+- `lake build` of the module exits 0 (comment-only change).
+
+Mirrors the #7019 `Corollary6_8_4` stale-docstring correction.
+
+## Current frontier
+
+Docstring-fidelity cleanups across chapters. Two sibling issues remain unclaimed:
+#7033 (Ch5 det⁻¹ banner) and #7034 (Ch3 axiom-cleanliness review).
+
+## Overall project progress
+
+Formalization essentially complete; only one genuine code `sorry` remains project-wide
+(`Chapter2/Problem2_16_3.lean`, G₂ `finrank_g_three`, owned by #6340). Remaining work is
+docstring/comment fidelity cleanup and report-only audits.
+
+## Next step
+
+A worker can claim #7033 or #7034 (both same class of low-risk fidelity work).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7032

Session: `c81176dc-a01a-4ec2-be60-0f85fbab65bc`

592efe4a doc(Ch6 #7032): correct stale '## Remaining sorry' block in Corollary6_8_3 (file sorry-free)

🤖 Prepared with Claude Code