### PR TITLE
feat(Ch5 docstring-fidelity): correct stale 'TODO: the genuine proof' det⁻¹-elimination banner above detInv_elim_of_polynomial in PolynomialRepEmbedding (now proved, 0 sorries)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/PolynomialRepEmbedding.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialRepEmbedding.lean
@@ -944,11 +944,14 @@ counterexample, with ℤ-weights `(1,-1),(0,0),(-1,1)`, fails `h_span` precisely
 because its negative-entry weights leave the `ℕ`-indexed weight spaces
 non-spanning). No homogeneity is asserted here; that is `matrixCoeff_isHomogeneous`.
 
-TODO (issue #4654 sub, det⁻¹ elimination): the genuine proof. Routes: (a) book's
-structural route — `R` (the matrix-coefficient ring) decomposes through
-`Sⁿ(V ⊗ V*) ⊗ (∧ᴺV*)^s` and `h_span` forces `s = 0`; (b) monoid-extension —
-`ρ : GLₙ → GL(M)` with all weights `≥ 0` extends to `Mₙ(k) → End(M)`, whose
-matrix coefficients are the bare polynomials. -/
+The det⁻¹ elimination is proved (issue #4695, completing the #4654 sub-task):
+the argument is packaged in `Etingof.DetInvElim.detInv_elim`, which realizes the
+monoid-extension route constructively. Starting from the kernel lemma
+(`Etingof.KernelLemmaK` / `KernelLemmaKPrime`, #4694) it builds a weight-eigenbasis
+of `M` and runs the right-translation argument: `h_span` (all weights `≥ 0`) forces
+the a-priori `det⁻¹` denominators to cancel, so `ρ : GLₙ → GL(M)` extends to
+`Mₙ(k) → End(M)` and the matrix coefficients are the bare polynomials `Q` produced
+here. This delegating theorem is the file's interface to that development. -/
 private theorem detInv_elim_of_polynomial (n : ℕ) [CharZero k] [IsAlgClosed k]
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
     (halg : Etingof.IsAlgebraicRepresentation N M.ρ)

--- a/progress/2026-07-20T23-22-13Z_d873c7b9.md
+++ b/progress/2026-07-20T23-22-13Z_d873c7b9.md
@@ -1,0 +1,32 @@
+## Accomplished
+Issue #7033 (Ch5 docstring-fidelity). Corrected the stale
+`TODO (issue #4654 sub, det⁻¹ elimination): the genuine proof` banner above
+`private theorem detInv_elim_of_polynomial` in
+`EtingofRepresentationTheory/Chapter5/PolynomialRepEmbedding.lean`. The theorem
+has a real, complete proof (delegates to `Etingof.DetInvElim.detInv_elim`), so the
+"the genuine proof is pending" framing was wrong. Rewrote the block to describe the
+completed monoid-extension / kernel-lemma / weight-eigenbasis / right-translation
+argument (issue #4695, #4694). Preserved the accurate multi-homogeneity-does-not-imply-
+divisibility exposition and the `h_span` counterexample untouched.
+
+Verified before editing:
+- comment-stripped genuine `sorry` count for the file = 0
+- `#print axioms detInv_elim_of_polynomial` = [propext, Classical.choice, Quot.sound]
+  (no sorryAx)
+- `lake build` of the module succeeds (8656 jobs; only pre-existing lint warnings)
+
+## Current frontier
+Docstring-fidelity cleanup of Ch5. One sibling issue (#7037, SchurModuleSpecialBlock)
+remains unclaimed in the same theme.
+
+## Overall project progress
+Formalization essentially complete; project-wide only one genuine code `sorry`
+remains (`Chapter2/Problem2_16_3.lean`, owned by #6340). Remaining work is
+docstring/comment fidelity: stale TODO/deferred banners outliving their proofs.
+
+## Next step
+A worker can claim #7037 (same docstring-fidelity theme in
+`Chapter5/SchurModuleSpecialBlock.lean`).
+
+## Blockers
+None.


### PR DESCRIPTION
Closes #7033

Session: `d873c7b9-b0be-41b3-aa67-4cbfc2cd72b7`

3bf91d6c doc(Ch5 #7033): correct stale 'TODO: the genuine proof' det⁻¹-elimination banner in PolynomialRepEmbedding (proved, 0 sorries)

🤖 Prepared with Claude Code