### PR TITLE
feat(Ch5 docstring-fidelity): correct stale 'proof is still open / long-term blocker' claim about Theorem5_23_2_i in SimpleSubrepExtraction (now proved sorry-free)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/SimpleSubrepExtraction.lean
+++ b/EtingofRepresentationTheory/Chapter5/SimpleSubrepExtraction.lean
@@ -16,12 +16,12 @@ part-(a) lemma `quotDetRep_irreducible_constituent_lastWeight_zero`
 
 ## Why a minimal invariant submodule, not complete reducibility
 
-`Theorem5_23_2_i` now states genuine complete reducibility
-(`IsSemisimpleModule k[GL_N] ρ.asModule`), but its proof is still open (the GL_N
-complete-reducibility infrastructure is a long-term blocker), so we cannot consume
-it here. Instead we take a *minimal nonzero invariant submodule* (an **atom** of
-the `k[GL_N]`-submodule lattice), which is simple as a representation without any
-complete-reducibility input.
+`Theorem5_23_2_i` now provides genuine complete reducibility
+(`IsSemisimpleModule k[GL_N] ρ.asModule`) and is proved sorry-free. We do not need
+to consume that theorem here, though: instead we take a *minimal nonzero invariant
+submodule* (an **atom** of the `k[GL_N]`-submodule lattice), which is simple as a
+representation without any complete-reducibility input. Retaining this route by
+design keeps the part-(a) construction elementary and self-contained.
 
 Two ingredients make this work:
 

--- a/progress/2026-07-20T23-23-29Z_17512508.md
+++ b/progress/2026-07-20T23-23-29Z_17512508.md
@@ -1,0 +1,34 @@
+## Accomplished
+
+Executed feature issue #7039 (Ch5 docstring-fidelity). Corrected the stale
+"Why a minimal invariant submodule, not complete reducibility" docstring block
+in `EtingofRepresentationTheory/Chapter5/SimpleSubrepExtraction.lean`. The block
+claimed `Theorem5_23_2_i`'s proof was "still open" and the GL_N
+complete-reducibility infrastructure a "long-term blocker". Both are stale:
+`Theorem5_23_2_i` in `Chapter5/Theorem5_23_2.lean` is now proved sorry-free, and
+`SimpleSubrepExtraction.lean` itself is sorry-free (both confirmed via
+comment-stripped `grep -nE '\bsorry\b'` = 0 matches).
+
+Reworded the clause to state that the semisimple theorem is now proved, and that
+the minimal-invariant-submodule route is retained *by design* (elementary,
+self-contained) rather than out of necessity. Preserved the two
+"Finite-dimensional reduction" / "Atom of a finite module" bullets verbatim.
+
+## Current frontier
+
+Comment/docstring-only change; diff limited to the `/-! -/` module docstring.
+No signatures, imports, def/instance bodies, or proof terms touched.
+
+## Overall project progress
+
+Stage 3 formalization ongoing; docstring-fidelity cleanup sweep across Ch5.
+Sibling docstring-fidelity issues #7041, #7042 remain unclaimed.
+
+## Next step
+
+A worker can claim #7041 or #7042 (same class of stale-docstring corrections in
+DetIrreducible / PolynomialTensorBridge).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7039

Session: `17512508-4c20-45d0-a0f0-383131b4594f`

ff0511fa doc(Ch5 #7039): correct stale 'proof still open / long-term blocker' claim about Theorem5_23_2_i in SimpleSubrepExtraction (both files sorry-free)

🤖 Prepared with Claude Code