### PR TITLE
feat(Ch5 docstring-fidelity): correct stale '## Status: equivariance deferred to a sibling issue' block in PolynomialTensorBridge (homogeneousPolyToTensor_equivariant proved sorry-free in-file)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/PolynomialTensorBridge.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialTensorBridge.lean
@@ -40,16 +40,17 @@ zero this is an iso onto its image.
 ## Main results
 
 * `homogeneousPolyToTensor_injective` — the bridge is injective.
+* `polyToTensor_rightTransl_of_isHomogeneous` — on homogeneous degree-`n`
+  polynomials, the bridge intertwines the right-translation action
+  `g · P(X) = P(X·g)` with the `g^⊗n ⊗ id` action on the tensor target.
+* `homogeneousPolyToTensor_equivariant` — the packaged GL_N-equivariance
+  statement on `homogeneousSubmodule`, built on the previous result.
 
-## Status
-
-Equivariance of the bridge under the GL_N-right-translation action on
-polynomials vs. the `g ↦ g^⊗n ⊗ 1` action on the tensor target is the
-intended companion property. It is deferred to a sibling issue so that
-the construction and injectivity land first (injectivity is the key
-property that `#2478` consumes via the left-inverse — equivariance will
-be stated and proved alongside the final `polynomialRep_embeds_in_tensorPower`
-assembly).
+Both the injectivity and equivariance properties are proved here, sorry-free.
+Injectivity is the property that `#2478` consumes via the left-inverse;
+equivariance records that the two actions being intertwined
+(right-translation `g · P(X) = P(X·g)` on polynomials vs. `g ↦ g^⊗n ⊗ 1`
+on `V^⊗n ⊗ (V^*)^⊗n`) agree under the bridge.
 -/
 
 open scoped TensorProduct

--- a/progress/2026-07-20T23-27-59Z_0af063db.md
+++ b/progress/2026-07-20T23-27-59Z_0af063db.md
@@ -1,0 +1,35 @@
+## Accomplished
+
+Resolved #7042 (Ch5 docstring-fidelity). Rewrote the stale `## Status` block
+in `EtingofRepresentationTheory/Chapter5/PolynomialTensorBridge.lean` that
+claimed GL_N-equivariance of the bridge was "deferred to a sibling issue" and
+"will be stated and proved alongside" a later assembly. Both claims were false:
+equivariance is proved sorry-free in this file.
+
+- Folded the `## Status` block into `## Main results`, dropping the deferred
+  language and rewording the genuine exposition (the two intertwined actions:
+  right-translation `g · P(X) = P(X·g)` vs. `g ↦ g^⊗n ⊗ 1`) to present tense.
+- Added `polyToTensor_rightTransl_of_isHomogeneous` and
+  `homogeneousPolyToTensor_equivariant` to the `## Main results` inventory.
+
+Comment/docstring-only change; no signature, import, or proof-body touched.
+
+## Current frontier
+
+Done. `lake build EtingofRepresentationTheory.Chapter5.PolynomialTensorBridge`
+succeeds (8585 jobs, only pre-existing style linter warnings). File remains
+sorry-free (0 matches). No "deferred to a sibling issue" / "will be stated and
+proved alongside" strings remain.
+
+## Overall project progress
+
+Chapter-5 docstring-fidelity sweep continues. This issue is a sibling of
+#7041, #7033, #7037, #7039, #7029/#7036.
+
+## Next step
+
+Pick up the next unclaimed feature issue.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7042

Session: `0af063db-ba8a-4a5b-aa13-f8f6635dc791`

bef88095 doc(Ch5 #7042): correct stale '## Status: equivariance deferred' block in PolynomialTensorBridge (homogeneousPolyToTensor_equivariant proved sorry-free in-file)

🤖 Prepared with Claude Code