### PR TITLE
feat(Ch2 docstring-fidelity): correct stale 'Parts (a) and (b) are recorded here as sorry statements / statement pass' block in Problem2_5_2 (both parts proved sorry-free; part (c) deferral genuine)

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Problem2_5_2.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_5_2.lean
@@ -17,11 +17,10 @@ A vector `v` is cyclic when `Submodule.span A {v} = ⊤` (the `A`-submodule it g
 `V`). Irreducibility is `IsSimpleModule A V`. Left ideals of `A` are `Submodule A A`, and `A/I` is
 the quotient module.
 
-Parts (a) and (b) are recorded here as `sorry` statements. Part (c) — the explicit example
+Parts (a) and (b) are proved sorry-free below, as `irreducible_iff_forall_cyclic` and
+`cyclic_iff_isoQuotient` respectively. Part (c) — the explicit example
 `A = ℂ[x, y]/I₂` acting on `V = A^*` by `(ρ(a)f)(b) = f(ba)` — requires constructing the coregular
 module structure and is deferred to a dedicated follow-up item.
-
-This is the **statement pass**.
 -/
 
 namespace Etingof.Problem2_5_2

--- a/progress/2026-07-20T23-28-12Z_64e3f96b.md
+++ b/progress/2026-07-20T23-28-12Z_64e3f96b.md
@@ -1,0 +1,43 @@
+## Accomplished
+
+Feature session for issue #7046 (Ch2 docstring-fidelity). Corrected the stale
+module docstring in `EtingofRepresentationTheory/Chapter2/Problem2_5_2.lean`:
+
+- Rewrote the sentence claiming "Parts (a) and (b) are recorded here as `sorry`
+  statements" to truthfully state both parts are proved sorry-free, naming the
+  two theorems `irreducible_iff_forall_cyclic` (2.5.2a) and
+  `cyclic_iff_isoQuotient` (2.5.2b).
+- Removed the trailing "This is the **statement pass**." line.
+- Preserved the genuine part-(c) deferral note verbatim in substance.
+
+Comment/docstring-only change (2 insertions, 3 deletions). No signature, proof,
+import, or def body touched.
+
+## Current frontier
+
+Verification complete:
+- `grep -nE '\bsorry\b'` returns only the corrected prose on line 20 (truthful
+  "proved sorry-free" reference), no live `sorry`.
+- `#print axioms` for both theorems reports `[propext, Classical.choice,
+  Quot.sound]` — no `sorryAx`.
+- `lake build EtingofRepresentationTheory.Chapter2.Problem2_5_2` succeeds.
+
+## Overall project progress
+
+Ongoing docstring-fidelity sweep across chapters (siblings: #7027/#7028/#7035
+Ch2; #7029/#7032/#7036 elsewhere). This continues correcting stale
+statement-first-phase docstrings on files that are now fully proved.
+
+## Next step
+
+PR created for #7046 with auto-merge enabled. Next worker picks the oldest
+unclaimed `feature` issue.
+
+## Blockers
+
+None.
+
+Note: the worktree carried pre-existing uncommitted changes to
+`.claude/commands/review.md`, `.claude/commands/summarize.md`, and
+`.claude/skills/agent-worker-flow/SKILL.md` from a prior session. These are
+unrelated to this issue and were left untouched / excluded from this PR.


### PR DESCRIPTION
Closes #7046

Session: `64e3f96b-1b44-4c20-b68f-22bd734ddce6`

84169d2c chore(#7046): progress entry for Problem2_5_2 docstring fidelity fix
b322627d doc(Ch2 #7046): correct stale 'sorry statements / statement pass' docstring in Problem2_5_2

🤖 Prepared with Claude Code