### PR TITLE
feat(Ch5 docstring-fidelity): correct stale 'Statement pass / with sorry proofs' banner in Problem5_11_1 (all A5 induced-rep decompositions proved sorry-free)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Problem5_11_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_11_1.lean
@@ -70,9 +70,11 @@ The resulting decompositions (dimensions in parentheses; `[G:H]·dim ρ` on the 
   * `Ind 1 ≅ 1 ⊕ 4 ⊕ 5²` (`15`) — the coset permutation representation;
   * each nontrivial `Ind χᵢ ≅ 3 ⊕ 3' ⊕ 4 ⊕ 5` (`15`).
 
-Statement pass: every decomposition is stated as `Nonempty (Ind_H^G ρ ≅ ⊞ …)` in `FDRep ℂ A₅`,
-with `sorry` proofs. `Ind_H^G` is `Etingof.Definition5_8_1`; the target biproducts use the
-catalogue objects `repTriv, repC3plus, repC3minus, repC4, repC5`.
+Every decomposition is stated as `Nonempty (Ind_H^G ρ ≅ ⊞ …)` in `FDRep ℂ A₅` and proved
+sorry-free, via character additivity over binary biproducts (`character_biprod`) together with
+the per-case induced-character computations (`ind_character_eq`). `Ind_H^G` is
+`Etingof.Definition5_8_1`; the target biproducts use the catalogue objects
+`repTriv, repC3plus, repC3minus, repC4, repC5`.
 -/
 
 open CategoryTheory CategoryTheory.Limits Etingof.Example4_8_1 Etingof.Example4_8_1.A5 Module

--- a/progress/2026-07-20T23-58-31Z_3cad4f95.md
+++ b/progress/2026-07-20T23-58-31Z_3cad4f95.md
@@ -1,0 +1,29 @@
+## Accomplished
+Resolved docstring-fidelity issue #7049 for `EtingofRepresentationTheory/Chapter5/Problem5_11_1.lean`.
+Rewrote the stale `Statement pass: ... with sorry proofs` sentence in the module docstring
+(lines ~73-75). It now truthfully states that every induced-representation decomposition is
+stated as `Nonempty (Ind_H^G ρ ≅ ⊞ …)` in `FDRep ℂ A₅` and **proved sorry-free**, via character
+additivity over binary biproducts (`character_biprod`) together with the per-case induced-character
+computations (`ind_character_eq`). Preserved verbatim in substance the accurate factual clauses:
+`Ind_H^G` is `Etingof.Definition5_8_1` and the targets use the catalogue objects
+`repTriv, repC3plus, repC3minus, repC4, repC5`.
+
+## Current frontier
+Comment/docstring-only change. No signature, proof term, import, or `def`/`abbrev` body touched.
+The (a)-(e) decomposition enumeration above the edited sentence is unchanged.
+
+## Overall project progress
+Ongoing docstring-fidelity sweep. This file's module docstring is now accurate; the file remains
+sorry-free.
+
+## Next step
+No follow-up for this file. Continue the docstring-fidelity sweep on remaining sibling files.
+
+## Blockers
+None.
+
+## Verification
+- Live-sorry scan (comment-stripped) returns nothing before and after the edit.
+- `git diff` shows only comment/docstring lines changed.
+- `lake build EtingofRepresentationTheory.Chapter5.Problem5_11_1` succeeds (8602 jobs;
+  only pre-existing unused-DecidablePred linter warnings).


### PR DESCRIPTION
Closes #7049

Session: `3cad4f95-1a7d-4e2a-8ccc-ed04a9fa54f3`

0a7b39d2 doc(Ch5 #7049): correct stale 'Statement pass / with sorry proofs' banner in Problem5_11_1 (all A5 induced-rep decompositions proved sorry-free)

🤖 Prepared with Claude Code