### PR TITLE
feat(Ch4 docstring-fidelity): correct stale '(deferred; see the sub-issue)' bullet on simpleModuleClassesPiEquiv in Exercise4_2_3_SemisimpleBaseChange (proved sorry-free at line 359)

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Exercise4_2_3_SemisimpleBaseChange.lean
+++ b/EtingofRepresentationTheory/Chapter4/Exercise4_2_3_SemisimpleBaseChange.lean
@@ -31,7 +31,7 @@ The count is assembled from four reusable building blocks:
 * `simpleModuleClassesCongr` — transport iso-classes of simple modules across an
   equivalence of module categories (proved here).
 * `simpleModuleClassesPiEquiv` — the simple modules of a finite product of rings are the
-  disjoint union of the simple modules of the factors (deferred; see the sub-issue).
+  disjoint union of the simple modules of the factors (proved here).
 * `simpleModuleClassesMatrixEquiv` — Morita: a matrix ring has the same simple count as
   its base ring (proved here from `ModuleCat.matrixEquivalence`).
 * `nonempty_simpleModuleClasses` / `subsingleton_simpleModuleClasses_divisionRing` —

--- a/progress/2026-07-20T23-58-42Z_6f955715.md
+++ b/progress/2026-07-20T23-58-42Z_6f955715.md
@@ -1,0 +1,25 @@
+## Accomplished
+Feature session for issue #7054 (docstring-fidelity, Ch4). Corrected the stale
+`(deferred; see the sub-issue)` parenthetical on the `simpleModuleClassesPiEquiv`
+bullet in the module docstring of
+`EtingofRepresentationTheory/Chapter4/Exercise4_2_3_SemisimpleBaseChange.lean`
+(line 34) to `(proved here)`, matching its three sibling bullets. The equiv is a
+fully constructed sorry-free `private noncomputable def` at line 359, used by
+`natCard_simpleModuleClasses_pi` at line 374. Comment/docstring-only edit — no
+signature, body, import, or proof term touched.
+
+## Current frontier
+Change built cleanly (`lake build ...Exercise4_2_3_SemisimpleBaseChange`, 8584
+jobs). File remains sorry-free. Ready to publish PR.
+
+## Overall project progress
+Stage 3 formalization + ongoing docstring-fidelity sweep. This is one more
+stale-docstring correction in the Exercise 4.2.3 family (siblings #7042, #7041,
+#7046, SplitSimples companion).
+
+## Next step
+Publish PR closing #7054 with auto-merge. Remaining sibling in the queue: #7055
+(Ch2 Exercise2_11_5 module-part docstring).
+
+## Blockers
+None.


### PR DESCRIPTION
Closes #7054

Session: `6f955715-b85c-4e9f-90be-23fd5242944a`

a8ac1125 progress: 2026-07-20T23-58-42Z docstring fix #7054
79eb0a67 doc(Ch4 #7054): correct stale '(deferred; see the sub-issue)' bullet on simpleModuleClassesPiEquiv (proved sorry-free at line 359)

🤖 Prepared with Claude Code