### PR TITLE
feat(Ch2 docstring-fidelity): correct stale 'classification of irreducibles is the deferred content / recorded as the spec' clause in Problem2_16_5 (both q-cases proved sorry-free: highest-weight existence + finrank bound)

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Problem2_16_5.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_16_5.lean
@@ -22,9 +22,22 @@ denominators so they are well-typed for every `q` (the coefficient `q - q⁻¹` 
   `K L = 1`,  `L K = 1`,  `K e = q²·(e K)`,  `K f = q⁻²·(f K)`,
   `(q - q⁻¹)·(e f - f e) = K - L`.
 
-The algebra and its generators are genuine (not sorried). The classification of irreducibles
-is the deferred content; we record the core structural statement (existence of a highest
-weight vector on any finite dimensional representation) as the spec.
+The algebra and its generators are genuine (not sorried). Substantial classification content
+for both cases is proved sorry-free in-file:
+
+* **`q` not a root of unity**: every nontrivial finite dimensional representation has a highest
+  weight vector (`exists_highest_weight_vector`), and on a simple such module the highest weight
+  eigenvalue of `K` is pinned down as `ε · q^(dim V - 1)` with `ε² = 1`
+  (`highest_weight_eigenvalue_of_not_isOfFinOrder`).
+* **`q` a root of unity**: `K` acts semisimply with the expected eigenvalue structure
+  (`Kop_isSemisimple_and_eigenvalues`), `K^(orderOf q)` acts as a scalar
+  (`Kpow_orderOf_isScalar`), and every finite dimensional simple module has bounded dimension,
+  `finrank ℂ V ≤ orderOf q` (`finrank_irreducible_le_of_isOfFinOrder`, assembled from
+  `finrank_le_of_epow_orderOf_eq_zero`, `finrank_le_of_fpow_orderOf_eq_zero`, and
+  `finrank_le_of_cyclic`).
+
+These are the core structural results of the classification; a complete enumeration of the
+irreducibles up to isomorphism is not assembled here.
 -/
 
 namespace Etingof.Problem2_16_5

--- a/progress/2026-07-21T00-33-16Z_27f42e0c.md
+++ b/progress/2026-07-21T00-33-16Z_27f42e0c.md
@@ -1,0 +1,30 @@
+## Accomplished
+Docstring-fidelity fix for #7057: corrected the stale statement-first-phase
+claim in `EtingofRepresentationTheory/Chapter2/Problem2_16_5.lean`. The
+`## Construction` section previously said "the classification of irreducibles
+is the deferred content; we record ... existence of a highest weight vector
+... as the spec." That understated the file: it proves substantial
+classification content sorry-free for both cases. Rewrote the final paragraph
+to name the proved results:
+- q not a root of unity: `exists_highest_weight_vector`,
+  `highest_weight_eigenvalue_of_not_isOfFinOrder`.
+- q a root of unity: `Kop_isSemisimple_and_eigenvalues`,
+  `Kpow_orderOf_isScalar`, `finrank_irreducible_le_of_isOfFinOrder`
+  (assembled from the three finrank helper lemmas).
+Explicitly noted a complete enumeration up to isomorphism is not assembled,
+to avoid overclaiming.
+
+## Current frontier
+Comment/docstring-only edit. No signature, proof term, or import touched.
+File remains sorry-free; `lake build` of the module succeeds.
+
+## Overall project progress
+Stage 3 formalization; ongoing docstring-fidelity sweep correcting stale
+deferral claims on now-proved files.
+
+## Next step
+Continue the docstring-fidelity sweep — e.g. #7055 (Exercise2_11_5) remains
+unclaimed.
+
+## Blockers
+None.


### PR DESCRIPTION
Closes #7057

Session: `27f42e0c-22e0-4e81-ac8b-65c6497a57bd`

3dbafeee doc(Ch2 #7057): correct stale 'classification of irreducibles is the deferred content / recorded as the spec' clause in Problem2_16_5 (both q-cases proved sorry-free)

🤖 Prepared with Claude Code