### PR TITLE
feat(Ch4 docstring-fidelity): correct stale 'Enumeration and count (deferred) ... proved in the follow-up sub-issue' claims in Exercise4_2_3_SplitSimples (Std_injective / exists_Std_linearEquiv / card_simpleModuleClasses proved sorry-free in-file)

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Exercise4_2_3_SplitSimples.lean
+++ b/EtingofRepresentationTheory/Chapter4/Exercise4_2_3_SplitSimples.lean
@@ -26,8 +26,9 @@ column-representation machinery, so the enumeration survives.
 * `SplitData.Std D i := Fin (D.d i) → K` — the `i`-th standard module, a simple, finite-dimensional
   `K[G]`-module with `IsScalarTower K (MonoidAlgebra K G) (D.Std i)`.
 
-The enumeration (`Std` pairwise non-isomorphic and exhaustive) and the resulting count
-`Nat.card (SimpleModuleClasses K[G]) = n` are stated here and proved in the follow-up.
+The enumeration (`Std` pairwise non-isomorphic via `Std_injective` and exhaustive via
+`exists_Std_linearEquiv`) and the resulting count `Nat.card (SimpleModuleClasses K[G]) = n`
+(`card_simpleModuleClasses` / `exists_splitSimples_count`) are proved sorry-free below.
 
 ## References
 
@@ -161,14 +162,15 @@ theorem isSimpleModule_Std (D : SplitData K G) (i : Fin D.n) :
     inferInstanceAs (IsSimpleModule (Matrix (Fin (D.d i)) (Fin (D.d i)) K) (Fin (D.d i) → K))
   exact IsSimpleModule.compHom (D.blockHom i).toRingHom (D.blockHom_surjective i)
 
-/-! ### Enumeration and count (deferred)
+/-! ### Enumeration and count
 
-The three remaining facts — the standard modules are pairwise non-isomorphic, they exhaust the
-simple `K[G]`-modules, and the resulting count `Nat.card (SimpleModuleClasses K[G]) = n` — mirror
-`IrrepDecomp.columnFDRep_injective` / `columnFDRep_surjective` / `n_eq_card_simples` from
-`Infrastructure/IrreducibleEnumeration.lean`, with the algebra isomorphism replaced by the
-surjection `π` (only surjectivity is used in that machinery). They are stated here and proved in
-the follow-up sub-issue. -/
+The three remaining facts — the standard modules are pairwise non-isomorphic (`Std_injective`),
+they exhaust the simple `K[G]`-modules (`exists_Std_linearEquiv`), and the resulting count
+`Nat.card (SimpleModuleClasses K[G]) = n` (`card_simpleModuleClasses` /
+`exists_splitSimples_count`) — mirror `IrrepDecomp.columnFDRep_injective` / `columnFDRep_surjective`
+/ `n_eq_card_simples` from `Infrastructure/IrreducibleEnumeration.lean`, with the algebra
+isomorphism replaced by the surjection `π` (only surjectivity is used in that machinery). All three
+are proved sorry-free below. -/
 
 /-- Over a simple artinian ring, any two simple modules are isomorphic: each is isomorphic to a
 minimal left ideal, and all minimal left ideals lie in the single isotypic component

--- a/progress/2026-07-21T01-05-00Z_7af6c386.md
+++ b/progress/2026-07-21T01-05-00Z_7af6c386.md
@@ -1,0 +1,34 @@
+## Accomplished
+
+Issue #7071 (Ch4 docstring-fidelity). Corrected stale "deferred / proved in the
+follow-up sub-issue" claims in
+`EtingofRepresentationTheory/Chapter4/Exercise4_2_3_SplitSimples.lean`:
+
+- Module docstring (lines 29-30): now states the enumeration and count are proved
+  sorry-free in-file, naming `Std_injective`, `exists_Std_linearEquiv`,
+  `card_simpleModuleClasses` / `exists_splitSimples_count`.
+- Section header (line 164): dropped "(deferred)".
+- Section paragraph (166-171): now describes the three facts as proved in-file
+  (naming the theorems), replacing "stated here and proved in the follow-up
+  sub-issue". Kept the accurate `IrrepDecomp` mirror reference.
+
+Comment-only change; no signature, proof term, or import touched. File builds
+successfully (`lake build` completes; only pre-existing `unusedFintypeInType`
+linter warnings remain).
+
+## Current frontier
+
+Docstring-fidelity sweep continues. #7072 (Ch6 Problem6_1_6) still unclaimed.
+
+## Overall project progress
+
+Files are largely sorry-free; ongoing work is the docstring-fidelity sweep
+correcting stale deferral claims on now-proved files.
+
+## Next step
+
+Pick up #7072 or the next unclaimed docstring-fidelity issue.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7071

Session: `7af6c386-8cab-43d3-9fb2-a28a2ef3c60e`

be9f6a54 doc(Ch4 #7071): correct stale 'deferred / proved in the follow-up' claims in Exercise4_2_3_SplitSimples (Std_injective / exists_Std_linearEquiv / card_simpleModuleClasses proved sorry-free in-file)

🤖 Prepared with Claude Code