### PR TITLE
feat(Ch4 docstring-fidelity): correct stale 'statement-pass formalization ... proof is deferred (sorry)' claim in Exercise4_2_3 (infrastructure proved sorry-free in-file; main theorem Etingof.Exercise4_2_3 assembled sorry-free in Exercise4_2_3_Assembly)

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Exercise4_2_3.lean
+++ b/EtingofRepresentationTheory/Chapter4/Exercise4_2_3.lean
@@ -25,12 +25,19 @@ isomorphism, obtained via the isomorphism-class setoid on a category
 The hypothesis "`|G| = 0` in `k`" is `(Fintype.card G : k) = 0`, i.e. the characteristic
 of `k` divides `|G|`.
 
-This is a statement-pass formalization: the statement is fixed faithfully and the proof
-is deferred (`sorry`). The mathematical content is that in the modular case the element
-`P = ∑_g g` is nonzero, central, nilpotent (`P² = |G| · P = 0`), and hence lies in the
-Jacobson radical of `k[G]`; the group algebra is therefore not semisimple, so the number
-of simple modules is strictly smaller than the dimension of its centre, which equals the
-number of conjugacy classes.
+This file is the proved-sorry-free infrastructure layer for Exercise 4.2.3. The
+mathematical content is that in the modular case the element `P = ∑_g g` is nonzero,
+central, nilpotent (`P² = |G| · P = 0`), and hence lies in the Jacobson radical of `k[G]`;
+the group algebra is therefore not semisimple. This file proves that non-semisimplicity
+(`not_isSemisimpleRing_of_card_eq_zero`), the count identification
+`card_irrepClasses_eq_card_simpleModuleClasses` (`IrrepClasses k G ≃ SimpleModuleClasses (k[G])`),
+and finiteness of the irreducibles (`finite_simpleModuleClasses`, `IrrepClasses.instFinite`).
+
+This file does not state the main comparison itself: the strict counting drop
+`Nat.card (IrrepClasses k G) < Nat.card (ConjClasses G)` (`Etingof.Exercise4_2_3`) is
+assembled sorry-free downstream in `Exercise4_2_3_Assembly.lean`, because the
+split-field and strict-bound machinery it depends on import this file (see the tail comment
+below).
 -/
 
 open CategoryTheory

--- a/progress/2026-07-21T00-56-53Z_427984f5.md
+++ b/progress/2026-07-21T00-56-53Z_427984f5.md
@@ -1,0 +1,32 @@
+## Accomplished
+Fixed #7074 (Ch4 docstring-fidelity). Rewrote the stale module-docstring
+sentence in `EtingofRepresentationTheory/Chapter4/Exercise4_2_3.lean` (was
+lines 28-33) that called the file a "statement-pass formalization" whose proof
+"is deferred (`sorry`)". The file is in fact proved sorry-free; the only prior
+occurrence of the word `sorry` was inside that docstring.
+
+New text truthfully states this file is the proved infrastructure layer, naming
+`not_isSemisimpleRing_of_card_eq_zero`,
+`card_irrepClasses_eq_card_simpleModuleClasses`
+(`IrrepClasses k G ≃ SimpleModuleClasses (k[G])`), `finite_simpleModuleClasses`,
+and `IrrepClasses.instFinite`, and that the main comparison
+`Etingof.Exercise4_2_3` (`Nat.card (IrrepClasses k G) < Nat.card (ConjClasses G)`)
+is assembled sorry-free downstream in `Exercise4_2_3_Assembly.lean`. Preserved
+the accurate `P = ∑_g g` mathematical-content description. Avoided em-dashes per
+style rules.
+
+Verified: Assembly file has no `sorry` and defines `theorem Exercise4_2_3` at
+line 76. Comment-only edit; no signature/proof/import change.
+
+## Current frontier
+Issue #7074 complete; PR opened.
+
+## Overall project progress
+Docstring-fidelity sweep continues (correcting stale deferred/sorry claims on
+sorry-free files). #7072 (Ch6 Problem6_1_6) remains unclaimed.
+
+## Next step
+Claim #7072 (Ch6 `Problem6_1_6.lean` docstring fix) next.
+
+## Blockers
+None.


### PR DESCRIPTION
Closes #7074

Session: `427984f5-f671-4a75-9cbc-4f4b0be9e8ea`

be7bca07 doc(Ch4 #7074): correct stale 'statement-pass / proof deferred (sorry)' claim in Exercise4_2_3

🤖 Prepared with Claude Code