### PR TITLE
feat(Ch6 docstring-fidelity): correct stale 'What remains ... Filed separately' block in Problem6_1_5_OrbitComorphism (injectivity via injective_orbitComorphism_of_isAlgDense in Problem6_1_5_OrbitInjective + N≤M/N<M assembly in Problem6_1_5_DimBound proved sorry-free)

### DIFF
--- a/EtingofRepresentationTheory/Chapter6/Problem6_1_5_OrbitComorphism.lean
+++ b/EtingofRepresentationTheory/Chapter6/Problem6_1_5_OrbitComorphism.lean
@@ -35,17 +35,21 @@ dimension bound `N ≤ M` to *injectivity of the orbit-map comorphism*; this fil
   localization, matching the principal-open case of the field-embedding bridge,
   `Etingof.Problem6_1_5.exists_field_embedding_of_injective_isLocalization`).
 
-## What remains (tracked as follow-ups to #4803)
+## Downstream
+
+Both consumers of this comorphism have since landed and are proved sorry-free:
 
 * **Injectivity of `orbitComorphism` from Zariski-density of the orbit** (the genuine
-  geometric input, Problem 6.1.2(a)). Over an infinite field a polynomial vanishing
-  on a Zariski-dense set is zero; converting S2a's topological density
-  (`Problem6_1_5_DenseOrbit.exists_dense_orbit_point`) to this algebraic statement
-  needs the Zariski topology on `𝔸ᴺ` pinned down and polynomial-evaluation
-  faithfulness. Filed separately.
-* **The dimension-bound assembly** `N ≤ M`: feed an injective `orbitComorphism` to
-  `Etingof.Problem6_1_5.dim_le_of_injective_comorphism_isLocalization`, transporting
-  the `GIdx m`-indexing to `Fin M` via `MvPolynomial.renameEquiv`. Filed separately.
+  geometric input, Problem 6.1.2(a)): over an infinite field a polynomial vanishing
+  on a Zariski-dense set is zero. This is proved in
+  `Problem6_1_5_OrbitInjective` as `injective_orbitComorphism_of_isAlgDense`, packaged
+  with the density input as `exists_injective_orbitComorphism`.
+* **The dimension-bound assembly** `N ≤ M` (and its strict form `N < M`): the injective
+  `orbitComorphism` feeds
+  `Etingof.Problem6_1_5.dim_le_of_injective_comorphism_isLocalization_index` in
+  `Problem6_1_5_DimBound`, yielding
+  `repSpace_finrank_le_repGroup_ambient_finrank` and
+  `repSpace_finrank_lt_repGroup_ambient_finrank`.
 -/
 
 open Matrix MvPolynomial

--- a/progress/2026-07-21T01-49-28Z_be54d2fd.md
+++ b/progress/2026-07-21T01-49-28Z_be54d2fd.md
@@ -1,0 +1,36 @@
+## Accomplished
+
+Resolved issue #7076 (docstring-fidelity, Ch6). Rewrote the stale
+"## What remains (tracked as follow-ups to #4803)" block (lines 38-48) in
+`EtingofRepresentationTheory/Chapter6/Problem6_1_5_OrbitComorphism.lean` into a
+"## Downstream" pointer block. Both listed follow-ups have landed sorry-free:
+
+- injectivity from Zariski-density → `injective_orbitComorphism_of_isAlgDense` /
+  `exists_injective_orbitComorphism` in `Problem6_1_5_OrbitInjective`;
+- the `N ≤ M` / `N < M` dimension-bound assembly →
+  `repSpace_finrank_le_repGroup_ambient_finrank` /
+  `repSpace_finrank_lt_repGroup_ambient_finrank` in `Problem6_1_5_DimBound`
+  (feeding `dim_le_of_injective_comorphism_isLocalization_index`).
+
+Dropped the "Filed separately" / "What remains" framing and the stale
+"follow-ups to #4803" attribution.
+
+## Current frontier
+
+Comment-only edit. `git diff` touches only docstring lines in the one target
+file. `grep -nE 'What remains|Filed separately'` returns nothing.
+`lake build EtingofRepresentationTheory.Chapter6.Problem6_1_5_OrbitComorphism`
+succeeds (8590 jobs).
+
+## Overall project progress
+
+Docstring-fidelity sweep continuing. This file's module docstring is now
+accurate; no signature, statement, proof, `def` body, or import changed.
+
+## Next step
+
+Next worker: pick up the next unclaimed docstring-fidelity or feature issue.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7076

Session: `be54d2fd-66b2-41d5-bf17-4e0e49791085`

8fdb2a0a doc(Ch6 #7076): replace stale 'What remains / Filed separately' block in Problem6_1_5_OrbitComorphism with a 'Downstream' pointer (both follow-ups landed sorry-free: injective_orbitComorphism_of_isAlgDense + repSpace_finrank_le/lt_repGroup_ambient_finrank)

🤖 Prepared with Claude Code