### PR TITLE
chore(work): route stale-claimed #6340 to replan (finrank_g_three false over char 2)

### DIFF
--- a/progress/2026-07-21T01-51-27Z.md
+++ b/progress/2026-07-21T01-51-27Z.md
@@ -1,0 +1,49 @@
+## Accomplished
+
+`/work` meta session. The unclaimed work queue was empty (`coordination queue-depth` = 0;
+verified this is genuine, not the #5956 stdout-corruption bug — `pod _filter-trusted-issues`
+returns valid JSON, so the local stderr workaround is active).
+
+Triaged the one actionable issue: **#6340** (`feat(Ch2 #Problem2.16.3a): prove
+finrank_g_three = 6`). It carried a stale `claimed` label from two dead sessions
+(`0257de43` / `aed6e359`, claimed 2026-07-10, ~10 days old). A prior worker's blocker
+(2026-07-11) established that **`finrank_g_three = 6` is FALSE over characteristic 2**:
+the only nonzero Jacobiator is `J(x̄,ȳ,b4) = −2·w` with `w = [b2,b4]`, so over 𝔽₂ (`2 = 0`)
+`w` is unconstrained, yielding an explicit 7-dimensional quotient over 𝔽₂ that satisfies
+both Serre relations. The theorem needs a characteristic hypothesis on its signature
+(`(2:k) ≠ 0` sharp, or `CharZero` to match the book's ℂ) — a signature/planner decision
+workers cannot make under this issue's constraints.
+
+Routed #6340 to `replan` via `coordination skip 6340 "…"` (removed `claimed`, added
+`replan`, posted a summarizing comment). It now appears in `coordination list-replan`.
+
+## Current frontier
+
+Work queue empty of unclaimed formalization items. #6340 is queued for replan triage
+(a planner must decide the characteristic hypothesis and re-issue the corrected signature).
+#7076 (Ch6 docstring-fidelity) is actively claimed as of 2026-07-21T01:47Z (session
+`be54d2fd`) — left untouched.
+
+## Overall project progress
+
+Formalization is deep into the tail: only a handful of open issues remain. Of the
+G₂/B₂/A₂ finrank part-(a) trio, `finrank_g_one = 3` (A₂) and `finrank_g_two = 4` (B₂,
+#6339) are proved sorry-free over all fields; `finrank_g_three` (G₂) is the remaining case
+and is now known to require a char ≠ 2 hypothesis. Other open non-formalization issues:
+#5956 (dev-pod stdout-corruption tooling bug, for the operator — do not claim), #5140
+(completeness-audit tracking), #2357 (pod planner-lock sentinel infra).
+
+## Next step
+
+A `/replan` session should triage #6340: decide the characteristic hypothesis for
+`finrank_g_three` (recommend `(2:k) ≠ 0` — sharp and more general than `CharZero`; the
+book works over ℂ so `CharZero` also matches), then re-issue with the corrected signature.
+Note the proof itself was never attempted — the prior worker stopped at statement
+correctness — so the re-issued item still carries the full G₂ dimension-6 proof (basis +
+lower/upper bounds, mirroring the n=1/n=2 templates).
+
+## Blockers
+
+None for this session. #6340 is blocked on a planner signature decision (now correctly
+routed to replan, not stranded). The n=2 char-2 concern raised in the blocker is moot:
+`finrank_g_two = 4` already compiles sorry-free, so Lean has verified it over all fields.


### PR DESCRIPTION
This adds the `/work` session handoff file recording that issue #6340 (`finrank_g_three = 6`) was routed to `replan`. The unclaimed work queue was empty; #6340 held a stale 10-day `claimed` label from dead sessions, and a prior blocker established the theorem is false over characteristic 2 (the sole Jacobiator `J(x̄,ȳ,b4) = −2w` leaves `w = [b2,b4]` unconstrained when `2 = 0`, giving a 7-dim quotient over 𝔽₂). Fixing it requires a characteristic hypothesis on the signature, a planner decision, so it was skipped to `replan` via `coordination skip`. No code changes; only `progress/`.

🤖 Prepared with Claude Code