### PR TITLE
feat(Ch5 docstring-fidelity): correct stale 'character orthogonality for S_n (not yet formalized)' + 'Lemma 5.13.1 sandwich over ℚ not yet generalized from ℂ' Key-dependencies claims in Theorem5_22_1 (youngSym_charValue_orthogonality + Etingof.Lemma5_13_1 used sorry-free in-file)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean
@@ -590,8 +590,8 @@ This is the central content of the Weyl character formula:
 
 1. **Scalar idempotent**: The Young symmetrizer `c_λ ∈ ℚ[S_n]` satisfies `c_λ² = α · c_λ`
    for some nonzero `α : ℚ`. This follows from the sandwich property
-   `a_λ · x · b_λ = ℓ(x) · c_λ` (Lemma 5.13.1, currently proved over ℂ,
-   needs generalization to ℚ).
+   `a_λ · x · b_λ = ℓ(x) · c_λ` (Lemma 5.13.1, used over ℚ via
+   `Etingof.Lemma5_13_1` at the `Sandwich proportionality` step below).
 
 2. **Trace formula**: Since `(1/α) · c_λ` is an idempotent projector onto `Im(c_λ) = L_λ`,
    `ch(L_λ) = (1/α) · ∑_{π ∈ S_n} c_λ(π) · permTracePoly(N, π)`
@@ -608,8 +608,11 @@ This is the central content of the Weyl character formula:
 **Key dependencies**:
 - `permTracePoly_eq_powerSumCycleProduct` (proved)
 - `Proposition5_21_1` (Frobenius formula, proved)
-- Lemma 5.13.1 sandwich property over ℚ (not yet generalized from ℂ)
-- Character orthogonality for S_n (not yet formalized) -/
+- Lemma 5.13.1 sandwich property over ℚ (proved; used via `Etingof.Lemma5_13_1`
+  at the `Sandwich proportionality` step in this file)
+- Character orthogonality for S_n (proved; `youngSym_charValue_orthogonality`
+  in this file, and `charValue_row_orthogonality` in
+  `Chapter5/CharacterOrthogonality.lean`) -/
 
 /-! #### Young symmetrizer endomorphism: idempotent property -/
 

--- a/progress/2026-07-21T02-00-20Z_a84c994e.md
+++ b/progress/2026-07-21T02-00-20Z_a84c994e.md
@@ -1,0 +1,45 @@
+## Accomplished
+
+Feature session (docstring-fidelity), issue #7082. Corrected the stale
+"Proof strategy" comment block in
+`EtingofRepresentationTheory/Chapter5/Theorem5_22_1.lean`:
+
+- Line 611: the "Lemma 5.13.1 sandwich property over ℚ (not yet generalized
+  from ℂ)" Key-dependencies bullet now reads "(proved; used via
+  `Etingof.Lemma5_13_1` at the `Sandwich proportionality` step in this file)".
+- Line 612: the "Character orthogonality for S_n (not yet formalized)" bullet
+  now reads "(proved; `youngSym_charValue_orthogonality` in this file, and
+  `charValue_row_orthogonality` in `Chapter5/CharacterOrthogonality.lean`)".
+- Lines 592-594: the strategy prose no longer says Lemma 5.13.1 "needs
+  generalization to ℚ"; it now notes the lemma is used over ℚ via
+  `Etingof.Lemma5_13_1` at the `Sandwich proportionality` step below.
+
+Verified before editing: the file has 0 sorries;
+`youngSym_charValue_orthogonality` is defined at line 3431 and consumed at
+line 3575; `Etingof.Lemma5_13_1` is used at line 2173 feeding
+`Sandwich proportionality` (line 2164); `charValue_row_orthogonality` exists
+in `Chapter5/CharacterOrthogonality.lean` (line 331).
+
+Comment-only edit inside the existing `/- ... -/` doc block; no signature,
+statement, proof term, def/instance body, or import changed. The
+`-- see issue #2841` marker near line 2258 was left untouched per the issue.
+
+## Current frontier
+
+Docstring-fidelity sweep continues across chapters. #7081 (Ch6
+Proposition6_6_7) is claimed by another session.
+
+## Overall project progress
+
+Stage 3 formalization with an ongoing docstring-fidelity sweep correcting
+stale "deferred / not-yet-formalized / blocked" claims on files now proved
+sorry-free.
+
+## Next step
+
+Continue the docstring-fidelity sweep on remaining stale-comment issues as
+planners surface them.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7082

Session: `a84c994e-d856-42b9-a2ff-e056a7a6bb10`

5966ca69 doc(Ch5 #7082): correct stale 'not yet formalized/generalized' Key-dependencies claims in Theorem5_22_1

🤖 Prepared with Claude Code