### PR TITLE
doc(Ch2): correct stale '## Blocked' section in Sl2Irrep — rhoLieHom (Leibniz) and irrep_isIrreducible are proved sorry-free

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Sl2Irrep.lean
+++ b/EtingofRepresentationTheory/Chapter2/Sl2Irrep.lean
@@ -23,13 +23,13 @@ The representation action (on components) is:
 - (ρ(e) · v)_k = (k+1) · v_{k+1}         (e picks up v_{k+1})
 - (ρ(f) · v)_k = (d - k) · v_{k-1}       (f picks up v_{k-1})
 
-## Blocked
+## What is and isn't formalized
 
-The Leibniz identity proof (`rho_map_lie`) requires verifying that the representation
-map preserves Lie brackets. This reduces to 9 generator pairs but each involves
-intricate casework on boundary conditions (k=0, k+1=d, nested boundaries).
-Similarly, irreducibility requires showing that any nonzero invariant subspace is the
-whole space. Both require significant additional work.
+The Leibniz identity is proved sorry-free by the `map_lie'` field of `rhoLieHom`
+(`sl2 →ₗ⁅ℂ⁆ Module.End ℂ (Fin d → ℂ)`), which carries out the bracket-preservation
+casework over the sl(2) generators. Irreducibility is proved sorry-free by
+`irrep_isIrreducible` (`LieModule.IsIrreducible ℂ sl2 (Fin d → ℂ)` for `[NeZero d]`),
+which shows that any nonzero invariant subspace is the whole space.
 
 Complete reducibility (Theorem 2.1.1(ii)) requires Weyl's complete reducibility theorem
 for semisimple Lie algebras, which is not in Mathlib.

--- a/progress/2026-07-21T02-18-44Z_3d95f39a.md
+++ b/progress/2026-07-21T02-18-44Z_3d95f39a.md
@@ -1,0 +1,37 @@
+## Accomplished
+
+Executed feature issue #7089 (doc-fidelity fix for `Chapter2/Sl2Irrep.lean`).
+Replaced the stale `## Blocked` section in the module docstring:
+
+- The first two paragraphs claimed the Leibniz identity (`rho_map_lie`, a symbol
+  that no longer exists) and irreducibility were undone / required significant
+  additional work. Both are in fact proved sorry-free: the Leibniz identity by
+  the `map_lie'` field of `rhoLieHom` (line 223), and irreducibility by
+  `irrep_isIrreducible` (line 398).
+- Retitled the section to `## What is and isn't formalized`, naming the actual
+  symbols, and kept the surviving third paragraph about Weyl complete
+  reducibility (Theorem 2.1.1(ii)) — a legitimate statement about Mathlib's
+  coverage, not a stale claim about this repo.
+
+Verified with `lake build EtingofRepresentationTheory.Chapter2.Sl2Irrep`:
+build completed successfully (2033 jobs), only pre-existing lint warnings.
+
+## Current frontier
+
+Docstring change only; no proof or statement changes. Ready to publish as PR
+closing #7089.
+
+## Overall project progress
+
+Codebase remains proof-complete except for the single genuine sorry
+`finrank_g_three` (Problem 2.16.3(a)), claimed under #7084. This turn was part
+of the ongoing docstring-fidelity sweep correcting stale "blocked / deferred"
+claims on files whose work is actually complete.
+
+## Next step
+
+Remaining unclaimed work: summarize issue #7087 (refresh sorry-landscape).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7089

Session: `3d95f39a-4fbc-44eb-b941-5ae25b481611`

688097e7 chore(#7089): progress entry for Sl2Irrep docstring fix
482d2448 doc(Ch2 #7089): replace stale '## Blocked' section in Sl2Irrep

🤖 Prepared with Claude Code