### PR TITLE
doc(Ch5/Ch9): apply 3 stale-docstring rewordings from #7088 audit (detTwist_dual_algIrrepρ_eq non-existent; clength_le_add proved; SchurModuleSpecialBlock 'gap' proved)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/LinearDualDetTwistCharacter.lean
+++ b/EtingofRepresentationTheory/Chapter5/LinearDualDetTwistCharacter.lean
@@ -35,8 +35,9 @@ Writing `m := s + lam.shift`, `λ' := lam.toNatWeight`, `σ := schurModuleRep k 
 * `detChar_zpow_diagUnit` — the determinant character power reads `t ^ z` on the
   torus: `(detChar ^ z) (diagUnit i t) = t ^ z`.
 
-* `detTwist_dual_algIrrepρ_eq` — collapsing the stacked twists on the
-  contragredient: `charTwistRep (det^s) ((algIrrepGLRepρ).dual)
+* Collapsing the stacked twists on the contragredient (inlined inside
+  `coeff_formalCharacter_detTwist_dual`, not a standalone lemma):
+  `charTwistRep (det^s) ((algIrrepGLRepρ).dual)
   = charTwistRep (det^{(m:ℤ)}) (Representation.dual σ)`, via `dual_charTwistRep`
   (#5552) + `charTwistRep_charTwistRep`.
 
@@ -141,7 +142,8 @@ theorem detChar_pow_mul_inv_neg_zpow (n : ℕ) (lam : DominantWeight n) (k : Typ
 ```
 
 Proof chain: `formalCharacter_coeff` →
-`glWeightSpace_eq_glWeightSpaceℤ` → `detTwist_dual_algIrrepρ_eq` (collapse) →
+`glWeightSpace_eq_glWeightSpaceℤ` → the inlined twist-collapse step
+(`dual_charTwistRep` + `charTwistRep_charTwistRep`) →
 `glWeightSpaceℤ_charTwist_shift` (the `det^m` twist shifts the weight by `m`) →
 `finrank_glWeightSpaceℤ_dual_eq` (the dual negates weights, #5533), using the weight
 eigenbasis of the Schur module (`exists_weight_eigenbasis` +

--- a/EtingofRepresentationTheory/Chapter5/SchurModuleSpecialBlock.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurModuleSpecialBlock.lean
@@ -25,8 +25,9 @@ The two halves of the statement reduce to:
 * **Uniqueness** (at most one `weightToPartition`-labelled block). Two simple
   `symGroupImage`-submodules with the same Specht character are isomorphic as
   `symGroupImage`-modules, hence equal by the decomposition's distinctness clause.
-  This "character determines the module over ℂ" step is the single remaining gap,
-  isolated as `simpleSymGroupImageSubmodule_iso_of_spechtCharacter_eq` below.
+  This "character determines the module over ℂ" step is the one genuinely
+  character-theoretic ingredient, proved below via
+  `simpleSymGroupImageSubmodule_iso_of_spechtCharacter_eq`.
 -/
 
 noncomputable section

--- a/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Length.lean
+++ b/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Length.lean
@@ -537,9 +537,9 @@ For a short exact sequence `0 → X₁ → X₂ → X₃ → 0`, the composition
 * `clength_add_le` (`clength X₁ + clength X₃ ≤ clength X₂`) — **proved**, modularity-free, from the
   down-interval isomorphism `height_mk_eq_height_top`, the epi-side inequality
   `height_top_le_coheight_kernel`, and the order lemma `height_add_coheight_le_height_top`.
-* `clength_le_add` (`clength X₂ ≤ clength X₁ + clength X₃`) — the Schreier-refinement direction; see
-  its docstring for the order-reflecting embedding `Subobject X₂ ↪ Subobject X₁ × Subobject X₃` that
-  remains to be discharged.
+* `clength_le_add` (`clength X₂ ≤ clength X₁ + clength X₃`) — the Schreier-refinement direction,
+  **proved**; see its docstring for the order-reflecting embedding
+  `Subobject X₂ ↪ Subobject X₁ × Subobject X₃` that discharges it.
 
 Finiteness of all three lengths (needed both for the `le_antisymm` to make sense and for the
 `ENat.toNat` arithmetic) comes from `FiniteDimensionalOrder (Subobject X)`, the order-theoretic form

--- a/progress/2026-07-21T02-56-38Z_20ff73bc.md
+++ b/progress/2026-07-21T02-56-38Z_20ff73bc.md
@@ -1,0 +1,56 @@
+## Accomplished
+
+Executed feature issue #7093 — applied the 3 stale-docstring corrections from
+the #7088 docstring-fidelity wave audit. **Comment-only edits, no code/signature/
+proof touched.** All three re-verified against `main` before editing and the
+three module targets build cleanly afterward (8670 jobs, only pre-existing
+unrelated warnings).
+
+1. `Chapter5/LinearDualDetTwistCharacter.lean` (lines 38, 143) — the module
+   docstring cited a non-existent lemma `detTwist_dual_algIrrepρ_eq`. That step
+   is inlined into `coeff_formalCharacter_detTwist_dual` (the `simp` at line 175
+   using `dual_charTwistRep` + `charTwistRep_charTwistRep`). Reworded both
+   mentions to describe the inlined collapse step instead of naming a lemma that
+   does not exist; did not invent a new lemma name.
+
+2. `Chapter9/KrullSchmidt/Length.lean:540-542` — `clength_additive`'s docstring
+   said `clength_le_add` "remains to be discharged". It is proved
+   (`private theorem clength_le_add`, line 501; consumed at line 549). Reworded
+   to say the Schreier-refinement direction is **proved** via the order-reflecting
+   embedding, consistent with line 56.
+
+3. `Chapter5/SchurModuleSpecialBlock.lean:28` — the module docstring called the
+   character-determines-module step "the single remaining gap", but
+   `simpleSymGroupImageSubmodule_iso_of_spechtCharacter_eq` is proved (line 69,
+   delegating to `Theorem5_22_1.lean`) and lines 52-53 already say "proved".
+   Reworded to "the one genuinely character-theoretic ingredient, proved below
+   via …", consistent with lines 52-53.
+
+## Current frontier
+
+Issue #7093 complete. PR opened with auto-merge.
+
+## Overall project progress
+
+Proof-complete: PR #7102 merged the last genuine sorry (`finrank_g_three`,
+#7084) into `main` at the start of this turn, so the tree is now sorry-free.
+Remaining open work is confidence/cleanup: docstring-drift fixes (#7099 still
+unclaimed) and the Chapter 7 fidelity review (#7103 still unclaimed).
+
+## Next step
+
+Pick up #7099 (2 more stale-'deferred' docstring rewords + 1 borderline, same
+comment-only pattern) or #7103 (Ch7 Example 7.3.2 fidelity review, read-only).
+
+## Blockers
+
+None.
+
+## Note for next session
+
+A pre-existing stash was created at the start of this turn ("pre-7093 leftover
+skill/command edits") holding uncommitted deletions in
+`.claude/commands/review.md`, `.claude/commands/summarize.md`, and
+`.claude/skills/agent-worker-flow/SKILL.md` that predated this session. They
+were stashed (not discarded) to work on a clean base and remain recoverable via
+`git stash list` in this worktree.


### PR DESCRIPTION
Closes #7093

Session: `20ff73bc-95b6-4a58-a315-8da8d1709dca`

3cf805a6 doc(#7093): apply 3 stale-docstring corrections from #7088 audit

🤖 Prepared with Claude Code