### PR TITLE
doc: apply stale-'deferred' docstring rewords found by #7096 sweep (PolynomialRepEmbedding, GL2ConjugacyClassCount, +1 borderline)

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Exercise4_2_3_FieldGeneral.lean
+++ b/EtingofRepresentationTheory/Chapter4/Exercise4_2_3_FieldGeneral.lean
@@ -56,7 +56,7 @@ open CategoryTheory
 open scoped TensorProduct
 
 -- `[Fintype G]` is used at proof time (cocenter dimension, finiteness of the class count) but
--- not in the statement types until the deferred proofs are filled in.
+-- not in the statement types.
 set_option linter.unusedFintypeInType false
 
 namespace Etingof

--- a/EtingofRepresentationTheory/Chapter5/GL2ConjugacyClassCount.lean
+++ b/EtingofRepresentationTheory/Chapter5/GL2ConjugacyClassCount.lean
@@ -69,7 +69,7 @@ counts then feed the class-count bridge `count_from_bridge`.
 
 /-! ## A class-count bridge
 
-The three deferred per-type counts all follow the same recipe: divide the number
+The three per-type counts all follow the same recipe: divide the number
 of *elements* of a type by the (constant) *size* of a conjugacy class of that
 type. The size of the class of `g` is `|G| / |C_G(g)|` by orbit–stabilizer, so if
 the centralizer order is constant equal to `d` across a conjugation-closed set

--- a/EtingofRepresentationTheory/Chapter5/PolynomialRepEmbedding.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialRepEmbedding.lean
@@ -1111,8 +1111,9 @@ constant. `h_span` (equivalently: `M` is a genuinely *polynomial* — not merely
 rational/algebraic — representation) rules such cases out; it holds for Schur
 modules by `SchurWeylFormalCharacterIso.glWeightSpace_schurModule_iSup_eq_top`.
 
-Proof strategy (the genuine mathematical content, deferred — see issue #4598
-decomposition): evaluate the matrix-coefficient identity at the scalar matrix
+Proof strategy (carried out below, assembled from `scalarGL_acts_as_pow` and
+`hpoly'_of_scalarGL_action`; issue #4598 decomposition): evaluate the
+matrix-coefficient identity at the scalar matrix
 `t • 1 = ∏ᵢ diagUnit i t`. By `h_span` the weight spaces span `M`, so
 `M.ρ (t • 1) = t^n • id` (each weight `μ` has `∑ μ = n` by `h_homog`). Hence
 every matrix coefficient `g ↦ b.repr (ρ g (b c)) a` is homogeneous of degree `n`

--- a/progress/2026-07-21T03-01-16Z_ff3e2128.md
+++ b/progress/2026-07-21T03-01-16Z_ff3e2128.md
@@ -1,0 +1,60 @@
+## Accomplished
+
+Applied issue #7099 — the stale-`deferred` docstring rewords found by the #7096
+whole-tree stale-completeness-prose sweep. Comment-only edits, no code /
+signature / proof changes:
+
+1. **`Chapter5/PolynomialRepEmbedding.lean:1114`** — docstring of
+   `polynomialRep_homogeneous_hpoly'`. Dropped "the genuine mathematical
+   content, deferred — see issue #4598 decomposition"; now reads "carried out
+   below, assembled from `scalarGL_acts_as_pow` and `hpoly'_of_scalarGL_action`;
+   issue #4598 decomposition". Verified both private theorems exist (lines 799,
+   1072) and are assembled in the theorem body (lines 1141-1142); file is
+   sorry-free.
+2. **`Chapter5/GL2ConjugacyClassCount.lean:72`** — `## A class-count bridge`
+   section prose. Dropped "deferred" → "The three per-type counts all follow the
+   same recipe:". The three counts are proved and consumed by
+   `card_conjClasses_eq` (line 940).
+3. **`Chapter4/Exercise4_2_3_FieldGeneral.lean:59`** (borderline) — deleted the
+   stale clause "until the deferred proofs are filled in" from the
+   `linter.unusedFintypeInType` justification comment. Kept the linter option
+   (only the clause deletion, per the issue's guidance).
+
+## Verification
+
+- `lake build` of all three modules: **Build completed successfully (8669
+  jobs)**. Only pre-existing linter warnings (long lines, deprecated lemma
+  names, unused-variable) — none from the comment text.
+- `git diff --stat`: 3 files, +5/-4, all comment lines.
+- `grep -n deferred` on the three files: the only remaining hit is
+  `PolynomialRepEmbedding.lean:492`, a legitimate usage (a genuine hypothesis
+  whose derivation is deferred to a follow-up), correctly out of scope and not
+  flagged by #7096.
+
+## Current frontier
+
+Issue #7099 complete. Together with #7093 (a different trio) this closes the
+tree-wide stale-completeness-prose class enumerated by #7096.
+
+## Overall project progress
+
+Formalization tree has exactly one genuine sorry (`finrank_g_three`, #7084).
+Docstring-fidelity cleanup ongoing; this turn removes 3 stale "deferred" labels.
+
+## Next step
+
+Merge the PR; pick up the next unclaimed issue from `coordination list-unclaimed`.
+
+## Blockers
+
+None.
+
+## Note for the next agent (housekeeping)
+
+This reused worktree carried pre-existing uncommitted deletions in
+`.claude/commands/review.md`, `.claude/commands/summarize.md`, and
+`.claude/skills/agent-worker-flow/SKILL.md` (unrelated to #7099). I stashed them
+(`git stash` entry: "pre-existing .claude edits from reused worktree (ff3e2128
+session)") before resetting the branch to `origin/main`, so they are preserved
+but not part of this PR. Their provenance is unknown; they delete documentation
+and may be a botched edit — inspect before restoring.


### PR DESCRIPTION
Closes #7099

Session: `ff3e2128-6876-4253-8871-ff8c703a842b`

520c83b9 doc(#7099): drop 3 stale 'deferred' docstring labels (proved decls)

🤖 Prepared with Claude Code