### PR TITLE
doc(Ch6): reword stale in-proof 'For now, sorry' comment at Theorem_Dynkin_classification:1189 (proof is complete) + whole-tree in-proof-sorry-comment sweep

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Corollary5_19_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Corollary5_19_2.lean
@@ -29,9 +29,9 @@ as partitions of n. The existential carries the genuine module-theoretic
 content: each `S p` (= `Vλ`) is a simple `symGroupImage`-module or zero,
 each `L p` (= `Lλ`) is a distinct irreducible `diagonalActionImage`-module
 or zero, and the iso decomposes `V⊗ⁿ` as `⊕_p S p ⊗ L p`. The proof
-delegates to `Theorem5_18_4_partition_decomposition`, whose `sorry` records
-the one open dependency (the Specht labelling of the simple
-`symGroupImage`-modules); see issue #5326.
+delegates to `Theorem5_18_4_partition_decomposition`, now complete: the Specht
+labelling of the simple `symGroupImage`-modules — formerly the one open
+dependency, tracked as #5326 — has been proved.
 (Etingof Corollary 5.19.2) -/
 theorem Etingof.Corollary5_19_2
     {k : Type u} [Field k] [IsAlgClosed k] [CharZero k]

--- a/EtingofRepresentationTheory/Chapter5/Discussion5_11_examples.lean
+++ b/EtingofRepresentationTheory/Chapter5/Discussion5_11_examples.lean
@@ -709,7 +709,7 @@ lemma zeta3_sum : (zeta3 : ℂ) ^ 2 + (zeta3 : ℂ) + 1 = 0 := by
 /-! ## The induced representations and their decompositions
 
 Each statement asserts an isomorphism of `S₃`-representations. The intended proof
-route (Etingof §5.11), which deliberately avoids the still-`sorry` induced-character
+route (Etingof §5.11), which follows the book in bypassing the induced-character
 formula `Etingof.Theorem5_9_1`, computes the multiplicity of each irreducible
 constituent by Frobenius reciprocity `Etingof.Theorem5_10_1`,
 `⟨Ind_H^G W, V_i⟩ = ⟨W, Res_H V_i⟩`, reducing each to a restriction over the 2- or

--- a/EtingofRepresentationTheory/Chapter5/Example5_1_3.lean
+++ b/EtingofRepresentationTheory/Chapter5/Example5_1_3.lean
@@ -731,9 +731,11 @@ every `FS(Wᵢ) = 1`; the abstract `ρ` is isomorphic to some `Wᵢ` (Schur), so
 The per-irreducible step `FS(Wᵢ) ∈ {±1}` is `frobeniusSchurIndicator_pm_one_of_simple_selfDual`,
 now proved via the Frobenius-Schur trace identity
 `Etingof.frobeniusSchurIndicator_eq_pm_one_of_self_dual_simple`
-(`FrobeniusSchurTraceIdentity.lean`). The remaining `sorry` in the axiom trace of this
-theorem comes only from `isRealType_of_frobeniusSchurIndicator_eq_one`'s dependency on
-`exists_nonzero_invariant_symmetric_of_FS_eq_one` (tracked as #5214). -/
+(`FrobeniusSchurTraceIdentity.lean`). The axiom trace of this theorem is now clean
+(`propext`, `Classical.choice`, `Quot.sound` only): the former gap in
+`isRealType_of_frobeniusSchurIndicator_eq_one` — its dependency on
+`exists_nonzero_invariant_symmetric_of_FS_eq_one`, formerly tracked as #5214 — has since
+been proved. -/
 theorem Etingof.isRealType_of_A5_even_standard
     {V : Type} [AddCommGroup V] [Module ℂ V] [Module.Finite ℂ V]
     (ρ : Representation ℂ (alternatingGroup (Fin 5)) V)

--- a/EtingofRepresentationTheory/Chapter5/Problem5_24_2_Bridge.lean
+++ b/EtingofRepresentationTheory/Chapter5/Problem5_24_2_Bridge.lean
@@ -38,8 +38,8 @@ The value on a permutation operator `symGroupAction σ` is a product of trace-of
 `traceWord`, one per cycle of `σ`: this is the tensor-trace ↔ trace-word identity supplied by
 the sibling sub-issue. The assembly sub-issue combines that identity with Schur–Weyl
 permutation-spanning (`Theorem5_18_4_centralizers`) and the range identification stated here
-(`weightedHomogeneous_invariant_mem_range_endTensorEval`) to discharge the remaining `sorry` in
-`Problem5_24_2.lean` (`weightedHomogeneous_invariant_mem_adjoin`).
+(`weightedHomogeneous_invariant_mem_range_endTensorEval`) to prove
+`weightedHomogeneous_invariant_mem_adjoin` in `Problem5_24_2.lean` (now complete, no `sorry`).
 -/
 
 noncomputable section

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_9_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_9_1.lean
@@ -41,7 +41,8 @@ throughout Chapter 5. The induced representation is `Etingof.Definition5_8_1`,
 i.e. Mathlib's `Representation.ind H.subtype ρ` on `Representation.IndV`.
 Frobenius reciprocity (the induction/restriction adjunction) is not yet in
 Mathlib, so the block-trace computation underlying this formula is proved
-directly here (currently `sorry`).
+directly here (via the abstract trace-on-coinvariants identity
+`Etingof.trace_coinvariantsMap`; the proof is complete).
 -/
 
 open Representation

--- a/EtingofRepresentationTheory/Chapter6/Theorem_Dynkin_classification.lean
+++ b/EtingofRepresentationTheory/Chapter6/Theorem_Dynkin_classification.lean
@@ -1186,7 +1186,9 @@ lemma branch_classification {n : ℕ} {adj : Matrix (Fin n) (Fin n) ℤ}
       -- Since B > 0 and f(b) > 0, the bracket > 0. QED.
       --
       -- We formalize this by computing B directly.
-      -- For now, sorry the computation and derive the result.
+      -- The computation is carried out in full below (no placeholder): we first
+      -- record f(b) > 0, then reduce (via `suffices hB_eq`) to the explicit closed
+      -- form for B and read off positivity of the bracket.
       have hfb_pos : (0 : ℤ) < f b := by
         rw [hfb]
         have : (0 : ℤ) < ↑(k - b) := by omega

--- a/progress/2026-07-21T03-17-09Z_91ab2e5b.md
+++ b/progress/2026-07-21T03-17-09Z_91ab2e5b.md
@@ -1,0 +1,62 @@
+## Accomplished
+
+Executed issue #7107 (feature/doc): reword stale in-proof/comment `sorry`
+placeholder mentions. PR #7120 (`Closes #7107`), two commits, comment-only,
+all six touched files build.
+
+- **Primary (in-proof placeholder):**
+  `Chapter6/Theorem_Dynkin_classification.lean:1189` — the
+  `-- For now, sorry the computation and derive the result.` comment
+  contradicted the complete derivation immediately below (`nlinarith`,
+  `suffices hB_eq`, `zify`/`linarith`). Reworded to describe the actual proof.
+
+- **Whole-tree sweep (deliverable 2)** — ran
+  `grep -rnwP '(?<![\w-])sorry(?![\w-])' … | grep -viE 'sorry-free'` and
+  triaged every match. Five further stale mentions found and reworded, each
+  verified against ground truth:
+  - `Chapter5/Theorem5_9_1.lean:44` "(currently `sorry`)" — proof reads as
+    complete (ends via `trace_coinvariantsMap`, no `sorry` token).
+  - `Chapter5/Discussion5_11_examples.lean:712` "still-`sorry` … Theorem5_9_1".
+  - `Chapter5/Example5_1_3.lean:734`, `Problem5_24_2_Bridge.lean:41`,
+    `Corollary5_19_2.lean:32` — axiom-trace/dependency `sorry` claims.
+    Verified stale via `#print axioms`: `isRealType_of_A5_even_standard`,
+    `weightedHomogeneous_invariant_mem_adjoin`, `Corollary5_19_2`,
+    `Theorem5_18_4_partition_decomposition` all depend only on
+    `[propext, Classical.choice, Quot.sound]` — no `sorryAx`.
+
+- **Left unchanged (correct prose):** `DetInvElim.lean:10` ("closes the lone
+  `sorry` of detInv_elim_of_polynomial" — accurate role description),
+  `KernelLemmaKPrime.lean:20` ("not a `sorry`'d placeholder"), and the many
+  "`sorry`-free"/"non-`sorry`" construction notes.
+
+Key finding: the whole tree now has **zero genuine `sorry` proof terms** and
+zero `axiom`/`sorryAx`/`admit` declarations. Every "active `sorry`" prose
+mention was therefore stale; all such have now been corrected.
+
+## Current frontier
+
+PR #7120 open. `coordination create-pr` warned auto-merge is unavailable
+(branch protection not configured), so the PR will not self-merge — it needs
+the planning-cycle merge step or a maintainer. My branch's changes are
+disjoint from the recently merged PRs (#7108/#7110 touched Sl2Irrep,
+PolynomialRepEmbedding, etc.), so no conflicts.
+
+## Overall project progress
+
+Stage 3+ (formalization) essentially complete: 0 sorry proof terms tree-wide.
+Ongoing work is fidelity review and stale-prose cleanup. This issue closes the
+in-proof-`sorry`-comment prose pattern (orthogonal to the completeness/"deferred"
+docstring sweeps #7088/#7093, #7096/#7099).
+
+## Next step
+
+Two remaining unclaimed feature items: #7111 (document that `V_d = Fin d → ℂ`
+realizes the book's polynomial model in `Sl2Irrep.lean`). Also worth a future
+sweep: confirm the various completeness/status docstrings that reference open
+issue numbers (#5214, #5326, etc.) now that those gaps are axiom-clean —
+several such issue-tracker cross-references may now be closable.
+
+## Blockers
+
+None. (Note: repo-wide auto-merge appears unconfigured; PRs land via the
+planning-cycle merge step, not auto-merge.)


### PR DESCRIPTION
Closes #7107

This PR rewords stale `sorry`-placeholder comments left over from top-down drafting, where the proof or dependency they describe is in fact complete. All changes are comment/docstring-only — no theorem statements, proof terms, or `def` bodies are touched, and every touched file still builds.

Primary deliverable — the one in-proof placeholder comment the issue anchored on:
- `Chapter6/Theorem_Dynkin_classification.lean:1189` — "For now, sorry the computation and derive the result" contradicted the complete derivation immediately below; reworded to describe the actual proof (record `f(b) > 0`, reduce via `suffices hB_eq` to the closed form, read off bracket positivity).

Whole-tree in-proof/comment `sorry`-mention sweep (deliverable 2) caught five further stale mentions, each verified against ground truth (`Etingof.Theorem5_9_1` reads as a complete proof; the four axiom-trace dependencies were checked with `#print axioms` and depend only on `[propext, Classical.choice, Quot.sound]`, no `sorryAx`):
- `Chapter5/Theorem5_9_1.lean:44` — header "(currently `sorry`)" for a proof that is complete.
- `Chapter5/Discussion5_11_examples.lean:712` — "still-`sorry` … `Theorem5_9_1`" (that theorem is proved).
- `Chapter5/Example5_1_3.lean:734` — "remaining `sorry` in the axiom trace … (tracked as #5214)"; `isRealType_of_A5_even_standard` is axiom-clean.
- `Chapter5/Problem5_24_2_Bridge.lean:41` — "discharge the remaining `sorry` … `weightedHomogeneous_invariant_mem_adjoin`"; that theorem is proved.
- `Chapter5/Corollary5_19_2.lean:32` — "`Theorem5_18_4_partition_decomposition`, whose `sorry` records the one open dependency (#5326)"; that theorem is proved.

Remaining tree matches are correct descriptive prose and were left unchanged: `DetInvElim.lean:10` ("this file closes the lone `sorry` of …" — accurate role description) and `KernelLemmaKPrime.lean:20` ("not a `sorry`'d placeholder"), plus the many "`sorry`-free" / "non-`sorry`" construction notes.

🤖 Prepared with Claude Code