### PR TITLE
feat(Ch4): formalize the representation-level regular-rep decomposition k[G] ≅ ⊕ᵢ dim(Vᵢ)·Vᵢ (equivariant refinement of Theorem 4.1.1 part ii)

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -141,6 +141,14 @@ cycle in #6859. Relatedly, a whole-group case split like `∀ g : Perm (Fin 3), 
 decide; … rcases this g` — `decide` on a hypothesis mentioning a *free* `g` errors with "expected
 type must not contain free variables".
 
+**`ext x` over-recurses on a `LinearMap`/`Representation` equation whose domain is
+`MonoidAlgebra k G`** — because `MonoidAlgebra k G` reduces to `G →₀ k`, `ext` peels past the
+LinearMap into the `Finsupp` and hands you `x : G` (or a `Finsupp` index), not `x : MonoidAlgebra k G`,
+so a follow-up `exact map_mul f (of g) x` fails with "argument x has type G". Fix: force one level
+with `refine LinearMap.ext fun x => ?_` (x is then the algebra element). Same idiom for the `comm`
+obligation of `Action.mkIso`: use `ext : 1` (not bare `ext`) to stop at the linear-map equation
+`f.hom ∘ₗ M.ρ g = N.ρ g ∘ₗ f.hom`.
+
 **To get `Module k ↥S` on an abstract `S : ModuleCat (k[G])` object** (needed for `k`-linear maps,
 `Basis`, `LinearMap.toSpanSingleton`, char-2 `x+x=0` via `two_smul`), install it locally:
 `letI : Module k ↥S := Module.compHom ↥S (algebraMap k (k[G]))`, then hand-prove

--- a/EtingofRepresentationTheory/Chapter4/Theorem4_1_1.lean
+++ b/EtingofRepresentationTheory/Chapter4/Theorem4_1_1.lean
@@ -86,3 +86,116 @@ theorem Etingof.Theorem4_1_1_algebra_iso
   ⟨D.n, D.columnFDRep, D.columnFDRep_simple, D.columnFDRep_injective,
     D.columnFDRep_surjective, ⟨D.endIso⟩,
     D.sum_finrank_sq_eq_card D.columnFDRep D.columnFDRep_simple D.columnFDRep_injective⟩
+
+/-! ### Representation-level form of part (ii)
+
+The book's part (ii) states that `ψ : k[G] → ⊕ᵢ End(Vᵢ)` is not merely an isomorphism of
+`k`-algebras but an **isomorphism of representations** of `G`, where `G` acts on both sides by
+left multiplication. On `k[G]` this is the *regular representation* `g · x = (of g) * x`; on
+`⊕ᵢ End(Vᵢ)` it is `g · (fᵢ) = (ρᵢ(g) ∘ fᵢ)`, i.e. left multiplication by `ψ(g) = ⊕ᵢ ρᵢ(g)`.
+The results below package the regular representation as an `FDRep`, equip `∏ᵢ End(Vᵢ)` with this
+left-multiplication `G`-action, and upgrade the Wedderburn algebra isomorphism `IrrepDecomp.endIso`
+to an isomorphism of representations. -/
+
+/-- The **regular representation** of `G` on the group algebra `k[G]`: `g` acts by left
+multiplication `x ↦ (of g) * x`. This is the left-hand side of the book's `ψ`, viewed as a
+representation of `G`. -/
+noncomputable def MonoidAlgebra.regularRep (k G : Type u) [Field k] [Group G] :
+    Representation k G (MonoidAlgebra k G) where
+  toFun g := Algebra.lmul k (MonoidAlgebra k G) (MonoidAlgebra.of k G g)
+  map_one' := by rw [map_one, map_one]
+  map_mul' g h := by rw [map_mul, map_mul]
+
+@[simp]
+theorem MonoidAlgebra.regularRep_apply (k G : Type u) [Field k] [Group G]
+    (g : G) (x : MonoidAlgebra k G) :
+    MonoidAlgebra.regularRep k G g x = MonoidAlgebra.of k G g * x := rfl
+
+/-- The regular representation packaged as a finite-dimensional representation `FDRep k G`. -/
+noncomputable def MonoidAlgebra.regularFDRep (k G : Type u) [Field k] [Group G] [Fintype G] :
+    FDRep k G :=
+  FDRep.of (MonoidAlgebra.regularRep k G)
+
+namespace IrrepDecomp
+
+variable {k G : Type u} [Field k] [IsAlgClosed k] [Group G] [Fintype G]
+  [NeZero (Nat.card G : k)]
+
+/-- The **endomorphism-algebra representation**: `∏ᵢ End(Vᵢ)` viewed as a representation of `G`,
+where `g` acts by left multiplication by `ψ(g) = ⊕ᵢ ρᵢ(g)` in the product algebra. This is the
+right-hand side of the book's `ψ` as a representation of `G`; `endRegRep_apply` certifies that the
+action is componentwise post-composition `fᵢ ↦ ρᵢ(g) ∘ fᵢ`. -/
+noncomputable def endRegRep (D : IrrepDecomp k G) :
+    Representation k G (Π i, Module.End k (D.columnFDRep i)) where
+  toFun g := Algebra.lmul k _ (D.endIso (MonoidAlgebra.of k G g))
+  map_one' := by rw [map_one, map_one, map_one]
+  map_mul' g h := by rw [map_mul, map_mul, map_mul]
+
+/-- The `i`-th component of `ψ(g) = endIso (of g)` is exactly the action `ρᵢ(g)` of `g` on the
+`i`-th irreducible representation `Vᵢ = columnFDRep i`. -/
+theorem endIso_of_apply (D : IrrepDecomp k G) (g : G) (i : Fin D.n) :
+    D.endIso (MonoidAlgebra.of k G g) i = (D.columnFDRep i).ρ g := by
+  have hproj : (D.iso (MonoidAlgebra.of k G g)) i = D.projRingHom i (MonoidAlgebra.of k G g) := rfl
+  have : D.endIso (MonoidAlgebra.of k G g) i =
+      Matrix.toLinAlgEquiv' (D.projRingHom i (MonoidAlgebra.of k G g)) := by
+    rw [← hproj]; rfl
+  rw [this]
+  ext v
+  rw [Matrix.toLinAlgEquiv'_apply]
+  rfl
+
+/-- The `G`-action of `endRegRep` is componentwise post-composition by `ρᵢ(g)`: for `F = (fᵢ)`,
+`(g · F)ᵢ = ρᵢ(g) ∘ fᵢ`. This certifies `endRegRep` is a faithful rendering of `⊕ᵢ End(Vᵢ)` with
+its natural left-multiplication `G`-action. -/
+theorem endRegRep_apply (D : IrrepDecomp k G) (g : G)
+    (F : Π i, Module.End k (D.columnFDRep i)) (i : Fin D.n) :
+    D.endRegRep g F i = (D.columnFDRep i).ρ g ∘ₗ F i := by
+  change (D.endIso (MonoidAlgebra.of k G g) * F) i = (D.columnFDRep i).ρ g ∘ₗ F i
+  rw [Pi.mul_apply, D.endIso_of_apply g i]
+  rfl
+
+/-- The Wedderburn algebra isomorphism `endIso` intertwines the regular representation with the
+left-multiplication action on `∏ᵢ End(Vᵢ)`: `ψ((of g) * x) = ψ(g) * ψ(x)`. -/
+theorem endIso_regularRep_comm (D : IrrepDecomp k G) (g : G) :
+    D.endIso.toLinearEquiv.toLinearMap ∘ₗ (MonoidAlgebra.regularRep k G) g =
+      D.endRegRep g ∘ₗ D.endIso.toLinearEquiv.toLinearMap := by
+  refine LinearMap.ext fun x => ?_
+  exact map_mul D.endIso (MonoidAlgebra.of k G g) x
+
+/-- `∏ᵢ End(Vᵢ)` with the left-multiplication `G`-action, packaged as an `FDRep k G`. -/
+noncomputable def endRegFDRep (D : IrrepDecomp k G) : FDRep k G :=
+  FDRep.of D.endRegRep
+
+/-- **Equivariant Wedderburn isomorphism.** The regular representation `k[G]` is isomorphic, as a
+representation of `G`, to `∏ᵢ End(Vᵢ)` with the left-multiplication action. This upgrades the
+algebra isomorphism `endIso` of `Theorem4_1_1_algebra_iso` to an isomorphism in `FDRep k G`. -/
+noncomputable def regularIso (D : IrrepDecomp k G) :
+    MonoidAlgebra.regularFDRep k G ≅ D.endRegFDRep :=
+  Action.mkIso D.endIso.toLinearEquiv.toFGModuleCatIso (fun g => by
+    ext : 1
+    exact D.endIso_regularRep_comm g)
+
+end IrrepDecomp
+
+/-- Maschke's theorem, part (ii), **representation-isomorphism form**.
+
+The book's part (ii) asserts that `ψ : k[G] → ⊕ᵢ End(Vᵢ)`, `g ↦ ⊕ᵢ g|_{Vᵢ}`, is an isomorphism
+*of representations* of `G` (both sides carrying the left-multiplication action), not only of
+`k`-algebras. This theorem records that content: there is a complete family `V : Fin n → FDRep k G`
+of the irreducible representations of `G` — each `Simple`, pairwise non-isomorphic, exhausting the
+simples — together with a representation `ρ_end` on `∏ᵢ End(Vᵢ)` whose action is
+`(g · F)ᵢ = ρᵢ(g) ∘ Fᵢ`, such that the regular representation `MonoidAlgebra.regularFDRep k G` is
+isomorphic in `FDRep k G` to `FDRep.of ρ_end`. The witnesses are the column-vector
+representations `columnFDRep` and the
+equivariant upgrade `IrrepDecomp.regularIso` of the Wedderburn isomorphism `IrrepDecomp.endIso`. -/
+theorem Etingof.Theorem4_1_1_regularRep_iso (k G : Type u)
+    [Field k] [IsAlgClosed k] [Group G] [Fintype G] [NeZero (Nat.card G : k)] :
+    ∃ (n : ℕ) (V : Fin n → FDRep k G) (ρ_end : Representation k G (Π i, Module.End k (V i))),
+      (∀ i, Simple (V i)) ∧
+      (∀ i j, Nonempty (V i ≅ V j) → i = j) ∧
+      (∀ W : FDRep k G, Simple W → ∃ i, Nonempty (W ≅ V i)) ∧
+      (∀ (g : G) (F : Π i, Module.End k (V i)) (i : Fin n), ρ_end g F i = (V i).ρ g ∘ₗ F i) ∧
+      Nonempty (MonoidAlgebra.regularFDRep k G ≅ FDRep.of ρ_end) :=
+  let D : IrrepDecomp k G := IrrepDecomp.mk'
+  ⟨D.n, D.columnFDRep, D.endRegRep, D.columnFDRep_simple, D.columnFDRep_injective,
+    D.columnFDRep_surjective, D.endRegRep_apply, ⟨D.regularIso⟩⟩

--- a/progress/2026-07-21T04-21-31Z_eece63f2.md
+++ b/progress/2026-07-21T04-21-31Z_eece63f2.md
@@ -1,0 +1,47 @@
+## Accomplished
+
+Feature session for #7134 (representation-level form of Maschke Theorem 4.1.1(ii)).
+Added to `EtingofRepresentationTheory/Chapter4/Theorem4_1_1.lean` (+113 lines):
+
+- `MonoidAlgebra.regularRep` / `MonoidAlgebra.regularFDRep` — the regular representation
+  of `G` on `k[G]` (`g · x = (of g) * x`) as a `Representation` and as an `FDRep k G`.
+  Plus `regularRep_apply` simp lemma.
+- `IrrepDecomp.endRegRep` / `endRegFDRep` — `∏ᵢ End(Vᵢ)` with the left-multiplication
+  `G`-action (`g` acts by left mult by `ψ(g) = ⊕ᵢ ρᵢ(g)`), as `Representation`/`FDRep`.
+- `IrrepDecomp.endIso_of_apply` — the `i`-th component of `ψ(g)` is exactly `ρᵢ(g)`.
+- `IrrepDecomp.endRegRep_apply` — certifies the target action is componentwise
+  post-composition `(g · F)ᵢ = ρᵢ(g) ∘ Fᵢ` (non-vacuity/faithfulness of the target).
+- `IrrepDecomp.endIso_regularRep_comm` + `IrrepDecomp.regularIso` — the equivariant
+  upgrade: `endIso` intertwines the two actions, giving an `FDRep k G` iso
+  `regularFDRep k G ≅ endRegFDRep`.
+- `Etingof.Theorem4_1_1_regularRep_iso` — the flagship: a complete family `V` of the
+  irreducibles (simple, pairwise non-iso, exhaustive) + a representation `ρ_end` on
+  `∏ᵢ End(Vᵢ)` with certified action `(g·F)ᵢ = ρᵢ(g)∘Fᵢ`, and an `FDRep` iso
+  `regularFDRep k G ≅ FDRep.of ρ_end`.
+
+This is the accepted "equivariant refinement of `D.endIso`" deliverable from #7134 —
+it captures the book's core representation-level claim that `ψ` is an isomorphism *of
+representations* (not merely algebras). `lake build …Chapter4.Theorem4_1_1` exits 0; all
+new declarations are axiom-clean `[propext, Classical.choice, Quot.sound]`.
+
+## Current frontier
+
+#7134 resolved via the equivariant-iso form. The alternative literal form
+`regularFDRep ≅ ⨁ᵢ (Vᵢ)^(dim Vᵢ)` (the book's final display `⊕ᵢ dim(Vᵢ)·Vᵢ`) is a
+corollary not yet formalized — see follow-up below.
+
+## Overall project progress
+
+Confidence/coverage phase. Theorem 4.1.1 now has: part (i) semisimple, part (ii) in
+sum-of-squares, algebra-iso, and representation-iso forms. The equivariant Wedderburn
+iso `IrrepDecomp.regularIso` is new infrastructure available for downstream work.
+
+## Next step
+
+Follow-up (filed): formalize the explicit `⨁ᵢ dim(Vᵢ)·Vᵢ` decomposition by decomposing
+each `endRegRep`-summand `End(Vᵢ)` into `dim Vᵢ` copies of `Vᵢ` (equivariant column
+decomposition), then combining over `i`. Builds directly on `IrrepDecomp.regularIso`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7134

Session: `eece63f2-2d28-4f08-9432-56f2dfafb095`

88318ebd feat(#7134): representation-level Maschke 4.1.1(ii) — equivariant Wedderburn iso k[G] ≅ ∏ᵢ End(Vᵢ)

🤖 Prepared with Claude Code