### PR TITLE
Fix fidelity of Theorem 5.10.1 (Frobenius reciprocity): stated in the reversed (left-adjoint) direction

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_10_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_10_1.lean
@@ -6,27 +6,40 @@ import Mathlib
 For a subgroup H ≤ G, a representation V of G, and a representation W of H,
 there is a natural isomorphism:
 
-  Hom_G(Ind_H^G W, V) ≅ Hom_H(W, Res_H^G V)
+  Hom_G(V, Ind_H^G W) ≅ Hom_H(Res_H^G V, W)
 
-This is the fundamental adjunction between induction and restriction functors.
+where `Ind_H^G W` is the book's **function-space (coinduced)** representation
+`{f : G → W | f(hx) = h·f(x)}` — the **right** adjoint of restriction. This is
+the fundamental adjunction between restriction and (co)induction functors, stated
+in the book's direction `Res ⊣ Coind`.
 
-Mathlib's `Rep.indResHomEquiv` provides a k-linear equivalence between
-`(Rep.ind H.subtype W ⟶ V)` and `(W ⟶ (Action.res _ H.subtype).obj V)`,
-which is precisely Frobenius reciprocity stated as Ind ⊣ Res.
+## Book statement (Etingof, Theorem 5.10.1)
+
+> The space `Hom_G(V, Ind_H^G W)` is naturally isomorphic to `Hom_H(Res_H^G V, W)`,
+
+with `V : Rep G`, `W : Rep H`, and `Ind_H^G W` the function-space representation.
+The book's proof constructs `F(α)v = (αv)(e)` for `α : V → Ind W`, i.e. the
+right-adjoint form `Res ⊣ Coind`. Mathlib's `Rep.coind` is precisely this
+function-space (coinduced) representation, and `Rep.resCoindHomEquiv` provides the
+`k`-linear equivalence realising the adjunction.
 
 ## Mathlib correspondence
 
-- `Rep.indResHomEquiv` — the k-linear equivalence (Frobenius reciprocity)
-- `Rep.indResAdjunction` — the categorical adjunction Ind ⊣ Res
-- `Rep.ind` — the induced representation functor
-- `Action.res` — the restriction functor
+- `Rep.resCoindHomEquiv` — the k-linear equivalence `(res φ B ⟶ A) ≃ₗ[k] (B ⟶ coind φ A)`
+- `Rep.resCoindAdjunction` — the categorical adjunction `Res ⊣ Coind`
+- `Rep.coind` — the coinduced (function-space) representation, right adjoint of `res`
+- `Rep.resFunctor` / `Rep.res` — the restriction functor along `φ`
+
+Instantiating `φ := H.subtype : ↥H →* G`, `B := V : Rep k G`, `A := W : Rep k ↥H`
+gives `(Res_H^G V ⟶ W) ≃ₗ[k] (V ⟶ Ind_H^G W)`; taking `.symm` states it in the
+book's orientation `Hom_G(V, Ind W) ≅ Hom_H(Res V, W)`.
 
 ## Book route vs. this formalization (completeness audit, epic #5338)
 
 The book concludes Theorem 5.10.1 from the tensor-hom adjunction of Problem
 2.11.6(b) applied to the `k[G]`-bimodule `k[G]` (see the Discussion in the proof
 of Problem 5.10.2). This formalization instead obtains the same equivalence
-directly from Mathlib's `Rep.indResHomEquiv`, so it does **not** depend on
+directly from Mathlib's `Rep.resCoindHomEquiv`, so it does **not** depend on
 Problem 2.11.6. See `Chapter2/Problem2_11_6.lean` for the audit conclusion that
 Problem 2.11.6 is not load-bearing for any formalized content.
 -/
@@ -34,12 +47,15 @@ Problem 2.11.6 is not load-bearing for any formalized content.
 open CategoryTheory
 
 /-- Frobenius reciprocity: there is a k-linear equivalence
-  Hom_G(Ind_H^G W, V) ≃ₗ[k] Hom_H(W, Res_H V).
-This is the adjunction between the induction and restriction functors.
-(Etingof Theorem 5.10.1) -/
+  Hom_G(V, Ind_H^G W) ≃ₗ[k] Hom_H(Res_H^G V, W),
+where `Ind_H^G W = Rep.coind H.subtype W` is the book's function-space (coinduced)
+representation — the **right** adjoint of restriction. The arrows match the book:
+maps `V ⟶ Ind W` of `G`-representations correspond to maps `Res V ⟶ W` of
+`H`-representations. (Etingof Theorem 5.10.1) -/
 theorem Etingof.Theorem5_10_1
     (k G : Type) [Field k] [Group G]
     (H : Subgroup G)
     (V : Rep k G) (W : Rep k ↥H) :
-    Nonempty ((Rep.ind H.subtype W ⟶ V) ≃ₗ[k] (W ⟶ (Rep.resFunctor H.subtype).obj V)) :=
-  ⟨Rep.indResHomEquiv H.subtype W V⟩
+    Nonempty ((V ⟶ Rep.coind H.subtype W) ≃ₗ[k]
+      ((Rep.resFunctor H.subtype).obj V ⟶ W)) :=
+  ⟨(Rep.resCoindHomEquiv H.subtype V W).symm⟩

--- a/progress/2026-07-21T08-01-29Z_98dd4537.md
+++ b/progress/2026-07-21T08-01-29Z_98dd4537.md
@@ -1,0 +1,45 @@
+## Accomplished
+
+Feature session (issue #7187): corrected the fidelity direction of
+**Theorem 5.10.1 (Frobenius reciprocity)** in
+`EtingofRepresentationTheory/Chapter5/Theorem5_10_1.lean`.
+
+- The headline `Etingof.Theorem5_10_1` previously asserted the **reversed**
+  (left-adjoint, tensor-induction) form `Hom_G(Ind W, V) ≅ Hom_H(W, Res V)` via
+  `Rep.indResHomEquiv` — a faithful proof of a *different* theorem than the book's.
+- Restated in the book's direction:
+  `Hom_G(V, Ind_H^G W) ≃ₗ[k] Hom_H(Res_H^G V, W)`, where `Ind_H^G W =
+  Rep.coind H.subtype W` is the **function-space (coinduced)** representation —
+  the right adjoint of restriction (`Res ⊣ Coind`). Proof is
+  `(Rep.resCoindHomEquiv H.subtype V W).symm`.
+- `resCoindHomEquiv φ B A : (res φ B ⟶ A) ≃ₗ[k] (B ⟶ coind φ A)`; instantiating
+  `φ := H.subtype`, `B := V`, `A := W` gives exactly the book's arrows
+  (`V ⟶ coind W` of G-reps ↔ `res V ⟶ W` of H-reps). No finiteness hypothesis
+  needed — chose option (a) from the issue (coinduction API exists in Mathlib's
+  `RepresentationTheory.Coinduced`).
+- Rewrote the module docstring to describe the book statement, the coinduced
+  (function-space) `Ind`, and the Mathlib correspondence.
+- `progress/items.json`: flipped `Chapter5/Theorem5.10.1` fidelity `gap → faithful`
+  with a resolution note referencing #7187.
+
+## Current frontier
+
+Issue #7187 complete. `lake build EtingofRepresentationTheory.Chapter5.Theorem5_10_1`
+succeeds; `#print axioms Etingof.Theorem5_10_1` = `[propext, Classical.choice,
+Quot.sound]` (no `sorryAx`).
+
+## Overall project progress
+
+Book is largely formalized; remaining unclaimed work is fidelity/completeness
+polish. After this fix, three feature issues remain unclaimed: #7180 (dim formula
+for Weyl character), #7185 (Krull-Schmidt uniqueness), #7188 (distinguish ℂ³₋/ℂ³₊
+Specht modules for S₄).
+
+## Next step
+
+Land the PR for #7187. A good next pick is #7188 (companion fidelity fix from the
+same re-audit #7183) or #7185.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3912,10 +3912,10 @@
     "start_line": 7,
     "end_line": 34,
     "status": "sorry_free",
-    "fidelity": "gap",
+    "fidelity": "faithful",
     "needs_statement": false,
     "sorry_free": true,
-    "fidelity_note": "[fidelity] Wrong adjunction direction. Book states Frobenius reciprocity as Hom_G(V, Ind_H^G W) ≅ Hom_H(Res V, W) (i.e., Res ⊣ CoInd direction, or equivalently: Ind is left adjoint gives Hom_G(Ind W, ",
+    "fidelity_note": "[fidelity RESOLVED #7187] Restated in the book's direction: Etingof.Theorem5_10_1 now asserts Hom_G(V, Ind_H^G W) ≃ₗ[k] Hom_H(Res_H^G V, W) via Mathlib's Rep.resCoindHomEquiv, with Ind_H^G W = Rep.coind H.subtype W the function-space (coinduced) representation and right adjoint of restriction (Res ⊣ Coind). Arrows now match the book: V ⟶ coind W of G-reps ↔ res V ⟶ W of H-reps. Builds sorry-free; #print axioms: propext/Classical.choice/Quot.sound only (no sorryAx). Previously stated the reversed left-adjoint tensor-induction form Hom_G(Ind W, V) ≅ Hom_H(W, Res V).",
     "fidelity_issue": 5621
   },
   {


### PR DESCRIPTION
Closes #7187

Session: `98dd4537-3d58-4f54-b060-2d152941d478`

3c0899b0 fix(#7187): restate Theorem 5.10.1 (Frobenius reciprocity) in book direction

🤖 Prepared with Claude Code