### PR TITLE
Fix fidelity of Example 5.12.3: distinguish the two 3-dim S₄ irreps ℂ³₋ (3,1) and ℂ³₊ (2,1,1)

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Example5_12_3.lean
+++ b/EtingofRepresentationTheory/Chapter5/Example5_12_3.lean
@@ -1,6 +1,8 @@
 import EtingofRepresentationTheory.Chapter5.CharValueHookFormula
 import EtingofRepresentationTheory.Chapter5.FRTHelpers
 import EtingofRepresentationTheory.Chapter5.Lemma5_13_1
+import EtingofRepresentationTheory.Chapter5.Theorem5_12_2_Distinct
+import EtingofRepresentationTheory.Chapter5.Problem5_24_1_b
 
 /-!
 # Example 5.12.3: Concrete Examples of Specht Modules
@@ -29,6 +31,13 @@ not merely a dimension. We capture this directly at the `ℂ[Sₙ]`-module level
 group element `σ` acts as `sign σ` on `V_{(1ⁿ)}` (sign representation). These
 distinguish the two one-dimensional representations, which a dimension count
 alone cannot.
+
+Likewise the book names the two `n = 4` three-dimensional cases as *distinct*
+irreducibles: `V_{(3,1)} = ℂ³₋` (standard) and `V_{(2,1,1)} = ℂ³₊ = ℂ³₋ ⊗ ℂ₋`.
+`Example5_12_3_sign_twist_31_211` witnesses the sign-twist relation `ℂ³₊ = ℂ³₋ ⊗ ℂ₋`
+(since `(2,1,1)` is the conjugate partition of `(3,1)`, `conjugatePartition_p_31`), and
+`Example5_12_3_specht_31_211_noniso` witnesses that the two are non-isomorphic — neither of
+which a dimension count (both `= 3`) can capture.
 
 ## Mathlib correspondence
 
@@ -257,6 +266,72 @@ theorem Example5_12_3_dim_211 :
       hookLengthProduct_eq_of p_211 [2, 1, 1] 8 (sortedParts_eq_of _ [2, 1, 1] rfl (by decide))
         (by decide)]
   rfl
+
+/-! ### The two 3-dimensional irreducibles `ℂ³₋` and `ℂ³₊`
+
+The book's Example 5.12.3 asserts more than `dim = 3` for the partitions `(3,1)` and
+`(2,1,1)`: it names them as the two *distinct* 3-dimensional irreducibles `ℂ³₋` (the
+standard representation) and `ℂ³₊ = ℂ³₋ ⊗ ℂ₋` (standard, twisted by sign). A dimension
+count alone (`Example5_12_3_dim_31`/`Example5_12_3_dim_211`, both `= 3`) cannot separate
+them. We pin the distinction down with two Lean witnesses.
+
+First, `(2,1,1)` is the conjugate (transpose) partition of `(3,1)`, so the
+conjugate-partition sign twist `spechtModule_signTwist_iso_conjugate` (Problem 5.24.1(b))
+specialises to a `ℂ`-linear equivalence `V_{(3,1)} ≃ V_{(2,1,1)}` intertwining the two
+`S₄`-actions by the sign character: `e(g • x) = sign(g) • (g • e x)`. This is exactly
+`V_{(2,1,1)} ≅ V_{(3,1)} ⊗ ℂ₋`, the book's `ℂ³₊ = ℂ³₋ ⊗ ℂ₋`.
+
+Second, the two modules are *not* isomorphic as `ℂ[S₄]`-modules
+(`Theorem5_12_2_distinct`): they are genuinely the two different 3-dimensional
+irreducibles, not two copies of one. -/
+
+/-- `(2,1,1)` is the conjugate (transpose) partition of `(3,1)`: reflecting the Young
+diagram of `(3,1)` (rows `3, 1`) across its main diagonal gives the column lengths
+`2, 1, 1`. -/
+theorem conjugatePartition_p_31 : conjugatePartition p_31 = p_211 := by
+  apply Nat.Partition.ext
+  show (↑(p_31.toYoungDiagram.transpose.rowLens) : Multiset ℕ) = ({2, 1, 1} : Multiset ℕ)
+  have hsp : p_31.sortedParts = [3, 1] := sortedParts_eq_of _ [3, 1] rfl (by decide)
+  have hc0 : p_31.toYoungDiagram.colLen 0 = 2 := by
+    rw [toYoungDiagram_colLen_eq, hsp]; decide
+  have hc1 : p_31.toYoungDiagram.colLen 1 = 1 := by
+    rw [toYoungDiagram_colLen_eq, hsp]; decide
+  have hc2 : p_31.toYoungDiagram.colLen 2 = 1 := by
+    rw [toYoungDiagram_colLen_eq, hsp]; decide
+  have hlen : p_31.toYoungDiagram.transpose.colLen 0 = 3 := by
+    rw [YoungDiagram.colLen_transpose, Nat.Partition.toYoungDiagram_rowLen_eq_getD, hsp]; rfl
+  have hrl : p_31.toYoungDiagram.transpose.rowLens = [2, 1, 1] := by
+    simp only [YoungDiagram.rowLens, hlen]
+    rw [show List.range 3 = [0, 1, 2] by decide]
+    simp only [List.map_cons, List.map_nil, YoungDiagram.rowLen_transpose, hc0, hc1, hc2]
+  rw [hrl]; rfl
+
+/-- **Etingof Example 5.12.3 (`ℂ³₊ = ℂ³₋ ⊗ ℂ₋`).** The Specht module `V_{(2,1,1)}` is the
+sign twist of `V_{(3,1)}`: there is a `ℂ`-linear equivalence `V_{(3,1)} ≃ V_{(2,1,1)}`
+intertwining the `S₄`-actions by the sign character, `e(g • x) = sign(g) • (g • e x)`.
+Equivalently `V_{(2,1,1)} ≅ V_{(3,1)} ⊗ ℂ₋`, so if `V_{(3,1)} = ℂ³₋` then `V_{(2,1,1)} =
+ℂ³₊`. Obtained from the conjugate-partition sign twist
+(`spechtModule_signTwist_iso_conjugate`, Problem 5.24.1(b)) via
+`conjugatePartition (3,1) = (2,1,1)`. -/
+theorem Example5_12_3_sign_twist_31_211 :
+    ∃ e : ↥(SpechtModule 4 p_31) ≃ₗ[ℂ] ↥(SpechtModule 4 p_211),
+      ∀ (g : Equiv.Perm (Fin 4)) (x : ↥(SpechtModule 4 p_31)),
+        e ((MonoidAlgebra.of ℂ (Equiv.Perm (Fin 4)) g) • x)
+          = ((Equiv.Perm.sign g : ℤ) : ℂ)
+              • ((MonoidAlgebra.of ℂ (Equiv.Perm (Fin 4)) g) • e x) := by
+  have h := spechtModule_signTwist_iso_conjugate 4 p_31
+  rw [conjugatePartition_p_31] at h
+  exact h
+
+/-- **Etingof Example 5.12.3 (`ℂ³₋ ≠ ℂ³₊`).** The two 3-dimensional Specht modules
+`V_{(3,1)}` and `V_{(2,1,1)}` are *not* isomorphic as `ℂ[S₄]`-modules: they are the two
+distinct 3-dimensional irreducibles `ℂ³₋` and `ℂ³₊`. Combined with the sign-twist
+equivalence `Example5_12_3_sign_twist_31_211`, this is the full book claim: `V_{(2,1,1)}`
+is `V_{(3,1)}` tensored with the sign character, and the result is a genuinely different
+representation. -/
+theorem Example5_12_3_specht_31_211_noniso :
+    IsEmpty (↥(SpechtModule 4 p_31) ≃ₗ[SymGroupAlgebra 4] ↥(SpechtModule 4 p_211)) :=
+  Theorem5_12_2_distinct 4 p_31 p_211 (by decide)
 
 /-! ## Representation-level structure: the trivial and sign characters
 

--- a/progress/2026-07-21T08-35-31Z_49051b12.md
+++ b/progress/2026-07-21T08-35-31Z_49051b12.md
@@ -1,0 +1,43 @@
+## Accomplished
+
+Fixed the fidelity gap in **Example 5.12.3** (issue #7188): the two 3-dimensional
+Specht modules `V_{(3,1)}` and `V_{(2,1,1)}` were previously captured only by dimension
+(both `= 3`), with the book's `ℂ³₋` / `ℂ³₊` distinction living only in doc-comment prose.
+Added three axiom-clean Lean witnesses to
+`EtingofRepresentationTheory/Chapter5/Example5_12_3.lean`:
+
+- `conjugatePartition_p_31 : conjugatePartition p_31 = p_211` — `(2,1,1)` is the conjugate
+  (transpose) partition of `(3,1)` (computed via `toYoungDiagram.transpose.rowLens` and the
+  file's own `toYoungDiagram_colLen_eq`).
+- `Example5_12_3_sign_twist_31_211` — `V_{(2,1,1)} ≅ V_{(3,1)} ⊗ ℂ₋`: a `ℂ`-linear
+  equivalence intertwining the `S₄`-actions by the sign character, `e(g•x) = sign(g)•(g•e x)`.
+  This is exactly the book's `ℂ³₊ = ℂ³₋ ⊗ ℂ₋`. Obtained by specialising the
+  conjugate-partition sign twist `spechtModule_signTwist_iso_conjugate` (Problem 5.24.1(b))
+  along `conjugatePartition_p_31`.
+- `Example5_12_3_specht_31_211_noniso` — the two are *not* isomorphic as `ℂ[S₄]`-modules
+  (`Theorem5_12_2_distinct`): `ℂ³₋ ≠ ℂ³₊`.
+
+Updated the module docstring and `progress/items.json` (`Chapter5/Example5.12.3` flipped
+`fidelity: gap → verified`).
+
+## Current frontier
+
+`Example5_12_3.lean` builds (exit 0, full `lake build` "Build completed successfully").
+`#print axioms` on all three new decls → `[propext, Classical.choice, Quot.sound]`
+(no `sorryAx`).
+
+## Overall project progress
+
+Stage 3 formalization + Stage 3.7 fidelity re-audit ongoing. This turn closes one of the
+re-audit fidelity gaps (Example 5.12.3). Remaining unclaimed fidelity/feature issues at
+turn start: #7180 (Thm 5.22.1 part 3 dimension formula), #7185 (Krull-Schmidt uniqueness),
+#7187 (Thm 5.10.1 Frobenius reciprocity direction — claimed by another agent).
+
+## Next step
+
+Pick up #7180 or #7185 (both `feature`). #7187 was already claimed.
+
+## Blockers
+
+None. Note: the (2,1)→ℂ² and (2,2)→ℂ² cases in Example 5.12.3 remain dimension-only, which
+is faithful (each of S₃/S₄ has a unique 2-dim irrep), so no further work is needed there.

--- a/progress/items.json
+++ b/progress/items.json
@@ -4042,9 +4042,9 @@
     "start_line": 26,
     "end_line": 6,
     "status": "sorry_free",
-    "fidelity": "gap",
+    "fidelity": "verified",
     "sorry_free": true,
-    "fidelity_note": "Trivial/sign claims now proved at the representation level: Example5_12_3_trivial_rep (every σ acts as identity on V_{(n)}) and Example5_12_3_sign_rep (every σ acts as sign σ on V_{(1ⁿ)}). Residual: the n=3,4 cases (ℂ², ℂ³₋, ℂ³₊) are still identified only by dimension, not by an explicit equivariant isomorphism to the named irreps.",
+    "fidelity_note": "Trivial/sign claims proved at the representation level (Example5_12_3_trivial_rep, Example5_12_3_sign_rep). The two 3-dim cases are now distinguished (#7188): Example5_12_3_sign_twist_31_211 witnesses ℂ³₊ = ℂ³₋ ⊗ sign (V_{(2,1,1)} ≅ V_{(3,1)} ⊗ sign, since (2,1,1) is the conjugate of (3,1), conjugatePartition_p_31), and Example5_12_3_specht_31_211_noniso witnesses ℂ³₋ ≠ ℂ³₊ (the two Specht modules are non-isomorphic ℂ[S₄]-modules). The (2,1)→ℂ² and (2,2)→ℂ² cases remain dimension-only, which is faithful since each of S₃/S₄ has a unique 2-dim irrep. All new decls axiom-clean (no sorryAx).",
     "fidelity_issue": 5637
   },
   {


### PR DESCRIPTION
Closes #7188

Session: `49051b12-d300-413d-ba63-7eb4fe7a74fe`

e78cb6b8 feat(#7188): distinguish the two 3-dim S₄ irreps ℂ³₋ (3,1) and ℂ³₊ (2,1,1)

🤖 Prepared with Claude Code