### PR TITLE
style(Ch7): rewrite comments and docstrings as mathematics, not formalization history

### DIFF
--- a/EtingofRepresentationTheory/Chapter7/Discussion_after_Example7_9_5.lean
+++ b/EtingofRepresentationTheory/Chapter7/Discussion_after_Example7_9_5.lean
@@ -13,7 +13,7 @@ splits, i.e. is isomorphic to `0 → X → X ⊕ Y → Y → 0`. An additive fun
 (Definition 7.9.1) preserves finite biproducts, hence sends a splitting to a
 splitting; and a split short complex is short exact. So an additive functor out
 of a semisimple category carries every short exact sequence to a short exact
-sequence — it is exact on both sides.
+sequence, so it is exact on both sides.
 
 ## Mathlib correspondence
 
@@ -27,7 +27,7 @@ exact). "Exact on both sides" is `ShortComplex.ShortExact`, which packages
 open CategoryTheory
 
 /-- Discussion after Example 7.9.5: an additive functor `F : C ⥤ D` between abelian
-categories, defined on a semisimple category `C`, is exact on both sides — it
+categories, defined on a semisimple category `C`, is exact on both sides: it
 carries every short exact sequence to a short exact sequence.
 
 In a semisimple category every short exact sequence `S` splits (Definition 7.9.4);

--- a/EtingofRepresentationTheory/Chapter7/Example7_2_2.lean
+++ b/EtingofRepresentationTheory/Chapter7/Example7_2_2.lean
@@ -19,7 +19,7 @@ import Mathlib.RepresentationTheory.Induced
 
 Etingof's Example 7.2.2 collects nine illustrations of functors. We formalize
 each item against Mathlib where the construction is available, and note the
-genuinely advanced ones (Schur and reflection functors) that are out of scope.
+advanced ones (Schur and reflection functors) that are out of scope.
 
 1. A category with one object is a monoid; a functor between such categories is
    a monoid homomorphism.
@@ -213,18 +213,18 @@ noncomputable example (k : Type*) [CommRing k] (n : ℕ) : ModuleCat k ⥤ Modul
 
 **Symmetric power `V ↦ Sⁿ V`.** Mathlib has the symmetric power `Sym[k]^n V`
 (`Mathlib.LinearAlgebra.TensorPower.Symmetric`, the quotient of `V^{⊗n}` by the
-symmetric-group action), but its functoriality — a `map` on linear maps together
-with the universal property — is not yet available (it is listed as future work
+symmetric-group action), but its functoriality (a `map` on linear maps together
+with the universal property) is not yet available (it is listed as future work
 in that file). Once `SymmetricPower.map` (or the symmetric universal property)
-lands upstream, `V ↦ Sⁿ V` assembles into an endofunctor of `ModuleCat k` exactly
+lands upstream, `V ↦ Sⁿ V` forms an endofunctor of `ModuleCat k` exactly
 as the exterior power does above. This is a missing-API gap, not a mathematical
 obstruction.
 
 **Schur functors `V ↦ Hom_{S_n}(π, V^{⊗n})`.** For a representation `π` of `Sₙ`,
 the Schur functor sends `V` to `Hom_{S_n}(π, V^{⊗n})`; the irreducible ones are
 labeled by Young diagrams. This requires the `Sₙ`-action on `V^{⊗n}` and the
-`Sₙ`-equivariant Hom, neither packaged as a functor in Mathlib. It is genuinely
-advanced and is deferred; the tensor-power functor above is the first ingredient. -/
+`Sₙ`-equivariant Hom, neither packaged as a functor in Mathlib. It is advanced
+and is deferred; the tensor-power functor above is the first ingredient. -/
 
 /-! ### (9) Reflection functors (scope note)
 
@@ -237,7 +237,7 @@ of `Q̄_i` at a source, with the companion `reflectionFunctorPlus` at a sink.
 
 Packaging these as `CategoryTheory.Functor`s between the representation categories
 `Rep(Q) ⥤ Rep(Q̄_i)` additionally requires the action on morphisms of representations
-plus the functor laws, which are not assembled here (BGP reflection functors are not
+plus the functor laws, which are not carried out here (BGP reflection functors are not
 in Mathlib). This is deferred pending a `CategoryTheory`-level quiver-representation
 category compatible with the object-level construction of Definition 6.6.4. -/
 

--- a/EtingofRepresentationTheory/Chapter7/Example7_3_2.lean
+++ b/EtingofRepresentationTheory/Chapter7/Example7_3_2.lean
@@ -28,7 +28,7 @@ universe u v
 /-- The canonical evaluation map gives a linear equivalence `V ≃ₗ[k] V**` for any
 finite-dimensional vector space V over a field k. (Etingof Example 7.3.2(1))
 
-The key point is that this isomorphism is *natural*: for any linear map `f : V →ₗ[k] W`,
+The key point is that this isomorphism is natural: for any linear map `f : V →ₗ[k] W`,
 the diagram `V → V** → W**` commutes with `V → W → W**`, which is captured by
 `Module.Dual.eval_naturality`. -/
 noncomputable def Etingof.double_dual_iso
@@ -47,12 +47,12 @@ theorem Etingof.double_dual_naturality
     f.dualMap.dualMap ∘ₗ Module.Dual.eval k V = Module.Dual.eval k W ∘ₗ f :=
   Module.Dual.eval_naturality f
 
-/-- **Example 7.3.2(1), second half.** On the category `Vect_k` of *all* vector
-spaces the identity and double-dual functors are *not* isomorphic. Concretely, `V` is
+/-- **Example 7.3.2(1), second half.** On the category `Vect_k` of all vector
+spaces the identity and double-dual functors are not isomorphic. Concretely, `V` is
 linearly isomorphic to its double dual `V**` if and only if `V` is finite-dimensional:
 in infinite dimension the double dual is strictly larger
 (`Module.rank k V < Module.rank k V** `, an Erdős–Kaplansky consequence), so no
-isomorphism — let alone a natural one — can exist. Contrast with `double_dual_iso`,
+isomorphism, let alone a natural one, can exist. Contrast with `double_dual_iso`,
 which supplies the isomorphism in the finite-dimensional case. -/
 theorem Etingof.linearEquiv_dualDual_iff_finiteDimensional (k V : Type u)
     [Field k] [AddCommGroup V] [Module k V] :
@@ -117,21 +117,21 @@ noncomputable def Etingof.doubleDualNatIso (k : Type u) [Field k] :
 
 Let `FVect'_k` be the groupoid of finite-dimensional `k`-vector spaces with *isomorphisms*
 as morphisms, and `F : FVect'_k → FVect'_k` the functor `V ↦ V*`, `a ↦ (a*)⁻¹`. Etingof's
-point is that `F` is *pointwise* isomorphic to the identity (`V ≅ V*` for every `V`) yet is
-*not naturally isomorphic* to it: a natural iso would give, for every `V`, an isomorphism
+point is that `F` is pointwise isomorphic to the identity (`V ≅ V*` for every `V`) yet is
+not naturally isomorphic to it: a natural iso would give, for every `V`, an isomorphism
 `V ≅ V*` compatible with the `GL(V)`-action, which is impossible because `V` and `V*` are
 inequivalent as `GL(V)`-representations.
 
-The positive half — `V ≅ V*` exactly when `V` is finite-dimensional — is
+The positive half, `V ≅ V*` exactly when `V` is finite-dimensional, is
 `linearEquiv_dual_iff_finiteDimensional` (Mathlib's
 `Basis.linearEquiv_dual_iff_finiteDimensional`, an Erdős–Kaplansky consequence, the same
 dichotomy `linearEquiv_dualDual_iff_finiteDimensional` gives for the double dual).
 
-The deeper content — *non-naturality* — is `dual_gl_natural_eq_zero` and its corollary
-`not_bijective_of_gl_natural_dual` below. The naturality of a would-be isomorphism `η : Id ≅ F`
+The deeper content, non-naturality, is `dual_gl_natural_eq_zero` and its corollary
+`not_bijective_of_gl_natural_dual` below. The naturality of a putative isomorphism `η : Id ≅ F`
 at the object `V`, tested against the automorphisms `a ∈ GL(V) = V ≃ₗ[k] V`, is exactly the
 `GL(V)`-equivariance square `a* ∘ η_V ∘ a = η_V`; a `k`-bilinear reading of this square,
-`B(a u, a w) = B(u, w)` for `B(u, w) := η_V u w`, says `B` is a `GL(V)`-*invariant* bilinear
+`B(a u, a w) = B(u, w)` for `B(u, w) := η_V u w`, says `B` is a `GL(V)`-invariant bilinear
 form. Over any field with a scalar `l ≠ 0`, `l² ≠ 1` (e.g. any field with more than three
 elements) the scalar automorphisms `a = l • 𝟙` already force `l² · B = B`, hence `B = 0` and
 `η_V = 0`. So no natural family can consist of isomorphisms once `V ≠ 0`: `F` is not naturally
@@ -154,9 +154,9 @@ theorem Etingof.linearEquiv_dual_iff_finiteDimensional (k V : Type u)
 
 /-- **Example 7.3.2(2), non-naturality obstruction.** Let `k` be a field containing a scalar
 `l ≠ 0` with `l² ≠ 1` (any field with more than three elements). If `η : V →ₗ[k] V*` is
-*natural with respect to `GL(V)`* — meaning for every linear automorphism `a : V ≃ₗ[k] V` the
+natural with respect to `GL(V)`, meaning for every linear automorphism `a : V ≃ₗ[k] V` the
 square `a* ∘ η ∘ a = η` commutes (equivalently, the bilinear form `B(u, w) = η u w` is
-`GL(V)`-invariant: `B(a u, a w) = B(u, w)`) — then `η = 0`.
+`GL(V)`-invariant: `B(a u, a w) = B(u, w)`), then `η = 0`.
 
 This is the `GL(V)`-representation obstruction behind Etingof's remark that the functor
 `F : V ↦ V*` on `FVect'_k` is not naturally isomorphic to the identity: only the scalar
@@ -187,8 +187,8 @@ theorem Etingof.dual_gl_natural_eq_zero
 `l² ≠ 1` (any field with more than three elements), no `GL(V)`-natural family can consist of
 isomorphisms when `V ≠ 0`. Concretely, a `GL(V)`-natural `η : V →ₗ[k] V*` is forced to be `0`
 (`dual_gl_natural_eq_zero`), hence not bijective. This is why the functor `F : V ↦ V*` on
-`FVect'_k` — pointwise isomorphic to the identity by `linearEquiv_dual_iff_finiteDimensional` —
-is nonetheless *not naturally isomorphic* to the identity functor. -/
+`FVect'_k` (pointwise isomorphic to the identity by `linearEquiv_dual_iff_finiteDimensional`)
+is nonetheless not naturally isomorphic to the identity functor. -/
 theorem Etingof.not_bijective_of_gl_natural_dual
     {k V : Type u} [Field k] [AddCommGroup V] [Module k V] [Nontrivial V]
     (η : V →ₗ[k] Module.Dual k V)
@@ -203,9 +203,9 @@ theorem Etingof.not_bijective_of_gl_natural_dual
 open CategoryTheory in
 /-- **Example 7.3.2(2), categorical form: the contragredient functor `F` on `FVect'_k`.**
 Etingof's `FVect'_k` is the groupoid of finite-dimensional `k`-vector spaces with
-*isomorphisms* as morphisms; we model it as `Core (FGModuleCat k)`. The contragredient
+isomorphisms as morphisms; we model it as `Core (FGModuleCat k)`. The contragredient
 functor `F` sends `V ↦ V*` and an isomorphism `a : V ≅ W` to `(a*)⁻¹ = (a⁻¹)* : V* ≅ W*`
-(the inverse of the transpose — this is why `F` is only functorial on the groupoid, not on
+(the inverse of the transpose; this is why `F` is only functorial on the groupoid, not on
 the whole category, where dualization is contravariant). -/
 noncomputable def Etingof.contragredientFunctor (k : Type u) [Field k] :
     Core (FGModuleCat.{u} k) ⥤ Core (FGModuleCat.{u} k) where
@@ -214,11 +214,11 @@ noncomputable def Etingof.contragredientFunctor (k : Type u) [Field k] :
 
 open CategoryTheory in
 /-- **Example 7.3.2(2), categorical form: `𝟭 ≇ F`.** On the groupoid `FVect'_k`
-(`Core (FGModuleCat k)`) the identity functor is *not* naturally isomorphic to the
+(`Core (FGModuleCat k)`) the identity functor is not naturally isomorphic to the
 contragredient functor `F : V ↦ V*`, over any field `k` with a scalar `l ≠ 0`, `l² ≠ 1`
 (any field with more than three elements). This is Etingof's statement that `F`, though
 pointwise isomorphic to the identity (`linearEquiv_dual_iff_finiteDimensional`), is not
-naturally isomorphic to it. The proof extracts, from a would-be natural isomorphism, its
+naturally isomorphic to it. The proof extracts, from a putative natural isomorphism, its
 component `η : k → k*` at the line `k` and the `GL(k)`-naturality square for scalar
 automorphisms, then invokes the obstruction `not_bijective_of_gl_natural_dual`: naturality
 forces `η = 0`, contradicting that a component of a natural isomorphism is an isomorphism. -/
@@ -261,23 +261,23 @@ endomorphism of `F` is a family of `k`-linear maps `η_M : M → M`, one for eve
 map) we have `η_N ∘ f = f ∘ η_M`. The book states, quoting Problem 2.3.17, that the
 ring of such natural endomorphisms is `A` itself.
 
-The heart of the statement is that any such family is *determined* by a single
+The heart of the statement is that any such family is determined by a single
 element `a := η_A 1 ∈ A`, and equals scalar multiplication by that element on every
 module. The proof is exactly the Problem 2.3.17 idea specialised across all modules:
 for `m ∈ M`, right multiplication `r_m : A → M`, `x ↦ x • m`, is `A`-linear
 (`LinearMap.toSpanSingleton`), so naturality applied to `r_m` and evaluated at
 `1 ∈ A` gives `η_M m = η_M (r_m 1) = r_m (η_A 1) = (η_A 1) • m`.
 
-The correspondence `a ↦ (m ↦ a • m)` is a *ring* isomorphism (composition of the
+The correspondence `a ↦ (m ↦ a • m)` is a ring isomorphism (composition of the
 families multiplies the elements in the same order: `a • (b • m) = (a*b) • m`), so
-`End(F) ≅ A` — not `Aᵒᵖ`. The opposite appears in Problem 2.3.17 only because there
-one composes `A`-linear self-maps of the *single* module `A`; here the elements act
+`End(F) ≅ A`, not `Aᵒᵖ`. The opposite appears in Problem 2.3.17 only because there
+one composes `A`-linear self-maps of the single module `A`; here the elements act
 uniformly on all modules by left multiplication.
 -/
 
 /-- **Example 7.3.2(3).** A natural endomorphism `η` of the forgetful functor
-`F : A-mod → Vect_k` — a `k`-linear map `η M : M →ₗ[k] M` for every `A`-module `M`,
-natural in `M` — acts on every module as scalar multiplication by the single element
+`F : A-mod → Vect_k`, a `k`-linear map `η M : M →ₗ[k] M` for every `A`-module `M`,
+natural in `M`, acts on every module as scalar multiplication by the single element
 `η A 1 ∈ A`. Consequently the natural endomorphisms of `F` are in bijection with `A`
 (each is determined by its value `η A 1`), which is the content of `End(F) = A`. The
 argument specialises Problem 2.3.17: naturality against right multiplication
@@ -312,19 +312,19 @@ theorem Etingof.forgetful_smul_comp
 /-!
 ## Example 7.3.2(4): `End(Id_{A-mod}) = Z(A)`
 
-A natural endomorphism of the *identity* functor on `A-mod` is a family of *`A`-linear*
+A natural endomorphism of the identity functor on `A-mod` is a family of `A`-linear
 maps `η_M : M → M`, one per `A`-module `M`, natural in `M`. As in sub-item (3) the
 family is determined by `c := η_A 1`: naturality against right multiplication
 `r_m : A → M`, `x ↦ x • m`, forces `η_M m = c • m`. But now the maps are `A`-linear,
-and `A`-linearity of `η_A` itself pins `c` down further — it must be *central*. Indeed
+and `A`-linearity of `η_A` itself pins `c` down further: it must be central. Indeed
 `η_A a = c • a` (determination) while `η_A a = η_A (a • 1) = a • c` (`A`-linearity), so
 `c * a = a * c` for every `a ∈ A`. Thus the natural endomorphisms of the identity
 functor are exactly the central elements: `End(Id_{A-mod}) = Z(A)`.
 -/
 
 /-- **Example 7.3.2(4).** A natural endomorphism `η` of the identity functor on
-`A-mod` — an `A`-linear map `η M : M →ₗ[A] M` for every `A`-module `M`, natural in
-`M` — acts on every module as scalar multiplication by the single element
+`A-mod`, an `A`-linear map `η M : M →ₗ[A] M` for every `A`-module `M`, natural in
+`M`, acts on every module as scalar multiplication by the single element
 `η A 1 ∈ A`. This is the exact analogue of `forgetful_natEnd_eq_smul`, now with
 `A`-linear (rather than merely `k`-linear) components. -/
 theorem Etingof.idFunctor_natEnd_eq_smul

--- a/EtingofRepresentationTheory/Chapter7/Example7_5_3.lean
+++ b/EtingofRepresentationTheory/Chapter7/Example7_5_3.lean
@@ -8,7 +8,7 @@ to the category of vector spaces is representable, and the representing object i
 the free rank 1 module (= the regular representation) `M = A`.
 
 But if `A` is infinite dimensional and we restrict attention to the category of
-**finite dimensional** modules, then the forgetful functor is, in general, **not**
+finite dimensional modules, then the forgetful functor is, in general, not
 representable. Etingof's witness is `A = c₀₀(ℤ)`, the algebra of complex functions on
 `ℤ` that vanish at all but finitely many points.
 
@@ -21,13 +21,13 @@ which says the forgetful functor from `R`-modules to types is representable by `
 
 ### Claim (2): non-representability on finite dimensional modules
 
-Etingof's algebra `A = c₀₀(ℤ)` is **non-unital** (there is no finitely supported
+Etingof's algebra `A = c₀₀(ℤ)` is non-unital (there is no finitely supported
 function equal to `1` everywhere), so its modules fall outside Mathlib's unital `Module`
 framework. We formalize the same obstruction over the polynomial algebra `A = k[x]`, an
 *equivalent* infinite dimensional algebra: it has infinitely many one dimensional simple
 modules (one `ℂ_μ` for each scalar `μ`, where `x` acts as `μ`), yet any finite dimensional
 module only "sees" finitely many of them through `Hom`. This is the identical phenomenon
-that makes `c₀₀(ℤ)` fail — infinitely many one dimensional simples, each finite dimensional
+that makes `c₀₀(ℤ)` fail: infinitely many one dimensional simples, each finite dimensional
 module reaching only finitely many.
 
 Concretely, a finite dimensional `k[x]`-module is a finite dimensional vector space `V`
@@ -110,7 +110,7 @@ theorem forgetfulHom_eq_bot_of_not_hasEigenvalue [FiniteDimensional k V]
 scalar `μ` for which the Hom space `Hom_A(M, ℂ_μ)` is zero, even though the target module
 `ℂ_μ` is one dimensional.
 
-This is the crux of the non-representability: an endomorphism of a finite dimensional
+This is the reason for the non-representability: an endomorphism of a finite dimensional
 space has finitely many eigenvalues, so over an infinite field some `μ` is not an
 eigenvalue, and then `forgetfulHom S μ = ⊥`. -/
 theorem exists_forgetfulHom_eq_bot [Infinite k] [FiniteDimensional k V]

--- a/EtingofRepresentationTheory/Chapter7/Example7_9_5.lean
+++ b/EtingofRepresentationTheory/Chapter7/Example7_9_5.lean
@@ -20,10 +20,10 @@ in `Mathlib.RepresentationTheory.Maschke`.
 We provide three statements, in increasing fidelity to the book:
 
 * `Etingof.maschke_semisimple`: the group algebra `k[G]` is a semisimple ring;
-* `Etingof.isSemisimpleCategory_moduleCat`: the bridge from a semisimple ring `R`
-  to the categorical statement of Definition 7.9.4 — the module category `ModuleCat R`
+* `Etingof.isSemisimpleCategory_moduleCat`: the passage from a semisimple ring `R`
+  to the categorical statement of Definition 7.9.4: the module category `ModuleCat R`
   is a semisimple abelian category (every short exact sequence splits);
-* `Etingof.maschke_isSemisimpleCategory`: the book's statement — the category of
+* `Etingof.maschke_isSemisimpleCategory`: the book's statement, that the category of
   representations of `G`, i.e. the category of `k[G]`-modules, is semisimple in the
   sense of Definition 7.9.4.
 -/
@@ -46,7 +46,7 @@ theorem Etingof.maschke_semisimple
     exact h.ne_zero
   infer_instance
 
-/-- Bridge from a semisimple ring to the categorical notion of Definition 7.9.4:
+/-- From a semisimple ring to the categorical notion of Definition 7.9.4:
 the module category over a semisimple ring is a semisimple abelian category, i.e.
 every short exact sequence of modules splits.
 
@@ -74,7 +74,7 @@ theorem Etingof.isSemisimpleCategory_moduleCat
 
 /-- Example 7.9.5: the category of representations of a finite group `G` over a field
 `k` whose characteristic does not divide `|G|` is semisimple in the sense of
-Definition 7.9.4 — every short exact sequence splits.
+Definition 7.9.4: every short exact sequence splits.
 
 Representations of `G` over `k` are exactly `k[G]`-modules, so the representation
 category is `ModuleCat (MonoidAlgebra k G)`. By Maschke's theorem the group algebra

--- a/EtingofRepresentationTheory/Chapter7/Example7_9_6.lean
+++ b/EtingofRepresentationTheory/Chapter7/Example7_9_6.lean
@@ -26,8 +26,8 @@ inclusion of group algebras `f : k[K] → k[G]`:
   `k[G] ⊗_{k[K]} -`).
 
 Restriction of scalars is always exact (parts (i) Res below). Extension of
-scalars is always right exact (it is a left adjoint), and it is left exact —
-hence exact — exactly when the ring map is flat. For the group-algebra
+scalars is always right exact (it is a left adjoint), and it is left exact,
+hence exact, exactly when the ring map is flat. For the group-algebra
 inclusion `k[K] → k[G]` of a subgroup, `k[G]` is free of rank `[G : K]` as a
 `k[K]`-module, hence flat, so `Ind_K^G` is exact. We record the flat hypothesis
 explicitly in `Etingof.extendScalars_exact_of_flat`.
@@ -136,7 +136,7 @@ theorem subsingleton_hom_zmod_int : Subsingleton (ZMod 2 →ₗ[ℤ] ℤ) := by
   rw [h2, map_zero, smul_eq_mul] at hmap
   omega
 
-/-- `Hom(ℤ/2ℤ, -)` is **not** right exact. Concretely, for any surjection
+/-- `Hom(ℤ/2ℤ, -)` is not right exact. Concretely, for any surjection
 `g : ℤ ↠ ℤ/2ℤ` (in particular the one from `0 → ℤ → ℤ → ℤ/2ℤ → 0`), the induced
 post-composition map `Hom(ℤ/2ℤ, ℤ) → Hom(ℤ/2ℤ, ℤ/2ℤ)` is not surjective: the
 identity of `ℤ/2ℤ` is not in its image, since the source `Hom(ℤ/2ℤ, ℤ)` is zero
@@ -184,7 +184,7 @@ theorem tmul_one_one_ne_zero : ((1 : ZMod 2) ⊗ₜ[ℤ] (1 : ℤ)) ≠ 0 := by
   simp only [TensorProduct.rid_tmul, one_smul] at himg
   exact one_ne_zero himg
 
-/-- `ℤ/2ℤ ⊗ -` is **not** left exact. Applying `lTensor (ℤ/2ℤ)` to the injection
+/-- `ℤ/2ℤ ⊗ -` is not left exact. Applying `lTensor (ℤ/2ℤ)` to the injection
 `(· * 2) : ℤ ↪ ℤ` (the map in `0 → ℤ → ℤ → ℤ/2ℤ → 0`) yields a non-injective map:
 it sends the nonzero element `1 ⊗ 1` to `1 ⊗ 2 = (2 • 1) ⊗ 1 = 0 ⊗ 1 = 0`.
 (Etingof Example 7.9.6(iii), negative direction) -/

--- a/EtingofRepresentationTheory/Chapter7/Exercise7_8_4.lean
+++ b/EtingofRepresentationTheory/Chapter7/Exercise7_8_4.lean
@@ -19,13 +19,13 @@ cochain complex of `k`-vector spaces, the identity morphism is homotopic to `0`.
 
 We also record the "in particular" consequence `Exercise7_8_4_split` (short exact
 sequences of vector spaces split) and the answer to the final question,
-`Exercise7_8_4_not_abelianGroups`: over `ℤ` this fails — there is a short exact
+`Exercise7_8_4_not_abelianGroups`: over `ℤ` this fails, since there is a short exact
 sequence of abelian groups (e.g. `0 → ℤ →^{·2} ℤ → ℤ/2 → 0`) that does not split.
 
 ## The contracting homotopy
 
 The proof of the headline claim is the elementary degreewise-splitting construction,
-valid for *unbounded* complexes.  For each degree `n` write `Kⁿ = Zⁿ ⊕ Wⁿ` where
+valid for unbounded complexes.  For each degree `n` write `Kⁿ = Zⁿ ⊕ Wⁿ` where
 `Zⁿ = ker dⁿ` and `Wⁿ` is a chosen complement.  Acyclicity gives
 `range dⁿ = ker dⁿ⁺¹ = Zⁿ⁺¹`, so `dⁿ` restricts to an isomorphism `Wⁿ ≅ Zⁿ⁺¹`.  The
 contracting homotopy `sⁿ⁺¹ : Kⁿ⁺¹ → Kⁿ` is the inverse of that isomorphism on `Zⁿ⁺¹`
@@ -166,7 +166,7 @@ lemma htpy_eq_zero (hK : K.Acyclic) {i j : ℤ} (h : ¬ i = j + 1) :
 end Etingof.Exercise7_8_4Aux
 
 /-- Exercise 7.8.4 (main claim): every acyclic (exact) cochain complex of vector spaces
-over a field `k` is contractible — its identity morphism is null-homotopic — which is
+over a field `k` is contractible (its identity morphism is null-homotopic), which is
 equivalent to being isomorphic to a direct sum of contractible complexes
 `0 → V →^{id} V → 0`. -/
 theorem Etingof.Exercise7_8_4 {k : Type u} [Field k]
@@ -198,8 +198,8 @@ theorem Etingof.Exercise7_8_4_split {k : Type u} [Field k]
   -- has a section and the short exact sequence splits.
   ⟨hS.splittingOfProjective⟩
 
-/-- Exercise 7.8.4 (final question): the statement is **not** true in the category of
-abelian groups — there is a short exact sequence of abelian groups that does not split.
+/-- Exercise 7.8.4 (final question): the statement is not true in the category of
+abelian groups, since there is a short exact sequence of abelian groups that does not split.
 -/
 theorem Etingof.Exercise7_8_4_not_abelianGroups :
     ∃ S : ShortComplex (ModuleCat.{0} ℤ), S.ShortExact ∧ IsEmpty S.Splitting := by
@@ -243,7 +243,7 @@ theorem Etingof.Exercise7_8_4_not_abelianGroups :
       exact ⟨x, hx⟩
   · -- No splitting: a retraction `r` of `·2` would give `2 * r 1 = 1` in `ℤ`.
     refine ⟨fun sp => ?_⟩
-    -- View the retraction as a genuine linear map `ρ : ℤ →ₗ[ℤ] ℤ` (the carriers are `ℤ`).
+    -- View the retraction as a linear map `ρ : ℤ →ₗ[ℤ] ℤ` (the carriers are `ℤ`).
     let ρ : ℤ →ₗ[ℤ] ℤ := sp.r.hom
     have hr : ρ.comp f = LinearMap.id := by
       have h := ModuleCat.hom_ext_iff.mp sp.f_r

--- a/EtingofRepresentationTheory/Chapter7/Exercise7_9_8.lean
+++ b/EtingofRepresentationTheory/Chapter7/Exercise7_9_8.lean
@@ -30,7 +30,7 @@ original quiver by `Etingof.reversedAtVertex_twice`. We transport it back to `Q`
 `Etingof.QuiverRepresentation.transportReversedTwice`, so that
 `Hom(V, F⁺ᵢ W)` is a hom-set of representations of `Q`.
 
-Part (a), `Exercise7_9_8`, is the resulting bijection of hom-sets — the hom-set half of
+Part (a), `Exercise7_9_8`, is the resulting bijection of hom-sets, the hom-set half of
 the adjunction `F⁻ᵢ ⊣ F⁺ᵢ`. (The full statement "`F⁺ᵢ` is right adjoint to `F⁻ᵢ`" would
 additionally package `F⁺ᵢ`/`F⁻ᵢ` as `CategoryTheory.Functor`s between the abelian
 categories `Rep(Q)` and `Rep(Q̄ᵢ)` and assert naturality of this bijection; the
@@ -110,7 +110,7 @@ theorem transportReversedTwice_mapLinear_heq
 
 /-! ### Transport packaged as `LinearEquiv`
 
-The two accessors above are stated with `HEq`. For the adjunction assembly it is far more
+The two accessors above are stated with `HEq`. For assembling the adjunction it is far more
 convenient to package the transport of the vertex space as an honest `LinearEquiv` (absorbing
 both the object-type transport and the transported `AddCommMonoid`/`Module` instances at once),
 so that transport-compatibility of `mapLinear` becomes a plain equation rather than an `HEq`.
@@ -169,9 +169,9 @@ end Etingof.QuiverRepresentation
 /-!
 ## Proof blueprint for `Exercise7_9_8` (the adjunction bijection)
 
-Status: the full adjunction bijection is now proved sorry-free (both `homFMinusEquivReduced`
-and `homTransportPlusEquivReduced`, hence `Exercise7_9_8`). This blueprint is retained as a
-guide to the assembly.
+The adjunction bijection is built from `homFMinusEquivReduced` and
+`homTransportPlusEquivReduced`, whose composite is `Exercise7_9_8`. This blueprint records
+the structure of the construction.
 
 **Key reduction.** Write `hi' := isSource_reversedAtVertex_isSink hi` (so `i` is a sink of
 `Q̄ᵢ`). Both hom-sets are equivalent to the *same* reduced data: a family
@@ -206,16 +206,16 @@ cokernel map out of `mkQ` / the kernel `subtype` being injective. Reusable ingre
 
 ## Decomposition (this file)
 
-The assembly is decomposed along the blueprint's two directions through a shared reduced-data
+The construction is decomposed along the blueprint's two directions through a shared reduced-data
 type `Etingof.AdjReducedData hi V W`: a family `h v : V v →ₗ W v` for `v ≠ i` subject to
 arrow-compatibility (A) away from `i` and the source constraint (C) at `i`. The main theorem
 `Exercise7_9_8` is assembled from two hom-set equivalences, each proved separately:
 
-* `homFMinusEquivReduced : Hom(F⁻ᵢV, W) ≃ AdjReducedData hi V W` — the cokernel side, using the
+* `homFMinusEquivReduced : Hom(F⁻ᵢV, W) ≃ AdjReducedData hi V W`, the cokernel side, using the
   `reflFunctorMinus_mapLinear_*` reductions and `Submodule.liftQ` (constraint (C) is exactly the
   well-definedness of the map out of the cokernel at `i`);
-* `homTransportPlusEquivReduced : Hom(V, transportReversedTwice (F⁺ᵢW)) ≃ AdjReducedData hi V W`
-  — the kernel side, using the `transportReversedTwice_*` accessors above together with the
+* `homTransportPlusEquivReduced : Hom(V, transportReversedTwice (F⁺ᵢW)) ≃ AdjReducedData hi V W`,
+  the kernel side, using the `transportReversedTwice_*` accessors above together with the
   `reflFunctorPlus_mapLinear_*` reductions and `LinearMap.codRestrict` (constraint (C) is exactly
   landing in the kernel, i.e. `Φ_comp_source_eq_zero`).
 -/

--- a/EtingofRepresentationTheory/Chapter7/KunnethChainComplexNat.lean
+++ b/EtingofRepresentationTheory/Chapter7/KunnethChainComplexNat.lean
@@ -2,13 +2,13 @@ import Mathlib
 import EtingofRepresentationTheory.Chapter7.Problem7_8_7
 
 /-!
-# Künneth for `ℕ`-indexed chain complexes: the `ℕ`/`ℤ` reindex bridge
+# Künneth for `ℕ`-indexed chain complexes via `ℕ`/`ℤ` reindexing
 
 Chapter 7's Künneth formula (`Etingof.Problem7_8_7_iv`) is stated for cohomologically indexed
-`CochainComplex (ModuleCat k) ℤ`. The `Tor`/`Ext` assembly of Problem 8.2.8, however, works with
+`CochainComplex (ModuleCat k) ℤ`. The `Tor`/`Ext` construction of Problem 8.2.8, however, works with
 its own complexes `P• ⊗_A N`, which are homologically indexed `ChainComplex (ModuleCat.{u} k) ℕ`
-(`= HomologicalComplex _ (ComplexShape.down ℕ)`). This file provides the bridge: a Künneth
-isomorphism for `ℕ`-indexed chain complexes, obtained by **reindexing** the `ℤ` result rather than
+(`= HomologicalComplex _ (ComplexShape.down ℕ)`). This file provides a Künneth
+isomorphism for `ℕ`-indexed chain complexes, obtained by reindexing the `ℤ` result rather than
 reproving it.
 
 ## The reindexing embedding
@@ -23,9 +23,9 @@ Homology transport is Mathlib's `HomologicalComplex.extendHomologyIso`:
 outside the image. These two facts are proved here as `homology_extend_iso` and
 `homology_extend_isZero`.
 
-## The crux: tensor ∘ extend compatibility
+## Tensor ∘ extend compatibility
 
-The remaining gap — with no direct Mathlib support — is the compatibility of `extend` with the
+The remaining step, with no direct Mathlib support, is the compatibility of `extend` with the
 monoidal (tensor) structure:
 
 `extend e C ⊗ extend e D ≅ extend e (C ⊗ D)`  (in the `up ℤ` monoidal structure).
@@ -37,26 +37,25 @@ Since `extend C` is supported on `ℤ≤0`, the only nonzero summands have `a = 
 categorical work is to assemble this degreewise identification into an isomorphism of complexes,
 matching the `ιTensorObj` injections and the Koszul-signed total differential (`d₁` and `d₂`
 summands). This is `nonempty_tensorObj_extend_iso` below, constructed via
-`TensorExtend.tensorObjExtendIso` (milestones (a)–(c), issue #6694).
+`TensorExtend.tensorObjExtendIso` (milestones (a)–(c)).
 
 Note `extend C ⊗ extend D` is itself supported on `ℤ≤0`, i.e. on the image of the embedding, so
 this iso can equivalently be read as "the `ℤ`-tensor of the extends is the extension of the
 `ℕ`-tensor".
 
-## The payoff
+## The resulting isomorphism
 
-`Hᵢ(C ⊗ D)` (`ℕ`) `≅ H_{-i}(extend (C ⊗ D))` `≅ H_{-i}(extend C ⊗ extend D)` (crux)
+`Hᵢ(C ⊗ D)` (`ℕ`) `≅ H_{-i}(extend (C ⊗ D))` `≅ H_{-i}(extend C ⊗ extend D)` (compatibility)
 `≅ ⨁_{a+b=-i} H_a(extend C) ⊗ H_b(extend D)` (Chapter 7 Künneth at universe `u`, degree `-i`)
 `≅ ⨁_{p+q=i} H_p(C) ⊗ H_q(D)` (reindex `a = -p`, `b = -q`; the `a > 0` / `b > 0` summands are
 zero by `homology_extend_isZero`).
 
-The final identification uses the **universe-general** `Problem7_8_7_iv` (universe half of #6666,
-PR https://github.com/.../pull/6673). The reindex of the coproduct is not a bare index bijection:
-the `ℤ`-side sum `⨁_{a+b=-i}` ranges over all of `ℤ × ℤ`, and the extra summands vanish only via
-`homology_extend_isZero`.
+The final identification uses the universe-general `Problem7_8_7_iv`. The reindex of the
+coproduct is not a bare index bijection: the `ℤ`-side sum `⨁_{a+b=-i}` ranges over all of
+`ℤ × ℤ`, and the extra summands vanish only via `homology_extend_isZero`.
 
 The main deliverable `kunnethChainComplexNat` is stated below (Prop-valued `Nonempty`), pinning the
-API that the Problem 8.2.8 assembler (#6657) consumes.
+API that the Problem 8.2.8 construction consumes.
 -/
 
 open CategoryTheory Limits MonoidalCategory HomologicalComplex
@@ -89,7 +88,7 @@ namespace TensorExtend
 
 This section constructs, for every `j' : ℤ`, the degreewise isomorphism
 `(extend C ⊗ extend D).X j' ≅ (extend (C ⊗ D)).X j'` (`tensorExtendXIso`), the object-level half
-of the crux `nonempty_tensorObj_extend_iso`. The nonzero degrees are `j' = -n`, where both sides
+of `nonempty_tensorObj_extend_iso`. The nonzero degrees are `j' = -n`, where both sides
 identify with `⨁_{p+q=n} C_p ⊗ D_q`; positive degrees are zero on both sides.
 
 The forward/inverse maps are assembled out of `mapBifunctorDesc` over the summand maps `phiFwd`
@@ -344,7 +343,7 @@ lemma extendXIso_inv_tensorExtendXIso_inv (n : ℕ) :
 ## Milestone (b): differential compatibility
 
 The degreewise isos `tensorExtendXIso` (milestone (a)) are packaged, via `fwdNeg_comm`, into an
-honest isomorphism of chain complexes `tensorObjExtendIso`, discharging the crux
+honest isomorphism of chain complexes `tensorObjExtendIso`, discharging
 `nonempty_tensorObj_extend_iso`. The only non-mechanical step is the Koszul sign match
 `negOnePow_neg_natCast`.
 -/
@@ -538,14 +537,14 @@ noncomputable def sigmaIsoOfInjOfIsZeroCompl (ι : I → J) (hι : Function.Inje
 
 end CoproductSupport
 
-/-- **Crux (tensor ∘ extend compatibility).** The `ℤ`-tensor of the extensions is the extension
+/-- **Tensor ∘ extend compatibility.** The `ℤ`-tensor of the extensions is the extension
 of the `ℕ`-tensor:
 `extend e C ⊗ extend e D ≅ extend e (C ⊗ D)`, `e = embeddingDownNat`.
 
 Degreewise both sides are `⨁_{p+q=n} C_p ⊗ D_q` at `-n` and zero at positive degrees; the content
 is matching the `ιTensorObj` injections and the Koszul-signed total differential. Universe-general
-and independent of Chapter 7. Constructed via `TensorExtend.tensorObjExtendIso` (milestones (a)–(c),
-issue #6694). -/
+and independent of Chapter 7. Constructed via `TensorExtend.tensorObjExtendIso` (milestones
+(a)–(c)). -/
 theorem nonempty_tensorObj_extend_iso (C D : ChainComplex (ModuleCat.{u} k) ℕ) :
     Nonempty (HomologicalComplex.tensorObj (C.extend ComplexShape.embeddingDownNat)
         (D.extend ComplexShape.embeddingDownNat) ≅
@@ -557,7 +556,7 @@ indexed over `ℕ`, the homology of the tensor product decomposes as a direct su
 `Hᵢ(C ⊗ D) ≅ ⨁_{p+q=i} H_p(C) ⊗ H_q(D)`.
 
 Reindexes Chapter 7's `Problem7_8_7_iv` along `embeddingDownNat`; see the module docstring for the
-route. Consumed by the Problem 8.2.8 `Tor`/`Ext` assembler (#6657). -/
+derivation. Consumed by the Problem 8.2.8 `Tor`/`Ext` construction. -/
 theorem kunnethChainComplexNat (C D : ChainComplex (ModuleCat.{u} k) ℕ) (i : ℕ) :
     Nonempty ((HomologicalComplex.tensorObj C D).homology i ≅
       ∐ fun (p : {p : ℕ × ℕ // p.1 + p.2 = i}) =>
@@ -568,7 +567,7 @@ theorem kunnethChainComplexNat (C D : ChainComplex (ModuleCat.{u} k) ℕ) (i : �
   let α₁ : (HomologicalComplex.tensorObj C D).homology i ≅
       ((HomologicalComplex.tensorObj C D).extend e).homology (-(i : ℤ)) :=
     (homology_extend_iso (HomologicalComplex.tensorObj C D) i).symm
-  -- Step 2: apply `H_{-i}` to the crux iso `extend (C ⊗ D) ≅ extend C ⊗ extend D`.
+  -- Step 2: apply `H_{-i}` to the compatibility iso `extend (C ⊗ D) ≅ extend C ⊗ extend D`.
   let φ : (HomologicalComplex.tensorObj C D).extend e ≅
       HomologicalComplex.tensorObj (C.extend e) (D.extend e) :=
     (nonempty_tensorObj_extend_iso C D).some.symm

--- a/EtingofRepresentationTheory/Chapter7/KunnethCochainComplexNat.lean
+++ b/EtingofRepresentationTheory/Chapter7/KunnethCochainComplexNat.lean
@@ -3,14 +3,14 @@ import EtingofRepresentationTheory.Chapter7.Problem7_8_7
 import EtingofRepresentationTheory.Chapter7.KunnethChainComplexNat
 
 /-!
-# Künneth for `ℕ`-indexed cochain complexes: the `ℕ`/`ℤ` reindex bridge (cochain case)
+# Künneth for `ℕ`-indexed cochain complexes via `ℕ`/`ℤ` reindexing (cochain case)
 
 Chapter 7's Künneth formula (`Etingof.Problem7_8_7_iv`) is stated for cohomologically indexed
-`CochainComplex (ModuleCat k) ℤ`. The `Ext` assembly of Problem 8.2.8, however, works with the Hom
-cochain complexes `Hom_A(P•, N)`, which are `ℕ`-indexed **cochain** complexes
+`CochainComplex (ModuleCat k) ℤ`. The `Ext` construction of Problem 8.2.8, however, works with the Hom
+cochain complexes `Hom_A(P•, N)`, which are `ℕ`-indexed cochain complexes
 `CochainComplex (ModuleCat.{u} k) ℕ` (`= HomologicalComplex _ (ComplexShape.up ℕ)`). This file
-provides the bridge: a Künneth isomorphism for `ℕ`-indexed cochain complexes, obtained by
-**reindexing** the `ℤ` result rather than reproving it.
+provides a Künneth isomorphism for `ℕ`-indexed cochain complexes, obtained by
+reindexing the `ℤ` result rather than reproving it.
 
 This is the exact mirror of `Etingof.kunnethChainComplexNat`
 (`EtingofRepresentationTheory/Chapter7/KunnethChainComplexNat.lean`, the `down ℕ` chain case) along
@@ -37,7 +37,7 @@ Mathlib ships `TensorSigns (ComplexShape.up ℤ)` and `TensorSigns (ComplexShape
 `up ℕ` complexes. We supply the missing instance here (`ε n = (-1)^n`, identical data to the
 `down ℕ` instance, only the `Rel` direction differs).
 
-## The crux: tensor ∘ extend compatibility
+## Tensor ∘ extend compatibility
 
 `extend e C ⊗ extend e D ≅ extend e (C ⊗ D)`  (in the `up ℤ` monoidal structure).
 
@@ -47,15 +47,15 @@ non-mechanical step is the sign match, here `negOnePow_natCast` (`Int.negOnePow 
 simpler than the chain case (no `negOnePow_neg`). This is `nonempty_tensorObj_extend_iso` below,
 constructed via `TensorExtend.tensorObjExtendIso`.
 
-## The payoff
+## The resulting isomorphism
 
-`Hᵢ(C ⊗ D)` (`ℕ`) `≅ Hᵢ(extend (C ⊗ D))` `≅ Hᵢ(extend C ⊗ extend D)` (crux)
+`Hᵢ(C ⊗ D)` (`ℕ`) `≅ Hᵢ(extend (C ⊗ D))` `≅ Hᵢ(extend C ⊗ extend D)` (compatibility)
 `≅ ⨁_{a+b=i} H_a(extend C) ⊗ H_b(extend D)` (Chapter 7 Künneth at universe `u`, degree `i`)
 `≅ ⨁_{p+q=i} H_p(C) ⊗ H_q(D)` (reindex `a = p`, `b = q`; the `a < 0` / `b < 0` summands are zero by
 `homology_extend_isZero_up`).
 
 The main deliverable `kunnethCochainComplexNat` is stated below (Prop-valued `Nonempty`), pinning
-the API that the Problem 8.2.8 `Ext` assembler consumes.
+the API that the Problem 8.2.8 `Ext` construction consumes.
 -/
 
 open CategoryTheory Limits MonoidalCategory HomologicalComplex
@@ -462,7 +462,7 @@ noncomputable def tensorObjExtendIso :
 
 end TensorExtendUp
 
-/-- **Crux (tensor ∘ extend compatibility, cochain case).** The `ℤ`-tensor of the extensions is the
+/-- **Tensor ∘ extend compatibility (cochain case).** The `ℤ`-tensor of the extensions is the
 extension of the `ℕ`-tensor:
 `extend e C ⊗ extend e D ≅ extend e (C ⊗ D)`, `e = embeddingUpNat`.
 
@@ -480,7 +480,7 @@ spaces indexed over `ℕ`, the homology of the tensor product decomposes as a di
 `Hⁱ(C ⊗ D) ≅ ⨁_{p+q=i} Hᵖ(C) ⊗ Hᵍ(D)`.
 
 Reindexes Chapter 7's `Problem7_8_7_iv` along `embeddingUpNat`; the exact mirror of
-`kunnethChainComplexNat`. Consumed by the Problem 8.2.8 `Ext` assembler on the Hom cochain
+`kunnethChainComplexNat`. Consumed by the Problem 8.2.8 `Ext` construction on the Hom cochain
 complexes `Hom_A(P•, N)`. -/
 theorem kunnethCochainComplexNat (C D : CochainComplex (ModuleCat.{u} k) ℕ) (i : ℕ) :
     Nonempty ((HomologicalComplex.tensorObj C D).homology i ≅
@@ -492,7 +492,7 @@ theorem kunnethCochainComplexNat (C D : CochainComplex (ModuleCat.{u} k) ℕ) (i
   let α₁ : (HomologicalComplex.tensorObj C D).homology i ≅
       ((HomologicalComplex.tensorObj C D).extend e).homology (i : ℤ) :=
     (homology_extend_iso_up (HomologicalComplex.tensorObj C D) i).symm
-  -- Step 2: apply `Hⁱ` to the crux iso `extend (C ⊗ D) ≅ extend C ⊗ extend D`.
+  -- Step 2: apply `Hⁱ` to the compatibility iso `extend (C ⊗ D) ≅ extend C ⊗ extend D`.
   let φ : (HomologicalComplex.tensorObj C D).extend e ≅
       HomologicalComplex.tensorObj (C.extend e) (D.extend e) :=
     (nonempty_tensorObj_extend_iso_up C D).some.symm

--- a/EtingofRepresentationTheory/Chapter7/Problem7_8_5.lean
+++ b/EtingofRepresentationTheory/Chapter7/Problem7_8_5.lean
@@ -29,7 +29,7 @@ open CategoryTheory
 /-- The connecting homomorphism `c_i : H^i(E) → H^{i+1}(C)` of Problem 7.8.5, for a
 short exact sequence `0 → C → D → E → 0` of complexes of abelian groups. This is the
 snake-lemma connecting map `S.ShortExact.δ`; part (i) (well-definedness) is the fact
-that it is a genuine morphism. -/
+that it is a morphism. -/
 noncomputable def Etingof.Problem7_8_5_connecting
     {S : ShortComplex (HomologicalComplex (ModuleCat.{0} ℤ) (ComplexShape.up ℤ))}
     (hS : S.ShortExact) (i j : ℤ) (hij : (ComplexShape.up ℤ).Rel i j) :

--- a/EtingofRepresentationTheory/Chapter7/Problem7_8_7.lean
+++ b/EtingofRepresentationTheory/Chapter7/Problem7_8_7.lean
@@ -149,7 +149,7 @@ lemma sMap_pMap : sMap C ≫ pMap C = 𝟙 (homologyZeroComplex C) := by
     rho_homologyπ]
 
 /-- `homologyMap (pMap ≫ sMap) = 𝟙`: the composite `pMap ≫ sMap` induces the identity on
-homology (the crux; `pMap ≫ sMap` is degreewise the projection onto a complement of the
+homology (here `pMap ≫ sMap` is degreewise the projection onto a complement of the
 boundaries, which is homologous to the identity). -/
 lemma homologyMap_pMap_sMap (i : ℤ) :
     HomologicalComplex.homologyMap (pMap C ≫ sMap C) i = 𝟙 (C.homology i) := by
@@ -301,7 +301,7 @@ theorem Problem7_8_7_iii (C : CochainComplex (ModuleCat.{u} k) ℤ) :
 ### Homology of a tensor of two zero-differential complexes
 
 The final step of the Künneth argument (part iv) identifies `Hⁱ(C ⊗ D)`, after the four-way
-split, with the homology of `tensorComplex (homologyZeroComplex C) (homologyZeroComplex D)` — a
+split, with the homology of `tensorComplex (homologyZeroComplex C) (homologyZeroComplex D)`, a
 tensor of two complexes whose differentials all vanish. Its differential vanishes in every
 degree, so its homology at `i` is its degree-`i` object, which is the internal coproduct of the
 `Cⱼ ⊗ Dₘ` over `j + m = i`. We package that identification as the reusable


### PR DESCRIPTION
This PR rewrites the comments and docstrings throughout Chapter 7 so they read as mathematics rather than a record of the formalization process. It removes PR and issue numbers and the associated process narrative, and replaces the informal register and em-dashes with plain research-paper prose. Only comments and docstrings change; the code is byte-identical after stripping comments (verified mechanically).

🤖 Prepared with Claude Code