### PR TITLE
style(Infrastructure): rewrite comments and docstrings as mathematics, not formalization history

### DIFF
--- a/EtingofRepresentationTheory/Infrastructure/BasicAlgebraExistence.lean
+++ b/EtingofRepresentationTheory/Infrastructure/BasicAlgebraExistence.lean
@@ -43,14 +43,8 @@ The proof is decomposed into two helper lemmas:
 
 * `morita_equiv_of_full_idempotent`: The Morita equivalence between `A` and
   the corner ring `eAe` for a full idempotent `e` (one with `AeA = A`). This
-  uses faithfulness (proven), fullness and essential surjectivity (both via the
+  uses faithfulness, fullness, and essential surjectivity (the latter two via the
   evaluation isomorphism `Ae ⊗_{eAe} eM ≅ M`) of the corner functor `M ↦ eM`.
-
-## Proof status
-
-All proofs are sorry-free. `cornerFunctor_essSurj`, `cornerFunctor_full`,
-and `cornerFunctor_faithful` are fully proved, giving the Morita equivalence
-`exists_basic_morita_equivalent`.
 -/
 
 universe u
@@ -81,16 +75,16 @@ theorem mem_jacobson_of_forall_isNilpotent_left_mul {R : Type*} [Ring R] {c : R}
 For a finite-dimensional algebra `A` over an algebraically closed field `k`,
 there exists a full idempotent `e ∈ A` such that the corner ring `eAe` is basic.
 
-### Proof strategy (uses available Mathlib infrastructure)
+### Proof strategy
 
-1. `IsArtinianRing.of_finite k A` — A is Artinian
-2. `IsSemiprimaryRing` instance (automatic from Artinian) — rad(A) nilpotent,
+1. `IsArtinianRing.of_finite k A`: A is Artinian
+2. `IsSemiprimaryRing` instance (automatic from Artinian): rad(A) nilpotent,
    A/rad(A) semisimple
-3. `IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed` — Wedderburn–Artin
+3. `IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed`: Wedderburn–Artin
    decomposition of A/rad(A) ≅ ∏ Mₙᵢ(k)
 4. Extract one diagonal idempotent E₁₁ per matrix block → complete orthogonal
    idempotents in A/rad(A)
-5. `CompleteOrthogonalIdempotents.lift_of_isNilpotent_ker` — lift to A
+5. `CompleteOrthogonalIdempotents.lift_of_isNilpotent_ker`: lift to A
 6. Sum of lifted idempotents is full (AeA = A) and eAe is basic -/
 /-! ### Helper lemmas for the main proof -/
 
@@ -242,10 +236,8 @@ private lemma isIdempotentElem_sum_orthogonal {R : Type*} [Ring R] {n : ℕ}
 by the Jacobson radical is a semisimple finite-dimensional algebra, and by Wedderburn-Artin
 it decomposes as a product of matrix algebras. This gives us orthogonal idempotents
 (one primitive per block) which can be lifted to A. The sum is a full idempotent with
-basic corner ring.
-
-This is the key construction: the existence statement is fully proved, with the
-proof obligations decomposed clearly below. -/
+basic corner ring. This construction produces the full idempotent underlying the
+basic algebra. -/
 lemma exists_full_idempotent_basic_corner
     (k : Type u) [Field k] [IsAlgClosed k]
     (A : Type u) [Ring A] [Algebra k A] [Module.Finite k A] :

--- a/EtingofRepresentationTheory/Infrastructure/FrobeniusCharacterBridge.lean
+++ b/EtingofRepresentationTheory/Infrastructure/FrobeniusCharacterBridge.lean
@@ -4,26 +4,25 @@ import EtingofRepresentationTheory.Chapter5.Theorem5_15_1
 import EtingofRepresentationTheory.Infrastructure.YoungSymTraceKronecker
 
 /-!
-# Frobenius Character Bridge
+# Frobenius character formula: relating `charValue` and `spechtModuleCharacter`
 
-Bridge infrastructure between `charValue` (polynomial coefficient definition over ℚ
+Infrastructure relating `charValue` (polynomial coefficient definition over ℚ
 with N variables) and `spechtModuleCharacter` (trace definition over ℂ with n variables).
 
 ## Key results
 
-* `alternantDet_eq_sign_mul_vandermondeProd` — exact alternant-Vandermonde identity
-* `charValue_cast_complex` — cast `charValue` from ℚ to ℂ
+* `alternantDet_eq_sign_mul_vandermondeProd`: exact alternant-Vandermonde identity
+* `charValue_cast_complex`: cast `charValue` from ℚ to ℂ
 
 ## Note
 
-This file provides only the alternant-Vandermonde identity and the ℚ → ℂ
-base-change lemma above. The Frobenius character bridge itself is completed in
-`Theorem5_22_1.lean`, where the main theorem `youngSym_charValue_orthogonality`
-is proved using an inlined version of the trace Kronecker identity. The two bridge
-lemmas once slated for this file are now proved (not `sorry`) in
-`Theorem5_22_1.lean`, not declared here:
+This file provides the alternant-Vandermonde identity and the ℚ → ℂ base-change
+lemma. The Frobenius character formula itself is proved in `Theorem5_22_1.lean`, as
+the theorem `youngSym_charValue_orthogonality`, using the trace Kronecker identity.
+The lemmas
 - `charValue_eq_spechtModuleCharacter`: Frobenius character formula for N variables
 - `weightToPartition_eq_iff`: antitone partition injectivity
+are proved in `Theorem5_22_1.lean`.
 -/
 
 noncomputable section

--- a/EtingofRepresentationTheory/Infrastructure/MoritaFGRestriction.lean
+++ b/EtingofRepresentationTheory/Infrastructure/MoritaFGRestriction.lean
@@ -18,11 +18,11 @@ A Morita equivalence `E : ModuleCat A ≌ ModuleCat B` (the definition underlyin
 `Etingof.MoritaEquivalent`) restricts to an equivalence of the finitely generated
 module categories `FGModuleCat A ≌ FGModuleCat B`.
 
-The crux is that an equivalence of module categories **preserves finite generation**:
-`E.functor.obj M` is finitely generated over `B` iff `M` is finitely generated over `A`.
-This is *not* a formal consequence of being an additive equivalence for a fixed module;
-it rests on the fact that the regular module is a compact projective generator, whose
-image under the equivalence is therefore again finitely generated.
+The main point is that an equivalence of module categories preserves finite
+generation: `E.functor.obj M` is finitely generated over `B` iff `M` is finitely
+generated over `A`. This is not a formal consequence of being an additive equivalence
+for a fixed module; it rests on the fact that the regular module is a compact
+projective generator, whose image under the equivalence is again finitely generated.
 
 ## Main results
 

--- a/EtingofRepresentationTheory/Infrastructure/RegularCharacter.lean
+++ b/EtingofRepresentationTheory/Infrastructure/RegularCharacter.lean
@@ -48,8 +48,6 @@ theorem regularCharacter_ne_one [Finite G] (g : G) (hg : g ≠ 1) :
   simp only [Matrix.trace, Matrix.diag_apply, LinearMap.toMatrix_apply]
   apply Finset.sum_eq_zero
   intro h _
-  -- v4.31: `convert ... using 1` leaves a `basisSingleOne.repr` residual; rewrite it
-  -- to the plain coefficient application first.
   rw [Finsupp.basisSingleOne_repr, LinearEquiv.refl_apply, Finsupp.coe_basisSingleOne]
   exact key h
 
@@ -198,7 +196,7 @@ is nonzero when cast to `k` (assuming `char(k) ∤ |G|`). This follows from the
 nondegeneracy of the identity-coefficient functional on `k[G]`.
 -/
 
-/-- The "regular trace" of `γ ∈ k[G]` — the trace of left multiplication by `γ` —
+/-- The "regular trace" of `γ ∈ k[G]` (the trace of left multiplication by `γ`)
 equals `|G| * γ(1)`, where `γ(1)` is the coefficient of the identity element. -/
 private theorem regTrace_eq_card_mul [Fintype G]
     (γ : MonoidAlgebra k G) :
@@ -224,8 +222,6 @@ private theorem regTrace_eq_card_mul [Fintype G]
   have := regularCharacter_eq (k := k) g
   rw [ofMulAction_eq_mulLeft] at this
   simp only [Finsupp.coe_basisSingleOne, Finsupp.single_apply]
-  -- v4.31: `convert this using 1` no longer reduces the ite; it splits into the
-  -- `mulLeft (single g 1) = mulLeft (of g)` defeq goal and the ite-arithmetic goal.
   convert this using 1
   · rfl
   · split_ifs <;> ring

--- a/EtingofRepresentationTheory/Infrastructure/SimpleModuleCount.lean
+++ b/EtingofRepresentationTheory/Infrastructure/SimpleModuleCount.lean
@@ -8,18 +8,18 @@ For a finite group `G` and an algebraically closed field `k` in which `|G|` is
 invertible, the number of isomorphism classes of simple `k[G]`-modules is
 `|ConjClasses G|` (Etingof Corollary 4.2.2, stated for `FDRep k G`).
 
-This file repackages that count as a **cardinality bound on abstract module
-families**: any `Fintype`-indexed family of pairwise non-isomorphic simple
+This file repackages that count as a cardinality bound on abstract module
+families: any `Fintype`-indexed family of pairwise non-isomorphic simple
 `k[G]`-modules, each finite-dimensional over `k`, has cardinality at most
 `|ConjClasses G|`. Two forms are provided:
 
-* `Etingof.card_le_card_conjClasses` — for modules living in `k`'s own universe
+* `Etingof.card_le_card_conjClasses`, for modules living in `k`'s own universe
   (`Type u`), which is the universe `FDRep k G` lives in;
-* `Etingof.card_le_card_conjClasses'` — for modules in an arbitrary universe,
+* `Etingof.card_le_card_conjClasses'`, for modules in an arbitrary universe,
   obtained by transporting each module to its `k`-linear small model
   `Fin (finrank k (M i)) → k : Type u`.
 
-The bridge from a `k[G]`-module to `FDRep k G` is `repOfModule`, the
+The passage from a `k[G]`-module to `FDRep k G` is `repOfModule`, the
 representation `g ↦ (x ↦ single g 1 • x)`, whose `asModule` recovers the
 original `k[G]`-action (`repOfModule_asAlgebraHom`).
 -/

--- a/EtingofRepresentationTheory/Infrastructure/SpechtModuleSimple.lean
+++ b/EtingofRepresentationTheory/Infrastructure/SpechtModuleSimple.lean
@@ -11,9 +11,9 @@ We prove that the Specht module V_λ = ℚ[S_n]·c_λ is a simple (irreducible) 
 
 ## Main results
 
-* `SpechtModuleK` — the left ideal k[S_n]·c_λ over a general commutative ring k
-* `YoungSymmetrizerZ_sandwich_basis` — c_ℤ * of(σ) * c_ℤ is proportional to c_ℤ
-* `SpechtModuleK_isSimpleModule` — ℚ[S_n]·c_λ is simple
+* `SpechtModuleK`: the left ideal k[S_n]·c_λ over a general commutative ring k
+* `YoungSymmetrizerZ_sandwich_basis`: c_ℤ * of(σ) * c_ℤ is proportional to c_ℤ
+* `SpechtModuleK_isSimpleModule`: ℚ[S_n]·c_λ is simple
 -/
 
 noncomputable section
@@ -232,7 +232,7 @@ semisimplicity of `k[S_n]` (Maschke, valid in characteristic zero). -/
 
 /-- General-`k` sandwich property: `c * x * c = f x • c` for a `k`-linear functional `f`.
 
-This works over **any** commutative ring `k`, because the proportionality constants
+This works over any commutative ring `k`, because the proportionality constants
 `β σ ∈ ℤ` are produced by `YoungSymmetrizerZ_sandwich_basis` over ℤ and merely cast
 into `k`; no injectivity of `ℤ → k` (hence no characteristic assumption) is needed. -/
 theorem YoungSymmetrizerK_sandwich_general (k : Type*) [CommRing k]


### PR DESCRIPTION
This PR rewrites the comments and docstrings in the Infrastructure files so they read as mathematics rather than a record of the formalization process. It removes PR and issue numbers, status sections, and tactic and version history, and replaces the informal register and em-dashes with plain research-paper prose. Only comments and docstrings change; the code is byte-identical after stripping comments (verified mechanically).

🤖 Prepared with Claude Code