### PR TITLE
style(Ch9): rewrite comments and docstrings as mathematics, not formalization history

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/Corollary9_7_3.lean
+++ b/EtingofRepresentationTheory/Chapter9/Corollary9_7_3.lean
@@ -27,7 +27,7 @@ theory of basic algebras from §9.7.
 Part (ii) uses the `Etingof.MoritaEquivalent` and `Etingof.IsBasicAlgebraSplit`
 definitions from this project.
 
-## Proof status
+## Proof outline
 
 Part (ii) (dimension bound) is proved using the Morita structural theorem
 and corner ring theory.
@@ -38,7 +38,7 @@ as a corner ring of the other, forcing equal dimensions, hence the corner
 rings are the full algebras.
 
 Part (i) existence delegates to `exists_basic_morita_equivalent` from
-`Infrastructure.BasicAlgebraExistence`, which is fully proved (sorry-free):
+`Infrastructure.BasicAlgebraExistence`:
 the basic algebra is constructed as a corner ring `eAe` from the
 Wedderburn-Artin decomposition of `A / rad(A)` and idempotent lifting.
 The statement requires `IsAlgClosed k` since over non-algebraically-closed fields,
@@ -47,18 +47,18 @@ simple modules need not be 1-dimensional.
 ## Scope: algebra version vs. categorical form
 
 The book's part (i) is stated for an abstract `k`-linear finite abelian category
-`𝒞`: *any* such `𝒞` is equivalent to the finite-dimensional modules over a unique
-basic algebra `B(𝒞)`. What is formalized here is the **algebra version**: the input
+`𝒞`: any such `𝒞` is equivalent to the finite-dimensional modules over a unique
+basic algebra `B(𝒞)`. What is formalized here is the algebra version: the input
 is a finite-dimensional algebra `A` (Theorem `Etingof.Corollary_9_7_3_i`), not an
 abstract category. The categorical input form is formalized as
 `Etingof.Corollary_9_7_3_i_categorical_fgModule` in `Corollary9_7_3Categorical.lean`:
 for a `k`-linear finite abelian category `𝒞` over an algebraically closed field with a
 progenerator `P`, it produces a basic `k`-algebra `B` together with a single equivalence
-`𝒞 ≌ FGModuleCat B` — the book's part (i) exactly. It composes
+`𝒞 ≌ FGModuleCat B`, the book's part (i) exactly. It composes
 `Etingof.Theorem_9_6_4_corollary` (`𝒞 ≌ FGModuleCat (End P)ᵐᵒᵖ` for the progenerator `P`,
-carried as an explicit hypothesis since there is no theorem yet that an abstract finite
-abelian category *has* a progenerator) with the algebra version applied to
-`A = (End P)ᵐᵒᵖ`. The two conjuncts are stitched into `𝒞 ≌ FGModuleCat B` via
+carried as an explicit hypothesis since the project has no theorem that an abstract finite
+abelian category has a progenerator) with the algebra version applied to
+`A = (End P)ᵐᵒᵖ`. The two conjuncts are combined into `𝒞 ≌ FGModuleCat B` via
 `Etingof.MoritaEquivalent.fgModuleCatEquiv` (`Infrastructure/MoritaFGRestriction.lean`),
 which restricts a Morita equivalence `ModuleCat A ≌ ModuleCat B` to the finitely
 generated subcategories by proving it preserves finite generation (the image of the
@@ -157,7 +157,7 @@ private noncomputable def Etingof.cornerRingAlgEquivOfUnit
 closed field k is Morita equivalent to some basic algebra B. That is, there exists
 a basic k-algebra B such that the module categories of A and B are equivalent.
 
-Here *basic* is the book's Definition 9.7.2 (`B/Rad(B)` commutative). The algebraic
+Here basic is the book's Definition 9.7.2 (`B/Rad(B)` commutative). The algebraic
 closure hypothesis is used in the construction of `B` as a corner ring `eAe`.
 
 (Etingof Corollary 9.7.3(i), algebra version) -/

--- a/EtingofRepresentationTheory/Chapter9/Corollary9_7_3Categorical.lean
+++ b/EtingofRepresentationTheory/Chapter9/Corollary9_7_3Categorical.lean
@@ -7,11 +7,11 @@ import EtingofRepresentationTheory.Infrastructure.MoritaFGRestriction
 /-!
 # Corollary 9.7.3(i), categorical input form
 
-The book's Corollary 9.7.3(i) is stated for an **abstract** `k`-linear finite abelian
+The book's Corollary 9.7.3(i) is stated for an abstract `k`-linear finite abelian
 category `𝒞`: any such `𝒞` is equivalent to the finite-dimensional modules over a unique
 basic algebra `B(𝒞)`. The main development in `Corollary9_7_3.lean` formalizes the
-**algebra version** (input = a finite-dimensional algebra `A`). This file records the
-**categorical input form**: the input is an abstract `IsFiniteAbelianCategory` together
+algebra version (input = a finite-dimensional algebra `A`). This file records the
+categorical input form: the input is an abstract `IsFiniteAbelianCategory` together
 with a progenerator, and the output packages both the Morita equivalence with a
 concrete finite-dimensional algebra and the existence of a basic algebra Morita
 equivalent to it.
@@ -29,37 +29,38 @@ Here `(End P)ᵐᵒᵖ` is the finite-dimensional algebra `A` whose finite-dimen
 modules realize `𝒞`. Because `End P = Hom(P, P)` is finite dimensional over `k` in a
 `k`-linear finite abelian category (Etingof §9.6, "check it!"), so is `(End P)ᵐᵒᵖ`.
 
-## The progenerator hypothesis (gap 1 of issue #5738)
+## The progenerator hypothesis
 
-The book asserts that *every* finite abelian category has a projective generator. The
-project does not (yet) prove existence of a progenerator in an abstract finite abelian
+The book asserts that every finite abelian category has a projective generator. The
+project does not prove existence of a progenerator in an abstract finite abelian
 category; matching how Theorem 9.6.4 is stated, the progenerator `P` is carried as an
 explicit hypothesis rather than produced.
 
-## Remaining gap: `FGModuleCat` vs. `ModuleCat` (gap 2 of issue #5738)
+## The single-equivalence form
 
-The book's single conclusion `𝒞 ≌ B-fmod` would combine the two conjuncts above into
-one equivalence `𝒞 ≌ FGModuleCat B`. Doing so requires restricting the Morita
+The book's single conclusion `𝒞 ≌ B-fmod` combines the two conjuncts above into
+one equivalence `𝒞 ≌ FGModuleCat B`. This requires restricting the Morita
 equivalence `ModuleCat (End P)ᵐᵒᵖ ≌ ModuleCat B` (which `Etingof.MoritaEquivalent`
-records at the level of the *full* module categories) to the finitely generated
+records at the level of the full module categories) to the finitely generated
 subcategories, i.e. proving that a Morita equivalence preserves and reflects finite
 generation of modules. Over the finite-dimensional algebras at hand this is the
-statement that the equivalence preserves finite `k`-dimension, but the general
+statement that the equivalence preserves finite `k`-dimension; the general
 categorical fact (a Morita equivalence sends f.g. modules to f.g. modules) is not
-available in Mathlib and requires the "finite epi from a generator onto a finitely
-generated object" step. That FG-restriction is tracked as a separate formalization
-item; once it lands, the two conjuncts here collapse to `𝒞 ≌ FGModuleCat B`.
+in Mathlib and uses the "finite epi from a generator onto a finitely
+generated object" step. The combined statement is
+`Etingof.Corollary_9_7_3_i_categorical_fgModule` below.
 -/
 
 open CategoryTheory
 
 universe v u
 
-/-- **Corollary 9.7.3(i), categorical input form** (partial: see the module docstring for
-the residual `FGModuleCat`-vs-`ModuleCat` gap). Let `𝒞` be a `k`-linear finite abelian
+/-- **Corollary 9.7.3(i), categorical input form.** This form yields the two facts
+separately; for the single equivalence `𝒞 ≌ FGModuleCat B` see
+`Etingof.Corollary_9_7_3_i_categorical_fgModule`. Let `𝒞` be a `k`-linear finite abelian
 category over an algebraically closed field `k`, and let `P` be a progenerator of `𝒞`.
 Then there is a basic `k`-algebra `B` such that `𝒞` is equivalent to the finite-dimensional
-`(End P)ᵐᵒᵖ`-modules, and `(End P)ᵐᵒᵖ` — a finite-dimensional `k`-algebra — is Morita
+`(End P)ᵐᵒᵖ`-modules, and `(End P)ᵐᵒᵖ`, a finite-dimensional `k`-algebra, is Morita
 equivalent to `B`.
 
 The finite-dimensional algebra `A = (End P)ᵐᵒᵖ` whose finite-dimensional modules realize
@@ -90,10 +91,10 @@ theorem Etingof.Corollary_9_7_3_i_categorical
     Etingof.exists_basic_morita_equivalent k (End P)ᵐᵒᵖ
   exact ⟨B, instR, instA, instF, hbasic, hcat, hmor⟩
 
-/-- **Corollary 9.7.3(i), categorical input form — single equivalence.** This closes
-gap 2 of issue #5738: the two conjuncts of `Etingof.Corollary_9_7_3_i_categorical`
+/-- **Corollary 9.7.3(i), categorical input form, single equivalence.** The two conjuncts
+of `Etingof.Corollary_9_7_3_i_categorical`
 (`𝒞 ≌ FGModuleCat (End P)ᵐᵒᵖ` and `(End P)ᵐᵒᵖ` Morita equivalent to a basic `B`) are
-stitched into the single book statement `𝒞 ≌ FGModuleCat B` with `B` basic.
+combined into the single book statement `𝒞 ≌ FGModuleCat B` with `B` basic.
 
 Let `𝒞` be a `k`-linear finite abelian category over an algebraically closed field `k`
 with a progenerator `P`. Then there is a basic `k`-algebra `B` such that `𝒞` is equivalent

--- a/EtingofRepresentationTheory/Chapter9/Definition9_3_1.lean
+++ b/EtingofRepresentationTheory/Chapter9/Definition9_3_1.lean
@@ -26,8 +26,8 @@ finite dimensional algebras.
 
 The entries `cᵢⱼ` are defined exactly as in the book: `dim_k Hom_A(Pᵢ, Pⱼ)`. This is the
 form of the definition stated at the start of §9.3 (`cᵢⱼ := dim Hom_A(Pᵢ, Pⱼ)`), and it is
-genuinely constructed from the input data — the algebra `A`, the ground field `k`, and the
-family `P` of projective covers — rather than from an externally supplied table of numbers.
+constructed from the input data (the algebra `A`, the ground field `k`, and the
+family `P` of projective covers) rather than from an externally supplied table of numbers.
 Concretely, the `(i, j)` entry is `Module.finrank k (P i →ₗ[A] P j)`, the `k`-dimension of
 the Hom space. By Proposition 9.2.3 (`Etingof.projective_cover_hom_multiplicity`) this
 equals the Jordan–Hölder multiplicity `[Pⱼ : Mᵢ]` whenever the `Pᵢ` are the projective

--- a/EtingofRepresentationTheory/Chapter9/Definition9_5_1.lean
+++ b/EtingofRepresentationTheory/Chapter9/Definition9_5_1.lean
@@ -4,7 +4,7 @@ import Mathlib.RingTheory.SimpleModule.Basic
 /-!
 # Definition 9.5.1: Linked simple modules and blocks
 
-Two **simple** finite dimensional modules `X, Y` are **linked** if there is a chain of
+Two simple finite dimensional modules `X, Y` are **linked** if there is a chain of
 *simple* modules `X = M₀, M₁, …, Mₙ = Y` such that for each consecutive pair `(Mᵢ, Mᵢ₊₁)`,
 either `Ext¹(Mᵢ, Mᵢ₊₁) ≠ 0` or `Ext¹(Mᵢ₊₁, Mᵢ) ≠ 0`. This is an equivalence relation on
 simple modules; its equivalence classes `S₁, …, Sₗ` partition the isomorphism classes of
@@ -15,7 +15,7 @@ objects `M` all of whose Jordan–Hölder composition factors lie in `Sₖ`.
 
 ## Fidelity note
 
-The chain in the book runs through **simple** modules only. This is essential: over a product
+The chain in the book runs through simple modules only. This is essential: over a product
 `A = A₁ × A₂`, taking simples `X` (block 1), `Y` (block 2) and a non-simple `N = N₁ ⊕ N₂` with
 `Ext¹(X, N) ≠ 0` and `Ext¹(N, Y) ≠ 0` would link `X` and `Y` if the chain were allowed to pass
 through `N`, even though `X` and `Y` lie in different blocks. The base relation
@@ -49,9 +49,9 @@ def Etingof.ExtAdjacent (X Y : ModuleCat.{v} R) : Prop :=
   Etingof.DirectlyExtLinked R X Y ∨ Etingof.DirectlyExtLinked R Y X
 
 /-- The base relation for the **linking of simple modules** (Etingof Definition 9.5.1): two
-modules are related if they are **both simple** and either Ext¹-adjacent or categorically
-isomorphic. The `IsSimpleModule` side conditions are essential — the book's chain runs through
-simple modules only — and the isomorphism clause supplies reflexivity up to isomorphism (the
+modules are related if they are both simple and either Ext¹-adjacent or categorically
+isomorphic. The `IsSimpleModule` side conditions are essential (the book's chain runs through
+simple modules only), and the isomorphism clause supplies reflexivity up to isomorphism (the
 linking relation is defined on isomorphism classes of simple modules). -/
 def Etingof.ExtOrIsoSimple (X Y : ModuleCat.{v} R) : Prop :=
   IsSimpleModule R X ∧ IsSimpleModule R Y ∧
@@ -59,7 +59,7 @@ def Etingof.ExtOrIsoSimple (X Y : ModuleCat.{v} R) : Prop :=
 
 /-- Two simple modules are **linked** (in the sense of Etingof Definition 9.5.1) if they are
 related by the equivalence closure of the simplicity-gated Ext¹-adjacency relation: there
-exists a chain `X = X₀, X₁, …, Xₙ = Y` of **simple** modules such that each consecutive pair
+exists a chain `X = X₀, X₁, …, Xₙ = Y` of simple modules such that each consecutive pair
 `(Xᵢ, Xᵢ₊₁)` satisfies `Ext¹(Xᵢ, Xᵢ₊₁) ≠ 0`, `Ext¹(Xᵢ₊₁, Xᵢ) ≠ 0`, or `Xᵢ ≅ Xᵢ₊₁`. -/
 def Etingof.AreLinked (X Y : ModuleCat.{v} R) : Prop :=
   Relation.EqvGen (Etingof.ExtOrIsoSimple R) X Y
@@ -81,7 +81,7 @@ theorem Etingof.areLinked_equivalence :
     @Equivalence (ModuleCat.{v} R) (Etingof.AreLinked R) :=
   Relation.EqvGen.is_equivalence _
 
-/-- **Base case of the block dévissage (Etingof 9.5.3(ii), step 1).** Two *simple* modules that
+/-- **Base case of the block dévissage (Etingof 9.5.3(ii), step 1).** Two simple modules that
 are not linked have vanishing `Ext¹`: `Ext¹(S, T)` is subsingleton. A nonzero element of
 `Ext¹(S, T)` would make `S` and `T` directly `Ext`-linked, hence `Ext`-adjacent, hence linked
 (a length-one chain), contradicting `¬ AreLinked`. This is the seed for the finite-length

--- a/EtingofRepresentationTheory/Chapter9/Discussion_after_Definition9_7_1.lean
+++ b/EtingofRepresentationTheory/Chapter9/Discussion_after_Definition9_7_1.lean
@@ -52,12 +52,12 @@ This file also formalizes these two "minimal basic algebra" claims:
 * **Dimension is minimized at `𝐧 = (1,…,1)`.** With `c_{ij} ≥ 0` (a `finrank`, hence a `ℕ`),
   `c_{ii} ≥ 1` (the identity spans a line in `End(P_i)`), and every multiplicity `n_i ≥ 1`,
   the dimension `∑ c_{ij} n_i n_j` is at least `∑ c_{ij}`
-  (`Etingof.sum_cartan_le_finrank_cartanAlgebra`), with equality **iff** every `n_i = 1`
+  (`Etingof.sum_cartan_le_finrank_cartanAlgebra`), with equality iff every `n_i = 1`
   (`Etingof.finrank_cartanAlgebra_eq_sum_cartan_iff`). The diagonal term `c_{ii} n_i^2`
   strictly grows once any `n_i ≥ 2`.
 
 * **Commutativity of the semisimple quotient.** The Wedderburn quotient
-  `B_𝐧 / Rad(B_𝐧) ≅ ⊕_i Mat_{n_i}(k)` is commutative **iff** every `n_i = 1`, because a
+  `B_𝐧 / Rad(B_𝐧) ≅ ⊕_i Mat_{n_i}(k)` is commutative iff every `n_i = 1`, because a
   matrix algebra `Mat_{n_i}(k)` is commutative iff `n_i ≤ 1` (elementary matrices `E_{ab}`,
   `E_{ba}` fail to commute once there are two indices). We model the quotient by its
   Wedderburn form `∀ i, Matrix (Fin (n i)) (Fin (n i)) k` and prove the criterion directly
@@ -213,7 +213,7 @@ theorem finrank_cartanAlgebra_one (P : ι → C) :
 /-- **Minimal dimension iff `𝐧 = (1,…,1)` (Etingof, discussion after Definition 9.7.1).**
 Assuming each multiplicity `n_i ≥ 1` and each diagonal Cartan number `c_{ii} ≥ 1` (the identity
 spans a line in `End(P_i)`), the dimension `dim B_𝐧 = ∑ c_{ij} n_i n_j` attains its minimum value
-`∑ c_{ij}` **exactly** when every `n_i = 1`. Any `n_i ≥ 2` strictly enlarges the diagonal term
+`∑ c_{ij}` exactly when every `n_i = 1`. Any `n_i ≥ 2` strictly enlarges the diagonal term
 `c_{ii} n_i^2`. -/
 theorem finrank_cartanAlgebra_eq_sum_cartan_iff (P : ι → C) (n : ι → ℕ)
     (hn : ∀ i, 1 ≤ n i) (hdiag : ∀ i, 1 ≤ cartanEntry k P i i) :
@@ -239,8 +239,8 @@ theorem finrank_cartanAlgebra_eq_sum_cartan_iff (P : ι → C) (n : ι → ℕ)
     ring
 
 omit [HasFiniteBiproducts C] [Fintype ι] in
-/-- Convenience: if `End(P_i) = Hom(P_i, P_i)` is nontrivial (it always is — it contains the
-nonzero identity when `P_i ≠ 0`), then `c_{ii} ≥ 1`, supplying the diagonal hypothesis of
+/-- Convenience: if `End(P_i) = Hom(P_i, P_i)` is nontrivial (it always is, since it contains the
+nonzero identity when `P_i ≠ 0`), then `c_{ii} ≥ 1`, giving the diagonal hypothesis of
 `finrank_cartanAlgebra_eq_sum_cartan_iff`. -/
 theorem one_le_cartanEntry_self (P : ι → C) (i : ι) [Nontrivial (P i ⟶ P i)] :
     1 ≤ cartanEntry k P i i := by
@@ -261,7 +261,7 @@ the elementary fact that `Mat_m(k)` is commutative iff `m ≤ 1`. -/
 
 variable {k : Type w} [Field k]
 
-/-- Over a nontrivial ring, a matrix algebra with two distinct indices is **non**commutative:
+/-- Over a nontrivial ring, a matrix algebra with two distinct indices is noncommutative:
 the elementary matrices `E_{ab}` and `E_{ba}` fail to commute (`E_{ab} E_{ba} = E_{aa}` but
 `E_{ba} E_{ab} = E_{bb}`). -/
 theorem exists_matrix_not_comm_of_ne {m : Type*} [Fintype m] {a b : m}
@@ -289,8 +289,8 @@ theorem matrix_mul_comm_of_subsingleton {m : Type*} [Fintype m] [Subsingleton m]
 
 /-- **Etingof, discussion after Definition 9.7.1 (commutativity criterion).** The Wedderburn
 semisimple quotient `B_𝐧 / Rad(B_𝐧) ≅ ⊕_i Mat_{n_i}(k)`, modelled as the product of matrix
-algebras `∀ i, Matrix (Fin (n i)) (Fin (n i)) k`, is commutative **iff** every multiplicity
-`n_i = 1` — i.e. iff `𝐧 = (1,…,1)`, the unique minimal member `B = B_(1,…,1)`. Each factor
+algebras `∀ i, Matrix (Fin (n i)) (Fin (n i)) k`, is commutative iff every multiplicity
+`n_i = 1`, i.e. iff `𝐧 = (1,…,1)`, the unique minimal member `B = B_(1,…,1)`. Each factor
 `Mat_{n_i}(k)` is commutative iff `n_i ≤ 1`, and with `n_i ≥ 1` this is `n_i = 1`. -/
 theorem semisimpleQuotient_comm_iff {ι : Type*} (n : ι → ℕ) (hn : ∀ i, 1 ≤ n i) :
     (∀ x y : (∀ i, Matrix (Fin (n i)) (Fin (n i)) k), x * y = y * x) ↔ ∀ i, n i = 1 := by

--- a/EtingofRepresentationTheory/Chapter9/Example9_4_4.lean
+++ b/EtingofRepresentationTheory/Chapter9/Example9_4_4.lean
@@ -30,13 +30,12 @@ The Hilbert syzygy theorem is not yet in Mathlib.
 ## Relation to Problem 8.2.10
 
 The book obtains this example from Problem 8.2.10(iv) (the Hilbert syzygies
-theorem). This formalization does not route through the explicit Koszul
-resolution of Problem 8.2.10; it proves the needed conclusion — the homological
-dimension of `k[x₁, …, xₙ]` is `n` — directly, via the degree-one Koszul short
-exact sequence `koszulSES_shortExact`, induction on the number of variables, and
-`hasHomologicalDimensionLE_polynomial`. `Etingof.Example_9_4_4` is therefore the
-machine-checked citation target for the load-bearing use of Problem 8.2.10; see
-`Chapter8/Problem8_2_10.lean` for the coverage record.
+theorem). This formalization does not use the explicit Koszul resolution of
+Problem 8.2.10; it proves the conclusion that the homological dimension of
+`k[x₁, …, xₙ]` is `n` directly, via the degree-one Koszul short exact sequence
+`koszulSES_shortExact`, induction on the number of variables, and
+`hasHomologicalDimensionLE_polynomial`. See `Chapter8/Problem8_2_10.lean` for the
+corresponding development of Problem 8.2.10.
 -/
 
 universe u

--- a/EtingofRepresentationTheory/Chapter9/Example9_5_2.lean
+++ b/EtingofRepresentationTheory/Chapter9/Example9_5_2.lean
@@ -14,14 +14,14 @@ Each block is equivalent to the category of vector spaces (since every module is
 sum of copies of one simple).
 
 (ii) If A is a commutative local artinian algebra, then A has only one block (since there
-is only one simple module — the residue field).
+is only one simple module, the residue field).
 
 (iii) The algebra from Problem 9.3.2 has one block.
 
 ## Scope of this file
 
-Part (i) is captured through the project's `Etingof.AreLinked` relation, which — faithful to
-Definition 9.5.1 — links **simple** modules via chains of *simple* modules connected by
+Part (i) is captured through the project's `Etingof.AreLinked` relation, which, faithful to
+Definition 9.5.1, links simple modules via chains of simple modules connected by
 `Ext¹`-adjacency. Over a semisimple ring `Ext¹` vanishes identically, so the linking relation
 on simples collapses to isomorphism. We prove `Etingof.semisimple_areLinked_iff_iso`: for
 simple `X, Y`, `AreLinked X Y ↔ X ≅ Y`, i.e. each block contains a single isomorphism class of
@@ -31,14 +31,14 @@ Note the relationship to the book's phrasing "each block is equivalent to the ca
 vector spaces". Etingof's block attached to a simple `S` is the full subcategory of modules
 whose Jordan–Hölder factors are all in `S`'s linking class (the predicate `Etingof.InBlock`);
 over a semisimple ring that subcategory is the isotypic component `{S^{⊕n}}`, equivalent to
-vector spaces. The statement formalized here is the load-bearing consequence "one simple object
+vector spaces. The statement formalized here is the consequence "one simple object
 per block". Promoting the Etingof "≃ Vec" subcategory equivalence would require an
 isotypic-subcategory equivalence beyond the scope of Definition 9.5.1.
 
-Part (iii) — "the algebra of Problem 9.3.2 has one block" — is now formalized. The
+Part (iii), "the algebra of Problem 9.3.2 has one block": the
 generators-and-relations algebra `A = ℂ⟨g, x⟩ / (gx + xg, x², g² - 1)` is constructed in
 `Chapter9/Problem9_3_2.lean`, together with its two non-isomorphic one-dimensional simple
-modules `S₊` and `S₋`. The two simples are linked by a genuine nonsplit extension
+modules `S₊` and `S₋`. The two simples are linked by a nonsplit extension
 `0 → S₋ → P₊ → S₊ → 0`, so `Ext¹(S₊, S₋) ≠ 0`; this is exactly the regime that part (i)
 (semisimple) excludes. We re-export the resulting `Etingof.AreLinked` statement as
 `Etingof.problem_9_3_2_single_block` below.
@@ -63,7 +63,7 @@ theorem Etingof.semisimple_not_extAdjacent
     haveI := Abelian.Ext.subsingleton_of_projective B A 0
     exact not_nontrivial _ h
 
-/-- For a semisimple ring, the linking relation on **simple** modules collapses to isomorphism:
+/-- For a semisimple ring, the linking relation on simple modules collapses to isomorphism:
 two simple modules are linked iff they are isomorphic. Equivalently, each block contains a
 single isomorphism class of simples. This is Etingof Example 9.5.2 (i) ("each block is
 equivalent to the category of vector spaces, and thus has only one simple object"): since
@@ -127,7 +127,7 @@ theorem Etingof.local_artinian_single_block
 /-- The algebra `A = ℂ⟨g, x⟩ / (gx + xg, x², g² - 1)` of Problem 9.3.2 has a single block:
 its two non-isomorphic simple modules `S₊` and `S₋` are `Etingof.AreLinked`, via the nonsplit
 extension `0 → S₋ → P₊ → S₊ → 0` (so `Ext¹(S₊, S₋) ≠ 0`). Unlike parts (i) and (ii), the
-linking here is a genuine nonsplit extension rather than an isomorphism.
+linking here is a nonsplit extension rather than an isomorphism.
 (Etingof Example 9.5.2 (iii); see `Chapter9/Problem9_3_2.lean` for the construction.) -/
 theorem Etingof.problem_9_3_2_single_block :
     Etingof.AreLinked Etingof.Problem932.A

--- a/EtingofRepresentationTheory/Chapter9/HomologicalDimensionRingEquiv.lean
+++ b/EtingofRepresentationTheory/Chapter9/HomologicalDimensionRingEquiv.lean
@@ -12,9 +12,9 @@ import EtingofRepresentationTheory.Chapter9.Definition9_4_3
 This file proves that `Etingof.homologicalDimension` (Definition 9.4.3) is invariant under a
 ring isomorphism `e : R ≃+* S`:
 
-* `Etingof.hasHomologicalDimensionLE_congr` — `HasHomologicalDimensionLE R d`
+* `Etingof.hasHomologicalDimensionLE_congr`: `HasHomologicalDimensionLE R d`
   iff `HasHomologicalDimensionLE S d`;
-* `Etingof.homologicalDimension_congr` — `homologicalDimension R = homologicalDimension S`.
+* `Etingof.homologicalDimension_congr`: `homologicalDimension R = homologicalDimension S`.
 
 ## Strategy
 
@@ -30,7 +30,7 @@ dimension-shifting short exact sequence coming from a projective presentation, m
 equivalence). The iff form (`hasProjectiveDimensionLT_map_iff`) follows by also applying the
 statement to `e.symm`.
 
-The lemmas are stated for two rings in the **same** universe, which is all the free-algebra
+The lemmas are stated for two rings in the same universe, which is all the free-algebra
 corollary of Problem 9.4.6 (i) (`homologicalDimension_freeAlgebra_eq_one`) needs, since
 `FreeAlgebra k (Fin n)` and the one-vertex path algebra are both `Type u`.
 -/

--- a/EtingofRepresentationTheory/Chapter9/HomologicalDimensionUlift.lean
+++ b/EtingofRepresentationTheory/Chapter9/HomologicalDimensionUlift.lean
@@ -6,18 +6,18 @@ import EtingofRepresentationTheory.Chapter9.HomologicalDimensionRingEquiv
 # Homological dimension is invariant under a universe lift
 
 `Etingof.homologicalDimension R` (Definition 9.4.3) quantifies over `ModuleCat.{u} R`, where `u`
-is the universe of `R`. This file proves that lifting `R` to a larger universe can only *increase*
+is the universe of `R`. This file proves that lifting `R` to a larger universe can only increase
 the collection of modules under consideration, so it cannot lower the homological dimension:
 
-* `Etingof.homologicalDimension_le_ulift` —
+* `Etingof.homologicalDimension_le_ulift`:
   `homologicalDimension R ≤ homologicalDimension (ULift R)`.
 
 ## Strategy
 
 The key categorical input is that the universe-lift functor
 `ModuleCat.uliftFunctor.{v, u} R : ModuleCat.{u} R ⥤ ModuleCat.{max u v} R` is additive, exact
-(preserves finite limits and colimits) and fully faithful, and — since `R : Type u` is `u`-small —
-preserves projective objects. A fully faithful exact functor preserving projectives *reflects*
+(preserves finite limits and colimits) and fully faithful, and, since `R : Type u` is `u`-small,
+preserves projective objects. A fully faithful exact functor preserving projectives reflects
 projective dimension: `HasProjectiveDimensionLT (F.obj X) n → HasProjectiveDimensionLT X n`
 (`Etingof.hasProjectiveDimensionLT_of_map`). This mirrors the preservation statement
 `hasProjectiveDimensionLT_map` from `HomologicalDimensionRingEquiv.lean`, but for a plain
@@ -29,9 +29,9 @@ Combined with the same-universe ring-equivalence transfer
 `ULift R`-module has projective dimension `≤ d`, then so does every small-universe `R`-module,
 which is exactly the inequality of homological dimensions.
 
-The reverse inequality (a universe lift cannot *raise* the homological dimension) is the harder
-direction — it requires reducing the projective dimension of arbitrary big modules to small ones
-(an Auslander-style argument) — and is not needed for the free-algebra corollary of Problem 9.4.6,
+The reverse inequality (a universe lift cannot raise the homological dimension) is harder: it
+requires reducing the projective dimension of arbitrary big modules to small ones (an
+Auslander-style argument), and is not needed for the free-algebra corollary of Problem 9.4.6,
 so it is not proved here.
 -/
 
@@ -46,12 +46,12 @@ section Reflect
 variable {C : Type*} {D : Type*} [Category C] [Category D] [Abelian C] [Abelian D]
 
 /-- A fully faithful additive exact functor `F : C ⥤ D` preserving projective objects (with `C`
-having enough projectives) *reflects* projective dimension: if `F.obj X` has projective dimension
+having enough projectives) reflects projective dimension: if `F.obj X` has projective dimension
 `< n`, then so does `X`.
 
 Strong induction on `n`, dual to `Etingof.hasProjectiveDimensionLT_map`. The base cases are
 `n = 0` (`F` is faithful, so it reflects zero objects) and `n = 1` (`F` reflects projectives,
-being full, faithful and epimorphism-preserving — `Functor.projective_of_map_projective`). For
+being full, faithful and epimorphism-preserving, by `Functor.projective_of_map_projective`). For
 `n + 2` one takes a projective presentation `0 → K → P → X → 0` in `C`, maps it to the short exact
 sequence `0 → F K → F P → F X → 0`, shifts `F X`'s dimension down to `F K`
 (`hasProjectiveDimensionLT_X₁`), applies the induction hypothesis to `K`, and shifts back up along

--- a/EtingofRepresentationTheory/Chapter9/Introduction_9_7.lean
+++ b/EtingofRepresentationTheory/Chapter9/Introduction_9_7.lean
@@ -27,23 +27,23 @@ The classification is the biconditional
 
 `IsProgenerator Q ↔ ∃ n : ι → ℕ, (∀ i, 1 ≤ n i) ∧ Nonempty (Q ≅ multBiproduct P n)`.
 
-* The **backward** direction (any such `multBiproduct` with all `n_i ≥ 1` is a
+* The backward direction (any such `multBiproduct` with all `n_i ≥ 1` is a
   progenerator) is the elementary "check it!" content and is proved here in full
   (`Etingof.isProgenerator_multBiproduct`). The argument: `multBiproduct P n` is a
   biproduct of projectives, hence projective; and the given progenerator `⨁ P` (one
-  copy of each `P_i`) is a *retract* of `multBiproduct P n` once every `n_i ≥ 1`, so
-  every object — already a quotient of a biproduct of copies of `⨁ P` — is a quotient
+  copy of each `P_i`) is a retract of `multBiproduct P n` once every `n_i ≥ 1`, so
+  every object, already a quotient of a biproduct of copies of `⨁ P`, is a quotient
   of a biproduct of copies of `multBiproduct P n`.
 
-* The **forward** direction (every progenerator is of this shape, with each `P_i`
-  occurring at least once) is the **Krull–Schmidt** content: a finitely generated
+* The forward direction (every progenerator is of this shape, with each `P_i`
+  occurring at least once) is the Krull–Schmidt content: a finitely generated
   projective object of a finite abelian category decomposes (essentially uniquely) into
   indecomposable projectives, each of which is one of the `P_i`, and generation forces
   every `P_i` to appear. Krull–Schmidt for finite abelian / finite-length additive
-  categories is **not in Mathlib**; it is built up in `Chapter9/KrullSchmidt/` and
+  categories is not in Mathlib; it is built up in `Chapter9/KrullSchmidt/` and
   consumed here. `Etingof.progenerator_decomposition` discharges this direction in full
   from the existence (`KrullSchmidt/Existence.lean`) and exchange
-  (`KrullSchmidt/Exchange.lean`) links.
+  (`KrullSchmidt/Exchange.lean`) results.
 -/
 
 open CategoryTheory CategoryTheory.Limits
@@ -149,7 +149,7 @@ and exhausting the indecomposable projectives up to isomorphism, with `⨁ P` a
 progenerator), then `Q ≅ ⊕_i n_i P_i` for a unique multiplicity vector `n` with every
 `n_i ≥ 1`.
 
-The proof assembles the **Krull–Schmidt** links built in `Chapter9/KrullSchmidt/`:
+The proof combines the Krull–Schmidt results built in `Chapter9/KrullSchmidt/`:
 1. `Q`, being projective in a finite (finite-length) abelian category, decomposes as a
    finite biproduct `Q ≅ ⨁ f` of indecomposable projective objects
    (`exists_indecomposable_projective_biproduct`).
@@ -221,7 +221,7 @@ theorem progenerator_decomposition {ι : Type v} [Fintype ι] (P : ι → C)
 Let `P : ι → 𝒞` be the indecomposable projective objects of a finite abelian category
 `𝒞` (each indecomposable, pairwise non-isomorphic, exhausting the indecomposable
 projectives, with `⨁ P` a progenerator). Then an object `Q` is a projective generator
-**iff** `Q ≅ ⊕_i n_i P_i` for some multiplicities `n_i ≥ 1`.
+iff `Q ≅ ⊕_i n_i P_i` for some multiplicities `n_i ≥ 1`.
 
 This is Etingof §9.7's `P_𝐧 = ⊕_{i=1}^m n_i P_i, n_i ≥ 1` classification ("check it!").
 The backward direction is proved in full; the forward direction is the Krull–Schmidt

--- a/EtingofRepresentationTheory/Chapter9/Introduction_9_7_Morita.lean
+++ b/EtingofRepresentationTheory/Chapter9/Introduction_9_7_Morita.lean
@@ -23,31 +23,31 @@ and, in the Discussion after Definition 9.7.1, its global restatement:
 
 This file formalizes both claims, building on three already-proven pieces:
 
-* `Etingof.Theorem_9_6_4_corollary_of_isNoetherian` — for any progenerator `P` of a finite
+* `Etingof.Theorem_9_6_4_corollary_of_isNoetherian`: for any progenerator `P` of a finite
   abelian category `𝒞` with `(End P)ᵐᵒᵖ` Noetherian, `𝒞 ≌ FGModuleCat (End P)ᵐᵒᵖ`. This is
   the ring-level Morita identification: the endomorphism algebra of a progenerator realizes
   `𝒞` as its module category. (The over-a-field headline is `Etingof.Theorem_9_6_4`.)
-* `Etingof.progenerator_iff_multBiproduct` — the §9.7 classification: an object `Q` is
-  a progenerator **iff** `Q ≅ P_𝐧 := ⊕ᵢ nᵢ Pᵢ` for some multiplicities `nᵢ ≥ 1`.
-* `Etingof.isProgenerator_multBiproduct` — each `P_𝐧` with all `nᵢ ≥ 1` is a
+* `Etingof.progenerator_iff_multBiproduct`, the §9.7 classification: an object `Q` is
+  a progenerator iff `Q ≅ P_𝐧 := ⊕ᵢ nᵢ Pᵢ` for some multiplicities `nᵢ ≥ 1`.
+* `Etingof.isProgenerator_multBiproduct`: each `P_𝐧` with all `nᵢ ≥ 1` is a
   progenerator.
 
 ## What is proved here
 
-The project's `IsFiniteAbelianCategory` is a *ring*-level abstraction (an abelian
+The project's `IsFiniteAbelianCategory` is a ring-level abstraction (an abelian
 category with enough projectives and finitely many simples; it carries no `k`-linear
 structure), so `B_𝐧 = (End P_𝐧)ᵐᵒᵖ` is a ring and the comparisons below are ring
 isomorphisms `≃+*` rather than `k`-algebra isomorphisms.
 
-* `Etingof.Bn` — the algebra `B_𝐧(𝒞) = (End P_𝐧)ᵐᵒᵖ`.
-* `Etingof.nonempty_equivalence_fgModuleCat_Bn` — **each `B_𝐧` realizes `𝒞`**:
+* `Etingof.Bn`: the algebra `B_𝐧(𝒞) = (End P_𝐧)ᵐᵒᵖ`.
+* `Etingof.nonempty_equivalence_fgModuleCat_Bn`, each `B_𝐧` realizes `𝒞`:
   `𝒞 ≌ FGModuleCat (B_𝐧)` (the `⊇` of the book's claim).
-* `Etingof.ringEquiv_endOp_iff_isBn` — **the capstone biconditional**: a ring `A` is
-  (isomorphic to) the endomorphism algebra `(End Q)ᵐᵒᵖ` of *some* progenerator `Q` of
-  `𝒞` **iff** `A ≃+* B_𝐧` for some `𝐧` with all `nᵢ ≥ 1`. Via Theorem 9.6.4 the
+* `Etingof.ringEquiv_endOp_iff_isBn`, the capstone biconditional: a ring `A` is
+  (isomorphic to) the endomorphism algebra `(End Q)ᵐᵒᵖ` of some progenerator `Q` of
+  `𝒞` iff `A ≃+* B_𝐧` for some `𝐧` with all `nᵢ ≥ 1`. Via Theorem 9.6.4 the
   left-hand side is exactly "`A`'s module category is `𝒞`", so this is precisely
   Etingof's "the `B_𝐧` are all the algebras whose module category is `𝒞`".
-* `Etingof.nonempty_fgModuleCat_equivalence_of_isBn` — **the Discussion restatement**:
+* `Etingof.nonempty_fgModuleCat_equivalence_of_isBn`, the Discussion restatement:
   all the `B_𝐧` lie in a single Morita class (their module categories are mutually
   equivalent, both being `𝒞`).
 -/
@@ -58,7 +58,7 @@ namespace CategoryTheory.Iso
 
 variable {C : Type u} [Category.{v} C] [Preadditive C] {X Y : C}
 
-/-- Conjugation by an isomorphism `e : X ≅ Y` as a **ring** isomorphism of endomorphism
+/-- Conjugation by an isomorphism `e : X ≅ Y` as a ring isomorphism of endomorphism
 rings, `End X ≃+* End Y`, `f ↦ e.inv ≫ f ≫ e.hom`. This upgrades Mathlib's multiplicative
 `Iso.conj` with additivity, which holds because composition is bilinear in a preadditive
 category. -/
@@ -103,7 +103,7 @@ theorem nonempty_equivalence_fgModuleCat_Bn
 /-- **§9.7 capstone biconditional.** Let `P : ι → 𝒞` be the indecomposable projectives of
 the finite abelian category `𝒞` (each indecomposable, pairwise non-isomorphic, exhausting
 the indecomposable projectives, with `⨁ P` a progenerator). Then a ring `A` is isomorphic
-to the endomorphism algebra `(End Q)ᵐᵒᵖ` of *some* progenerator `Q` of `𝒞` **iff** `A` is
+to the endomorphism algebra `(End Q)ᵐᵒᵖ` of some progenerator `Q` of `𝒞` iff `A` is
 isomorphic to some `B_𝐧` with all multiplicities `nᵢ ≥ 1`.
 
 By Theorem 9.6.4 the left-hand condition is exactly "`A`'s category of finitely generated

--- a/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Exchange.lean
+++ b/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Exchange.lean
@@ -4,18 +4,18 @@ import Mathlib.Algebra.Ring.Idempotent
 import Mathlib.CategoryTheory.Preadditive.Biproducts
 
 /-!
-# Exchange / uniqueness for indecomposable decompositions (Krull–Schmidt, link 4/5)
+# Exchange / uniqueness for indecomposable decompositions (Krull–Schmidt)
 
-This file is the **uniqueness** half of the Krull–Schmidt theorem for a finite abelian category
-`C`. Building on the local endomorphism rings of indecomposables (link 3/5,
-`KrullSchmidt/Fitting.lean`) it proves the Azumaya exchange property:
+This file is the uniqueness half of the Krull–Schmidt theorem for a finite abelian category
+`C`. Building on the local endomorphism rings of indecomposables
+(`KrullSchmidt/Fitting.lean`) it proves the Azumaya exchange property:
 
-* **`Etingof.indecomposable_summand_iso_factor`** — an indecomposable direct summand of a finite
+* **`Etingof.indecomposable_summand_iso_factor`**: an indecomposable direct summand of a finite
   biproduct of indecomposables is isomorphic to one of the factors.
 
 and bootstraps from it to full uniqueness of the multiset of factors:
 
-* **`Etingof.krullSchmidt_unique`** — two finite biproducts of indecomposables that are isomorphic
+* **`Etingof.krullSchmidt_unique`**: two finite biproducts of indecomposables that are isomorphic
   have the same factors up to a reindexing bijection.
 
 ## Proof of the exchange property
@@ -29,8 +29,8 @@ into a finite sum over the index set:
 ```
 
 Each summand `a k := (s ≫ π k) ≫ (ι k ≫ r)` is an endomorphism of `X`, and their sum is the unit
-`𝟙 X` of the ring `End X`. Because `End X` is **local** (`isLocalRing_End_of_indecomposable`, link
-3/5) and the nonunits of a local ring are closed under addition, a finite sum that is a unit must
+`𝟙 X` of the ring `End X`. Because `End X` is local (`isLocalRing_End_of_indecomposable`) and the
+nonunits of a local ring are closed under addition, a finite sum that is a unit must
 have a unit summand (`exists_isUnit_of_isUnit_sum`). So for some `k` the composite
 `a k = α ≫ β` is an isomorphism, where `α := s ≫ π k : X ⟶ Y k` and `β := ι k ≫ r : Y k ⟶ X`.
 
@@ -222,7 +222,7 @@ set_option linter.unusedFintypeInType false in
 /-- **Uniqueness of the indecomposable decomposition.** Two finite biproducts of indecomposables
 that are isomorphic have the same factors up to a reindexing bijection.
 
-This is the recommended companion result that pins the §9.7 multiplicities. It bootstraps from the
+This result pins the §9.7 multiplicities. It follows from the
 exchange property `indecomposable_summand_iso_factor` by induction on `Fintype.card κ`:
 
 * `κ` empty: `⨁ Y` is a zero object, so `⨁ Z` is zero, so `μ` is empty as well (any `Z m` would be

--- a/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Existence.lean
+++ b/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Existence.lean
@@ -3,9 +3,9 @@ import Mathlib.CategoryTheory.Limits.Shapes.BinaryBiproducts
 import Mathlib.CategoryTheory.Preadditive.Projective.Basic
 
 /-!
-# Existence of the indecomposable decomposition (Krull–Schmidt, link 2/5)
+# Existence of the indecomposable decomposition (Krull–Schmidt)
 
-This file proves the **existence** half of the Krull–Schmidt theorem for a finite abelian
+This file proves the existence half of the Krull–Schmidt theorem for a finite abelian
 category `C`: every object `X` is a finite biproduct of indecomposable objects
 (`Etingof.exists_indecomposable_biproduct`), together with a projective-preserving variant
 (`Etingof.exists_indecomposable_projective_biproduct`) consumed by the §9.7 projective-generator
@@ -16,7 +16,7 @@ classification.
 The argument is a strong induction on the composition length `Etingof.clength X` from
 `KrullSchmidt/Length.lean`:
 
-* `clength X = 0` (equivalently `IsZero X`): take the empty family — `⨁` over `Empty` is a zero
+* `clength X = 0` (equivalently `IsZero X`): take the empty family; `⨁` over `Empty` is a zero
   object, isomorphic to `X`.
 * `Indecomposable X`: take the one-element family `fun _ : PUnit => X`.
 * otherwise `X ≅ Y ⊞ Z` with both `Y`, `Z` nonzero; `clength_biprod` and
@@ -120,7 +120,7 @@ theorem exists_indecomposable_biproduct (X : C) :
   exact key (clength X) X rfl
 
 /-- **Projective-preserving existence.** A projective object of a finite abelian category is a
-finite biproduct of projective indecomposable objects. Used by the §9.7 assembly. -/
+finite biproduct of projective indecomposable objects. Used by the §9.7 classification. -/
 theorem exists_indecomposable_projective_biproduct {X : C} (hX : Projective X) :
     ∃ (κ : Type) (_ : Fintype κ) (f : κ → C),
       (∀ k, Projective (f k) ∧ CategoryTheory.Indecomposable (f k)) ∧ Nonempty (X ≅ ⨁ f) := by

--- a/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Fitting.lean
+++ b/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Fitting.lean
@@ -5,20 +5,20 @@ import Mathlib.RingTheory.Nilpotent.Basic
 import Mathlib.RingTheory.LocalRing.Basic
 
 /-!
-# Fitting's lemma and local endomorphism rings (Krull–Schmidt, link 3/5)
+# Fitting's lemma and local endomorphism rings (Krull–Schmidt)
 
-This file is the **hard core** of the Krull–Schmidt chain for a finite abelian category `C`. It
-records Fitting's lemma — the `ker`/`im` block decomposition of an endomorphism — and derives the
+This file is the hard core of the Krull–Schmidt chain for a finite abelian category `C`. It
+records Fitting's lemma (the `ker`/`im` block decomposition of an endomorphism) and derives the
 two facts the uniqueness half of Krull–Schmidt rests on:
 
-* **`Etingof.isNilpotent_or_isIso_of_indecomposable`** — every endomorphism of an indecomposable
+* **`Etingof.isNilpotent_or_isIso_of_indecomposable`**: every endomorphism of an indecomposable
   object is nilpotent or an isomorphism;
-* **`Etingof.isLocalRing_End_of_indecomposable`** — the endomorphism ring of an indecomposable
+* **`Etingof.isLocalRing_End_of_indecomposable`**: the endomorphism ring of an indecomposable
   object is local.
 
-## Design and the Fitting crux
+## Design and the Fitting decomposition
 
-Mathlib has the Fitting decomposition only for Artinian **modules**
+Mathlib has the Fitting decomposition only for Artinian modules
 (`Mathlib/RingTheory/Artinian/Module.lean`); there is nothing for an abstract abelian category.
 The categorical statement,
 
@@ -27,25 +27,24 @@ The categorical statement,
 ```
 
 needs the descending image chain `im (f^n)` and the ascending kernel chain `ker (f^n)` to
-*stabilise*. That stabilisation is exactly the finite-length input of `KrullSchmidt/Length.lean`:
-the chains are measured by `Etingof.clength`, whose finiteness/monotonicity is the (now proved,
-sorry-free) categorical Jordan–Hölder content of link 1/5. The Fitting decomposition
+stabilise. That stabilisation is exactly the finite-length input of `KrullSchmidt/Length.lean`:
+the chains are measured by `Etingof.clength`, whose finiteness and monotonicity is the
+categorical Jordan–Hölder content of that file. The Fitting decomposition
 `fitting_decomposition` is stated here in the convenient block-conjugation form
 
 ```
 f = e.hom ≫ biprod.map fK fI ≫ e.inv,   IsNilpotent fK,   IsIso fI,
 ```
 
-and is **proved** from the single finite-length input `Etingof.exists_pow_stabilizes`: at the
+and is proved from the single finite-length input `Etingof.exists_pow_stabilizes`: at the
 stabilising power `n` the image restriction `g' := image.ι (fⁿ) ≫ factorThruImage (fⁿ)` is an
 isomorphism. Given that iso the whole construction is elementary abelian-category algebra:
 `factorThruImage (fⁿ)` becomes a split epi (section `(g')⁻¹ ≫ image.ι (fⁿ)`), its kernel and image
 split `X` as a biproduct, `f` is block-diagonal because it preserves both summands (the kernel
 summand directly, the image summand because `f` maps `im (fⁿ)` into `im (fⁿ⁺¹) ⊆ im (fⁿ)`), and the
-two blocks are read off from `(fK)ⁿ = (fⁿ)|_K = 0` and `(fI)ⁿ = (fⁿ)|_I = g'`. The upstream
-`clength_*` finiteness lemmas that `exists_pow_stabilizes` rests on are all proved, sorry-free.
-**Everything downstream of `fitting_decomposition` in this file — the nilpotent-or-iso dichotomy and
-the local-ring property — is proved unconditionally from its statement.**
+two blocks are read off from `(fK)ⁿ = (fⁿ)|_K = 0` and `(fI)ⁿ = (fⁿ)|_I = g'`. The
+nilpotent-or-iso dichotomy and the local-ring property below follow from the statement of
+`fitting_decomposition` alone.
 
 The two reductions are elementary once the block form is in hand:
 
@@ -126,9 +125,9 @@ nilpotent and `fI` an isomorphism.
 
 `K` is the kernel `ker (factorThruImage (fⁿ)) = ker (fⁿ)` and `I` the eventual image `im (fⁿ)` for
 the stabilising power `n` supplied by `Etingof.exists_pow_stabilizes` (the finite-length content of
-`KrullSchmidt/Length.lean`, which rests on the proved, sorry-free `clength_*` lemmas); see the
-module doc for the proof outline. The downstream dichotomy and local-ring results below are proved
-unconditionally from this statement. -/
+`KrullSchmidt/Length.lean`, which rests on the `clength_*` lemmas); see the
+module doc for the proof outline. The downstream dichotomy and local-ring results below follow
+from this statement. -/
 theorem fitting_decomposition {X : C} (f : End X) :
     ∃ (K I : C) (e : X ≅ K ⊞ I) (fK : End K) (fI : End I),
       IsNilpotent fK ∧ IsIso (fI : I ⟶ I) ∧
@@ -219,7 +218,7 @@ theorem fitting_decomposition {X : C} (f : End X) :
         biprod.inl_fst, biprod.inl_snd, biprod.inr_fst, biprod.inr_snd, Category.comp_id,
         comp_zero, hfK, hfI, hA, hB]
   refine ⟨K, I, e, fK, fI, ?_, ?_, ?_⟩
-  · -- Step 5a: `fK` is nilpotent — `fK ^ n = 0`.
+  · -- Step 5a: `fK` is nilpotent: `fK ^ n = 0`.
     refine ⟨n, ?_⟩
     have hM : (e.conj f : K ⊞ I ⟶ K ⊞ I) = biprod.map (fK : K ⟶ K) (fI : I ⟶ I) := by
       rw [Iso.conj_apply]; exact hmap
@@ -231,7 +230,7 @@ theorem fitting_decomposition {X : C} (f : End X) :
       biprod.inl_desc_assoc, biprod.lift_fst, Category.comp_id] at h
     rw [← Category.assoc, hKg, zero_comp] at h
     exact h
-  · -- Step 5b: `fI` is an iso — `fI ^ n = i ≫ p` is an iso.
+  · -- Step 5b: `fI` is an iso: `fI ^ n = i ≫ p` is an iso.
     have hM : (e.conj f : K ⊞ I ⟶ K ⊞ I) = biprod.map (fK : K ⟶ K) (fI : I ⟶ I) := by
       rw [Iso.conj_apply]; exact hmap
     have hpow2 : biprod.map ((fK ^ n : End K) : K ⟶ K) ((fI ^ n : End I) : I ⟶ I)

--- a/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Length.lean
+++ b/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Length.lean
@@ -10,7 +10,7 @@ import Mathlib.Algebra.Homology.ShortComplex.Exact
 import Mathlib.Algebra.Homology.ShortComplex.ShortExact
 
 /-!
-# Composition length for finite abelian categories (Krull–Schmidt, link 1/5)
+# Composition length for finite abelian categories (Krull–Schmidt)
 
 This file introduces a `ℕ`-valued **composition length** `Etingof.clength X` for objects of a
 finite abelian category, together with the additivity property that every later Krull–Schmidt
@@ -28,39 +28,35 @@ clength X = (Order.height (⊤ : Subobject X)).toNat.
 
 For a finite-length object this height is finite and equals the length of any composition
 series, by the Jordan–Hölder theorem applied to the (modular) subobject lattice. The definition
-above is *total* — it returns a real `ℕ` for every object — so it can serve as the carrier of the
-API even before the finiteness/additivity content is in place. `Order.height` lives in `ℕ∞`, and
+above is total: it returns a value in `ℕ` for every object, so it can carry the API even before
+the finiteness and additivity content is in place. `Order.height` lives in `ℕ∞`, and
 `.toNat` sends `⊤` (the not-finite-length case, which does not occur in a finite abelian category)
 to `0`.
 
-## Mathlib correspondence and the additivity crux
+## Mathlib correspondence and additivity
 
 Mathlib develops Jordan–Hölder only abstractly (`Mathlib/Order/JordanHolder.lean`,
 `CompositionSeries`, `CompositionSeries.jordan_holder`) and concretely for `Submodule R M`
 (`JordanHolderModule.instJordanHolderLattice`). For the subobject lattice of an abelian category
-it has **neither** a `JordanHolderLattice` instance, **nor** the `IsModularLattice (Subobject X)`
-instance, **nor** the categorical second isomorphism theorem `(A ⊔ B)/A ≅ B/(A ⊓ B)` that such an
-instance needs. The Stacks-project route (tag `0FCK`) for categorical Jordan–Hölder is flagged as
+it has neither a `JordanHolderLattice` instance, nor the `IsModularLattice (Subobject X)`
+instance, nor the categorical second isomorphism theorem `(A ⊔ B)/A ≅ B/(A ⊓ B)` that such an
+instance needs. The Stacks-project approach (tag `0FCK`) for categorical Jordan–Hölder is noted as
 future work in `Mathlib/CategoryTheory/Noetherian.lean`.
 
-Consequently the **additivity** of `clength` over short exact sequences,
+Consequently the additivity of `clength` over short exact sequences,
 
 ```
 clength S.X₂ = clength S.X₁ + clength S.X₃,
 ```
 
-is the genuine categorical Jordan–Hölder content and is the hard part of this link. It is now
-**proved** (`clength_additive`), sorry-free, as `le_antisymm` of the two one-sided bounds:
-`clength_add_le` (the modularity-free lower bound, via the down-interval isomorphism
-`height_mk_eq_height_top` and the epi-side inequality `height_top_le_coheight_kernel`) and
-`clength_le_add` (the Schreier-refinement upper bound, via the order-reflecting embedding
-`Subobject X₂ ↪ Subobject X₁ × Subobject X₃` of `Φ_reflecting` and the product-order height bound
-`height_prod_le`). Finiteness of the height in a finite abelian category comes from the §9.6
-standing assumption recorded as `FiniteDimensionalOrder (Subobject X)`. The
-`clength_eq_zero` characterisation is likewise proved in both directions.
-
-This top-down split lets the downstream consumers (existence-of-decomposition and Fitting's-lemma
-sub-issues of #5153) build against the final `clength` API immediately.
+is the categorical Jordan–Hölder content and the hard part of the development. It is `le_antisymm`
+of the two one-sided bounds: `clength_add_le` (the modularity-free lower bound, via the
+down-interval isomorphism `height_mk_eq_height_top` and the epi-side inequality
+`height_top_le_coheight_kernel`) and `clength_le_add` (the Schreier-refinement upper bound, via the
+order-reflecting embedding `Subobject X₂ ↪ Subobject X₁ × Subobject X₃` of `Φ_reflecting` and the
+product-order height bound `height_prod_le`). Finiteness of the height in a finite abelian category
+comes from the §9.6 standing assumption recorded as `FiniteDimensionalOrder (Subobject X)`. The
+`clength_eq_zero` characterisation holds in both directions.
 -/
 
 universe w v u
@@ -89,7 +85,7 @@ theorem clength_eq_zero_of_isZero {X : C} (h : IsZero X) : clength X = 0 := by
   have hmin : IsMin (⊤ : Subobject X) := fun b _ => le_of_eq (Subsingleton.elim _ _)
   simp only [clength, Order.height_eq_zero.2 hmin, ENat.toNat_zero]
 
-/-- A **simple** object has composition length `1`: its subobject lattice is a two-element chain
+/-- A simple object has composition length `1`: its subobject lattice is a two-element chain
 `⊥ < ⊤` (`IsSimpleOrder (Subobject X)`), so the top element covers the bottom and its height is `1`.
 This is the length-`1` base case of the Jordan–Hölder count: the value `clength_additive` returns
 on the simple quotients of a composition series. -/
@@ -105,8 +101,8 @@ theorem clength_simple {X : C} (h : Simple X) : clength X = 1 := by
       simpa [Order.height_eq_zero.mpr isMin_bot] using this
   simp [clength, hheight]
 
-/-- The subobject lattice of a **zero object** is finite-dimensional as an order: it is a
-singleton, hence `Unique`. This is the base case of the finite-length induction that routes the
+/-- The subobject lattice of a zero object is finite-dimensional as an order: it is a
+singleton, hence `Unique`. This is the base case of the finite-length induction carrying the
 §9.6 standing assumption ("every object has finite length") into the `clength` API. -/
 theorem finiteDimensionalOrder_subobject_of_isZero {X : C} (h : IsZero X) :
     FiniteDimensionalOrder (Subobject X) := by
@@ -125,14 +121,14 @@ theorem height_top_lt_top {X : C} [FiniteDimensionalOrder (Subobject X)] :
   simpa using (Order.krullDim_ne_top_of_finiteDimensionalOrder
     (α := Subobject X)).lt_top
 
-/-- **`clength_eq_zero_iff`, discharged under the finite-length hypothesis.** When the subobject
-lattice of `X` is finite-dimensional as an order — the order-theoretic form of the §9.6 standing
-assumption that every object has finite length — composition length `0` characterises the zero
-object in *both* directions. This is the honest content of the `→` direction of
+/-- **`clength_eq_zero_iff` under the finite-length hypothesis.** When the subobject
+lattice of `X` is finite-dimensional as an order (the order-theoretic form of the §9.6 standing
+assumption that every object has finite length), composition length `0` characterises the zero
+object in both directions. This is the content of the `→` direction of
 `clength_eq_zero_iff`: it needs exactly that `Order.height (⊤ : Subobject X)` is finite (here
 `height_top_lt_top`), so that `clength X = 0` forces `Order.height ⊤ = 0`, i.e. `⊤` is minimal and
-`Subobject X` is a singleton. The unconditional `clength_eq_zero_iff` below then follows the moment
-that finiteness is available from the ambient category; see #5324 for the wiring. -/
+`Subobject X` is a singleton. The unconditional `clength_eq_zero_iff` below then follows once
+that finiteness is available from the ambient category. -/
 theorem clength_eq_zero_iff_of_finiteDimensionalOrder {X : C}
     [FiniteDimensionalOrder (Subobject X)] : clength X = 0 ↔ IsZero X := by
   refine ⟨fun h => ?_, clength_eq_zero_of_isZero⟩
@@ -148,21 +144,20 @@ theorem clength_eq_zero_iff_of_finiteDimensionalOrder {X : C}
 /-- An object has composition length `0` iff it is a zero object.
 
 The `←` direction is `clength_eq_zero_of_isZero`. The `→` direction needs that the height of
-`⊤ : Subobject X` is *finite* in a finite abelian category (`Order.height ... ≠ ⊤`); only then does
+`⊤ : Subobject X` is finite in a finite abelian category (`Order.height ... ≠ ⊤`); only then does
 `(Order.height ⊤).toNat = 0` force `Order.height ⊤ = 0`, i.e. `X` zero (via
 `Subobject.nontrivial_of_not_isZero`). That finiteness is the same categorical Jordan–Hölder input
 as `clength_additive`; see the module doc.
 
-**Finiteness routing (#5324).** This finiteness is *not* derivable from the bare data of an abelian
-category with enough projectives and finitely many simples: that data does **not** force every
+**Finiteness.** This finiteness is not derivable from the bare data of an abelian
+category with enough projectives and finitely many simples: that data does not force every
 object to have finite length. (Concretely, the category of all modules over `k[x]/(x²)` has one
 simple `k` and enough projectives yet has infinite-length objects, for which `clength = 0` while the
 object is nonzero, falsifying the `→` direction.) The missing ingredient is the §9.6
-finite-length standing assumption, which `Etingof.IsFiniteAbelianCategory` now records
+finite-length standing assumption, which `Etingof.IsFiniteAbelianCategory` records
 order-theoretically as `FiniteDimensionalOrder (Subobject X)` for every object `X` (see
 `Definition9_6_1.lean`). That instance is in scope here, so the unconditional statement follows
-immediately from `clength_eq_zero_iff_of_finiteDimensionalOrder`, whose proof is the honest `→`
-math. -/
+from `clength_eq_zero_iff_of_finiteDimensionalOrder`. -/
 theorem clength_eq_zero_iff {X : C} : clength X = 0 ↔ IsZero X :=
   clength_eq_zero_iff_of_finiteDimensionalOrder
 
@@ -227,7 +222,7 @@ private theorem height_mk_eq_height_top {X Y : C} (f : X ⟶ Y) [Mono f] :
 /-- In a finite-dimensional order with a top element, the height of any element plus its coheight is
 bounded by the height of the top: concatenate (`RelSeries.smash`) a maximal strictly increasing
 chain ending at `a` with one starting at `a`; the result is a chain ending below `⊤`. This needs
-**no modularity** and is the order-theoretic input to the lower bound
+no modularity and is the order-theoretic input to the lower bound
 `clength X₁ + clength X₃ ≤ clength X₂` for a short exact sequence (with `a` the image of `X₁`
 inside `X₂`). -/
 private theorem height_add_coheight_le_height_top {α : Type*} [Preorder α] [OrderTop α]
@@ -408,7 +403,7 @@ private theorem mem_pullback_obj {X Y : C} (f : X ⟶ Y) (y : Subobject Y) {x : 
 `f` (`(pullback f).obj A = (pullback f).obj B`) and the same image along `g`
 (`imageSubobject (A.arrow ≫ g) = imageSubobject (B.arrow ≫ g)`), then `B ≤ A`, hence `A = B`.
 
-This is the genuine categorical (second-isomorphism-theorem) content. We show the inclusion
+This is the categorical (second-isomorphism-theorem) content. We show the inclusion
 `ι := ofLE A B` is epi by a pseudoelement chase: a pseudoelement `b` of `B` has `g (B.arrow b)` in
 the common image, so `g (A.arrow a₀) = g (B.arrow b)` for some `a₀` of `A`; the "difference"
 `z` (`Abelian.Pseudoelement.sub_of_eq_image`) satisfies `g z = 0`, so `z ∈ im f = ker g`, and lies
@@ -490,7 +485,7 @@ private theorem Φ_reflecting {S : ShortComplex C} (hS : S.ShortExact) {A B : Su
   exact Abelian.Pseudoelement.pseudo_exact_of_exact
     (ShortComplex.cokernelSequence_exact A.arrow) (B.arrow b) hfin
 
-/-- **Upper bound (lengths)** — the genuine Schreier half of categorical Jordan–Hölder.
+/-- **Upper bound (lengths).** The Schreier half of categorical Jordan–Hölder.
 `clength X₂ ≤ clength X₁ + clength X₃` for a short exact sequence `0 → X₁ →ᶠ X₂ →ᵍ X₃ → 0`.
 
 The map `Φ B = ((pullback f).obj B, imageSubobject (B.arrow ≫ g)) : Subobject X₂ → Subobject X₁ ×
@@ -529,16 +524,16 @@ private theorem clength_le_add {S : ShortComplex C} (hS : S.ShortExact) :
   rw [← ENat.toNat_add h1 h3]
   exact ENat.toNat_le_toNat hheight (WithTop.add_ne_top.mpr ⟨h1, h3⟩)
 
-/-- **Additivity of composition length over short exact sequences** — the Krull–Schmidt crux.
+/-- **Additivity of composition length over short exact sequences.**
 
 For a short exact sequence `0 → X₁ → X₂ → X₃ → 0`, the composition length is additive,
 `clength X₂ = clength X₁ + clength X₃`. This is `le_antisymm` of the two one-sided bounds:
 
-* `clength_add_le` (`clength X₁ + clength X₃ ≤ clength X₂`) — **proved**, modularity-free, from the
+* `clength_add_le` (`clength X₁ + clength X₃ ≤ clength X₂`): modularity-free, from the
   down-interval isomorphism `height_mk_eq_height_top`, the epi-side inequality
   `height_top_le_coheight_kernel`, and the order lemma `height_add_coheight_le_height_top`.
-* `clength_le_add` (`clength X₂ ≤ clength X₁ + clength X₃`) — the Schreier-refinement direction,
-  **proved**; see its docstring for the order-reflecting embedding
+* `clength_le_add` (`clength X₂ ≤ clength X₁ + clength X₃`): the Schreier-refinement direction;
+  see its docstring for the order-reflecting embedding
   `Subobject X₂ ↪ Subobject X₁ × Subobject X₃` that discharges it.
 
 Finiteness of all three lengths (needed both for the `le_antisymm` to make sense and for the
@@ -565,7 +560,7 @@ For an inclusion of subobjects `A ≤ B` of a fixed `X`, the canonical short exa
 `0 → (A : C) → (B : C) → (B/A) → 0` (with `(A : C) → (B : C)` the inclusion `Subobject.ofLE`
 and `B/A` its cokernel) together with `clength_additive` gives `clength (A : C) ≤ clength (B : C)`,
 strictly so when `A < B` (then `B/A` is nonzero, so has positive length). This is the order-theoretic
-input that turns `clength` into a well-founded induction measure on `Subobject X`. -/
+input that makes `clength` a well-founded induction measure on `Subobject X`. -/
 
 /-- The composition-length identity attached to an inclusion `A ≤ B` of subobjects: the canonical
 short exact sequence `0 → (A : C) → (B : C) → cokernel (ofLE A B h) → 0` is exact, so
@@ -650,7 +645,7 @@ theorem exists_eventually_constant_of_monotone {X : C} {a : ℕ → Subobject X}
 
 The descending image chain `im (f^n)` and ascending kernel chain `ker (f^n)` of an endomorphism
 `f : End X` both stabilise, directly from the chain conditions above. These are the finite-length
-inputs that Fitting's lemma (`fitting_decomposition`, link 3/5) consumes. -/
+inputs that Fitting's lemma (`fitting_decomposition`) consumes. -/
 
 /-- The image chain `n ↦ im (f^n)` of an endomorphism is descending: `im (f^{n+1}) ≤ im (f^n)`,
 because `f^{n+1} = f ≫ f^n` factors through `f^n`. -/
@@ -713,8 +708,8 @@ private theorem exact_kernelSubobject_arrow {Y Z : C} (g : Y ⟶ Z) :
   change imageSubobject (kernelSubobject g).arrow = kernelSubobject g
   rw [imageSubobject_mono, Subobject.mk_arrow]
 
-/-- **Image restriction is an isomorphism at the stabilising power** — the precise finite-length
-input Fitting's lemma (`fitting_decomposition`, link 3/5) consumes. For an endomorphism `f` there is
+/-- **Image restriction is an isomorphism at the stabilising power.** The precise finite-length
+input Fitting's lemma (`fitting_decomposition`) consumes. For an endomorphism `f` there is
 a positive `n` at which `image.ι (fⁿ) ≫ factorThruImage (fⁿ)` is an isomorphism. -/
 theorem exists_pow_stabilizes {X : C} (f : End X) :
     ∃ n, 0 < n ∧ IsIso (Abelian.image.ι ((f : X ⟶ X) ^ n) ≫

--- a/EtingofRepresentationTheory/Chapter9/PathAlgebraArrowBimodule.lean
+++ b/EtingofRepresentationTheory/Chapter9/PathAlgebraArrowBimodule.lean
@@ -4,29 +4,29 @@ import Mathlib.LinearAlgebra.Finsupp.LinearCombination
 /-!
 # The arrow `S`-bimodule of a path algebra
 
-Third layer of the standard length-`1` projective resolution of path-algebra modules
-(Problem 9.4.6 (i), parent #6420). Write `A := PathAlgebra k Q`, `S := Q → k` the vertex
+In the standard length-`1` projective resolution of path-algebra modules
+(Problem 9.4.6 (i)), write `A := PathAlgebra k Q`, `S := Q → k` the vertex
 subalgebra (embedded by `f := vertexEmbedding : S →+* A`), and let `V` be the `S`-bimodule
-spanned by the **arrows** of `Q`. This file constructs `V` together with the two commuting
+spanned by the arrows of `Q`. This file constructs `V` together with the two commuting
 `S`-actions (by source and target vertex idempotents) and its inclusion into `A`.
 
 ## Contents
 
-* `Etingof.PathAlgebra.ArrowIndex Q` — the type of arrows `Σ a b, (a ⟶ b)`, with `src`/`tgt`.
-* `Etingof.PathAlgebra.arrowElt` / `arrowInclusion` — an arrow as the corresponding length-`1`
+* `Etingof.PathAlgebra.ArrowIndex Q`: the type of arrows `Σ a b, (a ⟶ b)`, with `src`/`tgt`.
+* `Etingof.PathAlgebra.arrowElt` / `arrowInclusion`: an arrow as the corresponding length-`1`
   path element of `A`, and its `k`-linear extension `V → A`.
 * `Etingof.PathAlgebra.vertexEmbedding_mul_arrowElt` /
-  `arrowElt_mul_vertexEmbedding` — left/right multiplication of an arrow by `f s` scales it by
+  `arrowElt_mul_vertexEmbedding`: left/right multiplication of an arrow by `f s` scales it by
   the source/target coordinate `s (src)` / `s (tgt)`. These realize the two `S`-actions inside
   `A` and are what make the resolution's boundary map `d` well-defined.
-* `Etingof.PathAlgebra.arrowSourceModule` / `arrowTargetModule` — the source and target
-  `S = (Q → k)`-module structures on `V` (as explicit `Module` *values*, to avoid a
+* `Etingof.PathAlgebra.arrowSourceModule` / `arrowTargetModule`: the source and target
+  `S = (Q → k)`-module structures on `V` (as explicit `Module` values, to avoid a
   typeclass diamond on the single carrier `ArrowIndex Q →₀ k`), the two commuting halves of the
   `S`-bimodule structure.
 
 The arrow bimodule `V`, together with the induction functor `A ⊗_S -` from
-`Chapter9/PathAlgebraInduction.lean`, assembles into the standard short complex
-`0 → A ⊗_S (V ⊗_S M) → A ⊗_S M → M → 0`; that assembly and its exactness are downstream work.
+`Chapter9/PathAlgebraInduction.lean`, forms the standard short complex
+`0 → A ⊗_S (V ⊗_S M) → A ⊗_S M → M → 0`.
 -/
 
 universe u
@@ -82,10 +82,10 @@ theorem ofPath_mul_ofPath (p q : QuiverPathIndex Q) :
 
 `V = ArrowIndex Q →₀ k` carries two commuting `S = (Q → k)`-module structures, scaling the
 arrow component `⟨a, b, e⟩` by the source coordinate `s a` (left action) and by the target
-coordinate `s b` (right action). We package these as explicit `Module` *values* rather than
+coordinate `s b` (right action). We package these as explicit `Module` values rather than
 instances: both act on the single carrier `ArrowIndex Q →₀ k`, so registering both as instances
-would create a diamond. The tensor-product assembly downstream selects the appropriate one via a
-type synonym. -/
+would create a diamond. The tensor-product construction that uses them selects the appropriate one
+via a type synonym. -/
 
 variable (k Q) in
 /-- The twisted scalar action `(s • v) i = s (wt i) * v i` on `ArrowIndex Q →₀ k`, where
@@ -143,7 +143,7 @@ This is the action over which the inner tensor `V ⊗_S M` is formed. -/
   wModule k Q ArrowIndex.tgt
 
 omit [DecidableEq Q] in
-/-- **The bimodule compatibility.** The source and target `S`-actions commute, so `V` is a genuine
+/-- **The bimodule compatibility.** The source and target `S`-actions commute, so `V` is an
 `(S, S)`-bimodule. -/
 theorem wSMul_comm (s t : Q → k) (v : ArrowIndex Q →₀ k) :
     wSMul k Q ArrowIndex.src s (wSMul k Q ArrowIndex.tgt t v)

--- a/EtingofRepresentationTheory/Chapter9/PathAlgebraConsSplitting.lean
+++ b/EtingofRepresentationTheory/Chapter9/PathAlgebraConsSplitting.lean
@@ -3,9 +3,9 @@ import EtingofRepresentationTheory.Chapter9.PathAlgebraLengthGrading
 /-!
 # Cons-splitting of the path algebra `A = PathAlgebra k Q`
 
-Sixth layer of the standard length-`1` projective resolution of path-algebra modules
-(Problem 9.4.6 (i), parent #6420). Write `A := PathAlgebra k Q`. Its length-graded pieces `A_n`
-(spanned by the length-`n` basis paths) satisfy the **cons-splitting**
+In the standard length-`1` projective resolution of path-algebra modules
+(Problem 9.4.6 (i)), write `A := PathAlgebra k Q`. Its length-graded pieces `A_n`
+(spanned by the length-`n` basis paths) satisfy the cons-splitting
 
 ```
 A_n ⊗_S V ≅ A_{n+1},   x ⊗ e ↦ x · e   (concatenation),
@@ -16,10 +16,10 @@ the `S`-bimodule isomorphism underlying `Mono (stdd M)` for the standard short c
 (`ofPath_mul_arrowElt`, from `Chapter9/PathAlgebraLengthGrading.lean`); the inverse decomposes a
 length-`(n+1)` path into its initial length-`n` path and its final arrow.
 
-This file records the **combinatorial core** of that iso: every path index of positive length is
-*uniquely* a length-`n` path index followed by one arrow. Mathlib's
+This file records the combinatorial core of that iso: every path index of positive length is
+uniquely a length-`n` path index followed by one arrow. Mathlib's
 `Quiver.Path.length_ne_zero_iff_eq_cons` supplies existence; `Quiver.Path.comp_inj` /
-`Quiver.Path.cons.injEq` supply uniqueness. These feed the genuine (non-`sorry`) inverse of the
+`Quiver.Path.cons.injEq` supply uniqueness. These give the inverse of the
 bundled `A_n ⊗_S V ≅ A_{n+1}` isomorphism.
 
 Template: the polynomial coordinate iso `coordMapCH` in `Chapter9/KoszulHelpers.lean` and its use

--- a/EtingofRepresentationTheory/Chapter9/PathAlgebraConsSplittingIso.lean
+++ b/EtingofRepresentationTheory/Chapter9/PathAlgebraConsSplittingIso.lean
@@ -4,10 +4,10 @@ import EtingofRepresentationTheory.Chapter9.PathAlgebraInducedGrading
 /-!
 # The cons-splitting degree shift for `A = PathAlgebra k Q`
 
-Seventh layer of the standard length-`1` projective resolution of path-algebra modules
-(Problem 9.4.6 (i), parent #6420). Write `A := PathAlgebra k Q`, `S := Q → k` the vertex
+In the standard length-`1` projective resolution of path-algebra modules
+(Problem 9.4.6 (i)), write `A := PathAlgebra k Q`, `S := Q → k` the vertex
 subalgebra, `V` the arrow bimodule (`Chapter9/PathAlgebraArrowBimodule.lean`). This file records
-the length-grading behaviour of **right multiplication by an arrow** and packages the resulting
+the length-grading behaviour of right multiplication by an arrow and packages the resulting
 degree-`(+1)` shift of the boundary map `d` of the standard short complex
 (`Chapter9/PathAlgebraStandardComplex.lean`), the noncommutative analogue of the `coeff_X_mul`
 shift used by `koszulSES_shortExact` (`Chapter9/Example9_4_4.lean`).
@@ -18,11 +18,11 @@ Here we add the analytic companion: multiplying a homogeneous degree-`n` element
 arrow (`arrowInclusion v`, degree `1`) lands exactly in degree `n + 1`
 (`lengthProj_mul_arrowInclusion`). This is the seed of both
 
-* **`Mono (stdd M)`** — the degree-`(N+1)` component of `d(ξ)` is the cons-splitting applied to the
-  top component `ξ_N` (issue #6512 deliverable 1), and
-* the bundled `S`-bimodule isomorphism `A_n ⊗_S V ≅ A_{n+1}` (deliverable 2b),
+* `Mono (stdd M)`: the degree-`(N+1)` component of `d(ξ)` is the cons-splitting applied to the
+  top component `ξ_N`, and
+* the bundled `S`-bimodule isomorphism `A_n ⊗_S V ≅ A_{n+1}`,
 
-both consumed by `standardResolution_shortExact` (issue #6512).
+both consumed by `standardResolution_shortExact`.
 -/
 
 universe u
@@ -144,10 +144,10 @@ theorem inducedCoordMapGen_injective : Function.Injective (inducedCoordMapGen N)
 /-! ## The degree shift of the boundary map `d`
 
 For a pure generator `a ⊗ (v ⊗ m)` of the domain `A ⊗_S (V ⊗_S M)`, the degree-`(n+1)` component
-of `d(a ⊗ v ⊗ m) = a·v ⊗ m − a ⊗ v·m` splits into the **cons-splitting** term
-`(lengthProj n a · v) ⊗ m` (the top half, using `lengthProj_mul_arrowInclusion`) and the **lower**
+of `d(a ⊗ v ⊗ m) = a·v ⊗ m − a ⊗ v·m` splits into the cons-splitting term
+`(lengthProj n a · v) ⊗ m` (the top half, using `lengthProj_mul_arrowInclusion`) and the lower
 term `−(lengthProj (n+1) a) ⊗ v·m`. This is the noncommutative analogue of the `coeff_X_mul` shift
-in `koszulSES_shortExact`, and the seed of the top-degree `Mono (stdd M)` argument (issue #6512). -/
+in `koszulSES_shortExact`, and the seed of the top-degree `Mono (stdd M)` argument. -/
 
 variable (M : ModuleCat.{u + 1} (PathAlgebra k Q))
 
@@ -188,7 +188,7 @@ where `ξ_n := inducedCoordMapGen (V ⊗_S M) ξ n` is the degree-`n` graded com
 noncommutative analogue of the `hshift_gen` relation in `koszulSES_shortExact`
 (`Chapter9/Example9_4_4.lean`): the `Φ` term carries the length shift `n → n+1` (right
 multiplication by an arrow, via `lengthProj_mul_arrowInclusion`), the `Ψ` term stays in degree
-`n+1`. It is what `standardResolution_shortExact` (issue #6512) plugs into for both `Mono (stdd M)`
+`n+1`. It is what `standardResolution_shortExact` plugs into for both `Mono (stdd M)`
 (top-degree base case) and middle exactness (downward telescoping). -/
 
 /-- The `S`-balanced additive bilinear map underlying the **top half** `Φ` of `d`:
@@ -315,8 +315,7 @@ noncomputable def stdδΨ :
   rw [stdδΨAddHom_tmul]
 
 /-- **The top half of `d`** `Φ : A ⊗_S (V ⊗_S M) → A ⊗_S M`, `Φ (a ⊗ v ⊗ m) = (a·v) ⊗ m`, the
-`A`-linear extension of `δΦ`. The cons-splitting `A_n ⊗_S V ≅ A_{n+1}` tensored with `M` (its
-graded-piece injectivity is the bundled iso of deliverable 2b). -/
+`A`-linear extension of `δΦ`. The cons-splitting `A_n ⊗_S V ≅ A_{n+1}` tensored with `M`. -/
 noncomputable def stdΦ : inducedVtensObj M ⟶ inducedRestrictObj M :=
   homEquivSymm (stdδΦ M)
 
@@ -352,7 +351,7 @@ theorem stdd_hom_eq_sub (x : inducedVtensObj M) :
 splits as `Φ (ξ_n) − Ψ (ξ_{n+1})`, where `ξ_j = inducedCoordMapGen (V ⊗_S M) ξ j` is the degree-`j`
 graded component. The noncommutative `hshift_gen`: the `Φ` term carries the length shift `n → n+1`,
 the `Ψ` term stays in degree `n+1`. Reduces on pure generators to `inducedCoordMap_stdd_tmul_succ`.
-Consumed by `standardResolution_shortExact` (#6512) for `Mono (stdd M)` and middle exactness. -/
+Consumed by `standardResolution_shortExact` for `Mono (stdd M)` and middle exactness. -/
 theorem inducedCoordMap_stdd_shift (s : inducedVtensObj M) (n : ℕ) :
     inducedCoordMap M ((stdd M).hom s) (n + 1)
       = (stdΦ M).hom (inducedCoordMapGen (VtensObj M) s n)
@@ -392,8 +391,8 @@ theorem inducedCoordMap_stdd_shift_zero (s : inducedVtensObj M) :
 
 The cons-splitting `A_n ⊗_S V ≅ A_{n+1}`, tensored with `M`, says that `Φ` restricts to an
 isomorphism from the degree-`n` part of `A ⊗_S (V ⊗_S M)` onto the degree-`(n+1)` part of
-`A ⊗_S M`. The **surjectivity** half of that graded iso is the piece consumed by
-`standardResolution_shortExact` (#6512): the downward middle-exactness telescoping needs, for each
+`A ⊗_S M`. The surjectivity half of that graded iso is the piece consumed by
+`standardResolution_shortExact`: the downward middle-exactness telescoping needs, for each
 `y : A ⊗_S M` and each `n`, a degree-`n` preimage `η` of the degree-`(n+1)` component of `y` under
 `Φ`. This is the noncommutative analogue of the cons-preimage `coordMapCHInv` in
 `koszulSES_shortExact` (`Chapter9/Example9_4_4.lean`), built here directly from the combinatorial
@@ -401,7 +400,7 @@ core `exists_ofPath_mul_arrowElt` (`Chapter9/PathAlgebraConsSplitting.lean`) rat
 abstract graded-piece isomorphism.
 
 Because `Φ (a ⊗ v ⊗ m) = (a·v) ⊗ m` raises the length degree by one
-(`lengthProj_mul_arrowInclusion`), the produced `η` is genuinely homogeneous of degree `n`
+(`lengthProj_mul_arrowInclusion`), the produced `η` is homogeneous of degree `n`
 (`inducedCoordMapGen (VtensObj M) η n = η` and vanishes in every other degree), so its degree-shift
 coordinate `inducedCoordMap_stdd_shift` collapses to `Φ η` at degree `n+1` and to `0` above. -/
 
@@ -442,8 +441,8 @@ theorem exists_stdΦ_preimage_single_tmul (x : QuiverPathIndex Q) (c : k) {n : �
 /-- **Graded surjectivity of `Φ` onto the top component (cons-preimage).** For every `y : A ⊗_S M`
 and every `n`, the degree-`(n+1)` homogeneous component `inducedCoordMap M y (n+1)` is `Φ η` for a
 degree-`n`-homogeneous `η : A ⊗_S (V ⊗_S M)`. This is the surjectivity half of the cons-splitting
-`A_n ⊗_S V ≅ A_{n+1}` (tensored with `M`), the missing infra that
-`standardResolution_shortExact` (#6512) plugs into for the middle-exactness downward telescoping.
+`A_n ⊗_S V ≅ A_{n+1}` (tensored with `M`), used by
+`standardResolution_shortExact` for the middle-exactness downward telescoping.
 Reduces, via additivity, to the single-path case `exists_stdΦ_preimage_single_tmul`. -/
 theorem exists_stdΦ_preimage_topDegree (y : inducedRestrictObj M) (n : ℕ) :
     ∃ η : inducedVtensObj M,

--- a/EtingofRepresentationTheory/Chapter9/PathAlgebraConsSplittingRetraction.lean
+++ b/EtingofRepresentationTheory/Chapter9/PathAlgebraConsSplittingRetraction.lean
@@ -3,12 +3,12 @@ import EtingofRepresentationTheory.Chapter9.PathAlgebraConsSplittingIso
 /-!
 # The retraction of `Φ` and injectivity of the cons-splitting
 
-Eighth layer of the standard length-`1` projective resolution of path-algebra modules
-(Problem 9.4.6 (i), parent #6420). Write `A := PathAlgebra k Q`, `S := Q → k` the vertex
+In the standard length-`1` projective resolution of path-algebra modules
+(Problem 9.4.6 (i)), write `A := PathAlgebra k Q`, `S := Q → k` the vertex
 subalgebra, `V` the arrow bimodule. The cons-splitting `A_n ⊗_S V ≅ A_{n+1}`
-(`Chapter9/PathAlgebraConsSplitting.lean`) has a **surjectivity** half already recorded
+(`Chapter9/PathAlgebraConsSplitting.lean`) has a surjectivity half already recorded
 (`exists_stdΦ_preimage_topDegree` in `Chapter9/PathAlgebraConsSplittingIso.lean`). This file
-supplies the **injectivity** half in the form actually consumed downstream: a genuine (non-`sorry`)
+supplies the injectivity half as a
 left inverse of the top-half boundary map
 
 ```
@@ -29,8 +29,8 @@ Only base-ring (`S = Q → k`) scalars move across the tensors (`TensorProduct.s
 `k` does not act on `A ⊗_S -`, so every coefficient is kept inside a `Finsupp` factor and shuttled
 between factors by the vertex `S`-actions.
 
-This is the injectivity content of the bundled `A_n ⊗_S V ≅ A_{n+1}` isomorphism (issue #6545) and
-the crux `Function.Injective (stdΦ M).hom` of `Mono (stdd M)` (issue #6561), which telescopes it up
+This is the injectivity content of the bundled `A_n ⊗_S V ≅ A_{n+1}` isomorphism, and
+the `Function.Injective (stdΦ M).hom` needed for `Mono (stdd M)`, which telescopes it up
 to the whole complex via the coordinate shift `inducedCoordMap_stdd_shift`.
 -/
 
@@ -289,10 +289,10 @@ theorem stdΦRet_leftInverse : Function.LeftInverse (stdΦRet M) (stdΦ M).hom :
       | add y z hy hz => rw [TensorProduct.tmul_add, map_add, map_add, hy, hz]
   | add η ζ hη hζ => rw [map_add, map_add, hη, hζ]
 
-/-- **Injectivity of the top-half boundary map `Φ = stdΦ M`.** The genuine (non-`sorry`) left
+/-- **Injectivity of the top-half boundary map `Φ = stdΦ M`.** The left
 inverse `stdΦRet M` witnesses that `Φ` is injective. This is the injectivity content of the
-cons-splitting `A_n ⊗_S V ≅ A_{n+1}` (tensored with `M`), the crux of `Mono (stdd M)` for the
-standard resolution (issue #6561). -/
+cons-splitting `A_n ⊗_S V ≅ A_{n+1}` (tensored with `M`), the core of `Mono (stdd M)` for the
+standard resolution. -/
 theorem stdΦ_injective : Function.Injective (stdΦ M).hom :=
   (stdΦRet_leftInverse M).injective
 

--- a/EtingofRepresentationTheory/Chapter9/PathAlgebraInducedGrading.lean
+++ b/EtingofRepresentationTheory/Chapter9/PathAlgebraInducedGrading.lean
@@ -5,11 +5,11 @@ import Mathlib.LinearAlgebra.DirectSum.Finsupp
 /-!
 # The length grading of the induced module `A ⊗_S M`
 
-Sixth layer of the standard length-`1` projective resolution of path-algebra modules
-(Problem 9.4.6 (i), parent #6420). Write `A := PathAlgebra k Q`, `S := Q → k` the vertex
+In the standard length-`1` projective resolution of path-algebra modules
+(Problem 9.4.6 (i)), write `A := PathAlgebra k Q`, `S := Q → k` the vertex
 subalgebra (`f := vertexEmbedding : S →+* A`). The length grading of `A`
 (`Chapter9/PathAlgebraLengthGrading.lean`) is transported to the induced module
-`A ⊗_S M` (`inducedRestrictObj M`), producing a **coordinate map**
+`A ⊗_S M` (`inducedRestrictObj M`), producing a coordinate map
 
 ```
 inducedCoordMap M : A ⊗_S M →ₗ[S] (ℕ →₀ A ⊗_S M)
@@ -17,7 +17,7 @@ inducedCoordMap M : A ⊗_S M →ₗ[S] (ℕ →₀ A ⊗_S M)
 
 injective with finite support, the noncommutative analogue of `coordMapCH`
 (`Chapter9/KoszulHelpers.lean`) used by `koszulSES_shortExact`. The key point is that the
-homogeneous decomposition `lengthGrading : A →ₗ (ℕ →₀ A)` is `S`-linear for the **right**
+homogeneous decomposition `lengthGrading : A →ₗ (ℕ →₀ A)` is `S`-linear for the right
 `S`-action `s • a = a * f s` that the tensor `A ⊗_S M` is formed over: right multiplication by
 `f s` preserves path length (`lengthGrading_mul_vertexEmbedding`). Injectivity is inherited from
 the left inverse `lengthTotalize` via `TensorProduct.map` and `TensorProduct.finsuppLeft`.

--- a/EtingofRepresentationTheory/Chapter9/PathAlgebraInduction.lean
+++ b/EtingofRepresentationTheory/Chapter9/PathAlgebraInduction.lean
@@ -8,19 +8,19 @@ import Mathlib.RingTheory.SimpleModule.InjectiveProjective
 /-!
 # The noncommutative induction functor `A ⊗_S -` for a path algebra
 
-Second layer of the standard length-`1` projective resolution of path-algebra modules
-(Problem 9.4.6 (i)). Write `A := PathAlgebra k Q` and `S := Q → k`, the commutative subalgebra
+In the standard length-`1` projective resolution of path-algebra modules
+(Problem 9.4.6 (i)), write `A := PathAlgebra k Q` and `S := Q → k`, the commutative subalgebra
 spanned by the trivial-path idempotents, embedded by `f := vertexEmbedding : S →+* A`.
 
-Mathlib's `ModuleCat.extendScalars` requires **commutative** rings on both sides, so it does not
+Mathlib's `ModuleCat.extendScalars` requires commutative rings on both sides, so it does not
 apply here: `A` is noncommutative and the image of `f` is not central. This file builds the
-missing **left** adjoint of `restrictScalars f` by hand:
+missing left adjoint of `restrictScalars f` by hand:
 
-* `Etingof.PathAlgebra.inducedModule : ModuleCat S ⥤ ModuleCat A`, `M ↦ A ⊗_S M`, with a genuine
-  (non-`sorry`) body — object map, morphism map, `map_id`, `map_comp`.
+* `Etingof.PathAlgebra.inducedModule : ModuleCat S ⥤ ModuleCat A`, `M ↦ A ⊗_S M`, with object map,
+  morphism map, `map_id`, and `map_comp`.
 * `Etingof.PathAlgebra.inducedRestrictAdj : inducedModule ⊣ restrictScalars f`, the tensor–hom
   adjunction for the noncommutative ring hom `f`.
-* `Etingof.PathAlgebra.projective_inducedModule_obj` — every `inducedModule.obj M` is a projective
+* `Etingof.PathAlgebra.projective_inducedModule_obj`: every `inducedModule.obj M` is a projective
   `A`-module, because `restrictScalars f` is exact and `S` is semisimple.
 
 ## The `S`-module structure on `A`
@@ -29,7 +29,7 @@ The tensor product `A ⊗_S M` regards `A` as a **right** `S`-module, `s • a =
 (`Etingof.PathAlgebra.instModuleVertex`). This right action is what makes left multiplication by
 `A` well-defined on the tensor: `a' * (a * f s) = (a' * a) * f s`, so left multiplication commutes
 with the `S`-action (`SMulCommClass S A A`), and `TensorProduct.leftModule` upgrades `A ⊗_S M` to a
-left `A`-module. Note this is a *different* `S`-action from the one `restrictScalars f` puts on an
+left `A`-module. Note this is a different `S`-action from the one `restrictScalars f` puts on an
 `A`-module (which uses left multiplication `s • n = f s • n`); the two live on different objects.
 -/
 
@@ -98,8 +98,8 @@ noncomputable def inducedMap {M M' : ModuleCat.{u + 1} (Q → k)} (l : M ⟶ M')
 theorem inducedMap_tmul {M M' : ModuleCat.{u + 1} (Q → k)} (l : M ⟶ M') (a : PathAlgebra k Q)
     (m : M) : (inducedMap l).hom (a ⊗ₜ[Q → k] m) = a ⊗ₜ[Q → k] l.hom m := rfl
 
-/-- **The induction functor** `A ⊗_S - : ModuleCat S ⥤ ModuleCat A`. Real (non-`sorry`) body:
-object map `inducedObj`, morphism map `inducedMap`, and the functoriality laws. -/
+/-- **The induction functor** `A ⊗_S - : ModuleCat S ⥤ ModuleCat A`, with object map `inducedObj`,
+morphism map `inducedMap`, and the functoriality laws. -/
 noncomputable def inducedModule :
     ModuleCat.{u + 1} (Q → k) ⥤ ModuleCat.{u + 1} (PathAlgebra k Q) where
   obj := inducedObj k Q

--- a/EtingofRepresentationTheory/Chapter9/PathAlgebraLengthGrading.lean
+++ b/EtingofRepresentationTheory/Chapter9/PathAlgebraLengthGrading.lean
@@ -4,8 +4,8 @@ import EtingofRepresentationTheory.Chapter9.KoszulHelpers
 /-!
 # Path-length grading of the path algebra `A = PathAlgebra k Q`
 
-Fifth layer of the standard length-`1` projective resolution of path-algebra modules
-(Problem 9.4.6 (i), parent #6420). This file provides the **length grading** infrastructure that
+The length grading of the path algebra, part of the standard length-`1` projective resolution
+of path-algebra modules (Problem 9.4.6 (i)). It provides the length-grading infrastructure that
 makes `Mono (stdd M)` and middle exactness of the standard short complex
 (`Chapter9/PathAlgebraStandardComplex.lean`) provable, the noncommutative analogue of the
 polynomial coordinate isomorphism `coordMapCH` in `Chapter9/KoszulHelpers.lean`.
@@ -17,22 +17,19 @@ polynomial coordinate isomorphism `coordMapCH` in `Chapter9/KoszulHelpers.lean`.
 lengthGrading : A →ₗ[k] (ℕ →₀ A)
 ```
 
-sending a basis path to its single homogeneous component. It is a section of the reassembly map
+sending a basis path to its single homogeneous component. It is a section of the summation map
 `lengthTotalize` (sum of components), hence injective. The homogeneous projections `lengthProj n`
 extract the degree-`n` part.
 
-Following the `PathAlgebra` def-leak convention (`Chapter2/Definition2_8_4.lean`), the coordinate
-map is typed with the underlying `QuiverPathIndex Q →₀ k` as its domain (so instance synthesis is
-unambiguous), while its graded components are genuine `PathAlgebra k Q` values (so their product is
-path concatenation).
+The coordinate map is typed with the underlying `QuiverPathIndex Q →₀ k` as its domain (so
+instance synthesis is unambiguous), while its graded components are `PathAlgebra k Q` values (so
+their product is path concatenation).
 
-The **cons-splitting** direction — every length-`(n+1)` path is uniquely a length-`n` path
-followed by one arrow — is recorded here at the path-index level (`pathLen_compSingle_arrow`,
-`lengthProj_ofPath_mul_arrowElt`), the seed of the `S`-bimodule isomorphism `A_n ⊗_S V ≅ A_{n+1}`
-used downstream.
-
-Template: `Chapter9/KoszulHelpers.lean` (`coordMapCH`, `finsupp_shift_eq_zero`) and its use in
-`Chapter9/Example9_4_4.lean` (`koszulSES_shortExact`).
+The cons-splitting direction, that every length-`(n+1)` path is uniquely a length-`n` path
+followed by one arrow, is recorded here at the path-index level (`pathLen_comp_arrow`,
+`lengthProj_ofPath_mul_arrowElt`), underlying the `S`-bimodule isomorphism `A_n ⊗_S V ≅ A_{n+1}`
+used downstream. It mirrors `coordMapCH` and `finsupp_shift_eq_zero` in
+`Chapter9/KoszulHelpers.lean`.
 -/
 
 universe u
@@ -79,7 +76,7 @@ noncomputable def lengthGrading :
     Finsupp.smul_single, ofPath, Finsupp.smul_single, smul_eq_mul, mul_one]
 
 variable (k Q) in
-/-- **Reassembly.** The `k`-linear map `(ℕ →₀ A) →ₗ[k] A` summing the graded components. It is a
+/-- **Totalization.** The `k`-linear map `(ℕ →₀ A) →ₗ[k] A` summing the graded components. It is a
 left inverse of `lengthGrading` (`lengthTotalize_lengthGrading`). -/
 noncomputable def lengthTotalize : (ℕ →₀ PathAlgebra k Q) →ₗ[k] PathAlgebra k Q :=
   Finsupp.lsum k fun _ => LinearMap.id
@@ -141,7 +138,7 @@ theorem lengthProj_lengthProj (m n : ℕ) (a : QuiverPathIndex Q →₀ k) :
         · rw [if_neg hmp, if_neg (fun h => hmp h.symm)]
       · rw [lengthProj_single, if_neg hpn, map_zero, ite_self]
 
-/-! ## The cons-splitting seed: concatenation shifts length -/
+/-! ## Cons-splitting: concatenation shifts length -/
 
 omit [DecidableEq Q] in
 /-- The length of a path followed by one arrow is one more. -/
@@ -150,7 +147,7 @@ theorem pathLen_comp_arrow {a b c : Q} (p : Quiver.Path a b) (e : b ⟶ c) :
   change (p.comp e.toPath).length = p.length + 1
   rw [Quiver.Path.length_comp, Quiver.Path.length_toPath]
 
-/-- **The cons-splitting seed.** The product of a basis path `⟨a, b, p⟩` and an arrow `e : b ⟶ c`
+/-- **Cons-splitting.** The product of a basis path `⟨a, b, p⟩` and an arrow `e : b ⟶ c`
 in `A` is the single basis path obtained by appending the arrow: `p · e = cons p e`. This is the
 `x ⊗ arrow ↦ x · arrow` map underlying the `S`-bimodule isomorphism `A_n ⊗_S V ≅ A_{n+1}`. -/
 theorem ofPath_mul_arrowElt {a b c : Q} (p : Quiver.Path a b) (e : b ⟶ c) :

--- a/EtingofRepresentationTheory/Chapter9/PathAlgebraLowerBound.lean
+++ b/EtingofRepresentationTheory/Chapter9/PathAlgebraLowerBound.lean
@@ -9,7 +9,7 @@ import Mathlib.LinearAlgebra.Span.Basic
 # Problem 9.4.6 (i), lower bound: the path algebra of a quiver with an edge is not semisimple
 
 The path algebra `A := PathAlgebra k Q` of a quiver with at least one edge has homological
-dimension *exactly* `1`. The upper bound `HasHomologicalDimensionLE A 1` is the standard
+dimension exactly `1`. The upper bound `HasHomologicalDimensionLE A 1` is the standard
 resolution (`Chapter9/Problem9_4_6.lean`). This file supplies the matching lower bound
 
 ```
@@ -21,12 +21,12 @@ i.e. `A` is not semisimple: it has a module of positive projective dimension.
 
 ## The augmentation module `S_b`
 
-Fix the target vertex `b` of an edge. The **augmentation at `b`** is the `k`-algebra
+Fix the target vertex `b` of an edge. The augmentation at `b` is the `k`-algebra
 homomorphism `ε_b : A → k`, `a ↦ a ⟨b, b, nil⟩` (the coefficient of the trivial path at `b`).
 Multiplicativity is the statement that a product of basis paths equals the trivial path `e_b`
-only when *both* factors are `e_b` (`comp_eq_some_nil_iff`). Pulling the regular `k`-module
-back along `ε_b` gives the one-dimensional **augmentation module** `S_b = k` on which every
-arrow acts as `0` and `e_b` acts as the identity — the simple module at vertex `b`.
+only when both factors are `e_b` (`comp_eq_some_nil_iff`). Pulling the regular `k`-module
+back along `ε_b` gives the one-dimensional augmentation module `S_b = k` on which every
+arrow acts as `0` and `e_b` acts as the identity, the simple module at vertex `b`.
 
 ## Why `S_b` is not projective (the template)
 
@@ -36,7 +36,7 @@ Mirror `not_hasHomologicalDimensionLE_zero_polynomial` (`Chapter9/Example9_4_4.l
 the chosen edge `a ⟶ b`, `x` acts as `0` on `S_b`, so `x · s(1) = s(x • 1) = 0` in `A`. But
 the coefficient of the basis path `x` in `x · s(1)` equals the coefficient of `e_b` in `s(1)`
 (`arrow_mul_apply_arrow`), which is `ε_b(s(1)) = 1` because `s` is a section. So
-`x · s(1) ≠ 0` — a contradiction.
+`x · s(1) ≠ 0`, a contradiction.
 -/
 
 universe u
@@ -200,7 +200,7 @@ theorem arrow_mul_apply_arrow {a b : Q} (e : a ⟶ b) (w : PathAlgebra k Q) :
 homological-dimension predicate quantifies over `Type (u+1)`-modules. We therefore realise the
 one-dimensional augmentation module on the `ULift`ed carrier `ULift.{u+1} k`. -/
 
-/-- The **augmentation module** `S_b` at a vertex `b`: the field `k` (universe-lifted to match
+/-- The augmentation module `S_b` at a vertex `b`: the field `k` (universe-lifted to match
 `PathAlgebra k Q`) regarded as a left `A = PathAlgebra k Q`-module through the augmentation
 `ε_b`, `a • v = ε_b(a) · v`. Only the trivial path at `b` acts as the identity; every arrow acts
 as `0`. It is the simple module at vertex `b`, and its positive projective dimension witnesses
@@ -252,7 +252,7 @@ not semisimple: it does not have homological dimension `0`.
 The augmentation module `S_b` at the target `b` of an edge `x : a ⟶ b` is not projective. If it
 were, the surjection `A ↠ S_b`, `p ↦ p • 1`, would split by a section `s`; then `x • 1 = 0`
 forces `x · s(1) = 0` in `A`, yet the `x`-coefficient of `x · s(1)` is the `e_b`-coefficient of
-`s(1)`, which is `1` because `s` is a section — a contradiction. -/
+`s(1)`, which is `1` because `s` is a section, a contradiction. -/
 theorem not_hasHomologicalDimensionLE_zero_pathAlgebra
     (hQ : ∃ a b : Q, Nonempty (a ⟶ b)) :
     ¬ Etingof.HasHomologicalDimensionLE (Etingof.PathAlgebra k Q) 0 := by

--- a/EtingofRepresentationTheory/Chapter9/PathAlgebraProjectiveCover.lean
+++ b/EtingofRepresentationTheory/Chapter9/PathAlgebraProjectiveCover.lean
@@ -21,9 +21,9 @@ the observation that `eᵢ · A · eⱼ` is spanned by the basis paths from `i` 
 
 ## Main definitions and results
 
-* `Etingof.PathAlgebra.pathAlgebraProj k Q i` — the projective cover `A · eᵢ`, as the principal
+* `Etingof.PathAlgebra.pathAlgebraProj k Q i`: the projective cover `A · eᵢ`, as the principal
   left submodule `Submodule.span A {eᵢ}` with its inherited `A`- and `k`-module structures.
-* `Etingof.PathAlgebra.pathAlgebraHomEquiv` —
+* `Etingof.PathAlgebra.pathAlgebraHomEquiv`:
   `(A·eᵢ →ₗ[A] A·eⱼ) ≃ₗ[k] (Quiver.Path i j →₀ k)`, the Hom-space identification.
 -/
 
@@ -67,7 +67,7 @@ noncomputable def eIdem (i : Q) : PathAlgebra k Q := ofPath ⟨i, i, Quiver.Path
 theorem eIdem_mul_self (i : Q) : (eIdem i : PathAlgebra k Q) * eIdem i = eIdem i := by
   rw [eIdem, ofPath_nil_mul_ofPath_nil, if_pos rfl]
 
-/-- Coefficient of `eᵢ * a` at an index `x`: it keeps the paths whose *source* is `i` and kills
+/-- Coefficient of `eᵢ * a` at an index `x`: it keeps the paths whose source is `i` and kills
 the others. -/
 theorem coeff_eIdem_mul (i : Q) (a : PathAlgebra k Q) (x : QuiverPathIndex Q) :
     coeff (eIdem i * a) x = if x.1 = i then coeff a x else 0 := by
@@ -91,7 +91,7 @@ theorem coeff_eIdem_mul (i : Q) (a : PathAlgebra k Q) (x : QuiverPathIndex Q) :
       · subst hx; simp [coeff_single, Ne.symm his]
       · simp [coeff_single, Ne.symm hx]
 
-/-- Coefficient of `a * eⱼ` at an index `x`: it keeps the paths whose *target* is `j` and kills
+/-- Coefficient of `a * eⱼ` at an index `x`: it keeps the paths whose target is `j` and kills
 the others. -/
 theorem coeff_mul_eIdem (j : Q) (a : PathAlgebra k Q) (x : QuiverPathIndex Q) :
     coeff (a * eIdem j) x = if x.2.1 = j then coeff a x else 0 := by
@@ -317,10 +317,10 @@ noncomputable def cutPathEquiv (i j : Q) :
     rw [Finsupp.comapDomain_apply]
     exact Finsupp.embDomain_apply_self _ _ _
 
-/-! ## Assembly: `Hom_A(A·eᵢ, A·eⱼ) ≅ (paths i → j) →₀ k` -/
+/-! ## The Hom-space identification `Hom_A(A·eᵢ, A·eⱼ) ≅ (paths i → j) →₀ k` -/
 
 variable (k Q) in
-/-- **The Hom-space identification (Problem 9.4.6 (ii) crux).**
+/-- **The Hom-space identification (Problem 9.4.6 (ii)).**
 `Hom_A(A·eᵢ, A·eⱼ) ≃ₗ[k] (Quiver.Path i j →₀ k)`, composing the idempotent Hom identification
 `homCutEquiv` with the cut/paths identification `cutPathEquiv`. -/
 noncomputable def pathAlgebraHomEquiv (i j : Q) :

--- a/EtingofRepresentationTheory/Chapter9/PathAlgebraStandardComplex.lean
+++ b/EtingofRepresentationTheory/Chapter9/PathAlgebraStandardComplex.lean
@@ -4,8 +4,8 @@ import EtingofRepresentationTheory.Chapter9.PathAlgebraInduction
 /-!
 # The standard short complex of a path-algebra module
 
-Fourth layer of the standard length-`1` projective resolution of path-algebra modules
-(Problem 9.4.6 (i), parent #6420). Write `A := PathAlgebra k Q`, `S := Q → k` the vertex
+Part of the standard length-`1` projective resolution of path-algebra modules
+(Problem 9.4.6 (i)). Write `A := PathAlgebra k Q`, `S := Q → k` the vertex
 subalgebra (embedded by `f := vertexEmbedding : S →+* A`), `V` the arrow `S`-bimodule
 (`Chapter9/PathAlgebraArrowBimodule.lean`), and let `A ⊗_S -` be the induction functor
 (`Chapter9/PathAlgebraInduction.lean`). This file assembles, for a left `A`-module `M`, the
@@ -23,12 +23,12 @@ with `d (a ⊗ v ⊗ m) = a·v ⊗ m − a ⊗ (v·m)` and `ε (a ⊗ m) = a·m`
 `V = ArrowIndex Q →₀ k` carries two commuting `S`-actions (`arrowSourceModule` /
 `arrowTargetModule`), realized inside `A` as left / right multiplication by vertex idempotents
 (`vertexEmbedding_mul_arrowElt` / `arrowElt_mul_vertexEmbedding`). The inner tensor `V ⊗_S M`
-is formed over the **target** action (balanced against the restricted `S`-action on `M`), and
-the surviving left `S`-module structure is the **source** action.
+is formed over the target action (balanced against the restricted `S`-action on `M`), and
+the surviving left `S`-module structure is the source action.
 
 Both `S`-actions live on the single carrier `ArrowIndex Q →₀ k`, and the tensor product also has
 its own canonical `S`-action, so registering the surviving source action naively would create a
-diamond. We break it with type synonyms: `ArrowTgt` carries the target action (used to *form* the
+diamond. We break it with type synonyms: `ArrowTgt` carries the target action (used to form the
 tensor), and `VtensCarrier M` carries the source action (the surviving structure) as its `S`-module
 instance, defined by hand via `TensorProduct.map (srcHom s) id` rather than the canonical tensor
 action.
@@ -87,7 +87,7 @@ theorem wSMul_single (wt : ArrowIndex Q → Q) (s : Q → k) (x : ArrowIndex Q) 
 
 /-! ## Source / target scaling under `arrowInclusion` -/
 
-/-- Scaling by the **source** action corresponds to left multiplication by `f s` inside `A`. -/
+/-- Scaling by the source action corresponds to left multiplication by `f s` inside `A`. -/
 theorem arrowInclusion_wSMul_src (s : Q → k) (v : ArrowIndex Q →₀ k) :
     arrowInclusion (wSMul k Q ArrowIndex.src s v)
       = vertexEmbedding k Q s * arrowInclusion v := by
@@ -98,7 +98,7 @@ theorem arrowInclusion_wSMul_src (s : Q → k) (v : ArrowIndex Q →₀ k) :
       rw [wSMul_single, arrowInclusion_single, arrowInclusion_single, mul_smul_comm,
         vertexEmbedding_mul_arrowElt, smul_smul, mul_comm c]
 
-/-- Scaling by the **target** action corresponds to right multiplication by `f s` inside `A`. -/
+/-- Scaling by the target action corresponds to right multiplication by `f s` inside `A`. -/
 theorem arrowInclusion_wSMul_tgt (s : Q → k) (v : ArrowIndex Q →₀ k) :
     arrowInclusion (wSMul k Q ArrowIndex.tgt s v)
       = arrowInclusion v * vertexEmbedding k Q s := by
@@ -112,8 +112,8 @@ theorem arrowInclusion_wSMul_tgt (s : Q → k) (v : ArrowIndex Q →₀ k) :
 /-! ## The target-action type synonym `ArrowTgt` -/
 
 variable (k Q) in
-/-- The arrow bimodule carrier `V = ArrowIndex Q →₀ k`, with the **target** `S`-action registered
-as its canonical `Module (Q → k)` structure. Used to *form* the inner tensor `V ⊗_S M`. -/
+/-- The arrow bimodule carrier `V = ArrowIndex Q →₀ k`, with the target `S`-action registered
+as its canonical `Module (Q → k)` structure. Used to form the inner tensor `V ⊗_S M`. -/
 def ArrowTgt : Type (u + 1) := ArrowIndex Q →₀ k
 
 noncomputable instance instAddCommGroupArrowTgt : AddCommGroup (ArrowTgt k Q) :=
@@ -127,7 +127,7 @@ noncomputable instance instModuleArrowTgt : Module (Q → k) (ArrowTgt k Q) :=
   arrowTargetModule k Q
 
 /-- The source-scaling endomorphism `v ↦ s ·_src v` of `V`, as a `(Q → k)`-linear map with
-respect to the *target* action. `(Q → k)`-linearity is exactly the bimodule commutativity
+respect to the target action. `(Q → k)`-linearity is exactly the bimodule commutativity
 `wSMul_comm`. This is the building block of the surviving source `S`-action on `V ⊗_S M`. -/
 noncomputable def srcHom (s : Q → k) : ArrowTgt k Q →ₗ[Q → k] ArrowTgt k Q where
   toFun v := wSMul k Q ArrowIndex.src s v
@@ -167,14 +167,14 @@ noncomputable abbrev restrictObj : ModuleCat.{u + 1} (Q → k) :=
   (restrictScalars (vertexEmbedding k Q)).obj M
 
 /-- Underlying carrier of `V ⊗_S M`: the tensor `ArrowTgt ⊗_{Q→k} M` (target-balanced). Its
-`Module (Q → k)` instance is overridden to be the surviving **source** action. -/
+`Module (Q → k)` instance is overridden to be the surviving source action. -/
 def VtensCarrier : Type (u + 1) :=
   TensorProduct (Q → k) (ArrowTgt k Q) (restrictObj M)
 
 noncomputable instance : AddCommGroup (VtensCarrier M) :=
   inferInstanceAs (AddCommGroup (TensorProduct (Q → k) (ArrowTgt k Q) (restrictObj M)))
 
-/-- The surviving **source** `S`-action on `V ⊗_S M`: `s • (v ⊗ m) = (s ·_src v) ⊗ m`,
+/-- The surviving source `S`-action on `V ⊗_S M`: `s • (v ⊗ m) = (s ·_src v) ⊗ m`,
 implemented as `TensorProduct.map (srcHom s) id`. Registered by hand (not the canonical tensor
 action, which is the target action). -/
 noncomputable instance instSMulVtens : SMul (Q → k) (VtensCarrier M) where

--- a/EtingofRepresentationTheory/Chapter9/PathAlgebraStandardResolution.lean
+++ b/EtingofRepresentationTheory/Chapter9/PathAlgebraStandardResolution.lean
@@ -5,8 +5,8 @@ import Mathlib.Algebra.Homology.ShortComplex.ShortExact
 /-!
 # The standard resolution short exact sequence
 
-Eighth (assembly) layer of the standard length-`1` projective resolution of path-algebra modules
-(Problem 9.4.6 (i), parent #6420). Write `A := PathAlgebra k Q`, `S := Q → k` the vertex
+The standard length-`1` projective resolution of path-algebra modules is completed here
+(Problem 9.4.6 (i)). Write `A := PathAlgebra k Q`, `S := Q → k` the vertex
 subalgebra, `V` the arrow bimodule. The standard short complex
 
 ```
@@ -14,14 +14,14 @@ A ⊗_S (V ⊗_S M) →ᵈ A ⊗_S M →ᵉ M
 ```
 
 (`Chapter9/PathAlgebraStandardComplex.lean`, `standardComplex M`) is assembled here into a short
-**exact** sequence `(standardComplex M).ShortExact`. `Epi ε` is `epi_stdε`; `d ≫ ε = 0` is
+exact sequence `(standardComplex M).ShortExact`. `Epi ε` is `epi_stdε`; `d ≫ ε = 0` is
 `stdd_comp_stdε`. This file adds the two remaining halves and assembles them:
 
 ## Injectivity of the boundary `d` (`Mono d`)
 
-The crux is the **injectivity of the top half** `Φ = stdΦ` of `d`
+The main point is the injectivity of the top half `Φ = stdΦ` of `d`
 (`Chapter9/PathAlgebraConsSplittingIso.lean`), i.e. the injectivity content of the cons-splitting
-`A_n ⊗_S V ≅ A_{n+1}` tensored with `M`. We build a genuine additive **retraction** `stdΦRetr` of
+`A_n ⊗_S V ≅ A_{n+1}` tensored with `M`. We build an additive retraction `stdΦRetr` of
 `Φ` from the combinatorial cons-decomposition (`Chapter9/PathAlgebraConsSplitting.lean`): every
 length-`(n+1)` basis path `q = p·e` splits into its initial length-`n` path `p` and final arrow
 `e`, and the retraction sends `(x·arrow) ⊗ m ↦ x ⊗ (arrow ⊗ m)`. Injectivity of `Φ` then feeds the
@@ -31,7 +31,7 @@ vanish, hence `ξ = 0` (`inducedCoordMapGen_injective`). This is the noncommutat
 top-degree argument `pm_koszul_injective` / `finsupp_shift_eq_zero` (`Chapter9/KoszulHelpers.lean`).
 
 Because the tensors are formed over `S = Q → k` (not the base field `k`), a bare `k`-scalar does not
-act on them. We route every `k`-scalar `r` through the **constant function** `const r : Q → k`,
+act on them. We express every `k`-scalar `r` through the constant function `const r : Q → k`,
 using `r • a = (const r) • a` in the path algebra (`kSMul_eq_constSMul`) together with the
 `S`-balancing of the tensors.
 
@@ -47,8 +47,8 @@ component) and the coordinate shift relations `inducedCoordMap_stdd_shift`(`_zer
 `stdε_injective_of_higher_coord_zero`): the multiplication `ε` is injective on the length-`0`
 component, so `ξ ∈ ker ε` concentrated in degree `0` is `0`.
 
-Consumer: `hasHomologicalDimensionLE_pathAlgebra_one` in `Chapter9/Problem9_4_6.lean` (issue
-#6438), completing Problem 9.4.6 (i).
+This is used by `hasHomologicalDimensionLE_pathAlgebra_one` (`Chapter9/Problem9_4_6.lean`) to
+complete Problem 9.4.6 (i).
 -/
 
 universe u
@@ -256,7 +256,7 @@ theorem Rbilin_mul_arrowInclusion (a : PathAlgebra k Q) (v : ArrowTgt k Q) (m : 
             rw [TensorProduct.smul_tmul, vtens_smul_def, vtens_smul_tmul, srcHom_apply, hz,
               TensorProduct.zero_tmul, TensorProduct.tmul_zero]
 
-/-- **The additive retraction inverts `Φ`.** `stdΦRetr ∘ Φ = id`; the retraction genuinely splits
+/-- **The additive retraction inverts `Φ`.** `stdΦRetr ∘ Φ = id`; the retraction splits
 off the arrow that `Φ` multiplied in. -/
 theorem stdΦRetr_stdΦ (x : inducedVtensObj M) :
     stdΦRetr M ((stdΦ M).hom x) = x := by
@@ -455,13 +455,13 @@ theorem standardComplex_exact : (standardComplex M).Exact := by
       intro n _; rw [← hF, hF0, Finsupp.zero_apply]
     exact standardComplex_exact_aux M 0 ξ hhigh hξ
 
-/-! ## Assembly of the short exact sequence -/
+/-! ## The short exact sequence -/
 
 /-- **The standard resolution short exact sequence**: `(standardComplex M).ShortExact`. Assembled
 from `Mono (stdd M)` (injectivity of `d`, `stdd_mono`), middle exactness `standardComplex_exact`,
 and `Epi (stdε M)` (`epi_stdε`). This is the length-`1` projective resolution of `M` over the path
-algebra, completing #6512 and feeding `hasHomologicalDimensionLE_pathAlgebra_one`
-(`Chapter9/Problem9_4_6.lean`, issue #6438). -/
+algebra, used by `hasHomologicalDimensionLE_pathAlgebra_one`
+(`Chapter9/Problem9_4_6.lean`). -/
 theorem standardResolution_shortExact : (standardComplex M).ShortExact where
   exact := standardComplex_exact M
   mono_f := stdd_mono M

--- a/EtingofRepresentationTheory/Chapter9/PathAlgebraVertexSubalgebra.lean
+++ b/EtingofRepresentationTheory/Chapter9/PathAlgebraVertexSubalgebra.lean
@@ -11,19 +11,19 @@ subalgebra spanned by the trivial-path idempotents `eᵢ = ofPath ⟨i, i, nil�
 This file supplies the reusable vertex-subalgebra layer that the noncommutative induction
 functor `A ⊗_S -` is built on:
 
-* `Etingof.PathAlgebra.isSemisimpleRing_vertexAlgebra` — `S = Q → k` is a semisimple ring
+* `Etingof.PathAlgebra.isSemisimpleRing_vertexAlgebra`: `S = Q → k` is a semisimple ring
   (a finite product of fields), so every `S`-module is projective.
-* `Etingof.PathAlgebra.ofPath_nil_mul_ofPath_nil` — orthogonality of the vertex idempotents,
+* `Etingof.PathAlgebra.ofPath_nil_mul_ofPath_nil`: orthogonality of the vertex idempotents,
   `eᵢ eⱼ = δᵢⱼ eᵢ`.
-* `Etingof.PathAlgebra.vertexEmbedding` — the ring homomorphism `S →+* A`,
+* `Etingof.PathAlgebra.vertexEmbedding`: the ring homomorphism `S →+* A`,
   `a ↦ ∑ i, a i • eᵢ`, along which restriction/induction of scalars is taken.
 
 ## Obstruction note
 
-The image of `vertexEmbedding` is **not central** in `A` (the idempotents `eᵢ` do not commute
+The image of `vertexEmbedding` is not central in `A` (the idempotents `eᵢ` do not commute
 with the arrows), so `A` is not a commutative-base `S`-algebra and Mathlib's `extendScalars`
-(which needs `[CommRing R] [CommRing S]`) does not apply. This is exactly why the induction
-functor `A ⊗_S -` is genuine new infrastructure; see issue #6420.
+(which needs `[CommRing R] [CommRing S]`) does not apply. This is why the induction
+functor `A ⊗_S -` requires new infrastructure.
 -/
 
 universe u
@@ -34,7 +34,7 @@ namespace Etingof.PathAlgebra
 
 /-- **Semisimplicity of the vertex algebra.** The subalgebra `S = Q → k` spanned by the trivial
 paths is a finite product of copies of the field `k`, hence a semisimple ring. Consequently
-every `S`-module is projective — the fact that makes both nonzero terms of the standard
+every `S`-module is projective, the fact that makes both nonzero terms of the standard
 resolution projective `A`-modules. -/
 theorem isSemisimpleRing_vertexAlgebra (k Q : Type*) [Field k] [Finite Q] :
     IsSemisimpleRing (Q → k) :=

--- a/EtingofRepresentationTheory/Chapter9/Problem9_3_2.lean
+++ b/EtingofRepresentationTheory/Chapter9/Problem9_3_2.lean
@@ -23,16 +23,15 @@ Etingof's Problem 9.3.2 asks to study the `ℂ`-algebra
 
 a four-dimensional algebra (basis `1, g, x, gx`). Its two simple modules are the two
 one-dimensional "sign" representations `S₊` (with `g = +1`, `x = 0`) and `S₋`
-(with `g = -1`, `x = 0`); they are non-isomorphic. The algebra is **not** semisimple:
-`x` is a nonzero nilpotent in the radical, and the two simples are linked by a genuine
+(with `g = -1`, `x = 0`); they are non-isomorphic. The algebra is not semisimple:
+`x` is a nonzero nilpotent in the radical, and the two simples are linked by a
 nonsplit extension
 
   `0 → S₋ → P₊ → S₊ → 0`,
 
 where `P₊ = ℂ²` carries `g = diag(1, -1)`, `x = [[0,0],[1,0]]`. This witnesses
 `Ext¹(S₊, S₋) ≠ 0`, so `S₊` and `S₋` are `Etingof.AreLinked`: the algebra has a single
-block. This is the content of Etingof Example 9.5.2 (iii), which until now was only a
-TODO comment in `Chapter9/Example9_5_2.lean`.
+block. This is the content of Etingof Example 9.5.2 (iii).
 
 The Ext nonvanishing is proved homologically rather than by hand: the covariant long
 exact sequence of `Ext(S₊, -)` applied to the displayed short exact sequence shows that

--- a/EtingofRepresentationTheory/Chapter9/Problem9_4_5.lean
+++ b/EtingofRepresentationTheory/Chapter9/Problem9_4_5.lean
@@ -24,26 +24,26 @@ Etingof Problem 9.4.5 has two parts.
   the Cartan matrix of `A`, then `det(C) = ±1`.
 
 * **(ii)** Compute the homological dimension of `k[t]/tⁿ` (`n > 1`) and of the algebra of
-  Problem 9.3.2. Both are **infinite**: `k[t]/tⁿ` with `n > 1` is a self-injective but
+  Problem 9.3.2. Both are infinite: `k[t]/tⁿ` with `n > 1` is a self-injective but
   non-semisimple algebra, so it has infinite global dimension; the four dimensional algebra
   `A = ℂ⟨g, x⟩/(gx+xg, x², g²-1)` of Problem 9.3.2 (which contains `k[x]/x²` and is likewise
   non-semisimple with a nonsplit self-extension) also has infinite homological dimension.
 
-## Statement-pass note
+## Formalization notes
 
 Part (i) uses `Etingof.algebraCartanMatrix` (Definition 9.3.1) for the Cartan matrix and
 `Etingof.homologicalDimension` (Definition 9.4.3) for the homological dimension; the entries
 of the Cartan matrix are natural numbers, so `det(C) = ±1` is stated after casting the matrix
-into `ℤ`. Part (ii) records the two concrete values as `homologicalDimension = ⊤`.
+into `ℤ`. Part (ii) gives both homological dimensions as `homologicalDimension = ⊤`.
 
 ## Correct hypotheses for part (i)
 
-The Cartan determinant is `±1` **only** when `C` is the genuine Cartan matrix of `A`, i.e.
+The Cartan determinant is `±1` only when `C` is the Cartan matrix of `A`, i.e.
 `P` really is the family of projective covers of a complete, irredundant set of
-representatives `M` of the simple `A`-modules. An earlier statement quantified over an
-arbitrary family `P : ι → Type*` with only `homologicalDimension A ≠ ⊤`; that statement is
-false (take `A = k`, `ι = Unit`, `P 0 = k²`: then `C = (4)` and `det = 4`). The restated
-theorem below carries the full §9.3/§9.4.5 setup, mirroring the hypotheses of Proposition
+representatives `M` of the simple `A`-modules. Quantifying over an arbitrary family
+`P : ι → Type*` with only `homologicalDimension A ≠ ⊤` gives a false statement (take
+`A = k`, `ι = Unit`, `P 0 = k²`: then `C = (4)` and `det = 4`). The theorem below therefore
+carries the full §9.3/§9.4.5 setup, mirroring the hypotheses of Proposition
 9.2.3 (`Etingof.projective_cover_hom_multiplicity`):
 
 * `A` is finite dimensional over `k`;
@@ -83,12 +83,12 @@ theorem det_eq_pm_one_of_mul_eq_one
     C.det = 1 ∨ C.det = -1 :=
   Int.eq_one_or_neg_one_of_mul_eq_one (by rw [← Matrix.det_mul, h, Matrix.det_one])
 
-/-- **Matrix assembly.** If every standard basis vector `eⱼ = Pi.single j 1` lies in the
-`ℤ`-column span of `C` (i.e. `C.mulVec d = eⱼ` for some integer vector `d`), then `C` has an
-integer right inverse `D`. Assemble `D` column by column from the witnessing vectors: column
+/-- **Building the right inverse.** If every standard basis vector `eⱼ = Pi.single j 1` lies in
+the `ℤ`-column span of `C` (i.e. `C.mulVec d = eⱼ` for some integer vector `d`), then `C` has an
+integer right inverse `D`. Build `D` column by column from the witnessing vectors: column
 `j` of `D` is the vector `d` with `C.mulVec d = eⱼ`, so column `j` of `C * D` is `eⱼ`, giving
 `C * D = 1`. This packages the `K₀` change-of-basis identity `C · D = 1` into the elementary
-`∃ D, C * D = 1` consumed by `det_eq_pm_one_of_mul_eq_one`. -/
+`∃ D, C * D = 1` used by `det_eq_pm_one_of_mul_eq_one`. -/
 theorem exists_right_inverse_of_forall_mulVec
     {ι : Type*} [Fintype ι] [DecidableEq ι] (C : Matrix ι ι ℤ)
     (h : ∀ j, ∃ d : ι → ℤ, C.mulVec d = Pi.single j 1) :
@@ -106,8 +106,8 @@ whose `i`-th entry is `dim_k Hom_A(Pᵢ, N)`. By Proposition 9.2.3
 (`Etingof.projective_cover_hom_multiplicity`) this equals the Jordan–Hölder multiplicity
 vector `([N : Mᵢ])ᵢ`, but the `Hom`-dimension form is manifestly independent of any choice
 of composition series and is additive on short exact sequences by
-`finrank_hom_additive_of_projective`. This is the concrete `K₀`-class function the Cartan
-determinant argument runs on. -/
+`finrank_hom_additive_of_projective`. This is the concrete `K₀`-class function underlying the
+Cartan determinant argument. -/
 noncomputable def homClassVector
     {k : Type*} [Field k] {A : Type*} [Ring A] [Algebra k A]
     {ι : Type*} (P : ι → Type*)
@@ -278,14 +278,14 @@ theorem homClassVector_eq_mulVec_of_equiv
   rw [homClassVector_congr P e, homClassVector_isotypic]
 
 /-- **Every indecomposable f.g. projective `A`-module is one of the `Pᵢ`.** Given the §9.3/§9.4.5
-setup — a complete family `M` of simple modules (`hM_complete`) and their indecomposable projective
-covers `P` (`hP_indec`, `hP_cover`) — any indecomposable finitely generated projective `A`-module
+setup (a complete family `M` of simple modules (`hM_complete`) and their indecomposable projective
+covers `P` (`hP_indec`, `hP_cover`)), any indecomposable finitely generated projective `A`-module
 `Q` is `A`-linearly isomorphic to some `P i`. This is the module-level PIM classification: `Q` has a
 simple quotient `Q ↠ M j₀` (`Q` nonzero and f.g. over the artinian `A`, so it has a maximal
 submodule), and `P j₀` also maps onto `M j₀` (`hP_cover` gives `dim_k Hom_A(P j₀, M j₀) = 1`), so
 by `Etingof.indecomposable_projective_iso_of_hom` (two indecomposable projectives with nonzero
 `Hom` to the same simple are isomorphic) `Q ≃ₗ[A] P j₀`. This mirrors `Etingof.Theorem_9_2_1_iii`
-but drops the `IsAlgClosed k` hypothesis, which that route does not use. -/
+but drops the `IsAlgClosed k` hypothesis, which that argument does not use. -/
 theorem indecProjective_iso_some_P
     {k : Type*} [Field k] {A : Type u} [Ring A] [Algebra k A] [FiniteDimensional k A]
     {ι : Type*} [Fintype ι] [DecidableEq ι]
@@ -502,7 +502,7 @@ The Cartan matrix `Etingof.algebraCartanMatrix P` (Definition 9.3.1) is built fr
 `P` of projective covers of the simple modules; its `ℕ`-entries are cast to `ℤ` to take the
 determinant. The hypotheses fix `M` as a complete, irredundant family of simple `A`-modules
 and `P i` as the indecomposable projective cover of `M i` (encoded by the essential-cover
-identity `dim_k Hom_A(Pᵢ, Mⱼ) = δᵢⱼ`), so that `C` is genuinely the change-of-basis matrix in
+identity `dim_k Hom_A(Pᵢ, Mⱼ) = δᵢⱼ`), so that `C` is the change-of-basis matrix in
 `K₀` between the simples `[Mᵢ]` and the projective indecomposables `[Pᵢ]`. -/
 theorem cartan_det_eq_pm_one
     {k : Type*} [Field k] {A : Type u} [Ring A] [Algebra k A] [FiniteDimensional k A]
@@ -526,7 +526,7 @@ theorem cartan_det_eq_pm_one
   suffices h : ∃ D : Matrix ι ι ℤ, C * D = 1 by
     obtain ⟨D, hD⟩ := h
     exact det_eq_pm_one_of_mul_eq_one C D hD
-  -- By the matrix assembly lemma, it suffices to express each standard basis vector `eⱼ` in
+  -- By the right-inverse lemma above, it suffices to express each standard basis vector `eⱼ` in
   -- the `ℤ`-column span of `C`. Since `homClassVector P (M j) = eⱼ` (essential cover, `hP_cover`)
   -- and the columns of `C` are the class vectors `homClassVector P (P i)`
   -- (`homClassVector_proj_eq_cartan_col`), this is exactly the statement that the class of the

--- a/EtingofRepresentationTheory/Chapter9/Problem9_4_6.lean
+++ b/EtingofRepresentationTheory/Chapter9/Problem9_4_6.lean
@@ -192,7 +192,7 @@ end AcyclicFinite
 /-- **Problem 9.4.6 (i), upper bound.** Every left `PathAlgebra k Q`-module has projective
 dimension `≤ 1`; equivalently, the path algebra has homological dimension `≤ 1`.
 
-This is the reusable core of Problem 9.4.6 (i): it is the *upper* bound
+This is the reusable core of Problem 9.4.6 (i): it is the upper bound
 `homologicalDimension (PathAlgebra k Q) ≤ 1`. Combined with the lower bound
 `¬ HasHomologicalDimensionLE (PathAlgebra k Q) 0` (non-semisimplicity once `Q` has an edge),
 it yields `homologicalDimension_pathAlgebra_eq_one`.
@@ -208,23 +208,23 @@ left `A`-module `M` the *standard resolution* is the length-`1` projective resol
 where `ε(a ⊗ m) = a · m` is the multiplication map. Both nonzero terms are projective `A`-modules
 because they are *induced* from `S`-modules (`A ⊗_S -`), `S` is semisimple (a finite product of
 fields), so every `S`-module is projective, and induction along `S → A` preserves projectives
-(it is left adjoint to restriction of scalars). Exactness — that `ker ε ≅ A ⊗_S (V ⊗_S M)` via
-`a ⊗ v ⊗ m ↦ av ⊗ m - a ⊗ vm` — is the analogue of the Koszul short exact sequence used for the
+(it is left adjoint to restriction of scalars). Exactness, that `ker ε ≅ A ⊗_S (V ⊗_S M)` via
+`a ⊗ v ⊗ m ↦ av ⊗ m - a ⊗ vm`, is the analogue of the Koszul short exact sequence used for the
 polynomial case (`Example 9.4.4`).
 
-## Obstruction / why this is genuinely new infrastructure
+## The noncommutative base extension
 
-Unlike the polynomial case, the base extension here is **noncommutative-induced**: the vertex
-idempotents `eᵢ` are *not central* in `A`, so `A` is not an `S`-algebra in the commutative sense
-and Mathlib's `ModuleCat.extendScalars` (which requires `[CommRing R] [CommRing S]`) does **not**
-apply. Building `A ⊗_S -` as a left `A`-module functor left-adjoint to `restrictScalars` along the
-non-central inclusion `S → A`, and its projectivity-preservation, is genuine new infrastructure not
-in Mathlib. See issue #6420 for the decomposition.
+Unlike the polynomial case, the base extension here is noncommutative: the vertex
+idempotents `eᵢ` are not central in `A`, so `A` is not an `S`-algebra in the commutative sense
+and Mathlib's `ModuleCat.extendScalars` (which requires `[CommRing R] [CommRing S]`) does not
+apply. The functor `A ⊗_S -` is instead built as a left `A`-module functor left-adjoint to
+`restrictScalars` along the non-central inclusion `S → A`, together with its preservation of
+projectives.
 
-## Assembly
+## Universes
 
 Because `Quiver.{u + 1} Q`, the path algebra `A = PathAlgebra k Q` lives in `Type (u + 1)`, so
-`HasHomologicalDimensionLE A 1` (Definition 9.4.3) quantifies over `ModuleCat.{u + 1} A` — exactly
+`HasHomologicalDimensionLE A 1` (Definition 9.4.3) quantifies over `ModuleCat.{u + 1} A`, exactly
 the universe the standard resolution `standardResolution_shortExact` is built at, so no universe
 uplift is needed. For each `M` the proof reads off `(standardComplex M).ShortExact`, notes both
 nonzero terms are projective (`projective_inducedModule_obj`), and applies dimension shifting
@@ -259,12 +259,12 @@ theorem homologicalDimension_pathAlgebra_eq_one
 /-! ## The free algebra as a path algebra
 
 We realize `k⟨x₁, …, xₙ⟩` as the path algebra of the one-vertex quiver `Q₀` with `n` loops, giving
-a genuine algebra isomorphism `freePathEquiv : FreeAlgebra k (Fin n) ≃ₐ[k] PathAlgebra k Q₀`.
+an algebra isomorphism `freePathEquiv : FreeAlgebra k (Fin n) ≃ₐ[k] PathAlgebra k Q₀`.
 
-**Universe note.** The two algebras do *not* live in the same universe: `FreeAlgebra k (Fin n)`
+**Universe note.** The two algebras do not live in the same universe: `FreeAlgebra k (Fin n)`
 is `Type u`, but `PathAlgebra k Q₀` is `Type (u+1)` because `Quiver.Path` lands in `Type (max u v)`
 and the standard-resolution machinery of `homologicalDimension_pathAlgebra_eq_one` hard-requires
-`Quiver.{u+1} Q₀`. Consequently the same-universe `homologicalDimension_congr` (from #6635) is *not*
+`Quiver.{u+1} Q₀`. Consequently the same-universe `homologicalDimension_congr` is not
 enough to conclude `homologicalDimension (FreeAlgebra k (Fin n)) = 1` from the path-algebra result;
 that final step additionally uses universe-lift invariance of `homologicalDimension`
 (`homologicalDimension_le_ulift`, `Chapter9/HomologicalDimensionUlift.lean`) to lift the free
@@ -400,8 +400,8 @@ noncomputable def freePathEquiv (k : Type u) [Field k] (n : ℕ) :
 
 /-! ## The free algebra is not semisimple (lower bound)
 
-Mirroring the path-algebra lower bound (`Chapter9/PathAlgebraLowerBound.lean`), the **augmentation
-module** — the field `k` on which every generator `xᵢ` acts as `0` — is not projective. If it were,
+Mirroring the path-algebra lower bound (`Chapter9/PathAlgebraLowerBound.lean`), the augmentation
+module, the field `k` on which every generator `xᵢ` acts as `0`, is not projective. If it were,
 the surjection `A ↠ k`, `p ↦ p • 1`, would split by an `A`-linear section `s`; writing `w = s(1)`,
 the relation `xᵢ • 1 = 0` forces `xᵢ · w = 0` in `A`. Since `A = FreeAlgebra k (Fin n)` is a domain
 and `xᵢ ≠ 0`, this gives `w = 0`, contradicting `ε(w) = 1` (as `s` is a section). Here `k` already
@@ -461,7 +461,7 @@ theorem not_hasHomologicalDimensionLE_zero_freeAlgebra
     have h1 := s.map_smul (FreeAlgebra.ι k ⟨0, hn⟩) (1 : k)
     rw [hact, map_zero] at h1
     rw [← smul_eq_mul]; exact h1.symm
-  -- `A` is a domain and `x₀ ≠ 0`, so `w = 0` — contradicting `ε(w) = 1`.
+  -- `A` is a domain and `x₀ ≠ 0`, so `w = 0`, contradicting `ε(w) = 1`.
   have hw0 : w = 0 := by
     rcases mul_eq_zero.mp hzero with h | h
     · exact absurd h (FreeAlgebra.ι_ne_zero (⟨0, hn⟩ : Fin n))
@@ -516,7 +516,7 @@ The projective covers `P` of the simple modules are supplied together with the d
 identification `hcover : Hom_A(Pᵢ, Pⱼ) ≅ (paths i → j) →₀ k` (for the path algebra these are
 `Pᵢ = A·eᵢ` with `Hom_A(Pᵢ, Pⱼ) ≅ eᵢ A eⱼ`, free on the paths from `i` to `j`). Acyclicity
 `hacyclic`, together with finiteness of the vertex set (`Fintype Q`) and of each arrow set
-(`Finite (i ⟶ j)`), makes each path type finite (`finite_path`), so `Nat.card` is the genuine
+(`Finite (i ⟶ j)`), makes each path type finite (`finite_path`), so `Nat.card` is the actual
 number of paths. -/
 theorem cartanMatrix_pathAlgebra_eq_pathCount
     {k : Type u} [Field k] {Q : Type u} [Quiver.{u + 1} Q] [Fintype Q] [DecidableEq Q]

--- a/EtingofRepresentationTheory/Chapter9/Problem9_5_3.lean
+++ b/EtingofRepresentationTheory/Chapter9/Problem9_5_3.lean
@@ -27,7 +27,7 @@ Etingof Problem 9.5.3 relates the block decomposition of a finite abelian catego
   of characteristic `2`. *(This concrete modular-representation computation is discharged in
   `Problem9_5_3_S3Char2.lean`: `k[S₃] ≅ M₂(k) × k[t]/(t²)`, giving exactly two blocks.)*
 
-## Statement-pass note
+## Formalization notes
 
 Blocks are `Etingof.Block R` and block membership is `Etingof.InBlock R S M` (Definition
 9.5.1). "Indecomposable central idempotent" is the predicate
@@ -36,7 +36,7 @@ Blocks are `Etingof.Block R` and block membership is `Etingof.InBlock R S M` (De
 of two nonzero orthogonal central idempotents).
 "`Hom(M, N) = 0`" is `Subsingleton (M ⟶ N)`, and "indecomposable object" is
 `CategoryTheory.Indecomposable`. Two blocks are distinct exactly when their representative
-simple modules are not `Etingof.AreLinked`. The proofs are complete (sorry-free).
+simple modules are not `Etingof.AreLinked`.
 -/
 
 universe v u
@@ -123,7 +123,7 @@ theorem centralCharacter_eq_false_iff {S : ModuleCat.{v} R} (hS : IsSimpleModule
 open scoped ModuleCat.Algebra in
 /-- **Naturality of a central scalar on `Ext`.** For a central element `z` of `R`, viewed as an
 endomorphism `z • 𝟙` of every module, pre-composing an `Ext` class with `z • 𝟙 X` equals
-post-composing it with `z • 𝟙 Y` — both equal the `z`-scalar multiple `z • α`. This is the
+post-composing it with `z • 𝟙 Y`: both equal the `z`-scalar multiple `z • α`. This is the
 mechanism behind linkage invariance of the central character: `z • 𝟙` is a natural transformation
 of the identity functor (centrality), and the category of `R`-modules is linear over the
 (commutative) center of `R`, so scalar multiplication by `z` acts the same way through either
@@ -333,7 +333,7 @@ theorem exists_simple_actsAsOne [Small.{v} R] {f : R} (hf0 : f ≠ 0)
   intro m
   exact Subtype.ext (by rw [SetLike.val_smul]; exact hfP m.val m.property)
 
-/-- **Block connectivity from indecomposability (injectivity crux of Problem 9.5.3(i)).** If an
+/-- **Block connectivity from indecomposability (injectivity step of Problem 9.5.3(i)).** If an
 *indecomposable* central idempotent `f` acts as the identity on two simple modules `S` and `T` of
 a ring `R` of finite length (`IsFiniteLength R R`), then `S` and `T` are linked.
 
@@ -341,7 +341,7 @@ This is the direction of the block ↔ idempotent bijection that fails for a dec
 `f = 1` acts as the identity on every simple, but simples in different blocks are unlinked): it is
 precisely the indecomposability of `f` that forces the simples of `R` into a single linkage class.
 
-The finite-length hypothesis is genuinely required: over `R = ℤ` the unit `1` is an indecomposable
+The finite-length hypothesis is required: over `R = ℤ` the unit `1` is an indecomposable
 central idempotent acting as the identity on every simple `ℤ/p`, yet `ℤ/p` and `ℤ/q` are unlinked
 for `p ≠ q`. (This mirrors the finiteness needed for the full bijection below.)
 
@@ -352,7 +352,7 @@ linked/unlinked summands are stable under every `R`-linear endomorphism, hence a
 ideals. The projection onto the linked summand, being left-`R`-linear, is right multiplication by a
 central idempotent `c` (centrality comes from commuting with right multiplication); then
 `f = f·c + f·(1 - c)` splits `f` into two orthogonal central idempotents, both nonzero because
-`f·c` acts as the identity on `S` and `f·(1 - c)` on `T` — contradicting indecomposability unless
+`f·c` acts as the identity on `S` and `f·(1 - c)` on `T`, contradicting indecomposability unless
 `S` and `T` are linked. -/
 theorem areLinked_of_actsAsOne_common [Small.{v} R] {f : R}
     (hfl : IsFiniteLength R R)
@@ -606,14 +606,12 @@ theorem areLinked_of_actsAsOne_common [Small.{v} R] {f : R}
 bijection between the blocks of the category of finite dimensional `R`-modules (linkage classes
 of simple modules) and the indecomposable central idempotents of `R`.
 
-The finiteness hypothesis is essential and was missing from the original statement of this item.
+The finiteness hypothesis is essential.
 Over a general ring the two sides differ: for `R = ℤ` the simple modules `ℤ/p` are pairwise
-unlinked (`Ext¹_ℤ(ℤ/p, ℤ/q) = 0` for `p ≠ q`), so there is one block per prime — infinitely many
-— while the only indecomposable central idempotent of `ℤ` is `1`. A finiteness assumption forcing
+unlinked (`Ext¹_ℤ(ℤ/p, ℤ/q) = 0` for `p ≠ q`), so there is one block per prime, infinitely many,
+while the only indecomposable central idempotent of `ℤ` is `1`. A finiteness assumption forcing
 a `1 = Σ eₖ` decomposition into primitive central idempotents (here: `FiniteDimensional k R`) is
-what makes the two sides match. We keep the ambient ring `R` and simply add that it is a finite
-dimensional `k`-algebra, so the block API (`Etingof.Block R`, `IsIndecomposableCentralIdempotent
-R`) is unchanged.
+what makes the two sides match.
 
 The proof runs through `centralIdempotent_smul_simple`: each simple module has a central character
 (which central idempotents act as `1`), linked simples share it
@@ -674,7 +672,7 @@ theorem blocks_equiv_indecomposableCentralIdempotents
   let Sof : ι → ModuleCat.{v} R := fun i => (hexS i).choose
   have hSof : ∀ i, IsSimpleModule R (Sof i) := fun i => (hexS i).choose_spec.1
   have hactOf : ∀ i, ∀ m : (Sof i : Type v), e i • m = m := fun i => (hexS i).choose_spec.2
-  -- The block ≃ index bijection. The `left_inv` round-trip is the injectivity crux.
+  -- The block ≃ index bijection. The `left_inv` round-trip is the injectivity step.
   let eB : Etingof.Block.{v} R ≃ ι :=
     { toFun := Quotient.lift idxOf hwd
       invFun := fun i => Quotient.mk (Etingof.blockSetoid R) ⟨Sof i, hSof i⟩
@@ -749,9 +747,9 @@ theorem compositionFactors_areLinked [Small.{v} R]
 
 /-- **Problem 9.5.3 (ii), decomposition.** Every indecomposable finite-length object lies in
 some block: there is a simple module `S` such that all composition factors of `M` are linked to
-`S`. The finite-length assumption is the genuine `IsFiniteLength R M` (the earlier
-"`∃ composition factor`" form was too weak — it does not force finite length, and the block
-statement is false without it, e.g. `M = ℤ` over `R = ℤ`). -/
+`S`. The finite-length assumption is `IsFiniteLength R M`; the weaker
+"`∃ composition factor`" form does not force finite length, and the block
+statement is false without it, e.g. `M = ℤ` over `R = ℤ`. -/
 theorem exists_block_of_indecomposable [Small.{v} R]
     {M : ModuleCat.{v} R} (hM : Indecomposable M) (hfl : IsFiniteLength R M) :
     ∃ S : ModuleCat.{v} R, IsSimpleModule R S ∧ Etingof.InBlock R S M := by

--- a/EtingofRepresentationTheory/Chapter9/Problem9_5_3_CompositionFactor.lean
+++ b/EtingofRepresentationTheory/Chapter9/Problem9_5_3_CompositionFactor.lean
@@ -8,10 +8,10 @@ Basic manipulation lemmas for `Etingof.IsCompositionFactor` (Definition 9.5.1), 
 `Problem9_5_3.lean` so that the dévissage (`Problem9_5_3_Devissage.lean`) and the main block
 statements (`Problem9_5_3.lean`) can both depend on them without an import cycle.
 
-* `isCompositionFactor_iff` — a composition factor is a simple quotient of a submodule.
-* `IsCompositionFactor.of_submodule` / `.of_surjective` — composition factors pull back along
+* `isCompositionFactor_iff`: a composition factor is a simple quotient of a submodule.
+* `IsCompositionFactor.of_submodule` / `.of_surjective`: composition factors pull back along
   submodule inclusions and push along surjections.
-* `exists_isCompositionFactor` — every nonzero module has a composition factor.
+* `exists_isCompositionFactor`: every nonzero module has a composition factor.
 -/
 
 universe v u

--- a/EtingofRepresentationTheory/Chapter9/Problem9_5_3_Connectivity.lean
+++ b/EtingofRepresentationTheory/Chapter9/Problem9_5_3_Connectivity.lean
@@ -217,7 +217,7 @@ theorem compositionFactors_areLinked_aux {M : ModuleCat.{v} R} (hM : Indecomposa
     (LinearEquiv.toModuleIso (Submodule.prodEquivOfIsCompl P Q hcompl)).symm ≪≫
       (ModuleCat.biprodIsoProd (ModuleCat.of R P) (ModuleCat.of R Q)).symm
   rcases hM.2 (ModuleCat.of R P) (ModuleCat.of R Q) iso with hZ | hZ
-  · -- `↥P = 0`: then `S`, a factor of `M ≅ ↥Q`, would be an unlinked factor — contradiction.
+  · -- `↥P = 0`: then `S`, a factor of `M ≅ ↥Q`, would be an unlinked factor, a contradiction.
     exfalso
     have hPbot : P = ⊥ := by
       have hsub : Subsingleton (P : Type v) := ModuleCat.isZero_iff_subsingleton.mp hZ

--- a/EtingofRepresentationTheory/Chapter9/Problem9_5_3_PrimitiveIdempotents.lean
+++ b/EtingofRepresentationTheory/Chapter9/Problem9_5_3_PrimitiveIdempotents.lean
@@ -21,14 +21,14 @@ this development and the block statements in `Problem9_5_3.lean`.
 
 ## Main results
 
-* `isIndecomposableCentralIdempotent_comm_iff` — in a commutative ring, indecomposability of an
+* `isIndecomposableCentralIdempotent_comm_iff`: in a commutative ring, indecomposability of an
   idempotent `e` says exactly that every idempotent below `e` is `0` or `e`.
-* `exists_completeOrthogonal_isIndecomposable_of_commArtinian` — a commutative Artinian ring has a
+* `exists_completeOrthogonal_isIndecomposable_of_commArtinian`: a commutative Artinian ring has a
   finite complete orthogonal family of indecomposable idempotents, unique up to reindexing.
-* `exists_completeOrthogonal_isIndecomposableCentral` — the corresponding decomposition for a
+* `exists_completeOrthogonal_isIndecomposableCentral`: the corresponding decomposition for a
   finite dimensional algebra `R`, obtained by transferring the decomposition of the (commutative
   Artinian) center `Z(R)` along the central inclusion `Z(R) ↪ R`.
-* `finite_isIndecomposableCentralIdempotent` — the indecomposable central idempotents form a
+* `finite_isIndecomposableCentralIdempotent`: the indecomposable central idempotents form a
   finite set.
 
 ## Proof strategy

--- a/EtingofRepresentationTheory/Chapter9/Problem9_5_3_S3Char2.lean
+++ b/EtingofRepresentationTheory/Chapter9/Problem9_5_3_S3Char2.lean
@@ -16,9 +16,9 @@ This file discharges part **(iii)** of Etingof Problem 9.5.3 (deferred by
 exactly two `2`-regular (odd-order) conjugacy classes of `S₃`, namely `{e}` and `{(123),(132)}`,
 so over a splitting field of characteristic `2` there are exactly **two** simple `k[S₃]`-modules:
 
-* the **trivial** simple, `1`-dimensional — in characteristic `2` the sign representation
+* the **trivial** simple, `1`-dimensional: in characteristic `2` the sign representation
   collapses onto the trivial one (`-1 = 1`), so the two char-`0` lines fuse into a single simple;
-* the **standard** simple, `2`-dimensional — it stays irreducible because `3` is invertible, and
+* the **standard** simple, `2`-dimensional: it stays irreducible because `3` is invertible, and
   it is the sum-zero subrepresentation of the permutation representation on `Fin 3 → k`.
 
 The standard simple has dimension `2 = |Syl₂(S₃)|`, hence is **projective**: it is a block of
@@ -31,18 +31,16 @@ unique simple is the trivial module. Altogether
 so `k[S₃]` has exactly two blocks, represented by the trivial and standard simples, and these two
 simples are **not** `Etingof.AreLinked`.
 
-## Status
+## Results
 
-All module and algebra *data* below are constructed genuinely (no `sorry` in any `def`): the
-trivial and standard representations are real objects, built over an arbitrary field of
-characteristic `2` by generalizing the char-`0` `S₃` catalogue in `Chapter4/Example4_3_S3.lean`
-off `ℂ`. Simplicity of the two modules, the non-linkage that separates the two blocks, the block
-count, and the **algebra decomposition** `k[S₃] ≅ M₂(k) × k[t]/(t²)` are all proven; the
-decomposition is realized as the algebra map `(rhoStd, psi) : k[S₃] → M₂(k) × k[t]/(t²)` — the
-standard representation in coordinates paired with the sign character — shown bijective by a
+The trivial and standard representations are built over an arbitrary field of
+characteristic `2`, generalizing the char-`0` `S₃` catalogue of `Chapter4/Example4_3_S3.lean`
+off `ℂ`. This file proves simplicity of the two modules, the non-linkage that separates the two
+blocks, the block count, and the algebra decomposition `k[S₃] ≅ M₂(k) × k[t]/(t²)`. The
+decomposition is realized as the algebra map `(rhoStd, psi) : k[S₃] → M₂(k) × k[t]/(t²)`, the
+standard representation in coordinates paired with the sign character, shown bijective by a
 `6 = 6` dimension count after surjectivity via the central idempotent `e = (123) + (132)`. The
-classification `simple_iff_triv_or_std` (there are exactly these two simples) is also proved, so
-this file is fully sorry-free. See the
+classification `simple_iff_triv_or_std` shows there are exactly these two simples. See the
 block framework in `Definition9_5_1.lean` and `Problem9_5_3.lean` for the `Etingof.Block` /
 `Etingof.AreLinked` machinery reused here.
 -/
@@ -57,7 +55,7 @@ abbrev S3 : Type := Equiv.Perm (Fin 3)
 
 variable (k : Type) [Field k] [CharP k 2]
 
-/-! ## Genuine module data
+/-! ## The two simple modules
 
 The two simple `k[S₃]`-modules, over an arbitrary field `k` of characteristic `2`. These are the
 char-`2` analogues of `trivRep` and `stdRep` from `Chapter4/Example4_3_S3.lean`, built here off a
@@ -88,8 +86,8 @@ omit [CharP k 2] in
   simp [sumLM, Finset.sum_apply]
 
 /-- The **standard** representation as the sum-zero subrepresentation of `permRepr`. In
-characteristic `2` the all-ones vector is *not* sum-zero (`1 + 1 + 1 = 3 = 1 ≠ 0`), so this is a
-genuine `2`-dimensional complement, and it is irreducible because `3` is invertible. -/
+characteristic `2` the all-ones vector is not sum-zero (`1 + 1 + 1 = 3 = 1 ≠ 0`), so this is a
+true `2`-dimensional complement, and it is irreducible because `3` is invertible. -/
 def stdSubr : Subrepresentation (permRepr k) where
   toSubmodule := LinearMap.ker (sumLM k)
   apply_mem_toSubmodule σ f hf := by
@@ -104,7 +102,7 @@ def stdRepr : Representation k S3 (stdSubr k).toSubmodule := (stdSubr k).toRepre
 
 /-! ### The two simples as `k[S₃]`-modules
 
-Via `Representation.asModule`, each representation becomes a genuine module over
+Via `Representation.asModule`, each representation becomes a module over
 `A = k[S₃] = MonoidAlgebra k S₃`, i.e. an object of `ModuleCat A`. These are the block
 representatives. -/
 
@@ -918,7 +916,7 @@ lemma rhoStd_swap02 : rhoStd k (MonoidAlgebra.single (Equiv.swap 0 2) 1) = !![0,
   fin_cases i <;> fin_cases j <;>
     simp [stdRepr_val, e0, e2]
 
-/-- The six group matrices span `M₂(k)`, so `rhoStd` is **surjective**. The four matrix units are
+/-- The six group matrices span `M₂(k)`, so `rhoStd` is surjective. The four matrix units are
 `k`-combinations of `ρ(1), ρ((123)), ρ((01)), ρ((02))` (in characteristic `2`, using `-1 = 1`). -/
 lemma rhoStd_surjective : Function.Surjective (rhoStd k) := by
   have m1 : (1 : Matrix (Fin 2) (Fin 2) k) ∈ (rhoStd k).range :=

--- a/EtingofRepresentationTheory/Chapter9/Problem9_5_3_Splitting.lean
+++ b/EtingofRepresentationTheory/Chapter9/Problem9_5_3_Splitting.lean
@@ -12,13 +12,13 @@ that group is trivial the only extension is the split one, so any short exact se
 
 ## Proof strategy
 
-Feed the short exact sequence into the **contravariant** `Ext` long exact sequence with target
+Apply the short exact sequence to the contravariant `Ext` long exact sequence with target
 `A`:
 `Ext C A 0 → Ext B A 0 → Ext A A 0 →[·∘extClass] Ext C A 1`.
 The connecting map `Ext A A 0 → Ext C A 1` sends the identity class `mk₀ (𝟙 A)` to
 `extClass ∘ (𝟙 A) = extClass`, which is `0` because `Ext¹(C, A)` is subsingleton. Exactness at
 `Ext A A 0` then produces a preimage `x₂ ∈ Ext B A 0` of `mk₀ (𝟙 A)` under precomposition with
-`f`. Realizing `x₂` as an honest morphism `r : B ⟶ A` via the degree-`0` bijection
+`f`. Realizing `x₂` as a morphism `r : B ⟶ A` via the degree-`0` bijection
 `Ext B A 0 ≃ (B ⟶ A)` gives `f ≫ r = 𝟙 A`, i.e. a retraction of `f`. A retraction of `f` in an
 abelian (hence balanced) category yields a splitting of the short complex
 (`ShortComplex.Splitting.ofExactOfRetraction`), whose induced isomorphism is `B ≅ A ⊞ C`.
@@ -51,7 +51,7 @@ theorem shortExact_splits_of_ext_subsingleton
   -- trivial group `Ext¹(C, A)`.
   obtain ⟨x₂, hx₂⟩ := Abelian.Ext.contravariant_sequence_exact₁ hSES A
     (Abelian.Ext.mk₀ (𝟙 A)) (show (1 : ℕ) + 0 = 1 from rfl) (Subsingleton.elim _ 0)
-  -- Realize `x₂ : Ext B A 0` as a genuine retraction `r : B ⟶ A` with `f ≫ r = 𝟙 A`.
+  -- Realize `x₂ : Ext B A 0` as a retraction `r : B ⟶ A` with `f ≫ r = 𝟙 A`.
   have hfr : f ≫ Abelian.Ext.homEquiv₀ x₂ = 𝟙 A := by
     apply (Abelian.Ext.mk₀_bijective A A).injective
     rw [← Abelian.Ext.mk₀_comp_mk₀, Abelian.Ext.mk₀_homEquiv₀_apply]

--- a/EtingofRepresentationTheory/Chapter9/Problem9_6_5.lean
+++ b/EtingofRepresentationTheory/Chapter9/Problem9_6_5.lean
@@ -19,16 +19,15 @@ where `P ⊗_B X` is the cokernel of `ψ = a_P ⊗ Id - Id ⊗ a_X : P ⊗ B ⊗
   `0 → K → P ⊗_B Hom(P, X) → X → 0` (third map `ξ`) and using (i) forces `K = 0`, so `ξ`
   is an isomorphism. Hence `F` and `G` are quasi-inverse and are equivalences of categories.
 
-## Statement-pass note
+## The three parts
 
-`F` is `hp.preadditiveCoyonedaObjFG : 𝒞 ⥤ FGModuleCat (End P)ᵐᵒᵖ` (Theorem 9.6.4) and
-`B\text{-fmod}` is `FGModuleCat (End P)ᵐᵒᵖ`. We render the whole problem as the existence of
-the quasi-inverse functor `G` together with the natural transformation `ξ`, bundling its three
-parts:
+Here `F` is `hp.preadditiveCoyonedaObjFG : 𝒞 ⥤ FGModuleCat (End P)ᵐᵒᵖ` (Theorem 9.6.4) and
+`B\text{-fmod}` is `FGModuleCat (End P)ᵐᵒᵖ`. The problem is the existence of the quasi-inverse
+functor `G` together with the natural transformation `ξ`, whose three parts are:
 
 * the natural isomorphism `G ⋙ F ≅ 𝟭` is part **(i)** (`F ∘ G ≅ Id`);
 * `ξ : F ⋙ G ⟶ 𝟭 𝒞` is the natural morphism of part **(ii)**, whose components
-  `ξ.app X : (P ⊗_B Hom(P, X)) → X` are epimorphisms (`Epi`, the categorical rendering of
+  `ξ.app X : (P ⊗_B Hom(P, X)) → X` are epimorphisms (`Epi`, the categorical form of
   "surjective");
 * `IsIso ξ` is the conclusion of part **(iii)** (`ξ` an isomorphism, i.e. `G ∘ F ≅ Id`).
 
@@ -38,15 +37,15 @@ book's "finite abelian category over a field `k` with a projective generator `P`
 
 ## Proof note
 
-The existential is discharged directly from Theorem 9.6.4: `F = hp.preadditiveCoyonedaObjFG`
-is proved there to be an *equivalence* (`IsEquivalence`, via essential surjectivity and full
-faithfulness — independently of any tensor construction, and this file imports that theorem,
-so there is no circularity). An equivalence carries a genuine quasi-inverse functor
+The existence follows directly from Theorem 9.6.4: `F = hp.preadditiveCoyonedaObjFG`
+is an equivalence (`IsEquivalence`, via essential surjectivity and full
+faithfulness, independently of any tensor construction, so there is no circularity). An
+equivalence carries a quasi-inverse functor
 `G := F.asEquivalence.inverse`; taking `ξ := (unit iso)⁻¹ : F ⋙ G ⟶ 𝟭 𝒞` gives a natural
 isomorphism, hence componentwise `Epi` (ii) and globally `IsIso` (iii), while the counit
-isomorphism supplies (i). The book's explicit `P ⊗_B -` functor is one *construction* of such
+isomorphism supplies (i). The book's explicit `P ⊗_B -` functor is one construction of such
 a quasi-inverse; since `F` is already known to be an equivalence, its abstract inverse serves
-as the required `G`, which is exactly the existential claim.
+as the required `G`, which is exactly the existence claim.
 -/
 
 universe u v w
@@ -80,9 +79,9 @@ theorem exists_quasiInverse_tensor_functor
       -- (iii) ξ is an isomorphism, so G ∘ F ≅ Id on 𝒞
       IsIso ξ := by
   -- `F = Hom(P, -) = hp.preadditiveCoyonedaObjFG` is an equivalence of categories by
-  -- Theorem 9.6.4 (proved there via essential surjectivity + fully faithful, independently
-  -- of the tensor construction — no circularity, since this file imports Theorem 9.6.4).
-  -- An equivalence has a genuine quasi-inverse functor `G := F⁻¹`, and the inverse of its
+  -- Theorem 9.6.4 (via essential surjectivity + fully faithful, independently
+  -- of the tensor construction, so there is no circularity).
+  -- An equivalence has a quasi-inverse functor `G := F⁻¹`, and the inverse of its
   -- unit isomorphism `ξ := (unit)⁻¹ : F ⋙ G ⟶ 𝟭 𝒞` is a natural isomorphism, so it is
   -- componentwise epi and is itself an isomorphism. This discharges the existential exactly
   -- as the book's `P ⊗_B -` construction does: it exhibits a quasi-inverse to `F`.

--- a/EtingofRepresentationTheory/Chapter9/Proposition9_1_1.lean
+++ b/EtingofRepresentationTheory/Chapter9/Proposition9_1_1.lean
@@ -40,7 +40,7 @@ theorem Etingof.idempotent_lifting_exists {A : Type*} [Ring A]
 /-- Idempotent lifting, Part (ii): any two liftings of an idempotent are conjugate
 by an element of 1 + I. (Etingof Proposition 9.1.1(ii))
 
-This is a stronger result than uniqueness — in the non-commutative case, two lifted
+This is a stronger result than uniqueness: in the non-commutative case, two lifted
 idempotents need not be equal but are always conjugate.
 
 The conjugating unit is `u = 1 + (2e₂ - 1)(e₁ - e₂)`, which lies in `1 + I` since

--- a/EtingofRepresentationTheory/Chapter9/ShapiroLemma.lean
+++ b/EtingofRepresentationTheory/Chapter9/ShapiroLemma.lean
@@ -30,7 +30,7 @@ For the polynomial ring map `Polynomial.C : R →+* R[X]`:
 - The evaluation-at-0 map provides a retraction of the unit `M → G(F(M))`
 - This gives: `HasProjectiveDimensionLT ((extendScalars C).obj M) n → HasProjectiveDimensionLT M n`
 
-Combined with the Ext long exact sequence and X-action vanishing (issue #1868),
+Combined with the Ext long exact sequence and X-action vanishing,
 this proves the lower bound in the Hilbert syzygy theorem.
 -/
 

--- a/EtingofRepresentationTheory/Chapter9/Theorem9_2_1.lean
+++ b/EtingofRepresentationTheory/Chapter9/Theorem9_2_1.lean
@@ -34,13 +34,13 @@ dim Hom_A(Pᵢ, Mⱼ) = δᵢⱼ.
 Uses Krull–Schmidt theorem (partially in Mathlib), Nakayama's lemma
 (`Ideal.eq_top_of_isUnit_of_forall_mem`), and lifting of idempotents.
 
-## Formalization approach
+## Hypotheses
 
-The three parts are stated as separate theorems sharing common hypotheses:
+The three parts share common hypotheses:
 a finite-dimensional algebra A over a field k, with a finite indexing type ι for the
 isomorphism classes of simple modules, and a family of simple modules indexed by ι.
 
-Part (i) is an existence statement producing the projective covers — it only requires
+Part (i) is an existence statement producing the projective covers: it only requires
 that the Mᵢ are pairwise non-isomorphic.
 Parts (ii) and (iii) additionally require that the Mᵢ exhaust all simple A-modules
 (up to isomorphism), since the decomposition of A and the completeness of the
@@ -88,7 +88,7 @@ theorem exists_isCoatom_submodule
 /-- Any nontrivial f.g. module Q over an artinian ring with an exhaustive family of simples M_i
 has a nonzero A-linear map to some M_{j₀}. The quotient Q/N by a coatom N is simple,
 hence isomorphic to some M_{j₀}, and the composition Q → Q/N ≅ M_{j₀} is nonzero.
-This is the key step in Theorem 9.2.1(iii) that does NOT need #1487. -/
+This is the key step in Theorem 9.2.1(iii). -/
 theorem exists_nonzero_hom_to_simple
     {R : Type u} [Ring R] [IsArtinianRing R]
     {ι : Type*} [Fintype ι] [DecidableEq ι]
@@ -205,8 +205,6 @@ lemma pi_single_one_comm {n : ℕ} {S : Fin n → Type*}
 
 end CentralAction
 
--- No separate section needed; infrastructure is inlined in the main proof below.
-
 /-- For a finite-dimensional algebra A over k with pairwise non-isomorphic simple modules
 M₁, ..., Mₘ, there exist orthogonal idempotents e₁, ..., eₘ in A (one per iso class of
 simple modules) such that eᵢ acts as a rank-1 projection on Mᵢ and as zero on Mⱼ for
@@ -276,7 +274,7 @@ lemma exists_orthogonal_idempotents_for_simples
   -- then lift to A. The rank property is stated in terms of the A-action,
   -- but depends only on the A/J-image (by hsmulRange_eq).
   --
-  -- We use `suffices` to separate the WA-based construction from the lifting.
+  -- Separate the Wedderburn-Artin construction from the lifting step.
   let π := Ideal.Quotient.mk (Ring.jacobson A)
   suffices ∃ (ebar : ι → A ⧸ Ring.jacobson A),
       OrthogonalIdempotents ebar ∧
@@ -318,7 +316,7 @@ lemma exists_orthogonal_idempotents_for_simples
   -- through A/J ≅ ∏ Mat(k)).
   --
   -- This uses the following infrastructure:
-  -- (i) Module structure on M_j over A/J (from J ≤ ann(M_j)) — available via
+  -- (i) Module structure on M_j over A/J (from J ≤ ann(M_j)), available via
   --     Module.IsTorsionBySet.module from Mathlib
   -- (ii) Module structure over the product ∏ Mat_{dⱼ}(k) via the WA equivalence
   -- (iii) Classification of simple modules over ∏ Mat_{dⱼ}(k): each simple module
@@ -350,7 +348,7 @@ lemma exists_orthogonal_idempotents_for_simples
       exact h_base.embedding ⟨σ, hσ_inj⟩
     -- Map through WA⁻¹ (ring homomorphism)
     have := horth_prod.map WA.symm.toRingEquiv.toRingHom
-    -- v4.31: `convert` no longer unfolds `Function.comp`; close the residual pointwise.
+    -- `convert` leaves `Function.comp` folded here; close the residual pointwise.
     convert this using 1
     funext i
     rfl
@@ -1098,7 +1096,7 @@ lemma leftIdeal_indecomposable_of_hom_delta
     haveI : IsNoetherian A ↥W₂ := isNoetherian_submodule' W₂
     haveI hW₁_nt : Nontrivial ↥W₁ := W₁.nontrivial_iff_ne_bot.mpr hW₁
     haveI hW₂_nt : Nontrivial ↥W₂ := W₂.nontrivial_iff_ne_bot.mpr hW₂
-    -- Get coatoms (maximal proper submodules) — exist since modules are finite/noetherian
+    -- Get coatoms (maximal proper submodules), which exist since modules are finite/noetherian
     obtain ⟨N₁, hN₁⟩ := IsCoatomic.exists_coatom (α := Submodule A ↥W₁)
     obtain ⟨N₂, hN₂⟩ := IsCoatomic.exists_coatom (α := Submodule A ↥W₂)
     -- The quotients W₁/N₁ and W₂/N₂ are simple modules
@@ -1462,8 +1460,8 @@ More precisely: given a finite family of pairwise non-isomorphic simple A-module
 for each index `i` there exists a type `P i` carrying the structure of an indecomposable
 projective A-module, together with a proof that dim_k Hom_A(P i, M j) = if i = j then 1 else 0.
 The uniqueness clause records that any indecomposable finitely generated projective module `Q`
-with the same Kronecker delta Hom property at index `i` is isomorphic to `P i` — matching the
-book's statement that `P_i` is the *unique* such module.
+with the same Kronecker delta Hom property at index `i` is isomorphic to `P i`, matching the
+book's statement that `P_i` is the unique such module.
 (Etingof Theorem 9.2.1(i)) -/
 theorem Etingof.Theorem_9_2_1_i
     [IsAlgClosed k]
@@ -2356,13 +2354,13 @@ theorem Etingof.Theorem_9_2_1_ii
   -- 4. A = ⊕_p A·e_p ≅ ⊕_p P_{p.1} ≅ ⊕_i (Fin (dim M_i) → P_i).
   haveI : IsArtinianRing A := isArtinian_of_tower k inferInstance
   -- Step 1: Construct complete orthogonal idempotents with the Hom delta property.
-  -- This is the core WA-based construction (established below — see detailed outline above).
+  -- This is the core Wedderburn-Artin construction of the complete orthogonal idempotents.
   suffices h_coi : ∃ (e : (Σ i : ι, Fin (Module.finrank k (M i))) → A),
       CompleteOrthogonalIdempotents e ∧
       ∀ (p : Σ i : ι, Fin (Module.finrank k (M i))) (j : ι),
         Module.finrank k (Etingof.Theorem921.smulRange (k := k) (A := A) (M j) (e p)) =
           if p.fst = j then 1 else 0 by
-    -- Assembly: Given the complete system, build the decomposition A ≅ ⊕_i (dim M_i) · P_i.
+    -- Given the complete system, build the decomposition A ≅ ⊕_i (dim M_i) · P_i.
     obtain ⟨e, he_coi, he_rank⟩ := h_coi
     -- Each left ideal A·e_p has the Hom delta property via finrank_hom_leftIdeal_eq
     set N : (Σ i : ι, Fin (Module.finrank k (M i))) → Submodule A A :=

--- a/EtingofRepresentationTheory/Chapter9/Theorem9_6_4.lean
+++ b/EtingofRepresentationTheory/Chapter9/Theorem9_6_4.lean
@@ -330,7 +330,7 @@ instance Etingof.IsProgenerator.essSurj_preadditiveCoyonedaObjFG
         intro k
         change α' k = ((preadditiveCoyonedaObj P).map f).hom k
         conv_rhs => rw [hf]; simp [ModuleCat.hom_ofHom]
-        -- v4.31: the conv leaves the residual reflexivity goal `α' k = α' k`; close it.
+        -- The conv leaves the residual reflexivity goal `α' k = α' k`; close it.
         rfl
       have hg_eq : g = α' (βm w) := by
         change g = βn (α (βm.symm (βm w)))
@@ -417,7 +417,7 @@ instance Etingof.IsProgenerator.essSurj_preadditiveCoyonedaObjFG
         intro k
         change α' k = ((preadditiveCoyonedaObj P).map f).hom k
         conv_rhs => rw [hf]; simp [ModuleCat.hom_ofHom]
-        -- v4.31: the conv leaves the residual reflexivity goal `α' k = α' k`; close it.
+        -- The conv leaves the residual reflexivity goal `α' k = α' k`; close it.
         rfl
       rw [← hα'_eq]
       change φ (βn.symm (βn (α (βm.symm h)))) = 0
@@ -445,7 +445,7 @@ instance Etingof.IsProgenerator.essSurj_preadditiveCoyonedaObjFG
 /-- In a `k`-linear finite abelian category over a field, the opposite endomorphism ring
 `(End P)ᵐᵒᵖ` of any object `P` is a Noetherian ring.
 
-Every `Hom`-space — in particular `End P` — is finite dimensional over `k`
+Every `Hom`-space, in particular `End P`, is finite dimensional over `k`
 (`Etingof.IsFiniteAbelianCategoryOverField.finiteDimensional_hom`, the §9.6 "check it!"),
 hence so is `(End P)ᵐᵒᵖ`, and a finite dimensional algebra over a field is Noetherian.
 


### PR DESCRIPTION
This PR rewrites the comments and docstrings throughout Chapter 9 so they read as mathematics rather than a record of the formalization process. It removes PR and issue numbers and the associated process narrative (layer and link labels, statement-pass notes, status and version history), and replaces the informal register and em-dashes with plain research-paper prose. Only comments and docstrings change; the code is byte-identical after stripping comments (verified mechanically).

🤖 Prepared with Claude Code