### PR TITLE
feat(Ch5): prove finrank Z(k[G]) = #ConjClasses via class-sum center basis

### DIFF
--- a/EtingofRepresentationTheory/Chapter5.lean
+++ b/EtingofRepresentationTheory/Chapter5.lean
@@ -204,6 +204,7 @@ import EtingofRepresentationTheory.Chapter5.GL2ConjugacyClassCount
 import EtingofRepresentationTheory.Chapter5.Lemma5_25_3
 import EtingofRepresentationTheory.Chapter5.Discussion5_25_4
 import EtingofRepresentationTheory.Chapter5.Discussion_complementary_series_summary
+import EtingofRepresentationTheory.Chapter5.GroupAlgebraCenter
 
 -- Section 5.26: Artin's Theorem
 import EtingofRepresentationTheory.Chapter5.Theorem5_26_1

--- a/EtingofRepresentationTheory/Chapter5/GroupAlgebraCenter.lean
+++ b/EtingofRepresentationTheory/Chapter5/GroupAlgebraCenter.lean
@@ -1,0 +1,138 @@
+import Mathlib
+
+/-!
+# The center of a finite group algebra and conjugacy classes
+
+The classical bridge underlying "over `ℂ` the number of irreducible representations of a
+finite group equals its number of conjugacy classes" has, as its group-algebra half, the
+statement that the center of the group algebra `k[G]` is spanned by the *class sums* and
+therefore has dimension equal to the number of conjugacy classes of `G`.
+
+This file proves that half:
+
+* `Etingof.GroupAlgebra.mem_center_iff_coeff` — an element of `k[G]` is central iff its
+  coefficient function is constant on conjugacy classes (a *class function*).
+* `Etingof.GroupAlgebra.centerEquivClassFun` — the resulting linear equivalence between the
+  center of `k[G]` and the space of functions on conjugacy classes.
+* `Etingof.GroupAlgebra.finrank_center_eq_card_conjClasses` — for a field `k` and a finite
+  group `G`, `dim_k Z(k[G]) = #(ConjClasses G)`.
+
+This is the Mathlib-missing input recorded in the Discussion after the `GL₂(𝔽_q)` completeness
+summary; it is a general result about group algebras, independent of the field being `ℂ`.
+-/
+
+namespace Etingof.GroupAlgebra
+
+open scoped MonoidAlgebra
+
+open MonoidAlgebra
+
+section General
+
+variable {k G : Type*} [CommRing k] [Group G]
+
+/-- An element `x` of the group algebra `k[G]` lies in the center iff its coefficient
+function is invariant under conjugation, i.e. it is constant on conjugacy classes. -/
+theorem mem_center_iff_coeff (x : MonoidAlgebra k G) :
+    x ∈ Subalgebra.center k (MonoidAlgebra k G) ↔ ∀ g h : G, x (g * h * g⁻¹) = x h := by
+  rw [Subalgebra.mem_center_iff]
+  constructor
+  · -- centrality ⇒ conjugation-invariance of coefficients
+    intro hx g h
+    have hcomm := hx (single g (1 : k))
+    have h1 : (single g (1 : k) * x) (g * h) = x h := by simp [single_mul_apply]
+    have h2 : (x * single g (1 : k)) (g * h) = x (g * h * g⁻¹) := by simp [mul_single_apply]
+    rw [hcomm] at h1
+    rw [h2] at h1
+    exact h1
+  · -- conjugation-invariance ⇒ commutes with every element
+    intro hcoeff y
+    -- it suffices that `x` commutes with every `single g c`
+    have hsingle : ∀ (g : G) (c : k), single g c * x = x * single g c := by
+      intro g c
+      ext h
+      rw [single_mul_apply, mul_single_apply, mul_comm]
+      congr 1
+      -- `x (g⁻¹ * h) = x (h * g⁻¹)`, conjugate of one another
+      have := hcoeff g (g⁻¹ * h)
+      rw [← mul_assoc, mul_inv_cancel, one_mul] at this
+      exact this.symm
+    -- extend from generators to all of `y` by linearity
+    conv_lhs => rw [← y.sum_single]
+    conv_rhs => rw [← y.sum_single]
+    simp only [Finsupp.sum]
+    rw [Finset.mul_sum, Finset.sum_mul]
+    exact Finset.sum_congr rfl fun g _ => hsingle g (y g)
+
+variable [Fintype G]
+
+omit [Group G] in
+/-- The value at `h` of the "diagonal" element `∑ g, single g (c g)` is just `c h`. -/
+private theorem apply_sum_single (c : G → k) (h : G) :
+    (∑ g : G, single g (c g)) h = c h := by
+  classical
+  rw [Finsupp.finsetSum_apply]
+  simp only [single_apply]
+  rw [Finset.sum_ite_eq' Finset.univ h c]
+  simp
+
+/-- The canonical central group-algebra element attached to a class function `f` is central:
+its coefficients are constant on conjugacy classes by construction. -/
+private theorem sum_single_classFun_mem_center (f : ConjClasses G → k) :
+    (∑ g : G, single g (f (ConjClasses.mk g))) ∈
+      Subalgebra.center k (MonoidAlgebra k G) := by
+  rw [mem_center_iff_coeff]
+  intro g h
+  rw [apply_sum_single (fun g => f (ConjClasses.mk g)),
+    apply_sum_single (fun g => f (ConjClasses.mk g))]
+  congr 1
+  rw [ConjClasses.mk_eq_mk_iff_isConj, isConj_iff]
+  exact ⟨g⁻¹, by group⟩
+
+end General
+
+section FieldCase
+
+variable (k G : Type*) [Field k] [Group G] [Fintype G]
+
+/-- The center of the finite group algebra `k[G]` is linearly equivalent to the space of
+class functions `ConjClasses G → k`, via `x ↦ (c ↦ coefficient of x on the class c)`. -/
+noncomputable def centerEquivClassFun :
+    ↥(Subalgebra.center k (MonoidAlgebra k G)) ≃ₗ[k] (ConjClasses G → k) where
+  toFun x c := Quotient.liftOn c (fun g => (x : MonoidAlgebra k G) g)
+    (fun a b hab => by
+      obtain ⟨c, rfl⟩ := isConj_iff.mp hab
+      exact ((mem_center_iff_coeff (x : MonoidAlgebra k G)).mp x.2 c a).symm)
+  map_add' x y := by
+    funext c
+    induction c using Quotient.inductionOn with
+    | h g => simp [AddMemClass.coe_add]
+  map_smul' r x := by
+    funext c
+    induction c using Quotient.inductionOn with
+    | h g => simp [SetLike.val_smul]
+  invFun f := ⟨∑ g : G, single g (f (ConjClasses.mk g)), sum_single_classFun_mem_center f⟩
+  left_inv x := by
+    apply Subtype.ext
+    ext h
+    exact apply_sum_single (fun g => (x : MonoidAlgebra k G) g) h
+  right_inv f := by
+    funext c
+    induction c using Quotient.inductionOn with
+    | h g => exact apply_sum_single (fun g => f (ConjClasses.mk g)) g
+
+omit [Fintype G] in
+/-- **The center of a finite group algebra has dimension equal to the number of conjugacy
+classes.** For a field `k` and a finite group `G`,
+`dim_k Z(k[G]) = #(ConjClasses G)`. This is the group-algebra half of the character-theoretic
+identity `#(irreducible ℂ-reps of G) = #(ConjClasses G)`. -/
+theorem finrank_center_eq_card_conjClasses [Finite G] :
+    Module.finrank k ↥(Subalgebra.center k (MonoidAlgebra k G)) = Nat.card (ConjClasses G) := by
+  haveI : Fintype G := Fintype.ofFinite _
+  haveI : Fintype (ConjClasses G) := Fintype.ofFinite _
+  rw [(centerEquivClassFun k G).finrank_eq, Module.finrank_fintype_fun_eq_card,
+    Nat.card_eq_fintype_card]
+
+end FieldCase
+
+end Etingof.GroupAlgebra

--- a/progress/2026-07-22T04-56-44Z_5b56e0b2.md
+++ b/progress/2026-07-22T04-56-44Z_5b56e0b2.md
@@ -1,0 +1,46 @@
+## Accomplished
+
+Feature session on #7254 (make GL₂(𝔽_q) completeness unconditional by proving the
+character-theoretic bridge `#(irreducible ℂ-reps of finite G) = #(ConjClasses G)`).
+
+Scope assessment: the issue is a substantial multi-lemma effort with two from-scratch
+Mathlib gaps plus a dependency on the still-open PR #7255 (the `constructed_irreps_complete`
+declarations it references are not yet on `main`). Decomposed into three follow-up issues and
+landed the hardest self-contained brick.
+
+**Landed** (`EtingofRepresentationTheory/Chapter5/GroupAlgebraCenter.lean`, sorry-free,
+axiom-clean — only `propext`/`Classical.choice`/`Quot.sound`):
+
+- `Etingof.GroupAlgebra.mem_center_iff_coeff` — `x ∈ Z(k[G])` iff its coefficient function is
+  conjugation-invariant (constant on conjugacy classes). CommRing `k`, group `G`.
+- `Etingof.GroupAlgebra.centerEquivClassFun` — `Z(k[G]) ≃ₗ[k] (ConjClasses G → k)` for a field
+  `k` and finite `G`, via `x ↦ (class ↦ coefficient of x on that class)`.
+- `Etingof.GroupAlgebra.finrank_center_eq_card_conjClasses` — `dim_k Z(k[G]) = #(ConjClasses G)`.
+
+This is the group-algebra half of the bridge, general in the field (not ℂ-specific).
+
+## Current frontier
+
+The remaining bricks are decomposed into:
+- **#7257** — `finrank_k Z(R) = #(Wedderburn factors)` for `R ≃ₐ Π Matrix` over an alg-closed
+  field (independent, ready to work).
+- **#7258** — assemble `#(irreps ℂ G) = #(ConjClasses G)` from the two center-dimension bricks
+  (`depends-on: #7257`).
+- **#7259** — discharge the `bridge` hypothesis of `Etingof.GL2.constructed_irreps_complete`
+  (`depends-on: #7258`, and on #7255 landing first).
+
+## Overall project progress
+
+Stage 3.7 fidelity/coverage work ongoing in Chapter 4/5. This turn advanced Chapter 5
+completeness infrastructure: the Mathlib-missing group-algebra-center dimension count is now a
+reusable, general, sorry-free theorem.
+
+## Next step
+
+Pick up #7257 (self-contained, no blockers). Note the pinned Mathlib is v4.32.0-rc1 —
+`MonoidAlgebra` uses direct Finsupp application `x g` with `single_mul_apply`/`mul_single_apply`,
+NOT the newer `.coeff` API found in a standalone `~/mathlib4` checkout.
+
+## Blockers
+
+None for #7257. #7259 additionally waits on PR #7255 merging to `main`.


### PR DESCRIPTION
Partial progress on #7254

Session: `5b56e0b2-373e-4d19-b414-38f42be839a1`

15157c5f progress: #7254 center-basis brick landed; decomposed remainder into #7257/#7258/#7259
daa1ac96 feat(Ch5 #7254): prove finrank Z(k[G]) = #ConjClasses via class-sum center basis

🤖 Prepared with Claude Code