### PR TITLE
feat(Ch4): reducible RHS model (⊕χ)⊕(q−2)V + character-additivity lemmas for Problem 4.12.6

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -299,6 +299,13 @@ finite `∑` over `Finset.univ`/`Fintype` of the fiber with per-summand `ι`/`π
 `CategoryTheory.op_sum`. Beware `Functor.map_id`/`map_sum` name-clash with Lean's monad `Functor`: use
 `CategoryTheory.Functor.map_id`.
 
+**`⨁` notation clash under `open CategoryTheory`.** In a file with `open CategoryTheory` (common in
+Chapter 4 files using `FDRep`/`Simple`), the `⨁` big-operator resolves to the *categorical biproduct*,
+not `DirectSum` — writing `⨁ (_ : ι), M` for a `DirectSum` then fails with a baffling
+`failed to synthesize Category ι`. Fix: write the type explicitly as `DirectSum ι (fun _ => M)`
+(or `open DirectSum` after the section). `Representation.directSum`/`.prod` and the
+character-additivity lemmas `char_prod`/`char_directSum` (Problem 4.12.6) are the usual companions.
+
 **Distinct-but-defeq local `Module k` instances break `rw`/`simp` on imported lemmas — use `erw`
 or a `rfl`-restatement.** This file's own `instModuleK`/`instModuleKObj` and `ExternalTensorFunctor`'s
 *private* `restrictModule₁` are all `Module.compHom X (algebraMap k Bᵐᵒᵖ)` — defeq but **syntactically

--- a/EtingofRepresentationTheory/Chapter4/Problem4_12_6.lean
+++ b/EtingofRepresentationTheory/Chapter4/Problem4_12_6.lean
@@ -1205,6 +1205,98 @@ theorem charRep_tprod_Vrep_equiv_Vrep [Fintype K] [DecidableEq K]
   exact equiv_of_character_eq _ _ (funext fun g => charRep_tprod_Vrep_character_eq_Vrep hK χ g)
 
 
+/-! ### The explicit right-hand side model `(⊕_χ charRep χ) ⊕ (q−2)·V`
+
+We assemble a concrete representation isomorphic to the right-hand side of the `V ⊗ V`
+decomposition and compute its character. Combined with `Vrep_tprod_Vrep_decomp_character`, this
+reduces the isomorphism `V ⊗ V ≅ (⊕ all q−1 characters) ⊕ (q−2)·V` to the *reducible* form of
+"characters determine the representation" (the multiplicities agree, so the two sides are
+isomorphic). The two additivity lemmas `char_prod`/`char_directSum` are general facts about
+characters (the character of a product resp. finite direct sum of representations is the sum of
+the characters) that are missing from Mathlib. -/
+
+/-- **Character additivity for products.** The character of a product representation is the sum
+of the characters of the two factors. -/
+theorem char_prod {V W : Type*} [AddCommGroup V] [Module ℂ V] [FiniteDimensional ℂ V]
+    [AddCommGroup W] [Module ℂ W] [FiniteDimensional ℂ W]
+    (ρ : Representation ℂ (Affine K) V) (σ : Representation ℂ (Affine K) W) (g : Affine K) :
+    (ρ.prod σ).character g = ρ.character g + σ.character g := by
+  change LinearMap.trace ℂ (V × W) ((ρ.prod σ) g) = _
+  exact LinearMap.trace_prodMap' (ρ g) (σ g)
+
+/-- **Character additivity for finite direct sums.** The character of a finite direct sum of
+representations is the sum of the characters of the summands. -/
+theorem char_directSum {ι : Type*} [Fintype ι]
+    {V : ι → Type*} [∀ i, AddCommGroup (V i)] [∀ i, Module ℂ (V i)]
+    [∀ i, FiniteDimensional ℂ (V i)]
+    (ρ : ∀ i, Representation ℂ (Affine K) (V i)) (g : Affine K) :
+    (Representation.directSum ρ).character g = ∑ i, (ρ i).character g := by
+  classical
+  simp only [Representation.character]
+  have hg : (Representation.directSum ρ) g = DirectSum.lmap (fun i => ρ i g) := rfl
+  rw [hg]
+  have hf : DirectSum.lmap (fun i => ρ i g)
+      = ∑ i, (DirectSum.lof ℂ ι V i) ∘ₗ (ρ i g) ∘ₗ (DirectSum.component ℂ ι V i) := by
+    ext i x
+    simp only [DirectSum.lmap_lof, LinearMap.sum_apply, LinearMap.comp_apply]
+    rw [Finset.sum_eq_single i]
+    · simp [DirectSum.component.lof_self]
+    · intro j _ hji
+      simp [DirectSum.component.of, Ne.symm hji]
+    · simp
+  rw [hf, map_sum]
+  refine Finset.sum_congr rfl (fun i _ => ?_)
+  rw [LinearMap.trace_comp_comm', LinearMap.comp_assoc,
+    DirectSum.component_comp_lof_same, LinearMap.comp_id]
+
+/-- The `Representation`-level character of the one-dimensional `charRep χ` is `g ↦ χ g`
+(compare `charRep_character`, which is stated for `FDRep.of (charRep χ)`). -/
+lemma charRep_character' (χ : Affine K →* ℂˣ) (g : Affine K) :
+    (charRep χ).character g = (χ g : ℂ) := by
+  have hg : charRep χ g = (χ g : ℂ) • LinearMap.id := rfl
+  change LinearMap.trace ℂ ℂ (charRep χ g) = _
+  rw [hg, map_smul, LinearMap.trace_id]
+  simp
+
+/-- The direct sum `⊕_χ charRep χ` of all `q−1` one-dimensional characters. -/
+noncomputable def charSumRep [Fintype (Affine K →* ℂˣ)] :
+    Representation ℂ (Affine K) (DirectSum (Affine K →* ℂˣ) (fun _ => ℂ)) :=
+  Representation.directSum (fun χ => charRep χ)
+
+/-- The direct sum of `q−2` copies of the `(q−1)`-dimensional irreducible `V`. -/
+noncomputable def VcopiesRep [Fintype K] :
+    Representation ℂ (Affine K) (DirectSum (Fin (Fintype.card K - 2)) (fun _ => (zeroSum K))) :=
+  Representation.directSum (fun _ => (Vsub (K := K)).toRepresentation)
+
+/-- **The explicit right-hand side model** `(⊕_χ charRep χ) ⊕ (q−2)·V`: the direct sum of the
+`q−1` one-dimensional characters together with `q−2` copies of the `(q−1)`-dimensional
+irreducible `V`. This is the concrete representation appearing on the right of the `V ⊗ V`
+decomposition. -/
+noncomputable def rhsRep [Fintype K] [Fintype (Affine K →* ℂˣ)] :
+    Representation ℂ (Affine K)
+      ((DirectSum (Affine K →* ℂˣ) (fun _ => ℂ)) ×
+        (DirectSum (Fin (Fintype.card K - 2)) (fun _ => (zeroSum K)))) :=
+  (charSumRep (K := K)).prod (VcopiesRep (K := K))
+
+/-- **Character of the right-hand side model.** The character of `(⊕_χ charRep χ) ⊕ (q−2)·V`
+is `(∑_χ χ(g)) + (q−2)·χ_V(g)`, matching exactly the right-hand side of
+`Vrep_tprod_Vrep_decomp_character`. -/
+theorem rhsRep_character [Fintype K] [Fintype (Affine K →* ℂˣ)]
+    (hK : 3 ≤ Fintype.card K) (g : Affine K) :
+    (rhsRep (K := K)).character g
+      = (∑ χ : Affine K →* ℂˣ, (χ g : ℂ))
+        + ((Fintype.card K : ℂ) - 2) * (Vsub (K := K)).toRepresentation.character g := by
+  rw [rhsRep, char_prod]
+  simp only [charSumRep, VcopiesRep]
+  rw [char_directSum, char_directSum]
+  congr 1
+  · exact Finset.sum_congr rfl (fun χ _ => charRep_character' χ g)
+  · rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul,
+      Nat.cast_sub (by omega)]
+    push_cast
+    ring
+
+
 /-! ### Classification up to isomorphism: uniqueness of the irreducibles
 
 The classification (`irreducible_dim`) shows every irreducible has dimension `1` or `q-1`. We now

--- a/progress/2026-07-22T13-04-27Z_832f1125.md
+++ b/progress/2026-07-22T13-04-27Z_832f1125.md
@@ -1,0 +1,35 @@
+## Accomplished
+Partial progress on #7308 (V⊗V ≅ (⊕χ)⊕(q−2)V isomorphism for Problem 4.12.6).
+Landed **deliverable 2** and two reusable character-additivity lemmas in
+`EtingofRepresentationTheory/Chapter4/Problem4_12_6.lean` (sorry-free):
+
+- `char_prod`: `(ρ.prod σ).character = ρ.character + σ.character` (via `LinearMap.trace_prodMap'`).
+- `char_directSum`: character of a finite `Representation.directSum` is the sum of the
+  characters (via `DirectSum.lmap` = `∑ lof ∘ ρ ∘ component` + `trace_comp_comm'`). Both are
+  genuine Mathlib gaps (no additivity-over-⊕ lemma exists upstream).
+- `charRep_character'`: `Representation`-level character of `charRep χ` is `χ g`.
+- `charSumRep` (⊕_χ charRep χ), `VcopiesRep` (q−2 copies of V), and `rhsRep` = their product.
+- `rhsRep_character`: `rhsRep.character g = (∑_χ χ(g)) + (q−2)·χ_V(g)`, matching exactly the RHS of
+  the existing `Vrep_tprod_Vrep_decomp_character`.
+
+## Current frontier
+Deliverables 1 and 3 remain: the *reducible* "characters determine the representation"
+capstone (equal characters ⟹ isomorphic for f.d. complex reps of a finite group — a
+semisimple-module Krull–Schmidt / multiplicity-uniqueness theorem NOT in Mathlib or the repo),
+and the final assembly `V ⊗ V ≅ rhsRep`. Decomposed into a follow-up issue.
+
+## Overall project progress
+Stage 3 (formalization) ongoing in Chapter 4. Problem 4.12.6 file builds sorry-free at 1500+
+lines; character-level V⊗V decomposition + irreducible-case iso already done; this turn adds the
+reducible RHS model + character. Remaining: the reducible characters-determine-rep capstone.
+
+## Next step
+Take the follow-up capstone issue: prove `equiv_of_character_eq` for *reducible* reps (or a
+module-level Krull–Schmidt uniqueness over `MonoidAlgebra ℂ G`), then assemble
+`(Vsub.tprod Vsub).Equiv rhsRep` from `Vrep_tprod_Vrep_decomp_character` + `rhsRep_character`.
+Infra pointers: `Mathlib/RingTheory/SimpleModule/Isotypic.lean` (`IsIsotypic.linearEquiv_fun`,
+isotypic components), `FDRep.scalar_product_char_eq_finrank_equivariant`, and the repo's
+`Chapter3/Remark3_1_3.evalDirectSumEquiv`.
+
+## Blockers
+None (capstone is large but tractable; routed to a follow-up issue).


### PR DESCRIPTION
Partial progress on #7308

Session: `832f1125-b7fa-41b7-98fb-276846186878`

60df9457 feat(Ch4): reducible RHS model (⊕χ)⊕(q−2)V + character-additivity lemmas for Problem 4.12.6

🤖 Prepared with Claude Code