### PR TITLE
feat(Ch4): expose explicit 1-dim rep parametrization by abelianization for Problem 4.12.2(c)

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Problem4_12_2.lean
+++ b/EtingofRepresentationTheory/Chapter4/Problem4_12_2.lean
@@ -37,10 +37,11 @@ The (a)–(d) theorems below are all proved (`sorry`-free):
   `V` acting on the two generators by the shift and the multiplication operators. (Uniqueness
   holds because `xGen, yGen` generate `G`; this also determines `ρ(g)` for every `g`.)
 * **(b)** `irreducible_iff`: any such `R_z` is irreducible iff `z ≠ 1`.
-* **(c)** `one_dim_reps_card`: there are exactly `p²` one-dimensional representations (group
-  homomorphisms `G → ℂˣ`, since `G^{ab} ≅ (ZMod p)²`); `R1_decomposes`: `R_1` is an internal
-  direct sum of `p` one-dimensional `G`-invariant subspaces (each of the `p` distinct
-  characters of the cyclic quotient occurs exactly once).
+* **(c)** `oneDimRepEquiv`: the explicit bijection `χ ↦ χ ∘ abHom` parametrizing the
+  one-dimensional representations (characters `G → ℂˣ`) by characters of the abelianization
+  `G^{ab} ≅ (ZMod p)²`; `one_dim_reps_card`: hence there are exactly `p²` of them;
+  `R1_decomposes`: `R_1` is an internal direct sum of `p` one-dimensional `G`-invariant
+  subspaces (each of the `p` distinct characters of the cyclic quotient occurs exactly once).
 * **(d)** `simple_iso_charRep_or_rhoHom`: the full classification — every finite-dimensional
   simple `G`-representation is isomorphic either to a `1`-dimensional character `charRep χ`
   (`χ : G → ℂˣ`) or to a `p`-dimensional `R_z = rhoHom z` (`z ≠ 1` a `p`-th root of unity).
@@ -511,19 +512,38 @@ theorem abHom_ker_le_ker [Fact p.Prime] (ρ : Heisenberg p →* ℂˣ) :
   rw [hg_eq]
   exact pow_mem central_mem_commutator _
 
-/-- **Part (c), classification of `1`-dimensional representations.** The one-dimensional
+/-- **Part (c), explicit classification of `1`-dimensional representations.** The one-dimensional
+complex representations of the Heisenberg group `G` are its group homomorphisms `G →* ℂˣ`, and
+since every such character kills the commutator subgroup they are exactly the pullbacks along the
+abelianization map `abHom : G →* (ZMod p)²` of characters of `(ZMod p)²`. This records that
+explicit parametrization as a bijection
+
+`(Multiplicative (ZMod p × ZMod p) →* ℂˣ) ≃ (Heisenberg p →* ℂˣ)`, `χ ↦ χ ∘ abHom`,
+
+mirroring the `GL₂` precedent `Etingof.Discussion_1dim_reps.characterCompDetEquiv`. The count
+`p²` (`one_dim_reps_card`) is the cardinality of the domain. -/
+noncomputable def oneDimRepEquiv (p : ℕ) [Fact p.Prime] :
+    (Multiplicative (ZMod p × ZMod p) →* ℂˣ) ≃ (Heisenberg p →* ℂˣ) :=
+  (MonoidHom.liftOfSurjective (abHom p) (abHom_surjective p)).symm.trans
+    (Equiv.subtypeUnivEquiv (fun ρ => abHom_ker_le_ker ρ))
+
+/-- The classification bijection sends a character `χ` of the abelianization `(ZMod p)²` to the
+one-dimensional representation `g ↦ χ (abHom g)` of `G`. -/
+@[simp]
+theorem oneDimRepEquiv_apply [Fact p.Prime]
+    (χ : Multiplicative (ZMod p × ZMod p) →* ℂˣ) :
+    oneDimRepEquiv p χ = χ.comp (abHom p) := rfl
+
+/-- **Part (c), count of `1`-dimensional representations.** The one-dimensional
 complex representations of the Heisenberg group are its group homomorphisms to `ℂˣ`, and there
-are exactly `p²` of them (the abelianization is `(ZMod p)²`). -/
+are exactly `p²` of them: `oneDimRepEquiv` bijects them with the characters of the abelianization
+`(ZMod p)²`. -/
 theorem one_dim_reps_card [Fact p.Prime] :
     Nat.card (Heisenberg p →* ℂˣ) = p ^ 2 := by
   haveI : NeZero p := ⟨(Fact.out : p.Prime).ne_zero⟩
-  -- Characters of `G` correspond bijectively to characters of the abelianization `(ZMod p)²`.
-  let e : (Multiplicative (ZMod p × ZMod p) →* ℂˣ) ≃ (Heisenberg p →* ℂˣ) :=
-    (MonoidHom.liftOfSurjective (abHom p) (abHom_surjective p)).symm.trans
-      (Equiv.subtypeUnivEquiv (fun ρ => abHom_ker_le_ker ρ))
   haveI : NeZero ((Monoid.exponent (Multiplicative (ZMod p × ZMod p)) : ℕ) : ℂ) :=
     ⟨Nat.cast_ne_zero.mpr Monoid.exponent_ne_zero_of_finite⟩
-  rw [← Nat.card_congr e,
+  rw [← Nat.card_congr (oneDimRepEquiv p),
     CommGroup.card_monoidHom_of_hasEnoughRootsOfUnity (Multiplicative (ZMod p × ZMod p)) ℂ,
     Nat.card_eq_fintype_card, Fintype.card_multiplicative, Fintype.card_prod, ZMod.card]
   ring

--- a/progress/2026-07-22T13-40-06Z_61c6edc1.md
+++ b/progress/2026-07-22T13-40-06Z_61c6edc1.md
@@ -1,0 +1,59 @@
+## Accomplished
+
+Executed feature issue #7321 (`/work` → `/feature`): expose the explicit
+1-dimensional-representation classification of the Heisenberg group as a named
+headline, upgrading Problem 4.12.2 part (c) from `covered_partial` to
+`covered_full`.
+
+- Added `Etingof.Problem4_12_2.oneDimRepEquiv`
+  `(Multiplicative (ZMod p × ZMod p) →* ℂˣ) ≃ (Heisenberg p →* ℂˣ)`, `χ ↦ χ ∘ abHom`,
+  lifting the previously proof-local `let e` out of `one_dim_reps_card`. This
+  mirrors the GL₂ sibling `Chapter5/Discussion_1dim_reps.characterCompDetEquiv`
+  (same construction: `MonoidHom.liftOfSurjective (abHom p) … |>.symm.trans
+  (Equiv.subtypeUnivEquiv …)`), and is the analogue that made that item
+  `covered_full`.
+- Added the `@[simp]` `oneDimRepEquiv_apply : oneDimRepEquiv p χ = χ.comp (abHom p)`
+  (`rfl`), pinning the map to the pullback along the abelianization.
+- Refactored `one_dim_reps_card` to derive `p²` as the domain cardinality of
+  `oneDimRepEquiv` (no longer an internal `let e`).
+- Updated the module docstring header entry for part (c).
+- Flipped `Chapter4/Problem4.12.2` part (c) to `covered_full` in
+  `progress/items.json`, recording the new `lean_decl` pointers and reason.
+
+Build: `lake build EtingofRepresentationTheory.Chapter4.Problem4_12_2` succeeds
+(only pre-existing `show`-linter style warnings, none in the new region). Axioms
+clean: `oneDimRepEquiv`, `oneDimRepEquiv_apply`, `one_dim_reps_card` all depend
+only on `{propext, Classical.choice, Quot.sound}` (no `sorryAx`).
+
+## Current frontier
+
+Problem 4.12.2 part (c) is now fully covered. Part (d) remains
+`covered_partial` (issue #7322: expose the grand-total count / exhaustion
+headline `p² + (p−1)`).
+
+## Overall project progress
+
+Chapter 4 §4.12 classification work ongoing. This turn closes one of the two
+follow-up gaps the 4.12.2 coverage audit (#7317 / PR #7324) opened.
+
+## Coordination note
+
+The 4.12.2 coverage audit PR #7324 (still open, CI in progress at handoff) is
+the PR that introduces the per-sub-part `derived` array on
+`Chapter4/Problem4.12.2` with (c)=`covered_partial`. This PR replicates that
+same structure but with (c)=`covered_full` (and the parent roll-up left at
+`covered_partial`, since (d) is still partial). The two PRs edit the same
+items.json region, so whichever lands second will conflict — the correct
+resolution keeps this PR's (c)=`covered_full` entry (and #7322 will later flip
+(d)). The Lean headline is the substantive deliverable and is conflict-free.
+
+## Next step
+
+Take issue #7322: expose the total-count / exhaustion headline for part (d)
+(number of irreducibles = `p² + (p−1)`, or the enumeration bijection
+`iso-classes ≃ (Heisenberg p →* ℂˣ) ⊕ {z ≠ 0}`), lifting the internal `have`s
+`hcardChar`/`hcardJ`/`hEsum` out of `simple_iso_charRep_or_rhoHom`.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3132,7 +3132,79 @@
     "status": "sorry_free",
     "coverage_note": "Statement in EtingofRepresentationTheory/Chapter4/Problem4_12_2.lean: Heisenberg group over 𝔽_p (order p³). COMPLETE and sorry-free (#print axioms irreducible_dim = {propext, Classical.choice, Quot.sound}). Part (a) (#6017): card_eq (|G|=p³) and exists_unique_rep — R_z built explicitly as ρ⟨a,b,c⟩f(t)=z^(b·t-c)·f(t-a), uniqueness via generator word decomposition (xGen,yGen generate G). Part (b) (#6037): irreducible_iff — R_z simple ↔ z≠1. Part (c) (#6070): one_dim_reps_card (Nat.card (Heisenberg p →* ℂˣ) = p²) via abHom + CommGroup.card_monoidHom_of_hasEnoughRootsOfUnity; R1_decomposes (R₁ = internal direct sum of p one-dim lines) via DFT characters as shift-eigenvectors. Part (d) (#6094, #7211): full classification simple_iso_charRep_or_rhoHom (every finite-dim simple G-rep ≅ either FDRep.of (charRep χ), dim 1, or FDRep.of (rhoHom z), z≠1, dim p) — exhibit the p² characters and the p-1 reps R_z (z≠1 a p-th root) as pairwise non-isomorphic simples (separated by dimension and by the central character z^{(-1).val}·p on ⟨0,0,1⟩ via FDRep.char_iso), squared dims summing to p²·1+(p-1)·p²=p³=|G|; inject the family into the complete enumeration exists_simples_sum_finrank_sq_eq_card, use positivity of every dim² to force surjectivity (pigeonhole), hence every simple ≅ one of the family. Uniqueness within branches: charRep_iso_iff (characters iso ↔ equal), rhoHom_iso_iff (R_z iso ↔ roots agree); branches disjoint by charRep_not_iso_rhoHom (dim 1≠p). irreducible_dim (every irreducible has dim 1 or p) now derived from the classification: σ transported to ℂ's universe via transportModule/repOfModule to U:FDRep, then read off dim of the matching family member. All five headlines axiom-clean {propext, Classical.choice, Quot.sound}.",
     "fidelity": "faithful",
-    "fidelity_note": "[fidelity gap #7204 → RESOLVED by #7211/#7218] Parts (a)-(c) FAITHFUL & non-vacuous as headlines: group model is genuine order-p^3 Heisenberg group with correct generator matrices; exists_unique_rep is a real ∃! with the book's two generator actions; irreducible_iff is genuine IsSimpleModule over ℂ[G] with two-directional ↔ z≠1; one_dim_reps_card (p^2 chars) + R1_decomposes (internal direct sum of p distinct 1-dim isotypic lines, Injective χ = 'each once'). Part (d) gap CLOSED: the full part-(d) classification (exactly p^2 irreps of dim 1 and p-1 of dim p, p^2·1+(p-1)·p^2=p^3=|G| via sum-of-squares), previously proved only inside irreducible_dim, is now exposed as the named headline simple_iso_charRep_or_rhoHom (#7211). Original report: progress/reviews/2026-07-21-ch4-problem4_12_2-heisenberg-fidelity.md. All headlines axiom-clean (propext/Classical.choice/Quot.sound, no sorryAx)."
+    "fidelity_note": "[fidelity gap #7204 → RESOLVED by #7211/#7218] Parts (a)-(c) FAITHFUL & non-vacuous as headlines: group model is genuine order-p^3 Heisenberg group with correct generator matrices; exists_unique_rep is a real ∃! with the book's two generator actions; irreducible_iff is genuine IsSimpleModule over ℂ[G] with two-directional ↔ z≠1; one_dim_reps_card (p^2 chars) + R1_decomposes (internal direct sum of p distinct 1-dim isotypic lines, Injective χ = 'each once'). Part (d) gap CLOSED: the full part-(d) classification (exactly p^2 irreps of dim 1 and p-1 of dim p, p^2·1+(p-1)·p^2=p^3=|G| via sum-of-squares), previously proved only inside irreducible_dim, is now exposed as the named headline simple_iso_charRep_or_rhoHom (#7211). Original report: progress/reviews/2026-07-21-ch4-problem4_12_2-heisenberg-fidelity.md. All headlines axiom-clean (propext/Classical.choice/Quot.sound, no sorryAx).",
+    "coverage": "covered_partial",
+    "coverage_arm": "audited",
+    "lean_file": [
+      "EtingofRepresentationTheory/Chapter4/Problem4_12_2.lean"
+    ],
+    "fidelity_decl": [
+      "Etingof.Problem4_12_2.exists_unique_rep",
+      "Etingof.Problem4_12_2.irreducible_iff",
+      "Etingof.Problem4_12_2.one_dim_reps_card",
+      "Etingof.Problem4_12_2.R1_decomposes",
+      "Etingof.Problem4_12_2.simple_iso_charRep_or_rhoHom",
+      "Etingof.Problem4_12_2.irreducible_dim"
+    ],
+    "derived": [
+      {
+        "part": "(a)",
+        "description": "Show R_z exists and is unique, and compute ρ(g) for all g ∈ G (including |G| = p³).",
+        "coverage": "covered_full",
+        "lean_decl": [
+          "Etingof.Problem4_12_2.exists_unique_rep",
+          "Etingof.Problem4_12_2.rhoHom",
+          "Etingof.Problem4_12_2.rhoLin",
+          "Etingof.Problem4_12_2.rhoLin_apply",
+          "Etingof.Problem4_12_2.rhoHom_xGen",
+          "Etingof.Problem4_12_2.rhoHom_yGen",
+          "Etingof.Problem4_12_2.card_eq",
+          "Etingof.Problem4_12_2.eq_gen_prod",
+          "Etingof.Problem4_12_2.closure_gens_eq_top"
+        ],
+        "reason": "FULL and faithful. exists_unique_rep is a genuine ∃! Representation ℂ (Heisenberg p) (ZMod p → ℂ) whose defining conditions are exactly the book's two generator actions ((ρ xGen f) t = f(t-1) and (ρ yGen f) t = z^t.val·f t), so both existence AND uniqueness are stated (uniqueness proved via xGen,yGen generating G: closure_gens_eq_top + eq_gen_prod). 'Compute ρ(g) for all g' is covered explicitly by rhoLin/rhoLin_apply: ρ⟨a,b,c⟩ f t = z^(b·t-c).val · f(t-a) for every g. |G| = p³ is card_eq (Fintype.card (Heisenberg p) = p^3). All axiom-clean."
+      },
+      {
+        "part": "(b)",
+        "description": "R_z is irreducible if and only if z ≠ 1.",
+        "coverage": "covered_full",
+        "lean_decl": [
+          "Etingof.Problem4_12_2.irreducible_iff"
+        ],
+        "reason": "FULL and faithful. irreducible_iff states IsSimpleModule (MonoidAlgebra ℂ (Heisenberg p)) ρ.asModule ↔ z ≠ 1 for any ρ satisfying the two generator conditions — a genuine two-directional iff over the group algebra, non-vacuous (the reverse direction constructs the invariant constant line when z = 1, the forward builds simplicity from the shift/scaling action). Matches the book's 'R_z irreducible ⟺ z ≠ 1' exactly. Axiom-clean."
+      },
+      {
+        "part": "(c)",
+        "description": "Classify all 1-dimensional representations of G; show R_1 decomposes into a direct sum of 1-dim reps, each occurring exactly once.",
+        "coverage": "covered_full",
+        "lean_decl": [
+          "Etingof.Problem4_12_2.oneDimRepEquiv",
+          "Etingof.Problem4_12_2.oneDimRepEquiv_apply",
+          "Etingof.Problem4_12_2.one_dim_reps_card",
+          "Etingof.Problem4_12_2.R1_decomposes",
+          "Etingof.Problem4_12_2.abHom",
+          "Etingof.Problem4_12_2.abHom_surjective",
+          "Etingof.Problem4_12_2.abHom_ker_le_ker"
+        ],
+        "reason": "FULL (upgraded from covered_partial by #7321). Both clauses are now exposed headlines. Classification clause: oneDimRepEquiv is the explicit bijection (Multiplicative (ZMod p × ZMod p) →* ℂˣ) ≃ (Heisenberg p →* ℂˣ), χ ↦ χ ∘ abHom (pinned by the simp lemma oneDimRepEquiv_apply), parametrizing every 1-dim representation of G by a character of the abelianization (ZMod p)² — the exact analogue of the GL₂ sibling Chapter5/Discussion_1dim_reps.characterCompDetEquiv that made that item covered_full. one_dim_reps_card (Nat.card (Heisenberg p →* ℂˣ) = p²) now derives from oneDimRepEquiv as the domain cardinality; abHom_surjective / abHom_ker_le_ker supply surjectivity and injectivity of the parametrization. Decomposition clause (already full): R1_decomposes exhibits R₁ as a genuine DirectSum.IsInternal of p one-dimensional G-invariant lines (each finrank = 1), each the isotypic line of a character χ i, with the p characters pairwise distinct (Function.Injective χ) — a faithful encoding of 'each 1-dim rep occurs exactly once'.",
+        "resolved_by_issue": 7321
+      },
+      {
+        "part": "(d)",
+        "description": "Use (a)–(c) and the sum-of-squares formula to classify all irreducible representations of G (answer: p² one-dimensional plus p−1 of dimension p).",
+        "coverage": "covered_partial",
+        "lean_decl": [
+          "Etingof.Problem4_12_2.simple_iso_charRep_or_rhoHom",
+          "Etingof.Problem4_12_2.irreducible_dim",
+          "Etingof.Problem4_12_2.charRep_iso_iff",
+          "Etingof.Problem4_12_2.rhoHom_iso_iff",
+          "Etingof.Problem4_12_2.charRep_not_iso_rhoHom"
+        ],
+        "reason": "PARTIAL. The exhaustion trichotomy IS exposed: simple_iso_charRep_or_rhoHom proves every simple FDRep is iso to a 1-dim charRep χ or a p-dim rhoHom z (z≠1) — genuine 'these are all the irreducibles' via Artin–Wedderburn exists_simples_sum_finrank_sq_eq_card + pigeonhole surjectivity. irreducible_dim gives the dim-1-or-p dichotomy; charRep_iso_iff / rhoHom_iso_iff / charRep_not_iso_rhoHom give pairwise inequivalence. What is missing at headline level is the assembled GRAND TOTAL: the counts p² (characters) and p−1 (the R_z), and the sum-of-squares identity p²·1²+(p−1)·p²=p³=|G|, appear only as internal `have`s (hcardChar, hcardJ, hEsum) inside simple_iso_charRep_or_rhoHom's proof — there is no exposed 'number of irreducibles = p² + (p−1)' count theorem nor a bundled enumeration bijection (iso-classes ≃ (Heisenberg p →* ℂˣ) ⊕ {z≠1}). Mirrors the iso-vs-character-level partials recorded for 4.12.6/4.12.9. Follow-up feature issue #7322 to expose the total-count/exhaustion headline.",
+        "followup_issue": 7322
+      }
+    ],
+    "last_updated": "2026-07-22"
   },
   {
     "id": "Chapter4/Problem4.12.3",


### PR DESCRIPTION
Closes #7321

Session: `61c6edc1-3c70-4bb5-b5bb-22215e20de76`

0a2da1e0 feat(Ch4): expose oneDimRepEquiv 1-dim classification headline for Problem 4.12.2(c)

🤖 Prepared with Claude Code