### PR TITLE
fix(Ch8): dedupe isoPrecompHomEquiv and rename clashing evalTensor so full lake build links

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Problem4_12_10_OrbitEval.lean
+++ b/EtingofRepresentationTheory/Chapter4/Problem4_12_10_OrbitEval.lean
@@ -87,47 +87,47 @@ variable {V : Type} [AddCommGroup V] [Module ℂ V] [Module.Finite ℂ V]
 
 /-- The evaluation of a degree-`n` **tensor** at a covector `p`, `⨂ᵢ vᵢ ↦ ∏ᵢ p vᵢ`, realised as
 the image of the constant `n`-fold tensor `⨂ₜ p` under `PiTensorProduct.dualDistrib`. -/
-def evalTensor (p : Module.Dual ℂ V) (n : ℕ) : (⨂[ℂ]^n V) →ₗ[ℂ] ℂ :=
+def evalTensorPow (p : Module.Dual ℂ V) (n : ℕ) : (⨂[ℂ]^n V) →ₗ[ℂ] ℂ :=
   PiTensorProduct.dualDistrib (⨂ₜ[ℂ] (_ : Fin n), p)
 
-@[simp] lemma evalTensor_tprod (p : Module.Dual ℂ V) (n : ℕ) (v : Fin n → V) :
-    evalTensor p n (PiTensorProduct.tprod ℂ v) = ∏ i, p (v i) := by
-  simp only [evalTensor, PiTensorProduct.dualDistrib_apply]
+@[simp] lemma evalTensorPow_tprod (p : Module.Dual ℂ V) (n : ℕ) (v : Fin n → V) :
+    evalTensorPow p n (PiTensorProduct.tprod ℂ v) = ∏ i, p (v i) := by
+  simp only [evalTensorPow, PiTensorProduct.dualDistrib_apply]
 
 /-- The evaluation of a degree-`n` **symmetric tensor** at a covector `p`, `⨂ₛᵢ vᵢ ↦ ∏ᵢ p vᵢ`.
-Since `∏ᵢ p vᵢ` is symmetric in the `vᵢ`, `evalTensor` descends through the symmetrization
+Since `∏ᵢ p vᵢ` is symmetric in the `vᵢ`, `evalTensorPow` descends through the symmetrization
 quotient `SymmetricPower.mk`. -/
 def evalAt (p : Module.Dual ℂ V) (n : ℕ) : Sym[ℂ]^n V →ₗ[ℂ] ℂ where
-  toFun := AddCon.lift _ (evalTensor p n).toAddMonoidHom (fun x y h => by
+  toFun := AddCon.lift _ (evalTensorPow p n).toAddMonoidHom (fun x y h => by
     induction h with
     | of x y h => cases h with
       | perm e f =>
-        show evalTensor p n (PiTensorProduct.tprod ℂ f)
-          = evalTensor p n (PiTensorProduct.tprod ℂ fun i => f (e i))
-        rw [evalTensor_tprod, evalTensor_tprod]
+        show evalTensorPow p n (PiTensorProduct.tprod ℂ f)
+          = evalTensorPow p n (PiTensorProduct.tprod ℂ fun i => f (e i))
+        rw [evalTensorPow_tprod, evalTensorPow_tprod]
         exact (Equiv.prod_comp e (fun i => p (f i))).symm
     | refl => rfl
     | symm _ ih => exact ih.symm
     | trans _ _ ih₁ ih₂ => exact ih₁.trans ih₂
     | add _ _ ih₁ ih₂ =>
-        show evalTensor p n (_ + _) = evalTensor p n (_ + _)
+        show evalTensorPow p n (_ + _) = evalTensorPow p n (_ + _)
         rw [map_add, map_add]
         exact congr_arg₂ (· + ·) ih₁ ih₂)
   map_add' x y := by
     refine AddCon.induction_on₂ x y (fun a b => ?_)
-    change evalTensor p n (a + b) = evalTensor p n a + evalTensor p n b
+    change evalTensorPow p n (a + b) = evalTensorPow p n a + evalTensorPow p n b
     rw [map_add]
   map_smul' r x := by
     refine AddCon.induction_on x (fun a => ?_)
-    change evalTensor p n (r • a) = r • evalTensor p n a
+    change evalTensorPow p n (r • a) = r • evalTensorPow p n a
     rw [map_smul]
 
 @[simp] lemma evalAt_mk (p : Module.Dual ℂ V) (n : ℕ) (x : ⨂[ℂ]^n V) :
-    evalAt p n (SymmetricPower.mk ℂ (Fin n) V x) = evalTensor p n x := rfl
+    evalAt p n (SymmetricPower.mk ℂ (Fin n) V x) = evalTensorPow p n x := rfl
 
 @[simp] lemma evalAt_mk_tprod (p : Module.Dual ℂ V) (n : ℕ) (v : Fin n → V) :
     evalAt p n (SymmetricPower.mk ℂ (Fin n) V (PiTensorProduct.tprod ℂ v)) = ∏ i, p (v i) := by
-  rw [evalAt_mk, evalTensor_tprod]
+  rw [evalAt_mk, evalTensorPow_tprod]
 
 /-- Naturality of `evalAt` in the covector: evaluating `symmetricPowerMap f x` at `p` is the same
 as evaluating `x` at the pulled-back covector `p ∘ₗ f`. -/
@@ -135,12 +135,12 @@ lemma evalAt_symmetricPowerMap (p : Module.Dual ℂ V) (n : ℕ) (f : V →ₗ[�
     evalAt p n (symmetricPowerMap f x) = evalAt (p ∘ₗ f) n x := by
   obtain ⟨y, rfl⟩ := LinearMap.range_eq_top.mp (SymmetricPower.range_mk ℂ (Fin n) V) x
   rw [symmetricPowerMap_mk, evalAt_mk, evalAt_mk]
-  have key : evalTensor p n ∘ₗ PiTensorProduct.map (fun _ : Fin n => f) = evalTensor (p ∘ₗ f) n := by
+  have key : evalTensorPow p n ∘ₗ PiTensorProduct.map (fun _ : Fin n => f) = evalTensorPow (p ∘ₗ f) n := by
     apply PiTensorProduct.ext
     apply MultilinearMap.ext
     intro v
     simp only [LinearMap.compMultilinearMap_apply, LinearMap.comp_apply,
-      PiTensorProduct.map_tprod, evalTensor_tprod]
+      PiTensorProduct.map_tprod, evalTensorPow_tprod]
   exact LinearMap.congr_fun key y
 
 /-! ## The orbit-evaluation map -/

--- a/EtingofRepresentationTheory/Chapter8/HomComplexHomologyK.lean
+++ b/EtingofRepresentationTheory/Chapter8/HomComplexHomologyK.lean
@@ -1,4 +1,5 @@
 import EtingofRepresentationTheory.Chapter8.ExtCohomologyHomK
+import EtingofRepresentationTheory.Chapter8.IsoPrecompHomEquiv
 import Mathlib.CategoryTheory.Abelian.Projective.Extend
 import Mathlib.Algebra.Homology.HomotopyCategory.HomComplexSingle
 import Mathlib.Algebra.Homology.HomotopyCategory.HomComplexCohomology
@@ -48,23 +49,6 @@ namespace Etingof
 variable (k : Type u) [Field k]
 variable {A : Type u} [Ring A] [Algebra k A]
 variable {M : ModuleCat.{u} A} (N : ModuleCat.{u} A) (P : ProjectiveResolution M)
-
-/-- Precomposition with an isomorphism, as an additive equivalence of hom-groups. -/
-def isoPrecompHomEquiv {C : Type*} [Category C] [Preadditive C] {X X' Y : C} (α : X ≅ X') :
-    (X ⟶ Y) ≃+ (X' ⟶ Y) where
-  toFun f := α.inv ≫ f
-  invFun g := α.hom ≫ g
-  left_inv f := by simp
-  right_inv g := by simp
-  map_add' f g := by simp only [Preadditive.comp_add]
-
-@[simp] lemma isoPrecompHomEquiv_apply {C : Type*} [Category C] [Preadditive C]
-    {X X' Y : C} (α : X ≅ X') (f : X ⟶ Y) :
-    isoPrecompHomEquiv α f = α.inv ≫ f := rfl
-
-@[simp] lemma isoPrecompHomEquiv_symm_apply {C : Type*} [Category C] [Preadditive C]
-    {X X' Y : C} (α : X ≅ X') (g : X' ⟶ Y) :
-    (isoPrecompHomEquiv α).symm g = α.hom ≫ g := rfl
 
 /-- The `AddCommGrp`-valued `HomComplex` of the projective resolution into `N[0]`, whose degree-`n`
 homology underlies the derived-category `Ext`. -/

--- a/EtingofRepresentationTheory/Chapter8/IsoPrecompHomEquiv.lean
+++ b/EtingofRepresentationTheory/Chapter8/IsoPrecompHomEquiv.lean
@@ -1,0 +1,34 @@
+import Mathlib.CategoryTheory.Preadditive.Basic
+
+/-!
+# Precomposition with an isomorphism as an additive equivalence
+
+`Etingof.isoPrecompHomEquiv` packages precomposition with an isomorphism `α : X ≅ X'` in a
+preadditive category as an additive equivalence `(X ⟶ Y) ≃+ (X' ⟶ Y)`. It is a small shared
+helper used by both `HomComplexHomologyK` and `Problem8_2_6_ii_Crux` to identify the degree-`i`
+terms of a `HomComplex` with categorical hom-groups; it lives in its own file so the two callers
+can import it without duplicating the definition.
+-/
+
+open CategoryTheory
+
+namespace Etingof
+
+/-- Precomposition with an isomorphism, as an additive equivalence of hom-groups. -/
+def isoPrecompHomEquiv {C : Type*} [Category C] [Preadditive C] {X X' Y : C} (α : X ≅ X') :
+    (X ⟶ Y) ≃+ (X' ⟶ Y) where
+  toFun f := α.inv ≫ f
+  invFun g := α.hom ≫ g
+  left_inv f := by simp
+  right_inv g := by simp
+  map_add' f g := by simp only [Preadditive.comp_add]
+
+@[simp] lemma isoPrecompHomEquiv_apply {C : Type*} [Category C] [Preadditive C]
+    {X X' Y : C} (α : X ≅ X') (f : X ⟶ Y) :
+    isoPrecompHomEquiv α f = α.inv ≫ f := rfl
+
+@[simp] lemma isoPrecompHomEquiv_symm_apply {C : Type*} [Category C] [Preadditive C]
+    {X X' Y : C} (α : X ≅ X') (g : X' ⟶ Y) :
+    (isoPrecompHomEquiv α).symm g = α.hom ≫ g := rfl
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_6_ii_Crux.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_6_ii_Crux.lean
@@ -1,4 +1,5 @@
 import EtingofRepresentationTheory.Chapter8.BarResolution
+import EtingofRepresentationTheory.Chapter8.IsoPrecompHomEquiv
 import EtingofRepresentationTheory.Chapter3.Problem3_9_1
 import Mathlib.CategoryTheory.Abelian.Projective.Ext
 import Mathlib.Algebra.Homology.HomotopyCategory.HomComplexSingle
@@ -31,23 +32,6 @@ open Etingof.BarResolution
 variable (k A W V : Type u) [Field k] [Ring A] [Algebra k A]
   [AddCommGroup V] [Module k V] [Module A V] [IsScalarTower k A V]
   [AddCommGroup W] [Module k W] [Module A W] [IsScalarTower k A W]
-
-/-- Precomposition with an isomorphism, as an additive equivalence of hom-groups. -/
-def isoPrecompHomEquiv {C : Type*} [Category C] [Preadditive C] {X X' Y : C} (α : X ≅ X') :
-    (X ⟶ Y) ≃+ (X' ⟶ Y) where
-  toFun f := α.inv ≫ f
-  invFun g := α.hom ≫ g
-  left_inv f := by simp
-  right_inv g := by simp
-  map_add' f g := by simp only [Preadditive.comp_add]
-
-@[simp] lemma isoPrecompHomEquiv_apply {C : Type*} [Category C] [Preadditive C]
-    {X X' Y : C} (α : X ≅ X') (f : X ⟶ Y) :
-    isoPrecompHomEquiv α f = α.inv ≫ f := rfl
-
-@[simp] lemma isoPrecompHomEquiv_symm_apply {C : Type*} [Category C] [Preadditive C]
-    {X X' Y : C} (α : X ≅ X') (g : X' ⟶ Y) :
-    (isoPrecompHomEquiv α).symm g = α.hom ≫ g := rfl
 
 /-- The bar cochain complex `Hom(barResolution, −)` lives here: it is the integer-graded
 extension of the bar chain complex. -/

--- a/progress/2026-07-22T13-57-17Z_446a871e.md
+++ b/progress/2026-07-22T13-57-17Z_446a871e.md
@@ -1,0 +1,54 @@
+## Accomplished
+
+Fixed issue #7326 (full `lake build` broken by duplicate symbols invisible to
+leaf-only CI). The default `lake build EtingofRepresentationTheory` target
+(Chapter aggregators + root) now succeeds green (9226 jobs).
+
+Found and resolved **two** independent duplicate-symbol collisions (the reporter
+saw only the first, since Lean aborts at the first colliding import):
+
+1. **`Etingof.isoPrecompHomEquiv`** — defined character-for-character identically
+   in `Chapter8/HomComplexHomologyK.lean` and `Chapter8/Problem8_2_6_ii_Crux.lean`
+   (both fully general `{C} [Category C] [Preadditive C]`). Extracted the def and
+   its two simp lemmas into a new shared file
+   `Chapter8/IsoPrecompHomEquiv.lean` (imports only
+   `Mathlib.CategoryTheory.Preadditive.Basic`), imported by both callers.
+   Chose a shared file over pointing one caller at the other to avoid dragging
+   the heavy `Ext` machinery of `HomComplexHomologyK` into the bar-resolution
+   `Crux` file.
+
+2. **`Etingof.evalTensor`** — a genuine *name clash* between two distinct objects:
+   `Chapter3/Remark3_1_3.lean` (`Hom_A(X,V) ⊗ X →ₗ V`, `g ⊗ x ↦ g x`) and
+   `Chapter4/Problem4_12_10_OrbitEval.lean` (`(Module.Dual ℂ V) (n) : ⨂ⁿV →ₗ ℂ`,
+   `⨂vᵢ ↦ ∏ p vᵢ`). Renamed the Chapter 4 one to `evalTensorPow`. The symbol is
+   used only within its own file (no downstream importer references the name), so
+   the rename is fully local.
+
+Verified there are no further clashes: after both fixes the root build links
+cleanly.
+
+## Current frontier
+
+Issue #7326 complete. PR created and auto-merge enabled.
+
+## Overall project progress
+
+Stage 3.x formalization of Chapters 4/5/8 ongoing. This was an infrastructure
+fix, not a content item. The root `lake build` is green again; note CI's
+leaf-only build (`find ... -mindepth 2 | xargs lake build`) still does not link
+the depth-1 aggregators, so future same-namespace duplicate `def`s could
+reintroduce this class of breakage undetected by CI.
+
+## Next step
+
+Resume the highest-priority unclaimed work item. Candidates at session start:
+#7306 (review Problem 4.12.7), #7320 (review Exercise 5.27.2), #7322 (feat
+4.12.2(d) exhaustion headline).
+
+Consider (future planner): a CI step that runs the default `lake build` target
+(or builds the Chapter aggregators + root) so this duplicate-symbol class is
+caught automatically rather than incidentally.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7326

Session: `446a871e-e541-40c0-9235-c393dd0ce089`

e2933b8c doc: progress note for #7326 full-build dedupe
cbec3c5d fix(Ch8): dedupe isoPrecompHomEquiv and rename clashing evalTensor so full lake build links

🤖 Prepared with Claude Code