### PR TITLE
review(Stage3.7): Problem 5.24.1 (Specht module V_λ ≅ ℂ[Sₙ]bₐaₐ & sign-twist duality V_λ⊗ℂ₋ = V_{λ*}) coverage-arm audit at sub-part granularity

### DIFF
--- a/progress/2026-07-22T14-02-15Z_66dfac3a.md
+++ b/progress/2026-07-22T14-02-15Z_66dfac3a.md
@@ -1,0 +1,59 @@
+## Accomplished
+
+Stage 3.7 **coverage-arm** audit of **Problem 5.24.1** (Chapter 5 — Specht module
+`V_λ ≅ ℂ[Sₙ]bₗaₗ` and the sign-twist duality `V_λ⊗ℂ₋ = V_{λ*}`), issue #7328.
+Report-only: no Lean proof edits.
+
+Compared the Lean **statements** (not just names) against the blob
+(`blobs/Chapter5/Problem5.24.1.md`) at sub-part granularity, applying the Stage
+3.2 step 6–7 fidelity tests. Verdicts:
+
+- **Part (a)** — `covered_full`. `Etingof.rowColIdeal_iso_spechtModule`
+  (`Problem5_24_1.lean`) is an exposed headline: an existential ℂ-linear
+  equivalence `rowColIdeal n la (= book V_λ = ℂ[Sₙ]·aₗbₗ) ≃ SpechtModule n la
+  (= V'_λ = ℂ[Sₙ]·bₗaₗ)` together with the intertwining condition
+  `e ((of g) • x) = (of g) • e x` for **every** group element `g`, i.e. a genuine
+  Sₙ-linear iso (not merely ℂ-linear, not vacuous). Built per the book's hint
+  (`Fa: x↦x·a`, `Gb: y↦y·b`, composites `α·id` from Lemma5_13_3 + Lemma5_13_1_dual).
+
+- **Part (b)** — `covered_full`. All three book clauses are exposed headlines:
+  - `signTwist_smul_of`: for any ℂ[Sₙ]-module `V`, `φ(of g) • v = sign(g)•((of g)•v)`
+    — the defining action of the sign-twist `V⊗ℂ₋` (action-identity form, arbitrary V).
+  - `signTwist_map_leftIdeal`: `Ideal.map (signTwist n) (span{a}) = span{signTwist n a}`
+    — the exact `φ(ℂ[Sₙ]a)=ℂ[Sₙ]φ(a)`.
+  - `spechtModule_signTwist_iso_conjugate`: existential ℂ-linear equiv
+    `SpechtModule n la ≃ SpechtModule n (conjugatePartition la)` with twisted
+    intertwining `e((of g)•x)=sign(g)•((of g)•e x)` — the genuine `V_λ⊗ℂ₋ ≅ V_{λ*}`,
+    with `conjugatePartition` the real transpose partition (rowLens of
+    `toYoungDiagram.transpose`).
+
+Roll-up `coverage = min = covered_full`. Recorded durable state in
+`progress/items.json` on `Chapter5/Problem5.24.1`: `coverage: covered_full`,
+`coverage_arm: audited`, `lean_file` (both files), `fidelity_decl` (4 headlines),
+and a `derived` array with per-sub-part `(a)/(b)` verdicts + `lean_decl` pointers
++ one-line claims. `status` (`proved`) and `coverage_note` left untouched.
+
+Both Lean files are sorry-free and free of `admit`/`native_decide`/`axiom`/`sorryAx`
+(verified by grep).
+
+## Current frontier
+
+Problem 5.24.1 coverage-arm audit closed. No follow-up feature issue was opened —
+both sub-parts are `covered_full` (deliverable step 3 requires a follow-up only for
+partials/gaps).
+
+## Overall project progress
+
+Stage 3.7 §-by-§ coverage-arm sweep continues. §4.12 (4.12.1 #7314, 4.12.2 #7317,
+4.12.7 #7306) and Ch5 Exercise 5.27.2 (#7320) in flight; this closes
+Chapter5/Problem5.24.1. `coverage_arm: audited` count in items.json now includes
+5.24.1.
+
+## Next step
+
+Continue the coverage-arm sweep on the remaining unclaimed review issues (#7306
+Problem 4.12.7, #7320 Exercise 5.27.2).
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -5199,7 +5199,47 @@
     "start_line": 3,
     "end_line": 14,
     "status": "proved",
-    "coverage_note": "BOTH PARTS PROVED sorry-free (axiom-clean: propext/Classical.choice/Quot.sound). Part (a) rowColIdeal_iso_spechtModule (Chapter5/Problem5_24_1.lean): S_n-equivariant iso C[S_n]·(a_lambda b_lambda) = V_lambda ≅ C[S_n]·(b_lambda a_lambda) = V'_lambda via mutually-inverse right-multiplication maps, using c_lambda²=α·c_lambda (Lemma5_13_3) + mirror (Lemma5_13_1_dual). Part (b) Chapter5/Problem5_24_1_b.lean: signTwist_smul_of (phi maps V to V⊗C_-), signTwist_map_leftIdeal (phi(C[S_n]·a)=C[S_n]·phi(a)), and spechtModule_signTwist_iso_conjugate (V_lambda⊗C_- ≅ V_{lambda*}). The last is the composite SpechtModule λ --phi--> C[S_n]·phi(c_λ) --·of τ⁻¹--> rowColIdeal λ* --part(a)--> SpechtModule λ*, where τ (transposePerm) is the tableau-transposition permutation conjugating the row/column subgroups of λ to the column/row subgroups of λ* (mem_rowSubgroup_conj/mem_columnSubgroup_conj); key algebraic identity of τ · phi(c_λ) · of τ⁻¹ = a_{λ*} b_{λ*} (key_identity). conjugatePartition parts_sum discharged (card_transpose)."
+    "coverage_note": "BOTH PARTS PROVED sorry-free (axiom-clean: propext/Classical.choice/Quot.sound). Part (a) rowColIdeal_iso_spechtModule (Chapter5/Problem5_24_1.lean): S_n-equivariant iso C[S_n]·(a_lambda b_lambda) = V_lambda ≅ C[S_n]·(b_lambda a_lambda) = V'_lambda via mutually-inverse right-multiplication maps, using c_lambda²=α·c_lambda (Lemma5_13_3) + mirror (Lemma5_13_1_dual). Part (b) Chapter5/Problem5_24_1_b.lean: signTwist_smul_of (phi maps V to V⊗C_-), signTwist_map_leftIdeal (phi(C[S_n]·a)=C[S_n]·phi(a)), and spechtModule_signTwist_iso_conjugate (V_lambda⊗C_- ≅ V_{lambda*}). The last is the composite SpechtModule λ --phi--> C[S_n]·phi(c_λ) --·of τ⁻¹--> rowColIdeal λ* --part(a)--> SpechtModule λ*, where τ (transposePerm) is the tableau-transposition permutation conjugating the row/column subgroups of λ to the column/row subgroups of λ* (mem_rowSubgroup_conj/mem_columnSubgroup_conj); key algebraic identity of τ · phi(c_λ) · of τ⁻¹ = a_{λ*} b_{λ*} (key_identity). conjugatePartition parts_sum discharged (card_transpose).",
+    "coverage": "covered_full",
+    "coverage_arm": "audited",
+    "lean_file": [
+      "EtingofRepresentationTheory/Chapter5/Problem5_24_1.lean",
+      "EtingofRepresentationTheory/Chapter5/Problem5_24_1_b.lean"
+    ],
+    "fidelity_decl": [
+      "Etingof.rowColIdeal_iso_spechtModule",
+      "Etingof.signTwist_smul_of",
+      "Etingof.signTwist_map_leftIdeal",
+      "Etingof.spechtModule_signTwist_iso_conjugate"
+    ],
+    "derived": [
+      {
+        "part": "(a)",
+        "description": "Show V'_λ := ℂ[Sₙ] bₗ aₗ is isomorphic to V_λ (the two orderings of the Young symmetrizer give isomorphic Sₙ-modules).",
+        "coverage": "covered_full",
+        "lean_decl": [
+          "Etingof.rowColIdeal",
+          "Etingof.rowColIdeal_iso_spechtModule"
+        ],
+        "reason": "FULL and faithful. rowColIdeal_iso_spechtModule is an exposed headline giving an existential ℂ-linear equivalence e : rowColIdeal n la (the book's V_λ = ℂ[Sₙ]·(aₗ bₗ)) ≃ SpechtModule n la (the project's V'_λ = ℂ[Sₙ]·(bₗ aₗ)) together with the intertwining condition e ((of g) • x) = (of g) • e x for EVERY group element g : Equiv.Perm (Fin n) — so e is a genuine Sₙ-linear iso, not merely ℂ-linear. The iso is built exactly per the book's hint (right-multiplication maps Fa: x ↦ x·a and Gb: y ↦ y·b, composites α·id via c_λ² = α·c_λ from Lemma5_13_3 and the mirror Lemma5_13_1_dual, α ≠ 0). Non-vacuous: both ideals are the actual principal left ideals and the equivalence is proved bijective. Axiom-clean."
+      },
+      {
+        "part": "(b)",
+        "description": "φ(s)=(-1)^s s maps any rep V to V⊗ℂ₋; φ(ℂ[Sₙ]a) = ℂ[Sₙ]φ(a); deduce V_λ⊗ℂ₋ = V_{λ*}, λ* the conjugate partition.",
+        "coverage": "covered_full",
+        "lean_decl": [
+          "Etingof.signTwist",
+          "Etingof.signTwist_of",
+          "Etingof.signTwist_bijective",
+          "Etingof.signTwist_smul_of",
+          "Etingof.signTwist_map_leftIdeal",
+          "Etingof.conjugatePartition",
+          "Etingof.spechtModule_signTwist_iso_conjugate"
+        ],
+        "reason": "FULL and faithful. All three book clauses are exposed headlines. (i) signTwist is the genuine sign-twist algebra automorphism φ(g)=sign(g)·g (signTwist_of), an involution hence bijective (signTwist_bijective). (ii) 'φ maps V to V⊗ℂ₋': signTwist_smul_of states, for ANY ℂ[Sₙ]-module V, (φ(of g)) • v = sign(g) • ((of g) • v) — exactly the defining action of the sign-character twist V⊗ℂ₋ on every group generator (action-identity form, stated for arbitrary V). (iii) 'φ(ℂ[Sₙ]a) = ℂ[Sₙ]φ(a)': signTwist_map_leftIdeal states Ideal.map (signTwist n) (Ideal.span {a}) = Ideal.span {signTwist n a} — the exact left-ideal identity. (iv) deduction V_λ⊗ℂ₋ = V_{λ*}: spechtModule_signTwist_iso_conjugate gives an existential ℂ-linear equivalence SpechtModule n la ≃ SpechtModule n (conjugatePartition la) with the twisted-intertwining e ((of g)•x) = sign(g) • ((of g) • e x) for every g — i.e. V_λ with sign-twisted action (= V_λ⊗ℂ₋) is iso to V_{λ*}. conjugatePartition is the genuine transpose partition (rowLens of toYoungDiagram.transpose, parts_sum via card_transpose), and the iso is the honest composite φ → right-mult by of τ⁻¹ (τ = transposePerm conjugating row/column subgroups) → part-(a) iso, anchored by key_identity τ·φ(c_λ)·of τ⁻¹ = a_{λ*} b_{λ*}. Non-vacuous throughout. Axiom-clean."
+      }
+    ],
+    "last_updated": "2026-07-22"
   },
   {
     "id": "Chapter5/Problem5.24.2",


### PR DESCRIPTION
Closes #7328

Session: `66dfac3a-4d38-4e41-ad52-c347e6b601f8`

fd6ecf41 review(Stage3.7 #7328): coverage-arm audit of Problem 5.24.1 Specht module — (a)/(b) both covered_full

🤖 Prepared with Claude Code