### PR TITLE
review(Stage3.7): Exercise 5.27.2 (redo Problems 4.12.1(a)/4.12.2/4.12.6 via Theorem 5.27.1 — semidirect-product classification) coverage-arm audit at sub-part granularity

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -59,6 +59,26 @@ target does not import. Running against the actual source file only needs the
 target's own already-built dependency oleans, so it works after a successful
 `lake build EtingofRepresentationTheory.<Module>`.
 
+## Editing `progress/items.json` (coverage-arm audits)
+
+Coverage-arm audits record verdicts by editing one entry in
+`progress/items.json` — a single ~8000-line JSON array shared by every session.
+When you rewrite it programmatically (e.g. Python `json.dump`), **match the
+existing serialization exactly or you will reformat the whole file** into a
+spurious multi-thousand-line diff that is merge-conflict bait and hides your real
+change. The file uses `indent=2`, `ensure_ascii=False` (unicode kept literal, not
+`\uXXXX`), and a trailing newline. Concretely:
+
+```python
+json.dump(items, open(p, "w"), indent=2, ensure_ascii=False)
+open(p, "a").write("\n")   # restore trailing newline json.dump omits
+```
+
+Then **verify the diff is localized** before committing:
+`git diff --stat progress/items.json` should report a handful of changed lines,
+not thousands. If it is large, `git checkout progress/items.json` and redo with
+the right format. Prefer editing the single target entry over touching others.
+
 ## Completing the Review
 
 Post your report as a comment on the review issue. Then close the issue yourself —

--- a/progress/2026-07-22T14-03-22Z_5b1300c8.md
+++ b/progress/2026-07-22T14-03-22Z_5b1300c8.md
@@ -1,0 +1,64 @@
+## Accomplished
+
+Stage 3.7 **coverage-arm** audit of **Exercise 5.27.2** (#7320) — "Redo Problems
+4.12.1(a), 4.12.2, and 4.12.6 using Theorem 5.27.1". Report-only; no Lean source
+modified. Recorded per-sub-part `coverage` verdicts, `lean_decl` pointers, and a
+roll-up in `progress/items.json` for `Chapter5/Exercise5.27.2` (previously had no
+`coverage` field).
+
+Swept declarations (all under namespace `Etingof.Exercise5_27_2`):
+
+- **(i) dihedral** — `dihedral_classification` (Dihedral.lean:496), transported
+  from `semidirect_classification` (192) via a genuine `≃*`
+  `dihedralEquiv : DihedralGroup N ≃* Multiplicative (ZMod N) ⋊[dihedralφ] Multiplicative (ZMod 2)`
+  (106). Applies `Etingof.Theorem5_27_1 (Multiplicative (ZMod 2)) (Multiplicative (ZMod N)) (dihedralφ N)`.
+- **(ii) Heisenberg** — `heisenberg_classification` (Heisenberg.lean:334), group
+  `HeisenbergGroup := (ZMod p × ZMod p) ⋊[shear] ZMod p` (126). Applies
+  `Etingof.Theorem5_27_1 (Multiplicative (ZMod p)) (Multiplicative (ZMod p × ZMod p)) (heisenbergφ p)` (345).
+- **(iii) affine** — `affine_classification (hq : 2 < Fintype.card K)`
+  (Affine.lean:197), group `AffineGroup := Multiplicative K ⋊[affineφ] Kˣ` (67).
+  Applies `Etingof.Theorem5_27_1 Kˣ (Multiplicative K) (affineφ K)` (209).
+
+**Verdicts:**
+
+| Sub-part | Coverage | Rationale |
+|---|---|---|
+| (i) dihedral | `covered_full` | Genuine `≃*` model; exhaustive up-to-iso classification with parity-split counts (Odd: 2+`(N-1)/2`, Even: 4+`(N-2)/2`). |
+| (ii) Heisenberg | `covered_full` | Exhaustive with headline counts `p²` dim-1, `p−1` dim-p. Group defined directly as the semidirect product (faithful standard presentation; no formal `MulEquiv` to the 3×3-unitriangular / Problem4_12_2 model — prose only). |
+| (iii) affine | `covered_partial` | Exhaustive with counts (`q−1` dim-1, one dim-`q−1`) but `2 < card K` drops `q=2` (𝔽₂), which the book and the original Chapter4/Problem4.12.6 both cover. Documented dimension-partition degeneracy, not an unsound gap. |
+
+Roll-up `coverage` = min = **`covered_partial`**.
+
+Fidelity spot-check (per deliverable 2): confirmed each `*_classification`
+genuinely `obtain`s its result from `Etingof.Theorem5_27_1` applied to a
+semidirect-product model (not an independent re-proof that merely imports the
+file), and each conclusion is a real exhaustive classification — `∃ n W`, all
+`Simple`, pairwise non-iso, completeness (every simple `≅` some family member),
+and counts/dimensions as headline conjuncts. `2 < card K` matches the book's
+`q > 2` intent for the dimension-partitioned form; it narrows scope only at the
+degenerate `q=2`.
+
+Opened follow-up **feature #7331** for the affine `q=2` narrowing; referenced
+from the affine `derived` item.
+
+## Current frontier
+
+Coverage arm for the §4.12 ↔ §5.27 semidirect-product thread is complete for
+5.27.2. Two sibling review issues remain unclaimed: #7306 (Problem 4.12.7
+quaternions), #7328 (Problem 5.24.1 Specht modules).
+
+## Overall project progress
+
+Stage 3.7 coverage-arm sweep in progress across Chapters 4–5. This turn brought
+the last un-coverage-audited exercise in the §4.12 ↔ §5.27 thread
+(`Chapter5/Exercise5.27.2`) into line with its already-audited siblings.
+
+## Next step
+
+Claim #7306 or #7328 (both `review` coverage-arm audits). Separately, feature
+#7331 (affine `q=2` via Theorem 5.27.1) and #7322 (Heisenberg total-count
+headline) are available for feature workers.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -5485,7 +5485,58 @@
     "start_line": 15,
     "end_line": 16,
     "status": "proved",
-    "coverage_note": "COMPLETE and sorry-free across three files, each redoing one Problem via Theorem 5.27.1. (4.12.6) Exercise5_27_2_Affine.lean: affine ax+b group over a finite field as Multiplicative K rtimes Kˣ; affine_classification (hyp 2<q, excluding the degenerate 𝔽₂ where the free rep also has dim q-1=1) gives q irreducibles (q-1 of dim 1 over the fixed trivial character indexed by ρ:Kˣ→*ℂˣ, one of dim q-1 over the single free orbit). Assembled from Theorem 5.27.1: stabilizer dichotomy (⊤ for trivial χ, ⊥ for nontrivial) + transitivity on nontrivial chars, closed-form fixed character ρ g, dims via index_top/index_bot+card_units, completeness via exists_charFDRep_iso and orbit base-point move (hvii/hix). (4.12.1(a)) Exercise5_27_2_Dihedral.lean: dihedral D_N as ZMod N rtimes ZMod 2 via inversion; parity classification. (4.12.2) Exercise5_27_2_Heisenberg.lean: Heisenberg over F_p as (ZMod p)² rtimes ZMod p via shear; p² dim-1 and p-1 dim-p. All three sorry-free."
+    "coverage_note": "[coverage-arm audited #7320, 2026-07-22] Roll-up = min across three sub-parts = covered_partial (dihedral covered_full, Heisenberg covered_full, affine covered_partial). Each *_classification theorem genuinely DISCHARGES its result by `obtain ... := Etingof.Theorem5_27_1 A G φ` applied to a semidirect-product model (not an independent re-proof that merely imports the file), and each conclusion is an EXHAUSTIVE up-to-iso classification: an explicit family W : Fin n → FDRep ℂ G with (i) ∀ i, Simple (W i), (ii) pairwise non-iso (Nonempty (W i ≅ W j) → i = j), (iii) completeness (∀ S simple, ∃ i, S ≅ W i), and (iv) counts/dimensions. Dihedral routes through a genuine MulEquiv dihedralEquiv : DihedralGroup N ≃* (Multiplicative (ZMod N) ⋊[dihedralφ] Multiplicative (ZMod 2)); Heisenberg and affine DEFINE the group directly as the semidirect product (faithful standard presentations; identification with the 3×3-unitriangular / x↦ax+b pictures argued in prose docstrings, no formal MulEquiv). Affine is covered_partial because affine_classification carries `hq : 2 < Fintype.card K`, dropping q=2 (𝔽₂) which the book — and the original Chapter4/Problem4.12.6 — cover; follow-up feature issue #7331. All three files sorry-free (grep: no sorry/admit/True). #print axioms not re-run (report-only, no fidelity re-audit).",
+    "coverage": "covered_partial",
+    "coverage_arm": "audited",
+    "lean_file": [
+      "EtingofRepresentationTheory/Chapter5/Exercise5_27_2_Dihedral.lean",
+      "EtingofRepresentationTheory/Chapter5/Exercise5_27_2_Heisenberg.lean",
+      "EtingofRepresentationTheory/Chapter5/Exercise5_27_2_Affine.lean"
+    ],
+    "lean_decl": [
+      "Etingof.Exercise5_27_2.dihedral_classification",
+      "Etingof.Exercise5_27_2.heisenberg_classification",
+      "Etingof.Exercise5_27_2.affine_classification"
+    ],
+    "derived": [
+      {
+        "part": "(i) dihedral (4.12.1(a))",
+        "claim": "Redo the D_N irreducible classification via Theorem 5.27.1 (DihedralGroup N as ZMod N ⋊ ZMod 2 by inversion).",
+        "coverage": "covered_full",
+        "lean_decl": [
+          "Etingof.Exercise5_27_2.dihedral_classification",
+          "Etingof.Exercise5_27_2.semidirect_classification",
+          "Etingof.Exercise5_27_2.dihedralEquiv",
+          "Etingof.Exercise5_27_2.DihedralSemidirect"
+        ],
+        "reason": "FULL. dihedralEquiv is a genuine ≃* (real toFun/invFun/left_inv/right_inv/map_mul', no stub) between Mathlib's DihedralGroup N and Multiplicative (ZMod N) ⋊[dihedralφ] Multiplicative (ZMod 2). semidirect_classification obtains its result via Etingof.Theorem5_27_1 (Multiplicative (ZMod 2)) (Multiplicative (ZMod N)) (dihedralφ N); dihedral_classification transports it across the resEquiv along dihedralEquiv. Conclusion is exhaustive: ∃ n W, (∀ i, Simple (W i)) ∧ pairwise-non-iso ∧ completeness ∧ (dim 1 or 2) ∧ parity-split counts — Odd N: 2 one-dim + (N-1)/2 two-dim; Even N: 4 one-dim + (N-2)/2 two-dim, matching Problem 4.12.1(a). Hypothesis only [NeZero N]; both parities handled. Sorry-free.",
+        "followup_issue": null
+      },
+      {
+        "part": "(ii) Heisenberg (4.12.2)",
+        "claim": "Redo the Heisenberg-group (over 𝔽_p) irreducible classification via Theorem 5.27.1 ((ZMod p)² ⋊ ZMod p by shear): p² dim-1 and p−1 dim-p.",
+        "coverage": "covered_full",
+        "lean_decl": [
+          "Etingof.Exercise5_27_2.heisenberg_classification",
+          "Etingof.Exercise5_27_2.HeisenbergGroup"
+        ],
+        "reason": "FULL. heisenberg_classification obtains its result via Etingof.Theorem5_27_1 (Multiplicative (ZMod p)) (Multiplicative (ZMod p × ZMod p)) (heisenbergφ p). Conclusion exhaustive: ∃ n W, (∀ i, Simple (W i)) ∧ pairwise-non-iso ∧ completeness ∧ (dim 1 or p) ∧ n = p²+(p-1) ∧ #{dim 1} = p² ∧ #{dim p} = p−1 — the counts are HEADLINE conjuncts, matching the book answer. Hypothesis only [Fact p.Prime]. Caveat (not a gap): HeisenbergGroup is DEFINED directly as Multiplicative (ZMod p × ZMod p) ⋊[heisenbergφ] Multiplicative (ZMod p) — a faithful standard presentation of the Heisenberg group; there is no formal MulEquiv to a 3×3-unitriangular matrix model nor to Chapter4/Problem4.12.2's `Heisenberg p` object, that identification is argued only in the module docstring. Sorry-free.",
+        "followup_issue": null
+      },
+      {
+        "part": "(iii) affine (4.12.6)",
+        "claim": "Redo the affine x↦ax+b group (over 𝔽_q) irreducible classification via Theorem 5.27.1 (Multiplicative K ⋊ Kˣ): q−1 dim-1 characters and one dim-(q−1) rep.",
+        "coverage": "covered_partial",
+        "lean_decl": [
+          "Etingof.Exercise5_27_2.affine_classification",
+          "Etingof.Exercise5_27_2.AffineGroup",
+          "Etingof.Exercise5_27_2.affineφ"
+        ],
+        "reason": "PARTIAL. affine_classification (hyp `2 < Fintype.card K`) obtains its result via Etingof.Theorem5_27_1 Kˣ (Multiplicative K) (affineφ K); conclusion is exhaustive for q>2: ∃ n W, (∀ i, Simple (W i)) ∧ pairwise-non-iso ∧ completeness ∧ n = q ∧ #{dim 1} = q−1 ∧ #{dim q−1} = 1, matching the book. AffineGroup is defined directly as Multiplicative K ⋊[affineφ] Kˣ (affineφ = left-mult action; faithful x↦ax+b model, correspondence in docstring, no formal MulEquiv). PARTIAL because `2 < Fintype.card K` silently DROPS q=2 (𝔽₂): the {1, q−1} dimension partition degenerates there (q−1=1, the two dim filters collide), so the counts cannot both hold and the theorem-as-phrased excludes it. Book Problem 4.12.6 covers all q, and Chapter4/Problem4.12.6 handles q=2 directly (≅ ℤ/2 via Example4_3_FiniteAbelianGroups) — the 5.27.1 route narrows scope. Documented genuine degeneracy, not an unsound gap. Follow-up feature issue #7331. Sorry-free.",
+        "followup_issue": 7331
+      }
+    ],
+    "last_updated": "2026-07-22"
   },
   {
     "id": "Chapter5/Exercise5.27.3",


### PR DESCRIPTION
Closes #7320

Session: `5b1300c8-8240-4c9c-bfa6-2dd76a12ffc1`

23f2af28 review(Stage3.7 #7320): coverage-arm audit of Exercise 5.27.2 via Theorem 5.27.1 — dihedral/Heisenberg covered_full, affine covered_partial (q=2 dropped, #7331)

🤖 Prepared with Claude Code