### PR TITLE
feat(Ch3): formalize converse direction of Problem 3.9.1(c) — unitriangular ext iso ⇒ f−f'∈B¹

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/Problem3_9_1.lean
+++ b/EtingofRepresentationTheory/Chapter3/Problem3_9_1.lean
@@ -237,6 +237,38 @@ theorem iso_of_sub_mem_coboundaries (f f' : A →ₗ[k] (W →ₗ[k] V))
   refine ⟨?_, rfl⟩
   simp only [add_assoc, ← key]
 
+/-- **Problem 3.9.1(c), converse.** If `φ : U_f → U_{f'}` is an isomorphism of extensions of
+the special unitriangular form `φ = [[1_V, X], [0, 1_W]]`, i.e. `φ (v, w) = (v + X w, w)` for
+some `X : W →ₗ[k] V`, then `f − f'` is a coboundary (`f − f' = dX ∈ B¹`).
+
+This is the exact mirror of `iso_of_sub_mem_coboundaries`: reading off the `(1,2)`-block of
+the intertwining identity `φ ∘ ρ_{U_f}(a) = ρ_{U_{f'}}(a) ∘ φ` at `(0, w)` gives
+`f a w + X (a • w) = a • X w + f' a w`, i.e. `(f − f') a w = a • X w − X (a • w) = dX(a)(w)`.
+It holds over **any** algebra `A`, with no irreducibility or finite-dimensionality
+hypotheses; the cocycle assumptions on `f, f'` are not needed for this direction (they are
+kept to match the book's `f, f' ∈ Z¹` framing). Together with
+`iso_of_sub_mem_coboundaries` this is the full biconditional of part (c). -/
+theorem converse_sub_mem_coboundaries_of_unitriangular_intertwines
+    (f f' : A →ₗ[k] (W →ₗ[k] V)) (_hf : IsCocycle k A V W f) (_hf' : IsCocycle k A V W f')
+    (φ : (V × W) ≃ₗ[k] (V × W)) (X : W →ₗ[k] V)
+    (hφX : ∀ p : V × W, (φ p : V × W) = (p.1 + X p.2, p.2))
+    (hφ : IntertwinesExt k A V W f f' φ) :
+    f - f' ∈ coboundaries k A V W := by
+  rw [mem_coboundaries_iff]
+  refine ⟨X, ?_⟩
+  ext a w
+  -- Off-diagonal `(1,2)`-block of `φ ∘ ρ_{U_f}(a) = ρ_{U_{f'}}(a) ∘ φ`, evaluated at `(0, w)`.
+  have h := LinearMap.congr_fun (hφ a) (0, w)
+  simp only [LinearMap.comp_apply, LinearEquiv.coe_coe, blockOp_apply, hφX, smul_zero,
+    zero_add] at h
+  -- `h : (f a w + X (a • w), a • w) = (a • X w + f' a w, a • w)`.
+  rw [Prod.ext_iff] at h
+  obtain ⟨h1, -⟩ := h
+  rw [coboundaryOf_apply]
+  simp only [LinearMap.sub_apply]
+  -- goal: `a • X w - X (a • w) = f a w - f' a w`
+  exact sub_eq_sub_iff_add_eq_add.mpr h1.symm
+
 /-- The "proportional ⇒ isomorphic" direction of Problem 3.9.1(d), in the nondegenerate case
 `c ≠ 0`. If `f − c • f'` is a coboundary for some nonzero scalar `c`, then the extensions
 `U_f` and `U_{f'}` are isomorphic representations, via the block map `φ = [[1, X], [0, c]]`.

--- a/progress/2026-07-22T18-32-21Z_d666e409.md
+++ b/progress/2026-07-22T18-32-21Z_d666e409.md
@@ -1,0 +1,45 @@
+## Accomplished
+
+Feature session for issue #7362: formalized the **converse direction of Problem
+3.9.1(c)**, previously missing from
+`EtingofRepresentationTheory/Chapter3/Problem3_9_1.lean`.
+
+- Added `converse_sub_mem_coboundaries_of_unitriangular_intertwines`: given
+  cocycles `f, f'` and an intertwiner `φ` of the special unitriangular form
+  `φ (v, w) = (v + X w, w)` (the book's `[[1_V, ∗], [0, 1_W]]`), it reads off the
+  `(1,2)`-block of the intertwining identity at `(0, w)` to conclude
+  `f − f' = dX ∈ B¹` (`coboundaries k A V W`). Reuses `IntertwinesExt` and
+  `mem_coboundaries_iff`. Holds over any algebra `A`; no irreducibility or
+  finite-dimensionality hypotheses (the exact mirror of the forward theorem
+  `iso_of_sub_mem_coboundaries`).
+- `lake build EtingofRepresentationTheory.Chapter3.Problem3_9_1` clean (the two
+  linter warnings at line 204 are pre-existing, on the forward theorem's unused
+  `hf`/`hf'`).
+- `#print axioms` on the new decl is clean: `[propext, Classical.choice,
+  Quot.sound]`, no `sorryAx`.
+- Updated `progress/items.json` for `Chapter3/Problem3.9.1`: item-level
+  `coverage` → `covered_full`; added the `derived` sub-part array (mirroring the
+  in-flight §3.9 audit PR #7363's structure) with part **(c)** now
+  `covered_full` (both `iso_of_sub_mem_coboundaries` and the new converse listed,
+  no `followup_issue`), and parts (a),(b),(d) `covered_full`.
+
+## Current frontier
+
+Problem 3.9.1 is now fully covered (all four parts `covered_full`). Ready to PR.
+
+## Overall project progress
+
+Stage 3.x formalization + coverage-arm audit sweep ongoing. This closes the one
+remaining gap (part (c) converse) flagged by coverage audit #7361 / PR #7363.
+
+## Next step
+
+Create PR closing #7362 with auto-merge. Note: the §3.9 coverage-arm audit PR
+#7363 was still building at session start and restructures the same 3.9.1
+items.json entry; whichever lands second may need a trivial conflict resolution
+(this PR encodes the final `covered_full` end state).
+
+## Blockers
+
+None. Potential (non-blocking) merge conflict with in-flight PR #7363 on the
+`progress/items.json` 3.9.1 entry — handled by the repair agent if it arises.

--- a/progress/items.json
+++ b/progress/items.json
@@ -2254,7 +2254,70 @@
     "status": "sorry_free",
     "sorry_free": true,
     "fidelity": "verified",
-    "lean_file": "EtingofRepresentationTheory/Chapter3/Problem3_9_1.lean"
+    "lean_file": [
+      "EtingofRepresentationTheory/Chapter3/Problem3_9_1.lean"
+    ],
+    "coverage": "covered_full",
+    "coverage_arm": "audited",
+    "coverage_note": "Coverage-arm audit (Stage 3.7, #7361) marked covered_partial (part (c) forward-only); follow-up #7362 formalized the (c) converse (converse_sub_mem_coboundaries_of_unitriangular_intertwines), lifting the item to covered_full. Problem3_9_1.lean (sorry-free, axiom-clean [propext, Classical.choice, Quot.sound]) now covers parts (a),(b),(c),(d) in full. (a) blockOp_mul_iff_isCocycle: genuine iff (block-triangular assignment is a representation) iff (f is a 1-cocycle). (b) coboundaryOf_isCocycle + coboundaryOf_eq_zero_iff + coboundaries_le_cocycles + Ext1: dX is a cocycle, dX=0 iff X is A-linear, B1 subset Z1, Ext1 = Z1/B1. (c) BOTH directions: forward iso_of_sub_mem_coboundaries (f-f' in B1 => unitriangular iso) and converse converse_sub_mem_coboundaries_of_unitriangular_intertwines (unitriangular iso [[1,*],[0,1]] => f-f' in B1), over any algebra A. (d) irreducible_ext_iso_iff_proportional: genuine iff over [IsAlgClosed k] for f.d. irreducible V,W, the faithful projective-space (P Ext1) classification. Ext1 is the in-book Z1/B1, not Mathlib's derived-functor Ext. Prior fidelity: verified.",
+    "last_updated": "2026-07-22",
+    "derived": [
+      {
+        "part": "(a) 1-cocycle condition",
+        "claim": "rho_U(a)=[[rho_V(a),f(a)],[0,rho_W(a)]] is a representation (multiplicative in a) iff f is a 1-cocycle f(ab)=rho_V(a).f(b)+f(a).rho_W(b); cocycles form Z1(W,V).",
+        "description": "Necessary-and-sufficient cocycle condition making the block-triangular assignment a representation; defines Z1.",
+        "source_span": "blobs/Chapter3/Problem3.9.1.md (a)",
+        "coverage": "covered_full",
+        "lean_decl": [
+          "Etingof.Problem3_9_1.IsCocycle",
+          "Etingof.Problem3_9_1.blockOp",
+          "Etingof.Problem3_9_1.blockOp_mul_iff_isCocycle",
+          "Etingof.Problem3_9_1.cocycles"
+        ],
+        "reason": "blockOp_mul_iff_isCocycle (line 67) is a genuine iff between multiplicativity of a |-> blockOp f a and IsCocycle f. blockOp (line 55) is the honest block-triangular operator (blockOp_apply: (v,w) |-> (a.v + f a w, a.w)); cocycles (line 90) is the Z1 subspace. Clean axioms."
+      },
+      {
+        "part": "(b) coboundaries, B1 subset Z1, Ext1",
+        "claim": "dX(a)=rho_V(a)X - X rho_W(a) is a cocycle vanishing iff X is A-linear; coboundaries B1 (isomorphic to Hom_k(W,V)/Hom_A(W,V)) form a subspace of Z1; Ext1(W,V)=Z1/B1.",
+        "description": "Coboundary map, its cocycle/kernel properties, and the definition of Ext1 as the quotient.",
+        "source_span": "blobs/Chapter3/Problem3.9.1.md (b)",
+        "coverage": "covered_full",
+        "lean_decl": [
+          "Etingof.Problem3_9_1.coboundaryOf",
+          "Etingof.Problem3_9_1.coboundaryOf_isCocycle",
+          "Etingof.Problem3_9_1.coboundaryOf_eq_zero_iff",
+          "Etingof.Problem3_9_1.coboundaries",
+          "Etingof.Problem3_9_1.coboundaries_le_cocycles",
+          "Etingof.Problem3_9_1.Ext1"
+        ],
+        "reason": "coboundaryOf_isCocycle (115) gives dX in Z1; coboundaryOf_eq_zero_iff (125) proves dX=0 iff X is A-linear (the kernel characterization behind B1 iso Hom_k/Hom_A); coboundaries_le_cocycles (178) gives B1 subset Z1; Ext1 (185) = Z1/B1. The named iso B1 iso Hom_k(W,V)/Hom_A(W,V) is not separately bundled but is immediate: coboundaryLinear has range = coboundaries (coboundaries_eq_range) and kernel = Hom_A (coboundaryOf_eq_zero_iff), so it is a first-isomorphism-theorem corollary of decls already present. Clean axioms."
+      },
+      {
+        "part": "(c) B1-equivalence classifies extensions",
+        "claim": "Forward: if f-f' in B1 then U_f iso U_{f'} as representations. Converse: if phi:U_f->U_{f'} is an isomorphism of unitriangular form [[1_V,*],[0,1_W]] then f-f' in B1. Thus Ext1 classifies extensions.",
+        "description": "Both directions relating B1-equivalence of cocycles to isomorphism of the corresponding extensions.",
+        "source_span": "blobs/Chapter3/Problem3.9.1.md (c)",
+        "coverage": "covered_full",
+        "lean_decl": [
+          "Etingof.Problem3_9_1.IntertwinesExt",
+          "Etingof.Problem3_9_1.iso_of_sub_mem_coboundaries",
+          "Etingof.Problem3_9_1.converse_sub_mem_coboundaries_of_unitriangular_intertwines"
+        ],
+        "reason": "BOTH directions now covered_full. FORWARD: iso_of_sub_mem_coboundaries (203) builds the genuine unitriangular intertwiner phi=[[1,X],[0,1]] from f-f'=dX and proves IntertwinesExt (a real k-linear equiv intertwining the block operators for every a), over any algebra A. CONVERSE: converse_sub_mem_coboundaries_of_unitriangular_intertwines (#7362) takes an intertwiner phi of the special unitriangular form (phi (v,w)=(v+X w,w) for some X) and reads off the (1,2)-block of the intertwining identity to conclude f-f' = dX in B1, over any algebra A with no irreducibility/finite-dimensionality hypotheses. It is the exact mirror of the forward proof and is distinct from the part-(d) theorem (which needs [IsAlgClosed k] + f.d. + irreducible and yields a possibly-nonunit ratio). Clean axioms [propext, Classical.choice, Quot.sound]. Gap from #7361 audit closed."
+      },
+      {
+        "part": "(d) iso classes <-> P Ext1",
+        "claim": "For finite-dimensional irreducible V,W, U_f iso U_{f'} iff f,f' proportional; nontrivial extensions are parametrized by P Ext1(W,V); every extension is trivial iff Ext1=0.",
+        "description": "Projective-space classification of isomorphism classes of extensions in the irreducible finite-dimensional case.",
+        "source_span": "blobs/Chapter3/Problem3.9.1.md (d)",
+        "coverage": "covered_full",
+        "lean_decl": [
+          "Etingof.Problem3_9_1.ext_iso_of_sub_smul_mem_coboundaries",
+          "Etingof.Problem3_9_1.irreducible_ext_iso_iff_proportional"
+        ],
+        "reason": "irreducible_ext_iso_iff_proportional (307) is a genuine iff: (exists phi, IntertwinesExt f f' phi) iff (exists c != 0, f - c.f' in B1) - the faithful P-form of the book's projective-space classification (a nonzero ratio = a line in P Ext1; f in B1 = the split/trivial class). [IsAlgClosed k] is the mathematically correct hypothesis, not an artificial narrowing: the P_k Ext1 parametrization needs End_A(V)=End_A(W)=k, which Schur (Corollary_2_3_10, used in the forward proof) supplies only over an algebraically closed field; the docstring records that over a non-closed field the classes are Ext1 mod D_V^x x D_W^x. Forward => block-decomposes an arbitrary phi; <= reuses ext_iso_of_sub_smul_mem_coboundaries. Clean axioms."
+      }
+    ]
   },
   {
     "id": "Chapter3/Problem3.9.2",


### PR DESCRIPTION
Closes #7362

Session: `d666e409-2bf4-4f69-a201-a57d41319c8c`

98232964 feat(Ch3): formalize converse of Problem 3.9.1(c) — unitriangular ext iso ⇒ f−f'∈B¹

🤖 Prepared with Claude Code