### PR TITLE
Problem 3.9.3: formalize dim Ext¹(S_i,S_j) = number of arrows i→j (path-algebra simples) — lifts covered_partial→full

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -5804,3 +5804,52 @@ matrices `2 • 1 - adj`) hits two recurring `omega` limitations that surface as
    equation compiler accepts the two-step recursion). Keep the smaller-index submatrix identities
    (`(C (m+1)).submatrix Fin.succ Fin.succ = C m`) as separate `ext … <;> split_ifs <;> omega`
    lemmas.
+
+## Taking `Ext¹`/cokernel of a `QuiverRepresentation` differential and computing `finrank` (#7376)
+
+`Etingof.QuiverRepresentation` bundles only `AddCommMonoid`/`Module` on each `obj v`
+(both `[instance]`). Forming a cokernel `codomain ⧸ LinearMap.range d` or an Ext module
+needs `AddCommGroup` on the carriers, and this is where the diamonds bite. Pattern that
+works (Problem 3.9.3, `dim Ext¹(S_i,S_j) = #(i ⟶ j)`):
+
+1. **Subtraction in the differential:** define the differential `d(f)_a = W_a ∘ f_i - f_j ∘ V_a`
+   with `letI : ∀ v, AddCommGroup (W.obj v) := fun _ => Etingof.Problem6_9_3.acg` *inside* the
+   def body (as the bare-function `extDiff` already does). `acg = { bundledInst with neg := (-1)•· }`
+   **extends** the bundled `AddCommMonoid`, so `acg.toAddCommMonoid` is defeq to it and the
+   subtraction lands in the bundled-monoid `LinearMap` space. Do **not** take
+   `[∀ v, AddCommGroup (W.obj v)]` as an instance argument on a *general* `V W` def — an abstract
+   group's monoid ≠ the bundled monoid, and `HSub` fails to synthesize (`?m` stuck).
+
+2. **Quotient/`finrank` at the use site:** instance search will **not** unfold `(simpleRep j).obj v`
+   to `Fin _ → k` to find `Pi.addCommGroup` (it stops at the bundled monoid). So the *statement*
+   `finrank k (Ext1Simple i j)` won't elaborate. Register a **low-priority** compatible instance
+   `instance (priority := 100) : AddCommGroup ((simpleRep j).obj v) := by change AddCommGroup (Fin _ → k); infer_instance`.
+   Low priority keeps the bundled `AddCommMonoid` preferred everywhere else; its `toAddCommMonoid`
+   is the same `Pi` monoid, so no downstream proof breaks (verify by building the chapter aggregate).
+   Specialize the Ext object to the concrete reps (`Ext1Simple i j`, an `abbrev` so `finrank` sees
+   the quotient's `Module`), not a general `Ext1 V W` (whose quotient-group ≠ range-submodule-monoid
+   for abstract `W`).
+
+3. **Zero differential between simples:** prove `d = 0` at `LinearMap` level, not element level.
+   `refine LinearMap.ext fun f => funext fun p => ?_` (a plain `ext f p x` drills to `x✝` and
+   leaves an unclosable `(0 - 0) x✝ = (0 f p) x✝`), then a `letI acg` to align the ambient group
+   with the one baked into the differential, `show <the toFun expr> = 0`,
+   `simp only [simpleRep, LinearMap.zero_comp, LinearMap.comp_zero]`, `exact sub_self 0`.
+   `sub_self`/`sub_zero` silently *fail to fire in `simp`* when the ambient `AddCommGroup` differs
+   from the term's — this is why the `letI acg` matters.
+
+4. **`finrank` of the codomain product:** `coker 0 ≅ codomain` via `Submodule.quotEquivOfEqBot _ hbot`
+   (first arg is the submodule, explicit) then `.finrank_eq`. `Module.finrank_pi_fintype k` needs
+   `Free`+`Finite` on each Hom component — supply `∀ r a, Module.Finite/Free k ((simpleRep r).obj a)`
+   as `∀`-quantified `haveI`s (via `change … (Fin _ → k); infer_instance`); `Module.Finite.linearMap`
+   / `Module.Free.linearMap` then derive the Hom instances. `Module.finrank_linearMap` gives
+   `finrank Hom = finrank dom * finrank cod`.
+
+5. **Collapsing the sigma-count `∑ p : (Σ a b, (a⟶b)), [a=i][b=j]`:** `rw [Fintype.sum_sigma]`
+   (outer) works, but the *inner* sigma sum lives under the `∑ a` binder — `rw` can't reach it and
+   `conv … ext a` fails (`ext` does not enter `Finset.sum`). Use `simp only [Fintype.sum_sigma]` for
+   the inner expansion. **`Finset.sum_const` does not fire in `simp only` on `∑ (e : a ⟶ b), C`** — a
+   full `simp [Finset.sum_const, Finset.card_univ, Finset.card_empty, mul_ite, ite_mul, apply_ite Finset.card, Fintype.sum_ite_eq', Finset.sum_ite_irrel, Finset.sum_const_zero]`
+   collapses the whole thing (it routes the constant arrow-sum through
+   `(if … then Finset.univ else ∅).card`, which `apply_ite Finset.card` + `Finset.card_univ`/`card_empty`
+   finish). Trace the intermediate goal with `trace_state` when a staged `simp only` stalls.

--- a/EtingofRepresentationTheory/Chapter3/Problem3_9_3.lean
+++ b/EtingofRepresentationTheory/Chapter3/Problem3_9_3.lean
@@ -324,6 +324,103 @@ theorem ext1_simpleRep_vanishes_iff [DecidableEq Q] (i j : Q) :
         rw [if_neg hb]; infer_instance
       exact LinearMap.ext fun x => Subsingleton.elim _ _
 
+/-! ### `Ext¹` between vertex simples: the exact dimension
+
+The criterion `ext1_simpleRep_vanishes_iff` only records *when* `Ext¹` vanishes. Here we
+compute its dimension exactly, formalizing the book's answer
+
+> `dim Ext¹(S_i, S_j)` = number of arrows `i → j`.
+
+We first upgrade the Ext differential `extDiff` (a bare function) to a genuine `k`-linear map
+`extDiffₗ`, form `Ext¹(V, W)` as its cokernel, and observe that between two vertex simples the
+differential is the zero map. Hence `Ext¹(S_i, S_j)` is isomorphic to its whole codomain
+`⨁_{a : i→j} Hom((S_i)_a, (S_j)_b)`, whose only nonzero components are the `Hom(k, k) ≅ k` at
+arrows `i → j`, giving `dim Ext¹(S_i, S_j) = #(i ⟶ j)`. -/
+
+/-- The `Fin _ → k` carriers of the vertex simples carry an `AddCommGroup` (compatibly with the
+bundled `AddCommMonoid`, since both are the `Pi` instances). Registering this — at low priority,
+so the bundled `AddCommMonoid` stays preferred elsewhere — lets us form the cokernel
+`Ext¹(S_i, S_j)` as a genuine `k`-module and take its `finrank`. -/
+instance (priority := 100) simpleRep_obj_addCommGroup [DecidableEq Q] (j v : Q) :
+    AddCommGroup ((simpleRep (k := k) j).obj v) := by
+  change AddCommGroup (Fin (if v = j then 1 else 0) → k); infer_instance
+
+/-- The Ext differential `d(f)_a = W_a ∘ f_i - f_j ∘ V_a` as a genuine `k`-linear map. This is
+the linear upgrade of the bare function `Etingof.Problem6_9_3.extDiff`; the subtraction uses the
+`AddCommGroup` structure `Etingof.Problem6_9_3.acg` (which extends the bundled `AddCommMonoid` on
+each `W.obj v`). Its cokernel is `Ext¹(V, W)`. -/
+noncomputable def extDiffₗ (V W : QuiverRepresentation k Q) :
+    (∀ i, V.obj i →ₗ[k] W.obj i) →ₗ[k]
+      (∀ p : (Σ i j, (i ⟶ j)), V.obj p.1 →ₗ[k] W.obj p.2.1) :=
+  letI : ∀ v, AddCommGroup (W.obj v) := fun _ => Etingof.Problem6_9_3.acg (k := k)
+  { toFun := fun f p => W.mapLinear p.2.2 ∘ₗ f p.1 - f p.2.1 ∘ₗ V.mapLinear p.2.2
+    map_add' := fun f g => by
+      funext p
+      simp only [Pi.add_apply, LinearMap.comp_add, LinearMap.add_comp]
+      abel
+    map_smul' := fun c f => by
+      funext p
+      simp only [Pi.smul_apply, RingHom.id_apply, LinearMap.comp_smul, LinearMap.smul_comp,
+        smul_sub] }
+
+/-- `Ext¹(S_i, S_j)` for two vertex simples, as the cokernel of the Ext differential. Since both
+simples have all arrow maps zero, this differential is the zero map (`extDiffₗ_simpleRep_eq_zero`)
+and `Ext¹(S_i, S_j)` is its whole codomain `⨁_{a : i→j} Hom((S_i)_a, (S_j)_b)`. -/
+abbrev Ext1Simple [DecidableEq Q] (i j : Q) : Type _ :=
+  (∀ p : (Σ a b : Q, (a ⟶ b)),
+      (simpleRep (k := k) i).obj p.1 →ₗ[k] (simpleRep (k := k) j).obj p.2.1) ⧸
+    LinearMap.range (extDiffₗ (simpleRep (k := k) i) (simpleRep (k := k) j))
+
+/-- Between two vertex simples every arrow map is zero, so the Ext differential is the zero
+linear map. -/
+theorem extDiffₗ_simpleRep_eq_zero [DecidableEq Q] (i j : Q) :
+    extDiffₗ (simpleRep (k := k) i) (simpleRep j) = 0 := by
+  letI : ∀ v, AddCommGroup ((simpleRep (k := k) j).obj v) :=
+    fun _ => Etingof.Problem6_9_3.acg (k := k)
+  refine LinearMap.ext fun f => funext fun p => ?_
+  show (simpleRep (k := k) j).mapLinear p.2.2 ∘ₗ f p.1
+      - f p.2.1 ∘ₗ (simpleRep (k := k) i).mapLinear p.2.2 = 0
+  simp only [simpleRep, LinearMap.zero_comp, LinearMap.comp_zero]
+  exact sub_self (0 : (simpleRep (k := k) i).obj p.1 →ₗ[k] (simpleRep (k := k) j).obj p.2.1)
+
+/-- **`Ext¹` between irreducibles, dimension.** For a finite quiver `Q`, the Ext group between
+the vertex simples `S_i` and `S_j` has dimension equal to the number of arrows `i → j`:
+`dim Ext¹(S_i, S_j) = #(i ⟶ j)`. This is the exact computation strengthening the vanishing
+criterion `ext1_simpleRep_vanishes_iff` (`Ext¹(S_i, S_j) = 0 ↔ #(i ⟶ j) = 0`). -/
+theorem finrank_ext1_simpleRep [DecidableEq Q] [Fintype Q] [∀ a b : Q, Fintype (a ⟶ b)]
+    (i j : Q) :
+    Module.finrank k (Ext1Simple (k := k) i j) = Fintype.card (i ⟶ j) := by
+  -- The differential vanishes, so `Ext¹ = coker 0` is isomorphic to its whole codomain.
+  have hbot : LinearMap.range (extDiffₗ (simpleRep (k := k) i) (simpleRep j)) = ⊥ := by
+    rw [extDiffₗ_simpleRep_eq_zero, LinearMap.range_zero]
+  refine (Submodule.quotEquivOfEqBot _ hbot).finrank_eq.trans ?_
+  -- The `Fin _ → k` carriers are finite and free; this propagates to the Hom components, so both
+  -- `finrank_pi_fintype` and `finrank_linearMap` below have the instances they need.
+  haveI hobjFin : ∀ r a : Q, Module.Finite k ((simpleRep (k := k) r).obj a) := fun r a => by
+    change Module.Finite k (Fin (if a = r then 1 else 0) → k); infer_instance
+  haveI hobjFree : ∀ r a : Q, Module.Free k ((simpleRep (k := k) r).obj a) := fun r a => by
+    change Module.Free k (Fin (if a = r then 1 else 0) → k); infer_instance
+  -- `finrank` of the product is the sum over arrows of the finrank of each Hom component.
+  rw [Module.finrank_pi_fintype k]
+  -- Each Hom component has finrank `(if p.1 = i then 1 else 0) * (if p.2.1 = j then 1 else 0)`.
+  have hcomp : ∀ p : (Σ a b : Q, (a ⟶ b)),
+      Module.finrank k ((simpleRep (k := k) i).obj p.1 →ₗ[k] (simpleRep (k := k) j).obj p.2.1)
+        = (if p.1 = i then 1 else 0) * (if p.2.1 = j then 1 else 0) := by
+    intro p
+    rw [Module.finrank_linearMap]
+    congr 1
+    · show Module.finrank k (Fin (if p.1 = i then 1 else 0) → k) = _
+      rw [Module.finrank_pi k, Fintype.card_fin]
+    · show Module.finrank k (Fin (if p.2.1 = j then 1 else 0) → k) = _
+      rw [Module.finrank_pi k, Fintype.card_fin]
+  simp only [hcomp]
+  -- Expand the sum over `Σ a b, (a ⟶ b)` into iterated sums, then collapse: the innermost
+  -- arrow-sum contributes `#(a ⟶ b)`, and the two `if`s select `a = i` and `b = j`.
+  rw [Fintype.sum_sigma]
+  simp only [Fintype.sum_sigma]
+  simp [Finset.sum_const, Finset.card_univ, Finset.card_empty, mul_ite, ite_mul,
+    apply_ite Finset.card, Fintype.sum_ite_eq', Finset.sum_ite_irrel, Finset.sum_const_zero]
+
 /-- **Classification of 2-dimensional representations.** For a quiver without oriented cycles,
 a representation `ρ` of total dimension `2` is either decomposable, necessarily a direct sum
 `S_i ⊕ S_j` of two simples, or indecomposable, in which case there is a single arrow

--- a/progress/2026-07-22T20-10-17Z_661479fa.md
+++ b/progress/2026-07-22T20-10-17Z_661479fa.md
@@ -1,0 +1,48 @@
+## Accomplished
+
+Formalized the full **Ext¹ dimension computation** for the vertex simples of an
+acyclic path algebra (issue #7376), completing the previously `covered_partial`
+sub-question of **Problem 3.9.3**. In
+`EtingofRepresentationTheory/Chapter3/Problem3_9_3.lean`:
+
+- `extDiffₗ` — the Ext differential `d(f)_a = W_a ∘ f_i - f_j ∘ V_a` as a genuine
+  `k`-linear map (linear upgrade of the bare function `Problem6_9_3.extDiff`); the
+  subtraction uses `Problem6_9_3.acg` so it extends the bundled `AddCommMonoid`.
+- `Ext1Simple i j` — `Ext¹(S_i, S_j)` as the cokernel of `extDiffₗ`.
+- `simpleRep_obj_addCommGroup` — a low-priority `AddCommGroup` instance on the
+  `Fin _ → k` carriers, needed to form the cokernel and take its `finrank`
+  (compatible with the bundled monoid, so nothing downstream changes).
+- `extDiffₗ_simpleRep_eq_zero` — the differential vanishes between two simples.
+- `finrank_ext1_simpleRep` — **the book's answer**
+  `dim Ext¹(S_i, S_j) = #(i ⟶ j)`, via `coker 0 ≅ codomain`, `finrank_pi_fintype`,
+  `finrank_linearMap`, and a sigma-sum count.
+
+`lake build EtingofRepresentationTheory.Chapter3.Problem3_9_3` succeeds; the whole
+`Chapter3` aggregate builds. `#print axioms finrank_ext1_simpleRep` shows only
+`propext, Classical.choice, Quot.sound` — no `sorryAx`.
+
+`progress/items.json`: `Chapter3/Problem3.9.3` lifted `covered_partial →
+covered_full` (all three sub-questions now full), added `lean_decl` and a
+`coverage_note`, and reconciled the stale `sorry_free: false → true`.
+
+## Current frontier
+
+Problem 3.9.3 is fully covered. Note: the §3.9-audit PR **#7377** (still open) will
+add `coverage: covered_partial` to this same item; whoever merges second must keep
+`covered_full` (the note documents that #7376 lifted it).
+
+## Overall project progress
+
+Stage 3.7 (coverage-arm audit + follow-up formalizations) ongoing. This turn closed
+a `covered_partial → covered_full` follow-up. Two review items remain unclaimed
+(#7342 §5.8 induction lemmas, #7346 Exercise 5.3.3).
+
+## Next step
+
+A planner should reconcile #7376/#7377 ordering on the shared `items.json` entry
+(keep `covered_full`). Workers can pick up #7342 or #7346.
+
+## Blockers
+
+None. Potential merge conflict with #7377 on the single `items.json` line for
+Chapter3/Problem3.9.3 — resolvable by keeping `covered_full`.

--- a/progress/items.json
+++ b/progress/items.json
@@ -2478,8 +2478,17 @@
     "start_line": 17,
     "end_line": 17,
     "status": "sorry_free",
-    "sorry_free": false,
+    "sorry_free": true,
     "fidelity": "verified",
+    "coverage": "covered_full",
+    "lean_decl": [
+      "Etingof.Problem3_9_3.simpleRep_isIrreducible",
+      "Etingof.Problem3_9_3.irreducible_isSimpleRep",
+      "Etingof.Problem3_9_3.ext1_simpleRep_vanishes_iff",
+      "Etingof.Problem3_9_3.finrank_ext1_simpleRep",
+      "Etingof.Problem3_9_3.two_dim_classification"
+    ],
+    "coverage_note": "All three sub-questions are covered_full. Irreducibles: simpleRep_isIrreducible (each vertex simple S_i is irreducible) and irreducible_isSimpleRep (over a finite acyclic quiver every irreducible is isomorphic to some S_i). Ext^1 between simples: ext1_simpleRep_vanishes_iff gives the vanishing criterion and, completing the previously covered_partial dimension count (#7376), finrank_ext1_simpleRep proves the book’s exact formula dim Ext^1(S_i, S_j) = #(i ⟶ j): Ext^1 is defined as the cokernel of the linear Ext differential extDiffₗ, which vanishes between two simples, so Ext^1(S_i,S_j) is its whole codomain and finrank counts the arrows i→j. 2-dimensional representations: two_dim_classification. Sorry-free, #print axioms shows no sorryAx.",
     "lean_file": "EtingofRepresentationTheory/Chapter3/Problem3_9_3.lean"
   },
   {


### PR DESCRIPTION
Closes #7376

Session: `661479fa-e930-4771-8869-6245ef63d5fd`

e0cf84f9 feat(Ch3): formalize dim Ext¹(S_i,S_j) = #(i→j) for path-algebra simples (#7376)

🤖 Prepared with Claude Code