### PR TITLE
feat(Ch9 #Definition9.7.1): expose Morita equivalence on fmod and reconcile with full-module API

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/Corollary9_7_3Categorical.lean
+++ b/EtingofRepresentationTheory/Chapter9/Corollary9_7_3Categorical.lean
@@ -122,3 +122,20 @@ theorem Etingof.Corollary_9_7_3_i_categorical_fgModule
   obtain ⟨eFG⟩ := Etingof.MoritaEquivalent.fgModuleCatEquiv hmor
   obtain ⟨eC⟩ := hcat
   exact ⟨B, instR, instA, instF, hbasic, ⟨eC.trans eFG⟩⟩
+
+/-- **Corollary 9.7.3(i), algebra version, book-faithful `fmod` form.** Any
+finite-dimensional algebra `A` over an algebraically closed field `k` is Morita equivalent
+(in the book's sense, on finite-dimensional/finitely generated modules) to some basic
+algebra `B`.
+
+This is `Etingof.Corollary_9_7_3_i` with its conclusion transported along the forward
+reconciliation `Etingof.MoritaEquivalent.toFmod` to the literal book notion
+`Etingof.MoritaEquivalentFmod`.
+(Etingof Corollary 9.7.3(i), algebra version) -/
+theorem Etingof.Corollary_9_7_3_i_fmod
+    {k : Type v} [Field k] [IsAlgClosed k]
+    (A : Type v) [Ring A] [Algebra k A] [Module.Finite k A] :
+    ∃ (B : Type v) (_ : Ring B) (_ : Algebra k B) (_ : Module.Finite k B),
+      Etingof.IsBasicAlgebra k B ∧ Etingof.MoritaEquivalentFmod A B := by
+  obtain ⟨B, instR, instA, instF, hbasic, hmor⟩ := Etingof.Corollary_9_7_3_i k A
+  exact ⟨B, instR, instA, instF, hbasic, hmor.toFmod⟩

--- a/EtingofRepresentationTheory/Chapter9/Definition9_7_1.lean
+++ b/EtingofRepresentationTheory/Chapter9/Definition9_7_1.lean
@@ -1,32 +1,61 @@
 import Mathlib.Algebra.Category.ModuleCat.Basic
 import Mathlib.Algebra.Category.ModuleCat.Biproducts
 import Mathlib.Algebra.Category.ModuleCat.Algebra
+import Mathlib.Algebra.Category.FGModuleCat.Basic
 import Mathlib.CategoryTheory.Equivalence
 import Mathlib.CategoryTheory.Linear.LinearFunctor
 import Mathlib.CategoryTheory.Preadditive.AdditiveFunctor
 
 universe u v
 
+open CategoryTheory
+
 /-!
 # Definition 9.7.1: Morita equivalence
 
-Two finite dimensional algebras A and B are **Morita equivalent** if the categories
-A-fmod and B-fmod are equivalent as abelian categories.
+Two finite dimensional algebras `A` and `B` are **Morita equivalent** if the categories
+`A`-fmod and `B`-fmod are equivalent as abelian categories.
 
 ## Mathlib correspondence
 
-This can be expressed as `CategoryTheory.Equivalence (ModuleCat R) (ModuleCat S)` in Mathlib,
-though the finite-dimensional constraint requires additional bundling.
+For a finite-dimensional `k`-algebra `A`, the book's category `A`-fmod of
+finite-dimensional modules is exactly the category of finitely generated `A`-modules:
+a finitely generated module over a finite-dimensional algebra is finite dimensional over
+`k`, and conversely a finite-dimensional module is finitely generated. This category is
+`FGModuleCat A` in Mathlib, so the book's definition is expressed literally as
+`Etingof.MoritaEquivalentFmod` below: `Nonempty (FGModuleCat A ≌ FGModuleCat B)`.
+
+We also keep the auxiliary notion `Etingof.MoritaEquivalent`, an equivalence of the
+*full* module categories `Nonempty (ModuleCat A ≌ ModuleCat B)`. For finite-dimensional
+algebras `ModuleCat A` is the ind-completion of `FGModuleCat A`, so the two notions
+agree; the forward implication `MoritaEquivalent → MoritaEquivalentFmod` is
+`Etingof.MoritaEquivalent.toFmod` (in `Infrastructure/MoritaFGRestriction.lean`), obtained
+by restricting a full-module equivalence to the finitely generated subcategories. The
+converse (recovering a full-module equivalence from an equivalence of finite-dimensional
+modules) is the Morita reconstruction theorem and is not yet formalized. The full-module
+notion is the one produced by the concrete constructions in this project (the corner
+functor `M ↦ eM` and `exists_basic_morita_equivalent`), and every book-level conclusion
+is exposed on the faithful `fmod` notion via the forward implication.
 -/
 
-/-- Morita equivalence of algebras, in the sense of Etingof Definition 9.7.1.
-Two algebras A and B are Morita equivalent if their module categories are equivalent.
-The book restricts to finite-dimensional modules, but we use the full module category
-as Mathlib does not have a standalone finite-dimensional module category. -/
+/-- **Morita equivalence, Etingof Definition 9.7.1 (book-faithful form).**
+
+Two algebras `A` and `B` are Morita equivalent if their categories of
+finitely generated modules are equivalent. For finite-dimensional algebras
+`FGModuleCat A` is the book's category `A`-fmod of finite-dimensional modules, so this is
+the literal book definition. -/
+def Etingof.MoritaEquivalentFmod (A : Type u) [Ring A] (B : Type u) [Ring B] : Prop :=
+  Nonempty (FGModuleCat.{u} A ≌ FGModuleCat.{u} B)
+
+/-- Morita equivalence of algebras via the full module categories.
+
+Two algebras `A` and `B` are equivalent here if their categories of *all* modules are
+equivalent. For finite-dimensional algebras this agrees with the book-faithful
+`Etingof.MoritaEquivalentFmod` (the full module category is the ind-completion of the
+finite-dimensional one); the forward direction is `Etingof.MoritaEquivalent.toFmod`.
+This full-module notion is what the concrete constructions in this project produce. -/
 def Etingof.MoritaEquivalent (A : Type u) [Ring A] (B : Type v) [Ring B] : Prop :=
   Nonempty (ModuleCat.{max u v} A ≌ ModuleCat.{max u v} B)
-
-open CategoryTheory
 
 /-- k-linear Morita equivalence of k-algebras.
 
@@ -49,6 +78,18 @@ def Etingof.KLinearMoritaEquivalent (k : Type*) [Field k]
       letI : E.functor.IsEquivalence := E.isEquivalence_functor
       Functor.additive_of_preserves_binary_products E.functor
     E.functor.Linear k
+
+/-- k-linear Morita equivalence of k-algebras, book-faithful `fmod` form.
+
+Two k-algebras `A` and `B` are k-linearly Morita equivalent (on finitely generated
+modules) if there is an equivalence `FGModuleCat A ≌ FGModuleCat B` whose functor is
+k-linear on Hom spaces. This is the k-linear refinement of
+`Etingof.MoritaEquivalentFmod`, matching `Etingof.KLinearMoritaEquivalent` on the full
+module categories. -/
+def Etingof.KLinearMoritaEquivalentFmod (k : Type*) [Field k]
+    (A : Type u) [Ring A] [Algebra k A]
+    (B : Type u) [Ring B] [Algebra k B] : Prop :=
+  ∃ (E : FGModuleCat.{u} A ≌ FGModuleCat.{u} B), E.functor.Linear k
 
 namespace Etingof
 
@@ -88,6 +129,57 @@ lemma KLinearMoritaEquivalent.trans' {k : Type*} [Field k]
   haveI : E₂.functor.Additive :=
     letI : E₂.functor.IsEquivalence := E₂.isEquivalence_functor
     Functor.additive_of_preserves_binary_products E₂.functor
+  haveI := hlin₂
+  refine ⟨E₁.trans E₂, ?_⟩
+  change (E₁.functor ⋙ E₂.functor).Linear k
+  infer_instance
+
+/-! ## Book-faithful `fmod` Morita equivalence: reflexivity, symmetry, transitivity -/
+
+/-- Book-faithful Morita equivalence is reflexive. -/
+lemma MoritaEquivalentFmod.refl (A : Type u) [Ring A] : MoritaEquivalentFmod A A :=
+  ⟨CategoryTheory.Equivalence.refl⟩
+
+/-- Book-faithful Morita equivalence is symmetric. -/
+lemma MoritaEquivalentFmod.symm {A : Type u} [Ring A] {B : Type u} [Ring B]
+    (h : MoritaEquivalentFmod A B) : MoritaEquivalentFmod B A :=
+  h.map CategoryTheory.Equivalence.symm
+
+/-- Book-faithful Morita equivalence is transitive. -/
+lemma MoritaEquivalentFmod.trans {A : Type u} [Ring A] {B : Type u} [Ring B]
+    {C : Type u} [Ring C]
+    (h₁ : MoritaEquivalentFmod A B) (h₂ : MoritaEquivalentFmod B C) :
+    MoritaEquivalentFmod A C := by
+  obtain ⟨e₁⟩ := h₁
+  obtain ⟨e₂⟩ := h₂
+  exact ⟨e₁.trans e₂⟩
+
+/-- k-linear book-faithful Morita equivalence implies the bare book-faithful notion. -/
+lemma KLinearMoritaEquivalentFmod.toMoritaEquivalentFmod {k : Type*} [Field k]
+    {A : Type u} [Ring A] [Algebra k A]
+    {B : Type u} [Ring B] [Algebra k B]
+    (h : KLinearMoritaEquivalentFmod k A B) : MoritaEquivalentFmod A B :=
+  let ⟨E, _⟩ := h; ⟨E⟩
+
+/-- k-linear book-faithful Morita equivalence is symmetric. -/
+lemma KLinearMoritaEquivalentFmod.symm' {k : Type*} [Field k]
+    {A : Type u} [Ring A] [Algebra k A]
+    {B : Type u} [Ring B] [Algebra k B]
+    (h : KLinearMoritaEquivalentFmod k A B) : KLinearMoritaEquivalentFmod k B A := by
+  obtain ⟨E, hlin⟩ := h
+  haveI := hlin
+  exact ⟨E.symm, Equivalence.inverseLinear k E⟩
+
+/-- k-linear book-faithful Morita equivalence is transitive. -/
+lemma KLinearMoritaEquivalentFmod.trans' {k : Type*} [Field k]
+    {A : Type u} [Ring A] [Algebra k A]
+    {B : Type u} [Ring B] [Algebra k B]
+    {C : Type u} [Ring C] [Algebra k C]
+    (h₁ : KLinearMoritaEquivalentFmod k A B)
+    (h₂ : KLinearMoritaEquivalentFmod k B C) : KLinearMoritaEquivalentFmod k A C := by
+  obtain ⟨E₁, hlin₁⟩ := h₁
+  obtain ⟨E₂, hlin₂⟩ := h₂
+  haveI := hlin₁
   haveI := hlin₂
   refine ⟨E₁.trans E₂, ?_⟩
   change (E₁.functor ⋙ E₂.functor).Linear k

--- a/EtingofRepresentationTheory/Infrastructure/MoritaFGRestriction.lean
+++ b/EtingofRepresentationTheory/Infrastructure/MoritaFGRestriction.lean
@@ -236,4 +236,16 @@ theorem MoritaEquivalent.fgModuleCatEquiv {A B : Type u} [Ring A] [Ring B]
     exact finite_functor_iff E M
   exact ⟨E.congrFullSubcategory hobj⟩
 
+/-- **Reconciliation, forward direction.** A full-module Morita equivalence implies the
+book-faithful Morita equivalence on finitely generated modules (Etingof Definition 9.7.1).
+
+For finite-dimensional algebras `FGModuleCat` is the book's category `A`-fmod, so this says
+the full-module notion `Etingof.MoritaEquivalent` refines to the literal book definition
+`Etingof.MoritaEquivalentFmod`. The converse (reconstructing a full-module equivalence from
+an equivalence of finite-dimensional modules) is the Morita reconstruction theorem and is
+not yet formalized. -/
+theorem MoritaEquivalent.toFmod {A B : Type u} [Ring A] [Ring B]
+    (h : Etingof.MoritaEquivalent A B) : Etingof.MoritaEquivalentFmod A B :=
+  MoritaEquivalent.fgModuleCatEquiv h
+
 end Etingof

--- a/EtingofRepresentationTheory/Infrastructure/MoritaFGRestriction.lean
+++ b/EtingofRepresentationTheory/Infrastructure/MoritaFGRestriction.lean
@@ -248,4 +248,26 @@ theorem MoritaEquivalent.toFmod {A B : Type u} [Ring A] [Ring B]
     (h : Etingof.MoritaEquivalent A B) : Etingof.MoritaEquivalentFmod A B :=
   MoritaEquivalent.fgModuleCatEquiv h
 
+/-- **Reconciliation, forward direction, k-linear.** A k-linear full-module Morita
+equivalence restricts to a k-linear Morita equivalence on finitely generated modules.
+
+The restricted functor is `(ModuleCat.isFG B).lift ((ModuleCat.isFG A).ι ⋙ E.functor)`;
+since the full-subcategory inclusions are k-linear and `E.functor` is k-linear by
+hypothesis, its restriction is k-linear, checked through the faithful inclusion
+`(ModuleCat.isFG B).ι`. -/
+theorem KLinearMoritaEquivalent.toFmod {k : Type u} [Field k]
+    {A B : Type u} [Ring A] [Algebra k A] [Ring B] [Algebra k B]
+    (h : Etingof.KLinearMoritaEquivalent k A B) :
+    Etingof.KLinearMoritaEquivalentFmod k A B := by
+  obtain ⟨E, hlin⟩ := h
+  haveI := hlin
+  have hobj : (ModuleCat.isFG.{u} B).inverseImage E.functor = ModuleCat.isFG.{u} A := by
+    funext M; exact propext (finite_functor_iff E M)
+  refine ⟨E.congrFullSubcategory hobj, ⟨fun {X Y} f r => ?_⟩⟩
+  apply (ModuleCat.isFG.{u} B).ι.map_injective
+  change E.functor.map ((ModuleCat.isFG.{u} A).ι.map (r • f))
+      = (ModuleCat.isFG.{u} B).ι.map (r • (E.congrFullSubcategory hobj).functor.map f)
+  simp only [Functor.Linear.map_smul]
+  rfl
+
 end Etingof

--- a/progress/2026-07-22T20-26-20Z_efdc2471.md
+++ b/progress/2026-07-22T20-26-20Z_efdc2471.md
@@ -1,0 +1,60 @@
+## Accomplished
+
+Feature #7382 — fix(Ch9 #Definition9.7.1): expose Morita equivalence on the
+book's finite-dimensional module category and reconcile with the existing
+full-module API.
+
+- **Book-faithful definition** (`Chapter9/Definition9_7_1.lean`): added
+  `Etingof.MoritaEquivalentFmod A B := Nonempty (FGModuleCat A ≌ FGModuleCat B)`,
+  the literal `A`-fmod definition (for a finite-dimensional algebra, finitely
+  generated = finite-dimensional over `k`). Added the k-linear refinement
+  `Etingof.KLinearMoritaEquivalentFmod` (functor k-linear on Hom spaces), and
+  `refl`/`symm`/`trans` API for both fmod notions plus
+  `KLinearMoritaEquivalentFmod.toMoritaEquivalentFmod`.
+- **Reconciliation forward direction** (`Infrastructure/MoritaFGRestriction.lean`):
+  `MoritaEquivalent.toFmod` (full-module ⇒ fmod, via the existing
+  `fgModuleCatEquiv`) and the k-linear arm `KLinearMoritaEquivalent.toFmod`
+  (restriction to f.g. modules stays k-linear, checked through the faithful
+  full-subcategory inclusion).
+- **Consumer bridge**: restated the algebra version of Corollary 9.7.3(i) on the
+  faithful notion as `Etingof.Corollary_9_7_3_i_fmod`
+  (`Chapter9/Corollary9_7_3Categorical.lean`). The categorical form
+  `Corollary_9_7_3_i_categorical_fgModule` already concludes `C ≌ FGModuleCat B`,
+  so it was already fmod-faithful.
+- **Docstring cleanup**: removed the stale claim that Mathlib has no standalone
+  finite-dimensional module category (FGModuleCat is used throughout); rewrote the
+  module docstring to make `MoritaEquivalentFmod` the primary book definition and
+  document `MoritaEquivalent` as the auxiliary ind-completion form.
+- **Metadata**: updated `progress/items.json` note for `Chapter9/Definition9.7.1`
+  (JSON re-validated, 593 items).
+- All new declarations sorry-free: `#print axioms` shows only
+  `[propext, Classical.choice, Quot.sound]`. Full affected chain builds
+  (2448 jobs).
+
+## Current frontier
+
+Forward reconciliation (both plain and k-linear) is complete and consumers are
+bridged. The converse — an equivalence of finite-dimensional module categories
+implies an equivalence of the full module categories (the Morita reconstruction
+theorem) — is documented in the definition docstrings and the items.json note as
+not yet formalized. It requires progenerator/ind-completion machinery
+(`ModuleCat A ≌ Ind (FGModuleCat A)` for Artinian `A`) that is not in Mathlib and
+is a multi-session undertaking.
+
+## Overall project progress
+
+Stage 3.7 exercise-coverage sweep continues in Chapter 3 (siblings under review).
+This turn was a Chapter 9 definition-faithfulness fix from the completeness-audit
+queue. Definition 9.7.1 now exposes the literal book notion.
+
+## Next step
+
+Optional follow-up: formalize the converse (Morita reconstruction) to upgrade the
+forward bridges to a full biconditional, and add k-linear-fmod variants of
+`Corollary_9_7_3_i_unique` / `_ii` if a fully fmod-native uniqueness statement is
+wanted. Otherwise, next worker: claim another unclaimed `review` or `feature`
+issue.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -8547,7 +8547,8 @@
     "end_line": 8,
     "status": "sorry_free",
     "fidelity": "verified",
-    "sorry_free": true
+    "sorry_free": true,
+    "notes": "Book-faithful notion Etingof.MoritaEquivalentFmod := Nonempty (FGModuleCat A ≌ FGModuleCat B) is the literal A-fmod definition (finitely generated = finite-dimensional over a finite-dimensional algebra), with k-linear refinement KLinearMoritaEquivalentFmod and refl/symm/trans API. Reconciled with the auxiliary full-module Etingof.MoritaEquivalent via forward bridges MoritaEquivalent.toFmod and KLinearMoritaEquivalent.toFmod (Infrastructure/MoritaFGRestriction). Corollary 9.7.3(i) exposed on the faithful notion as Corollary_9_7_3_i_fmod. Converse (fmod-equivalence ⇒ full-module equivalence, the Morita reconstruction theorem) not yet formalized. Stale 'no finite-dimensional module category in Mathlib' docstring removed."
   },
   {
     "id": "Chapter9/Discussion_after_Definition9.7.1",


### PR DESCRIPTION
Partial progress on #7382

Session: `efdc2471-f204-476c-bf9c-a374d95b67f4`

81cc3afb chore(Ch9 #Definition9.7.1): record book-faithful Morita metadata and progress
a86fe5c8 feat(Ch9 #Definition9.7.1): add k-linear forward Morita reconciliation bridge
d756b79c feat(Ch9 #Definition9.7.1): expose book-faithful Morita equivalence on fmod

🤖 Prepared with Claude Code