### PR TITLE
fidelity(Ch3 Theorem 3.10.2): remove unfaithful finite-dimensionality assumptions on A and B

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/Theorem3_10_2.lean
+++ b/EtingofRepresentationTheory/Chapter3/Theorem3_10_2.lean
@@ -4,6 +4,7 @@ import Mathlib.RingTheory.TensorProduct.Basic
 import Mathlib.Algebra.Algebra.Tower
 import Mathlib.LinearAlgebra.TensorProduct.Basis
 import Mathlib.RingTheory.Artinian.Module
+import Mathlib.Algebra.Polynomial.AlgebraMap
 import EtingofRepresentationTheory.Chapter3.Theorem3_2_2
 
 /-!
@@ -731,3 +732,60 @@ theorem Etingof.tensor_product_irreducible_classification_unique
       = TensorProduct.map ((Algebra.lsmul k k W' : B →ₐ[k] _) b) LinearMap.id
           ((TensorProduct.comm k V' W') (e ((TensorProduct.comm k W V) x)))
   rw [comm_map_apply, hB, comm_map_apply]
+
+/-! ## Regression: the theorem applies to an infinite-dimensional algebra
+
+Theorem 3.10.2 assumes finite-dimensionality of the *representations*, not of the
+algebras `A`, `B`. The polynomial algebra `k[X]` is infinite-dimensional over `k`, yet the
+base field `k` is a one-dimensional (hence finite-dimensional and simple) `k[X]`-module with
+`X` acting as `0` (restriction of scalars along the augmentation `k[X] → k`, `p ↦ p(0)`).
+
+The examples below confirm that `Etingof.tensor_product_irreducible` and
+`Etingof.tensor_product_irreducible_classification` apply with `A = B = k[X]`. This would be
+impossible if the removed `[FiniteDimensional k A]` / `[FiniteDimensional k B]` assumptions
+were still present: no `FiniteDimensional k k[X]` instance exists, so instance resolution
+would fail. -/
+section InfiniteDimensionalRegression
+
+open Polynomial
+
+variable (k : Type*) [Field k] [IsAlgClosed k]
+
+/-- `k` as a `k[X]`-module with `X` acting as `0`: restriction of scalars along the
+augmentation `k[X] → k`, `p ↦ p(0)`. -/
+noncomputable local instance polyEvalModule : Module k[X] k :=
+  Module.compHom k ((aeval (0 : k)).toRingHom)
+
+local instance : IsScalarTower k k[X] k where
+  smul_assoc c p x := by
+    change aeval (0 : k) (c • p) * x = c • (aeval (0 : k) p * x)
+    rw [map_smul]
+    exact smul_mul_assoc c (aeval (0 : k) p) x
+
+local instance : SMulCommClass k[X] k[X] k where
+  smul_comm p q x := by
+    change aeval (0 : k) p * (aeval (0 : k) q * x) = aeval (0 : k) q * (aeval (0 : k) p * x)
+    ring
+
+/-- `k` is simple as a `k[X]`-module: a `k[X]`-submodule restricts to a `k`-submodule of the
+field `k`, which is `⊥` or `⊤`. -/
+local instance : IsSimpleModule k[X] k :=
+  { toIsSimpleOrder :=
+    { eq_bot_or_eq_top := fun N => by
+        rcases eq_bot_or_eq_top (N.restrictScalars k) with h | h
+        · refine Or.inl (Submodule.restrictScalars_injective k k[X] k ?_)
+          rw [Submodule.restrictScalars_bot]; exact h
+        · refine Or.inr (Submodule.restrictScalars_injective k k[X] k ?_)
+          rw [Submodule.restrictScalars_top]; exact h } }
+
+/-- Part (i) applies with the infinite-dimensional algebra `A = B = k[X]`. -/
+example : True := by
+  have := Etingof.tensor_product_irreducible k k[X] k[X] k k
+  trivial
+
+/-- Part (ii) applies with the infinite-dimensional algebra `A = B = k[X]`. -/
+example : True := by
+  have := Etingof.tensor_product_irreducible_classification k k[X] k[X] k
+  trivial
+
+end InfiniteDimensionalRegression

--- a/EtingofRepresentationTheory/Chapter3/Theorem3_10_2.lean
+++ b/EtingofRepresentationTheory/Chapter3/Theorem3_10_2.lean
@@ -126,8 +126,8 @@ Pick nonzero u ∈ U, decompose using a basis of V, and use a rank-1 projection
 to extract a nonzero pure tensor. Then the A- and B-actions generate all of V ⊗ W. -/
 theorem Etingof.tensor_product_irreducible (k : Type*) (A B V W : Type*)
     [Field k] [IsAlgClosed k]
-    [Ring A] [Algebra k A] [FiniteDimensional k A]
-    [Ring B] [Algebra k B] [FiniteDimensional k B]
+    [Ring A] [Algebra k A]
+    [Ring B] [Algebra k B]
     [AddCommGroup V] [Module k V] [Module A V] [IsScalarTower k A V]
     [AddCommGroup W] [Module k W] [Module B W] [IsScalarTower k B W]
     [FiniteDimensional k V] [FiniteDimensional k W]
@@ -182,8 +182,8 @@ section Part2Helpers
 open scoped TensorProduct
 
 variable {k : Type*} {A B : Type*} [Field k] [IsAlgClosed k]
-  [Ring A] [Algebra k A] [FiniteDimensional k A]
-  [Ring B] [Algebra k B] [FiniteDimensional k B]
+  [Ring A] [Algebra k A]
+  [Ring B] [Algebra k B]
 
 variable {M : Type*} [AddCommGroup M] [Module k M] [FiniteDimensional k M]
   [Module A M] [IsScalarTower k A M]
@@ -233,7 +233,7 @@ noncomputable def evalMap : V₀ ⊗[k] (V₀ →ₗ[A] M) →ₗ[k] M :=
         have h1 : f ((algebraMap k A c) • v) = (algebraMap k A c) • f v := f.map_smul _ _
         rwa [algebraMap_smul, algebraMap_smul] at h1 }
 
-omit [IsAlgClosed k] [FiniteDimensional k A] [FiniteDimensional k M] in
+omit [IsAlgClosed k] [FiniteDimensional k M] in
 @[simp]
 theorem evalMap_tmul (v : V₀) (f : V₀ →ₗ[A] M) :
     evalMap V₀ (v ⊗ₜ[k] f) = f v := by
@@ -251,8 +251,8 @@ theorem Etingof.tensor_product_irreducible_classification.{u}
     (k : Type*) (A B : Type*)
     (M : Type u)
     [Field k] [IsAlgClosed k]
-    [Ring A] [Algebra k A] [FiniteDimensional k A]
-    [Ring B] [Algebra k B] [FiniteDimensional k B]
+    [Ring A] [Algebra k A]
+    [Ring B] [Algebra k B]
     [AddCommGroup M] [Module k M] [FiniteDimensional k M]
     [Module A M] [IsScalarTower k A M]
     [Module B M] [IsScalarTower k B M]

--- a/progress/2026-07-22T21-35-21Z_4f1e00e3.md
+++ b/progress/2026-07-22T21-35-21Z_4f1e00e3.md
@@ -1,0 +1,41 @@
+## Accomplished
+
+Fidelity fix for **Theorem 3.10.2** (issue #7391): removed the unfaithful
+`[FiniteDimensional k A]` / `[FiniteDimensional k B]` assumptions from both public
+declarations.
+
+- `Etingof.tensor_product_irreducible` (part i) and
+  `Etingof.tensor_product_irreducible_classification` (part ii) no longer assume the
+  *algebras* are finite-dimensional. The book (`blobs/Chapter3/Theorem3.10.2.md`) assumes
+  only that the *representations* `V`, `W`, `M` are finite-dimensional.
+- Verified the removal is sound: `Etingof.density_theorem_part1` needs only
+  `FiniteDimensional k V/W`, and `isArtinian_of_tower` needs only `IsArtinian k M`; neither
+  uses algebra finiteness.
+- Generalized the `Part2Helpers` section variables (dropped the two assumptions there too)
+  and fixed the `omit` clause on `evalMap_tmul`.
+- Added a regression section instantiating both parts with the infinite-dimensional
+  algebra `A = B = k[X]` acting on the finite-dimensional simple module `k` (`X ↦ 0`, via
+  `Module.compHom` along the augmentation `k[X] → k`). Built local instances
+  `IsScalarTower k k[X] k`, `SMulCommClass k[X] k[X] k`, `IsSimpleModule k[X] k`. These
+  examples only elaborate because no `FiniteDimensional k k[X]` instance exists, so they
+  guard against re-adding the assumptions.
+- Updated `progress/items.json` fidelity note (`fidelity_issue` → 7391).
+
+## Current frontier
+
+Complete. `lake build EtingofRepresentationTheory.Chapter3.Theorem3_10_2` and the downstream
+user `EtingofRepresentationTheory.Chapter5.Theorem5_6_1` both build cleanly. `#print axioms`
+on both theorems shows only `[propext, Classical.choice, Quot.sound]` (no `sorryAx`).
+
+## Overall project progress
+
+Stage 3.7 (coverage-arm audits / fidelity fixes). This closes a fidelity gap where a
+theorem statement silently narrowed the book's claim.
+
+## Next step
+
+None for this item. PR opened closing #7391.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -2692,10 +2692,10 @@
     "end_line": 16,
     "status": "sorry_free",
     "fidelity": "verified",
-    "notes": "All sorries resolved. Uniqueness of V, W (Theorem 3.10.2(ii)'s '**unique** V and W') added as companion theorem Etingof.tensor_product_irreducible_classification_unique (#5614).",
+    "notes": "All sorries resolved. Uniqueness of V, W (Theorem 3.10.2(ii)'s '**unique** V and W') added as companion theorem Etingof.tensor_product_irreducible_classification_unique (#5614). Algebra-finiteness assumptions [FiniteDimensional k A]/[FiniteDimensional k B] removed as unfaithful (#7391): the book assumes only the representations V/W/M are finite-dimensional.",
     "sorry_free": true,
-    "fidelity_note": "[resolved #5614] Existence is tensor_product_irreducible_classification; uniqueness up to isomorphism is the companion tensor_product_irreducible_classification_unique (V ≅ V' as A-modules, W ≅ W' as B-modules for any two A-B-equivariant factorizations), via Schur's lemma.",
-    "fidelity_issue": 5614
+    "fidelity_note": "[resolved #7391] The public parts (i) tensor_product_irreducible and (ii) tensor_product_irreducible_classification no longer assume [FiniteDimensional k A]/[FiniteDimensional k B]; the density theorem (Etingof.density_theorem_part1) and isArtinian_of_tower need only FiniteDimensional k V/W/M, matching the book. A regression test instantiates both with the infinite-dimensional A=B=k[X] acting on the finite-dimensional simple module k (X↦0). [resolved #5614] Existence is tensor_product_irreducible_classification; uniqueness up to isomorphism is the companion tensor_product_irreducible_classification_unique (V ≅ V' as A-modules, W ≅ W' as B-modules for any two A-B-equivariant factorizations), via Schur's lemma.",
+    "fidelity_issue": 7391
   },
   {
     "id": "Chapter3/Remark3.10.3",


### PR DESCRIPTION
Closes #7391

Session: `4f1e00e3-f272-4492-b436-493555d8ec40`

5f684410 chore(progress): handoff for Ch3 Theorem 3.10.2 fidelity fix (#7391)
d9a20f0d test(Ch3 #7391): regression examples applying Theorem 3.10.2 to k[X]
d15631cf fix(Ch3 #7391): remove unfaithful FiniteDimensional k A/B assumptions from Theorem 3.10.2

🤖 Prepared with Claude Code