### PR TITLE
fix(Ch9 Definition9.4.1): give the zero module book projective dimension 0

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/Definition9_4_1.lean
+++ b/EtingofRepresentationTheory/Chapter9/Definition9_4_1.lean
@@ -8,20 +8,104 @@ A module M has a **projective resolution** if there exists an exact sequence
 … → P₁ → P₀ → M → 0 where each Pᵢ is projective.
 
 The **projective dimension** pd(M) of M is the length of the shortest finite projective
-resolution of M. If no finite projective resolution exists, pd(M) = ∞.
+resolution of M. If no finite projective resolution exists, pd(M) = ∞. Etingof records the
+basic edge case that a projective module has projective dimension `0`; this includes the zero
+module, whose one-term resolution `0 → 0 → 0` is already projective.
 
-## Mathlib correspondence
+## Mathlib correspondence and the bottom edge case
 
-Mathlib defines `CategoryTheory.projectiveDimension` for objects in an abelian category,
-via vanishing of Ext groups. We specialize this to `ModuleCat R`.
+Mathlib defines `CategoryTheory.projectiveDimension` for objects in an abelian category, via
+vanishing of Ext groups, valued in `WithBot ℕ∞`. Its convention differs from the book at a
+single point: the zero object is assigned the value `⊥`, so that `= 0` characterizes the
+*nonzero* projective objects (`CategoryTheory.projectiveDimension_eq_zero_iff`). The book instead
+assigns the zero module the value `0`, so that `= 0` characterizes *all* projective modules,
+zero included.
+
+We therefore expose two names:
+
+* `Etingof.projectiveDimensionRaw` — the verbatim Mathlib value, retaining `⊥` on the zero
+  module. Downstream homological infrastructure that needs the raw `WithBot ℕ∞` value uses this.
+* `Etingof.projectiveDimension` — the book-faithful value `max 0 (raw)`, which agrees with the
+  raw value everywhere except on the zero module, where it takes the source value `0`.
+
+The two conventions answer every "`≤ n`" query (for `n : ℕ`) identically
+(`projectiveDimension_le_iff`), and differ only at the bottom: `raw = ⊥` versus `book = 0` on the
+zero module. In particular all finite-dimension results transfer unchanged.
 -/
 
 universe u
 
-/-- The projective dimension of a module, in the sense of Etingof Definition 9.4.1.
-Defined as `CategoryTheory.projectiveDimension` applied to the corresponding object
-of `ModuleCat R`. Returns a value in `WithBot ℕ∞`: `⊥` if M is zero, a natural number
-for the finite case, or `⊤` if no finite projective resolution exists. -/
-noncomputable def Etingof.projectiveDimension
+open CategoryTheory
+
+/-- The raw Mathlib projective dimension of a module, `CategoryTheory.projectiveDimension`
+applied to the corresponding object of `ModuleCat R`. Returns a value in `WithBot ℕ∞`: `⊥` if
+`M` is zero, a natural number for the finite case, or `⊤` if no finite projective resolution
+exists. This is the internal value; the book-faithful `Etingof.projectiveDimension` normalizes
+the zero-module edge case to `0`. -/
+noncomputable def Etingof.projectiveDimensionRaw
     (R : Type u) [Ring R] (M : ModuleCat.{u} R) : WithBot ℕ∞ :=
   CategoryTheory.projectiveDimension M
+
+/-- The projective dimension of a module, in the sense of Etingof Definition 9.4.1: the length of
+the shortest finite projective resolution, with the book convention that every projective module
+-- including the zero module -- has projective dimension `0`.
+
+Concretely this is `max 0 (Etingof.projectiveDimensionRaw R M)`, which coincides with the raw
+Mathlib value on every nonzero module and normalizes the zero module's value from `⊥` to `0`
+(see `Etingof.projectiveDimension_eq_zero_iff`). -/
+noncomputable def Etingof.projectiveDimension
+    (R : Type u) [Ring R] (M : ModuleCat.{u} R) : WithBot ℕ∞ :=
+  max 0 (Etingof.projectiveDimensionRaw R M)
+
+namespace Etingof
+
+variable {R : Type u} [Ring R]
+
+/-- The book projective dimension is nonnegative: it never takes the value `⊥`. -/
+lemma zero_le_projectiveDimension (M : ModuleCat.{u} R) :
+    (0 : WithBot ℕ∞) ≤ Etingof.projectiveDimension R M :=
+  le_max_left _ _
+
+/-- The raw Mathlib projective dimension of a nonzero module is nonnegative. -/
+lemma zero_le_projectiveDimensionRaw_of_not_isZero (M : ModuleCat.{u} R)
+    (hM : ¬ Limits.IsZero M) : (0 : WithBot ℕ∞) ≤ Etingof.projectiveDimensionRaw R M := by
+  have h : Etingof.projectiveDimensionRaw R M ≠ ⊥ := by
+    rw [Etingof.projectiveDimensionRaw, Ne, CategoryTheory.projectiveDimension_eq_bot_iff]
+    exact hM
+  obtain ⟨b, hb⟩ := WithBot.ne_bot_iff_exists.1 h
+  calc (0 : WithBot ℕ∞) = ((0 : ℕ∞) : WithBot ℕ∞) := by rw [WithBot.coe_zero]
+    _ ≤ (b : WithBot ℕ∞) := WithBot.coe_le_coe.2 zero_le
+    _ = Etingof.projectiveDimensionRaw R M := hb
+
+/-- The book and raw projective dimensions answer every finite `≤ n` query identically:
+`pd M ≤ n ↔ HasProjectiveDimensionLE M n` for `n : ℕ`. -/
+lemma projectiveDimension_le_iff (M : ModuleCat.{u} R) (n : ℕ) :
+    Etingof.projectiveDimension R M ≤ (n : WithBot ℕ∞) ↔ HasProjectiveDimensionLE M n := by
+  simp only [Etingof.projectiveDimension, Etingof.projectiveDimensionRaw, max_le_iff]
+  rw [CategoryTheory.projectiveDimension_le_iff]
+  refine ⟨fun h => h.2, fun h => ⟨?_, h⟩⟩
+  calc (0 : WithBot ℕ∞) = ((0 : ℕ) : WithBot ℕ∞) := by rw [Nat.cast_zero]
+    _ ≤ (n : WithBot ℕ∞) := by exact_mod_cast Nat.zero_le n
+
+/-- **Book characterization of projective dimension zero.** A module has projective dimension `0`
+in the book's sense exactly when it is projective. Unlike the raw Mathlib
+`projectiveDimension_eq_zero_iff` (which excludes the zero module), this includes `M = 0`. -/
+lemma projectiveDimension_eq_zero_iff (M : ModuleCat.{u} R) :
+    Etingof.projectiveDimension R M = 0 ↔ Projective M := by
+  rw [le_antisymm_iff, and_iff_left (zero_le_projectiveDimension M)]
+  rw [show (0 : WithBot ℕ∞) = ((0 : ℕ) : WithBot ℕ∞) from by rw [Nat.cast_zero],
+    projectiveDimension_le_iff, ← projective_iff_hasProjectiveDimensionLE_zero]
+
+/-- The zero module has book projective dimension `0`, matching the source (a projective module
+has projective dimension `0`). Under the raw Mathlib convention it is `⊥`. -/
+lemma projectiveDimension_eq_zero_of_isZero (M : ModuleCat.{u} R) (hM : Limits.IsZero M) :
+    Etingof.projectiveDimension R M = 0 :=
+  (projectiveDimension_eq_zero_iff M).2 hM.projective
+
+/-- On a nonzero module the book projective dimension coincides with the raw Mathlib value; the
+two conventions differ only on the zero module. -/
+lemma projectiveDimension_eq_raw_of_not_isZero (M : ModuleCat.{u} R) (hM : ¬ Limits.IsZero M) :
+    Etingof.projectiveDimension R M = Etingof.projectiveDimensionRaw R M := by
+  rw [Etingof.projectiveDimension, max_eq_right (zero_le_projectiveDimensionRaw_of_not_isZero M hM)]
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter9/Problem9_4_2.lean
+++ b/EtingofRepresentationTheory/Chapter9/Problem9_4_2.lean
@@ -70,17 +70,22 @@ theorem projectiveDimension_succ_of_nonsplit
   have hX3ne : ¬ Limits.IsZero S.X₃ := fun h => hX3proj h.projective
   have hX1ne : ¬ Limits.IsZero S.X₁ := fun h => by
     haveI := h.injective; exact hns.false hS.splittingOfInjective
+  -- On the nonzero modules `S.X₁`, `S.X₃` the book projective dimension agrees with the raw
+  -- Mathlib value, so the book statement reduces to the raw dimension-shifting identity.
+  rw [Etingof.projectiveDimension_eq_raw_of_not_isZero S.X₃ hX3ne,
+    Etingof.projectiveDimension_eq_raw_of_not_isZero S.X₁ hX1ne]
   change CategoryTheory.projectiveDimension S.X₃ = CategoryTheory.projectiveDimension S.X₁ + 1
   have aux (n : ℕ) : CategoryTheory.projectiveDimension S.X₃ ≤ (n : WithBot ℕ∞) ↔
       CategoryTheory.projectiveDimension S.X₁ + 1 ≤ (n : WithBot ℕ∞) := by
     match n with
     | 0 =>
-      rw [projectiveDimension_le_iff, ← projective_iff_hasProjectiveDimensionLE_zero,
+      rw [CategoryTheory.projectiveDimension_le_iff, ← projective_iff_hasProjectiveDimensionLE_zero,
         Nat.cast_zero, ENat.WithBot.add_one_le_zero_iff, projectiveDimension_eq_bot_iff]
       exact iff_of_false hX3proj hX1ne
     | n + 1 =>
       nth_rw 2 [← Nat.cast_one, Nat.cast_add]
-      simp only [ENat.WithBot.add_le_add_natCast_right_iff, projectiveDimension_le_iff]
+      simp only [ENat.WithBot.add_le_add_natCast_right_iff,
+        CategoryTheory.projectiveDimension_le_iff]
       exact hS.hasProjectiveDimensionLT_X₃_iff n hP
   refine eq_of_forall_ge_iff (fun N ↦ ?_)
   induction N with

--- a/progress/2026-07-22T22-50-11Z_cbea4e6c.md
+++ b/progress/2026-07-22T22-50-11Z_cbea4e6c.md
@@ -1,0 +1,50 @@
+## Accomplished
+
+Executed issue #7426 — `fix(Ch9 Definition9.4.1): give the zero module book projective dimension 0`.
+
+Etingof defines projective dimension so that every projective module (the zero module included)
+has projective dimension `0`. The previous `Etingof.projectiveDimension` was a verbatim alias of
+Mathlib's `CategoryTheory.projectiveDimension`, whose `WithBot ℕ∞` convention assigns the zero
+object `⊥`, disagreeing with the book on that edge case while the docstring claimed to be the book
+definition.
+
+Changes in `EtingofRepresentationTheory/Chapter9/Definition9_4_1.lean`:
+
+- Added `Etingof.projectiveDimensionRaw` — the raw Mathlib value (retains `⊥` on the zero module),
+  for downstream homological infrastructure that needs the raw `WithBot ℕ∞`.
+- Redefined `Etingof.projectiveDimension R M := max 0 (projectiveDimensionRaw R M)` — book-faithful:
+  agrees with the raw value on every nonzero module and normalizes the zero module to `0`.
+- Proved the source-facing characterization `projectiveDimension_eq_zero_iff : pd M = 0 ↔ Projective M`
+  (including `M = 0`, unlike Mathlib's `projectiveDimension_eq_zero_iff` which excludes it).
+- Proved `projectiveDimension_eq_zero_of_isZero` (zero module has book pd `0`).
+- Proved `projectiveDimension_le_iff : pd M ≤ (n : ℕ) ↔ HasProjectiveDimensionLE M n`, showing the
+  two conventions answer every finite `≤ n` query identically — the documented relationship.
+- Proved `projectiveDimension_eq_raw_of_not_isZero` (the two conventions coincide off the zero
+  module) plus helpers `zero_le_projectiveDimension`, `zero_le_projectiveDimensionRaw_of_not_isZero`.
+
+Migrated the one downstream consumer, `Problem9_4_2.projectiveDimension_succ_of_nonsplit`: its
+statement is unchanged (in a nonsplit sequence both ends are nonzero, so book = raw there), and the
+proof now reduces to the raw identity via `projectiveDimension_eq_raw_of_not_isZero`. Fully
+qualified `CategoryTheory.projectiveDimension_le_iff` at two sites where the new
+`Etingof.projectiveDimension_le_iff` would otherwise shadow it.
+
+## Current frontier
+
+Issue #7426 complete. `lake build EtingofRepresentationTheory.Chapter9` passes with no errors; the
+two edited files build warning-free. `#print axioms` on the new lemmas shows only
+`propext, Classical.choice, Quot.sound`. No new sorries.
+
+## Overall project progress
+
+Stage 3.x formalization ongoing. This is a definition-fidelity fix (highest-priority class per
+CLAUDE.md). Item `Chapter9/Definition9.4.1` remains `sorry_free` / `fidelity: verified`.
+
+## Next step
+
+Pick up the next unclaimed feature/fidelity issue. Several sibling Ch9 definition-fidelity issues
+remain (#7424 FGModuleCat, #7425 categorical Morita k-linearity, #7422/#7423 homological-dimension
+API).
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7426

Session: `cbea4e6c-3675-4ab6-bf4a-2799fbc7f071`

da02739b fix(Ch9 #Definition9.4.1): give the zero module book projective dimension 0

🤖 Prepared with Claude Code