### PR TITLE
Complete Definition 9.3.1: prove Cartan-matrix diagonal entries are positive

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/Definition9_3_1.lean
+++ b/EtingofRepresentationTheory/Chapter9/Definition9_3_1.lean
@@ -2,7 +2,11 @@ import Mathlib.Data.Matrix.Basic
 import Mathlib.RingTheory.SimpleModule.Basic
 import Mathlib.Order.JordanHolder
 import Mathlib.LinearAlgebra.Dimension.Finrank
+import Mathlib.LinearAlgebra.Dimension.Finite
 import Mathlib.LinearAlgebra.FiniteDimensional.Defs
+import Mathlib.RingTheory.Finiteness.Basic
+import Mathlib.Algebra.Module.LinearMap.Defs
+import EtingofRepresentationTheory.Chapter2.Definition2_3_8
 
 /-!
 # Definition 9.3.1: Cartan matrix
@@ -57,3 +61,97 @@ noncomputable def Etingof.algebraCartanMatrix
     [∀ i, Module k (P i)] [∀ i, SMulCommClass A k (P i)] :
     Matrix ι ι ℕ :=
   Matrix.of fun i j => Module.finrank k (P i →ₗ[A] P j)
+
+/-!
+## Sign of the entries (Definition 9.3.1)
+
+Etingof records immediately after the definition that the Cartan matrix "is a matrix
+with nonnegative entries, whose diagonal entries are positive". Nonnegativity is built
+into the `ℕ`-valued codomain of `Etingof.algebraCartanMatrix`; the substantive endpoint
+is diagonal positivity, `0 < cᵢᵢ`. The `(i, i)` entry is
+
+`cᵢᵢ = dim_k Hom_A(Pᵢ, Pᵢ) = dim_k End_A(Pᵢ)`,
+
+and the identity endomorphism `id : Pᵢ →ₗ[A] Pᵢ` is a nonzero element of this space
+whenever `Pᵢ` is nonzero (i.e. `Nontrivial (P i)`), so the dimension is positive. Since
+each `Pᵢ` is the projective cover of a simple module `Mᵢ`, it is nonzero — and more
+specifically indecomposable, which already carries nonzeroness in
+`Etingof.IsIndecomposable`.
+-/
+
+omit [Algebra k A] in
+/-- Nonnegativity of the Cartan matrix entries (Etingof Definition 9.3.1: "a matrix with
+nonnegative entries"). Automatic from the `ℕ`-valued codomain, exposed here at the
+Cartan-matrix API boundary. -/
+theorem Etingof.algebraCartanMatrix_entry_nonneg
+    {ι : Type*} (P : ι → Type*)
+    [∀ i, AddCommGroup (P i)] [∀ i, Module A (P i)]
+    [∀ i, Module k (P i)] [∀ i, SMulCommClass A k (P i)]
+    (i j : ι) : 0 ≤ Etingof.algebraCartanMatrix (k := k) (A := A) P i j :=
+  Nat.zero_le _
+
+/-- **Diagonal positivity of the Cartan matrix**: `0 < cᵢᵢ` (Etingof Definition 9.3.1,
+"a matrix ... whose diagonal entries are positive").
+
+The `(i, i)` entry is `dim_k Hom_A(Pᵢ, Pᵢ) = dim_k End_A(Pᵢ)`. The identity endomorphism
+is a nonzero element of `Pᵢ →ₗ[A] Pᵢ` whenever `Pᵢ` is nonzero, so this dimension is
+positive. The hypotheses are exactly those supplied by the projective-cover family:
+`Nontrivial (P i)` (each projective cover of a simple module is nonzero) and
+`Module.Finite k (P i)` (finite dimensionality, making the Hom space finite dimensional
+over `k`). -/
+theorem Etingof.algebraCartanMatrix_diag_pos
+    {ι : Type*} (P : ι → Type*)
+    [∀ i, AddCommGroup (P i)] [∀ i, Module A (P i)]
+    [∀ i, Module k (P i)] [∀ i, SMulCommClass A k (P i)]
+    [∀ i, IsScalarTower k A (P i)]
+    (i : ι) [Module.Finite k (P i)] [Nontrivial (P i)] :
+    0 < Etingof.algebraCartanMatrix (k := k) (A := A) P i i := by
+  change 0 < Module.finrank k (P i →ₗ[A] P i)
+  -- The `A`-linear endomorphisms form a `k`-subspace of the (finite-dimensional) `k`-linear
+  -- endomorphisms, via the injective scalar-restriction map; hence finite dimensional.
+  haveI : Module.Finite k (P i →ₗ[A] P i) :=
+    Module.Finite.of_injective (LinearMap.restrictScalarsₗ k A (P i) (P i) k)
+      (LinearMap.restrictScalars_injective k)
+  rw [Module.finrank_pos_iff (R := k)]
+  -- Nontriviality of the endomorphism space: the identity is not the zero map.
+  obtain ⟨x, hx⟩ := exists_ne (0 : P i)
+  refine nontrivial_of_ne (LinearMap.id : P i →ₗ[A] P i) 0 ?_
+  intro h
+  exact hx (by have := LinearMap.congr_fun h x; simpa using this)
+
+/-- Diagonal positivity of the Cartan matrix from indecomposability of the projective
+covers. This is the form matching Etingof's hypotheses: each projective cover `Pᵢ` is
+indecomposable, and `Etingof.IsIndecomposable` carries nonzeroness (`Nontrivial`). -/
+theorem Etingof.algebraCartanMatrix_diag_pos_of_indecomposable
+    {ι : Type*} (P : ι → Type*)
+    [∀ i, AddCommGroup (P i)] [∀ i, Module A (P i)]
+    [∀ i, Module k (P i)] [∀ i, SMulCommClass A k (P i)]
+    [∀ i, IsScalarTower k A (P i)]
+    (i : ι) [Module.Finite k (P i)]
+    (hP : Etingof.IsIndecomposable A (P i)) :
+    0 < Etingof.algebraCartanMatrix (k := k) (A := A) P i i :=
+  haveI : Nontrivial (P i) := hP.1
+  Etingof.algebraCartanMatrix_diag_pos P i
+
+omit [Algebra k A] in
+/-- Nonnegativity of the integer-cast Cartan matrix, in the form used by downstream
+matrix arguments (`C.map (Nat.cast : ℕ → ℤ)`, e.g. in `homClassVector_projective_eq_mulVec`). -/
+theorem Etingof.algebraCartanMatrix_intCast_entry_nonneg
+    {ι : Type*} (P : ι → Type*)
+    [∀ i, AddCommGroup (P i)] [∀ i, Module A (P i)]
+    [∀ i, Module k (P i)] [∀ i, SMulCommClass A k (P i)]
+    (i j : ι) :
+    (0 : ℤ) ≤ ((Etingof.algebraCartanMatrix (k := k) (A := A) P).map (Nat.cast : ℕ → ℤ)) i j := by
+  rw [Matrix.map_apply]; exact Int.natCast_nonneg _
+
+/-- Diagonal positivity of the integer-cast Cartan matrix, in the form used by downstream
+matrix arguments. -/
+theorem Etingof.algebraCartanMatrix_intCast_diag_pos
+    {ι : Type*} (P : ι → Type*)
+    [∀ i, AddCommGroup (P i)] [∀ i, Module A (P i)]
+    [∀ i, Module k (P i)] [∀ i, SMulCommClass A k (P i)]
+    [∀ i, IsScalarTower k A (P i)]
+    (i : ι) [Module.Finite k (P i)] [Nontrivial (P i)] :
+    (0 : ℤ) < ((Etingof.algebraCartanMatrix (k := k) (A := A) P).map (Nat.cast : ℕ → ℤ)) i i := by
+  rw [Matrix.map_apply]
+  exact_mod_cast Etingof.algebraCartanMatrix_diag_pos P i

--- a/progress/2026-07-22T23-04-25Z_f4c63117.md
+++ b/progress/2026-07-22T23-04-25Z_f4c63117.md
@@ -1,0 +1,50 @@
+## Accomplished
+
+Closed issue #7440: exposed the sign observations of Etingof Definition 9.3.1
+("a matrix with nonnegative entries, whose diagonal entries are positive") at the
+`Etingof.algebraCartanMatrix` API boundary in
+`EtingofRepresentationTheory/Chapter9/Definition9_3_1.lean`:
+
+- `algebraCartanMatrix_entry_nonneg` — nonnegativity (automatic for the ℕ-valued codomain).
+- `algebraCartanMatrix_diag_pos` — the substantive endpoint `0 < cᵢᵢ`. Proof: the
+  `(i,i)` entry is `dim_k End_A(Pᵢ)`; the identity endomorphism is a nonzero element
+  whenever `Pᵢ` is nonzero, and the endomorphism space is finite dimensional over `k`
+  (an injective `k`-linear image of `restrictScalarsₗ` into the finite-dimensional
+  `k`-linear endomorphisms), so `finrank_pos_iff` gives positivity. Hypotheses are those
+  the projective-cover family supplies: `Nontrivial (P i)` and `Module.Finite k (P i)`.
+- `algebraCartanMatrix_diag_pos_of_indecomposable` — the same, taking
+  `Etingof.IsIndecomposable A (P i)` (whose `.1` field is `Nontrivial (P i)`), matching
+  Etingof's actual hypothesis on the covers.
+- `algebraCartanMatrix_intCast_entry_nonneg` / `algebraCartanMatrix_intCast_diag_pos` —
+  the `C.map (Nat.cast : ℕ → ℤ)` forms used by downstream matrix arguments
+  (e.g. `homClassVector_projective_eq_mulVec`).
+
+Updated `progress/items.json` fidelity_note for `Chapter9/Definition9.3.1` to record the
+residual is closed.
+
+## Current frontier
+
+Definition 9.3.1's stated sign properties are now fully represented in Lean.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. This is a completeness/fidelity fill on an existing
+sorry-free definition; no new sorries introduced.
+
+## Key decisions / patterns
+
+- `algebraCartanMatrix`'s output type is `Matrix ι ι ℕ`, so `k` and `A` are phantom in
+  applications — references must pass `(k := k) (A := A)` explicitly (as existing
+  consumers already do).
+- Hom-space finite-dimensionality over `k` is obtained via
+  `Module.Finite.of_injective (LinearMap.restrictScalarsₗ k A (P i) (P i) k)
+  (LinearMap.restrictScalars_injective k)`, the pattern already used in Problem9_4_5.
+
+## Next step
+
+Other Chapter 9 completeness issues remain (e.g. #7422 right homological dimension,
+#7423 basic-algebra Morita API, #7434 vertex-simple projective covers).
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -8801,7 +8801,7 @@
     "fidelity": "verified",
     "needs_statement": false,
     "sorry_free": true,
-    "fidelity_note": "wave-2 gap #5631 (degenerate wrapper of arbitrary function) repaired: algebraCartanMatrix is now genuinely constructed as c_ij = finrank k (P i →ₗ[A] P j), the book's dim Hom_A(P_i, P_j); wave-9 re-verified. Residual noted in wave-9: the prose observation 'positive diagonal entries' has no Lean lemma"
+    "fidelity_note": "wave-2 gap #5631 (degenerate wrapper of arbitrary function) repaired: algebraCartanMatrix is now genuinely constructed as c_ij = finrank k (P i →ₗ[A] P j), the book's dim Hom_A(P_i, P_j); wave-9 re-verified. #7440 closes the wave-9 residual: the prose 'nonnegative entries, positive diagonal entries' observation is now exposed as lemmas (algebraCartanMatrix_entry_nonneg, algebraCartanMatrix_diag_pos via the nonzero identity endomorphism, algebraCartanMatrix_diag_pos_of_indecomposable, plus ℤ-cast forms for downstream matrix use)"
   },
   {
     "id": "Chapter9/Problem9.3.2",


### PR DESCRIPTION
Closes #7440

Session: `f4c63117-7e12-4052-a236-799392fc4912`

271b0462 feat(Ch9 #Definition9.3.1): prove Cartan-matrix nonnegativity and diagonal positivity

🤖 Prepared with Claude Code