### PR TITLE
fix(Ch9 Definition9.7.1): categorical Morita equivalence is not automatically k-linear

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/Definition9_7_1.lean
+++ b/EtingofRepresentationTheory/Chapter9/Definition9_7_1.lean
@@ -60,16 +60,32 @@ def Etingof.MoritaEquivalent (A : Type u) [Ring A] (B : Type v) [Ring B] : Prop 
 /-- k-linear Morita equivalence of k-algebras.
 
 Two k-algebras A and B are k-linearly Morita equivalent if there exists an
-equivalence of their module categories whose functor is k-linear on Hom spaces.
+equivalence of their module categories whose functor is k-linear on Hom spaces,
+i.e. commutes with the central `k`-action `algebraMap k A • -` on morphisms.
+This `k`-linearity of the functor is exactly the compatibility condition needed
+to promote a bare (additive) equivalence of module categories to a `k`-linear
+one; it is what lets us upgrade the resulting ring isomorphisms to k-algebra
+isomorphisms.
 
-For k-algebras, every categorical equivalence is automatically k-linear
-(Eilenberg-Watts theorem), so this is equivalent to bare `MoritaEquivalent`.
-We use the k-linear version because Eilenberg-Watts is not yet formalized, and
-the k-linearity is needed to upgrade ring isomorphisms to k-algebra isomorphisms.
+**k-linearity is genuinely an extra condition, not automatic.** A bare
+categorical equivalence `ModuleCat A ≌ ModuleCat B` need not be `k`-linear.
+By Eilenberg-Watts every such equivalence is given by tensoring with an
+`(A, B)`-bimodule, but the two central `k`-actions on that bimodule (through `A`
+and through `B`) need not agree, and only their agreement forces `k`-linearity.
+Concretely, if `k` has a nontrivial field automorphism `σ`, restricting scalars
+along `σ` is an additive self-equivalence of `ModuleCat k` that is `σ`-semilinear
+rather than `k`-linear. So `MoritaEquivalent A B` does **not** imply
+`KLinearMoritaEquivalent k A B`; the two are inequivalent and we track the
+`k`-linear refinement separately. (The forgetting direction
+`KLinearMoritaEquivalent → MoritaEquivalent` is the honest one, and is
+`KLinearMoritaEquivalent.toMoritaEquivalent` below.)
 
 All Morita equivalences constructed in this project (via the corner functor
-`M ↦ eM`) are provably k-linear, so this definition is satisfied by all
-concrete instances. -/
+`M ↦ eM`) come with an explicit proof of `k`-linearity
+(`cornerFunctor_linear_k`), so they satisfy this definition. Downstream
+consumers (`MoritaStructural`, `Corollary_9_7_3_i_unique`, `Corollary_9_7_3_ii`)
+take `KLinearMoritaEquivalent` as a hypothesis; a bare `MoritaEquivalent` is
+never silently upgraded to it. -/
 def Etingof.KLinearMoritaEquivalent (k : Type*) [Field k]
     (A : Type u) [Ring A] [Algebra k A]
     (B : Type u) [Ring B] [Algebra k B] : Prop :=

--- a/progress/2026-07-22T23-52-25Z_c5fc8345.md
+++ b/progress/2026-07-22T23-52-25Z_c5fc8345.md
@@ -1,0 +1,50 @@
+## Accomplished
+
+Fixed issue #7425: corrected the false automatic-k-linearity claim in
+`Definition9_7_1.lean`.
+
+- Rewrote the docstring of `Etingof.KLinearMoritaEquivalent`. The old text
+  asserted that "every categorical equivalence is automatically k-linear
+  (Eilenberg-Watts theorem), so this is equivalent to bare `MoritaEquivalent`."
+  This is false: a bare additive/categorical equivalence of module categories
+  need not respect the central `k`-actions. The new docstring states this
+  correctly, gives the semilinear counterexample (restriction of scalars along a
+  nontrivial field automorphism `σ` of `k` is `σ`-semilinear, not `k`-linear),
+  and explains that `MoritaEquivalent A B` does **not** imply
+  `KLinearMoritaEquivalent k A B`.
+- Stated the actual compatibility condition needed to promote a bare equivalence
+  to a `k`-linear one: the functor must be `k`-linear on Hom spaces, i.e. commute
+  with the central action `algebraMap k A • -`. This is exactly what the
+  predicate `E.functor.Linear k` already encodes, so no new definition was
+  required.
+- Audited all consumers of `KLinearMoritaEquivalent`
+  (`MoritaStructural`, `Corollary_9_7_3_i_unique`, `Corollary_9_7_3_ii`,
+  `klinear_morita_equiv_of_full_idempotent`, `KLinearMoritaEquivalent.toFmod`,
+  the `symm'`/`trans'` combinators). Every consumer either takes k-linearity as
+  an explicit hypothesis or supplies a real proof (`cornerFunctor_linear_k`).
+  No consumer silently upgrades bare `MoritaEquivalent` to the k-linear notion.
+  Documented this in the docstring.
+- No converse API (`MoritaEquivalent → KLinearMoritaEquivalent`) exists in the
+  file, so acceptance criterion 3 (prove a converse under the compatibility
+  hypothesis) is vacuous; the only honest direction is the forgetting map
+  `KLinearMoritaEquivalent.toMoritaEquivalent`, now referenced in the docstring.
+
+## Current frontier
+
+`Definition9_7_1.lean` builds cleanly (`lake build ...Chapter9.Definition9_7_1`,
+1939 jobs). The change is documentation-only; no proof/statement logic changed.
+
+## Overall project progress
+
+Stage 3 formalization ongoing; this was a targeted definition-correctness
+(`completeness-audit`) fix in Chapter 9's Morita-equivalence development.
+
+## Next step
+
+Pick the next unclaimed `feature` issue. The sibling definition-correctness
+issue #7443 (finite vs arbitrary progenerators in Definition 9.6.2) is a good
+candidate and is more substantive.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7425

Session: `c5fc8345-f549-4ae5-bd8c-21ad0b0abaad`

c098f999 fix(Ch9 Definition9.7.1): correct false automatic k-linearity claim

🤖 Prepared with Claude Code