### PR TITLE
Restore importability of Proposition 3.1.4

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/Proposition3_1_4.lean
+++ b/EtingofRepresentationTheory/Chapter3/Proposition3_1_4.lean
@@ -146,11 +146,11 @@ theorem subrepresentation_of_semisimple_pi (n : ι → ℕ)
   -- A simple submodule of `W` lies in some isotypic component `C i`.
   have iso_of_le : ∀ {k : ι} {t : Submodule A ↥W} (_ : IsSimpleModule A ↥t),
       t ≤ C k → Nonempty (↥t ≃ₗ[A] V k) := by
-    intro k t _ hle
+    intro k t hsimp hle
+    haveI := hsimp
     have hit : IsIsotypicOfType A ↥t (V k) := le_isotypicComponent_iff.mp hle
-    haveI : IsSimpleModule A ↥(⊤ : Submodule A ↥t) :=
-      (LinearEquiv.isSimpleModule_iff Submodule.topEquiv).mpr ‹_›
-    exact ⟨Submodule.topEquiv.symm.trans (hit ⊤).some⟩
+    -- `↥t` is a simple submodule of itself, hence isomorphic to `V k`.
+    exact isIsotypicOfType_submodule_iff.mp hit t le_rfl
   have simple_mem : ∀ {s : Submodule A ↥W}, IsSimpleModule A ↥s → ∃ i, s ≤ C i := by
     intro s hs
     haveI := hs

--- a/progress/2026-07-23T00-46-52Z_f6ed35cc.md
+++ b/progress/2026-07-23T00-46-52Z_f6ed35cc.md
@@ -1,0 +1,45 @@
+## Accomplished
+
+Restored importability of `EtingofRepresentationTheory/Chapter3/Proposition3_1_4.lean`
+(issue #7496). The `iso_of_le` helper inside `subrepresentation_of_semisimple_pi`
+went through `↥(⊤ : Submodule A ↥t)` (a triple-nested submodule coercion), whose
+`AddCommGroup ↥⊤` / `IsSimpleModule A ↥⊤` instances no longer synthesize on the
+current toolchain (errors at lines 151, 153).
+
+Replaced the `⊤`-based argument with a direct application of Mathlib's
+`isIsotypicOfType_submodule_iff`: from `hit : IsIsotypicOfType A ↥t (V k)` and the
+simplicity of `↥t`, applying the iff at `m := t, le_rfl` yields `Nonempty (↥t ≃ₗ[A] V k)`
+without ever forming `↥⊤`. Four-line change, no new hypotheses.
+
+Verified:
+- `lake env lean EtingofRepresentationTheory/Chapter3/Proposition3_1_4.lean` — no errors.
+- `lake build EtingofRepresentationTheory.Chapter3.Proposition3_1_4` — 1586 jobs, success.
+- No `sorry`/`admit`/`axiom` in the file.
+
+Public endpoints preserved: `subrepresentation_of_semisimple_pi` and the source-facing
+`subrepresentation_of_semisimple`. Tracker entry `Chapter3/Proposition3.1.4` already
+reads `sorry_free: true, fidelity: verified`, which is now accurate again; no metadata
+change required.
+
+## Current frontier
+
+Issue #7496 complete. The regression was purely the `↥⊤` instance-synthesis break.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. Several sibling "Restore importability" regressions
+remain open with the same flavor of toolchain breakage: #7495 (Krull-Schmidt 3.8.1,
+top-submodule finrank), #7494 (Theorem 4.10.2, deprecated `Finsupp.finset_sum_apply`),
+#7492 (Exercise 8.2.9, quotient scalar rewrites), #7491 (Example 9.4.4, large),
+#7490 (Proposition 6.6.6, large). #7495 in particular may share the `↥⊤`-instance root
+cause and could take the same `isIsotypicOfType_submodule_iff`-style rewrite or an
+explicit `Submodule.topEquiv`/finrank restatement.
+
+## Next step
+
+Pick up another importability regression, e.g. #7495 (Krull-Schmidt) — it is localized
+(single unsolved `finrank ↥⊤ ≤ finrank V` goal) and foundational.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7496

Session: `f6ed35cc-4764-45aa-adc4-e140714753a4`

46e1511a fix(Ch3 Proposition3.1.4): restore importability by avoiding ↥⊤ instance synthesis

🤖 Prepared with Claude Code