### PR TITLE
Restore importability of the Krull–Schmidt theorem

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/Theorem3_8_1.lean
+++ b/EtingofRepresentationTheory/Chapter3/Theorem3_8_1.lean
@@ -207,7 +207,8 @@ theorem Etingof.krull_schmidt_existence (k : Type*) (A : Type*) (V : Type*)
       (∀ i, Etingof.IsIndecomposable A (W i)) ∧
       iSup W = ⊤ ∧ iSupIndep W := by
   obtain ⟨n, W, _, hindec, hsup, hind⟩ := krull_schmidt_existence_aux k A V
-    (Module.finrank k V) ⊤ (by simp [Submodule.restrictScalars_top])
+    (Module.finrank k V) ⊤
+      (by rw [Submodule.restrictScalars_top, finrank_top])
   exact ⟨n, W, hindec, hsup, hind⟩
 
 /-- Key step for Krull-Schmidt uniqueness: given an indecomposable direct summand W₀ in one

--- a/progress/2026-07-23T00-51-22Z_10cfeeac.md
+++ b/progress/2026-07-23T00-51-22Z_10cfeeac.md
@@ -1,0 +1,38 @@
+## Accomplished
+
+Fixed the importability regression in `EtingofRepresentationTheory/Chapter3/Theorem3_8_1.lean` (Krull–Schmidt theorem, issue #7495).
+
+The `krull_schmidt_existence` proof invoked `krull_schmidt_existence_aux` with a
+`by simp [Submodule.restrictScalars_top]` side goal to discharge
+`Module.finrank k ((⊤ : Submodule A V).restrictScalars k) ≤ Module.finrank k V`.
+On the current toolchain `simp` reduced `restrictScalars ⊤` to `⊤` but no longer
+closed the residual `finrank k ↥⊤ ≤ finrank k V`, leaving an unsolved goal at
+line 210 and aborting the file (so both public endpoints became unimportable).
+
+Replaced the tactic with an explicit rewrite:
+`by rw [Submodule.restrictScalars_top, finrank_top]`, which rewrites
+`finrank k ↥⊤` to `finrank k V` and closes by `rfl`.
+
+## Current frontier
+
+Complete. The file fresh-checks cleanly (`lake env lean … Theorem3_8_1.lean`,
+exit 0, no errors/sorry) and its `lake build` target succeeds (1593 jobs). Both
+public endpoints `Etingof.krull_schmidt_existence` and
+`Etingof.krull_schmidt_uniqueness` are importable and sorry-free. Bumped the
+`items.json` entry's `last_updated` to 2026-07-23 and noted the fix.
+
+## Overall project progress
+
+Stage 3 formalization ongoing; a wave of "restore importability" regressions
+(#7490–#7495 etc.) from toolchain/API drift is being cleared. This closes the
+Krull–Schmidt regression.
+
+## Next step
+
+Other importability regressions remain unclaimed: #7494 (Theorem 4.10.2,
+`Finsupp.finset_sum_apply` deprecation), #7492 (Exercise 8.2.9), #7491
+(Example 9.4.4), #7490 (Proposition 6.6.6). Same class of fix.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -2382,9 +2382,9 @@
     "status": "sorry_free",
     "coverage": "covered_full",
     "fidelity": "verified",
-    "note": "Existence and uniqueness are proved sorry-free, including the inductive uniqueness step.",
+    "note": "Existence and uniqueness are proved sorry-free, including the inductive uniqueness step. Importability regression (finrank ⊤ ≤ finrank V step) fixed 2026-07-23 via finrank_top.",
     "sorry_free": true,
-    "last_updated": "2026-07-22"
+    "last_updated": "2026-07-23"
   },
   {
     "id": "Chapter3/Lemma3.8.2",


### PR DESCRIPTION
Closes #7495

Session: `10cfeeac-19c0-47f5-9935-04bf591bde7e`

2106f212 fix(Ch3 Theorem3.8.1): restore importable Krull-Schmidt via finrank_top

🤖 Prepared with Claude Code