### PR TITLE
Restore importability of Theorem 4.10.2

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Theorem4_10_2.lean
+++ b/EtingofRepresentationTheory/Chapter4/Theorem4_10_2.lean
@@ -209,8 +209,13 @@ private lemma IrrepDecomp.frobeniusDet_eq_signSmul_prod [NeZero (Nat.card G : k)
     funext g h
     rw [of_apply, leftMulMatrix_monoidAlgebra_entry]
     change σ (g * h⁻¹) = (∑ s : G, σ s • MonoidAlgebra.of k G s : MonoidAlgebra k G) (g * h⁻¹)
-    rw [Finsupp.finset_sum_apply]
-    simp [MonoidAlgebra.of_apply, Finsupp.smul_apply, Finsupp.single_apply]
+    -- Push the pointwise evaluation through the finite sum. The sum lives in
+    -- `MonoidAlgebra k G`, so `Finsupp.finsetSum_apply` cannot match the coercion
+    -- directly; apply the evaluation `AddMonoidHom` via `map_sum` instead.
+    rw [show (∑ s : G, σ s • MonoidAlgebra.of k G s : MonoidAlgebra k G) (g * h⁻¹)
+          = ∑ s : G, (σ s • MonoidAlgebra.of k G s : MonoidAlgebra k G) (g * h⁻¹) from
+        map_sum (Finsupp.applyAddHom (g * h⁻¹)) _ _]
+    simp [MonoidAlgebra.of_apply, MonoidAlgebra.single_apply]
   -- Evaluate the scalar smul on the RHS
   have hsmul : MvPolynomial.eval σ
       (((Equiv.Perm.sign (Equiv.inv G) : ℤ) : k) • ∏ i : Fin D.n, D.blockPoly i ^ D.d i) =

--- a/progress/2026-07-23T00-59-49Z_dc3805ce.md
+++ b/progress/2026-07-23T00-59-49Z_dc3805ce.md
@@ -1,0 +1,46 @@
+## Accomplished
+
+Fixed issue #7494: restored importability of `Theorem 4.10.2` (Frobenius
+determinant factorization).
+
+- `EtingofRepresentationTheory/Chapter4/Theorem4_10_2.lean` no longer passed a
+  fresh `lake env lean` check. In the proof of `hLHS_eq`, the step
+  `rw [Finsupp.finset_sum_apply]` failed: the lemma is deprecated (now
+  `Finsupp.finsetSum_apply`), and more importantly its `Finsupp` coercion no
+  longer matched the `MonoidAlgebra k G` coercion on the finite sum
+  `∑ s, σ s • MonoidAlgebra.of k G s`, giving an application type mismatch
+  (`MonoidAlgebra k G` vs `G →₀ k`).
+- Replaced the `rw` with a `map_sum (Finsupp.applyAddHom (g * h⁻¹))` step that
+  pushes the pointwise evaluation through the sum in term mode, where the
+  definitional equality `MonoidAlgebra k G = G →₀ k` is accepted by `isDefEq`
+  (unlike the syntactic pattern match `rw` requires). Then `simp` with
+  `MonoidAlgebra.of_apply, MonoidAlgebra.single_apply` closes the goal.
+- The public factorization theorem and all helper endpoints are unchanged.
+- Updated `progress/items.json` entry `Chapter4/Theorem4.10.2`: bumped
+  `last_updated` to 2026-07-23 and noted the regression repair. The
+  sorry_free / verified / covered_full metadata was already in place.
+
+## Current frontier
+
+Verification complete: fresh `lake env lean` on the file is error/sorry free,
+and `lake build EtingofRepresentationTheory.Chapter4.Theorem4_10_2` completes
+successfully (8583 jobs). The only remaining warning in the file is a
+pre-existing `linter.style.show` warning at line 971, unrelated to this fix.
+
+## Overall project progress
+
+Phase 3 formalization / completeness-audit remediation. Many open
+`completeness-audit` issues remain (several "restore importability" regressions
+like #7491, #7492, #7504, #7505, plus feature work). This turn cleared one
+importability regression.
+
+## Next step
+
+Pick up another unclaimed issue. The other "restore importability" regressions
+(#7491 Example 9.4.4, #7492 Exercise 8.2.9, #7504 Theorem 8.1.1, #7505 Theorem
+9.6.4, #7490 Prop 6.6.6) are similarly high value — each likely a toolchain/API
+regression on a single file that fails a fresh Lean check.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3583,10 +3583,10 @@
     "end_line": 16,
     "status": "sorry_free",
     "fidelity": "verified",
-    "notes": "All sorries resolved: blockPoly_irreducible proved via retraction argument",
+    "notes": "All sorries resolved: blockPoly_irreducible proved via retraction argument. Repaired hLHS_eq (#7494): the group-algebra coefficient evaluation now pushes pointwise application through the finite sum via `map_sum (Finsupp.applyAddHom _)` instead of the deprecated `Finsupp.finset_sum_apply`, which no longer matched the `MonoidAlgebra`/`Finsupp` coercion.",
     "sorry_free": true,
     "coverage": "covered_full",
-    "last_updated": "2026-07-22"
+    "last_updated": "2026-07-23"
   },
   {
     "id": "Chapter4/Discussion_before_Lemma4.10.3",


### PR DESCRIPTION
Closes #7494

Session: `dc3805ce-b631-42f2-9c24-899c1183c937`

a5a557e4 chore(progress): record #7494 Theorem 4.10.2 importability repair
dbfb12c8 fix(Ch4 Theorem4.10.2): repair group-algebra coefficient evaluation in hLHS_eq

🤖 Prepared with Claude Code