### PR TITLE
fix(Ch8 Theorem8.1.1): restore fresh-buildable Hom-exactness endpoint

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -247,6 +247,20 @@ apply Sigma.hom_ext; intro b; rw [Sigma.ι_desc_assoc]; exact Projective.factorT
 lesson: when a Mathlib instance/lemma quietly uses full transparency, bypass it with an explicit
 term rather than fighting heartbeats.
 
+**Applying a hypothesis/lemma whose implicit *type* arguments are still metavariables postpones
+its explicit args as synthetic-opaque metavariables — a later premise then either whnf-loops or
+fails with a spurious "Application type mismatch: … expected LinearMap.range ?m = …".** Hit in
+#7504 (`Chapter8/Theorem8_1_1.lean`, reverse direction of `Theorem_8_1_1_i_iff_iv`): applying
+`hex : ∀ {K M N : Type v} … (ι) (π), Injective ι → … → range ι = ker π → _` as
+`hex (ker f).subtype f _ hfsurj (Submodule.range_subtype _)` left `K`/`M`/`N` unsolved, so `ι`
+became a postponed `?m` and the exactness premise `range ?m = ker π` had to `whnf`-reduce the heavy
+`f := p ∘ₗ e.toLinearMap` term to unify — timing out at 200k heartbeats (making the file
+non-importable). Passing a concrete `ι` or ascribing its type does **not** help; the postponement is
+driven by the unsolved implicit *type* args. **Fix:** pin them by name at the call site —
+`hex (K := ↥(ker f)) (M := P →₀ Shrink.{v} R) (N := P) ι f hι hfsurj hexact` — so every explicit arg
+elaborates eagerly against a concrete expected type and the premises unify syntactically. Hoist
+`ι`/`hι`/`hexact` into `let`/`have` bindings first to keep the call readable.
+
 **When an inline proof over huge *concrete* terms times out heartbeats, lift the heavy structural
 argument into a standalone helper `def`/lemma whose hypotheses are the *abstract* objects.** Hit in
 #6767 (`Chapter8/ExternalTensorResolution.lean`): the degree-0 `quasiIso` goal assembled a cokernel

--- a/EtingofRepresentationTheory/Chapter8/Theorem8_1_1.lean
+++ b/EtingofRepresentationTheory/Chapter8/Theorem8_1_1.lean
@@ -127,9 +127,13 @@ theorem Etingof.Theorem_8_1_1_i_iff_iv
   · intro hex
     refine Module.Projective.of_lifting_property'' (fun p hp ↦ ?_)
     let e := Finsupp.mapRange.linearEquiv (α := P) (Shrink.linearEquiv R R)
-    have hfsurj : Function.Surjective (p ∘ₗ e.toLinearMap) := hp.comp e.surjective
-    obtain ⟨-, -, hsurj⟩ := hex (LinearMap.ker (p ∘ₗ e.toLinearMap)).subtype
-      (p ∘ₗ e.toLinearMap) Subtype.coe_injective hfsurj (Submodule.range_subtype _)
+    let f := p ∘ₗ e.toLinearMap
+    let ι : ↥(LinearMap.ker f) →ₗ[R] (P →₀ Shrink.{v} R) := (LinearMap.ker f).subtype
+    have hfsurj : Function.Surjective f := hp.comp e.surjective
+    have hι : Function.Injective ι := Subtype.coe_injective
+    have hexact : LinearMap.range ι = LinearMap.ker f := Submodule.range_subtype _
+    obtain ⟨-, -, hsurj⟩ :=
+      hex (K := ↥(LinearMap.ker f)) (M := P →₀ Shrink.{v} R) (N := P) ι f hι hfsurj hexact
     obtain ⟨h, hh⟩ := hsurj LinearMap.id
     refine ⟨e.toLinearMap ∘ₗ h, ?_⟩
     rw [← LinearMap.comp_assoc]

--- a/progress/2026-07-23T01-32-00Z_83bd89dd.md
+++ b/progress/2026-07-23T01-32-00Z_83bd89dd.md
@@ -1,0 +1,49 @@
+## Accomplished
+
+Worked issue #7504 (Restore all four projective-module equivalences in Theorem 8.1.1).
+
+The defect: `EtingofRepresentationTheory/Chapter8/Theorem8_1_1.lean` failed a fresh Lean
+check — `lake env lean` hit a `(deterministic) timeout at whnf` at line 132 (the reverse
+direction of `Etingof.Theorem_8_1_1_i_iff_iv`). The argument `Submodule.range_subtype _`
+left the target submodule as a metavariable, and unifying it against the exactness premise
+`range ι = ker π` forced a whnf reduction of the heavy `p ∘ₗ e.toLinearMap` term that blew
+through the 200000-heartbeat budget. Since the file aborted there, the four-way theorem was
+not importable.
+
+Fix (Chapter 8, sorry-free, axioms `[propext, Classical.choice, Quot.sound]` only):
+
+- In `Theorem_8_1_1_i_iff_iv`'s reverse direction, hoisted the pieces out as named
+  `let`/`have` bindings: `f := p ∘ₗ e.toLinearMap`, `ι` given an explicit ascribed type
+  `↥(ker f) →ₗ[R] (P →₀ Shrink.{v} R)`, plus `hι`, `hfsurj`, and `hexact` as standalone
+  facts. Then applied `hex` with the implicit type arguments pinned
+  (`K := ↥(ker f)`, `M := P →₀ Shrink.{v} R`, `N := P`).
+  Pinning `K`, `M`, `N` stops the elaborator from postponing `ι` as a synthetic-opaque
+  metavariable, so the exactness premise unifies syntactically with no whnf loop.
+- The public statement is unchanged: all three theorems (`..._i_iff_ii`, `..._i_iff_iii`,
+  `..._i_iff_iv`) still prove the book's four conditions equivalent — lifting, splitting,
+  free-direct-summand (over a genuine `Module.Free` module), and exactness of `Hom_A(P,-)`.
+- `progress/items.json`: bumped `Chapter8/Theorem8.1.1` `last_updated` to 2026-07-23
+  (metadata was already `sorry_free`/`covered_full`/`verified`; now genuinely importable).
+
+Verification: `lake env lean` at the default heartbeat budget (200000) is green,
+`lake build EtingofRepresentationTheory.Chapter8.Theorem8_1_1` succeeds (1592 jobs), and
+`#print axioms` on all three endpoints shows no `sorryAx`.
+
+## Current frontier
+
+Theorem 8.1.1 imports cleanly again. No further work needed on this item.
+
+## Overall project progress
+
+Phase 3 (formalization) ongoing. This closes one of the `completeness-audit`
+fresh-buildability regressions. Many sibling "restore importability / fresh-buildable"
+issues remain unclaimed (e.g. #7492 Exercise 8.2.9, #7491, #7490, ...).
+
+## Next step
+
+Pick up another `completeness-audit` fresh-build regression. #7492 (Exercise 8.2.9,
+quotient scalar-action rewrites failing at lines 291/333) is a well-diagnosed candidate.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -8581,7 +8581,7 @@
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
-    "last_updated": "2026-07-22"
+    "last_updated": "2026-07-23"
   },
   {
     "id": "Chapter8/Definition8.1.2",


### PR DESCRIPTION
Closes #7504

Session: `83bd89dd-e2d2-47ce-88b8-ab80ba08e814`

2809149c fix(Ch8 Theorem8.1.1): restore fresh-buildable Hom-exactness endpoint

🤖 Prepared with Claude Code