### PR TITLE
fix(Ch9): restore fresh-buildable biproductSumIso in Existence.lean

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Existence.lean
+++ b/EtingofRepresentationTheory/Chapter9/KrullSchmidt/Existence.lean
@@ -65,10 +65,13 @@ noncomputable def biproductSumIso (f₁ : κ₁ → C) (f₂ : κ₂ → C) :
     | Sum.inl a => biproduct.ι f₁ a ≫ biprod.inl
     | Sum.inr b => biproduct.ι f₂ b ≫ biprod.inr
   hom_inv_id := by
-    apply biprod.hom_ext' <;> apply biproduct.hom_ext' <;> rintro j <;> simp
+    apply biprod.hom_ext' <;> apply biproduct.hom_ext' <;> rintro j <;>
+      simp only [biprod.inl_desc_assoc, biprod.inr_desc_assoc, biproduct.ι_desc_assoc,
+        Category.comp_id] <;>
+      exact biproduct.ι_desc _ _
   inv_hom_id := by
     apply biproduct.hom_ext'
-    rintro (a | b) <;> simp
+    rintro (a | b) <;> rw [biproduct.ι_desc_assoc] <;> simp
 
 end BiproductSum
 

--- a/progress/2026-07-23T02-49-18Z_73264734.md
+++ b/progress/2026-07-23T02-49-18Z_73264734.md
@@ -1,0 +1,29 @@
+## Accomplished
+Repaired `biproductSumIso` in `EtingofRepresentationTheory/Chapter9/KrullSchmidt/Existence.lean`
+(#7549). The two coherence fields (`hom_inv_id`, `inv_hom_id`) no longer elaborate under a plain
+`simp` because `biproduct.ι_desc` cannot fire through the dependent `match` family: the index
+source `Sum.elim f₁ f₂ (Sum.inl j)` is only defeq (not syntactic) to `f₁ j`, so `rw`/`simp`'s
+discrimination-tree matching rejects it. Fixed by peeling with `simp only` and discharging the
+match-desc step with a defeq-aware `exact biproduct.ι_desc _ _` (hom side) and
+`rw [biproduct.ι_desc_assoc] <;> simp` (inv side).
+
+`lake env lean .../Existence.lean` now elaborates from source (exit 0, only the pre-existing
+`clength_eq_of_iso` unused-section-variable warning). `#print axioms` on
+`exists_indecomposable_biproduct`, `exists_indecomposable_projective_biproduct`, and
+`biproductSumIso` shows only \[propext, Classical.choice, Quot.sound\] — no `sorryAx`.
+
+## Current frontier
+Existence.lean and its two public existence endpoints pass independently.
+
+## Overall project progress
+Phase 3 formalization, completeness-audit regression wave. This restores the Ch9 Krull–Schmidt
+existence source. Merged 4 ready PRs at cycle start (#7558, #7551, #7541, #7528).
+
+## Next step
+The §9.7 downstream re-verification (`Exchange.lean`, `Introduction_9_7.lean`,
+`progenerator_decomposition`) is conditional on #7552 (Fitting/local-endomorphism chain), which is
+still OPEN and fails from source. That verification must be run once #7552 lands, against source
+rather than stale oleans. Landing this as `--partial` so a planner tracks that residual.
+
+## Blockers
+§9.7 downstream verification blocked by #7552 (still open, Fitting.lean fails to elaborate).


### PR DESCRIPTION
This PR restores fresh-buildable elaboration of `biproductSumIso` in
`EtingofRepresentationTheory/Chapter9/KrullSchmidt/Existence.lean` (#7549). Its two coherence
fields no longer elaborated under a plain `simp`: `biproduct.ι_desc` cannot fire through the
dependent `match` family, because the biproduct index source `Sum.elim f₁ f₂ (Sum.inl j)` is only
defeq (not syntactically equal) to `f₁ j`, so `rw`/`simp` discrimination-tree matching rejects it.
The hom side is discharged with a defeq-aware `exact biproduct.ι_desc _ _` after peeling the
`biprod.desc` layer, and the inv side with `rw [biproduct.ι_desc_assoc] <;> simp`.

After the change, `lake env lean EtingofRepresentationTheory/Chapter9/KrullSchmidt/Existence.lean`
elaborates from source (only the pre-existing `clength_eq_of_iso` unused-section-variable warning
remains). `#print axioms` on `exists_indecomposable_biproduct`,
`exists_indecomposable_projective_biproduct`, and `biproductSumIso` reports only
`[propext, Classical.choice, Quot.sound]` — no `sorryAx`.

Partial: the §9.7 downstream re-verification (`Exchange.lean`, `Introduction_9_7.lean`,
`progenerator_decomposition`) is conditional on #7552 (Fitting/local-endomorphism chain), which is
still open and fails to elaborate from source. That check must run against source once #7552 lands.

🤖 Prepared with Claude Code