### PR TITLE
Restore the canonical semisimple decomposition endpoint of Remark 3.1.3

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/Remark3_1_3.lean
+++ b/EtingofRepresentationTheory/Chapter3/Remark3_1_3.lean
@@ -358,7 +358,11 @@ of `V`. By pairwise non-isomorphism these components are independent (`iSupIndep
 theorem evalDirectSum_injective
     (hpair : ∀ i j, i ≠ j → IsEmpty (X i ≃ₗ[A] X j)) :
     Function.Injective (evalDirectSum k A X V) := by
-  refine (injective_iff_map_eq_zero (evalDirectSum k A X V)).mpr fun ξ hξ => ?_
+  suffices h : ∀ ξ, evalDirectSum k A X V ξ = 0 → ξ = 0 by
+    intro ξ₁ ξ₂ he
+    have hsub : evalDirectSum k A X V (ξ₁ - ξ₂) = 0 := by rw [map_sub, he, sub_self]
+    exact sub_eq_zero.mp (h _ hsub)
+  intro ξ hξ
   have hindep := iSupIndep_isotypicComponent k A X V hpair
   -- evalDirectSum ξ expands to the sum of the per-component evaluations
   have hexpand : evalDirectSum k A X V ξ = ∑ i, evalTensor k A (X i) V (ξ i) := by

--- a/progress/2026-07-23T02-30-00Z_acd127a2.md
+++ b/progress/2026-07-23T02-30-00Z_acd127a2.md
@@ -1,0 +1,39 @@
+## Accomplished
+
+Fixed the fresh-build regression in `EtingofRepresentationTheory/Chapter3/Remark3_1_3.lean`
+(issue #7502). `evalDirectSum_injective` used
+`injective_iff_map_eq_zero (evalDirectSum ...)`, which stopped synthesizing the
+`AddMonoidHomClass` instance for the bundled `k`-linear map, then reported "no goals"
+on the follow-up tactic.
+
+Replaced the fragile `injective_iff_map_eq_zero` entry point with a `suffices h : ∀ ξ,
+evalDirectSum k A X V ξ = 0 → ξ = 0` reduction, deriving `Function.Injective` from `h` via
+`map_sub` and `sub_eq_zero`. This avoids both the stuck `AddMonoidHomClass` synthesis and the
+`LinearMap.ker_eq_bot` unification problems (the semilinear coercion would not match the
+concrete map under `rw`/`.mp`). The core Schur/isotypic-independence argument is unchanged.
+
+`evalDirectSum_surjective` and the public `evalDirectSumEquiv` are untouched and still import.
+No axiom or admission introduced; the file is sorry-free.
+
+Restored the tracker metadata for `Chapter3/Remark3.1.3` to
+`status: sorry_free`, `sorry_free: true`, `fidelity: verified`, `coverage: covered_full`
+and dropped the `fidelity_issue` pointer.
+
+## Current frontier
+
+Issue #7502 complete. Fresh check (`lake env lean ...Remark3_1_3.lean`) and the lake build
+target both pass (1953 jobs, exit 0).
+
+## Overall project progress
+
+Stage 3 formalization; many "restore fresh-buildable" regression issues remain unclaimed
+(#7505, #7512, #7513, ...). These are individual API-drift repairs.
+
+## Next step
+
+Pick up the next oldest unclaimed regression issue (e.g. #7505, finite-abelian-category
+equivalence of Theorem 9.6.4).
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -1898,13 +1898,12 @@
     "end_page": "43",
     "start_line": 13,
     "end_line": 13,
-    "status": "partially_proved",
-    "sorry_free": false,
-    "notes": "The file constructs the correct evaluation map and canonical-equivalence API, but currently fails to elaborate in evalDirectSum_injective, so evalDirectSumEquiv cannot be imported; regression #7502.",
-    "fidelity": "partial",
-    "coverage": "covered_partial",
-    "fidelity_issue": 7502,
-    "last_updated": "2026-07-22"
+    "status": "sorry_free",
+    "sorry_free": true,
+    "notes": "The file constructs the correct evaluation map and canonical-equivalence API; evalDirectSum_injective, evalDirectSum_surjective, and the public evalDirectSumEquiv all elaborate and import cleanly (regression #7502 fixed).",
+    "fidelity": "verified",
+    "coverage": "covered_full",
+    "last_updated": "2026-07-23"
   },
   {
     "id": "Chapter3/Discussion_before_Proposition3.1.4",


### PR DESCRIPTION
Closes #7502

Session: `acd127a2-38b4-4f10-9382-63d3ca5006e9`

539b7d22 fix(Ch3 Remark3.1.3): restore fresh-buildable evalDirectSum_injective

🤖 Prepared with Claude Code