### PR TITLE
fix(Ch2 Definition2.8.4): restore fresh-buildable path algebra and finite-quiver unit

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -125,6 +125,31 @@ construction of the reflection functor `F⁻`. Same knob as the `@[implicit_redu
 mass `Module`/`HasQuotient` synthesis failures, grep the warnings for "class type must be
 marked" first — it points straight at the culprit.
 
+**For a `def Foo := Bar` wrapper (e.g. `def PathAlgebra := _ →₀ k`) with re-exposed
+`inferInstanceAs` instances, two more traps beyond the `rw`/`exact` split — both hit while
+restoring `Definition2_8_4.lean` (#7499), cost ~15 iterations:**
+- **A type ascription `(e : Foo)` is *erased* during elaboration**, so a `Finset.sum`/`∑`
+  over `(summand : Foo)` still takes the summand's *native* `Bar` `AddCommMonoid`, not `Foo`'s
+  (confirmed with `set_option pp.all`). `Finset.sum_mul`/`mul_sum` then "make no progress"
+  because they expect the ambient semiring's monoid. **Fix: build the summand from a function
+  whose *declared return type* is `Foo`** (here `ofPath x : PathAlgebra := single x 1`), so the
+  sum genuinely lives in `Foo`'s structure. Keep the public `Finsupp.single`-form lemma for
+  downstream clients and add a definitionally-equal `foo_eq_sum` (`:= rfl`) in the `Foo` form
+  for the internal proof.
+- **After `Finset.sum_mul` fires, the result sum is in the *semiring-derived* `AddCommMonoid`,
+  but `Finset.sum_ite_eq'`/`simp` re-synthesize the *group-derived* one** → the two are defeq
+  but `rw`/`simp` won't match ("did not find pattern" on syntactically-identical goals).
+  **Fix: evaluate the sum with `Finset.sum_eq_single_of_mem`**, which consumes the goal's sum
+  as-is (no instance re-synthesis); discharge its `∀ b ≠ a, f b = 0` side goal with a term-mode
+  `(hterm b).trans (if_neg …)` (a bare `rw` leaves an unclosed `0 = 0` across the same diamond).
+- **Ring-law instance fields (`left_distrib`, `zero_mul`, `smul_mul`, …) whose old `change …;
+  rw [map_add]` broke: rewrite them term-mode** as `map_add (mulLinear a) b c` /
+  `(LinearMap.congr_fun (map_add …) c).trans (LinearMap.add_apply …)`. And for
+  `Finsupp.induction_linear` leaking `Bar`-typed pieces into `Foo` multiplication, wrap a
+  `Foo`-native `induction_linear` (`:= Finsupp.induction_linear …`) whose step binders are `Foo`.
+  Small `Finsupp`-typed helpers (`c • single x 1 = single x c`, `c • 0 = 0`) proved by `rw` then
+  applied to `Foo` goals by `exact` cover the `SMulZeroClass k Foo`-not-synthesizable gaps.
+
 **Same failure for `AddCommGrpCat`/`ModuleCat` homology goals in `ConcreteCategory.hom` form**
 (cost ~5 iterations in #6952, `Chapter8/HomComplexHomologyK.lean`). After
 `AddCommGrpCat.comp_apply`, terms read `ConcreteCategory.hom f (ConcreteCategory.hom g x)`; the

--- a/EtingofRepresentationTheory/Chapter2/Definition2_8_4.lean
+++ b/EtingofRepresentationTheory/Chapter2/Definition2_8_4.lean
@@ -109,13 +109,30 @@ with coefficient `1`. -/
 noncomputable def ofPath (x : QuiverPathIndex Q) : PathAlgebra k Q :=
   Finsupp.single x 1
 
-/-- The product of two basis paths (as a raw `Finsupp`): the concatenated path with coefficient `1`
-when composable, and `0` otherwise. This is deliberately typed as the underlying
-`QuiverPathIndex Q →₀ k` rather than `PathAlgebra k Q`, so that the bilinear multiplication
-`mulLinear` built from it has a single consistent (leak-free) `Finsupp` type; `PathAlgebra k Q` is
-definitionally this type, so `compSingle x y` is still usable wherever a `PathAlgebra k Q` value is
-expected. -/
-noncomputable def compSingle (x y : QuiverPathIndex Q) : QuiverPathIndex Q →₀ k :=
+/-- Scaling a basis path by `c` reindexes its coefficient: `c • single x 1 = single x c`. Stated at
+the underlying `QuiverPathIndex Q →₀ k` type so the `Finsupp.smul_single` rewrite fires directly;
+it is applied to `PathAlgebra k Q` goals through the definitional equality (an `exact` closes the
+`instances`-transparency gap that would block a direct rewrite). -/
+theorem smul_single_one (c : k) (x : QuiverPathIndex Q) :
+    c • Finsupp.single x (1 : k) = Finsupp.single x c := by
+  rw [Finsupp.smul_single, smul_eq_mul, mul_one]
+
+/-- Scaling the zero path algebra element gives zero. Proved at the underlying
+`QuiverPathIndex Q →₀ k` type: instance synthesis does not find `SMulZeroClass k (PathAlgebra k Q)`
+directly (the `def` wrapper hides the `Finsupp` module from synthesis), so the generic `smul_zero`
+is applied at the `Finsupp` type and transported to `PathAlgebra k Q` through the definitional
+equality. -/
+theorem smul_pathAlgebra_zero (c : k) : c • (0 : PathAlgebra k Q) = 0 :=
+  (smul_zero c : c • (0 : QuiverPathIndex Q →₀ k) = 0)
+
+/-- The product of two basis paths: the concatenated path with coefficient `1` when composable,
+and `0` otherwise. This is typed as `PathAlgebra k Q` (not the underlying `QuiverPathIndex Q →₀ k`)
+so that goals such as `(a * b) • compSingle x y * Finsupp.single z c`, which arise in the
+associativity and unit proofs, stay homogeneously typed. Were `compSingle` typed as the raw
+`Finsupp`, such a product would mix a `Finsupp`-valued scalar action with the `PathAlgebra`
+multiplication and fail the `instances`-transparency type check. `PathAlgebra k Q` is definitionally
+`QuiverPathIndex Q →₀ k`, so `compSingle` still feeds the `Finsupp`-typed `mulLinear` below. -/
+noncomputable def compSingle (x y : QuiverPathIndex Q) : PathAlgebra k Q :=
   (x.comp y).elim 0 (fun z => Finsupp.single z (1 : k))
 
 /-- On composable basis paths, `compSingle` is the single concatenated path. -/
@@ -127,7 +144,7 @@ theorem compSingle_eq {a b d : Q} (p : Quiver.Path a b) (q : Quiver.Path b d) :
 /-- On non-composable basis paths, `compSingle` is zero. -/
 theorem compSingle_eq_zero {a b c d : Q} (p : Quiver.Path a b) (q : Quiver.Path c d)
     (h : b ≠ c) :
-    compSingle (⟨a, b, p⟩ : QuiverPathIndex Q) ⟨c, d, q⟩ = (0 : QuiverPathIndex Q →₀ k) := by
+    compSingle (⟨a, b, p⟩ : QuiverPathIndex Q) ⟨c, d, q⟩ = (0 : PathAlgebra k Q) := by
   rw [compSingle, QuiverPathIndex.comp_eq_none _ _ h]; rfl
 
 /-- Multiplying a trivial path `p_i` on the left: the result is the original path if it starts at
@@ -138,7 +155,7 @@ theorem compSingle_nil_left (i a b : Q) (p : Quiver.Path a b) :
   by_cases h : i = a
   · subst h
     rw [compSingle_eq, Quiver.Path.nil_comp, if_pos rfl]
-  · rw [compSingle_eq_zero _ _ h, if_neg h]
+  · rw [if_neg h]; exact compSingle_eq_zero _ _ h
 
 /-- Multiplying a trivial path `p_i` on the right: the result is the original path if it ends at
 `i`, and zero otherwise. -/
@@ -148,7 +165,7 @@ theorem compSingle_nil_right (i a b : Q) (p : Quiver.Path a b) :
   by_cases h : b = i
   · subst h
     rw [compSingle_eq, Quiver.Path.comp_nil, if_pos rfl]
-  · rw [compSingle_eq_zero _ _ h, if_neg h]
+  · rw [if_neg h]; exact compSingle_eq_zero _ _ h
 
 variable (k Q)
 
@@ -156,7 +173,7 @@ variable (k Q)
 concatenation; it is extended bilinearly to the whole free module. Phrasing the product as a
 `LinearMap` makes all distributive laws hold definitionally (they are `map_add`/`map_zero`). -/
 noncomputable def mulLinear :
-    (QuiverPathIndex Q →₀ k) →ₗ[k] (QuiverPathIndex Q →₀ k) →ₗ[k] (QuiverPathIndex Q →₀ k) :=
+    (QuiverPathIndex Q →₀ k) →ₗ[k] (QuiverPathIndex Q →₀ k) →ₗ[k] PathAlgebra k Q :=
   Finsupp.lsum k fun x =>
     (LinearMap.id : k →ₗ[k] k).smulRight
       (Finsupp.lsum k fun y => (LinearMap.id : k →ₗ[k] k).smulRight (compSingle x y))
@@ -168,18 +185,18 @@ below. -/
 noncomputable instance : NonUnitalNonAssocRing (PathAlgebra k Q) :=
   { (inferInstance : AddCommGroup (PathAlgebra k Q)) with
     mul := fun f g => mulLinear k Q f g
-    left_distrib := fun a b c => by
-      change mulLinear k Q a (b + c) = mulLinear k Q a b + mulLinear k Q a c
-      rw [map_add]
-    right_distrib := fun a b c => by
-      change mulLinear k Q (a + b) c = mulLinear k Q a c + mulLinear k Q b c
-      rw [map_add]; rfl
-    zero_mul := fun a => by
-      change mulLinear k Q 0 a = 0
-      rw [map_zero]; rfl
-    mul_zero := fun a => by
-      change mulLinear k Q a 0 = 0
-      rw [map_zero] }
+    -- The distributive/annihilation laws are `map_add`/`map_zero` of the bilinear `mulLinear`.
+    -- They are stated in term mode (rather than via `change`/`rw`) because a tactic goal
+    -- containing `mulLinear k Q a` with `a : PathAlgebra k Q` is not type-correct at the
+    -- `instances` transparency level (`mulLinear` expects the underlying `Finsupp`), so `rw`
+    -- refuses to fire; term-mode elaboration checks against the goal up to definitional
+    -- equality and accepts the defeq `PathAlgebra k Q = QuiverPathIndex Q →₀ k`.
+    left_distrib := fun a b c => map_add (mulLinear k Q a) b c
+    right_distrib := fun a b c =>
+      (LinearMap.congr_fun (map_add (mulLinear k Q) a b) c).trans (LinearMap.add_apply _ _ _)
+    zero_mul := fun a =>
+      (LinearMap.congr_fun (map_zero (mulLinear k Q)) a).trans (LinearMap.zero_apply a)
+    mul_zero := fun a => map_zero (mulLinear k Q a) }
 
 variable {k Q}
 
@@ -197,15 +214,13 @@ theorem single_mul_single (x y : QuiverPathIndex Q) (a b : k) :
 
 /-- Scalars commute past the multiplication on the left (the product is `k`-linear in its
 first argument). -/
-theorem smul_mul (r : k) (a b : PathAlgebra k Q) : (r • a) * b = r • (a * b) := by
-  change mulLinear k Q (r • a) b = r • mulLinear k Q a b
-  rw [map_smul]; rfl
+theorem smul_mul (r : k) (a b : PathAlgebra k Q) : (r • a) * b = r • (a * b) :=
+  (LinearMap.congr_fun (map_smul (mulLinear k Q) r a) b).trans (LinearMap.smul_apply r _ b)
 
 /-- Scalars commute past the multiplication on the right (the product is `k`-linear in its
 second argument). -/
-theorem mul_smul' (r : k) (a b : PathAlgebra k Q) : a * (r • b) = r • (a * b) := by
-  change mulLinear k Q a (r • b) = r • mulLinear k Q a b
-  rw [map_smul]
+theorem mul_smul' (r : k) (a b : PathAlgebra k Q) : a * (r • b) = r • (a * b) :=
+  map_smul (mulLinear k Q a) r b
 
 /-- Associativity of the multiplication on three basis paths. This is where the associativity of
 path concatenation (`Quiver.Path.comp_assoc`) enters; the partial composition cases all collapse
@@ -245,17 +260,32 @@ theorem single_mul_single_assoc (x y z : QuiverPathIndex Q) (a b c : k) :
     · rw [single_mul_single, compSingle_eq_zero _ _ hbc, smul_zero, zero_mul,
         single_mul_single, compSingle_eq_zero _ _ hde, smul_zero, mul_zero]
 
+/-- Linearity induction for `PathAlgebra k Q`: to prove a predicate for every element it suffices
+to prove it for `0`, for sums, and for the basis paths `Finsupp.single x a`. This transports
+`Finsupp.induction_linear` to `PathAlgebra k Q`. Crucially the step hypotheses are stated with
+`PathAlgebra k Q`-typed pieces, rather than the underlying `QuiverPathIndex Q →₀ k` pieces that
+`Finsupp.induction_linear` would introduce by unfolding the `def`. Keeping the pieces at
+`PathAlgebra k Q` means the ring multiplication in the downstream `mul_assoc`/`one_mul`/`mul_one`
+proofs stays homogeneously typed, so `rw` with `add_mul`, `mul_add`, `zero_mul`, `mul_zero`, and
+`Finset.sum_mul` continues to fire (a `QuiverPathIndex Q →₀ k` piece fed to the `PathAlgebra k Q`
+multiplication is not type-correct at the `instances` transparency level, which blocks `rw`). -/
+@[elab_as_elim]
+theorem induction_linear {motive : PathAlgebra k Q → Prop} (f : PathAlgebra k Q)
+    (zero : motive 0) (add : ∀ g h : PathAlgebra k Q, motive g → motive h → motive (g + h))
+    (single : ∀ (x : QuiverPathIndex Q) (a : k), motive (Finsupp.single x a)) : motive f :=
+  Finsupp.induction_linear f zero add single
+
 /-- Associativity of path-algebra multiplication, reduced to the basis case via bilinearity. -/
 protected theorem mul_assoc (f g h : PathAlgebra k Q) : f * g * h = f * (g * h) := by
-  induction f using Finsupp.induction_linear with
+  induction f using PathAlgebra.induction_linear with
   | zero => simp only [zero_mul]
   | add f1 f2 hf1 hf2 => rw [add_mul, add_mul, add_mul, hf1, hf2]
   | single x a =>
-    induction g using Finsupp.induction_linear with
+    induction g using PathAlgebra.induction_linear with
     | zero => simp only [mul_zero, zero_mul]
     | add g1 g2 hg1 hg2 => rw [mul_add, add_mul, add_mul, mul_add, hg1, hg2]
     | single y b =>
-      induction h using Finsupp.induction_linear with
+      induction h using PathAlgebra.induction_linear with
       | zero => simp only [mul_zero]
       | add h1 h2 hh1 hh2 => rw [mul_add, mul_add, mul_add, hh1, hh2]
       | single z c => exact single_mul_single_assoc x y z a b c
@@ -269,9 +299,14 @@ noncomputable instance : NonUnitalRing (PathAlgebra k Q) :=
     mul_assoc := PathAlgebra.mul_assoc }
 
 /-- For a quiver with finitely many vertices, the sum `∑ᵢ pᵢ` of the trivial paths is the
-candidate unit of the path algebra (Remark 2.8.5). -/
+candidate unit of the path algebra (Remark 2.8.5). The summand is written with `ofPath`, whose
+declared return type is `PathAlgebra k Q`, so the finite sum genuinely uses the `PathAlgebra k Q`
+additive structure. Writing the summand as a bare `Finsupp.single …` (even ascribed to
+`PathAlgebra k Q`) would leave the sum in the native `QuiverPathIndex Q →₀ k` additive structure
+(the ascription is erased during elaboration), and `Finset.sum_mul`/`Finset.mul_sum` in the unit
+proofs would then fail to recognise it as a product in the path-algebra semiring. -/
 noncomputable def one [Fintype Q] : PathAlgebra k Q :=
-  ∑ i, Finsupp.single (⟨i, i, Quiver.Path.nil⟩ : QuiverPathIndex Q) (1 : k)
+  ∑ i, ofPath (⟨i, i, Quiver.Path.nil⟩ : QuiverPathIndex Q)
 
 noncomputable instance [Fintype Q] : One (PathAlgebra k Q) := ⟨one k Q⟩
 
@@ -281,49 +316,60 @@ theorem one_def [Fintype Q] :
     (1 : PathAlgebra k Q) = ∑ i, Finsupp.single (⟨i, i, Quiver.Path.nil⟩ : QuiverPathIndex Q) 1 :=
   rfl
 
+/-- The unit written as a sum of `ofPath` basis paths. Definitionally identical to `one_def`, but
+the summand `ofPath` has declared type `PathAlgebra k Q`, so the finite sum genuinely lives in the
+`PathAlgebra k Q` additive structure. This is the form the `one_mul`/`mul_one` proofs rewrite with,
+so that `Finset.sum_mul`/`Finset.mul_sum` recognise the product in the path-algebra semiring;
+`one_def` keeps the `Finsupp.single` form used by downstream clients. -/
+theorem one_eq_ofPath_sum [Fintype Q] :
+    (1 : PathAlgebra k Q) = ∑ i, ofPath (⟨i, i, Quiver.Path.nil⟩ : QuiverPathIndex Q) :=
+  rfl
+
 /-- The sum of trivial paths is a left unit (Remark 2.8.5). -/
 protected theorem one_mul [Fintype Q] (f : PathAlgebra k Q) : (1 : PathAlgebra k Q) * f = f := by
-  induction f using Finsupp.induction_linear with
+  induction f using PathAlgebra.induction_linear with
   | zero => rw [mul_zero]
   | add f g hf hg => rw [mul_add, hf, hg]
   | single x a =>
     obtain ⟨xa, xb, xp⟩ := x
-    rw [one_def, Finset.sum_mul]
+    rw [one_eq_ofPath_sum, Finset.sum_mul]
     have hterm : ∀ i : Q,
         (@HMul.hMul (PathAlgebra k Q) (PathAlgebra k Q) (PathAlgebra k Q) _
-          (Finsupp.single (⟨i, i, Quiver.Path.nil⟩ : QuiverPathIndex Q) (1 : k))
+          (ofPath (⟨i, i, Quiver.Path.nil⟩ : QuiverPathIndex Q))
           (Finsupp.single (⟨xa, xb, xp⟩ : QuiverPathIndex Q) a))
         = if i = xa then (Finsupp.single (⟨xa, xb, xp⟩ : QuiverPathIndex Q) a : PathAlgebra k Q)
           else 0 := by
       intro i
+      unfold ofPath
       rw [single_mul_single, compSingle_nil_left]
       by_cases h : i = xa
-      · rw [one_mul, if_pos h, Finsupp.smul_single, smul_eq_mul, mul_one, if_pos h]
-      · rw [if_neg h, smul_zero, if_neg h]
-    rw [Finset.sum_congr rfl fun i _ => hterm i,
-      Finset.sum_ite_eq' Finset.univ xa, if_pos (Finset.mem_univ xa)]
+      · rw [one_mul, if_pos h, if_pos h]; exact smul_single_one a _
+      · rw [if_neg h, if_neg h]; exact smul_pathAlgebra_zero _
+    rw [Finset.sum_eq_single_of_mem xa (Finset.mem_univ xa)
+        (fun b _ hb => (hterm b).trans (if_neg hb)), hterm xa, if_pos rfl]
 
 /-- The sum of trivial paths is a right unit (Remark 2.8.5). -/
 protected theorem mul_one [Fintype Q] (f : PathAlgebra k Q) : f * (1 : PathAlgebra k Q) = f := by
-  induction f using Finsupp.induction_linear with
+  induction f using PathAlgebra.induction_linear with
   | zero => rw [zero_mul]
   | add f g hf hg => rw [add_mul, hf, hg]
   | single x a =>
     obtain ⟨xa, xb, xp⟩ := x
-    rw [one_def, Finset.mul_sum]
+    rw [one_eq_ofPath_sum, Finset.mul_sum]
     have hterm : ∀ i : Q,
         (@HMul.hMul (PathAlgebra k Q) (PathAlgebra k Q) (PathAlgebra k Q) _
           (Finsupp.single (⟨xa, xb, xp⟩ : QuiverPathIndex Q) a)
-          (Finsupp.single (⟨i, i, Quiver.Path.nil⟩ : QuiverPathIndex Q) (1 : k)))
+          (ofPath (⟨i, i, Quiver.Path.nil⟩ : QuiverPathIndex Q)))
         = if xb = i then (Finsupp.single (⟨xa, xb, xp⟩ : QuiverPathIndex Q) a : PathAlgebra k Q)
           else 0 := by
       intro i
+      unfold ofPath
       rw [single_mul_single, compSingle_nil_right]
       by_cases h : xb = i
-      · rw [mul_one, if_pos h, Finsupp.smul_single, smul_eq_mul, mul_one, if_pos h]
-      · rw [if_neg h, smul_zero, if_neg h]
-    rw [Finset.sum_congr rfl fun i _ => hterm i,
-      Finset.sum_ite_eq Finset.univ xb, if_pos (Finset.mem_univ xb)]
+      · rw [mul_one, if_pos h, if_pos h]; exact smul_single_one a _
+      · rw [if_neg h, if_neg h]; exact smul_pathAlgebra_zero _
+    rw [Finset.sum_eq_single_of_mem xb (Finset.mem_univ xb)
+        (fun b _ hb => (hterm b).trans (if_neg (Ne.symm hb))), hterm xb, if_pos rfl]
 
 variable (k Q)
 
@@ -344,8 +390,8 @@ noncomputable instance [Fintype Q] : Algebra k (PathAlgebra k Q) :=
 /-- **Remark 2.8.5.** For a quiver with finitely many vertices, the sum of the trivial paths
 `∑ᵢ pᵢ` is the unit of the path algebra. -/
 theorem sum_trivialPaths_eq_one [Fintype Q] :
-    (∑ i, ofPath (⟨i, i, Quiver.Path.nil⟩ : QuiverPathIndex Q) : PathAlgebra k Q) = 1 := by
-  rw [one_def]; rfl
+    (∑ i, ofPath (⟨i, i, Quiver.Path.nil⟩ : QuiverPathIndex Q) : PathAlgebra k Q) = 1 :=
+  one_eq_ofPath_sum.symm
 
 end PathAlgebra
 

--- a/EtingofRepresentationTheory/Chapter9/PathAlgebraLowerBound.lean
+++ b/EtingofRepresentationTheory/Chapter9/PathAlgebraLowerBound.lean
@@ -125,11 +125,10 @@ theorem coeffAt_single (x y : QuiverPathIndex Q) (c : k) :
 open Classical in
 theorem coeffAt_compSingle (x y z : QuiverPathIndex Q) :
     coeffAt z (compSingle x y : PathAlgebra k Q) = if x.comp y = some z then (1 : k) else 0 := by
-  change (compSingle x y : QuiverPathIndex Q →₀ k) z = _
   rw [compSingle]
   cases h : x.comp y with
   | none => simp
-  | some w => simp [Finsupp.single_apply]
+  | some w => rw [Option.elim_some, coeffAt_single]; simp
 
 /-! ## The augmentation ring homomorphism `ε_b : A → k` -/
 

--- a/progress/2026-07-23T05-53-22Z_b2b8de3b.md
+++ b/progress/2026-07-23T05-53-22Z_b2b8de3b.md
@@ -1,0 +1,54 @@
+## Accomplished
+
+Restored fresh-buildable Definition 2.8.4 (path algebra) and Remark 2.8.5 (finite-quiver
+unit), issue #7499. The file `EtingofRepresentationTheory/Chapter2/Definition2_8_4.lean`
+failed a fresh `lake env lean` check: a stricter Lean type-correctness rule now rejects tactic
+goals that are ill-typed at the `instances` transparency level, which the old proofs produced
+whenever a `PathAlgebra k Q`-typed value met an operation typed on the underlying
+`QuiverPathIndex Q →₀ k` (the `def` wrapper's re-exposed instances are defeq but not
+syntactically equal to `Finsupp`'s).
+
+Root-cause fixes (public API preserved; changes are additive helpers plus proof rewrites):
+
+- Typed `mulLinear`'s codomain and `compSingle` at `PathAlgebra k Q` so products land
+  homogeneously in the path algebra (fixes `single_mul_single`, `single_mul_single_assoc`).
+- Rewrote the `NonUnitalNonAssocRing` distributive/annihilation laws and `smul_mul`/`mul_smul'`
+  in term mode (`map_add`/`map_zero`/`map_smul` via `LinearMap.congr_fun`/`add_apply`), which
+  elaborate at default transparency and tolerate the `PathAlgebra = Finsupp` defeq that `rw`
+  refused.
+- Added `PathAlgebra.induction_linear`, a linearity induction whose step pieces are
+  `PathAlgebra k Q`-typed (not the `Finsupp` pieces `Finsupp.induction_linear` leaks), so
+  `mul_assoc`/`one_mul`/`mul_one` keep `add_mul`/`mul_add`/`Finset.sum_mul` firing.
+- Added `smul_single_one` and `smul_pathAlgebra_zero` (stated at `Finsupp`, applied through
+  defeq) for the unit proofs; `SMulZeroClass k (PathAlgebra k Q)` is not synthesizable directly.
+- Kept `one_def` in its original `Finsupp.single` form (public, used by `Problem2_8_6`); added
+  the definitionally-equal `one_eq_ofPath_sum` (summand `ofPath` has declared type
+  `PathAlgebra k Q`, so the finite sum genuinely lives in the path-algebra additive structure,
+  which `Finset.sum_mul`/`mul_sum` require). Unit proofs evaluate the resulting sum with
+  `Finset.sum_eq_single_of_mem`, sidestepping a semiring-vs-group `AddCommMonoid` diamond.
+
+## Current frontier
+
+Complete. Definition 2.8.4 file, its `lake build` target, and downstream clients build fresh
+and sorry-free.
+
+## Overall project progress
+
+Stage 3 formalization maintenance. This turn resolved one completeness-audit regression
+(#7499). Tracker entries `Chapter2/Definition2.8.4` and `Chapter2/Remark2.8.5` restored to
+`status: sorry_free`, `fidelity: verified`, `sorry_free: true`, `coverage: covered_full`.
+
+## Next step
+
+Pick the next unclaimed `completeness-audit` regression (many open: #7505, #7512, #7513, ...).
+
+## Blockers
+
+None. Verified:
+- `lake env lean EtingofRepresentationTheory/Chapter2/Definition2_8_4.lean` — clean (1 harmless
+  unused-variable warning on `smul_single_one`).
+- `lake build` of `Definition2_8_4`, `Chapter2.Problem2_8_6`, and Chapter 9 path-algebra
+  clients (`PathAlgebraInduction`, `PathAlgebraArrowBimodule`, `PathAlgebraConsSplitting`,
+  `PathAlgebraInducedGrading`) plus `Discussion_quiver_rep_bijection` — all succeed.
+- `#print axioms` on `sum_trivialPaths_eq_one`, `mul_assoc`, `one_mul`, `mul_one` — only
+  `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`).

--- a/progress/items.json
+++ b/progress/items.json
@@ -978,13 +978,12 @@
     "end_page": "20",
     "start_line": 2,
     "end_line": 4,
-    "status": "partially_proved",
-    "fidelity": "partial",
-    "sorry_free": false,
-    "coverage": "covered_partial",
-    "coverage_note": "The intended path-algebra declarations are present, but the current defining file fails to elaborate across the opaque PathAlgebra/Finsupp boundary in multiplication, associativity, and unit proofs; regression #7499.",
-    "fidelity_issue": 7499,
-    "last_updated": "2026-07-22"
+    "status": "sorry_free",
+    "fidelity": "verified",
+    "sorry_free": true,
+    "coverage": "covered_full",
+    "coverage_note": "The PathAlgebra structure, its NonUnitalNonAssocRing/NonUnitalRing/Ring/Algebra instances, and the path-concatenation multiplication all build fresh and sorry-free; the def-vs-Finsupp transparency boundary is bridged with term-mode ring-law proofs and a PathAlgebra-native linearity induction (#7499).",
+    "last_updated": "2026-07-23"
   },
   {
     "id": "Chapter2/Remark2.8.5",
@@ -994,12 +993,12 @@
     "end_page": "20",
     "start_line": 5,
     "end_line": 5,
-    "status": "partially_proved",
-    "fidelity": "partial",
-    "coverage": "covered_partial",
-    "coverage_note": "PathAlgebra.sum_trivialPaths_eq_one and the finite-quiver algebra instance have the right signatures, but their defining file currently fails to elaborate and they cannot be imported; regression #7499.",
-    "fidelity_issue": 7499,
-    "last_updated": "2026-07-22"
+    "status": "sorry_free",
+    "fidelity": "verified",
+    "coverage": "covered_full",
+    "coverage_note": "PathAlgebra.sum_trivialPaths_eq_one and the finite-quiver Ring/Algebra instances build fresh and sorry-free; the unit ∑ᵢ pᵢ is proved a two-sided identity via Finset.sum_eq_single_of_mem over the ofPath-form unit (#7499).",
+    "last_updated": "2026-07-23",
+    "sorry_free": true
   },
   {
     "id": "Chapter2/Problem2.8.6",
@@ -2800,18 +2799,18 @@
     "coverage_note": "The Ext¹ computation and the infinite indecomposable family in part (b) are proved. For part (a), two_dim_is_extension only reduces an arbitrary two-dimensional module to an extension of one-dimensional modules; it does not provide normal forms or the isomorphism criterion obtained by splitting distinct weights and quotienting self-extension classes by automorphisms. The requested classification remains #6276.",
     "derived": [
       {
-      "part": "(a) Ext¹(Vₐ,V_b) and 2-dim reps of ℂ[x₁..xₙ]",
+        "part": "(a) Ext¹(Vₐ,V_b) and 2-dim reps of ℂ[x₁..xₙ]",
         "claim": "For A=ℂ[x₁..xₙ] with 1-dim reps Vₐ,V_b (xᵢ acts by aᵢ,bᵢ): Ext¹(Vₐ,Vₐ)≅ℂⁿ and Ext¹(Vₐ,V_b)=0 for a≠b; every 2-dim rep is an extension of two 1-dim reps.",
         "description": "Full Ext¹ computation (ℂⁿ for equal weights, 0 for distinct) plus classification of 2-dim representations as extensions of 1-dim ones.",
         "source_span": "blobs/Chapter3/Problem3.9.2.md (a)",
-      "coverage": "covered_partial",
+        "coverage": "covered_partial",
         "lean_decl": [
           "Etingof.Problem3_9_2.ext1_self",
           "Etingof.Problem3_9_2.ext1_subsingleton_of_ne",
           "Etingof.Problem3_9_2.two_dim_is_extension"
         ],
-      "reason": "The Ext¹ spaces are computed and every 2D module is shown to be an extension. The file does not turn this into an up-to-isomorphism classification: no explicit normal forms, split/distinct-weight theorem, projective parameter for nonzero self-extensions, or iff isomorphism criterion is exposed.",
-      "followup_issue": 6276
+        "reason": "The Ext¹ spaces are computed and every 2D module is shown to be an extension. The file does not turn this into an up-to-isomorphism classification: no explicit normal forms, split/distinct-weight theorem, projective parameter for nonzero self-extensions, or iff isomorphism criterion is exposed.",
+        "followup_issue": 6276
       },
       {
         "part": "(b) infinitely many indecomposables of the zero-mult algebra",


### PR DESCRIPTION
Closes #7499

Session: `b2b8de3b-b2bc-4bb9-be14-46dfac2cc0bd`

c58fe269 fix(Ch2 Definition2.8.4): restore fresh-buildable path algebra and finite-quiver unit

🤖 Prepared with Claude Code