### PR TITLE
chore(Ch9): verify §9.7 progenerator_decomposition from source

### DIFF
--- a/progress/2026-07-23T07-22-28Z_e9d9e817.md
+++ b/progress/2026-07-23T07-22-28Z_e9d9e817.md
@@ -1,0 +1,47 @@
+## Accomplished
+
+Verification session for issue #7580 (residual of #7549): re-verified the §9.7
+downstream endpoint `Etingof.progenerator_decomposition` **from source**, against
+the now-restored dependencies `KrullSchmidt/Existence.lean` (PR #7568) and
+`KrullSchmidt/Fitting.lean` (PR #7573).
+
+Steps taken:
+- `lake exe cache get` (Mathlib oleans present, nothing to download).
+- Confirmed `Exchange.lean`, `Existence.lean`, `Fitting.lean`, and
+  `Introduction_9_7.lean` contain no `sorry`, `admit`, or `axiom`.
+- **Forced a genuine from-source rebuild**: deleted the `.olean`/`.ilean`/`.c`
+  artifacts for all four modules, then `lake build ...Introduction_9_7`. All four
+  recompiled fresh (jobs 2248–2251) and the build completed successfully (2251 jobs),
+  so the endpoint is checked against freshly-rebuilt `Existence.lean` and
+  `Fitting.lean`, not compiled artifacts.
+- Axiom check against the fresh build:
+  - `Etingof.progenerator_decomposition` → `[propext, Classical.choice, Quot.sound]`
+  - `Etingof.progenerator_iff_multBiproduct` (downstream consumer) →
+    `[propext, Classical.choice, Quot.sound]`
+  No `sorryAx` in either.
+
+All four acceptance criteria of #7580 are satisfied. No code change was required —
+the endpoint was already fresh-buildable and axiom-clean once its dependencies
+landed on `main`; this session confirmed it definitively.
+
+## Current frontier
+
+Issue #7580 verification complete. No source edits. Closed the issue directly with
+the build/axiom evidence (verification task, nothing to fix — no PR needed).
+
+## Overall project progress
+
+Chapter 9 Krull–Schmidt / §9.7 chain is fully restored and axiom-clean from source:
+`Existence.lean` (#7568), `Fitting.lean` (#7573), `Exchange.lean`, and the §9.7
+classification endpoints `progenerator_decomposition` / `progenerator_iff_multBiproduct`
+all elaborate cleanly. Numerous completeness-audit restoration issues remain open
+across Chapters 2–7.
+
+## Next step
+
+Pick up another completeness-audit restoration issue from `coordination list-unclaimed`
+(e.g. the Ch5 / Ch4 "restore fresh-buildable" cluster).
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR records the from-source verification of the Chapter 9 §9.7 downstream endpoint `Etingof.progenerator_decomposition` (the residual of #7549), now that its dependencies `KrullSchmidt/Existence.lean` (#7568) and `KrullSchmidt/Fitting.lean` (#7573) are restored on `main`. It adds only a progress note; no source change was required.

Verification performed:
- `Exchange.lean`, `Existence.lean`, `Fitting.lean`, `Introduction_9_7.lean` contain no `sorry`, `admit`, or `axiom`.
- Deleted the four modules' `.olean`/`.ilean`/`.c` artifacts and forced a genuine recompile via `lake build ...Introduction_9_7`; all four rebuilt fresh and the build completed successfully (2251 jobs), so the endpoint is checked against freshly-rebuilt `Existence.lean` and `Fitting.lean`, not compiled artifacts.
- `#print axioms` against the fresh build:
  - `Etingof.progenerator_decomposition` → `[propext, Classical.choice, Quot.sound]`
  - `Etingof.progenerator_iff_multBiproduct` (downstream consumer) → `[propext, Classical.choice, Quot.sound]`
  No `sorryAx` in either.

All four acceptance criteria of #7580 are satisfied.

Closes #7580

🤖 Prepared with Claude Code