### PR TITLE
Add the exact-functor predicate from Definition 7.9.3

### DIFF
--- a/EtingofRepresentationTheory/Chapter7/Definition7_9_3.lean
+++ b/EtingofRepresentationTheory/Chapter7/Definition7_9_3.lean
@@ -28,3 +28,41 @@ in Mathlib. -/
 abbrev Etingof.RightExactFunctor {C : Type*} {D : Type*} [CategoryTheory.Category C]
     [CategoryTheory.Category D] (F : CategoryTheory.Functor C D) :=
   CategoryTheory.Limits.PreservesFiniteColimits F
+
+/-- An exact functor, in the sense of Etingof Definition 7.9.3: one that is
+both left exact and right exact.
+
+Etingof states this for an additive functor between abelian categories, where
+left/right exactness are the sequence conditions of the definition. We record
+the general-category form: `Etingof.LeftExactFunctor F ∧ Etingof.RightExactFunctor F`,
+i.e. `F` preserves finite limits and finite colimits. In the book's
+additive/abelian setting these preservation properties are exactly the two
+half-exactness conditions, so this specializes to Etingof's notion. -/
+def Etingof.ExactFunctor {C : Type*} {D : Type*} [CategoryTheory.Category C]
+    [CategoryTheory.Category D] (F : CategoryTheory.Functor C D) : Prop :=
+  Etingof.LeftExactFunctor F ∧ Etingof.RightExactFunctor F
+
+namespace Etingof
+
+variable {C : Type*} {D : Type*} [CategoryTheory.Category C]
+  [CategoryTheory.Category D] {F : CategoryTheory.Functor C D}
+
+/-- A functor is exact iff it is both left exact and right exact. -/
+theorem exactFunctor_iff :
+    ExactFunctor F ↔ LeftExactFunctor F ∧ RightExactFunctor F :=
+  Iff.rfl
+
+/-- An exact functor is left exact. -/
+theorem ExactFunctor.leftExact (h : ExactFunctor F) : LeftExactFunctor F :=
+  h.1
+
+/-- An exact functor is right exact. -/
+theorem ExactFunctor.rightExact (h : ExactFunctor F) : RightExactFunctor F :=
+  h.2
+
+/-- A functor that is both left exact and right exact is exact. -/
+theorem ExactFunctor.mk (hL : LeftExactFunctor F) (hR : RightExactFunctor F) :
+    ExactFunctor F :=
+  ⟨hL, hR⟩
+
+end Etingof

--- a/progress/2026-07-23T10-20-41Z_e3b02a87.md
+++ b/progress/2026-07-23T10-20-41Z_e3b02a87.md
@@ -1,0 +1,37 @@
+## Accomplished
+
+Closed the fidelity gap in Definition 7.9.3 (issue #7484). Etingof's third
+definition — an exact functor as one that is both left and right exact — was
+present only in prose; the Lean file exposed `Etingof.LeftExactFunctor` and
+`Etingof.RightExactFunctor` but no `Etingof.ExactFunctor`.
+
+Added to `EtingofRepresentationTheory/Chapter7/Definition7_9_3.lean`:
+- `Etingof.ExactFunctor F : Prop := LeftExactFunctor F ∧ RightExactFunctor F`
+  (both components are Prop-valued in current Mathlib, so `∧` is well-formed).
+- `exactFunctor_iff` connecting exactness to the conjunction of its components.
+- Projection lemmas `ExactFunctor.leftExact`, `ExactFunctor.rightExact` and the
+  constructor `ExactFunctor.mk`.
+
+Updated `progress/items.json` for `Chapter7/Definition7.9.3`: coverage
+`covered_partial` → `covered_full`, fidelity `partial` → `verified`, refreshed
+the coverage note, and dropped the now-resolved `fidelity_issue: 7484`.
+
+## Current frontier
+
+Fresh check of `EtingofRepresentationTheory/Chapter7/Definition7_9_3.lean`
+passes (`lake env lean` exits 0). No downstream refactor was needed — the
+issue explicitly noted none is required, and nothing imports the new symbol yet.
+
+## Overall project progress
+
+Phase 3 formalization ongoing; this is a small completeness-audit fix restoring
+full coverage for one definition item. Broad unclaimed queue (~44 items) remains,
+mostly "restore fresh-buildable" regressions and completeness-audit gaps.
+
+## Next step
+
+Pick up another unclaimed completeness-audit or fresh-buildable issue.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -8791,12 +8791,11 @@
     "start_line": 27,
     "end_line": 51,
     "status": "sorry_free",
-    "fidelity": "partial",
+    "fidelity": "verified",
     "sorry_free": true,
-    "coverage": "covered_partial",
-    "coverage_note": "LeftExactFunctor and RightExactFunctor are public, but the source's third definition—ExactFunctor as their conjunction—is absent; follow-up #7484.",
-    "fidelity_issue": 7484,
-    "last_updated": "2026-07-22"
+    "coverage": "covered_full",
+    "coverage_note": "LeftExactFunctor, RightExactFunctor, and ExactFunctor (their conjunction, with exactFunctor_iff and projection/constructor lemmas) are all public.",
+    "last_updated": "2026-07-23"
   },
   {
     "id": "Chapter7/Definition7.9.4",


### PR DESCRIPTION
Closes #7484

Session: `e3b02a87-7188-4f94-a0d2-3118fa0ad647`

b5e678dd feat(Ch7 Definition 7.9.3): add the exact-functor predicate

🤖 Prepared with Claude Code