### PR TITLE
fix(Ch7 Example 7.8.3): expose the canonical splitting witness

### DIFF
--- a/EtingofRepresentationTheory/Chapter7.lean
+++ b/EtingofRepresentationTheory/Chapter7.lean
@@ -28,6 +28,7 @@ import EtingofRepresentationTheory.Chapter7.Example7_5_3
 import EtingofRepresentationTheory.Chapter7.Example7_6_3
 import EtingofRepresentationTheory.Chapter7.Example7_7_2
 import EtingofRepresentationTheory.Chapter7.Example7_8_3
+import EtingofRepresentationTheory.Chapter7.Example7_8_3_Test
 import EtingofRepresentationTheory.Chapter7.Example7_9_2
 import EtingofRepresentationTheory.Chapter7.Example7_9_5
 import EtingofRepresentationTheory.Chapter7.Example7_9_6

--- a/EtingofRepresentationTheory/Chapter7/Example7_8_3.lean
+++ b/EtingofRepresentationTheory/Chapter7/Example7_8_3.lean
@@ -11,19 +11,77 @@ extension of Z by X.
 ## Mathlib correspondence
 
 Split exact sequences are available in Mathlib. `CategoryTheory.ShortComplex.Splitting`
-captures the notion of a splitting of a short complex.
+captures the notion of a splitting of a short complex. The book asserts that the
+canonical sequence is *split*, which is strictly stronger than short exactness, so
+the primary public object here is the splitting witness itself; short exactness is
+recovered as its consequence.
 -/
 
 open CategoryTheory CategoryTheory.Limits
 
+namespace Etingof
+
+variable {C : Type*} [Category C] [Preadditive C] [HasBinaryBiproducts C]
+
+/-- The canonical short complex `X --inl→ X ⊞ Z --snd→ Z` of Etingof Example 7.8.3. -/
+noncomputable abbrev splitShortComplex (X Z : C) : ShortComplex C :=
+  ShortComplex.mk (biprod.inl : X ⟶ X ⊞ Z) biprod.snd (by simp)
+
+/-- The canonical **splitting** of the sequence `0 → X → X ⊞ Z → Z → 0`
+(Etingof Example 7.8.3).
+
+This is the witness that the sequence is *split*, i.e. that it represents the
+trivial extension of `Z` by `X`. Its retraction is `biprod.fst` and its section is
+`biprod.inr`; see `split_exact_sequence_splitting_r`, `split_exact_sequence_splitting_s`,
+and the retraction/section identities below. -/
+noncomputable def split_exact_sequence_splitting (X Z : C) :
+    (splitShortComplex X Z).Splitting :=
+  ShortComplex.Splitting.ofHasBinaryBiproduct X Z
+
+/-- The retraction of the canonical splitting is the first biproduct projection. -/
+@[simp]
+theorem split_exact_sequence_splitting_r (X Z : C) :
+    (split_exact_sequence_splitting X Z).r = biprod.fst := rfl
+
+/-- The section of the canonical splitting is the second biproduct injection. -/
+@[simp]
+theorem split_exact_sequence_splitting_s (X Z : C) :
+    (split_exact_sequence_splitting X Z).s = biprod.inr := rfl
+
+/-- The retraction identity: `biprod.inl ≫ biprod.fst = 𝟙 X`. -/
+theorem split_exact_sequence_f_r (X Z : C) :
+    (biprod.inl : X ⟶ X ⊞ Z) ≫ (split_exact_sequence_splitting X Z).r = 𝟙 X :=
+  (split_exact_sequence_splitting X Z).f_r
+
+/-- The section identity: `biprod.inr ≫ biprod.snd = 𝟙 Z`. -/
+theorem split_exact_sequence_s_g (X Z : C) :
+    (split_exact_sequence_splitting X Z).s ≫ (biprod.snd : X ⊞ Z ⟶ Z) = 𝟙 Z :=
+  (split_exact_sequence_splitting X Z).s_g
+
+/-- The splitting compatibility identity `r ≫ f + g ≫ s = 𝟙 (X ⊞ Z)`. -/
+theorem split_exact_sequence_splitting_id (X Z : C) :
+    (split_exact_sequence_splitting X Z).r ≫ (biprod.inl : X ⟶ X ⊞ Z) +
+      (biprod.snd : X ⊞ Z ⟶ Z) ≫ (split_exact_sequence_splitting X Z).s = 𝟙 (X ⊞ Z) :=
+  (split_exact_sequence_splitting X Z).id
+
+/-- The canonical map `X → X ⊞ Z` is a split monomorphism. -/
+noncomputable def split_exact_sequence_splitMono (X Z : C) :
+    SplitMono (biprod.inl : X ⟶ X ⊞ Z) :=
+  (split_exact_sequence_splitting X Z).splitMono_f
+
+/-- The canonical map `X ⊞ Z → Z` is a split epimorphism. -/
+noncomputable def split_exact_sequence_splitEpi (X Z : C) :
+    SplitEpi (biprod.snd : X ⊞ Z ⟶ Z) :=
+  (split_exact_sequence_splitting X Z).splitEpi_g
+
 /-- A split short exact sequence: 0 → X → X ⊕ Z → Z → 0.
 (Etingof Example 7.8.3)
 
-In any preadditive category with binary biproducts and kernels/cokernels,
+In any preadditive category with binary biproducts and a zero object,
 the short complex `X --inl→ X ⊞ Z --snd→ Z` admits a splitting
-(and is therefore short exact). -/
-noncomputable def Etingof.split_exact_sequence
-    {C : Type*} [Category C] [Preadditive C] [HasZeroObject C]
-    [HasBinaryBiproducts C] [HasKernels C] [HasCokernels C]
-    (X Z : C) : (ShortComplex.mk (biprod.inl : X ⟶ X ⊞ Z) biprod.snd (by simp)).ShortExact :=
-  (ShortComplex.Splitting.ofHasBinaryBiproduct X Z).shortExact
+(`split_exact_sequence_splitting`) and is therefore short exact. -/
+theorem split_exact_sequence [HasZeroObject C] (X Z : C) :
+    (splitShortComplex X Z).ShortExact :=
+  (split_exact_sequence_splitting X Z).shortExact
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter7/Example7_8_3_Test.lean
+++ b/EtingofRepresentationTheory/Chapter7/Example7_8_3_Test.lean
@@ -1,0 +1,55 @@
+import EtingofRepresentationTheory.Chapter7.Example7_8_3
+
+/-!
+# Downstream import/`#check` test for Example 7.8.3
+
+This file imports `Chapter7/Example7_8_3.lean` and pins the public API of the split
+short exact sequence `0 → X → X ⊞ Z → Z → 0`. Its purpose is to catch a regression in
+the source even when cached oleans would otherwise hide it from the aggregate build:
+because this file `import`s the item file and re-elaborates the endpoints, it forces a
+fresh check of their public signatures.
+
+The book's assertion is that the sequence is *split*, which is stronger than short
+exactness. The key regression this test guards against is the splitting witness
+disappearing behind a `.ShortExact`-only public surface (issue #7562).
+
+See issue #7562 (expose the canonical splitting witness).
+-/
+
+open CategoryTheory CategoryTheory.Limits
+
+-- The primary public object is an actual `ShortComplex.Splitting`, not just short
+-- exactness.
+#check @Etingof.split_exact_sequence_splitting
+#check @Etingof.split_exact_sequence
+#check @Etingof.split_exact_sequence_splitMono
+#check @Etingof.split_exact_sequence_splitEpi
+
+section
+variable {C : Type*} [Category C] [Preadditive C] [HasBinaryBiproducts C]
+
+-- Clients must be able to recover the splitting witness from the public API, and use
+-- its retraction/section identities, without reaching into any private namespace.
+noncomputable example (X Z : C) : (Etingof.splitShortComplex X Z).Splitting :=
+  Etingof.split_exact_sequence_splitting X Z
+
+example (X Z : C) :
+    (biprod.inl : X ⟶ X ⊞ Z) ≫ (Etingof.split_exact_sequence_splitting X Z).r = 𝟙 X :=
+  Etingof.split_exact_sequence_f_r X Z
+
+example (X Z : C) :
+    (Etingof.split_exact_sequence_splitting X Z).s ≫ (biprod.snd : X ⊞ Z ⟶ Z) = 𝟙 Z :=
+  Etingof.split_exact_sequence_s_g X Z
+
+-- The retraction and section are the expected biproduct maps.
+example (X Z : C) : (Etingof.split_exact_sequence_splitting X Z).r = biprod.fst :=
+  Etingof.split_exact_sequence_splitting_r X Z
+
+example (X Z : C) : (Etingof.split_exact_sequence_splitting X Z).s = biprod.inr :=
+  Etingof.split_exact_sequence_splitting_s X Z
+
+-- Short exactness remains available as a consequence of the splitting.
+example [HasZeroObject C] (X Z : C) : (Etingof.splitShortComplex X Z).ShortExact :=
+  Etingof.split_exact_sequence X Z
+
+end

--- a/progress/2026-07-23T10-35-33Z_2cc21fdd.md
+++ b/progress/2026-07-23T10-35-33Z_2cc21fdd.md
@@ -1,0 +1,52 @@
+## Accomplished
+
+Executed feature issue #7562 (`fix(Ch7 Example 7.8.3): expose the canonical splitting
+witness`) via the `/work` escape hatch.
+
+- Merged ready PR #7587 (Exercise 8.2.9 importability) at the start of the cycle.
+- Rewrote `Chapter7/Example7_8_3.lean` so the primary public object is the actual
+  `ShortComplex.Splitting` witness, not just short exactness:
+  - `Etingof.split_exact_sequence_splitting X Z : (splitShortComplex X Z).Splitting`
+    (the canonical splitting from `ShortComplex.Splitting.ofHasBinaryBiproduct`).
+  - `Etingof.splitShortComplex X Z` abbreviation for the canonical
+    `0 → X → X ⊞ Z → Z → 0` short complex.
+  - Named retraction/section identities: `split_exact_sequence_f_r`
+    (`inl ≫ r = 𝟙 X`), `split_exact_sequence_s_g` (`s ≫ snd = 𝟙 Z`), and the
+    compatibility `split_exact_sequence_splitting_id`.
+  - `split_exact_sequence_splitting_r`/`_s` identify the retraction/section as
+    `biprod.fst`/`biprod.inr` (both `rfl`, `@[simp]`).
+  - `split_exact_sequence_splitMono`/`splitEpi` exposing the split mono/epi.
+  - `split_exact_sequence` retained as the `.ShortExact` consequence of the splitting
+    (now a `theorem`, silencing the defProp linter).
+- Tightened section variables: the splitting needs only `Preadditive` +
+  `HasBinaryBiproducts`; `HasZeroObject` is added only on `split_exact_sequence`
+  (`Splitting.shortExact` requires exactly that). Dropped the unused
+  `HasKernels`/`HasCokernels` assumptions.
+- Added `Chapter7/Example7_8_3_Test.lean` (downstream import/`#check` regression test)
+  and registered it in `Chapter7.lean`, matching the project's `*_Test.lean` convention.
+- Updated `progress/items.json`: `Chapter7/Example7.8.3` → `covered_full` / `full`
+  fidelity / `proved`.
+
+Verification: both files fresh-check with `lake env lean` (exit 0, no warnings after
+variable tightening); `lake build EtingofRepresentationTheory.Chapter7` succeeds
+(8629 jobs); `#print axioms` on all endpoints shows only `propext, Classical.choice,
+Quot.sound` (no `sorryAx`). No `sorry`/`admit`/`native_decide`/replacement axiom.
+
+## Current frontier
+
+Issue #7562 complete. PR to be created closing it.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. Many open `completeness-audit` feature issues remain
+(restore-fresh-buildable regressions and API-exposure gaps across Chapters 2–9).
+
+## Next step
+
+Pick another unclaimed `feature` issue. The larger "restore fresh-buildable" items
+(e.g. #7512 Theorem 5.15.1 at 2831 lines, #7490 Prop 6.6.6) are higher-value but need
+a dedicated session; smaller API-exposure items like this one merge cleanly.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -8658,13 +8658,12 @@
     "end_page": "192",
     "start_line": 21,
     "end_line": 21,
-    "status": "partially_proved",
-    "fidelity": "partial",
+    "status": "proved",
+    "fidelity": "full",
     "sorry_free": true,
-    "coverage": "covered_partial",
-    "coverage_issue": 7562,
-    "coverage_note": "The canonical sequence is proved short exact, but the public declaration projects away the canonical ShortComplex.Splitting witness, so the source's split/trivial-extension structure is not exposed (#7562).",
-    "last_updated": "2026-07-22"
+    "coverage": "covered_full",
+    "coverage_note": "The public API now exposes the canonical ShortComplex.Splitting witness (split_exact_sequence_splitting) with named retraction/section identities (split_exact_sequence_f_r, split_exact_sequence_s_g), the split mono/epi (split_exact_sequence_splitMono/splitEpi), and short exactness (split_exact_sequence) as a consequence of the splitting. A downstream import/#check regression test (Example7_8_3_Test.lean) pins the signatures. Closes #7562.",
+    "last_updated": "2026-07-23"
   },
   {
     "id": "Chapter7/Exercise7.8.4",


### PR DESCRIPTION
Closes #7562

Session: `2cc21fdd-6d3e-428c-9c9c-ede0c0f3852d`

b81b571e fix(Ch7 Example 7.8.3): expose the canonical splitting witness

🤖 Prepared with Claude Code