### PR TITLE
fix(Ch7): restore k-linearity of induction in Example 7.9.2

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -486,6 +486,20 @@ context (`theorem extMapHom_tmul … := rfl`) so its LHS matches syntactically. 
 `erw`s in one call — each does an expensive defeq search and the combined term blows up `whnf`; keep
 them on separate lines.
 
+**A stale `simp only [...]` in a helper that mirrors a Mathlib sibling lemma: re-copy the
+sibling's *current* proof instead of debugging the old argument list (#7526).** In
+`Chapter7/Example7_9_2.lean`, `left_adjoint_linear` (the `Functor.Linear` companion of
+`Adjunction.left_adjoint_additive`) had a hand-tuned `simp only [homEquiv_unit,
+Functor.map_smul, ← Functor.comp_map, ← adj.unit.naturality, …]` that left an unsolved goal
+against current Mathlib (the `←`-naturality/`comp_smul`/`id_map` args reported "unused" and
+never fired). The fix was not to repair the chain but to open Mathlib's present proof of the
+sibling (`left_adjoint_additive`: `set_option backward.defeqAttrib.useBackward true in … :=
+(adj.homEquiv _ _).injective (by simp [homEquiv_unit])`) and mirror it verbatim for `map_smul`.
+When a stale-proof regression is on a lemma that names a Mathlib analogue in its docstring,
+grep Mathlib for that analogue and copy its proof style first — it is usually a one-liner and
+tracks the API drift you are fighting. (Also: `set_option … in` must sit *before* the
+docstring, not between docstring and `lemma`.)
+
 **Discharging an `↔`/membership goal over a `Prop` def with `omega`: use `unfold theDef; omega`, not
 `simp only [theDef]; omega`.** For a decidable `Prop` def built from `∨`/`∧`/`=`/`≤` over `ℕ` (e.g. an
 explicit graph adjacency pattern like `armAdjIdx` in `Chapter6/Problem6_1_3_continued_tildeE.lean`),

--- a/EtingofRepresentationTheory/Chapter7.lean
+++ b/EtingofRepresentationTheory/Chapter7.lean
@@ -30,6 +30,7 @@ import EtingofRepresentationTheory.Chapter7.Example7_7_2
 import EtingofRepresentationTheory.Chapter7.Example7_8_3
 import EtingofRepresentationTheory.Chapter7.Example7_8_3_Test
 import EtingofRepresentationTheory.Chapter7.Example7_9_2
+import EtingofRepresentationTheory.Chapter7.Example7_9_2_Test
 import EtingofRepresentationTheory.Chapter7.Example7_9_5
 import EtingofRepresentationTheory.Chapter7.Example7_9_6
 import EtingofRepresentationTheory.Chapter7.Exercise7_8_4

--- a/EtingofRepresentationTheory/Chapter7/Example7_9_2.lean
+++ b/EtingofRepresentationTheory/Chapter7/Example7_9_2.lean
@@ -38,16 +38,16 @@ namespace Etingof
 
 /-! ## A linear companion to `Adjunction.left_adjoint_additive` -/
 
+set_option backward.defeqAttrib.useBackward true in
 /-- If `adj : F ⊣ G` is an adjunction between `R`-linear categories and the right
 adjoint `G` is additive and `R`-linear, then the left adjoint `F` is `R`-linear.
 This is the `Functor.Linear` companion of
-`CategoryTheory.Adjunction.left_adjoint_additive`. -/
+`CategoryTheory.Adjunction.left_adjoint_additive`, and is proved in the same style. -/
 lemma left_adjoint_linear {C D : Type*} [Category C] [Category D] [Preadditive C]
     [Preadditive D] (R : Type*) [Semiring R] [Linear R C] [Linear R D]
     {F : C ⥤ D} {G : D ⥤ C} (adj : F ⊣ G) [G.Additive] [G.Linear R] : F.Linear R where
-  map_smul {X Y} f r := (adj.homEquiv X (F.obj Y)).injective <| by
-    simp only [Adjunction.homEquiv_unit, Functor.map_smul, Linear.comp_smul,
-      ← Functor.comp_map, ← adj.unit.naturality, Functor.id_map, Linear.smul_comp]
+  map_smul {X Y} f r :=
+    (adj.homEquiv X (F.obj Y)).injective (by simp [Adjunction.homEquiv_unit])
 
 /-! ## The three functors of Example 7.9.2 -/
 

--- a/EtingofRepresentationTheory/Chapter7/Example7_9_2_Test.lean
+++ b/EtingofRepresentationTheory/Chapter7/Example7_9_2_Test.lean
@@ -1,0 +1,54 @@
+import EtingofRepresentationTheory.Chapter7.Example7_9_2
+
+/-!
+# Downstream import/`#check` test for Example 7.9.2
+
+This file imports `Chapter7/Example7_9_2.lean` and pins the public API asserting that the
+functors `Ind_K^G`, `Res_K^G`, and `Hom_G(V, ?)` on `Rep k G` are additive and `k`-linear.
+Its purpose is to catch a regression in the source even when cached oleans would otherwise
+hide it from the aggregate build: because this file `import`s the item file and
+re-elaborates the endpoints, it forces a fresh check of their public signatures.
+
+The regression this test guards against is the linear companion `left_adjoint_linear`
+(and hence `indFunctor_linear`) failing to elaborate against the current categorical
+linearity API (issue #7526).
+
+See issue #7526 (restore k-linearity of induction in Example 7.9.2).
+-/
+
+open CategoryTheory Opposite
+
+-- The `k`-linearity of induction rests on the linear companion of
+-- `Adjunction.left_adjoint_additive`; pin it and the three functor endpoints.
+#check @Etingof.left_adjoint_linear
+#check @Etingof.resFunctor_additive
+#check @Etingof.resFunctor_linear
+#check @Etingof.indFunctor_additive
+#check @Etingof.indFunctor_linear
+#check @Etingof.homGFunctor_additive
+#check @Etingof.homGFunctor_linear
+
+section
+universe u
+variable {k G H : Type u} [Field k] [Group G] [Group H] (φ : G →* H)
+
+-- Clients must be able to recover additivity and `k`-linearity of restriction and
+-- induction from the public API.
+example : (Rep.resFunctor (k := k) φ).Additive := Etingof.resFunctor_additive φ
+example : (Rep.resFunctor (k := k) φ).Linear k := Etingof.resFunctor_linear φ
+example : (Rep.indFunctor.{u} k φ).Additive := Etingof.indFunctor_additive φ
+example : (Rep.indFunctor.{u} k φ).Linear k := Etingof.indFunctor_linear φ
+
+-- The covariant hom-functor `Hom_G(V, ?)` is additive and `k`-linear.
+example (V : Rep k G) : ((linearCoyoneda k (Rep k G)).obj (op V)).Additive :=
+  Etingof.homGFunctor_additive V
+example (V : Rep k G) : ((linearCoyoneda k (Rep k G)).obj (op V)).Linear k :=
+  Etingof.homGFunctor_linear V
+
+-- The linear companion transfers `k`-linearity across any adjunction, not just induction.
+example {C D : Type*} [Category C] [Category D] [Preadditive C] [Preadditive D]
+    [Linear k C] [Linear k D] {F : C ⥤ D} {J : D ⥤ C} (adj : F ⊣ J)
+    [J.Additive] [J.Linear k] : F.Linear k :=
+  Etingof.left_adjoint_linear k adj
+
+end

--- a/progress/2026-07-23T11-01-17Z_a959dca7.md
+++ b/progress/2026-07-23T11-01-17Z_a959dca7.md
@@ -1,0 +1,39 @@
+## Accomplished
+
+Fixed issue #7526 — restored k-linearity of induction in Example 7.9.2.
+
+- `EtingofRepresentationTheory/Chapter7/Example7_9_2.lean` no longer elaborated: the
+  helper `Etingof.left_adjoint_linear` (the `Functor.Linear` companion of
+  `Adjunction.left_adjoint_additive`) left an unsolved goal, which in turn broke
+  `indFunctor_linear`.
+- Reproved `left_adjoint_linear` in the exact style Mathlib now uses for
+  `Adjunction.left_adjoint_additive`: `set_option backward.defeqAttrib.useBackward true in`
+  plus `(adj.homEquiv X (F.obj Y)).injective (by simp [Adjunction.homEquiv_unit])`.
+  This replaces the brittle multi-lemma `simp only` that had gone stale.
+- Added a downstream import/`#check` regression test
+  `Chapter7/Example7_9_2_Test.lean`, mirroring the existing `Example7_8_3_Test.lean`
+  convention, and imported it from the `Chapter7.lean` aggregator.
+- Verified: `lake env lean` direct-checks both files; `lake build` of both targets
+  succeeds; `#print axioms` on `indFunctor_linear`, `resFunctor_linear`,
+  `homGFunctor_linear`, and `left_adjoint_linear` shows only
+  `[propext, Classical.choice, Quot.sound]` (no `sorryAx`).
+- Updated `progress/items.json`: `Chapter7/Example7.9.2` → proved / full / covered_full.
+
+## Current frontier
+
+Issue #7526 complete. PR pending creation.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing; this was a regression-restore (completeness-audit)
+item. Many similar "restore fresh-buildable" issues remain unclaimed (e.g. #7490,
+#7491, #7512, #7522, #7527).
+
+## Next step
+
+Create the PR for #7526 and enable auto-merge. Next worker can pick another restore
+issue from the queue.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -8768,13 +8768,12 @@
     "end_page": "194",
     "start_line": 25,
     "end_line": 26,
-    "status": "partially_proved",
-    "fidelity": "partial",
+    "status": "proved",
+    "fidelity": "full",
     "sorry_free": true,
-    "coverage": "covered_partial",
-    "coverage_note": "The intended Ind, Res, and Hom endpoints are source-present, but Example7_9_2.lean fails a fresh check in left_adjoint_linear, preventing indFunctor_linear from rebuilding; regression #7526.",
-    "coverage_issue": 7526,
-    "last_updated": "2026-07-22"
+    "coverage": "covered_full",
+    "coverage_note": "Ind, Res, and Hom additive/k-linear endpoints all fresh-check; left_adjoint_linear reproved in the style of Adjunction.left_adjoint_additive, with a downstream import/#check regression test Example7_9_2_Test.lean (#7526).",
+    "last_updated": "2026-07-23"
   },
   {
     "id": "Chapter7/Definition7.9.3",


### PR DESCRIPTION
Closes #7526

Session: `a959dca7-6ea6-404f-9599-b30c384874d3`

26f0f963 doc(skill): note re-copying Mathlib sibling proofs for stale simp-only regressions
41845373 fix(Ch7): restore k-linearity of induction in Example 7.9.2

🤖 Prepared with Claude Code