### PR TITLE
fix(Ch5): restore fresh-buildable rational-form Corollary 5.12.4

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -200,6 +200,21 @@ restoring `Definition2_8_4.lean` (#7499), cost ~15 iterations:**
   Small `Finsupp`-typed helpers (`c • single x 1 = single x c`, `c • 0 = 0`) proved by `rw` then
   applied to `Foo` goals by `exact` cover the `SMulZeroClass k Foo`-not-synthesizable gaps.
 
+**`TensorProduct.finsuppScalarRight`/`finsuppScalarLeft` rewrites that stop matching on a
+`MonoidAlgebra ℚ G` factor (#7522, `Chapter5/Corollary5_12_4.lean`).** These lemmas
+(`finsuppScalarRight_apply_tmul_apply`, …) are stated over `ι →₀ R`, but `MonoidAlgebra R G`
+is `G →₀ R` with `MonoidAlgebra.addCommMonoid` *overriding the `AddCommMonoid.nsmul` field*
+(the "abuses definitional equality" TODO in Mathlib's `MonoidAlgebra/Defs.lean`). The two
+instances are defeq at `default` (so the `def` composing `finsuppScalarRight` with a
+base-changed submodule inclusion still elaborates) but not reducibly equal, so `rw`/`simp`
+report "did not find pattern" and even leave the goal "not type-correct under `instances`
+transparency". **Fix: don't fight the rewrite — build the value term with explicit `Finsupp`
+typing** (`have h := finsuppScalarRight_apply_tmul_apply (R := …) … (↑w) g`, passing the
+`MonoidAlgebra`-typed coercion where `ι →₀ R` is expected; it unifies by defeq) **then
+transport with `refine h.trans ?_`** (`Eq.trans`'s first argument unifies up to defeq, unlike
+`rw`). Close the residual scalar goal with `Algebra.smul_def`, `mul_comm`, `rfl`. Only the
+one coefficient lemma broke; the surrounding `def`s and other proofs were untouched.
+
 **A `neg_smul`/cast rewrite tail that breaks under a Mathlib bump: close it with `push_cast;
 module` instead of chasing the rewrite (#7530, `Chapter2/Problem2_7_4.lean`).** A proof ending
 `rw […, ← Nat.cast_smul_eq_nsmul (R := k) (n + 1), neg_smul]; congr 1; push_cast; ring` regressed

--- a/EtingofRepresentationTheory/Chapter5.lean
+++ b/EtingofRepresentationTheory/Chapter5.lean
@@ -67,6 +67,7 @@ import EtingofRepresentationTheory.Chapter5.Theorem5_12_2_DistinctGeneral
 import EtingofRepresentationTheory.Chapter5.Theorem5_12_2_Classification
 import EtingofRepresentationTheory.Chapter5.Example5_12_3
 import EtingofRepresentationTheory.Chapter5.Corollary5_12_4
+import EtingofRepresentationTheory.Chapter5.Corollary5_12_4_Test
 
 -- Section 5.13: Young Projectors
 import EtingofRepresentationTheory.Chapter5.Lemma5_13_1

--- a/EtingofRepresentationTheory/Chapter5/Corollary5_12_4.lean
+++ b/EtingofRepresentationTheory/Chapter5/Corollary5_12_4.lean
@@ -68,8 +68,15 @@ private theorem Tmap_tmul (z : ℂ) (w : SpechtModuleK ℚ n la) :
   change (TensorProduct.finsuppScalarRight ℚ ℂ ℂ (Equiv.Perm (Fin n)))
       (LinearMap.baseChange ℂ (((SpechtModuleK ℚ n la).subtype).restrictScalars ℚ)
         (z ⊗ₜ[ℚ] w)) g = _
-  rw [LinearMap.baseChange_tmul, TensorProduct.finsuppScalarRight_apply_tmul_apply,
-    Finsupp.smul_apply, MonoidAlgebra.mapRingHom_apply, smul_eq_mul, Algebra.smul_def, mul_comm]
+  rw [LinearMap.baseChange_tmul]
+  -- `finsuppScalarRight` expects its `Finsupp`-typed factor, but the base-changed
+  -- element carries the `MonoidAlgebra` instances (defeq, but not syntactically equal:
+  -- `MonoidAlgebra.addCommMonoid` overrides the `nsmul` field). Build the coefficient
+  -- value with the `Finsupp` typing and transport across the defeq via `Eq.trans`.
+  have h := TensorProduct.finsuppScalarRight_apply_tmul_apply (R := ℚ) (S := ℂ) (M := ℂ)
+    (ι := Equiv.Perm (Fin n)) z ((SpechtModuleK ℚ n la).subtype w) g
+  refine h.trans ?_
+  rw [Algebra.smul_def, mul_comm]
   rfl
 
 private theorem Tmap_injective : Function.Injective (Tmap n la) := by

--- a/EtingofRepresentationTheory/Chapter5/Corollary5_12_4_Test.lean
+++ b/EtingofRepresentationTheory/Chapter5/Corollary5_12_4_Test.lean
@@ -1,0 +1,37 @@
+import EtingofRepresentationTheory.Chapter5.Corollary5_12_4
+
+/-!
+# Downstream import/`#check` test for Corollary 5.12.4
+
+This file imports `Chapter5/Corollary5_12_4.lean` and pins the public signatures of the
+rational-form results. Its purpose is to catch a regression in the source of Corollary
+5.12.4 even when cached oleans would otherwise hide it from the aggregate build: because
+this file `import`s the corollary file and re-elaborates the endpoint statements, it forces
+a fresh check of their public API.
+
+See issue #7522 (restore fresh-buildable rational-form Corollary 5.12.4).
+-/
+
+-- The public endpoints must remain importable under these names.
+#check @Etingof.SpechtModule_complexification
+#check @Etingof.Corollary5_12_4
+
+open scoped TensorProduct
+
+-- Signature lock and application test for the complexification isomorphism. Applying it
+-- and destructuring the witness forces a fresh elaboration of the `ℂ`-linear equivalence
+-- `ℂ ⊗_ℚ V_λ^ℚ ≃ V_λ` and its `Sₙ`-equivariance clause; any drift makes this fail.
+example (n : ℕ) (la : Nat.Partition n) :
+    True := by
+  obtain ⟨_e, _hequiv⟩ := Etingof.SpechtModule_complexification n la
+  trivial
+
+-- Signature lock and application test for the corollary. Given a simple `ℂ[Sₙ]`-module,
+-- the theorem must produce a partition together with the classification isomorphism, the
+-- simplicity of the rational Specht module, and the complexification equivalence.
+example (n : ℕ) (M : Type)
+    [AddCommGroup M] [Module (Etingof.SymGroupAlgebra n) M]
+    [IsSimpleModule (Etingof.SymGroupAlgebra n) M] :
+    True := by
+  obtain ⟨_la, _hclass, _hsimple, _e, _hequiv⟩ := Etingof.Corollary5_12_4 n M
+  trivial

--- a/progress/2026-07-23T11-13-30Z_dd3e46b8.md
+++ b/progress/2026-07-23T11-13-30Z_dd3e46b8.md
@@ -1,0 +1,46 @@
+## Accomplished
+
+Fixed the fresh-build regression in `Chapter5/Corollary5_12_4.lean` (issue #7522).
+`lake env lean EtingofRepresentationTheory/Chapter5/Corollary5_12_4.lean` now succeeds
+from source, with no `sorry`/`admit`/axiom.
+
+Root cause: `TensorProduct.finsuppScalarRight ℚ ℂ ℂ (Equiv.Perm (Fin n))` expects its
+second tensor factor typed as `Equiv.Perm (Fin n) →₀ ℚ` with `Finsupp` instances, but the
+base-changed Specht-module element carries `MonoidAlgebra ℚ (Equiv.Perm (Fin n))`
+instances. `MonoidAlgebra.addCommMonoid` overrides the `AddCommMonoid.nsmul` field (the
+"abuses definitional equality" TODO in Mathlib's `MonoidAlgebra/Defs.lean`), so the two are
+defeq at `default` transparency (the `Tmap` def still elaborates) but not reducibly equal,
+which is why `rw`/`simp` could no longer match `finsuppScalarRight_apply_tmul_apply`.
+
+Fix (in `Tmap_tmul`): build the coefficient value with an explicit `Finsupp`-typed
+application of `finsuppScalarRight_apply_tmul_apply`, then transport across the defeq with
+`Eq.trans` (`refine h.trans ?_`, which unifies up to defeq). The residual scalar goal closes
+with `Algebra.smul_def`, `mul_comm`, and `rfl`. Only `Tmap_tmul` was broken; every other
+declaration in the file was unaffected.
+
+Added `Chapter5/Corollary5_12_4_Test.lean` pinning the public API
+(`Etingof.SpechtModule_complexification`, `Etingof.Corollary5_12_4`) with `#check` and
+application `example`s, and imported it from `Chapter5.lean` so a future source regression
+surfaces even under cached oleans.
+
+## Current frontier
+
+Issue #7522 complete. Both `Corollary5_12_4.lean` and `Corollary5_12_4_Test.lean` build
+from source cleanly (no errors/warnings).
+
+## Overall project progress
+
+Phase 3 formalization; ongoing "restore fresh-buildable" regression sweep across chapters.
+Many sibling `fix(ChX): restore fresh-buildable ...` issues remain unclaimed (e.g. #7516,
+#7518, #7522-done, #7523, #7527, #7531-#7560).
+
+## Next step
+
+Pick the next unclaimed `fix(...)` regression issue. Several of these are MonoidAlgebra/
+Finsupp instance-drift breakages of the same shape as #7522 — the `Eq.trans`-across-defeq
+pattern here is a reusable fix for `finsuppScalarRight`/`finsuppScalarLeft` rewrites that
+stopped matching after the `MonoidAlgebra.addCommMonoid` `nsmul` override.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7522

Session: `dd3e46b8-2715-4562-adf4-63bdb1f0319c`

94c7bc67 fix(Ch5): restore fresh-buildable rational-form Corollary 5.12.4

🤖 Prepared with Claude Code