### PR TITLE
fix(Ch5 Def 5.23.1): require an actual GL representation in IsAlgebraicRepresentation

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/CleanCharacterExtractionBase.lean
+++ b/EtingofRepresentationTheory/Chapter5/CleanCharacterExtractionBase.lean
@@ -109,7 +109,7 @@ now using the general-`k` density core
 theorem formalCharacter_simples_coeff_eq_zero_of_torus_trace_eq_zero_general
     (N : ℕ) {ι : Type} [Fintype ι] [DecidableEq ι]
     (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
-    (hLalg : ∀ i, Etingof.IsAlgebraicRepresentation N (L i).ρ)
+    (hLalg : ∀ i, Etingof.IsAlgebraicCoefficientFamily N (L i).ρ)
     (hLsimp : ∀ i, IsSimpleModule (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
         (Representation.asModule (L i).ρ))
     (hLdist : Pairwise (fun i j => ¬ Nonempty ((L i) ≅ (L j))))

--- a/EtingofRepresentationTheory/Chapter5/CleanConstituentExtraction.lean
+++ b/EtingofRepresentationTheory/Chapter5/CleanConstituentExtraction.lean
@@ -72,8 +72,8 @@ theorem subFDRep_iSup_glWeightSpace_eq_top (N : ℕ)
 to an invariant submodule is algebraic. -/
 theorem subFDRep_isAlgebraic (N : ℕ)
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k)) (σ : Subrepresentation M.ρ)
-    (hM : Etingof.IsAlgebraicRepresentation N M.ρ) :
-    Etingof.IsAlgebraicRepresentation N (subFDRep M σ).ρ := by
+    (hM : Etingof.IsAlgebraicCoefficientFamily N M.ρ) :
+    Etingof.IsAlgebraicCoefficientFamily N (subFDRep M σ).ρ := by
   have hrestrict := hM.restrict σ.toSubmodule (fun g v hv => σ.apply_mem_toSubmodule g hv)
   -- `simpa only [subFDRep, FDRep.of_ρ']` over-unfolds the carrier/action;
   -- `(subFDRep M σ).ρ` is defeq to the restricted action `σ.toRepresentation`,
@@ -87,24 +87,24 @@ formal characters sum to `char M`. Proved by a `finrank` induction: peel a simpl
 the strictly-smaller quotient. -/
 theorem formalCharacter_eq_sum_simple_factors (N : ℕ)
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
-    (halg : Etingof.IsAlgebraicRepresentation N M.ρ)
+    (halg : Etingof.IsAlgebraicCoefficientFamily N M.ρ)
     (hM : ⨆ μ : Fin N →₀ ℕ, glWeightSpace k N M (fun i => μ i) = ⊤) :
     ∃ (p : ℕ) (W : Fin p → FDRep k (Matrix.GeneralLinearGroup (Fin N) k)),
       (∀ j, IsSimpleModule (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
           (Representation.asModule (W j).ρ)) ∧
-      (∀ j, Etingof.IsAlgebraicRepresentation N (W j).ρ) ∧
+      (∀ j, Etingof.IsAlgebraicCoefficientFamily N (W j).ρ) ∧
       (∀ j, ⨆ μ : Fin N →₀ ℕ, glWeightSpace k N (W j) (fun i => μ i) = ⊤) ∧
       formalCharacter k N M = ∑ j, formalCharacter k N (W j) := by
   classical
   -- Strong induction on `finrank k M`.
   suffices H : ∀ n (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k)),
       Module.finrank k M = n →
-      Etingof.IsAlgebraicRepresentation N M.ρ →
+      Etingof.IsAlgebraicCoefficientFamily N M.ρ →
       (⨆ μ : Fin N →₀ ℕ, glWeightSpace k N M (fun i => μ i) = ⊤) →
       ∃ (p : ℕ) (W : Fin p → FDRep k (Matrix.GeneralLinearGroup (Fin N) k)),
         (∀ j, IsSimpleModule (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
             (Representation.asModule (W j).ρ)) ∧
-        (∀ j, Etingof.IsAlgebraicRepresentation N (W j).ρ) ∧
+        (∀ j, Etingof.IsAlgebraicCoefficientFamily N (W j).ρ) ∧
         (∀ j, ⨆ μ : Fin N →₀ ℕ, glWeightSpace k N (W j) (fun i => μ i) = ⊤) ∧
         formalCharacter k N M = ∑ j, formalCharacter k N (W j) by
     exact H _ M rfl halg hM
@@ -148,7 +148,7 @@ theorem formalCharacter_eq_sum_simple_factors (N : ℕ)
             σ.asSubmodule := hσasSub ▸ hSsimple
         have h2 := isSimpleModule_toRepresentation_asModule σ h1
         simpa only [subFDRep, FDRep.of_ρ'] using h2
-      have hsubalg : Etingof.IsAlgebraicRepresentation N (subFDRep M σ).ρ :=
+      have hsubalg : Etingof.IsAlgebraicCoefficientFamily N (subFDRep M σ).ρ :=
         subFDRep_isAlgebraic k N M σ halg
       have hsubspan : ⨆ μ : Fin N →₀ ℕ, glWeightSpace k N (subFDRep M σ) (fun i => μ i) = ⊤ :=
         subFDRep_iSup_glWeightSpace_eq_top k N M σ hM
@@ -163,7 +163,7 @@ theorem formalCharacter_eq_sum_simple_factors (N : ℕ)
         have hxσ : x ∈ σ.asSubmodule := hσasSub ▸ hxS
         rw [Subrepresentation.mem_asSubmodule_iff] at hxσ
         exact ⟨x, hxσ, hx0⟩
-      have hquot_alg : Etingof.IsAlgebraicRepresentation N (quotientFDRep M σ).ρ :=
+      have hquot_alg : Etingof.IsAlgebraicCoefficientFamily N (quotientFDRep M σ).ρ :=
         quotientFDRep_isAlgebraic M σ halg
       have hquot_span :
           ⨆ μ : Fin N →₀ ℕ, glWeightSpace k N (quotientFDRep M σ) (fun i => μ i) = ⊤ :=
@@ -239,7 +239,7 @@ combination) into `formalCharacter_simples_coeff_eq_zero_of_torus_trace_eq_zero_
 (torus-trace ⟹ coefficients zero). -/
 theorem coeff_zero_of_char_combination_zero (N : ℕ) {ι : Type} [Fintype ι]
     (R : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
-    (hRalg : ∀ i, Etingof.IsAlgebraicRepresentation N (R i).ρ)
+    (hRalg : ∀ i, Etingof.IsAlgebraicCoefficientFamily N (R i).ρ)
     (hRsimp : ∀ i, IsSimpleModule (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
         (Representation.asModule (R i).ρ))
     (hRspan : ∀ i, ⨆ μ : Fin N →₀ ℕ, glWeightSpace k N (R i) (fun j => μ j) = ⊤)
@@ -265,7 +265,7 @@ non-isomorphic, via `formalCharacter_eq_of_FDRep_iso`) and applying the regroupe
 caller's concrete `Sum.elim` family. -/
 theorem net_coeff_zero_of_char_combination_zero (N : ℕ) {ι : Type} [Fintype ι]
     (R : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
-    (hRalg : ∀ i, Etingof.IsAlgebraicRepresentation N (R i).ρ)
+    (hRalg : ∀ i, Etingof.IsAlgebraicCoefficientFamily N (R i).ρ)
     (hRsimp : ∀ i, IsSimpleModule (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
         (Representation.asModule (R i).ρ))
     (hRspan : ∀ i, ⨆ μ : Fin N →₀ ℕ, glWeightSpace k N (R i) (fun j => μ j) = ⊤)
@@ -335,7 +335,7 @@ combination `∑_{ν∈S} c_ν S_ν` of Schur polynomials and `L ↪ M` is a sim
 then `char L = S_ν` for some `ν ∈ S` with `c_ν > 0`. -/
 theorem clean_simple_constituent_formalCharacter_eq_schurPoly_mem (N : ℕ)
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
-    (halg : Etingof.IsAlgebraicRepresentation N M.ρ)
+    (halg : Etingof.IsAlgebraicCoefficientFamily N M.ρ)
     (h_span : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M (fun i => μ i) = ⊤)
     (S : Finset {l : Fin N → ℕ // Antitone l})
     (c : {l : Fin N → ℕ // Antitone l} → ℕ)
@@ -366,7 +366,7 @@ theorem clean_simple_constituent_formalCharacter_eq_schurPoly_mem (N : ℕ)
     intro g v
     apply e'.injective
     rw [e'.apply_symm_apply, he', e'.apply_symm_apply]
-  have hsubalg : Etingof.IsAlgebraicRepresentation N (subFDRep M σL).ρ :=
+  have hsubalg : Etingof.IsAlgebraicCoefficientFamily N (subFDRep M σL).ρ :=
     subFDRep_isAlgebraic k N M σL halg
   have hsubspan : ⨆ μ : Fin N →₀ ℕ, glWeightSpace k N (subFDRep M σL) (fun i => μ i) = ⊤ :=
     subFDRep_iSup_glWeightSpace_eq_top k N M σL h_span
@@ -374,7 +374,7 @@ theorem clean_simple_constituent_formalCharacter_eq_schurPoly_mem (N : ℕ)
     have h0 := formalCharacter_eq_of_rep_iso k N L.ρ (subFDRep M σL).ρ e' he'
     rwa [formalCharacter_FDRep_of_ρ, formalCharacter_FDRep_of_ρ] at h0
   -- ### Step B: short-exact-sequence split `char M = char L + ∑_j char (W j)`.
-  have hquotalg : Etingof.IsAlgebraicRepresentation N (quotientFDRep M σL).ρ :=
+  have hquotalg : Etingof.IsAlgebraicCoefficientFamily N (quotientFDRep M σL).ρ :=
     quotientFDRep_isAlgebraic M σL halg
   have hquotspan :
       ⨆ μ : Fin N →₀ ℕ, glWeightSpace k N (quotientFDRep M σL) (fun i => μ i) = ⊤ :=
@@ -395,9 +395,9 @@ theorem clean_simple_constituent_formalCharacter_eq_schurPoly_mem (N : ℕ)
     · exact hLsimp
     · exact hWsimp j
     · exact schurModule_isSimple_general k N ν.1.val ν.1.property
-  have hRalg : ∀ i, Etingof.IsAlgebraicRepresentation N (R i).ρ := by
+  have hRalg : ∀ i, Etingof.IsAlgebraicCoefficientFamily N (R i).ρ := by
     rintro (_ | j | ν)
-    · exact IsAlgebraicRepresentation.of_linearEquiv e'.symm he'symm hsubalg
+    · exact IsAlgebraicCoefficientFamily.of_linearEquiv e'.symm he'symm hsubalg
     · exact hWalg j
     · exact schurModule_isAlgebraic (k := k) N ν.1.val
   have hRspan : ∀ i, ⨆ μ : Fin N →₀ ℕ, glWeightSpace k N (R i) (fun j => μ j) = ⊤ := by

--- a/EtingofRepresentationTheory/Chapter5/CleanQuotientHelpers.lean
+++ b/EtingofRepresentationTheory/Chapter5/CleanQuotientHelpers.lean
@@ -14,7 +14,7 @@ additivity `Etingof.CleanCharExtraction.formalCharacter_add_of_shortExact`. To r
 induction it needs, for an invariant submodule `S = σ.toSubmodule ≤ M`:
 
 * the quotient `M ⧸ S` carried as a `GL_N`-representation that is still algebraic (so the
-  induction hypothesis applies to it): `IsAlgebraicRepresentation.quotient`;
+  induction hypothesis applies to it): `IsAlgebraicCoefficientFamily.quotient`;
 * the packaging of `S ↪ M ↠ M ⧸ S` as an equivariant short exact sequence of `FDRep`s, so that
   `formalCharacter_add_of_shortExact` applies directly: `subFDRep`, `quotientFDRep`, the
   equivariant inclusion/projection, exactness, and
@@ -34,17 +34,17 @@ namespace Etingof
 representation `ρ` on `Y` and an invariant submodule `K` (`K ≤ K.comap (ρ g)` for every `g`),
 the induced action `g ↦ Submodule.mapQ K K (ρ g)` on `Y ⧸ K` is algebraic.
 
-The proof mirrors `Etingof.IsAlgebraicRepresentation.restrict`: choose a complement `K'` of `K`,
+The proof mirrors `Etingof.IsAlgebraicCoefficientFamily.restrict`: choose a complement `K'` of `K`,
 which provides a linear section `s : Y ⧸ K → Y` of the quotient map `q = K.mkQ`
 (`q ∘ s = id`); the quotient matrix coefficients are then the sub-block
 `∑_{d,e} (B.repr (s (b' c)) d) · P e d · (b'.repr (q (B e)) a)` of the ambient polynomial
 coefficients `P`, hence polynomial. -/
-theorem IsAlgebraicRepresentation.quotient {k : Type*} [Field k] {N : ℕ}
+theorem IsAlgebraicCoefficientFamily.quotient {k : Type*} [Field k] {N : ℕ}
     {Y : Type*} [AddCommGroup Y] [Module k Y] [Module.Finite k Y]
     {ρ : Matrix.GeneralLinearGroup (Fin N) k → Y →ₗ[k] Y}
-    (h : Etingof.IsAlgebraicRepresentation N ρ)
+    (h : Etingof.IsAlgebraicCoefficientFamily N ρ)
     (K : Submodule k Y) (hK : ∀ g, K ≤ K.comap (ρ g)) :
-    Etingof.IsAlgebraicRepresentation N (fun g => Submodule.mapQ K K (ρ g) (hK g)) := by
+    Etingof.IsAlgebraicCoefficientFamily N (fun g => Submodule.mapQ K K (ρ g) (hK g)) := by
   classical
   haveI : Module.Finite k (Y ⧸ K) := Module.Finite.of_surjective K.mkQ K.mkQ_surjective
   obtain ⟨M, B, P, hP⟩ := h
@@ -154,10 +154,10 @@ theorem subFDRep_range_eq_quotientFDRep_ker
   rw [Submodule.range_subtype, Submodule.ker_mkQ]
 
 /-- **The quotient `FDRep` is algebraic when `M` is.** Specializes
-`IsAlgebraicRepresentation.quotient` to the quotient `FDRep`. -/
+`IsAlgebraicCoefficientFamily.quotient` to the quotient `FDRep`. -/
 theorem quotientFDRep_isAlgebraic (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
-    (σ : Subrepresentation M.ρ) (hM : Etingof.IsAlgebraicRepresentation N M.ρ) :
-    Etingof.IsAlgebraicRepresentation N (quotientFDRep M σ).ρ :=
+    (σ : Subrepresentation M.ρ) (hM : Etingof.IsAlgebraicCoefficientFamily N M.ρ) :
+    Etingof.IsAlgebraicCoefficientFamily N (quotientFDRep M σ).ρ :=
   hM.quotient σ.toSubmodule (fun g => σ.apply_mem_toSubmodule g)
 
 /-- **Weight saturation passes to the quotient.** If the `ℕ`-weight spaces of `M` span `M`,

--- a/EtingofRepresentationTheory/Chapter5/ConstituentCharacterExtraction.lean
+++ b/EtingofRepresentationTheory/Chapter5/ConstituentCharacterExtraction.lean
@@ -103,7 +103,7 @@ the classification API `schurPoly_linearIndependent` / `decompose_polynomial_gl_
 consumer indexing `S` by `BoundedPartition` reads off `ν.parts := ν.val`. -/
 theorem simple_constituent_formalCharacter_eq_schurPoly_mem (N n : ℕ)
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
-    (halg : Etingof.IsAlgebraicRepresentation N M.ρ)
+    (halg : Etingof.IsAlgebraicCoefficientFamily N M.ρ)
     (h_span : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M (fun i => μ i) = ⊤)
     (h_homog : ∀ μ : Fin N → ℕ, glWeightSpace k N M μ ≠ ⊥ → ∑ i, μ i = n)
     (S : Finset {l : Fin N → ℕ // Antitone l})

--- a/EtingofRepresentationTheory/Chapter5/Definition5_23_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Definition5_23_1.lean
@@ -29,18 +29,27 @@ noncomputable def Etingof.evalAtGL {k : Type*} [Field k] {n : ℕ}
               (fun _ => ((g : Matrix (Fin n) (Fin n) k).det)⁻¹))
     p
 
-/-- A finite-dimensional representation ρ of GL_n(k) on Y is *algebraic*
-(also called rational or polynomial) if there exists a basis of Y such that
-all matrix coefficients of ρ(g) are polynomial functions of the matrix entries
-gᵢⱼ and det(g)⁻¹.
+/-- A family of endomorphisms `ρ : GL_n(k) → (Y →ₗ[k] Y)` has *algebraic matrix
+coefficients* if there exists a basis of Y such that all matrix coefficients of
+`ρ g` are polynomial functions of the matrix entries `gᵢⱼ` and `det(g)⁻¹`.
 
 Concretely: there exist polynomials Pₐ_c ∈ k[Xᵢⱼ, D] (where Xᵢⱼ are
 variables for the n² matrix entries and D represents 1/det) such that
 for all g ∈ GL_n(k), the (a,c)-th matrix coefficient of ρ(g) equals
 Pₐ_c(gᵢⱼ, det(g)⁻¹).
 
+This is the *raw coefficient-regularity* condition on an arbitrary family. It
+does **not** by itself require `ρ` to be a group representation (see the
+regression `exists_algebraicCoefficientFamily_not_representation`). The textbook
+notion of an algebraic representation is `Etingof.IsAlgebraicRepresentation`,
+which bundles this condition with a genuine `Representation`. The name is kept
+distinct precisely because the reusable transport lemmas
+(`IsAlgebraicCoefficientFamily.restrict`, `.detTwist`, `.of_linearEquiv`, …)
+naturally act on raw families, some of which are not packaged as
+`Representation` objects.
+
 (Etingof Definition 5.23.1) -/
-def Etingof.IsAlgebraicRepresentation
+def Etingof.IsAlgebraicCoefficientFamily
     {k : Type*} [Field k]
     (n : ℕ)
     {Y : Type*} [AddCommGroup Y] [Module k Y] [Module.Finite k Y]
@@ -49,3 +58,66 @@ def Etingof.IsAlgebraicRepresentation
     (P : Fin m → Fin m → MvPolynomial (Etingof.GLCoordVars n) k),
     ∀ (g : Matrix.GeneralLinearGroup (Fin n) k) (a c : Fin m),
       b.repr (ρ g (b c)) a = Etingof.evalAtGL g (P a c)
+
+/-- **Definition 5.23.1 (algebraic representation).** A finite-dimensional
+representation `ρ` of `GL_n(k)` on `Y` is *algebraic* (also called *rational* or
+*polynomial*) if its matrix coefficients are polynomial functions of the entries
+`gᵢⱼ` and of `det(g)⁻¹`.
+
+Unlike `IsAlgebraicCoefficientFamily`, the input here is a bundled
+`Representation k (GL_n k) Y` — a genuine group homomorphism `g ↦ ρ g` — so the
+identity and multiplicativity action laws are part of the data. The predicate
+then asserts algebraicity of the underlying coefficient family `⇑ρ`. This
+faithfully captures Etingof's notion, whose subject is *a representation*.
+
+(Etingof Definition 5.23.1) -/
+def Etingof.IsAlgebraicRepresentation
+    {k : Type*} [Field k]
+    (n : ℕ)
+    {Y : Type*} [AddCommGroup Y] [Module k Y] [Module.Finite k Y]
+    (ρ : Representation k (Matrix.GeneralLinearGroup (Fin n) k) Y) : Prop :=
+  Etingof.IsAlgebraicCoefficientFamily n (fun g => ρ g)
+
+/-- `IsAlgebraicRepresentation` unfolds to algebraicity of the underlying
+coefficient family. This is definitional, but stated for readability at use
+sites and to bridge the two predicates. -/
+theorem Etingof.isAlgebraicRepresentation_iff
+    {k : Type*} [Field k] (n : ℕ)
+    {Y : Type*} [AddCommGroup Y] [Module k Y] [Module.Finite k Y]
+    (ρ : Representation k (Matrix.GeneralLinearGroup (Fin n) k) Y) :
+    Etingof.IsAlgebraicRepresentation n ρ ↔
+      Etingof.IsAlgebraicCoefficientFamily n (fun g => ρ g) :=
+  Iff.rfl
+
+/-- **Compatibility wrapper.** A genuine representation whose coefficient family
+is algebraic is an algebraic representation. -/
+theorem Etingof.IsAlgebraicCoefficientFamily.toRepresentation
+    {k : Type*} [Field k] (n : ℕ)
+    {Y : Type*} [AddCommGroup Y] [Module k Y] [Module.Finite k Y]
+    {ρ : Representation k (Matrix.GeneralLinearGroup (Fin n) k) Y}
+    (h : Etingof.IsAlgebraicCoefficientFamily n (fun g => ρ g)) :
+    Etingof.IsAlgebraicRepresentation n ρ := h
+
+/-- **Regression witness.** Coefficient-regularity alone does not imply the
+representation laws: over a nonzero finite-dimensional `Y`, the constant-zero
+family has (trivially polynomial) zero matrix coefficients, hence is an
+`IsAlgebraicCoefficientFamily`, yet it fails `ρ 1 = 1` and so is not the
+coefficient family of any representation. This is exactly the family the old,
+too-broad `IsAlgebraicRepresentation` mistakenly accepted. -/
+theorem Etingof.exists_algebraicCoefficientFamily_not_representation
+    {k : Type*} [Field k] (n : ℕ)
+    {Y : Type*} [AddCommGroup Y] [Module k Y] [Module.Finite k Y]
+    [Nontrivial Y] :
+    ∃ ρ : Matrix.GeneralLinearGroup (Fin n) k → Y →ₗ[k] Y,
+      Etingof.IsAlgebraicCoefficientFamily n ρ ∧ ρ 1 ≠ LinearMap.id := by
+  classical
+  refine ⟨fun _ => 0, ?_, ?_⟩
+  · -- Zero coefficients are the evaluation of the zero polynomial.
+    refine ⟨_, Module.finBasis k Y, fun _ _ => 0, fun g a c => ?_⟩
+    simp [Etingof.evalAtGL]
+  · -- `0 = id` would force every vector to be zero, contradicting nontriviality.
+    intro h
+    obtain ⟨y, hy⟩ := exists_ne (0 : Y)
+    have hz := congrArg (fun f : Y →ₗ[k] Y => f y) h
+    simp only [LinearMap.zero_apply, LinearMap.id_apply] at hz
+    exact hy hz.symm

--- a/EtingofRepresentationTheory/Chapter5/DetClearing.lean
+++ b/EtingofRepresentationTheory/Chapter5/DetClearing.lean
@@ -5,7 +5,7 @@ import EtingofRepresentationTheory.Chapter5.PolynomialWeightSaturation
 
 This file proves Step 1 of the proof of `Theorem5_23_2_i`: from an algebraic
 representation `ρ` (matrix coefficients in
-`k[Xᵢⱼ, det⁻¹]`, i.e. `Etingof.IsAlgebraicRepresentation`) we produce an exponent `s`
+`k[Xᵢⱼ, det⁻¹]`, i.e. `Etingof.IsAlgebraicCoefficientFamily`) we produce an exponent `s`
 such that the `det^s`-twist `g ↦ (det g)^s • ρ g` is polynomial (det⁻¹-free, i.e.
 `Etingof.IsPolynomialRepresentation`).
 
@@ -148,11 +148,11 @@ theorem eval_clearPoly {k : Type*} [Field k] {N : ℕ}
 
 /-- **Det-clearing (Step 1 of `Theorem5_23_2_i`).** An algebraic `GL_N(k)`-representation
 admits an exponent `s` such that its `det^s`-twist is polynomial (det⁻¹-free). -/
-theorem IsAlgebraicRepresentation.exists_detPow_twist_isPolynomial
+theorem IsAlgebraicCoefficientFamily.exists_detPow_twist_isPolynomial
     {k : Type*} [Field k] {N : ℕ}
     {Y : Type*} [AddCommGroup Y] [Module k Y] [Module.Finite k Y]
     {ρ : Matrix.GeneralLinearGroup (Fin N) k → Y →ₗ[k] Y}
-    (h : Etingof.IsAlgebraicRepresentation N ρ) :
+    (h : Etingof.IsAlgebraicCoefficientFamily N ρ) :
     ∃ s : ℕ, IsPolynomialRepresentation N
       (fun g => ((Matrix.GeneralLinearGroup.det g : k) ^ s) • ρ g) := by
   classical

--- a/EtingofRepresentationTheory/Chapter5/DetInvElim.lean
+++ b/EtingofRepresentationTheory/Chapter5/DetInvElim.lean
@@ -164,7 +164,7 @@ are right-torus weight vectors (weight `wt c ∈ ℕ^N`) spanning a right-`GL_N`
 subspace, so the kernel lemma lands each `evalAtGL g (R a c)` in `k[Xᵢⱼ]`. -/
 theorem detInv_elim [CharZero k] [IsAlgClosed k] (n : ℕ)
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
-    (halg : Etingof.IsAlgebraicRepresentation N M.ρ)
+    (halg : Etingof.IsAlgebraicCoefficientFamily N M.ρ)
     (h_span : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M (fun i => μ i) = ⊤) :
     ∃ (d : ℕ) (b : Module.Basis (Fin d) k M)
        (Q : Fin d → Fin d → MvPolynomial (Fin N × Fin N) k),

--- a/EtingofRepresentationTheory/Chapter5/DetTwistAlgebraic.lean
+++ b/EtingofRepresentationTheory/Chapter5/DetTwistAlgebraic.lean
@@ -6,12 +6,12 @@ import EtingofRepresentationTheory.Chapter5.Proposition5_22_2
 
 This file proves `detTwistedSchurModuleRep_isAlgebraic`: the determinant-twisted
 Schur module representation `g ↦ det(g) • L_λ(g)` is an algebraic representation
-of `GL_N(k)` in the sense of `Etingof.IsAlgebraicRepresentation`
+of `GL_N(k)` in the sense of `Etingof.IsAlgebraicCoefficientFamily`
 (Definition 5.23.1). This is the algebraicity hypothesis consumed by
 `decompose_polynomial_gl_rep` at the call site `schurModule_shift_iso_detTwist`.
 
 The general algebraicity infrastructure (`glTensorRep_isAlgebraic`,
-`IsAlgebraicRepresentation.restrict`, `IsAlgebraicRepresentation.detTwist`) lives
+`IsAlgebraicCoefficientFamily.restrict`, `IsAlgebraicCoefficientFamily.detTwist`) lives
 in `GLRepAlgebraic`, so that `schurModule_shift_iso_detTwist` can build its own
 algebraicity hypothesis inline without an import cycle. This file combines them at
 the concrete `detTwistedSchurModuleRep`:
@@ -31,16 +31,16 @@ namespace Etingof
 an algebraic representation of `GL_N(k)` (Etingof Definition 5.23.1).
 
 Built from `glTensorRep_isAlgebraic` (the diagonal action is algebraic),
-`IsAlgebraicRepresentation.restrict` (restrict to the Schur module submodule,
-giving `schurModuleRep`), and `IsAlgebraicRepresentation.detTwist` (twist by the
+`IsAlgebraicCoefficientFamily.restrict` (restrict to the Schur module submodule,
+giving `schurModuleRep`), and `IsAlgebraicCoefficientFamily.detTwist` (twist by the
 determinant character). -/
 theorem detTwistedSchurModuleRep_isAlgebraic (k : Type) [Field k] [IsAlgClosed k]
     [CharZero k] (N : ℕ) (lam : Fin N → ℕ) :
-    Etingof.IsAlgebraicRepresentation N
+    Etingof.IsAlgebraicCoefficientFamily N
       (FDRep.of (detTwistedSchurModuleRep k N lam)).ρ := by
   rw [FDRep.of_ρ']
   have hrestrict :
-      Etingof.IsAlgebraicRepresentation N (schurModuleRep k N lam) :=
+      Etingof.IsAlgebraicCoefficientFamily N (schurModuleRep k N lam) :=
     (glTensorRep_isAlgebraic k N (∑ i, lam i)).restrict
       (SchurModuleSubmodule k N lam)
       (fun g v hv => glTensorRep_mem_range k N lam g v hv)

--- a/EtingofRepresentationTheory/Chapter5/FormalCharacterTorusTrace.lean
+++ b/EtingofRepresentationTheory/Chapter5/FormalCharacterTorusTrace.lean
@@ -18,7 +18,7 @@ Both sides equal `∑_μ dim(M_μ) · ∏_i (t i)^(μ i)`, the sum over weights 
 weight-space dimension times the torus character `∏ t_i^{μ_i}`.
 
 This is the `formalCharacter ↔ torus-trace` connection. The hypothesis is the span
-condition `⨆_μ glWeightSpace = ⊤` rather than `IsAlgebraicRepresentation` directly,
+condition `⨆_μ glWeightSpace = ⊤` rather than `IsAlgebraicCoefficientFamily` directly,
 the form every downstream weight-space theorem in the project takes (cf.
 `FormalCharacterIso.finrank_eq_sum_glWeightSpace`, `DetInvElim`,
 `PolynomialRepEmbedding`). For algebraic representations the span condition holds.

--- a/EtingofRepresentationTheory/Chapter5/GLRepAlgebraic.lean
+++ b/EtingofRepresentationTheory/Chapter5/GLRepAlgebraic.lean
@@ -201,6 +201,12 @@ theorem glTensorRep_isAlgebraic (k : Type*) [Field k] (N n : ℕ) :
   refine Finset.prod_congr rfl fun m _ => ?_
   rw [evalAtGL_X_inl]
 
+/-- The diagonal action `g ↦ g^{⊗n}`, viewed as a genuine `Representation`, is an
+algebraic representation in the sense of Definition 5.23.1. -/
+theorem glTensorRep_isAlgebraicRepresentation (k : Type*) [Field k] (N n : ℕ) :
+    Etingof.IsAlgebraicRepresentation N (glTensorRep k N n) :=
+  (glTensorRep_isAlgebraic k N n).toRepresentation
+
 /-! ### Algebraicity transfers along an equivariant linear equivalence -/
 
 /-- **Algebraicity transfers along an intertwining `k`-linear equivalence.** If `ρ` is
@@ -350,5 +356,13 @@ theorem schurModule_isAlgebraic {k : Type*} [Field k] [IsAlgClosed k] (N : ℕ)
   exact (glTensorRep_isAlgebraic k N (∑ i, lam i)).restrict
     (SchurModuleSubmodule k N lam)
     (fun g v hv => glTensorRep_mem_range k N lam g v hv)
+
+/-- **The Schur module is an algebraic representation.** Packaged form of
+`schurModule_isAlgebraic` against the bundled representation `(SchurModule …).ρ`,
+matching Definition 5.23.1's textbook subject. -/
+theorem schurModule_isAlgebraicRepresentation {k : Type*} [Field k] [IsAlgClosed k]
+    (N : ℕ) (lam : Fin N → ℕ) :
+    Etingof.IsAlgebraicRepresentation N (SchurModule k N lam).ρ :=
+  (schurModule_isAlgebraic N lam).toRepresentation
 
 end Etingof

--- a/EtingofRepresentationTheory/Chapter5/GLRepAlgebraic.lean
+++ b/EtingofRepresentationTheory/Chapter5/GLRepAlgebraic.lean
@@ -4,16 +4,16 @@ import EtingofRepresentationTheory.Chapter5.Theorem5_22_1
 /-!
 # General algebraicity infrastructure for `GL_N(k)`-representations
 
-This file collects the reusable lemmas about `Etingof.IsAlgebraicRepresentation`
+This file collects the reusable lemmas about `Etingof.IsAlgebraicCoefficientFamily`
 (Definition 5.23.1) that are independent of any particular twisted Schur module:
 
 * `evalAtGL_mul` / `evalAtGL_sum` / `evalAtGL_prod` / `evalAtGL_C` / `evalAtGL_X_inl`:
   ring-homomorphism behaviour of evaluation `evalAtGL g`.
 * `detPolyGL` and `evalAtGL_detPolyGL`: the determinant of the generic matrix as a
   polynomial in the coordinate ring, and its evaluation.
-* `IsAlgebraicRepresentation.detTwist`: twisting an algebraic representation by the
+* `IsAlgebraicCoefficientFamily.detTwist`: twisting an algebraic representation by the
   determinant character keeps it algebraic.
-* `IsAlgebraicRepresentation.restrict`: the restriction of an algebraic representation
+* `IsAlgebraicCoefficientFamily.restrict`: the restriction of an algebraic representation
   to an invariant submodule is algebraic.
 * `glTensorRep_isAlgebraic`: the diagonal action `g ↦ g^{⊗n}` on `(k^N)^{⊗n}` is
   algebraic.
@@ -85,11 +85,11 @@ theorem evalAtGL_detPolyGL {k : Type*} [Field k] {N : ℕ}
 
 /-- Twisting an algebraic representation by the determinant character keeps it
 algebraic: each coefficient polynomial is multiplied by `detPolyGL`. -/
-theorem IsAlgebraicRepresentation.detTwist {k : Type*} [Field k] {N : ℕ}
+theorem IsAlgebraicCoefficientFamily.detTwist {k : Type*} [Field k] {N : ℕ}
     {Y : Type*} [AddCommGroup Y] [Module k Y] [Module.Finite k Y]
     {ρ : Matrix.GeneralLinearGroup (Fin N) k → Y →ₗ[k] Y}
-    (h : Etingof.IsAlgebraicRepresentation N ρ) :
-    Etingof.IsAlgebraicRepresentation N
+    (h : Etingof.IsAlgebraicCoefficientFamily N ρ) :
+    Etingof.IsAlgebraicCoefficientFamily N
       (fun g => (Matrix.GeneralLinearGroup.det g : k) • ρ g) := by
   obtain ⟨m, b, P, hP⟩ := h
   refine ⟨m, b, fun a c => detPolyGL k N * P a c, fun g a c => ?_⟩
@@ -103,13 +103,13 @@ submodule `W` is algebraic. Choosing a basis of `W`, a linear projection
 `π : Y → W`, and the ambient basis `B`, the new matrix coefficients expand as
 `k`-linear combinations of `evalAtGL g (P e d)` with constant coefficients
 coming from `B.repr (W.subtype (b' c))` and `b'.repr (π (B e))`. -/
-theorem IsAlgebraicRepresentation.restrict {k : Type*} [Field k] {N : ℕ}
+theorem IsAlgebraicCoefficientFamily.restrict {k : Type*} [Field k] {N : ℕ}
     {Y : Type*} [AddCommGroup Y] [Module k Y] [Module.Finite k Y]
     {ρ : Matrix.GeneralLinearGroup (Fin N) k → Y →ₗ[k] Y}
-    (h : Etingof.IsAlgebraicRepresentation N ρ)
+    (h : Etingof.IsAlgebraicCoefficientFamily N ρ)
     (W : Submodule k Y) [Module.Finite k W]
     (hW : ∀ g, ∀ v ∈ W, ρ g v ∈ W) :
-    Etingof.IsAlgebraicRepresentation N (fun g => (ρ g).restrict (hW g)) := by
+    Etingof.IsAlgebraicCoefficientFamily N (fun g => (ρ g).restrict (hW g)) := by
   classical
   obtain ⟨M, B, P, hP⟩ := h
   -- Basis of the submodule, indexed by `Fin (finrank k W)`.
@@ -188,7 +188,7 @@ theorem repr_glTensorRep_tBasisAlg {k : Type*} [Field k] {N n : ℕ}
 /-- The diagonal action `g ↦ g^{⊗n}` on `(k^N)^{⊗n}` is algebraic. The matrix
 coefficient in the standard tensor basis is the monomial `∏ₘ X_{(h m, f m)}`. -/
 theorem glTensorRep_isAlgebraic (k : Type*) [Field k] (N n : ℕ) :
-    Etingof.IsAlgebraicRepresentation N (glTensorRep k N n) := by
+    Etingof.IsAlgebraicCoefficientFamily N (glTensorRep k N n) := by
   classical
   set ι := Fin n → Fin N
   set eqv : Fin (Fintype.card ι) ≃ ι := (Fintype.equivFin ι).symm with heqv
@@ -210,15 +210,15 @@ transported basis `b.map e` are the very same polynomials as those of `ρ` in `b
 
 This lets the abstract simple summands produced by the equivariant decomposition of an
 algebraic representation inherit algebraicity from the ambient rep. -/
-theorem IsAlgebraicRepresentation.of_linearEquiv {k : Type*} [Field k] {N : ℕ}
+theorem IsAlgebraicCoefficientFamily.of_linearEquiv {k : Type*} [Field k] {N : ℕ}
     {Y Z : Type*} [AddCommGroup Y] [Module k Y] [Module.Finite k Y]
     [AddCommGroup Z] [Module k Z] [Module.Finite k Z]
     {ρ : Matrix.GeneralLinearGroup (Fin N) k → Y →ₗ[k] Y}
     {σ : Matrix.GeneralLinearGroup (Fin N) k → Z →ₗ[k] Z}
     (e : Y ≃ₗ[k] Z)
     (hcomm : ∀ g y, e (ρ g y) = σ g (e y))
-    (h : Etingof.IsAlgebraicRepresentation N ρ) :
-    Etingof.IsAlgebraicRepresentation N σ := by
+    (h : Etingof.IsAlgebraicCoefficientFamily N ρ) :
+    Etingof.IsAlgebraicCoefficientFamily N σ := by
   obtain ⟨m, b, P, hP⟩ := h
   refine ⟨m, b.map e, P, fun g a c => ?_⟩
   -- The image basis `b.map e` reproduces `b`'s coordinates after pushing `e` through.
@@ -324,11 +324,11 @@ is again algebraic. In the dual basis `b.dualBasis`, the `(a,c)`-matrix coeffici
 `(dual ρ) g` is `b.repr (ρ g⁻¹ (b a)) c`, the `(c,a)`-coefficient of `ρ` read at `g⁻¹`; the
 inverse evaluation is absorbed into the polynomials by the substitution `invSubst`
 (`evalAtGL_bind₁_invSubst`). -/
-theorem IsAlgebraicRepresentation.dual {k : Type*} [Field k] {N : ℕ}
+theorem IsAlgebraicCoefficientFamily.dual {k : Type*} [Field k] {N : ℕ}
     {Y : Type*} [AddCommGroup Y] [Module k Y] [Module.Finite k Y]
     (ρ : Representation k (Matrix.GeneralLinearGroup (Fin N) k) Y)
-    (h : Etingof.IsAlgebraicRepresentation N ρ) :
-    Etingof.IsAlgebraicRepresentation N (Representation.dual ρ) := by
+    (h : Etingof.IsAlgebraicCoefficientFamily N ρ) :
+    Etingof.IsAlgebraicCoefficientFamily N (Representation.dual ρ) := by
   obtain ⟨m, b, P, hP⟩ := h
   refine ⟨m, b.dualBasis, fun a c => MvPolynomial.bind₁ (invSubst k N) (P c a), fun g a c => ?_⟩
   rw [evalAtGL_bind₁_invSubst, Representation.dual_apply, Module.Dual.transpose_apply,
@@ -340,12 +340,12 @@ theorem IsAlgebraicRepresentation.dual {k : Type*} [Field k] {N : ℕ}
 /-- **The Schur module `L_λ` is algebraic.** `SchurModule k N lam` is the restriction of
 the (algebraic) tensor power `V^{⊗n}` to the Young-symmetrizer image
 `SchurModuleSubmodule`, so algebraicity is inherited from `glTensorRep_isAlgebraic` via
-`IsAlgebraicRepresentation.restrict`. (The det-twisted analogue is
+`IsAlgebraicCoefficientFamily.restrict`. (The det-twisted analogue is
 `detTwistedSchurModuleRep_isAlgebraic`.) -/
 theorem schurModule_isAlgebraic {k : Type*} [Field k] [IsAlgClosed k] (N : ℕ)
     (lam : Fin N → ℕ) :
-    Etingof.IsAlgebraicRepresentation N (SchurModule k N lam).ρ := by
-  change Etingof.IsAlgebraicRepresentation N (FDRep.of (schurModuleRep k N lam)).ρ
+    Etingof.IsAlgebraicCoefficientFamily N (SchurModule k N lam).ρ := by
+  change Etingof.IsAlgebraicCoefficientFamily N (FDRep.of (schurModuleRep k N lam)).ρ
   rw [FDRep.of_ρ']
   exact (glTensorRep_isAlgebraic k N (∑ i, lam i)).restrict
     (SchurModuleSubmodule k N lam)

--- a/EtingofRepresentationTheory/Chapter5/LinearDualContragredientHalf.lean
+++ b/EtingofRepresentationTheory/Chapter5/LinearDualContragredientHalf.lean
@@ -82,12 +82,12 @@ theorem iSup_glWeightSpace_eq_top_of_eigenbasis (n d : ℕ)
 omit [IsAlgClosed k] [CharZero k] in
 /-- **A `det^m`-power twist preserves algebraicity.** Twisting an algebraic
 `GL_n`-representation by the `m`-th power of the determinant character (for `m : ℕ`)
-keeps it algebraic, by iterating `IsAlgebraicRepresentation.detTwist`. -/
+keeps it algebraic, by iterating `IsAlgebraicCoefficientFamily.detTwist`. -/
 theorem isAlgebraic_charTwist_detChar_natPow {Y : Type} [AddCommGroup Y] [Module k Y]
     [Module.Finite k Y] (n m : ℕ)
     (ρ : Representation k (Matrix.GeneralLinearGroup (Fin n) k) Y)
-    (h : Etingof.IsAlgebraicRepresentation n ρ) :
-    Etingof.IsAlgebraicRepresentation n
+    (h : Etingof.IsAlgebraicCoefficientFamily n ρ) :
+    Etingof.IsAlgebraicCoefficientFamily n
       (charTwistRep (detChar k n ^ ((m : ℕ) : ℤ)) ρ) := by
   induction m with
   | zero =>
@@ -200,18 +200,18 @@ theorem linearDual_half_detTwist_contragredient (n : ℕ) (lam : DominantWeight 
     iSup_glWeightSpace_eq_top_of_eigenbasis n d M v.dualBasis
       (fun c i => m - wt c i) hMeigen
   -- Algebraicity of `M.ρ = charTwistRep (det^m) (dual σ)`.
-  have hσalg : Etingof.IsAlgebraicRepresentation n (schurModuleRep k n lz) :=
+  have hσalg : Etingof.IsAlgebraicCoefficientFamily n (schurModuleRep k n lz) :=
     schurModule_isAlgebraic (k := k) n lz
-  have halg : Etingof.IsAlgebraicRepresentation n M.ρ := by
+  have halg : Etingof.IsAlgebraicCoefficientFamily n M.ρ := by
     -- Unfold `M.ρ` to the native nested twist (`show`), collapse it, then iterate the
     -- determinant-power twist closure on the algebraic dual of the Schur module.
-    change Etingof.IsAlgebraicRepresentation n
+    change Etingof.IsAlgebraicCoefficientFamily n
       (charTwistRep (detChar k n ^ s)
         (Representation.dual (charTwistRep (detChar k n ^ (-(lam.shift : ℤ)))
           (schurModuleRep k n lz))))
     rw [dual_charTwistRep, charTwistRep_charTwistRep, detChar_pow_mul_inv_neg_zpow]
     exact isAlgebraic_charTwist_detChar_natPow n m _
-      (IsAlgebraicRepresentation.dual (schurModuleRep k n lz) hσalg)
+      (IsAlgebraicCoefficientFamily.dual (schurModuleRep k n lz) hσalg)
   -- Formal character of `M` is `schurPoly n ν`.
   have h_char : formalCharacter k n M = schurPoly n ν := by
     rw [hM_def]

--- a/EtingofRepresentationTheory/Chapter5/PeterWeylMatrixCoeff.lean
+++ b/EtingofRepresentationTheory/Chapter5/PeterWeylMatrixCoeff.lean
@@ -26,7 +26,7 @@ contragredient pairing, which is `GL_n`-invariant
 ## Construction
 
 `L_λ` is an algebraic representation (`algIrrepGLRepρ_isAlgebraic`, assembled from
-`schurModule_isAlgebraic` plus `IsAlgebraicRepresentation.detInvTwist` for the
+`schurModule_isAlgebraic` plus `IsAlgebraicCoefficientFamily.detInvTwist` for the
 `det^{-shift}` twist): there is a basis `b` and matrix-coefficient polynomials `P` with
 `b.repr (ρ(g) (b c)) a = evalAtGL g (P a c)`. The map is
 
@@ -72,11 +72,11 @@ theorem evalAtGL_pow {k : Type*} [Field k] {N : ℕ}
 algebraic representation `ρ` by `det^{-s}` (i.e. `g ↦ (det g)⁻ˢ • ρ g`) keeps it
 algebraic: each coefficient polynomial is multiplied by `Dˢ` (the `s`-th power of
 the formal `det⁻¹` variable), which evaluates to `(det g)⁻ˢ`. -/
-theorem IsAlgebraicRepresentation.detInvTwist {k : Type*} [Field k] {N : ℕ}
+theorem IsAlgebraicCoefficientFamily.detInvTwist {k : Type*} [Field k] {N : ℕ}
     {Y : Type*} [AddCommGroup Y] [Module k Y] [Module.Finite k Y]
     {ρ : Matrix.GeneralLinearGroup (Fin N) k → Y →ₗ[k] Y}
-    (h : Etingof.IsAlgebraicRepresentation N ρ) (s : ℕ) :
-    Etingof.IsAlgebraicRepresentation N
+    (h : Etingof.IsAlgebraicCoefficientFamily N ρ) (s : ℕ) :
+    Etingof.IsAlgebraicCoefficientFamily N
       (fun g : Matrix.GeneralLinearGroup (Fin N) k =>
         (((g : Matrix (Fin N) (Fin N) k).det)⁻¹) ^ s • ρ g) := by
   obtain ⟨m, b, P, hP⟩ := h
@@ -103,9 +103,9 @@ variable (n : ℕ) (lam : DominantWeight n) (k : Type) [Field k] [IsAlgClosed k]
 
 /-- **`L_λ = algIrrepGLRepρ` is an algebraic representation.** It is the Schur
 module (algebraic, `schurModule_isAlgebraic`) twisted by `det^{-λ.shift}`; the
-twist keeps it algebraic by `IsAlgebraicRepresentation.detInvTwist`. -/
+twist keeps it algebraic by `IsAlgebraicCoefficientFamily.detInvTwist`. -/
 theorem algIrrepGLRepρ_isAlgebraic :
-    Etingof.IsAlgebraicRepresentation n (fun g => algIrrepGLRepρ n lam k g) := by
+    Etingof.IsAlgebraicCoefficientFamily n (fun g => algIrrepGLRepρ n lam k g) := by
   have hfun : (fun g => algIrrepGLRepρ n lam k g)
       = (fun g : Matrix.GeneralLinearGroup (Fin n) k =>
           (((g : Matrix (Fin n) (Fin n) k).det)⁻¹) ^ lam.shift •

--- a/EtingofRepresentationTheory/Chapter5/PolynomialGLDecomposition.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialGLDecomposition.lean
@@ -194,13 +194,13 @@ consumers can invoke the classification core
 The hypothesis `h_span`, that the `ℕ`-indexed weight spaces span `M`, is
 essential (it says `M` is polynomial, not merely algebraic). It is used by
 `polynomial_homog_rep_equivariant_embedding`; without it the statement is
-false, since `IsAlgebraicRepresentation` together with `h_homog` admits the
+false, since `IsAlgebraicCoefficientFamily` together with `h_homog` admits the
 counterexample `M = Sym²(V) ⊗ det⁻¹` (`N = 2`, `n = 0`), which has no embedding
 into `V^{⊗0}`. -/
 theorem polynomial_homog_rep_asModule_embeds_directSum_simple
     [IsAlgClosed k] [CharZero k] (n : ℕ)
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
-    (halg : Etingof.IsAlgebraicRepresentation N M.ρ)
+    (halg : Etingof.IsAlgebraicCoefficientFamily N M.ρ)
     (h_span : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M (fun i => μ i) = ⊤)
     (h_homog : ∀ μ : Fin N → ℕ, glWeightSpace k N M μ ≠ ⊥ → ∑ i, μ i = n) :
     ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)
@@ -313,7 +313,7 @@ single-`schurPoly` left side has a single summand. -/
 theorem decompose_polynomial_gl_rep
     [IsAlgClosed k] [CharZero k] (n : ℕ)
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
-    (halg : Etingof.IsAlgebraicRepresentation N M.ρ)
+    (halg : Etingof.IsAlgebraicCoefficientFamily N M.ρ)
     (h_span : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M (fun i => μ i) = ⊤)
     (h_homog : ∀ μ : Fin N → ℕ, glWeightSpace k N M μ ≠ ⊥ → ∑ i, μ i = n) :
     ∃ (ι : Type) (_ : Fintype ι) (_ : DecidableEq ι)

--- a/EtingofRepresentationTheory/Chapter5/PolynomialGLSemisimple.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialGLSemisimple.lean
@@ -66,7 +66,7 @@ direct sum of simple `GLAlg`-modules) with the fact that a direct sum of simple
 modules is semisimple. -/
 theorem polynomialHomogRep_isSemisimple (n : ℕ)
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
-    (halg : Etingof.IsAlgebraicRepresentation N M.ρ)
+    (halg : Etingof.IsAlgebraicCoefficientFamily N M.ρ)
     (h_span : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M (fun i => μ i) = ⊤)
     (h_homog : ∀ μ : Fin N → ℕ, glWeightSpace k N M μ ≠ ⊥ → ∑ i, μ i = n) :
     IsSemisimpleModule (GLAlg k N) (Representation.asModule M.ρ) := by
@@ -254,7 +254,7 @@ theorem glWeightSpace_restrict (σ : Subrepresentation M.ρ) (μ : Fin N → ℕ
 theorem degSubrep_isAlgebraic
     (hpoly : IsPolynomialRepresentation N M.ρ)
     (h_span : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M (fun i => μ i) = ⊤) (d : ℕ) :
-    Etingof.IsAlgebraicRepresentation N (FDRep.of (degSubrep k N M h_span d).toRepresentation).ρ :=
+    Etingof.IsAlgebraicCoefficientFamily N (FDRep.of (degSubrep k N M h_span d).toRepresentation).ρ :=
   (hpoly.isAlgebraic).restrict (degSubrep k N M h_span d).toSubmodule
     (fun g v hv => (degSubrep k N M h_span d).apply_mem_toSubmodule g hv)
 

--- a/EtingofRepresentationTheory/Chapter5/PolynomialRepEmbedding.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialRepEmbedding.lean
@@ -200,7 +200,7 @@ theorem polynomialRep_embeds_in_tensorPower_inj
     [CharZero k]
     [Module.Finite k M]
     (ρ : Matrix.GeneralLinearGroup (Fin N) k →* (M →ₗ[k] M))
-    (_halg : IsAlgebraicRepresentation N (ρ : _ → _))
+    (_halg : IsAlgebraicCoefficientFamily N (ρ : _ → _))
     (hpoly : ∃ (d : ℕ) (b : Module.Basis (Fin d) k M)
        (P : Fin d → Fin d → MvPolynomial (Fin N × Fin N) k),
          (∀ a c, (P a c).IsHomogeneous n) ∧
@@ -472,7 +472,7 @@ theorem polynomialRep_embeds_in_tensorPower
     [CharZero k]
     [Module.Finite k M]
     (ρ : Matrix.GeneralLinearGroup (Fin N) k →* (M →ₗ[k] M))
-    (_halg : IsAlgebraicRepresentation N (ρ : _ → _))
+    (_halg : IsAlgebraicCoefficientFamily N (ρ : _ → _))
     (hpoly : ∃ (d : ℕ) (b : Module.Basis (Fin d) k M)
        (P : Fin d → Fin d → MvPolynomial (Fin N × Fin N) k),
          (∀ a c, (P a c).IsHomogeneous n) ∧
@@ -676,7 +676,7 @@ theorem polynomialRep_embeds_in_tensorPower' (n : ℕ)
     [CharZero k]
     [Module.Finite k M]
     (ρ : Matrix.GeneralLinearGroup (Fin N) k →* (M →ₗ[k] M))
-    (halg : IsAlgebraicRepresentation N (ρ : _ → _))
+    (halg : IsAlgebraicCoefficientFamily N (ρ : _ → _))
     (hpoly' : ∃ (d : ℕ) (b : Module.Basis (Fin d) k M)
        (P : Fin d → Fin d → MvPolynomial (Fin N × Fin N) k),
          (∀ a c, (P a c).IsHomogeneous n) ∧
@@ -773,7 +773,7 @@ Schur modules at
 private theorem scalarGL_acts_as_pow (n : ℕ)
     [CharZero k] [IsAlgClosed k]
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
-    (halg : Etingof.IsAlgebraicRepresentation N M.ρ)
+    (halg : Etingof.IsAlgebraicCoefficientFamily N M.ρ)
     (h_span : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M (fun i => μ i) = ⊤)
     (h_homog : ∀ μ : Fin N → ℕ, glWeightSpace k N M μ ≠ ⊥ → ∑ i, μ i = n)
     (t : kˣ) :
@@ -947,7 +947,7 @@ to `Mₙ(k) → End(M)` and the matrix coefficients are the bare polynomials `Q`
 produced here. -/
 private theorem detInv_elim_of_polynomial (n : ℕ) [CharZero k] [IsAlgClosed k]
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
-    (halg : Etingof.IsAlgebraicRepresentation N M.ρ)
+    (halg : Etingof.IsAlgebraicCoefficientFamily N M.ρ)
     (h_span : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M (fun i => μ i) = ⊤) :
     ∃ (d : ℕ) (b : Module.Basis (Fin d) k M)
        (Q : Fin d → Fin d → MvPolynomial (Fin N × Fin N) k),
@@ -1045,7 +1045,7 @@ Identity over all of `GL` upgrades to a polynomial identity by
 private theorem hpoly'_of_scalarGL_action (n : ℕ)
     [CharZero k] [IsAlgClosed k]
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
-    (halg : Etingof.IsAlgebraicRepresentation N M.ρ)
+    (halg : Etingof.IsAlgebraicCoefficientFamily N M.ρ)
     (h_span : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M (fun i => μ i) = ⊤)
     (h_scalar : ∀ t : kˣ, M.ρ (scalarGL k N t) = ((t : k) ^ n) • LinearMap.id) :
     ∃ (d : ℕ) (b : Module.Basis (Fin d) k M)
@@ -1070,11 +1070,11 @@ matrix coefficients given, in a suitable basis, by homogeneous degree-`n`
 polynomials in the bare matrix entries `Fin N × Fin N`, i.e. the raw
 `hpoly'` witness consumed by `polynomialRep_embeds_in_tensorPower'`.
 
-This passes from `Etingof.IsAlgebraicRepresentation` (matrix coefficients in
+This passes from `Etingof.IsAlgebraicCoefficientFamily` (matrix coefficients in
 `k[Xᵢⱼ, D]`, `D = det⁻¹`, no homogeneity) to the bare-entry homogeneous data.
 
 **Hypotheses.** `h_span`, that the `ℕ`-indexed weight spaces span `M`, is
-essential. Without it the theorem is false: `IsAlgebraicRepresentation` allows
+essential. Without it the theorem is false: `IsAlgebraicCoefficientFamily` allows
 weights in `ℤ^N` (the `det⁻¹` variable), whereas the bare-entry-polynomial
 conclusion needs all weights in `ℕ^N`. Counterexample (`N = 2`, `n = 0`):
 `M = Sym²(V) ⊗ det⁻¹` is algebraic and satisfies `h_homog` vacuously (its only
@@ -1097,7 +1097,7 @@ degree-`n` polynomial. -/
 theorem polynomialRep_homogeneous_hpoly'
     [CharZero k] [IsAlgClosed k]
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
-    (halg : Etingof.IsAlgebraicRepresentation N M.ρ)
+    (halg : Etingof.IsAlgebraicCoefficientFamily N M.ρ)
     (h_span : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M (fun i => μ i) = ⊤)
     (h_homog : ∀ μ : Fin N → ℕ, glWeightSpace k N M μ ≠ ⊥ → ∑ i, μ i = n) :
     ∃ (d : ℕ) (b : Module.Basis (Fin d) k M)
@@ -1122,7 +1122,7 @@ from the primed embedding lemma. Downstream, the Schur-Weyl construction views
 theorem polynomial_homog_rep_equivariant_embedding
     [CharZero k] [IsAlgClosed k]
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
-    (halg : Etingof.IsAlgebraicRepresentation N M.ρ)
+    (halg : Etingof.IsAlgebraicCoefficientFamily N M.ρ)
     (h_span : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M (fun i => μ i) = ⊤)
     (h_homog : ∀ μ : Fin N → ℕ, glWeightSpace k N M μ ≠ ⊥ → ∑ i, μ i = n) :
     ∃ (m : ℕ) (φ : M →ₗ[k] (Fin m → TensorPower k (StdV k N) n)),

--- a/EtingofRepresentationTheory/Chapter5/PolynomialWeightSaturation.lean
+++ b/EtingofRepresentationTheory/Chapter5/PolynomialWeightSaturation.lean
@@ -48,7 +48,7 @@ namespace Etingof
 algebraic, in the sense of Etingof §5.23) if there is a basis in which all matrix
 coefficients of `ρ(g)` are polynomials in the entries `gᵢⱼ` alone, with no `det(g)⁻¹`.
 
-This is the strengthening of `Etingof.IsAlgebraicRepresentation` where the
+This is the strengthening of `Etingof.IsAlgebraicCoefficientFamily` where the
 coefficient polynomials lie in the subring `k[Xᵢⱼ]` (equivalently, the range of
 `MvPolynomial.rename Sum.inl` inside `k[Xᵢⱼ, D]`). -/
 def IsPolynomialRepresentation
@@ -70,7 +70,7 @@ theorem IsPolynomialRepresentation.isAlgebraic
     {k : Type*} [Field k] {N : ℕ}
     {Y : Type*} [AddCommGroup Y] [Module k Y] [Module.Finite k Y]
     {ρ : Matrix.GeneralLinearGroup (Fin N) k → Y →ₗ[k] Y}
-    (h : IsPolynomialRepresentation N ρ) : Etingof.IsAlgebraicRepresentation N ρ := by
+    (h : IsPolynomialRepresentation N ρ) : Etingof.IsAlgebraicCoefficientFamily N ρ := by
   obtain ⟨m, b, P, hP⟩ := h
   refine ⟨m, b, fun a c => MvPolynomial.rename Sum.inl (P a c), fun g a c => ?_⟩
   rw [hP g a c, Etingof.evalAtGL, MvPolynomial.eval_rename]

--- a/EtingofRepresentationTheory/Chapter5/Proposition5_22_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Proposition5_22_2.lean
@@ -434,7 +434,7 @@ theorem schurModule_shift_iso_detTwist (N : ℕ) (lam : Fin N → ℕ) (hlam : A
   -- The det-twisted Schur module representation is algebraic (assembled from the general
   -- algebraicity infrastructure in `GLRepAlgebraic`; the concrete packaging is
   -- `detTwistedSchurModuleRep_isAlgebraic`, which lives downstream and so is inlined here).
-  have halg : Etingof.IsAlgebraicRepresentation N
+  have halg : Etingof.IsAlgebraicCoefficientFamily N
       (FDRep.of (detTwistedSchurModuleRep k N lam)).ρ := by
     rw [FDRep.of_ρ']
     exact ((Etingof.glTensorRep_isAlgebraic k N (∑ i, lam i)).restrict

--- a/EtingofRepresentationTheory/Chapter5/QuotDetDegreeAlgebraic.lean
+++ b/EtingofRepresentationTheory/Chapter5/QuotDetDegreeAlgebraic.lean
@@ -8,15 +8,15 @@ import EtingofRepresentationTheory.Chapter5.CauchyWeightSpaceDimension
 The theorem `quotDetRep_irreducible_constituent_lastWeight_zero` passes the degree-`d`
 component `(A/det)_d = quotDetDegreeFDRep k N d` to the part-C ingredient
 `Etingof.simple_constituent_formalCharacter_eq_schurPoly_mem`, which requires the
-hypothesis `Etingof.IsAlgebraicRepresentation N M.ρ`. This file supplies that
+hypothesis `Etingof.IsAlgebraicCoefficientFamily N M.ρ`. This file supplies that
 hypothesis for `quotDetDegreeFDRep`.
 
 The proof has three steps:
 
-* `IsAlgebraicRepresentation.of_surjective_equivariant`: a general transport
+* `IsAlgebraicCoefficientFamily.of_surjective_equivariant`: a general transport
   lemma: algebraicity passes along a surjective `GL_N`-equivariant `k`-linear
   map onto a finite-dimensional target. (The dual of
-  `IsAlgebraicRepresentation.restrict`, which handles invariant submodules.)
+  `IsAlgebraicCoefficientFamily.restrict`, which handles invariant submodules.)
 * `polyRightDegreeFDRep_isAlgebraic`: the degree-`d` component `A_d` of the
   coordinate ring under right translation is algebraic. On the monomial basis the
   right translation `R_g X_{ij} = ∑_l g_{lj} X_{il}` has matrix coefficients that
@@ -43,17 +43,17 @@ Choosing a `k`-linear section `s : Z → Y` of `π`, a basis `b'` of `Z`, and th
 algebraicity basis `B` of `Y`, the new matrix coefficient `b'.repr (σ g (b' c)) a`
 expands as a `k`-linear combination of `evalAtGL g (P e d)` with constant
 coefficients from `B.repr (s (b' c))` and `b'.repr (π (B e))`. This mirrors
-`IsAlgebraicRepresentation.restrict`, with the invariant-submodule inclusion
+`IsAlgebraicCoefficientFamily.restrict`, with the invariant-submodule inclusion
 replaced by the section `s` and the projection replaced by `π`. -/
-theorem IsAlgebraicRepresentation.of_surjective_equivariant {k : Type*} [Field k] {N : ℕ}
+theorem IsAlgebraicCoefficientFamily.of_surjective_equivariant {k : Type*} [Field k] {N : ℕ}
     {Y Z : Type*} [AddCommGroup Y] [Module k Y] [Module.Finite k Y]
     [AddCommGroup Z] [Module k Z] [Module.Finite k Z]
     {ρ : Matrix.GeneralLinearGroup (Fin N) k → Y →ₗ[k] Y}
     {σ : Matrix.GeneralLinearGroup (Fin N) k → Z →ₗ[k] Z}
     (π : Y →ₗ[k] Z) (hπ_surj : Function.Surjective π)
     (hcomm : ∀ g y, π (ρ g y) = σ g (π y))
-    (h : Etingof.IsAlgebraicRepresentation N ρ) :
-    Etingof.IsAlgebraicRepresentation N σ := by
+    (h : Etingof.IsAlgebraicCoefficientFamily N ρ) :
+    Etingof.IsAlgebraicCoefficientFamily N σ := by
   classical
   obtain ⟨M, B, P, hP⟩ := h
   -- Basis of the target, indexed by `Fin (finrank k Z)`.
@@ -167,7 +167,7 @@ theorem evalAtGL_rightTransPoly {k : Type*} [Field k] {N : ℕ}
 is the span of the degree-`d` monomials; right translation acts on this monomial basis
 with matrix coefficients `rightTransPoly`, polynomial in the entries of `g`. -/
 theorem polyRightDegreeFDRep_isAlgebraic (k : Type*) [Field k] (N d : ℕ) :
-    Etingof.IsAlgebraicRepresentation N (polyRightDegreeFDRep k N d).ρ := by
+    Etingof.IsAlgebraicCoefficientFamily N (polyRightDegreeFDRep k N d).ρ := by
   classical
   set S : Finset ((Fin N × Fin N) →₀ ℕ) := Finset.univ.finsuppAntidiag d with hS
   -- degree-`d` monomials, as elements of the carrier `A_d`
@@ -245,10 +245,10 @@ theorem polyRightDegreeFDRep_isAlgebraic (k : Type*) [Field k] (N d : ℕ) :
 
 /-- **`(A/det)_d` is algebraic.** It is the image of the algebraic `A_d` under the
 surjective `GL_N`-equivariant quotient map `A_d → (A/det)_d`, so algebraicity transfers
-by `IsAlgebraicRepresentation.of_surjective_equivariant`. This is the part-C hypothesis
+by `IsAlgebraicCoefficientFamily.of_surjective_equivariant`. This is the part-C hypothesis
 required by `quotDetRep_irreducible_constituent_lastWeight_zero`. -/
 theorem quotDetDegreeFDRep_isAlgebraic (k : Type*) [Field k] (N d : ℕ) :
-    Etingof.IsAlgebraicRepresentation N
+    Etingof.IsAlgebraicCoefficientFamily N
       (Etingof.CauchyDetQuotient.quotDetDegreeFDRep k N d).ρ := by
   have hmem_π : ∀ x ∈ MvPolynomial.homogeneousSubmodule (Fin N × Fin N) k d,
       Submodule.mkQ (Etingof.KernelLemmaKPrime.detSubmodule k N) x
@@ -258,7 +258,7 @@ theorem quotDetDegreeFDRep_isAlgebraic (k : Type*) [Field k] (N d : ℕ) :
   let πmap : polyRightDegreeFDRep k N d →ₗ[k]
       Etingof.CauchyDetQuotient.quotDetDegreeFDRep k N d :=
     (Submodule.mkQ (Etingof.KernelLemmaKPrime.detSubmodule k N)).restrict hmem_π
-  refine IsAlgebraicRepresentation.of_surjective_equivariant πmap ?_ ?_
+  refine IsAlgebraicCoefficientFamily.of_surjective_equivariant πmap ?_ ?_
     (polyRightDegreeFDRep_isAlgebraic k N d)
   · -- surjectivity: every element of `(A/det)_d` is `mk` of a degree-`d` polynomial
     rintro ⟨_, f, hf, rfl⟩

--- a/EtingofRepresentationTheory/Chapter5/RealizationCoreAnalytic.lean
+++ b/EtingofRepresentationTheory/Chapter5/RealizationCoreAnalytic.lean
@@ -84,7 +84,7 @@ theorem detTwist_clearing
     [FiniteDimensional k S.toSubmodule]
     {m : ℕ} (B : Module.Basis (Fin m) k S.toSubmodule) (r : ℕ)
     (hr_ge : ∀ i, detExp ((S.toSubmodule.subtype (B i)) : Localization.Away (detPoly k n)) ≤ r) :
-      Etingof.IsAlgebraicRepresentation n
+      Etingof.IsAlgebraicCoefficientFamily n
         ⇑(charTwistRep (detChar k n ^ r) S.toRepresentation) ∧
       ∃ φ : S.toSubmodule →ₗ[k] MvPolynomial (Fin n × Fin n) k,
         Function.Injective φ ∧
@@ -183,7 +183,7 @@ theorem detTwist_clearing
       rw [charTwistRep_apply, Submodule.coe_smul, hS_coe, he_coe, charTwistRep_apply]
     rw [hL, hR]
   -- The twisted `S`-action is algebraic.
-  have hMalg : Etingof.IsAlgebraicRepresentation n
+  have hMalg : Etingof.IsAlgebraicCoefficientFamily n
       ⇑(charTwistRep (detChar k n ^ r) S.toRepresentation) :=
     ((boundedRightRep_isAlgebraic k n d).restrict U hU_inv).of_linearEquiv e hcomm
   -- The polynomial embedding `φ = subtype ∘ U.subtype ∘ e.symm`.
@@ -212,14 +212,14 @@ theorem detTwist_clearing
 common-denominator `det^r`-twist with `r` chosen large enough, is a polynomial
 representation: it is algebraic, its `ℕ`-weight spaces span, and it embeds `GL_n`-equivariantly into
 `k[Xᵢⱼ]`. The clearing exponent is taken `r = r₀ + s`, where `r₀` clears the basis denominators and
-`s` (from `IsAlgebraicRepresentation.exists_detPow_twist_isPolynomial`) makes the twist det⁻¹-free;
+`s` (from `IsAlgebraicCoefficientFamily.exists_detPow_twist_isPolynomial`) makes the twist det⁻¹-free;
 weight-spanning then follows from `polynomial_rep_iSup_glWeightSpace_eq_top`. -/
 theorem exists_detTwist_polyEmbedding_of_simple_subrep
     (n : ℕ) (k : Type) [Field k] [IsAlgClosed k] [CharZero k]
     (S : Subrepresentation (localRightRep k n))
     [FiniteDimensional k S.toSubmodule] :
     ∃ r : ℕ,
-      Etingof.IsAlgebraicRepresentation n
+      Etingof.IsAlgebraicCoefficientFamily n
         ⇑(charTwistRep (detChar k n ^ r) S.toRepresentation) ∧
       (⨆ μ : Fin n →₀ ℕ,
         glWeightSpace k n

--- a/EtingofRepresentationTheory/Chapter5/RightTranslationHullDecomp.lean
+++ b/EtingofRepresentationTheory/Chapter5/RightTranslationHullDecomp.lean
@@ -29,8 +29,8 @@ Using this intertwining:
 * `rightHull_isSemisimple`, complete reducibility of the right-translation hull: the hull,
   as a `localRightRep`-representation, is a semisimple `k[GL_N]`-module. The `det^r`-twist of the
   hull is algebraic (transport `boundedRightRep_isAlgebraic` across `numEmbed` via
-  `IsAlgebraicRepresentation.of_linearEquiv`, restricting to the hull via
-  `IsAlgebraicRepresentation.restrict`), hence completely reducible (`Theorem5_23_2_i`);
+  `IsAlgebraicCoefficientFamily.of_linearEquiv`, restricting to the hull via
+  `IsAlgebraicCoefficientFamily.restrict`), hence completely reducible (`Theorem5_23_2_i`);
   untwisting by `det⁻ʳ` (`isSemisimpleModule_charTwistRep`) recovers the hull.
 
 The finer statement, that the constituents are exactly the irreducibles `L_λ = algIrrepGLRepρ`
@@ -103,7 +103,7 @@ theorem boundedSubrep_toRepresentation_coe (d : ℕ)
 polynomial in the entries of `g` (`evalAtGL_rightTransPoly`). Mirrors the homogeneous Cauchy
 component `polyRightDegreeFDRep_isAlgebraic`, over the full `≤ d` filtration. -/
 theorem boundedRightRep_isAlgebraic (k : Type*) [Field k] (N d : ℕ) :
-    Etingof.IsAlgebraicRepresentation N
+    Etingof.IsAlgebraicCoefficientFamily N
       ⇑(boundedSubrep k N d).toRepresentation := by
   classical
   set W := (boundedSubrep k N d).toSubmodule with hW
@@ -215,7 +215,7 @@ theorem numEmbed_injective (r : ℕ) :
 
 The `det^r`-twist of the hull (`r` the normal-form exponent of `φ`) is, via `numEmbed`, equivalent
 to a `polyRightRep`-invariant subspace of the bounded-degree polynomials, hence algebraic
-(`boundedRightRep_isAlgebraic` + `IsAlgebraicRepresentation.restrict` /
+(`boundedRightRep_isAlgebraic` + `IsAlgebraicCoefficientFamily.restrict` /
 `.of_linearEquiv`); an algebraic representation is completely reducible (`Theorem5_23_2_i`), and
 untwisting by `det⁻ʳ` (`isSemisimpleModule_charTwistRep`) recovers the hull. -/
 theorem rightHull_isSemisimple (k : Type) [Field k] [IsAlgClosed k] [CharZero k] {N : ℕ}
@@ -295,7 +295,7 @@ theorem rightHull_isSemisimple (k : Type) [Field k] [IsAlgClosed k] [CharZero k]
       rw [charTwistRep_apply, Submodule.coe_smul, hrh_coe, he_coe, charTwistRep_apply]
     rw [hL, hR]
   -- the twisted hull is algebraic
-  have htwAlg : Etingof.IsAlgebraicRepresentation N
+  have htwAlg : Etingof.IsAlgebraicCoefficientFamily N
       ⇑(charTwistRep (detChar k N ^ r) (rightHullSubrep φ).toRepresentation) :=
     ((boundedRightRep_isAlgebraic k N d).restrict U hU_inv).of_linearEquiv e hcomm
   -- algebraic ⟹ semisimple; untwist by `det⁻ʳ` to recover the hull

--- a/EtingofRepresentationTheory/Chapter5/SchurWeylFormalCharacterIso.lean
+++ b/EtingofRepresentationTheory/Chapter5/SchurWeylFormalCharacterIso.lean
@@ -432,7 +432,7 @@ theorem schurWeyl_simples_formalCharacter_linearIndependent_general
               (Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
                 (S i)).tprod (L i).ρ) g (e v))
     (hLtop : ∀ i, ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N (L i) (fun j => μ j) = ⊤)
-    (hLalg : ∀ i, Etingof.IsAlgebraicRepresentation N (L i).ρ)
+    (hLalg : ∀ i, Etingof.IsAlgebraicCoefficientFamily N (L i).ρ)
     (hLsimp : ∀ i, IsSimpleModule
         (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
         (Representation.asModule (L i).ρ))
@@ -601,8 +601,8 @@ private theorem isAlgebraic_of_equivariant_linearEquiv
     {ρ' : Matrix.GeneralLinearGroup (Fin N) k → Y' →ₗ[k] Y'}
     (φ : Y ≃ₗ[k] Y')
     (hφ : ∀ g y, φ (ρ g y) = ρ' g (φ y))
-    (h : Etingof.IsAlgebraicRepresentation N ρ) :
-    Etingof.IsAlgebraicRepresentation N ρ' := by
+    (h : Etingof.IsAlgebraicCoefficientFamily N ρ) :
+    Etingof.IsAlgebraicCoefficientFamily N ρ' := by
   obtain ⟨m, b, P, hP⟩ := h
   refine ⟨m, b.map φ, P, fun g a c => ?_⟩
   have h2 : (b.map φ).repr (φ (ρ g (b c))) = b.repr (ρ g (b c)) := by
@@ -619,7 +619,7 @@ algebraic, `glTensorRep_isAlgebraic`), via `x ↦ e⁻¹ (lof i (s ⊗ x))` for 
 `s ∈ S i`; a left inverse is the equivariant projection used in
 `schurWeyl_simple_summand_glWeightSpace_top`. Restricting the algebraic structure to the
 (invariant) image and transporting it back through the embedding gives algebraicity of
-`(L i).ρ`. This supplies the `IsAlgebraicRepresentation` hypothesis of
+`(L i).ρ`. This supplies the `IsAlgebraicCoefficientFamily` hypothesis of
 `schurWeyl_simples_formalCharacter_linearIndependent_general`. -/
 theorem schurWeyl_simple_summand_isAlgebraic
     (k : Type) [Field k] [IsAlgClosed k] [CharZero k]
@@ -637,7 +637,7 @@ theorem schurWeyl_simple_summand_isAlgebraic
               (Representation.trivial k (Matrix.GeneralLinearGroup (Fin N) k)
                 (S i)).tprod (L i).ρ) g (e v))
     (hSne : ∀ i, 0 < Module.finrank k (S i)) :
-    ∀ i, Etingof.IsAlgebraicRepresentation N (L i).ρ := by
+    ∀ i, Etingof.IsAlgebraicCoefficientFamily N (L i).ρ := by
   classical
   intro i
   -- A basis vector `s₀ = bS i0 ∈ S i` and the dual coordinate `φ` with `φ s₀ = 1`.
@@ -684,7 +684,7 @@ theorem schurWeyl_simple_summand_isAlgebraic
     obtain ⟨x, rfl⟩ := hv
     exact ⟨(L i).ρ g x, (hs_equiv g x).symm⟩
   -- `glTensorRep` restricted to `W` is algebraic (`glTensorRep_isAlgebraic` + `restrict`).
-  have hWalg : Etingof.IsAlgebraicRepresentation N
+  have hWalg : Etingof.IsAlgebraicCoefficientFamily N
       (fun g => (glTensorRep k N n g).restrict (hWinv g)) :=
     (Etingof.glTensorRep_isAlgebraic k N n).restrict W hWinv
   -- Transport algebraicity back through `s : L i ≃ W`.
@@ -772,7 +772,7 @@ theorem schurWeyl_simples_formalCharacter_classification_core_general
     have hLtop : ∀ i, ⨆ (μ : Fin N →₀ ℕ),
         glWeightSpace k N (L i) (fun j => μ j) = ⊤ :=
       schurWeyl_simple_summand_glWeightSpace_top k N n L e he hSne
-    have hLalg : ∀ i, Etingof.IsAlgebraicRepresentation N (L i).ρ :=
+    have hLalg : ∀ i, Etingof.IsAlgebraicCoefficientFamily N (L i).ρ :=
       schurWeyl_simple_summand_isAlgebraic k N n L e he hSne
     have hLI := schurWeyl_simples_formalCharacter_linearIndependent_general
       k N n L e he hLtop hLalg hLsimp hLdist
@@ -855,14 +855,14 @@ implication): the `L_λ`-side is supplied internally by `schurModule_isAlgebraic
 Like weight saturation, algebraicity is not determined by `formalCharacter`, so it
 must come from `L`'s polynomial source; at the call site
 (`iso_of_formalCharacter_eq_schurPoly`) it transports from the algebraic ambient
-representation via `IsAlgebraicRepresentation.of_linearEquiv`. -/
+representation via `IsAlgebraicCoefficientFamily.of_linearEquiv`. -/
 theorem simpleRep_iso_schurModule_of_formalCharacter_eq (N : ℕ)
     (lam : Fin N → ℕ) (hlam : Antitone lam)
     (L : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
     (hLsimp : IsSimpleModule (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin N) k))
       (Representation.asModule L.ρ))
     (hLtop : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N L (fun i => μ i) = ⊤)
-    (hLalg : Etingof.IsAlgebraicRepresentation N L.ρ)
+    (hLalg : Etingof.IsAlgebraicCoefficientFamily N L.ρ)
     (h : formalCharacter k N L = schurPoly N lam) :
     Nonempty (L ≅ SchurModule k N lam) := by
   by_contra hno
@@ -884,9 +884,9 @@ theorem simpleRep_iso_schurModule_of_formalCharacter_eq (N : ℕ)
     rw [Fin.forall_fin_two]; exact ⟨hLsimp, hSsimp⟩
   -- Both members of the family are algebraic: `L` by hypothesis, `S = L_λ` by
   -- `schurModule_isAlgebraic`. This is the input to character independence.
-  have hSalg : Etingof.IsAlgebraicRepresentation N S.ρ := by
+  have hSalg : Etingof.IsAlgebraicCoefficientFamily N S.ρ := by
     rw [hSdef]; exact schurModule_isAlgebraic N lam
-  have halg : ∀ i, Etingof.IsAlgebraicRepresentation N (![L, S] i).ρ := by
+  have halg : ∀ i, Etingof.IsAlgebraicCoefficientFamily N (![L, S] i).ρ := by
     rw [Fin.forall_fin_two]; exact ⟨by simpa using hLalg, by simpa using hSalg⟩
   have hdist : Pairwise (fun i j => ¬ Nonempty ((![L, S] i) ≅ (![L, S] j))) := by
     have hsym : ¬ Nonempty (S ≅ L) := fun ⟨e⟩ => hno ⟨e.symm⟩
@@ -935,7 +935,7 @@ The downstream use is in `schurModule_shift_iso_detTwist` (Proposition 5.22.2). 
 theorem iso_of_formalCharacter_eq_schurPoly (N : ℕ)
     (lam : Fin N → ℕ) (hlam : Antitone lam)
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
-    (halg : Etingof.IsAlgebraicRepresentation N M.ρ)
+    (halg : Etingof.IsAlgebraicCoefficientFamily N M.ρ)
     (h_span : ⨆ (μ : Fin N →₀ ℕ), glWeightSpace k N M (fun i => μ i) = ⊤)
     (h : formalCharacter k N M = schurPoly N lam)
     (_h_dim : Module.finrank k M = Module.finrank k (SchurModule k N lam)) :
@@ -1040,9 +1040,9 @@ theorem iso_of_formalCharacter_eq_schurPoly (N : ℕ)
       (fun g v => Representation.kEquivOfAsModuleEquiv_intertwines hφ' g v)
       (Representation.kEquivOfAsModuleEquiv hφ').surjective h_span
   -- Algebraicity of `L (f 0)` transports from the algebraic ambient rep `M` along the
-  -- `k`-linear GL-equivariant equivalence `hφ'` (`IsAlgebraicRepresentation.of_linearEquiv`).
-  have hLf0alg : Etingof.IsAlgebraicRepresentation N (L (f 0)).ρ :=
-    Etingof.IsAlgebraicRepresentation.of_linearEquiv
+  -- `k`-linear GL-equivariant equivalence `hφ'` (`IsAlgebraicCoefficientFamily.of_linearEquiv`).
+  have hLf0alg : Etingof.IsAlgebraicCoefficientFamily N (L (f 0)).ρ :=
+    Etingof.IsAlgebraicCoefficientFamily.of_linearEquiv
       (Representation.kEquivOfAsModuleEquiv hφ')
       (fun g v => Representation.kEquivOfAsModuleEquiv_intertwines hφ' g v) halg
   have hLS : Nonempty (L (f 0) ≅ SchurModule k N lam) :=

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_23_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_23_2.lean
@@ -67,7 +67,7 @@ the GL-rep classification infrastructure (cf. `iso_of_formalCharacter_eq_schurPo
 (one valid approach), this proves complete reducibility via the
 `det`-twist reduction to the polynomial case:
 
-1. *det-clearing* (`IsAlgebraicRepresentation.exists_detPow_twist_isPolynomial`):
+1. *det-clearing* (`IsAlgebraicCoefficientFamily.exists_detPow_twist_isPolynomial`):
    some power `s` makes the twist `g ↦ det(g)^s • ρ(g)` a *polynomial*
    (`det⁻¹`-free) representation.
 2. The twist is the representation `charTwistRep (det^s) ρ`.
@@ -86,7 +86,7 @@ theorem Theorem5_23_2_i
     (n : ℕ)
     {Y : Type} [AddCommGroup Y] [Module k Y] [Module.Finite k Y]
     (ρ : Representation k (Matrix.GeneralLinearGroup (Fin n) k) Y)
-    (halg : Etingof.IsAlgebraicRepresentation n ⇑ρ) :
+    (halg : Etingof.IsAlgebraicCoefficientFamily n ⇑ρ) :
     IsSemisimpleModule
       (MonoidAlgebra k (Matrix.GeneralLinearGroup (Fin n) k)) ρ.asModule := by
   classical

--- a/EtingofRepresentationTheory/Chapter5/TraceVanishingDensity.lean
+++ b/EtingofRepresentationTheory/Chapter5/TraceVanishingDensity.lean
@@ -23,7 +23,7 @@ complement is the zero locus of `det · discr` (`discrPoly`). Clearing the `det�
 denominator yields a polynomial vanishing off `{det · discr ≠ 0}`, which
 `eq_zero_of_eval_eq_zero_off_zeroLocus` forces to be identically zero.
 
-The hypothesis is `IsAlgebraicRepresentation` (regularity of the character), not merely
+The hypothesis is `IsAlgebraicCoefficientFamily` (regularity of the character), not merely
 `hLtop` (spanning `ℕ`-weight spaces): the latter is strictly weaker for abstract-group
 representations and does not by itself make the character regular. At the call site each
 `L i` is a summand of the polynomial representation `V^{⊗n}`, hence algebraic.
@@ -42,7 +42,7 @@ algebraic `GL_N`-representation `M`, the character `g ↦ trace_k (M.ρ g)` equa
 matrix-coefficient polynomials in any algebraic-rep basis). Valid over any field. -/
 theorem trace_eq_evalAtGL_of_algebraic
     (M : FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
-    (hM : Etingof.IsAlgebraicRepresentation N M.ρ) :
+    (hM : Etingof.IsAlgebraicCoefficientFamily N M.ρ) :
     ∃ T : MvPolynomial (Etingof.GLCoordVars N) k,
       ∀ g, LinearMap.trace k M (M.ρ g) = Etingof.evalAtGL g T := by
   obtain ⟨m, b, P, hP⟩ := hM
@@ -67,7 +67,7 @@ the `k = ℂ` specialisation. -/
 theorem trace_combination_vanishes_of_torus_vanishes_of_algebraic
     (N : ℕ) {ι : Type} [Fintype ι]
     (L : ι → FDRep k (Matrix.GeneralLinearGroup (Fin N) k))
-    (hLalg : ∀ i, Etingof.IsAlgebraicRepresentation N (L i).ρ)
+    (hLalg : ∀ i, Etingof.IsAlgebraicCoefficientFamily N (L i).ρ)
     (c : ι → k)
     (htorus : ∀ t : Fin N → kˣ,
         ∑ i, c i • LinearMap.trace k (L i) ((L i).ρ (diagTorus k N t)) = 0)

--- a/progress/2026-07-23T13-08-51Z_f95f9fa2.md
+++ b/progress/2026-07-23T13-08-51Z_f95f9fa2.md
@@ -1,0 +1,44 @@
+## Accomplished
+
+Fixed issue #7461 — `Etingof.IsAlgebraicRepresentation` (Definition 5.23.1) was
+too broad: it took an arbitrary family `ρ : GL_N(k) → (Y →ₗ[k] Y)` and only
+checked matrix-coefficient regularity, so the constant-zero family satisfied it
+despite not being a representation (`ρ 1 ≠ id`).
+
+- Renamed the raw coefficient-regularity predicate to
+  `Etingof.IsAlgebraicCoefficientFamily` (its honest content). This is a pure
+  mechanical rename across all 23 downstream transport/consumer files, which
+  genuinely act on raw families (e.g. `.restrict`, `.detTwist`, `.of_linearEquiv`
+  produce raw families not packaged as `Representation`).
+- Introduced the honest `Etingof.IsAlgebraicRepresentation` on a bundled
+  `Representation k (GL_N k) Y`, defined as algebraicity of the underlying
+  coefficient family. The identity/multiplicativity laws are now part of the data.
+- Added: `isAlgebraicRepresentation_iff` (definitional bridge),
+  `IsAlgebraicCoefficientFamily.toRepresentation` (compatibility wrapper), and
+  `exists_algebraicCoefficientFamily_not_representation` (regression witness: the
+  constant-zero family over a nonzero `Y` is an algebraic coefficient family but
+  fails `ρ 1 = id`).
+- Exposed genuine book representations as algebraic representations:
+  `glTensorRep_isAlgebraicRepresentation` and `schurModule_isAlgebraicRepresentation`.
+- Updated Definition 5.23.1 coverage metadata to `covered_full` / `fidelity: full`.
+
+Full `lake build` passes (9248 jobs). No new sorries.
+
+## Current frontier
+
+Issue #7461 complete. Branch `agent/f95f9fa2`, two commits.
+
+## Overall project progress
+
+Stage 3 formalization / completeness-audit fixes ongoing. ~48 other unclaimed
+`completeness-audit` feature issues remain in the queue.
+
+## Next step
+
+Create PR closing #7461 with auto-merge. Next worker: claim another
+`completeness-audit` issue (e.g. #7483 virtual-representation indexing, another
+definition-correctness item).
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -6499,13 +6499,12 @@
     "start_line": 9,
     "end_line": 10,
     "status": "sorry_free",
-    "fidelity": "partial",
+    "fidelity": "full",
     "needs_statement": false,
     "sorry_free": true,
-    "coverage": "covered_partial",
-    "fidelity_note": "IsAlgebraicRepresentation checks regular matrix coefficients for an arbitrary GL-valued endomorphism family but does not require the identity or multiplication action laws, so it accepts families that are not representations. Follow-up #7461.",
-    "fidelity_issue": 7461,
-    "last_updated": "2026-07-22"
+    "coverage": "covered_full",
+    "fidelity_note": "Etingof.IsAlgebraicRepresentation now takes a bundled Representation k (GL_N k) Y, so the identity/multiplicativity action laws are part of the data; it asserts algebraicity of the underlying coefficient family. The raw coefficient-regularity predicate is retained under the honest name IsAlgebraicCoefficientFamily for the reusable transport lemmas, with a definitional bridge (isAlgebraicRepresentation_iff), a compatibility wrapper (IsAlgebraicCoefficientFamily.toRepresentation), and a regression witness (exists_algebraicCoefficientFamily_not_representation) showing the constant-zero family is an algebraic coefficient family but not a representation. Genuine book representations glTensorRep and (SchurModule …).ρ are exposed as algebraic representations. Fixed #7461.",
+    "last_updated": "2026-07-23"
   },
   {
     "id": "Chapter5/Discussion_after_Definition5.23.1",


### PR DESCRIPTION
This PR makes `Etingof.IsAlgebraicRepresentation` (Definition 5.23.1) require an actual GL representation. The predicate previously took an arbitrary family `ρ : GL_N(k) → (Y →ₗ[k] Y)` and only checked matrix-coefficient regularity, so the constant-zero family satisfied it despite failing the representation laws (`ρ 1 ≠ id`). It now takes a bundled `Representation k (GL_N k) Y`, whose identity and multiplicativity laws are part of the data, and asserts algebraicity of the underlying coefficient family — faithfully capturing Etingof's notion whose subject is a representation.

The raw coefficient-regularity condition is retained under the honest name `IsAlgebraicCoefficientFamily`, since the reusable transport lemmas (`.restrict`, `.detTwist`, `.of_linearEquiv`, `.dual`) act on raw families that are not packaged as `Representation` objects; migrating the 23 downstream files is a mechanical rename. A definitional bridge (`isAlgebraicRepresentation_iff`), a compatibility wrapper (`IsAlgebraicCoefficientFamily.toRepresentation`), and a regression witness (`exists_algebraicCoefficientFamily_not_representation`, exhibiting the constant-zero family as an algebraic coefficient family that is not a representation) accompany the change, and the genuine book representations `glTensorRep` and `(SchurModule …).ρ` are exposed as algebraic representations.

Closes #7461

🤖 Prepared with Claude Code
