### PR TITLE
Add the ordinary Young tableaux defined in Definition 5.12.1

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Definition5_12_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Definition5_12_1.lean
@@ -41,12 +41,31 @@ def colOfPos : List ℕ → ℕ → ℕ
 noncomputable def _root_.Nat.Partition.sortedParts {n : ℕ} (la : Nat.Partition n) : List ℕ :=
   la.parts.sort (· ≥ ·)
 
+/-- An (ordinary) **Young tableau** of shape `λ` is *any* filling of the cells of the
+Young diagram by the numbers `1, …, n` without repetition, i.e. a bijection from the
+cells to `Fin n`. Row and column monotonicity are **not** required. (Etingof
+Definition 5.12.1: "the result of filling the numbers `1, …, n` into the squares of
+`Y_λ` in some way (without repetitions)".)
+
+For shape `(2)` the filling `[2, 1]` is a genuine Young tableau even though it is not
+standard. The increasing left-to-right, top-to-bottom tableau `T_λ` is merely one
+particular example; see `canonicalYoungTableau`. The strictly-increasing
+`StandardYoungTableau` is the refinement obtained by additionally imposing
+monotonicity; see `StandardYoungTableau.toYoungTableau` for the forgetful bridge. -/
+noncomputable def YoungTableau (n : ℕ) (la : Nat.Partition n) : Type :=
+  let parts := la.sortedParts
+  let Cell := { c : ℕ × ℕ // c.1 < parts.length ∧ c.2 < parts.getD c.1 0 }
+  { f : Cell → Fin n // Function.Bijective f }
+
 /-- A standard Young tableau of shape λ is a filling of a Young diagram with 0..n-1
 such that entries increase along rows and down columns. (Etingof Definition 5.12.1)
 
 Concretely: a bijection from cells of the diagram to `Fin n`, strictly increasing
 along rows and down columns. A cell (i, j) is valid when i < number of rows and
-j < length of row i (using the canonical descending-sorted parts). -/
+j < length of row i (using the canonical descending-sorted parts).
+
+This is the refinement of the ordinary `YoungTableau` by row/column monotonicity;
+the forgetful map is `StandardYoungTableau.toYoungTableau`. -/
 noncomputable def StandardYoungTableau (n : ℕ) (la : Nat.Partition n) : Type :=
   let parts := la.sortedParts
   let Cell := { c : ℕ × ℕ // c.1 < parts.length ∧ c.2 < parts.getD c.1 0 }
@@ -54,6 +73,13 @@ noncomputable def StandardYoungTableau (n : ℕ) (la : Nat.Partition n) : Type :
     Function.Bijective f ∧
     (∀ c₁ c₂ : Cell, c₁.1.1 = c₂.1.1 → c₁.1.2 < c₂.1.2 → f c₁ < f c₂) ∧
     (∀ c₁ c₂ : Cell, c₁.1.2 = c₂.1.2 → c₁.1.1 < c₂.1.1 → f c₁ < f c₂) }
+
+/-- Every standard Young tableau is in particular an ordinary Young tableau: forget the
+row/column monotonicity conditions and keep the underlying bijective filling. This is
+the explicit bridge between the two notions of Etingof Definition 5.12.1. -/
+noncomputable def StandardYoungTableau.toYoungTableau {n : ℕ} {la : Nat.Partition n}
+    (T : StandardYoungTableau n la) : YoungTableau n la :=
+  ⟨T.1, T.2.1⟩
 
 /-- The row subgroup P_λ of S_n: permutations preserving each row of
 the Young diagram. (Etingof Definition 5.12.1)
@@ -184,5 +210,175 @@ theorem exists_pos_of_cell (parts : List ℕ) (r c : ℕ)
       exact ⟨p + k, by simp [List.sum_cons]; omega,
         by simp [rowOfPos]; omega,
         by simp [colOfPos]; omega⟩
+
+/-! ## The canonical increasing tableau `T_λ`
+
+Etingof singles out the tableau `T_λ` obtained by "filling in the numbers in increasing
+order, left to right, top to bottom". We construct it here, as both an ordinary
+`YoungTableau` and a `StandardYoungTableau`, so that the two notions of
+Definition 5.12.1 are connected by a concrete example. -/
+
+/-- The linear position (0-indexed) of cell `(r, c)` in the canonical left-to-right,
+top-to-bottom filling: all `(la.sortedParts.take r).sum` cells in earlier rows, plus the
+`c` cells to its left in row `r`. -/
+def posOfCell (parts : List ℕ) (rc : ℕ × ℕ) : ℕ :=
+  (parts.take rc.1).sum + rc.2
+
+/-- The sorted parts of a partition of `n` sum to `n`. -/
+private theorem sortedParts_sum (n : ℕ) (la : Nat.Partition n) :
+    la.sortedParts.sum = n := by
+  have h := Multiset.sort_eq la.parts (· ≥ ·)
+  have hcoe : (la.sortedParts : Multiset ℕ).sum = la.parts.sum := congrArg Multiset.sum h
+  rw [Multiset.sum_coe] at hcoe
+  rw [hcoe, la.parts_sum]
+
+/-- `rowOfPos` returns a value less than the list length for valid positions. -/
+private theorem rowOfPos_lt_length (parts : List ℕ) (k : ℕ) (hk : k < parts.sum) :
+    rowOfPos parts k < parts.length := by
+  induction parts generalizing k with
+  | nil => simp [List.sum_nil] at hk
+  | cons p ps ih =>
+    simp only [rowOfPos, List.length_cons]
+    split_ifs with h
+    · omega
+    · have : k - p < ps.sum := by simp [List.sum_cons] at hk; omega
+      have := ih _ this; omega
+
+/-- take-sums are monotone in the truncation length (over `ℕ`). -/
+private theorem sum_take_le (l : List ℕ) (a b : ℕ) (h : a ≤ b) :
+    (l.take a).sum ≤ (l.take b).sum := by
+  calc (l.take a).sum
+      = ((l.take b).take a).sum := by rw [List.take_take, Nat.min_eq_left h]
+    _ ≤ ((l.take b).take a).sum + ((l.take b).drop a).sum := Nat.le_add_right _ _
+    _ = (l.take b).sum := by rw [← List.sum_append, List.take_append_drop]
+
+/-- Round trip: the canonical position of the cell at position `k` is `k` again. -/
+private theorem posOfCell_rowColOfPos (parts : List ℕ) (k : ℕ) (hk : k < parts.sum) :
+    posOfCell parts (rowOfPos parts k, colOfPos parts k) = k := by
+  induction parts generalizing k with
+  | nil => simp [List.sum_nil] at hk
+  | cons p ps ih =>
+    by_cases hlt : k < p
+    · simp only [rowOfPos, colOfPos, hlt, if_true, posOfCell, List.take_zero,
+        List.sum_nil, Nat.zero_add]
+    · have hk' : k - p < ps.sum := by simp [List.sum_cons] at hk; omega
+      simp only [rowOfPos, colOfPos, hlt, if_false, posOfCell]
+      rw [show 1 + rowOfPos ps (k - p) = rowOfPos ps (k - p) + 1 from Nat.add_comm _ _,
+          List.take_succ_cons, List.sum_cons]
+      have := ih (k - p) hk'
+      simp only [posOfCell] at this
+      omega
+
+/-- Round trip: the position of a valid cell `(r, c)` sits back in row `r`, column `c`. -/
+private theorem rowColOfPos_posOfCell (parts : List ℕ) (r c : ℕ)
+    (hr : r < parts.length) (hc : c < parts.getD r 0) :
+    rowOfPos parts (posOfCell parts (r, c)) = r ∧
+    colOfPos parts (posOfCell parts (r, c)) = c := by
+  induction parts generalizing r with
+  | nil => simp at hr
+  | cons p ps ih =>
+    cases r with
+    | zero =>
+      have hcp : c < p := by rwa [List.getD_cons_zero] at hc
+      refine ⟨?_, ?_⟩ <;>
+        simp only [posOfCell, List.take_zero, List.sum_nil, Nat.zero_add, rowOfPos, colOfPos,
+          hcp, if_true]
+    | succ r =>
+      have hr' : r < ps.length := by simpa using hr
+      have hc' : c < ps.getD r 0 := by rwa [List.getD_cons_succ] at hc
+      have hpos : posOfCell (p :: ps) (r + 1, c) = p + posOfCell ps (r, c) := by
+        simp only [posOfCell, List.take_succ_cons, List.sum_cons]; ring
+      rw [hpos]
+      obtain ⟨ih1, ih2⟩ := ih r hr' hc'
+      have hge : ¬ (p + posOfCell ps (r, c) < p) := by omega
+      refine ⟨?_, ?_⟩
+      · simp only [rowOfPos, hge, if_false, Nat.add_sub_cancel_left, ih1]; omega
+      · simp only [colOfPos, hge, if_false, Nat.add_sub_cancel_left, ih2]
+
+/-- The canonical position of a valid cell is a genuine position, i.e. `< parts.sum`. -/
+private theorem posOfCell_lt_sum (parts : List ℕ) (r c : ℕ)
+    (hr : r < parts.length) (hc : c < parts.getD r 0) :
+    posOfCell parts (r, c) < parts.sum := by
+  have hgetD : parts.getD r 0 = parts[r] := List.getD_eq_getElem parts 0 hr
+  have hsucc : (parts.take (r + 1)).sum = (parts.take r).sum + parts[r] :=
+    List.sum_take_succ parts r hr
+  have hle : (parts.take (r + 1)).sum ≤ (parts.take parts.length).sum :=
+    sum_take_le parts (r + 1) parts.length hr
+  rw [List.take_length] at hle
+  simp only [posOfCell]
+  rw [hgetD] at hc
+  omega
+
+/-- The underlying filling of the canonical tableau `T_λ`: cell `(r, c) ↦ posOfCell`. -/
+private noncomputable def canonicalFun (n : ℕ) (la : Nat.Partition n) :
+    { c : ℕ × ℕ // c.1 < la.sortedParts.length ∧ c.2 < la.sortedParts.getD c.1 0 } → Fin n :=
+  fun cell => ⟨posOfCell la.sortedParts cell.1, by
+    have h := posOfCell_lt_sum la.sortedParts cell.1.1 cell.1.2 cell.2.1 cell.2.2
+    rw [sortedParts_sum] at h; exact h⟩
+
+/-- The canonical filling is a bijection: it uses every number `1, …, n` exactly once. -/
+private theorem canonicalFun_bijective (n : ℕ) (la : Nat.Partition n) :
+    Function.Bijective (canonicalFun n la) := by
+  have hsum : la.sortedParts.sum = n := sortedParts_sum n la
+  refine Function.bijective_iff_has_inverse.mpr
+    ⟨fun k => ⟨(rowOfPos la.sortedParts k.val, colOfPos la.sortedParts k.val),
+      rowOfPos_lt_length la.sortedParts k.val (by omega),
+      colOfPos_lt_getD la.sortedParts k.val (by omega)⟩, ?_, ?_⟩
+  · intro cell
+    apply Subtype.ext
+    obtain ⟨⟨r, c⟩, hr, hc⟩ := cell
+    simp only [canonicalFun]
+    obtain ⟨e1, e2⟩ := rowColOfPos_posOfCell la.sortedParts r c hr hc
+    rw [e1, e2]
+  · intro k
+    apply Fin.ext
+    simp only [canonicalFun]
+    exact posOfCell_rowColOfPos la.sortedParts k.val (by omega)
+
+/-- Along a fixed row, the canonical filling increases left to right. -/
+private theorem canonicalFun_row_inc (n : ℕ) (la : Nat.Partition n)
+    (c₁ c₂ : { c : ℕ × ℕ // c.1 < la.sortedParts.length ∧ c.2 < la.sortedParts.getD c.1 0 })
+    (hrow : c₁.1.1 = c₂.1.1) (hcol : c₁.1.2 < c₂.1.2) :
+    canonicalFun n la c₁ < canonicalFun n la c₂ := by
+  simp only [canonicalFun, Fin.mk_lt_mk, posOfCell]
+  rw [hrow]
+  omega
+
+/-- Down a fixed column, the canonical filling increases top to bottom. -/
+private theorem canonicalFun_col_inc (n : ℕ) (la : Nat.Partition n)
+    (c₁ c₂ : { c : ℕ × ℕ // c.1 < la.sortedParts.length ∧ c.2 < la.sortedParts.getD c.1 0 })
+    (hcol : c₁.1.2 = c₂.1.2) (hrow : c₁.1.1 < c₂.1.1) :
+    canonicalFun n la c₁ < canonicalFun n la c₂ := by
+  simp only [canonicalFun, Fin.mk_lt_mk, posOfCell]
+  have hr1 : c₁.1.1 < la.sortedParts.length := c₁.2.1
+  have hgetD : la.sortedParts.getD c₁.1.1 0 = la.sortedParts[c₁.1.1] :=
+    List.getD_eq_getElem la.sortedParts 0 hr1
+  have hc1 : c₁.1.2 < la.sortedParts.getD c₁.1.1 0 := c₁.2.2
+  have hsucc : (la.sortedParts.take (c₁.1.1 + 1)).sum
+      = (la.sortedParts.take c₁.1.1).sum + la.sortedParts[c₁.1.1] :=
+    List.sum_take_succ la.sortedParts c₁.1.1 hr1
+  have hle : (la.sortedParts.take (c₁.1.1 + 1)).sum ≤ (la.sortedParts.take c₂.1.1).sum :=
+    sum_take_le la.sortedParts (c₁.1.1 + 1) c₂.1.1 (by omega)
+  rw [hgetD] at hc1
+  omega
+
+/-- The **canonical (increasing) Young tableau** `T_λ`, as an *ordinary* Young tableau:
+cell `(r, c)` receives the number equal to its position in the left-to-right,
+top-to-bottom reading order. (Etingof Definition 5.12.1, the example tableau `T_λ`.) -/
+noncomputable def canonicalYoungTableau (n : ℕ) (la : Nat.Partition n) : YoungTableau n la :=
+  ⟨canonicalFun n la, canonicalFun_bijective n la⟩
+
+/-- The canonical tableau `T_λ` is standard: it strictly increases along rows and down
+columns. This is the increasing tableau singled out in Etingof Definition 5.12.1. -/
+noncomputable def canonicalStandardYoungTableau (n : ℕ) (la : Nat.Partition n) :
+    StandardYoungTableau n la :=
+  ⟨canonicalFun n la, canonicalFun_bijective n la,
+    canonicalFun_row_inc n la, canonicalFun_col_inc n la⟩
+
+/-- The standard canonical tableau, viewed as an ordinary tableau via the forgetful
+bridge, is the ordinary canonical tableau. -/
+theorem canonicalStandardYoungTableau_toYoungTableau (n : ℕ) (la : Nat.Partition n) :
+    (canonicalStandardYoungTableau n la).toYoungTableau = canonicalYoungTableau n la :=
+  rfl
 
 end Etingof

--- a/progress/2026-07-23T14-05-49Z_a029e1cf.md
+++ b/progress/2026-07-23T14-05-49Z_a029e1cf.md
@@ -1,0 +1,49 @@
+## Accomplished
+
+Resolved issue #7460 (feature): added the ordinary Young tableau type of Etingof
+Definition 5.12.1, which the project previously lacked.
+
+In `EtingofRepresentationTheory/Chapter5/Definition5_12_1.lean`:
+
+- `YoungTableau n la`: any bijective filling of the diagram cells by `Fin n`, with
+  **no** monotonicity requirement (the book's actual definition; e.g. `[2,1]` for
+  shape `(2)` is now representable).
+- `StandardYoungTableau.toYoungTableau`: the explicit forgetful bridge from the
+  strict-increase refinement to the ordinary tableau.
+- `posOfCell` plus round-trip lemmas (`posOfCell_rowColOfPos`,
+  `rowColOfPos_posOfCell`) against the existing `rowOfPos`/`colOfPos`, a bound
+  lemma, and monotonicity lemmas.
+- `canonicalYoungTableau` and `canonicalStandardYoungTableau`: the canonical
+  increasing tableau `T_λ` exposed as both notions, with
+  `canonicalStandardYoungTableau_toYoungTableau` connecting them by `rfl`.
+- Updated `progress/items.json` for `Chapter5/Definition5.12.1` to
+  `coverage: covered_full`, `fidelity: verified`.
+
+Key decision: `StandardYoungTableau` was left byte-for-byte unchanged (it is used
+pervasively downstream, including `unfold StandardYoungTableau` in `SYTFintype`
+and `FRTHelpers`). Rather than making it a subtype of `YoungTableau`, I added the
+ordinary type alongside and bridged via a coercion, which the issue explicitly
+allowed.
+
+## Current frontier
+
+Feature complete. Target file builds sorry-free (axioms: propext,
+Classical.choice, Quot.sound only). Direct dependents (`PolytabloidBasis`,
+`SYTFintype`, `Theorem5_17_1`, `TabloidModule`, `FRTHelpers`) and the full
+project (`lake build`, 9248 jobs) build successfully.
+
+## Overall project progress
+
+Phase 3 formalization ongoing; this closes one `completeness-audit` fidelity gap
+in Chapter 5. Many similar `feature`/`completeness-audit` issues remain unclaimed.
+
+## Next step
+
+Pick up the next unclaimed `feature` issue. Related nearby work: #7437
+(normalized `a·b` Young-projector convention) and #7460's optional extension
+(generalizing the row/column subgroup API from the canonical tableau to arbitrary
+ordinary tableaux, which this issue noted as useful-but-not-required).
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -5407,12 +5407,11 @@
     "start_line": 29,
     "end_line": 9,
     "status": "sorry_free",
-    "fidelity": "partial",
+    "fidelity": "verified",
     "sorry_free": true,
-    "coverage": "covered_partial",
-    "fidelity_note": "Lean exposes only StandardYoungTableau, imposing strict row and column increase. The source first defines an arbitrary bijective Young tableau and only then selects a canonical increasing tableau; the general object is missing. Follow-up #7460.",
-    "fidelity_issue": 7460,
-    "last_updated": "2026-07-22"
+    "coverage": "covered_full",
+    "fidelity_note": "Lean now exposes both the ordinary bijective YoungTableau of the source and its refinement StandardYoungTableau, connected by the forgetful bridge StandardYoungTableau.toYoungTableau, and constructs the canonical increasing tableau T_lambda (canonicalYoungTableau / canonicalStandardYoungTableau) as both notions. Resolved by #7460.",
+    "last_updated": "2026-07-23"
   },
   {
     "id": "Chapter5/Discussion_Young_projectors",


### PR DESCRIPTION
Closes #7460

Session: `a029e1cf-d420-475e-ac40-816fa42ba83c`

1212dba1 chore: progress entry for #7460 (ordinary Young tableau)
b6d0fb36 feat(Ch5 Def 5.12.1): add the ordinary Young tableau type and canonical T_λ

🤖 Prepared with Claude Code