### PR TITLE
feat(Ch5): restore Etingof's normalized a_λ,b_λ,c_λ=a_λb_λ Young projectors and source-form Lemma 5.13.1

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Definition5_12_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Definition5_12_1.lean
@@ -13,9 +13,20 @@ A **Young tableau** of shape λ is a filling of the Young diagram with numbers 1
 The **row subgroup** P_λ ⊂ S_n consists of permutations preserving each row.
 The **column subgroup** Q_λ ⊂ S_n consists of permutations preserving each column.
 
-The **Young symmetrizer** c_λ = b_λ · a_λ (column antisymmetrizer × row symmetrizer) where:
-- a_λ = Σ_{g ∈ P_λ} g
-- b_λ = Σ_{g ∈ Q_λ} sign(g) · g
+Etingof's Young projectors (Discussion after Definition 5.12.1) are the **normalized**
+elements of ℂ[S_n]
+- a_λ = |P_λ|⁻¹ Σ_{g ∈ P_λ} g   (`youngProjectorRow`),
+- b_λ = |Q_λ|⁻¹ Σ_{g ∈ Q_λ} sign(g) · g   (`youngProjectorCol`),
+- c_λ = a_λ · b_λ   (`youngProjector`, row-then-column).
+
+This file *also* provides the **unnormalized** sums `RowSymmetrizer = Σ_{g ∈ P_λ} g` and
+`ColumnAntisymmetrizer = Σ_{g ∈ Q_λ} sign(g) · g`, and the element
+`YoungSymmetrizer = ColumnAntisymmetrizer · RowSymmetrizer` (the *opposite*, unnormalized
+`b_λ · a_λ` order). `YoungSymmetrizer` is the generator used by the downstream
+`SpechtModule` construction; it is NOT Etingof's `c_λ`. The two are related by the
+positive scalar `|P_λ| · |Q_λ|` and the factor order swap (see
+`Etingof.youngProjectorCol_mul_youngProjectorRow` and the source-order
+`Etingof.Lemma5_13_1_source` in `Lemma5_13_1.lean`).
 
 ## Mathlib correspondence
 
@@ -116,19 +127,44 @@ noncomputable def ColumnAntisymmetrizer (n : ℕ) (la : Nat.Partition n) :
   ∑ g : (ColumnSubgroup n la),
     ((↑(Equiv.Perm.sign g.val) : ℤ) : ℂ) • MonoidAlgebra.of ℂ _ g.val
 
-/-- The Young symmetrizer c_λ = b_λ · a_λ in the group algebra ℂ[S_n].
-(Etingof Definition 5.12.1)
+/-- The **unnormalized** element `b_λ · a_λ = ColumnAntisymmetrizer · RowSymmetrizer` in
+the group algebra ℂ[S_n], where a_λ = ∑_{g ∈ P_λ} g and b_λ = ∑_{g ∈ Q_λ} sign(g) · g.
 
-Here a_λ = ∑_{g ∈ P_λ} g and b_λ = ∑_{g ∈ Q_λ} sign(g) · g,
-where P_λ is the row subgroup and Q_λ is the column subgroup.
-
-**Convention**: We use c_λ = b_λ · a_λ (column × row) following Fulton-Harris
-and Etingof. This convention ensures polytabloids lie in the Specht module:
-the polytabloid e_T = κ_T · of(σ_T) · a_λ is a left multiple of b_λ · a_λ
-for the canonical filling. -/
+**Warning on naming/convention.** This is *not* Etingof's Young projector `c_λ`. Etingof
+defines the normalized `c_λ = a_λ · b_λ` (row-then-column); see `youngProjector`. The
+element here differs from `c_λ` both in normalization (by the positive scalar
+`|P_λ| · |Q_λ|`) and in factor order (`b_λ · a_λ` vs `a_λ · b_λ`), and the factors do not
+commute. It is retained under this name because it is the historical generator of the
+downstream `SpechtModule` left ideal ℂ[S_n]·(b_λ a_λ): the ordering makes polytabloids
+`e_T = κ_T · of(σ_T) · a_λ` left multiples of `b_λ · a_λ` for the canonical filling. The
+precise relationship to the source projectors is
+`Etingof.youngProjectorCol_mul_youngProjectorRow`. -/
 noncomputable def YoungSymmetrizer (n : ℕ) (la : Nat.Partition n) :
     MonoidAlgebra ℂ (Equiv.Perm (Fin n)) :=
   ColumnAntisymmetrizer n la * RowSymmetrizer n la
+
+/-- Etingof's **normalized row projector** `a_λ = |P_λ|⁻¹ ∑_{g ∈ P_λ} g` in ℂ[S_n]
+(Discussion of Young projectors after Definition 5.12.1). Unlike `RowSymmetrizer`, this is
+a genuine idempotent: `youngProjectorRow_mul_self`. -/
+noncomputable def youngProjectorRow (n : ℕ) (la : Nat.Partition n) :
+    MonoidAlgebra ℂ (Equiv.Perm (Fin n)) :=
+  (Nat.card (RowSubgroup n la) : ℂ)⁻¹ • RowSymmetrizer n la
+
+/-- Etingof's **normalized column projector** `b_λ = |Q_λ|⁻¹ ∑_{g ∈ Q_λ} sign(g) · g` in
+ℂ[S_n] (Discussion of Young projectors after Definition 5.12.1). A genuine idempotent:
+`youngProjectorCol_mul_self`. -/
+noncomputable def youngProjectorCol (n : ℕ) (la : Nat.Partition n) :
+    MonoidAlgebra ℂ (Equiv.Perm (Fin n)) :=
+  (Nat.card (ColumnSubgroup n la) : ℂ)⁻¹ • ColumnAntisymmetrizer n la
+
+/-- Etingof's **Young projector** `c_λ = a_λ · b_λ` (row-then-column, normalized), the
+source-faithful element of ℂ[S_n] from the Discussion after Definition 5.12.1.
+
+This is the honest formalization of Etingof's `c_λ`. It is distinct from the
+implementation element `YoungSymmetrizer = b_λ · a_λ` (opposite order, unnormalized). -/
+noncomputable def youngProjector (n : ℕ) (la : Nat.Partition n) :
+    MonoidAlgebra ℂ (Equiv.Perm (Fin n)) :=
+  youngProjectorRow n la * youngProjectorCol n la
 
 /-! ## Helper lemmas for rowOfPos and colOfPos -/
 

--- a/EtingofRepresentationTheory/Chapter5/Lemma5_13_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Lemma5_13_1.lean
@@ -3,9 +3,16 @@ import EtingofRepresentationTheory.Chapter5.Definition5_12_1
 /-!
 # Lemma 5.13.1: Young Projector Linear Functional
 
-For x ∈ ℂ[S_n], we have b_λ · x · a_λ = ℓ_λ(x) · c_λ, where ℓ_λ is a linear
-functional on ℂ[S_n]. Here a_λ = Σ_{g ∈ P_λ} g and b_λ = Σ_{g ∈ Q_λ} sign(g) · g,
-and c_λ = b_λ · a_λ is the Young symmetrizer.
+For x ∈ ℂ[S_n], Etingof's Lemma 5.13.1 states `a_λ · x · b_λ = ℓ_λ(x) · c_λ` for the
+normalized projectors `a_λ, b_λ` and `c_λ = a_λ · b_λ`. See `Etingof.Lemma5_13_1_source`
+for exactly this statement.
+
+For historical reasons this file also proves two *unnormalized* sandwich identities:
+`Etingof.Lemma5_13_1` gives the opposite-order `b_λ · x · a_λ = ℓ(x) · (b_λ a_λ)` (matching
+the downstream `YoungSymmetrizer = b_λ a_λ` generator), and `Etingof.Lemma5_13_1_dual`
+gives the source-order `a_λ · x · b_λ = ℓ(x) · (a_λ b_λ)` on the unnormalized sums. The
+source-faithful `Etingof.Lemma5_13_1_source` is obtained from the dual by rescaling, since
+the normalized projectors differ from the unnormalized sums by nonzero scalars.
 -/
 
 namespace Etingof
@@ -536,6 +543,104 @@ private theorem dual_sandwich_not_mem {n : ℕ} {la : Nat.Partition n}
     rw [of_col_mul_ColumnAntisymmetrizer u hu_col, Algebra.mul_smul_comm, Algebra.mul_smul_comm]
   exact h1.trans (hσt ▸ h2)
 
+/-! ## Idempotence of the normalized Young projectors and the convention bridge -/
+
+private lemma sign_cast_sq {n : ℕ} (g : Equiv.Perm (Fin n)) :
+    ((↑(↑(Equiv.Perm.sign g) : ℤ) : ℂ)) * ((↑(↑(Equiv.Perm.sign g) : ℤ) : ℂ)) = 1 := by
+  have hmul : (Equiv.Perm.sign g : ℤˣ) * (Equiv.Perm.sign g : ℤˣ) = 1 := Int.units_mul_self _
+  have h : ((Equiv.Perm.sign g : ℤˣ) : ℤ) * ((Equiv.Perm.sign g : ℤˣ) : ℤ) = 1 := by
+    have := congrArg Units.val hmul
+    simpa using this
+  exact_mod_cast h
+
+/-- The unnormalized row sum is idempotent up to the scalar `|P_λ|`:
+`RowSymmetrizer² = |P_λ| • RowSymmetrizer`. -/
+theorem RowSymmetrizer_mul_self {n : ℕ} (la : Nat.Partition n) :
+    RowSymmetrizer n la * RowSymmetrizer n la =
+      (Nat.card (RowSubgroup n la) : ℂ) • RowSymmetrizer n la := by
+  classical
+  have hexp : RowSymmetrizer n la
+      = ∑ g : (RowSubgroup n la), MonoidAlgebra.of ℂ (G n) (g : Equiv.Perm (Fin n)) := rfl
+  calc RowSymmetrizer n la * RowSymmetrizer n la
+      = (∑ g : (RowSubgroup n la), MonoidAlgebra.of ℂ (G n) (g : Equiv.Perm (Fin n)))
+          * RowSymmetrizer n la := by rw [← hexp]
+    _ = ∑ g : (RowSubgroup n la),
+          MonoidAlgebra.of ℂ (G n) (g : Equiv.Perm (Fin n)) * RowSymmetrizer n la := by
+          rw [Finset.sum_mul]
+    _ = ∑ _g : (RowSubgroup n la), RowSymmetrizer n la := by
+          refine Finset.sum_congr rfl (fun g _ => ?_)
+          exact of_row_mul_RowSymmetrizer (g : Equiv.Perm (Fin n)) g.2
+    _ = (Nat.card (RowSubgroup n la) : ℂ) • RowSymmetrizer n la := by
+          rw [Finset.sum_const, Finset.card_univ, Nat.card_eq_fintype_card,
+            Nat.cast_smul_eq_nsmul]
+
+/-- The unnormalized column sum is idempotent up to the scalar `|Q_λ|`:
+`ColumnAntisymmetrizer² = |Q_λ| • ColumnAntisymmetrizer`. -/
+theorem ColumnAntisymmetrizer_mul_self {n : ℕ} (la : Nat.Partition n) :
+    ColumnAntisymmetrizer n la * ColumnAntisymmetrizer n la =
+      (Nat.card (ColumnSubgroup n la) : ℂ) • ColumnAntisymmetrizer n la := by
+  classical
+  have hexp : ColumnAntisymmetrizer n la
+      = ∑ g : (ColumnSubgroup n la),
+          ((↑(↑(Equiv.Perm.sign (g : Equiv.Perm (Fin n))) : ℤ) : ℂ)) •
+            MonoidAlgebra.of ℂ (G n) (g : Equiv.Perm (Fin n)) := rfl
+  calc ColumnAntisymmetrizer n la * ColumnAntisymmetrizer n la
+      = (∑ g : (ColumnSubgroup n la),
+          ((↑(↑(Equiv.Perm.sign (g : Equiv.Perm (Fin n))) : ℤ) : ℂ)) •
+            MonoidAlgebra.of ℂ (G n) (g : Equiv.Perm (Fin n)))
+          * ColumnAntisymmetrizer n la := by rw [← hexp]
+    _ = ∑ g : (ColumnSubgroup n la),
+          ((↑(↑(Equiv.Perm.sign (g : Equiv.Perm (Fin n))) : ℤ) : ℂ)) •
+            (MonoidAlgebra.of ℂ (G n) (g : Equiv.Perm (Fin n)) * ColumnAntisymmetrizer n la) := by
+          rw [Finset.sum_mul]; simp_rw [Algebra.smul_mul_assoc]
+    _ = ∑ _g : (ColumnSubgroup n la), ColumnAntisymmetrizer n la := by
+          refine Finset.sum_congr rfl (fun g _ => ?_)
+          rw [of_col_mul_ColumnAntisymmetrizer (g : Equiv.Perm (Fin n)) g.2, smul_smul,
+            sign_cast_sq, one_smul]
+    _ = (Nat.card (ColumnSubgroup n la) : ℂ) • ColumnAntisymmetrizer n la := by
+          rw [Finset.sum_const, Finset.card_univ, Nat.card_eq_fintype_card,
+            Nat.cast_smul_eq_nsmul]
+
+/-- Etingof's normalized row projector `a_λ` is idempotent: `a_λ² = a_λ`. -/
+theorem youngProjectorRow_mul_self {n : ℕ} (la : Nat.Partition n) :
+    youngProjectorRow n la * youngProjectorRow n la = youngProjectorRow n la := by
+  have hne : (Nat.card (RowSubgroup n la) : ℂ) ≠ 0 := by
+    have : 0 < Nat.card (RowSubgroup n la) := Nat.card_pos
+    exact_mod_cast this.ne'
+  have hs : ((Nat.card (RowSubgroup n la) : ℂ)⁻¹ * (Nat.card (RowSubgroup n la) : ℂ)⁻¹)
+      * (Nat.card (RowSubgroup n la) : ℂ) = (Nat.card (RowSubgroup n la) : ℂ)⁻¹ := by
+    rw [mul_assoc, inv_mul_cancel₀ hne, mul_one]
+  simp only [youngProjectorRow]
+  rw [Algebra.smul_mul_assoc, Algebra.mul_smul_comm, RowSymmetrizer_mul_self, smul_smul,
+    smul_smul, hs]
+
+/-- Etingof's normalized column projector `b_λ` is idempotent: `b_λ² = b_λ`. -/
+theorem youngProjectorCol_mul_self {n : ℕ} (la : Nat.Partition n) :
+    youngProjectorCol n la * youngProjectorCol n la = youngProjectorCol n la := by
+  have hne : (Nat.card (ColumnSubgroup n la) : ℂ) ≠ 0 := by
+    have : 0 < Nat.card (ColumnSubgroup n la) := Nat.card_pos
+    exact_mod_cast this.ne'
+  have hs : ((Nat.card (ColumnSubgroup n la) : ℂ)⁻¹ * (Nat.card (ColumnSubgroup n la) : ℂ)⁻¹)
+      * (Nat.card (ColumnSubgroup n la) : ℂ) = (Nat.card (ColumnSubgroup n la) : ℂ)⁻¹ := by
+    rw [mul_assoc, inv_mul_cancel₀ hne, mul_one]
+  simp only [youngProjectorCol]
+  rw [Algebra.smul_mul_assoc, Algebra.mul_smul_comm, ColumnAntisymmetrizer_mul_self, smul_smul,
+    smul_smul, hs]
+
+/-- **Convention bridge.** The normalized reversed product `b_λ · a_λ` is the downstream
+`YoungSymmetrizer = ColumnAntisymmetrizer · RowSymmetrizer` divided by the positive scalar
+`|P_λ| · |Q_λ|`. This makes the (previously undocumented) normalization-and-order swap
+between Etingof's projectors and the implementation generator explicit and honest. -/
+theorem youngProjectorCol_mul_youngProjectorRow {n : ℕ} (la : Nat.Partition n) :
+    youngProjectorCol n la * youngProjectorRow n la =
+      ((Nat.card (RowSubgroup n la) : ℂ) * (Nat.card (ColumnSubgroup n la) : ℂ))⁻¹
+        • YoungSymmetrizer n la := by
+  have hscalar : (Nat.card (ColumnSubgroup n la) : ℂ)⁻¹ * (Nat.card (RowSubgroup n la) : ℂ)⁻¹
+      = ((Nat.card (RowSubgroup n la) : ℂ) * (Nat.card (ColumnSubgroup n la) : ℂ))⁻¹ := by
+    rw [mul_inv]; ring
+  rw [youngProjectorCol, youngProjectorRow, YoungSymmetrizer, Algebra.smul_mul_assoc,
+    Algebra.mul_smul_comm, smul_smul, hscalar]
+
 end Etingof
 
 open Etingof Pointwise in
@@ -638,3 +743,25 @@ theorem Etingof.Lemma5_13_1_dual
       simp [MonoidAlgebra.of_apply, mul_one]
     conv_lhs => rw [hsingle]
     rw [Algebra.mul_smul_comm, Algebra.smul_mul_assoc, hf, smul_smul, hℓ, mul_comm]
+
+open Etingof Pointwise in
+/-- **Lemma 5.13.1 (source form).** For `x ∈ ℂ[S_n]`, `a_λ · x · b_λ = ℓ_λ(x) · c_λ`, where
+`a_λ = youngProjectorRow`, `b_λ = youngProjectorCol` and `c_λ = youngProjector = a_λ · b_λ`
+are Etingof's *normalized* projectors, and `ℓ_λ` is a linear functional on `ℂ[S_n]`. This is
+the identity exactly as stated in the book. It is obtained from the unnormalized
+`Etingof.Lemma5_13_1_dual` by rescaling, with the *same* functional `ℓ_λ` (both sides carry
+the identical `|P_λ|⁻¹|Q_λ|⁻¹` factor). -/
+theorem Etingof.Lemma5_13_1_source
+    (n : ℕ) (la : Nat.Partition n) :
+    ∃ ℓ : MonoidAlgebra ℂ (Equiv.Perm (Fin n)) →ₗ[ℂ] ℂ,
+      ∀ x, youngProjectorRow n la * x * youngProjectorCol n la =
+        ℓ x • youngProjector n la := by
+  obtain ⟨ℓ, hℓ⟩ := Etingof.Lemma5_13_1_dual n la
+  refine ⟨ℓ, fun x => ?_⟩
+  have key := hℓ x
+  simp only [youngProjectorRow, youngProjectorCol, youngProjector, Algebra.smul_mul_assoc,
+    Algebra.mul_smul_comm]
+  rw [key]
+  simp only [smul_smul]
+  congr 1
+  ring

--- a/progress/2026-07-23T14-45-18Z_43662f08.md
+++ b/progress/2026-07-23T14-45-18Z_43662f08.md
@@ -1,0 +1,47 @@
+## Accomplished
+
+Feature session on issue #7437 ("Definition 5.12.1 / Lemma 5.13.1: restore Etingof's
+normalized a·b Young-projector convention").
+
+- **Definition5_12_1.lean**: added the source-faithful normalized Young projectors
+  `youngProjectorRow` (a_λ = |P_λ|⁻¹ Σ_{P_λ} g), `youngProjectorCol`
+  (b_λ = |Q_λ|⁻¹ Σ_{Q_λ} sign(g) g), and `youngProjector` (c_λ = a_λ·b_λ, row-then-column).
+  Corrected the module docstring and the `YoungSymmetrizer` docstring, which had falsely
+  claimed the unnormalized `b_λ·a_λ` `YoungSymmetrizer` was Etingof's convention; they now
+  clearly mark `YoungSymmetrizer` as the unnormalized reversed-order implementation
+  generator distinct from `c_λ`.
+- **Lemma5_13_1.lean**: added `RowSymmetrizer_mul_self`, `ColumnAntisymmetrizer_mul_self`
+  (scalar idempotence of the unnormalized sums); `youngProjectorRow_mul_self`,
+  `youngProjectorCol_mul_self` (genuine idempotence a_λ²=a_λ, b_λ²=b_λ); the convention
+  bridge `youngProjectorCol_mul_youngProjectorRow` (b_λ·a_λ = (|P_λ||Q_λ|)⁻¹•YoungSymmetrizer);
+  and `Etingof.Lemma5_13_1_source`, the book's normalized sandwich
+  `a_λ·x·b_λ = ℓ(x)·c_λ`, derived from the existing unnormalized `Lemma5_13_1_dual` by
+  rescaling with the same functional ℓ.
+- All new declarations are axiom-clean (`propext, Classical.choice, Quot.sound`; no `sorryAx`).
+- Full `lake build` succeeds (9248 jobs, 0 errors). Existing `Lemma5_13_1` / `Lemma5_13_1_dual`
+  statements were left untouched (they are used by ~10 downstream files); everything was added.
+- Updated `progress/items.json` coverage metadata for `Chapter5/Discussion_Young_projectors`
+  and `Chapter5/Lemma5.13.1`.
+
+## Current frontier
+
+Core of #7437 delivered. One issue bullet is only partially met: a formal
+`ℂ[Sₙ]`-module isomorphism connecting the downstream `SpechtModule = ℂ[Sₙ]·(b_λ·a_λ)` to
+Etingof's source ideal `ℂ[Sₙ]·c_λ` (c_λ = a_λ·b_λ). Because a_λ, b_λ do not commute this
+is a genuinely separate theorem; filed as follow-up **#7612**. The previously *undocumented*
+convention swap is now documented and bridged at the algebra level.
+
+## Overall project progress
+
+Stage 3 formalization, completeness-audit fixes. This closes the definition-correctness
+gap for the Young-projector convention (a foundational Chapter 5 object). Roughly 45
+unclaimed feature issues remain in the queue.
+
+## Next step
+
+Land this as a partial PR closing the documented/definitional parts of #7437, with #7612
+tracking the residual module iso. A future session can pick up #7612.
+
+## Blockers
+
+None. #7612 is an enhancement, not a blocker.

--- a/progress/items.json
+++ b/progress/items.json
@@ -5424,9 +5424,9 @@
     "end_line": 18,
     "status": "sorry_free",
     "coverage": "covered_partial",
-    "coverage_note": "The repository defines unnormalized row/column sums and names b_λa_λ as YoungSymmetrizer, whereas the source defines normalized projectors and c_λ=a_λb_λ. No formal bridge to the opposite convention or source Specht module is exposed. Follow-up #7437.",
-    "followup_issue": 7437,
-    "last_updated": "2026-07-22",
+    "coverage_note": "The source-normalized projectors are now defined faithfully in Definition5_12_1.lean: youngProjectorRow (a_λ = |P_λ|⁻¹Σ_{P_λ}g), youngProjectorCol (b_λ = |Q_λ|⁻¹Σ_{Q_λ}sign(g)g), youngProjector (c_λ = a_λ·b_λ), with idempotence a_λ²=a_λ, b_λ²=b_λ (Lemma5_13_1.lean). The docstrings no longer misrepresent the unnormalized b_λa_λ YoungSymmetrizer as Etingof's convention, and the algebra bridge youngProjectorCol_mul_youngProjectorRow exposes b_λa_λ = (|P_λ||Q_λ|)⁻¹•YoungSymmetrizer. Residual: a module-level iso ℂ[Sₙ]·(b_λa_λ) ≅ ℂ[Sₙ]·c_λ (source order, non-commuting factors) is not yet exposed; follow-up #7612 (#7437).",
+    "followup_issue": 7612,
+    "last_updated": "2026-07-23",
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -5523,11 +5523,11 @@
     "end_line": 23,
     "status": "sorry_free",
     "needs_statement": false,
-    "notes": "Both unnormalized sandwich identities are proved, including the source-order identity as Lemma5_13_1_dual. However, the source's normalized a_λ,b_λ and named c_λ=a_λb_λ are absent, while the primary theorem/name uses the opposite b_λa_λ convention; #7437.",
+    "notes": "The book's normalized sandwich a_λ·x·b_λ = ℓ(x)·c_λ (c_λ=a_λb_λ) is now exposed as Etingof.Lemma5_13_1_source, built by rescaling the unnormalized Lemma5_13_1_dual with the same functional ℓ. The two unnormalized sandwich identities remain: Lemma5_13_1 (opposite-order b_λ·x·a_λ, matching the downstream YoungSymmetrizer generator) and Lemma5_13_1_dual (source-order on unnormalized sums). Idempotence of a_λ,b_λ and the convention bridge youngProjectorCol_mul_youngProjectorRow are also proved. All axiom-clean. Residual module-level ideal iso tracked in #7612 (#7437).",
     "sorry_free": true,
-    "coverage": "covered_partial",
-    "followup_issue": 7437,
-    "last_updated": "2026-07-22"
+    "coverage": "covered_full",
+    "followup_issue": 7612,
+    "last_updated": "2026-07-23"
   },
   {
     "id": "Chapter5/Discussion_end_of_Lemma5.13.1_proof",


### PR DESCRIPTION
This PR restores Etingof's normalized Young-projector convention (Definition 5.12.1 discussion / Lemma 5.13.1). It adds the source-faithful projectors `youngProjectorRow` (a_λ = |P_λ|⁻¹ Σ_{P_λ} g), `youngProjectorCol` (b_λ = |Q_λ|⁻¹ Σ_{Q_λ} sign(g) g) and `youngProjector` (c_λ = a_λ·b_λ, row-then-column), proves their idempotence (a_λ²=a_λ, b_λ²=b_λ), and exposes `Etingof.Lemma5_13_1_source`, the book's normalized sandwich identity a_λ·x·b_λ = ℓ_λ(x)·c_λ, obtained by rescaling the existing unnormalized `Lemma5_13_1_dual` with the same linear functional.

It also corrects the `Definition5_12_1.lean` docstrings that had falsely described the unnormalized reversed-order `YoungSymmetrizer = b_λ·a_λ` as Etingof's convention, and makes the normalization-and-order swap explicit via the algebra bridge `youngProjectorCol_mul_youngProjectorRow : b_λ·a_λ = (|P_λ||Q_λ|)⁻¹ • YoungSymmetrizer`. The historical `YoungSymmetrizer` generator (used by the downstream `SpechtModule` left ideal) is kept under its name but now honestly documented as the unnormalized `b_λ·a_λ` element, distinct from `c_λ`. Helper facts `RowSymmetrizer_mul_self` and `ColumnAntisymmetrizer_mul_self` support the idempotence proofs. All new declarations are axiom-clean (propext, Classical.choice, Quot.sound; no sorryAx), and the full `lake build` succeeds. The pre-existing `Lemma5_13_1` and `Lemma5_13_1_dual` statements are left untouched, since they are consumed by downstream files.

This is a partial resolution of #7437: the remaining bullet, a formal ℂ[Sₙ]-module isomorphism connecting the downstream `SpechtModule = ℂ[Sₙ]·(b_λ·a_λ)` to Etingof's source ideal `ℂ[Sₙ]·c_λ` (c_λ = a_λ·b_λ), is a genuinely separate theorem because the factors do not commute; it is tracked in #7612. The previously undocumented convention swap is now both documented and bridged at the algebra level.

🤖 Prepared with Claude Code
