### PR TITLE
fix(Ch5): restore the highest-weight and Peter–Weyl source chain

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/AlgIrrepGLNonIso.lean
+++ b/EtingofRepresentationTheory/Chapter5/AlgIrrepGLNonIso.lean
@@ -7,6 +7,15 @@ import EtingofRepresentationTheory.Chapter5.LinearDualDetTwistCharacter
 import EtingofRepresentationTheory.Chapter5.SchurPolyShift
 import EtingofRepresentationTheory.Chapter5.Theorem5_22_1
 
+-- These mirror the lakefile's project-wide `[leanOptions]` so the module also
+-- type-checks under a bare `lake env lean` fresh check (which does not read
+-- lakefile options). `maxSynthPendingDepth 3` clears the deep Schur-module
+-- `asModule`/instance chains; `backward.isDefEq.respectTransparency false`
+-- restores the pre-v4.29 full-transparency `isDefEq` the `charTwistRep`/Schur
+-- carrier defeqs rely on.
+set_option maxSynthPendingDepth 3
+set_option backward.isDefEq.respectTransparency false
+
 /-!
 # Pairwise non-isomorphism of the irreducibles `L_λ` for distinct dominant weights
 

--- a/EtingofRepresentationTheory/Chapter5/AlgIrrepGLRep.lean
+++ b/EtingofRepresentationTheory/Chapter5/AlgIrrepGLRep.lean
@@ -3,6 +3,15 @@ import EtingofRepresentationTheory.Chapter5.Theorem5_23_2Core
 import EtingofRepresentationTheory.Chapter5.KernelLemmaKPrime
 import EtingofRepresentationTheory.Chapter5.SchurModuleSimple
 
+-- These mirror the lakefile's project-wide `[leanOptions]` so the module also
+-- type-checks under a bare `lake env lean` fresh check (which does not read
+-- lakefile options). `maxSynthPendingDepth 3` clears the deep Schur-module
+-- `asModule`/instance chains; `backward.isDefEq.respectTransparency false`
+-- restores the pre-v4.29 full-transparency `isDefEq` the `charTwistRep`/Schur
+-- carrier defeqs rely on.
+set_option maxSynthPendingDepth 3
+set_option backward.isDefEq.respectTransparency false
+
 /-!
 # `AlgIrrepGLRep`: the `GL_N(k)`-representation structure on `AlgIrrepGL`
 

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_23_2_PeterWeyl.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_23_2_PeterWeyl.lean
@@ -10,6 +10,15 @@ import EtingofRepresentationTheory.Chapter5.RightTranslationHullDecomp
 import EtingofRepresentationTheory.Chapter5.RealizationCoreAnalytic
 import EtingofRepresentationTheory.Chapter5.SchurModuleContragredientHalf
 
+-- These mirror the lakefile's project-wide `[leanOptions]` so the module also
+-- type-checks under a bare `lake env lean` fresh check (which does not read
+-- lakefile options). `maxSynthPendingDepth 3` clears the deep Schur-module
+-- `asModule`/instance chains; `backward.isDefEq.respectTransparency false`
+-- restores the pre-v4.29 full-transparency `isDefEq` the `charTwistRep`/Schur
+-- carrier defeqs rely on.
+set_option maxSynthPendingDepth 3
+set_option backward.isDefEq.respectTransparency false
+
 /-!
 # Theorem 5.23.2(ii): the `GL_n × GL_n`-equivariant Peter-Weyl decomposition
 

--- a/progress/2026-07-23T19-26-41Z_77f430b7.md
+++ b/progress/2026-07-23T19-26-41Z_77f430b7.md
@@ -1,0 +1,56 @@
+## Accomplished
+
+Resolved issue #7534 (fix(Ch5): restore the highest-weight and Peter–Weyl source chain).
+
+Diagnosis: the three files named in the issue
+
+- `Chapter5/AlgIrrepGLRep.lean`
+- `Chapter5/AlgIrrepGLNonIso.lean`
+- `Chapter5/Theorem5_23_2_PeterWeyl.lean`
+
+were **not** mathematically broken. All three compile cleanly under `lake build`
+(the project's CI and source of truth), are sorry-free, and their endpoints
+(`algIrrepGLRep_isSimple`, `algIrrepGLRepρ`, `algIrrepGLRepρ_isSimpleModule`,
+`algIrrepGLRepρ_noniso`, `algIrrepGLRepρ_iso_iff_eq`, `Theorem5_23_2_ii_equivariant`)
+are axiom-clean (`[propext, Classical.choice, Quot.sound]` only).
+
+The failures cited in the issue came from running `lake env lean <file>` **without**
+the lakefile's `[leanOptions]`. This is exactly the spurious-failure mode documented
+in `.claude/skills/lean-formalization/SKILL.md`: a bare `lake env lean` does not read
+`[leanOptions]`, so `maxSynthPendingDepth = 3` and
+`backward.isDefEq.respectTransparency = false` are missing and the Schur-module
+`asModule`/carrier defeqs and deep instance chains fail spuriously.
+
+Fix: declared the two options in-file (after the imports) in each of the three files,
+mirroring the project-wide lakefile settings and the existing per-declaration
+`set_option backward.isDefEq.respectTransparency false` precedent (9 files). This makes
+each module pass a bare `lake env lean` fresh check as well as `lake build`.
+
+Verification (all green):
+- bare `lake env lean` on each of the three files: 0 errors, no sorry/admit.
+- `lake build` of `...Theorem5_23_2_PeterWeyl` (+ deps): success, 8688 jobs.
+- `#print axioms` on all six named endpoints: standard three axioms only.
+
+## Current frontier
+
+#7534 complete. The change is 27 lines total (9 per file), purely `set_option`
+declarations plus an explanatory comment; no mathematical content touched.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. Many open `completeness-audit` issues describe files as
+"no longer rebuilds" based on a bare `lake env lean` check. #7534 turned out to be a
+false positive of that kind. Sibling audit issues may share the same root cause and are
+worth checking against `lake build` before attempting rewrites.
+
+## Next step
+
+For other `fix(ChX): restore ... fresh-buildable` issues, first run
+`lake build EtingofRepresentationTheory.<Module>` and `lake env lean` with
+`-DmaxSynthPendingDepth=3 -Dbackward.isDefEq.respectTransparency=false` before assuming
+real breakage. If `lake build` is clean, the fix is to declare the missing leanOptions
+in-file rather than to rewrite proofs.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7534

Session: `77f430b7-2d44-4533-8166-6709e76a9796`

ed310bdf fix(Ch5 #7534): make the highest-weight/Peter-Weyl chain fresh-buildable

🤖 Prepared with Claude Code