### PR TITLE
Restore the finite-abelian-category equivalence of Theorem 9.6.4

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/Theorem9_6_4.lean
+++ b/EtingofRepresentationTheory/Chapter9/Theorem9_6_4.lean
@@ -115,26 +115,23 @@ instance Etingof.IsProgenerator.full_preadditiveCoyonedaObj
       biproduct.desc (fun i => (f : (P ⟶ X) → (P ⟶ Y)) (biproduct.ι F i ≫ π)) = 0
     rw [biproduct.desc_eq, Preadditive.comp_sum]
     simp_rw [← Category.assoc _ (biproduct.π _ _), ← hlin]
-    -- Now goal is: ∑ j, f((φ ≫ kernel.ι π ≫ π_j) ≫ (ι_j ≫ π)) = 0
-    rw [← map_sum f.hom]
-    -- Goal: f(∑ j, (φ ≫ kernel.ι π ≫ π_j) ≫ (ι_j ≫ π)) = 0
-    -- Factor out common terms from the sum
-    simp_rw [Category.assoc]
-    -- f(φ ≫ ∑ j, (kernel.ι π ≫ π_j ≫ ι_j ≫ π)) = 0
-    -- Goal: f(∑ j, (φ ≫ kernel.ι π ≫ π_j) ≫ (ι_j ≫ π)) = 0
-    -- after simp_rw [Category.assoc]:
-    -- f(φ ≫ ∑ j, kernel.ι π ≫ π_j ≫ ι_j ≫ π) = 0
-    -- But ← Preadditive.comp_sum only pulled out φ.
-    -- The sum under f is ∑ x, φ ≫ kernel.ι π ≫ π_x ≫ ι_x ≫ π
-    -- Use a direct have for the whole argument
-    have key : (∑ x, φ ≫ kernel.ι π ≫ biproduct.π (fun _ : Fin n => P) x ≫
-        biproduct.ι F x ≫ π : P ⟶ X) = 0 := by
-      rw [← Preadditive.comp_sum, ← Preadditive.comp_sum]
+    -- Now goal is: ∑ j, f((φ ≫ kernel.ι π ≫ π_j) ≫ (ι_j ≫ π)) = 0.
+    -- Fold the finite sum into the additive map `f`. We use `map_sum` in term
+    -- mode (`refine … .symm.trans`) rather than `rw`, since the summand type
+    -- `P ⟶ X` and the module carrier `↑((preadditiveCoyonedaObj P).obj X)` are
+    -- only defeq at default transparency, and `rw`'s motive check runs at
+    -- `instances` transparency (which would reject the rewrite).
+    refine (map_sum (ConcreteCategory.hom f) _ Finset.univ).symm.trans ?_
+    -- Goal: f(∑ x, (φ ≫ kernel.ι π ≫ π_x) ≫ (ι_x ≫ π)) = 0
+    have key : (∑ x, ((φ ≫ kernel.ι π) ≫ biproduct.π (fun _ : Fin n => P) x) ≫
+        (biproduct.ι F x ≫ π) : P ⟶ X) = 0 := by
+      simp_rw [Category.assoc, ← Preadditive.comp_sum]
       have : ∑ j : Fin n, biproduct.π F j ≫ biproduct.ι F j ≫ π = π := by
         simp_rw [← Category.assoc]
         rw [← Preadditive.sum_comp, biproduct.total, Category.id_comp]
       rw [this, kernel.condition, comp_zero]
-    rw [key, map_zero]
+    -- `congrArg`/`map_zero` in term mode again avoids the transparency friction.
+    exact (congrArg (ConcreteCategory.hom f) key).trans (map_zero _)
   -- Factor h through π to get g : X → Y with π ≫ g = h
   refine ⟨Abelian.epiDesc π h h_kernel, ?_⟩
   -- Show (preadditiveCoyonedaObj P).map g = f, i.e., ∀ α : P → X, α ≫ g = f(α)
@@ -153,13 +150,18 @@ instance Etingof.IsProgenerator.full_preadditiveCoyonedaObj
     biproduct.desc (fun i => (f : (P ⟶ X) → (P ⟶ Y)) (biproduct.ι F i ≫ π)) = _
   rw [biproduct.desc_eq, Preadditive.comp_sum]
   simp_rw [← Category.assoc _ (biproduct.π _ _), ← hlin]
-  rw [← map_sum f.hom]
-  simp_rw [Category.assoc]
-  rw [← Preadditive.comp_sum]
-  have : ∑ j : Fin n, biproduct.π F j ≫ biproduct.ι F j ≫ π = π := by
-    simp_rw [← Category.assoc]
-    rw [← Preadditive.sum_comp, biproduct.total, Category.id_comp]
-  rw [this]
+  -- As in `h_kernel`, fold the sum into `f` in term mode to avoid the
+  -- `P ⟶ X` / module-carrier transparency mismatch under `rw`.
+  refine (map_sum (ConcreteCategory.hom f) _ Finset.univ).symm.trans ?_
+  -- Goal: f(∑ j, (β ≫ π_j) ≫ (ι_j ≫ π)) = f(β ≫ π) where β = factorThru α π.
+  have key : (∑ j, (Projective.factorThru α π ≫ biproduct.π (fun _ : Fin n => P) j) ≫
+      (biproduct.ι F j ≫ π) : P ⟶ X) = Projective.factorThru α π ≫ π := by
+    simp_rw [Category.assoc, ← Preadditive.comp_sum]
+    have : ∑ j : Fin n, biproduct.π F j ≫ biproduct.ι F j ≫ π = π := by
+      simp_rw [← Category.assoc]
+      rw [← Preadditive.sum_comp, biproduct.total, Category.id_comp]
+    rw [this]
+  exact congrArg (ConcreteCategory.hom f) key
 
 -- Hom(P, X) is finitely generated as an (End P)ᵒᵖ-module when P is a progenerator.
 -- Proof: P^n ↠ X gives Hom(P, P^n) ↠ Hom(P, X) (since P is projective), and
@@ -205,7 +207,12 @@ instance Etingof.IsProgenerator.finite_hom_module
       ({ toFun := fun f => biproduct.lift (fun i => f i)
          map_add' := fun f g => by
            apply biproduct.hom_ext; intro i
-           simp [Preadditive.add_comp, biproduct.lift_π]
+           -- The residual `f i + g i = f i + g i` differs only in the `End P`
+           -- ring-add vs Hom-add instance path (defeq via `End` unfolding). Match
+           -- the project-wide `backward.isDefEq.respectTransparency false` locally so
+           -- `simp` discharges it whether checked via `lake build` or `lake env lean`.
+           set_option backward.isDefEq.respectTransparency false in
+           simp only [Preadditive.add_comp, biproduct.lift_π, Pi.add_apply]
          map_smul' := fun s f => by
            apply biproduct.hom_ext; intro i
            simp only [RingHom.id_apply, biproduct.lift_π]
@@ -263,7 +270,10 @@ private noncomputable def Etingof.freeModuleIsoHom
   right_inv g := by apply biproduct.hom_ext; intro i; simp [biproduct.lift_π]
   map_add' a b := by
     apply biproduct.hom_ext; intro i
-    simp [biproduct.lift_π, MulOpposite.unop_add, Preadditive.add_comp]
+    -- See `map_add'` above: the residual `End P` ring-add vs Hom-add goal is defeq
+    -- via `End` unfolding, so match the project transparency setting locally.
+    set_option backward.isDefEq.respectTransparency false in
+    simp only [biproduct.lift_π, MulOpposite.unop_add, Preadditive.add_comp, Pi.add_apply]
   map_smul' s v := by
     apply biproduct.hom_ext; intro i
     simp only [biproduct.lift_π, RingHom.id_apply]
@@ -276,6 +286,9 @@ private noncomputable def Etingof.freeModuleIsoHom
 -- f.g. (End P is Noetherian), giving (End P)^m → (End P)^n → M → 0.
 -- By fullness, lift to P^m → P^n in C; let X = coker. Then Hom(P, X) ≅ M.
 set_option maxHeartbeats 400000 in
+-- The essential-surjectivity construction chains a free presentation, a fullness
+-- lift, and a cokernel identification; elaborating the whole pipeline exceeds the
+-- default heartbeat budget.
 instance Etingof.IsProgenerator.essSurj_preadditiveCoyonedaObjFG
     {C : Type u} [Category.{v} C]
     [Etingof.IsFiniteAbelianCategory C]
@@ -349,7 +362,7 @@ instance Etingof.IsProgenerator.essSurj_preadditiveCoyonedaObjFG
         change g = βn (α (βm.symm (βm w)))
         simp only [LinearEquiv.symm_apply_apply]
         change g = βn ((LinearMap.ker φ).subtype (ψ w))
-        rw [hw]; simp [Submodule.coe_subtype, LinearEquiv.apply_symm_apply]
+        rw [hw]; simp [LinearEquiv.apply_symm_apply]
       rw [hg_eq, hα'_eq]
       -- goal: π_star (βm w ≫ f) = 0, i.e., (βm w ≫ f) ≫ cokernel.π f = 0
       change (βm w ≫ f) ≫ cokernel.π f = 0

--- a/progress/2026-07-23T19-49-14Z_57142d82.md
+++ b/progress/2026-07-23T19-49-14Z_57142d82.md
@@ -1,0 +1,56 @@
+## Accomplished
+
+Fixed the regression in issue #7505: restored the finite-abelian-category
+equivalence of Theorem 9.6.4 so that `Chapter9/Theorem9_6_4.lean` elaborates
+cleanly again, under both a fresh `lake env lean` check and its `lake build`
+target (and the whole `Chapter9` aggregate, 8650 jobs).
+
+Root cause was Mathlib API drift plus a transparency-sensitive defeq:
+
+- **Coyoneda coercion drift.** ModuleCat morphism coercion now displays as
+  `ConcreteCategory.hom f` rather than `ModuleCat.Hom.hom f`. The fullness proof
+  folded a finite sum into `f` with `rw [← map_sum f.hom]`, whose motive check
+  (run at `instances` transparency) rejected the summands: `P ⟶ X` and the module
+  carrier `↑((preadditiveCoyonedaObj P).obj X)` are only defeq at default
+  transparency. Rewrote both fold sites in term mode
+  (`refine (map_sum (ConcreteCategory.hom f) _ Finset.univ).symm.trans ?_` then
+  `congrArg (ConcreteCategory.hom f) key` / `map_zero`), which checks at default
+  transparency and sidesteps the friction.
+- **End/Hom additive proofs.** Two hand-built `LinearMap.map_add'` obligations
+  reduced to `x = x` where the two `+` differ only by `End P` ring-add vs
+  Preadditive Hom-add (same instance, needs `End` unfolded). `simp`'s closing
+  reflexivity check honors `backward.isDefEq.respectTransparency`, which the
+  project sets to `false` in `lakefile.toml` (applied by `lake build` but not by
+  a bare `lake env lean`). Scoped that same option locally to the two `simp only`
+  calls so both checks discharge the goal identically, with no dead `rfl`.
+- Added the linter-requested comment on the `maxHeartbeats 400000` bump and
+  dropped an unused `Submodule.coe_subtype` simp argument.
+
+No signatures changed; the public chain (`Theorem_9_6_4`, its Noetherian engine,
+and both corollaries producing `C ≌ FGModuleCat (End P)ᵐᵒᵖ`) is intact. No
+`sorry`/`admit`/`axiom` introduced. Updated the two `progress/items.json` tracker
+entries (`Chapter9/Discussion_before_Theorem9.6.4` and `Chapter9/Theorem9.6.4`)
+to full/sorry-free/covered.
+
+## Current frontier
+
+Issue #7505 complete. PR being created.
+
+## Overall project progress
+
+Stage 3 formalization ongoing; this turn resolved one of the "restore importable
+endpoint" regressions. Many sibling regressions remain unclaimed (e.g. #7490
+Proposition 6.6.6, #7491 Example 9.4.4, and the Chapter 4/5 `fix(...)` set).
+
+## Next step
+
+The remaining "restore importable endpoint" regressions likely share the same
+Mathlib coercion / transparency drift; the term-mode `map_sum` fold and the
+locally-scoped `backward.isDefEq.respectTransparency false` are reusable patterns.
+Note that `lake env lean <file>` does NOT apply `lakefile.toml` leanOptions, so a
+file can pass `lake build` yet fail a bare `lake env lean` (and vice versa) on
+transparency-sensitive `simp`/`rw` steps — check both.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -9668,11 +9668,10 @@
       "wave": 1,
       "result": "covered"
     },
-    "fidelity": "partial",
-    "coverage": "covered_partial",
-    "coverage_note": "The equivalence functor setup is source-present, but Theorem9_6_4.lean currently fails fresh elaboration, preventing the setup from rebuilding into the required equivalence; regression #7505.",
-    "coverage_issue": 7505,
-    "last_updated": "2026-07-22"
+    "fidelity": "full",
+    "coverage": "covered",
+    "coverage_note": "The equivalence functor setup is source-present and Theorem9_6_4.lean now elaborates cleanly under both fresh `lake env lean` and its `lake build` target, so the setup rebuilds into the required equivalence; regression #7505 resolved.",
+    "last_updated": "2026-07-23"
   },
   {
     "id": "Chapter9/Theorem9.6.4",
@@ -9682,17 +9681,16 @@
     "end_page": "219",
     "start_line": 7,
     "end_line": 10,
-    "status": "partially_proved",
-    "fidelity": "partial",
+    "status": "proved",
+    "fidelity": "full",
     "needs_statement": false,
-    "notes": "Theorem_9_6_4 has the book-faithful finitely generated-module target and an intended faithful/full/essentially-surjective proof. Its current implementation does not elaborate; see #7505.",
-    "attention_needed": true,
+    "notes": "Theorem_9_6_4 has the book-faithful finitely generated-module target and a faithful/full/essentially-surjective proof, all importable. The over-a-field corollaries derive the Noetherian hypothesis and the finite-dimensional module category.",
+    "attention_needed": false,
     "sorries": 0,
-    "sorry_free": false,
-    "fidelity_note": "The earlier extra-Noetherian-hypothesis gap was repaired, but the current file fails to elaborate in the coyoneda coercions and finite-biproduct additive proofs, so the source-facing equivalence cannot be imported; regression #7505.",
-    "coverage": "covered_partial",
-    "fidelity_issue": 7505,
-    "last_updated": "2026-07-22"
+    "sorry_free": true,
+    "fidelity_note": "The coyoneda coercion and finite-biproduct additive proofs were repaired for current Mathlib (ConcreteCategory.hom coercion and End/Hom transparency), so the source-facing equivalence imports cleanly; regression #7505 resolved.",
+    "coverage": "covered",
+    "last_updated": "2026-07-23"
   },
   {
     "id": "Chapter9/Problem9.6.5",


### PR DESCRIPTION
Closes #7505

Session: `57142d82-6d76-4b7f-84f7-8496b15d3faa`

fced7641 fix(Ch9): restore importable Theorem 9.6.4 equivalence (#7505)

🤖 Prepared with Claude Code