### PR TITLE
fix(Ch5): restore quaternionic-type even-dimension endpoint

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/FrobeniusSchurRealType.lean
+++ b/EtingofRepresentationTheory/Chapter5/FrobeniusSchurRealType.lean
@@ -250,6 +250,11 @@ theorem exists_nonzero_invariant_symmetric_of_FS_eq_one
           Equiv.sum_comp (Equiv.inv G) (fun g => ρ.character (g * g))]
     rw [invOf_eq_inv, smul_eq_mul]
     exact hFS
+  -- `IsProj.trace` needs freeness of the range/kernel; over the field `ℂ` these hold, but
+  -- type-class search does not fire `Module.Free.of_divisionRing` here, so supply it explicitly.
+  haveI : Module.Free ℂ ↥Λ.invariants := Module.Free.of_divisionRing ℂ ↥Λ.invariants
+  haveI : Module.Free ℂ ↥(LinearMap.ker (Representation.averageMap Λ)) :=
+    Module.Free.of_divisionRing ℂ ↥(LinearMap.ker (Representation.averageMap Λ))
   have hP_trace : LinearMap.trace ℂ Bil P = (Module.finrank ℂ Λ.invariants : ℂ) := by
     rw [hPdef]; exact (Λ.isProj_averageMap).trace
   -- the symmetric-part projector `Psym = ½(P + τ P)`, projecting onto symmetric invariants
@@ -276,6 +281,10 @@ theorem exists_nonzero_invariant_symmetric_of_FS_eq_one
       ← two_smul ℂ (Psym C), smul_smul, show (2⁻¹ * 2 : ℂ) = 1 by norm_num, one_smul]
   -- the rank counting: `2 · dim(symmetric invariants) = dim(invariants) + 1`
   have hisproj := (LinearMap.isProj_range_iff_isIdempotentElem Psym).mpr hPsymidem
+  haveI : Module.Free ℂ ↥(LinearMap.range Psym) :=
+    Module.Free.of_divisionRing ℂ ↥(LinearMap.range Psym)
+  haveI : Module.Free ℂ ↥(LinearMap.ker Psym) :=
+    Module.Free.of_divisionRing ℂ ↥(LinearMap.ker Psym)
   have hPsym_trace_eq : LinearMap.trace ℂ Bil Psym
       = (Module.finrank ℂ (LinearMap.range Psym) : ℂ) := hisproj.trace
   have hPsym_trace2 : LinearMap.trace ℂ Bil Psym
@@ -426,6 +435,11 @@ theorem frobeniusSchurIndicator_eq_one_of_isRealType
           Equiv.sum_comp (Equiv.inv G) (fun g => ρ.character (g * g))]
     rw [invOf_eq_inv, smul_eq_mul, Etingof.frobeniusSchurIndicator]
     simp only [Representation.character]
+  -- `IsProj.trace` needs freeness of the range/kernel; over the field `ℂ` these hold, but
+  -- type-class search does not fire `Module.Free.of_divisionRing` here, so supply it explicitly.
+  haveI : Module.Free ℂ ↥Λ.invariants := Module.Free.of_divisionRing ℂ ↥Λ.invariants
+  haveI : Module.Free ℂ ↥(LinearMap.ker (Representation.averageMap Λ)) :=
+    Module.Free.of_divisionRing ℂ ↥(LinearMap.ker (Representation.averageMap Λ))
   have hP_trace : LinearMap.trace ℂ Bil P = (Module.finrank ℂ Λ.invariants : ℂ) := by
     rw [hPdef]; exact (Λ.isProj_averageMap).trace
   -- the symmetric-part projector `Psym = ½(P + τ P)`
@@ -451,6 +465,10 @@ theorem frobeniusSchurIndicator_eq_one_of_isRealType
     rw [Module.End.mul_apply, hPsymapp (Psym C), hPfixPsym C, hτfixPsym C,
       ← two_smul ℂ (Psym C), smul_smul, show (2⁻¹ * 2 : ℂ) = 1 by norm_num, one_smul]
   have hisproj := (LinearMap.isProj_range_iff_isIdempotentElem Psym).mpr hPsymidem
+  haveI : Module.Free ℂ ↥(LinearMap.range Psym) :=
+    Module.Free.of_divisionRing ℂ ↥(LinearMap.range Psym)
+  haveI : Module.Free ℂ ↥(LinearMap.ker Psym) :=
+    Module.Free.of_divisionRing ℂ ↥(LinearMap.ker Psym)
   have hPsym_trace_eq : LinearMap.trace ℂ Bil Psym
       = (Module.finrank ℂ (LinearMap.range Psym) : ℂ) := hisproj.trace
   have hPsym_trace2 : LinearMap.trace ℂ Bil Psym
@@ -484,7 +502,8 @@ theorem frobeniusSchurIndicator_eq_one_of_isRealType
     rw [Submodule.nontrivial_iff_ne_bot]
     intro hbot
     exact hBsne (by simpa using (hbot ▸ hBsmem : (Bs : Bil) ∈ (⊥ : Submodule ℂ Bil)))
-  have hspos : 0 < s := by rw [hs]; exact Module.finrank_pos
+  have hspos : 0 < s := by
+    rw [hs]; exact Module.finrank_pos (R := ℂ) (M := ↥(LinearMap.range Psym))
   -- symmetric invariants sit inside all invariants, so `s ≤ d`
   have hsd_le : s ≤ d := by
     rw [hs, hd]

--- a/progress/2026-07-23T20-19-28Z_25bd01b7.md
+++ b/progress/2026-07-23T20-19-28Z_25bd01b7.md
@@ -1,0 +1,40 @@
+## Accomplished
+
+Fixed the compiler regression in `EtingofRepresentationTheory/Chapter5/FrobeniusSchurRealType.lean`
+(issue #7527). The file no longer elaborated: `IsProj.trace` and `Module.finrank_pos` failed to
+find `Module.Free`/`Nontrivial` instances on the `invariants`, `range Psym`, and kernel submodules.
+
+Root cause: over the field ℂ these submodules are free via the priority-100 instance
+`Module.Free.of_divisionRing`, but type-class search no longer fires it here — a synthesis
+explosion (traced via `set_option trace.Meta.synthInstance`) rather than a genuinely missing
+instance. `Complex.instSemiring` is defeq to the DivisionRing-derived semiring (confirmed by
+`rfl`), and `Module.Free.of_divisionRing ℂ ↥p` typechecks when the module argument is given
+explicitly.
+
+Fix: supply the four `Module.Free` instances explicitly (via `haveI ... := Module.Free.of_divisionRing ℂ ↥p`)
+before each `IsProj.trace` call in both `exists_nonzero_invariant_symmetric_of_FS_eq_one` and
+`frobeniusSchurIndicator_eq_one_of_isRealType`, and pin `Module.finrank_pos`'s `R`/`M` arguments
+so `Nontrivial` is not resolved against a metavariable. `Module.Finite` instances still synthesize
+fine, so no changes there.
+
+## Current frontier
+
+Issue #7527 complete. `lake env lean` on the file is clean (only pre-existing unused-section-variable
+linter warnings, which the reproduction in the issue already showed). `lake build` of the module
+and downstream importers (`Example5_1_3`, `Exercise5_3_3`, `Remark4_5_5`) all succeed. No
+sorry/admit/axiom. Endpoint `even_finrank_of_isQuaternionicType` preserved.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. Many "restore endpoint" regression issues remain open in the queue
+(#7490, #7491, #7531, #7535, #7537–#7548, #7550, #7553–#7564, etc.) — all similar toolchain
+regressions where the tracker claims coverage but a file no longer elaborates.
+
+## Next step
+
+Pick up another restore/regression issue from the queue. The `Module.Free.of_divisionRing` explicit-
+instance pattern here is likely reusable for other Chapter 5 files that trace projectors over ℂ.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7527

Session: `25bd01b7-801d-4a15-97b7-6803766bf556`

5846b1a5 chore: progress entry for #7527 FrobeniusSchurRealType regression fix
8b51580c fix(Ch5): restore Module.Free instances in FrobeniusSchurRealType

🤖 Prepared with Claude Code