### PR TITLE
doc: guard against lake-env-lean false-positive regressions (#7490 not a regression)

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -91,6 +91,17 @@ with `lake build <Module>` before debugging — the on-`main` file fails `lake e
 too. (Some places below still say `lake env lean`; prefer `lake build` when the file uses
 these instances.)
 
+The lakefile *also* drops `weak.backward.isDefEq.respectTransparency = false` under `lake
+env lean`. That option restores pre-v4.29 `isDefEq` transparency, which the
+`addCommGroupOfRing` instance diamonds in the Chapter 6 reflection-functor infrastructure
+(`ReflectionFunctorInfrastructure`, `Proposition6_6_6[_source]`, `Corollary6_8_3`, …) rely
+on; without it, `Module k (DirectSum …)` synthesis (e.g. under `Submodule.Quotient.equiv`)
+fails spuriously. **A "restore/regression" issue whose reproduction is `lake env lean
+<file>` and whose errors are `synthInstanceFailed` / `Module k (DirectSum …)` is very
+likely a false positive — verify the premise with `lake build <Module>` before doing any
+work.** (2026-07: issue #7490 was filed this way; all four files build clean under `lake
+build` and the endpoints are axiom-clean.)
+
 **Two Mathlib lemmas can produce the *same* `1`/`0`/`Pi.single i 1` through *different*
 typeclass paths — `rw` then fails syntactically, `exact` succeeds by defeq.** Classic case
 (cost real iterations in #6597, `Chapter9/Problem9_5_3_PrimitiveIdempotents.lean`):

--- a/progress/2026-07-24T00-58-24Z_0723e650.md
+++ b/progress/2026-07-24T00-58-24Z_0723e650.md
@@ -1,0 +1,53 @@
+## Accomplished
+
+Investigated issue #7490 ("Restore both importable endpoints of Proposition 6.6.6")
+and determined it is **not a regression**. No code change was needed.
+
+Key findings, with evidence posted to the issue and the claim released via
+`coordination skip 7490` with a "close as invalid" directive:
+
+- All four relevant modules build cleanly under `lake build` (CI's method):
+  - `EtingofRepresentationTheory.Chapter6.ReflectionFunctorInfrastructure`
+  - `EtingofRepresentationTheory.Chapter6.Proposition6_6_6`
+  - `EtingofRepresentationTheory.Chapter6.Proposition6_6_6_source`
+  - `EtingofRepresentationTheory.Chapter6.Corollary6_8_3`
+- Endpoints `Etingof.Proposition6_6_6_sink` and `Etingof.Proposition6_6_6_source`
+  exist, are importable, and depend only on `[propext, Classical.choice, Quot.sound]`
+  (no `sorryAx`). Both files contain zero `sorry`/`admit`/`axiom`.
+
+## Current frontier
+
+Root cause of the false positive: the issue's reproduction runs `lake env lean <file>`.
+Bare `lean` does **not** read the lakefile's `leanOptions`, so it drops the project-wide
+`weak.backward.isDefEq.respectTransparency = false`. That option is what restores the
+pre-v4.29 `isDefEq` transparency behavior on which the `addCommGroupOfRing` instance
+diamonds in the reflection-functor infrastructure depend; without it, `Module k (DirectSum …)`
+synthesis fails spuriously (the ~26 "errors").
+
+Conclusive check: adding `set_option backward.isDefEq.respectTransparency false` after the
+imports of `Proposition6_6_6.lean` makes `lake env lean` compile it with **0 errors**.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. #7490 resolved as invalid (skipped → replan with a
+close directive for the planner). No metrics changed; no files modified (experimental
+edits to `ReflectionFunctorInfrastructure.lean` / `Proposition6_6_6.lean` were reverted —
+working tree is clean apart from the pre-existing `.claude/` modifications that were
+present at session start and are unrelated to this work).
+
+## Next step
+
+- A planner should close #7490 as invalid (see the issue comment and skip reason).
+- Re-verify other open "restore …" issues that reproduce failures with `lake env lean <file>`
+  by re-checking with `lake build EtingofRepresentationTheory.<Module>` first. Those whose
+  errors are instance-synthesis / `Module k (DirectSum …)` failures are likely the same false
+  positive. Those whose errors are tactic-level (`rewrite`/`simp`/`constructor` failures — e.g.
+  #7491 Example 9.4.4 looked tactic-level) are more likely genuine and are unaffected by the
+  transparency option.
+- Consider documenting in the worker skill that single-module fresh checks must use
+  `lake build EtingofRepresentationTheory.<Module>`, never `lake env lean <file>` (which
+  omits lakefile `leanOptions`).
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR closes #7490, which is **not a regression**: the two reported endpoints
`Etingof.Proposition6_6_6_sink` and `Etingof.Proposition6_6_6_source` (and the
`ReflectionFunctorInfrastructure` / `Corollary6_8_3` files) already build cleanly under
`lake build` — CI's method — and are axiom-clean (`[propext, Classical.choice, Quot.sound]`,
no `sorryAx`), with zero `sorry`/`admit`/`axiom`.

The issue's reproduction ran `lake env lean <file>`, which does not apply the lakefile's
`[leanOptions]`. In particular it drops `weak.backward.isDefEq.respectTransparency = false`,
the flag that restores pre-v4.29 `isDefEq` transparency; without it the `addCommGroupOfRing`
instance diamonds make `Module k (DirectSum …)` synthesis fail spuriously, producing the
reported errors. Adding that one option back makes the bare `lake env lean` check pass with
zero errors, confirming the diagnosis.

To prevent the same false positive from consuming future sessions, this adds a note to the
`lean-formalization` skill: a restore/regression issue reproduced with `lake env lean <file>`
whose errors are `synthInstanceFailed` / `Module k (DirectSum …)` should be re-verified with
`lake build <Module>` before any work. Also records the session progress file for #7490.

No project Lean sources are changed — none needed changing.

🤖 Prepared with Claude Code
