### PR TITLE
Give a concrete pair of nonisomorphic Morita-equivalent rings for Remark 7.7.4

### DIFF
--- a/EtingofRepresentationTheory/Chapter7.lean
+++ b/EtingofRepresentationTheory/Chapter7.lean
@@ -35,6 +35,7 @@ import EtingofRepresentationTheory.Chapter7.Example7_9_5
 import EtingofRepresentationTheory.Chapter7.Example7_9_6
 import EtingofRepresentationTheory.Chapter7.Exercise7_8_4
 import EtingofRepresentationTheory.Chapter7.Problem7_7_3
+import EtingofRepresentationTheory.Chapter7.Remark7_7_4
 import EtingofRepresentationTheory.Chapter7.Problem7_8_5
 import EtingofRepresentationTheory.Chapter7.Exercise7_9_7
 import EtingofRepresentationTheory.Chapter7.Exercise7_9_8

--- a/EtingofRepresentationTheory/Chapter7/Remark7_7_4.lean
+++ b/EtingofRepresentationTheory/Chapter7/Remark7_7_4.lean
@@ -1,0 +1,65 @@
+import Mathlib.RingTheory.Morita.Matrix
+import EtingofRepresentationTheory.Chapter9.Discussion_after_Definition9_7_1
+
+/-!
+# Remark 7.7.4: the module category does not determine the ring
+
+Etingof's Remark 7.7.4 warns that Definition 7.7.1 (visualizing an abelian category as the
+category of modules over a ring `A`) has a drawback: even when `𝒞` is the whole category
+`A`-mod, the ring `A` is **not** determined by `𝒞`. Two different, nonisomorphic rings can have
+equivalent module categories; such rings are called **Morita equivalent**.
+
+This file records a concrete witness of that phenomenon: `R = ℚ` and its `2 × 2` matrix ring
+`Matrix (Fin 2) (Fin 2) ℚ`.
+
+* Their module categories are equivalent (`nonempty_moduleCat_equiv_matrix`), via Mathlib's
+  `ModuleCat.matrixEquivalence`. This is the positive, Morita-equivalence half.
+* Yet they are not isomorphic as rings (`isEmpty_ringEquiv_matrix`): a ring isomorphism out of
+  the commutative ring `ℚ` would transport commutativity to `Matrix (Fin 2) (Fin 2) ℚ`, which is
+  noncommutative (`Etingof.exists_matrix_not_comm_of_ne`).
+
+`morita_equivalent_not_ringEquiv` packages the two halves as the counterexample asserted by the
+remark. The further philosophical claim of the remark — that many abelian categories admit no
+natural or manageable ring `A` at all — remains prose.
+-/
+
+open CategoryTheory
+
+namespace Etingof
+
+/-- **Remark 7.7.4 (positive half).** `ℚ` and its `2 × 2` matrix ring have equivalent module
+categories, i.e. they are Morita equivalent. This is `ModuleCat.matrixEquivalence` for the index
+`Fin 2` and base ring `ℚ`. -/
+theorem nonempty_moduleCat_equiv_matrix :
+    Nonempty (ModuleCat.{0} ℚ ≌ ModuleCat.{0} (Matrix (Fin 2) (Fin 2) ℚ)) :=
+  ⟨ModuleCat.matrixEquivalence ℚ (0 : Fin 2)⟩
+
+/-- **Remark 7.7.4 (negative half).** There is no ring isomorphism `ℚ ≃+* Matrix (Fin 2) (Fin 2) ℚ`.
+A ring isomorphism out of the commutative ring `ℚ` would make its image commutative, but the matrix
+ring is noncommutative (`Etingof.exists_matrix_not_comm_of_ne`, using the distinct indices `0 ≠ 1`
+in `Fin 2`). -/
+theorem isEmpty_ringEquiv_matrix :
+    IsEmpty (ℚ ≃+* Matrix (Fin 2) (Fin 2) ℚ) := by
+  refine ⟨fun f => ?_⟩
+  obtain ⟨x, y, hxy⟩ :=
+    exists_matrix_not_comm_of_ne (k := ℚ) (m := Fin 2) (a := 0) (b := 1) (by decide)
+  refine hxy ?_
+  -- A ring equivalence transports commutativity of `ℚ` to `Matrix (Fin 2) (Fin 2) ℚ`.
+  have ha : f (f.symm x) = x := f.apply_symm_apply x
+  have hb : f (f.symm y) = y := f.apply_symm_apply y
+  calc
+    x * y = f (f.symm x) * f (f.symm y) := by rw [ha, hb]
+    _ = f (f.symm x * f.symm y) := (f.map_mul _ _).symm
+    _ = f (f.symm y * f.symm x) := by rw [mul_comm]
+    _ = f (f.symm y) * f (f.symm x) := f.map_mul _ _
+    _ = y * x := by rw [ha, hb]
+
+/-- **Remark 7.7.4.** The module category does not determine the ring: `ℚ` and
+`Matrix (Fin 2) (Fin 2) ℚ` have equivalent module categories (they are Morita equivalent) yet are
+not isomorphic as rings. -/
+theorem morita_equivalent_not_ringEquiv :
+    Nonempty (ModuleCat.{0} ℚ ≌ ModuleCat.{0} (Matrix (Fin 2) (Fin 2) ℚ)) ∧
+      IsEmpty (ℚ ≃+* Matrix (Fin 2) (Fin 2) ℚ) :=
+  ⟨nonempty_moduleCat_equiv_matrix, isEmpty_ringEquiv_matrix⟩
+
+end Etingof

--- a/progress/2026-07-24T04-15-00Z_f464b4ff.md
+++ b/progress/2026-07-24T04-15-00Z_f464b4ff.md
@@ -1,0 +1,39 @@
+## Accomplished
+
+Executed feature issue #7470 — "Give a concrete pair of nonisomorphic Morita-equivalent rings
+for Remark 7.7.4".
+
+- Added `EtingofRepresentationTheory/Chapter7/Remark7_7_4.lean` with the concrete counterexample
+  for Remark 7.7.4 (the module category does not determine the ring):
+  - `Etingof.nonempty_moduleCat_equiv_matrix` — `ℚ` and `Matrix (Fin 2) (Fin 2) ℚ` have equivalent
+    module categories, via Mathlib's `ModuleCat.matrixEquivalence`.
+  - `Etingof.isEmpty_ringEquiv_matrix` — no ring isomorphism `ℚ ≃+* Matrix (Fin 2) (Fin 2) ℚ`; a
+    ring iso out of commutative `ℚ` transports commutativity to the matrix ring, contradicting
+    `Etingof.exists_matrix_not_comm_of_ne` (indices `0 ≠ 1` in `Fin 2`).
+  - `Etingof.morita_equivalent_not_ringEquiv` — the two halves packaged together.
+- Registered the file in `EtingofRepresentationTheory/Chapter7.lean`.
+- Updated `progress/items.json` for `Chapter7/Remark7.7.4`: fidelity `partial` → `full`,
+  coverage `covered_partial` → `covered`, refreshed coverage note, dropped `fidelity_issue`.
+
+Sorry-free: `lake build EtingofRepresentationTheory.Chapter7.Remark7_7_4` succeeds and
+`#print axioms Etingof.morita_equivalent_not_ringEquiv` reports only
+`[propext, Classical.choice, Quot.sound]` (no `sorryAx`).
+
+## Current frontier
+
+Issue #7470 complete. PR to follow.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. One more Chapter 7 completeness-audit gap closed (Remark 7.7.4).
+
+## Next step
+
+Open the PR for #7470 and let auto-merge land it. Other unclaimed items remain in the queue;
+note #7645 is blocked until infra PR #7646 lands in main.
+
+## Blockers
+
+None for this item. A universe note for successors: `ModuleCat.matrixEquivalence` produces an
+equivalence whose module-object universes are `max`-ed, so the `Nonempty (…)` statement must pin
+both `ModuleCat.{0}` sides to unify (see the file).

--- a/progress/items.json
+++ b/progress/items.json
@@ -8556,12 +8556,11 @@
     "start_line": 9,
     "end_line": 10,
     "status": "sorry_free",
-    "fidelity": "partial",
+    "fidelity": "full",
     "sorry_free": true,
-    "coverage": "covered_partial",
-    "coverage_note": "Mathlib supplies the matrix-ring module-category equivalence, but the project exposes no combined witness that the equivalent module categories come from nonisomorphic rings; follow-up #7470.",
-    "fidelity_issue": 7470,
-    "last_updated": "2026-07-22"
+    "coverage": "covered",
+    "coverage_note": "Chapter7/Remark7_7_4.lean gives the concrete Morita counterexample: ℚ and Matrix (Fin 2) (Fin 2) ℚ have equivalent module categories (ModuleCat.matrixEquivalence) yet no ring isomorphism (Etingof.exists_matrix_not_comm_of_ne transports commutativity), packaged as Etingof.morita_equivalent_not_ringEquiv. The prose claim that many abelian categories admit no natural ring remains philosophical.",
+    "last_updated": "2026-07-24"
   },
   {
     "id": "Chapter7/Discussion_after_Remark7.7.4",


### PR DESCRIPTION
Closes #7470

Session: `f464b4ff-2333-4faf-8983-d98c436665ed`

a6c18231 feat(Ch7 #7470): concrete nonisomorphic Morita-equivalent rings for Remark 7.7.4

🤖 Prepared with Claude Code