### PR TITLE
Prove the image-preimage subobject correspondence g⁻¹(g P) = P ⊔ ker g (pullback_exists_obj_sup, #7645 split)

### DIFF
--- a/EtingofRepresentationTheory/Infrastructure/HasFiniteLengthSubobject.lean
+++ b/EtingofRepresentationTheory/Infrastructure/HasFiniteLengthSubobject.lean
@@ -156,12 +156,93 @@ theorem map_pullback_obj_inf {X Y : C} (f : X ⟶ Y) [Mono f] (P : Subobject Y) 
   rw [inf_comm, Subobject.inf_def]
   exact (Subobject.inf_eq_map_pullback' (MonoOver.mk f) P).symm
 
+/-- A subobject `Q` lies below `S` as soon as `Q.arrow` becomes zero after composing with the
+cokernel projection of `S.arrow`: in an abelian category `S.arrow` is the kernel of its own
+cokernel, so `Q.arrow` factors through `S.arrow`. -/
+private theorem le_of_arrow_comp_cokernel {X : C} (Q S : Subobject X)
+    (h : Q.arrow ≫ cokernel.π S.arrow = 0) : Q ≤ S :=
+  Subobject.le_of_comm (Abelian.monoLift S.arrow Q.arrow h) (Abelian.monoLift_comp _ _ _)
+
 /-- **Image–pullback correspondence (join).** For an arbitrary morphism `g`, the preimage under
 `g` of the image `g(P)` of a subobject `P` is `P` joined with the kernel of `g`. This is the
 other half of the subobject correspondence used to prove length additivity. -/
 theorem pullback_exists_obj_sup {X Y : C} (g : X ⟶ Y) (P : Subobject X) :
     (Subobject.pullback g).obj ((Subobject.«exists» g).obj P) = P ⊔ kernelSubobject g := by
-  sorry
+  refine le_antisymm ?_ ?_
+  · -- `pullback g (∃_g P) ≤ P ⊔ ker g`.  We show `Q.arrow ≫ cokernel.π S.arrow = 0`.
+    set Q := (Subobject.pullback g).obj ((Subobject.«exists» g).obj P) with hQ
+    set S := P ⊔ kernelSubobject g with hS
+    -- Epi–mono factorisation `g = e ≫ image.ι g`.
+    set e := Limits.factorThruImage g with he
+    have hgfac : e ≫ Limits.image.ι g = g := Limits.image.fac g
+    -- `(ker g).arrow` and `kernel.ι e` both die against `cokernel.π S.arrow`.
+    have hKc : (kernelSubobject g).arrow ≫ cokernel.π S.arrow = 0 := by
+      rw [← Subobject.ofLE_arrow (le_sup_right : kernelSubobject g ≤ S), Category.assoc,
+        cokernel.condition, comp_zero]
+    have hkerc : Limits.kernel.ι e ≫ cokernel.π S.arrow = 0 := by
+      have hkeg : Limits.kernel.ι e ≫ g = 0 := by
+        calc Limits.kernel.ι e ≫ g
+            = (Limits.kernel.ι e ≫ e) ≫ Limits.image.ι g := by rw [Category.assoc, hgfac]
+          _ = 0 := by rw [Limits.kernel.condition, zero_comp]
+      have hfac := kernelSubobject_factors g (Limits.kernel.ι e) hkeg
+      rw [← Subobject.factorThru_arrow (kernelSubobject g) (Limits.kernel.ι e) hfac,
+        Category.assoc, hKc, comp_zero]
+    -- `c̄ : image g ⟶ cokernel S.arrow` with `e ≫ c̄ = cokernel.π S.arrow`.
+    set cbar := Abelian.epiDesc e (cokernel.π S.arrow) hkerc with hcbar
+    have hecbar : e ≫ cbar = cokernel.π S.arrow := Abelian.comp_epiDesc e _ hkerc
+    -- `v : ∃_g P ⟶ image g` with `v ≫ image.ι g = (∃_g P).arrow`.
+    let F' : Limits.MonoFactorisation (P.arrow ≫ g) :=
+      { I := Limits.image g
+        m := Limits.image.ι g
+        e := P.arrow ≫ e
+        fac := by rw [Category.assoc, hgfac] }
+    set v := (Subobject.imageFactorisation g P).isImage.lift F' with hvdef
+    have hv : v ≫ Limits.image.ι g = ((Subobject.«exists» g).obj P).arrow := by
+      have h := (Subobject.imageFactorisation g P).isImage.lift_fac F'
+      rw [Subobject.imageFactorisation_F_m] at h
+      exact h
+    -- The image factorisation of `P.arrow ≫ g` through `∃_g P`, with `F.e` a (strong) epi.
+    set fe := (Subobject.imageFactorisation g P).F.e with hfe
+    have hfefac : fe ≫ ((Subobject.«exists» g).obj P).arrow = P.arrow ≫ g := by
+      have h := (Subobject.imageFactorisation g P).F.fac
+      rw [Subobject.imageFactorisation_F_m] at h
+      exact h
+    haveI : Epi fe := by
+      rw [hfe]
+      haveI : StrongEpi ((Subobject.imageFactorisation g P).F.e) :=
+        Limits.strongEpi_of_strongEpiMonoFactorisation
+          (Classical.choice (Limits.HasStrongEpiMonoFactorisations.has_fac (P.arrow ≫ g)))
+          (Subobject.imageFactorisation g P).isImage
+      infer_instance
+    -- `v ≫ c̄ = 0`: precomposing with the epi `fe` gives `P.arrow ≫ (e ≫ c̄) = P.arrow ≫ π = 0`.
+    have hfev : fe ≫ v = P.arrow ≫ e := by
+      rw [← cancel_mono (Limits.image.ι g), Category.assoc, hv, hfefac, Category.assoc, hgfac]
+    have hvc : v ≫ cbar = 0 := by
+      rw [← cancel_epi fe, comp_zero, ← Category.assoc, hfev, Category.assoc, hecbar,
+        ← Subobject.ofLE_arrow (le_sup_left : P ≤ S), Category.assoc, cokernel.condition,
+        comp_zero]
+    -- Assemble `Q.arrow ≫ cokernel.π S.arrow = 0` using `Q.arrow ≫ e = w ≫ v`.
+    refine le_of_arrow_comp_cokernel Q S ?_
+    set w := Subobject.pullbackπ g ((Subobject.«exists» g).obj P) with hw
+    have hwsq : w ≫ ((Subobject.«exists» g).obj P).arrow = Q.arrow ≫ g :=
+      (Subobject.isPullback g ((Subobject.«exists» g).obj P)).w
+    have hQe : Q.arrow ≫ e = w ≫ v := by
+      rw [← cancel_mono (Limits.image.ι g), Category.assoc, Category.assoc, hv, hwsq, hgfac]
+    calc Q.arrow ≫ cokernel.π S.arrow
+        = Q.arrow ≫ e ≫ cbar := by rw [hecbar]
+      _ = (Q.arrow ≫ e) ≫ cbar := by rw [Category.assoc]
+      _ = (w ≫ v) ≫ cbar := by rw [hQe]
+      _ = w ≫ v ≫ cbar := by rw [Category.assoc]
+      _ = w ≫ 0 := by rw [hvc]
+      _ = 0 := comp_zero
+  · -- `P ⊔ ker g ≤ pullback g (∃_g P)`.
+    refine sup_le ?_ ?_
+    · exact leOfHom ((Subobject.existsPullbackAdj g).unit.app P)
+    · refine Subobject.le_of_comm
+        ((Subobject.isPullback g ((Subobject.«exists» g).obj P)).lift 0
+          (kernelSubobject g).arrow ?_) ?_
+      · rw [zero_comp, kernelSubobject_arrow_comp]
+      · exact (Subobject.isPullback g ((Subobject.«exists» g).obj P)).lift_snd _ _ _
 
 /-- **Modularity of the subobject lattice.** The lattice of subobjects of an object in an abelian
 category is modular. Not currently in Mathlib; needed for the short-exact length-additivity

--- a/progress/2026-07-24T05-44-21Z_1369d5ff.md
+++ b/progress/2026-07-24T05-44-21Z_1369d5ff.md
@@ -1,0 +1,44 @@
+## Accomplished
+Discharged the `pullback_exists_obj_sup` sorry (issue #7653) in
+`EtingofRepresentationTheory/Infrastructure/HasFiniteLengthSubobject.lean`.
+
+Proved, for an arbitrary morphism `g : X ⟶ Y` in an abelian category and a subobject
+`P : Subobject X`:
+`(pullback g).obj ((«exists» g).obj P) = P ⊔ kernelSubobject g`.
+
+Proof (fully categorical, no pseudoelements, no five lemma):
+- **(≥)** `sup_le`: `P ≤ pullback g (∃_g P)` is the unit of `existsPullbackAdj`;
+  `ker g ≤ pullback g (∃_g P)` via `IsPullback.lift 0 (ker g).arrow` (the kernel arrow
+  composes to `0` with `g`).
+- **(≤)** Show `Q.arrow ≫ cokernel.π S.arrow = 0` (`S = P ⊔ ker g`), which gives `Q ≤ S`
+  through the new private helper `le_of_arrow_comp_cokernel` (`Abelian.monoLift`: an
+  abelian subobject is the kernel of its cokernel). To get the zero: factor `g = e ≫ image.ι g`
+  with `e = factorThruImage g` epi; build `c̄ = Abelian.epiDesc e (cokernel.π S.arrow)`
+  (needs `kernel.ι e ≫ cokernel.π S.arrow = 0`, true since `kernel.ι e` factors through
+  `ker g ≤ S`); build `v : ∃_g P ⟶ image g` from the image universal property with
+  `v ≫ image.ι g = (∃_g P).arrow`; the image factorisation epi `fe : P ⟶ ∃_g P`
+  (`StrongEpi` via `strongEpi_of_strongEpiMonoFactorisation`) cancels to give `v ≫ c̄ = 0`;
+  finally `Q.arrow ≫ e = w ≫ v` (from the pullback square, `w = pullbackπ`) yields
+  `Q.arrow ≫ (e ≫ c̄) = 0`.
+
+## Current frontier
+`lake build EtingofRepresentationTheory.Infrastructure.HasFiniteLengthSubobject` succeeds.
+The only remaining `sorry` in the file is `isModularLattice_subobject` (issue #7652), which
+is out of scope for #7653.
+
+## Overall project progress
+Phase 3 formalization ongoing. This closes one of the two `#7645`-split infrastructure
+sorries feeding the `of_shortExact` finite-length bridge. The bridge assembly
+(`finiteDimensionalOrder_subobject_of_hasFiniteLength`) still depends on the modularity
+sorry (#7652).
+
+## Next step
+Claim #7652 (`isModularLattice_subobject`): prove the subobject lattice of an abelian
+category is modular. Note the Frobenius reciprocity theorem
+`CategoryTheory.exists_inf_pullback_eq_exists_inf` (RegularCategory/Basic.lean) is available
+but needs a `Regular C` instance from `Abelian C` (constructible: abelian ⟹ regularEpi=epi,
+epi stable under base change, has coequalizers). A pseudoelement or SES/short-five-lemma
+argument is the alternative.
+
+## Blockers
+None.


### PR DESCRIPTION
Closes #7653

Session: `1369d5ff-f65b-442d-a980-52be8b1a303c`

063bb7ed feat(Infra #7653): prove pullback_exists_obj_sup (image-preimage join correspondence)

🤖 Prepared with Claude Code