### PR TITLE
complete Example 6.2.3: classify the three A2 indecomposables up to isomorphism

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -6311,3 +6311,44 @@ the group in scope when you also need the bundled `Module`/`Module.Finite`. Inst
    for the group-keyed argument by `default`-transparency defeq. For anything messier (positivity),
    factor a standalone helper lemma with plain `[AddCommGroup M] [Module k M] [FiniteDimensional k M]`
    hypotheses and apply it with `@` + explicit `addCommGroupOfRing`.
+
+## Constructing named "representatives" and isomorphisms for classify-up-to-iso tasks (#7404, A₂ quiver)
+
+For completeness-audit issues that upgrade a dimension/invariant *necessary condition* to a
+full "isomorphic to exactly one representative" classification (Examples 6.2.3/6.2.4, 3.5.6,
+Gabriel-style A_n), define a bespoke `Iso` structure (commuting `LinearEquiv`s), the explicit
+representatives, and an `∃!` theorem. Reuse the existing invariant theorem to prove *existence*;
+uniqueness falls out of the representatives having distinct invariants (`Iso.finrank_eq`). Three
+non-obvious traps cost most of the iterations:
+
+1. **The zero object must be universe-floating.** A representation bundles carrier types
+   `Vᵢ : Type*` at independent universes. When you claim `ρ.Iso (rep_ker k)` for an *arbitrary*
+   `ρ`, the representative's zero carrier must unify its universe with `ρ.Vᵢ`. Use `PUnit`
+   (its universe floats), **not** a fixed-universe zero like `Fin 0 → k : Type u_k` — the latter
+   forces `ρ.Vᵢ : Type u_k`, silently destroying generality. `PUnit` has `Module k`,
+   `FiniteDimensional k`, `Module.Free k`, `Subsingleton` at every universe, and
+   `finrank_zero_of_subsingleton` gives its finrank.
+
+2. **Representatives must be `abbrev`, not `def`.** Instance search (`Subsingleton (rep_ker k).V₂`,
+   `Module k (rep_ker k).V₁`) and `finrank_zero_of_subsingleton` only see through a structure
+   projection if the enclosing value is reducible. A plain `def` blocks unfolding and you get
+   `failed to synthesize Subsingleton …`. If you *also* index representatives by `Fin n` via a
+   plain `def rep : Fin n → …`, insert `change Nonempty (ρ.Iso (rep_ker k))` to expose the
+   reducible `abbrev` form before building the `Iso` (the `change`, not `show`, avoids the style
+   linter since it genuinely rewrites the goal).
+
+3. **Build the component equivs inline as structure fields**, e.g.
+   `exact ⟨{ e₁ := (FiniteDimensional.nonempty_linearEquiv_of_finrank_eq proof).some, … }⟩`.
+   A pre-`obtain ⟨e₂⟩ := … (M' := (rep_ker k).V₂)` pins `PUnit`'s floating universe to a *default*
+   (often `0`) that then mismatches the `Iso` field's expected universe (`Type mismatch … sort
+   Type 0 vs Type (max …)`). Letting the field's expected type drive elaboration fixes the universe.
+
+For the "identity" representative `k ≃ k` with map `f`, the intertwiner needs
+`e₂ := fEq.symm.trans e₁` where `fEq := LinearEquiv.ofBijective ρ.f ⟨hinj, hsurj⟩` and
+`hsurj := (LinearMap.injective_iff_surjective_of_finrank_eq_finrank …).mp hinj`; then
+`fEq.symm (ρ.f x) = x` is `fEq.symm_apply_apply x` (uses `fEq x = ρ.f x` definitionally).
+Indecomposability of each representative: reduce a compatible `IsCompl` decomposition to the
+finrank bookkeeping (`Submodule.finrank_add_eq_of_isCompl` + `Submodule.finrank_mono` + `omega`);
+submodules of the zero carrier are `⊥` via a one-line
+`submodule_eq_bot_of_subsingleton` (`eq_bot_iff`; `Subsingleton.elim`), avoiding a fresh
+`finrank (rep_ker k).V₂` that would re-trigger trap 1.

--- a/EtingofRepresentationTheory/Chapter6/Example6_2_3.lean
+++ b/EtingofRepresentationTheory/Chapter6/Example6_2_3.lean
@@ -168,3 +168,192 @@ theorem Etingof.Example_6_2_3 (k : Type*) [Field k] (ρ : A₂Rep k)
       · right; exact hq₁
     right; right; exact ⟨hV₁_dim1, hdim_eq ▸ hV₁_dim1, hf_inj⟩
 
+
+/-!
+## Classification: the three indecomposable representatives
+
+We construct the three canonical indecomposable representations, prove each is
+indecomposable, and prove every indecomposable A₂-representation is isomorphic to
+exactly one of them. This upgrades the dimension-vector necessary condition above to
+a full classification of isomorphism classes.
+-/
+
+open Module
+
+/-- Isomorphism of A₂-representations. -/
+structure A₂Rep.Iso {k : Type*} [Field k] (ρ σ : A₂Rep k) where
+  e₁ : ρ.V₁ ≃ₗ[k] σ.V₁
+  e₂ : ρ.V₂ ≃ₗ[k] σ.V₂
+  comm : ∀ x, e₂ (ρ.f x) = σ.f (e₁ x)
+
+namespace A₂Rep.Iso
+
+/-- The identity isomorphism. -/
+def refl {k : Type*} [Field k] (ρ : A₂Rep k) : ρ.Iso ρ where
+  e₁ := LinearEquiv.refl k ρ.V₁
+  e₂ := LinearEquiv.refl k ρ.V₂
+  comm := fun _ => rfl
+
+/-- The inverse of an isomorphism. -/
+def symm {k : Type*} [Field k] {ρ σ : A₂Rep k} (e : ρ.Iso σ) : σ.Iso ρ where
+  e₁ := e.e₁.symm
+  e₂ := e.e₂.symm
+  comm := fun y => by
+    apply e.e₂.injective
+    rw [e.e₂.apply_symm_apply, e.comm, e.e₁.apply_symm_apply]
+
+/-- Composition of isomorphisms. -/
+def trans {k : Type*} [Field k] {ρ σ τ : A₂Rep k} (e : ρ.Iso σ) (e' : σ.Iso τ) : ρ.Iso τ where
+  e₁ := e.e₁.trans e'.e₁
+  e₂ := e.e₂.trans e'.e₂
+  comm := fun x => by
+    simp only [LinearEquiv.trans_apply]
+    rw [e.comm, e'.comm]
+
+/-- Isomorphic A₂-representations have equal dimensions at both vertices. -/
+lemma finrank_eq {k : Type*} [Field k] {ρ σ : A₂Rep k} (e : ρ.Iso σ) :
+    Module.finrank k ρ.V₁ = Module.finrank k σ.V₁ ∧
+    Module.finrank k ρ.V₂ = Module.finrank k σ.V₂ :=
+  ⟨e.e₁.finrank_eq, e.e₂.finrank_eq⟩
+
+end A₂Rep.Iso
+
+/-- The kernel representative `k → 0`. -/
+abbrev A₂Rep.rep_ker (k : Type*) [Field k] : A₂Rep k where
+  V₁ := k
+  V₂ := PUnit
+  f := 0
+
+/-- The cokernel representative `0 → k`. -/
+abbrev A₂Rep.rep_cok (k : Type*) [Field k] : A₂Rep k where
+  V₁ := PUnit
+  V₂ := k
+  f := 0
+
+/-- The identity representative `k ≃ k`. -/
+abbrev A₂Rep.rep_id (k : Type*) [Field k] : A₂Rep k where
+  V₁ := k
+  V₂ := k
+  f := LinearMap.id
+
+namespace A₂Rep
+
+/-- Every submodule of a subsingleton module is trivial. -/
+theorem submodule_eq_bot_of_subsingleton {k M : Type*} [Field k] [AddCommGroup M] [Module k M]
+    [Subsingleton M] (p : Submodule k M) : p = ⊥ := by
+  rw [eq_bot_iff]; intro x _; rw [Submodule.mem_bot]; exact Subsingleton.elim _ _
+
+/-- The kernel representative `k → 0` is indecomposable. -/
+theorem rep_ker_indecomposable (k : Type*) [Field k] : (rep_ker k).Indecomposable := by
+  refine ⟨Or.inl Module.finrank_pos, ?_⟩
+  intro p₁ q₁ p₂ q₂ hpq₁ _ _ _
+  have hp₂ : p₂ = ⊥ := submodule_eq_bot_of_subsingleton p₂
+  have hq₂ : q₂ = ⊥ := submodule_eq_bot_of_subsingleton q₂
+  have hsum : Module.finrank k p₁ + Module.finrank k q₁ = 1 := by
+    rw [Submodule.finrank_add_eq_of_isCompl hpq₁]; exact finrank_self k
+  rcases Nat.eq_zero_or_pos (Module.finrank k p₁) with h0 | hpos
+  · exact Or.inl ⟨Submodule.finrank_eq_zero.mp h0, hp₂⟩
+  · exact Or.inr ⟨Submodule.finrank_eq_zero.mp (by omega), hq₂⟩
+
+/-- The cokernel representative `0 → k` is indecomposable. -/
+theorem rep_cok_indecomposable (k : Type*) [Field k] : (rep_cok k).Indecomposable := by
+  refine ⟨Or.inr Module.finrank_pos, ?_⟩
+  intro p₁ q₁ p₂ q₂ _ hpq₂ _ _
+  have hp₁ : p₁ = ⊥ := submodule_eq_bot_of_subsingleton p₁
+  have hq₁ : q₁ = ⊥ := submodule_eq_bot_of_subsingleton q₁
+  have hsum : Module.finrank k p₂ + Module.finrank k q₂ = 1 := by
+    rw [Submodule.finrank_add_eq_of_isCompl hpq₂]; exact finrank_self k
+  rcases Nat.eq_zero_or_pos (Module.finrank k p₂) with h0 | hpos
+  · exact Or.inl ⟨hp₁, Submodule.finrank_eq_zero.mp h0⟩
+  · exact Or.inr ⟨hq₁, Submodule.finrank_eq_zero.mp (by omega)⟩
+
+/-- The identity representative `k ≃ k` is indecomposable. -/
+theorem rep_id_indecomposable (k : Type*) [Field k] : (rep_id k).Indecomposable := by
+  refine ⟨Or.inl Module.finrank_pos, ?_⟩
+  intro p₁ q₁ p₂ q₂ hpq₁ hpq₂ hp hq
+  have hsum₁ : Module.finrank k p₁ + Module.finrank k q₁ = 1 := by
+    rw [Submodule.finrank_add_eq_of_isCompl hpq₁]; exact finrank_self k
+  have hsum₂ : Module.finrank k p₂ + Module.finrank k q₂ = 1 := by
+    rw [Submodule.finrank_add_eq_of_isCompl hpq₂]; exact finrank_self k
+  have hp₁₂ : p₁ ≤ p₂ := fun x hx => by simpa using hp x hx
+  have hq₁₂ : q₁ ≤ q₂ := fun x hx => by simpa using hq x hx
+  have hfp : Module.finrank k p₁ ≤ Module.finrank k p₂ := Submodule.finrank_mono hp₁₂
+  have hfq : Module.finrank k q₁ ≤ Module.finrank k q₂ := Submodule.finrank_mono hq₁₂
+  rcases Nat.eq_zero_or_pos (Module.finrank k p₁) with h0 | hpos
+  · refine Or.inl ⟨Submodule.finrank_eq_zero.mp h0, Submodule.finrank_eq_zero.mp (by omega)⟩
+  · refine Or.inr ⟨Submodule.finrank_eq_zero.mp (by omega), Submodule.finrank_eq_zero.mp (by omega)⟩
+
+/-- The three representatives, indexed by `Fin 3`. -/
+def rep (k : Type*) [Field k] : Fin 3 → A₂Rep k
+  | 0 => rep_ker k
+  | 1 => rep_cok k
+  | 2 => rep_id k
+
+/-- Dimension vector of an A₂-representation. -/
+noncomputable def dimvec (k : Type*) [Field k] (σ : A₂Rep k) : ℕ × ℕ :=
+  (Module.finrank k σ.V₁, Module.finrank k σ.V₂)
+
+theorem Iso.dimvec_eq {k : Type*} [Field k] {ρ σ : A₂Rep k} (e : ρ.Iso σ) :
+    dimvec k ρ = dimvec k σ := by
+  obtain ⟨h₁, h₂⟩ := e.finrank_eq
+  simp [dimvec, h₁, h₂]
+
+theorem dimvec_rep_ker (k : Type*) [Field k] : dimvec k (rep_ker k) = (1, 0) := by
+  simp [dimvec, finrank_self, finrank_zero_of_subsingleton]
+
+theorem dimvec_rep_cok (k : Type*) [Field k] : dimvec k (rep_cok k) = (0, 1) := by
+  simp [dimvec, finrank_self, finrank_zero_of_subsingleton]
+
+theorem dimvec_rep_id (k : Type*) [Field k] : dimvec k (rep_id k) = (1, 1) := by
+  simp [dimvec, finrank_self]
+
+/-- The three representatives are indecomposable. -/
+theorem rep_indecomposable (k : Type*) [Field k] (i : Fin 3) : (rep k i).Indecomposable := by
+  fin_cases i
+  · exact rep_ker_indecomposable k
+  · exact rep_cok_indecomposable k
+  · exact rep_id_indecomposable k
+
+/-- Every indecomposable A₂-representation is isomorphic to exactly one of the three
+representatives. This is the full classification of Example 6.2.3. -/
+theorem exists_unique_iso_rep (k : Type*) [Field k] (ρ : A₂Rep k) (hind : ρ.Indecomposable) :
+    ∃! i : Fin 3, Nonempty (ρ.Iso (rep k i)) := by
+  -- Existence, from the dimension-vector classification.
+  have hexists : ∃ i : Fin 3, Nonempty (ρ.Iso (rep k i)) := by
+    rcases Etingof.Example_6_2_3 k ρ hind with ⟨h1, h2⟩ | ⟨h1, h2⟩ | ⟨h1, h2, hinj⟩
+    · refine ⟨0, ?_⟩
+      change Nonempty (ρ.Iso (rep_ker k))
+      exact ⟨{ e₁ := (FiniteDimensional.nonempty_linearEquiv_of_finrank_eq
+                  (by rw [h1]; exact (finrank_self k).symm)).some,
+               e₂ := (FiniteDimensional.nonempty_linearEquiv_of_finrank_eq
+                  (by rw [h2]; exact finrank_zero_of_subsingleton.symm)).some,
+               comm := fun _ => Subsingleton.elim _ _ }⟩
+    · refine ⟨1, ?_⟩
+      change Nonempty (ρ.Iso (rep_cok k))
+      haveI hsub : Subsingleton ρ.V₁ := Module.finrank_zero_iff.mp h1
+      exact ⟨{ e₁ := (FiniteDimensional.nonempty_linearEquiv_of_finrank_eq
+                  (by rw [h1]; exact finrank_zero_of_subsingleton.symm)).some,
+               e₂ := (FiniteDimensional.nonempty_linearEquiv_of_finrank_eq
+                  (by rw [h2]; exact (finrank_self k).symm)).some,
+               comm := fun x => by rw [Subsingleton.elim x 0]; simp }⟩
+    · refine ⟨2, ?_⟩
+      change Nonempty (ρ.Iso (rep_id k))
+      obtain ⟨e₁⟩ := FiniteDimensional.nonempty_linearEquiv_of_finrank_eq
+        (R := k) (M := ρ.V₁) (M' := (rep_id k).V₁) (by rw [h1]; exact (finrank_self k).symm)
+      have hsurj := (LinearMap.injective_iff_surjective_of_finrank_eq_finrank
+        (by rw [h1, h2])).mp hinj
+      let fEq : ρ.V₁ ≃ₗ[k] ρ.V₂ := LinearEquiv.ofBijective ρ.f ⟨hinj, hsurj⟩
+      refine ⟨{ e₁ := e₁, e₂ := fEq.symm.trans e₁, comm := fun x => ?_ }⟩
+      have hfx : fEq.symm (ρ.f x) = x := fEq.symm_apply_apply x
+      simp only [LinearEquiv.trans_apply, hfx]
+      rfl
+  obtain ⟨i, hi⟩ := hexists
+  refine ⟨i, hi, fun j hj => ?_⟩
+  -- Uniqueness: two representatives isomorphic to ρ are isomorphic, hence equal dimvec.
+  obtain ⟨ei⟩ := hi
+  obtain ⟨ej⟩ := hj
+  have hdv : dimvec k (rep k j) = dimvec k (rep k i) := (ej.symm.trans ei).dimvec_eq
+  fin_cases i <;> fin_cases j <;>
+    simp_all [rep, dimvec_rep_ker, dimvec_rep_cok, dimvec_rep_id]
+
+end A₂Rep

--- a/progress/2026-07-24T06-23-29Z_ba26fc58.md
+++ b/progress/2026-07-24T06-23-29Z_ba26fc58.md
@@ -1,0 +1,50 @@
+## Accomplished
+
+Completed issue #7404 (Example 6.2.3: classify the three A₂ indecomposables up to
+isomorphism). The file previously proved only a necessary condition on the dimension
+vector of an assumed indecomposable `A₂Rep`. Added the full classification:
+
+- `A₂Rep.Iso`: isomorphisms of A₂-representations (a commuting pair of `LinearEquiv`s),
+  with `refl`/`symm`/`trans` and `finrank_eq`/`dimvec_eq` invariants.
+- The three canonical representatives `A₂Rep.rep_ker` (k → 0), `A₂Rep.rep_cok` (0 → k),
+  `A₂Rep.rep_id` (k ≅ k), packaged as `A₂Rep.rep : Fin 3 → A₂Rep k`.
+- `rep_ker_indecomposable`, `rep_cok_indecomposable`, `rep_id_indecomposable`, and
+  `rep_indecomposable` proving each representative is indecomposable.
+- `A₂Rep.exists_unique_iso_rep`: every indecomposable A₂-representation is isomorphic to
+  **exactly one** of the three representatives (`∃!`). Existence reuses the retained
+  dimension-vector theorem `Etingof.Example_6_2_3`; uniqueness follows from the distinct
+  dimension vectors of the representatives.
+- Helper `submodule_eq_bot_of_subsingleton`.
+
+Retained the original `Etingof.Example_6_2_3` (now used as a lemma for existence) and
+updated the Chapter 6 coverage verdict to point at the new classification decl.
+
+## Current frontier
+
+Issue #7404 fully done; PR being created.
+
+## Overall project progress
+
+Stage 3.7 completeness-audit fixes ongoing. Many similar "classify up to isomorphism"
+issues remain unclaimed (e.g. #7402 A3 orientation, #7419 Example 3.5.6, #7404's siblings).
+
+## Next step
+
+Pick up another completeness-audit feature issue (e.g. #7402 Example 6.2.4, which is the
+A₃ analogue and can reuse this A₂ `Iso`/representative pattern).
+
+## Blockers
+
+None. Build is clean (`lake build EtingofRepresentationTheory.Chapter6` succeeds, no new
+`sorry`/axioms). Only pre-existing `push_neg` deprecation warnings remain in the file.
+
+## Key patterns discovered
+
+- The zero object for a representative must use a **universe-floating** type (`PUnit`) so
+  its universe can unify with an arbitrary target `ρ.Vᵢ`; a fixed-universe zero
+  (`Fin 0 → k : Type u_k`) would wrongly constrain `ρ`.
+- Representatives are `abbrev` so structure-projection instances (`Subsingleton`,
+  `Module`) resolve through them; a plain `def` (`A₂Rep.rep`) needs a `change ... rep_ker`
+  step to expose the reducible form before building an `Iso`.
+- Build equivs **inline as structure fields** (not via a pre-`obtain`) so the field's
+  expected type pins the floating universe consistently.

--- a/progress/coverage-audit/verdicts-Chapter6.json
+++ b/progress/coverage-audit/verdicts-Chapter6.json
@@ -36,9 +36,9 @@
   },
   {
     "id": "Chapter6/Example6.2.3",
-    "lean_decl": "Etingof.Example_6_2_3",
+    "lean_decl": "A₂Rep.exists_unique_iso_rep",
     "verdict": "verified",
-    "reason": "Every indecomposable A2-rep (structure V1 -f-> V2) has dim vector in {(1,0),(0,1),(1,1 with f injective)}. Matches the book's three indecomposables 1->0, 0->1, 1~1. Indecomposability defined faithfully via compatible IsCompl decompositions.",
+    "reason": "Full classification now formalized. A₂Rep.exists_unique_iso_rep proves every indecomposable A₂-representation is isomorphic to exactly one of the three explicit representatives rep_ker (1→0), rep_cok (0→1), rep_id (1≅1) via A₂Rep.Iso; each is proved indecomposable (rep_indecomposable) and the three are pairwise nonisomorphic (distinct dimvec). The earlier dimension-vector necessary condition Etingof.Example_6_2_3 is retained and used to prove existence.",
     "dropped_conjunct": null
   },
   {


### PR DESCRIPTION
Closes #7404

Session: `ba26fc58-5019-492a-8a43-c027147b5176`

61275601 feat(Ch6 #7404): classify the three A₂ indecomposables up to isomorphism

🤖 Prepared with Claude Code