### PR TITLE
feat(Ch4 #7433): generalize Corollary 4.2.4 to alg-closed char-0 k

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Corollary4_2_4.lean
+++ b/EtingofRepresentationTheory/Chapter4/Corollary4_2_4.lean
@@ -3,32 +3,41 @@ import Mathlib
 /-!
 # Corollary 4.2.4: Representations Determined by Characters
 
-If k has characteristic 0, any finite dimensional representation of G is determined
-by its character: χ_V = χ_W implies V ≅ W.
+Following the book-wide convention, `k` is an algebraically closed field. If `k` has
+characteristic zero, then any finite dimensional representation of a finite group `G` is
+determined by its character: `χ_V = χ_W` implies `V ≅ W`.
+
+The argument is carried out over an arbitrary algebraically closed characteristic-zero field
+`k`, matching the source hypotheses. `Etingof.Corollary4_2_4_complex` records the classical
+special case `k = ℂ`.
 -/
 
 open FDRep CategoryTheory CategoryTheory.Limits Module
 
+variable {k : Type} [Field k] [IsAlgClosed k] [CharZero k]
+
+omit [IsAlgClosed k] in
 /-- Equal characters ⟹ equal Hom-space dimensions from any S. -/
 private lemma hom_finrank_eq_of_char_eq
     {G : Type} [Group G] [Fintype G]
-    (V W : FDRep ℂ G)
+    (V W : FDRep k G)
     (h : FDRep.character V = FDRep.character W)
-    (S : FDRep ℂ G) :
-    finrank ℂ (S ⟶ V) = finrank ℂ (S ⟶ W) := by
-  have : Invertible (Fintype.card G : ℂ) :=
+    (S : FDRep k G) :
+    finrank k (S ⟶ V) = finrank k (S ⟶ W) := by
+  have : Invertible (Fintype.card G : k) :=
     invertibleOfNonzero (Nat.cast_ne_zero.mpr Fintype.card_ne_zero)
   have h1 := scalar_product_char_eq_finrank_equivariant S V
   have h2 := scalar_product_char_eq_finrank_equivariant S W
   rw [h] at h1
   exact_mod_cast h1.symm.trans h2
 
+omit [IsAlgClosed k] in
 /-- Equal characters imply equal dimension. -/
 private lemma finrank_eq_of_char_eq
     {G : Type} [Group G] [Fintype G]
-    (V W : FDRep ℂ G)
+    (V W : FDRep k G)
     (h : FDRep.character V = FDRep.character W) :
-    finrank ℂ V = finrank ℂ W := by
+    finrank k V = finrank k W := by
   have h1 := FDRep.char_one V
   have h2 := FDRep.char_one W
   have h3 := congr_fun h 1
@@ -37,8 +46,8 @@ private lemma finrank_eq_of_char_eq
 /-- In a preadditive k-linear category, Hom into a biproduct decomposes as a product. -/
 private noncomputable def homBiprodLinearEquiv
     {G : Type} [Group G] [Fintype G]
-    (T X Y : FDRep ℂ G) [HasBinaryBiproduct X Y] :
-    (T ⟶ X ⊞ Y) ≃ₗ[ℂ] (T ⟶ X) × (T ⟶ Y) where
+    (T X Y : FDRep k G) [HasBinaryBiproduct X Y] :
+    (T ⟶ X ⊞ Y) ≃ₗ[k] (T ⟶ X) × (T ⟶ Y) where
   toFun f := (f ≫ biprod.fst, f ≫ biprod.snd)
   map_add' f g := by simp
   map_smul' r f := by simp
@@ -49,18 +58,20 @@ private noncomputable def homBiprodLinearEquiv
     rw [Category.assoc, Category.assoc, ← Preadditive.comp_add, biprod.total, Category.comp_id]
   right_inv p := by simp
 
+omit [IsAlgClosed k] [CharZero k] in
 private lemma finrank_hom_biprod_eq
     {G : Type} [Group G] [Fintype G]
-    (T X Y : FDRep ℂ G) [HasBinaryBiproduct X Y] :
-    finrank ℂ (T ⟶ X ⊞ Y) = finrank ℂ (T ⟶ X) + finrank ℂ (T ⟶ Y) := by
+    (T X Y : FDRep k G) [HasBinaryBiproduct X Y] :
+    finrank k (T ⟶ X ⊞ Y) = finrank k (T ⟶ X) + finrank k (T ⟶ Y) := by
   rw [← finrank_prod]
   exact LinearEquiv.finrank_eq (homBiprodLinearEquiv T X Y)
 
-/-- In FDRep ℂ G, Hom dimensions are preserved by isomorphism in the target. -/
+omit [IsAlgClosed k] [CharZero k] in
+/-- In FDRep k G, Hom dimensions are preserved by isomorphism in the target. -/
 private lemma finrank_hom_iso
     {G : Type} [Group G] [Fintype G]
-    (T V W : FDRep ℂ G) (φ : V ≅ W) :
-    finrank ℂ (T ⟶ V) = finrank ℂ (T ⟶ W) :=
+    (T V W : FDRep k G) (φ : V ≅ W) :
+    finrank k (T ⟶ V) = finrank k (T ⟶ W) :=
   LinearEquiv.finrank_eq
     { toFun := fun f => f ≫ φ.hom
       map_add' := fun f g => by simp
@@ -69,18 +80,20 @@ private lemma finrank_hom_iso
       left_inv := fun f => by simp
       right_inv := fun f => by simp }
 
+omit [IsAlgClosed k] [CharZero k] in
 /-- finrank is preserved by FDRep isomorphisms. -/
 private lemma finrank_iso
     {G : Type} [Group G] [Fintype G]
-    (V W : FDRep ℂ G) (φ : V ≅ W) :
-    finrank ℂ V = finrank ℂ W :=
+    (V W : FDRep k G) (φ : V ≅ W) :
+    finrank k V = finrank k W :=
   LinearEquiv.finrank_eq (FDRep.isoToLinearEquiv φ)
 
+omit [IsAlgClosed k] [CharZero k] in
 /-- finrank of a biproduct in FDRep equals the sum of finranks. -/
 private lemma finrank_biprod
     {G : Type} [Group G] [Fintype G]
-    (X Y : FDRep ℂ G) [HasBinaryBiproduct X Y] :
-    finrank ℂ (X ⊞ Y : FDRep ℂ G) = finrank ℂ X + finrank ℂ Y := by
+    (X Y : FDRep k G) [HasBinaryBiproduct X Y] :
+    finrank k (X ⊞ Y : FDRep k G) = finrank k X + finrank k Y := by
   rw [← finrank_prod]
   apply LinearEquiv.finrank_eq
   refine {
@@ -92,15 +105,15 @@ private lemma finrank_biprod
                         (biprod.inr : Y ⟶ X ⊞ Y).hom.hom.hom p.2
     left_inv := fun v => by
       show ((biprod.fst ≫ biprod.inl + biprod.snd ≫ biprod.inr :
-        (X ⊞ Y : FDRep ℂ G) ⟶ (X ⊞ Y))).hom.hom.hom v = v
+        (X ⊞ Y : FDRep k G) ⟶ (X ⊞ Y))).hom.hom.hom v = v
       rw [biprod.total]; rfl
     right_inv := fun p => by
-      have hzero : ∀ (A B : FDRep ℂ G) (x : A.V), (0 : A ⟶ B).hom.hom.hom x = 0 := by
+      have hzero : ∀ (A B : FDRep k G) (x : A.V), (0 : A ⟶ B).hom.hom.hom x = 0 := by
         intro A B x
         show (0 : A.V.obj ⟶ B.V.obj).hom x = 0
-        change (0 : A.V.obj →ₗ[ℂ] B.V.obj) x = 0
+        change (0 : A.V.obj →ₗ[k] B.V.obj) x = 0
         exact LinearMap.zero_apply x
-      have hid : ∀ (A : FDRep ℂ G) (x : A.V), (𝟙 A : A ⟶ A).hom.hom.hom x = x := fun _ _ => rfl
+      have hid : ∀ (A : FDRep k G) (x : A.V), (𝟙 A : A ⟶ A).hom.hom.hom x = x := fun _ _ => rfl
       ext <;> dsimp only
       · change ((biprod.fst : X ⊞ Y ⟶ X)).hom.hom.hom
             ((biprod.inl : X ⟶ X ⊞ Y).hom.hom.hom p.1 +
@@ -117,48 +130,51 @@ private lemma finrank_biprod
              ((biprod.inr ≫ biprod.snd : Y ⟶ Y)).hom.hom.hom p.2 = p.2
         rw [biprod.inl_snd, biprod.inr_snd, hzero, hid, zero_add] }
 
+omit [IsAlgClosed k] [CharZero k] in
 /-- Zero case: if V is zero and all Hom dimensions match, then W is also zero. -/
 private lemma iso_of_hom_finrank_eq_zero
     {G : Type} [Group G] [Fintype G]
-    (V W : FDRep ℂ G)
+    (V W : FDRep k G)
     (hV0 : IsZero V)
-    (h : ∀ S : FDRep ℂ G, finrank ℂ (S ⟶ V) = finrank ℂ (S ⟶ W)) :
+    (h : ∀ S : FDRep k G, finrank k (S ⟶ V) = finrank k (S ⟶ W)) :
     Nonempty (V ≅ W) := by
   have hWV : Subsingleton (W ⟶ V) := ⟨fun f g => hV0.eq_of_tgt f g⟩
-  have h1 : finrank ℂ (W ⟶ V) = 0 := Module.finrank_zero_of_subsingleton
-  have h2 : finrank ℂ (W ⟶ W) = 0 := by rw [← h W]; exact h1
+  have h1 : finrank k (W ⟶ V) = 0 := Module.finrank_zero_of_subsingleton
+  have h2 : finrank k (W ⟶ W) = 0 := by rw [← h W]; exact h1
   have hWW : Subsingleton (W ⟶ W) := Module.finrank_zero_iff.mp h2
   have hW : IsZero W := by
     rw [IsZero.iff_id_eq_zero]
     exact Subsingleton.eq_zero _
   exact ⟨hV0.iso hW⟩
 
+omit [CharZero k] in
 /-- Simple FDRep objects have positive finrank. -/
 private lemma finrank_pos_of_simple
     {G : Type} [Group G] [Fintype G]
-    (S : FDRep ℂ G) [Simple S] : 0 < finrank ℂ S := by
+    (S : FDRep k G) [Simple S] : 0 < finrank k S := by
   by_contra h
   push_neg at h
-  have h0 : finrank ℂ S = 0 := Nat.eq_zero_of_le_zero h
-  have hSS : finrank ℂ (S ⟶ S) = 1 := by
+  have h0 : finrank k S = 0 := Nat.eq_zero_of_le_zero h
+  have hSS : finrank k (S ⟶ S) = 1 := by
     rw [FDRep.finrank_hom_simple_simple]; simp
   have hsub : Subsingleton S := Module.finrank_zero_iff.mp h0
   have hsub2 : Subsingleton (S ⟶ S) := by
     constructor; intro f g
     exact Action.Hom.ext (FGModuleCat.hom_ext (LinearMap.ext (fun x => hsub.elim _ _)))
-  have : finrank ℂ (S ⟶ S) = 0 := Module.finrank_zero_of_subsingleton
+  have : finrank k (S ⟶ S) = 0 := Module.finrank_zero_of_subsingleton
   omega
 
-/-- In FDRep ℂ G (semisimple by Maschke), any nonzero morphism from a simple object
+omit [IsAlgClosed k] in
+/-- In FDRep k G (semisimple by Maschke), any nonzero morphism from a simple object
 is mono and splits: if f : S ⟶ W is nonzero with S simple, then W ≅ S ⊞ W'. -/
 private lemma biprod_of_nonzero_from_simple
     {G : Type} [Group G] [Fintype G]
-    (S W : FDRep ℂ G) [Simple S] (f : S ⟶ W) (hf : f ≠ 0) :
-    ∃ (W' : FDRep ℂ G), Nonempty (W ≅ S ⊞ W') := by
+    (S W : FDRep k G) [Simple S] (f : S ⟶ W) (hf : f ≠ 0) :
+    ∃ (W' : FDRep k G), Nonempty (W ≅ S ⊞ W') := by
   -- f is mono since S is simple and f ≠ 0
   haveI : Mono f := mono_of_nonzero_from_simple hf
   -- S is Injective by Maschke's theorem, so f is a split mono
-  haveI : NeZero (Nat.card G : ℂ) := ⟨Nat.cast_ne_zero.mpr Nat.card_pos.ne'⟩
+  haveI : NeZero (Nat.card G : k) := ⟨Nat.cast_ne_zero.mpr Nat.card_pos.ne'⟩
   haveI : Injective S := inferInstance
   haveI : IsSplitMono f := IsSplitMono.mk' ⟨Injective.factorThru (𝟙 S) f, Injective.comp_factorThru (𝟙 S) f⟩
   -- FDRep is abelian, so f has a cokernel
@@ -170,10 +186,11 @@ private lemma biprod_of_nonzero_from_simple
     HasBinaryBiproduct.mk ⟨bc, hbl⟩
   exact ⟨cokernel f, ⟨biprod.uniqueUpToIso S (cokernel f) hbl⟩⟩
 
+omit [IsAlgClosed k] [CharZero k] in
 /-- A split mono in FDRep gives a biproduct decomposition with the cokernel. -/
 private lemma biprod_of_split_mono
     {G : Type} [Group G] [Fintype G]
-    (Y V : FDRep ℂ G) (f : Y ⟶ V) [Mono f] [IsSplitMono f] :
+    (Y V : FDRep k G) (f : Y ⟶ V) [Mono f] [IsSplitMono f] :
     Nonempty (V ≅ Y ⊞ cokernel f) := by
   have hcok := cokernelIsCokernel f
   let bc := binaryBiconeOfIsSplitMonoOfCokernel hcok
@@ -182,20 +199,21 @@ private lemma biprod_of_split_mono
     HasBinaryBiproduct.mk ⟨bc, hbl⟩
   exact ⟨biprod.uniqueUpToIso Y (cokernel f) hbl⟩
 
-/-- In FDRep ℂ G (semisimple by Maschke), any nonzero object has a simple direct summand. -/
+omit [IsAlgClosed k] in
+/-- In FDRep k G (semisimple by Maschke), any nonzero object has a simple direct summand. -/
 private lemma exists_simple_biprod
     {G : Type} [Group G] [Fintype G]
-    (V : FDRep ℂ G) (hV : ¬IsZero V) :
-    ∃ (S V' : FDRep ℂ G), Simple S ∧ Nonempty (V ≅ S ⊞ V') := by
+    (V : FDRep k G) (hV : ¬IsZero V) :
+    ∃ (S V' : FDRep k G), Simple S ∧ Nonempty (V ≅ S ⊞ V') := by
   -- Helper: zero finrank implies IsZero
-  have isZero_of_finrank_zero : ∀ (W : FDRep ℂ G), finrank ℂ W = 0 → IsZero W := by
+  have isZero_of_finrank_zero : ∀ (W : FDRep k G), finrank k W = 0 → IsZero W := by
     intro W h0; rw [IsZero.iff_id_eq_zero]
     have hsub : Subsingleton W := Module.finrank_zero_iff.mp h0
     exact Action.Hom.ext (FGModuleCat.hom_ext (LinearMap.ext (fun x => hsub.elim _ _)))
-  haveI : NeZero (Nat.card G : ℂ) := ⟨Nat.cast_ne_zero.mpr Nat.card_pos.ne'⟩
+  haveI : NeZero (Nat.card G : k) := ⟨Nat.cast_ne_zero.mpr Nat.card_pos.ne'⟩
   -- Strong induction on finrank
-  suffices key : ∀ (n : ℕ) (V : FDRep ℂ G), ¬IsZero V → finrank ℂ V ≤ n →
-      ∃ (S V' : FDRep ℂ G), Simple S ∧ Nonempty (V ≅ S ⊞ V') from
+  suffices key : ∀ (n : ℕ) (V : FDRep k G), ¬IsZero V → finrank k V ≤ n →
+      ∃ (S V' : FDRep k G), Simple S ∧ Nonempty (V ≅ S ⊞ V') from
     key _ V hV le_rfl
   intro n
   induction n with
@@ -212,7 +230,7 @@ private lemma exists_simple_biprod
       obtain ⟨V', ⟨φ⟩⟩ := biprod_of_nonzero_from_simple V V (𝟙 V) hid
       exact ⟨V, V', hS, ⟨φ⟩⟩
     · -- V is not simple: extract a nonzero non-iso mono
-      have h_exists : ∃ (Y : FDRep ℂ G) (f : Y ⟶ V), Mono f ∧ f ≠ 0 ∧ ¬IsIso f := by
+      have h_exists : ∃ (Y : FDRep k G) (f : Y ⟶ V), Mono f ∧ f ≠ 0 ∧ ¬IsIso f := by
         by_contra h_all
         apply hS
         refine ⟨fun {Y} f _ => ⟨?_, ?_⟩⟩
@@ -237,17 +255,17 @@ private lemma exists_simple_biprod
       -- Y is nonzero
       have hY : ¬IsZero Y := fun hY0 => hfne (hY0.eq_of_src f 0)
       -- cokernel f is nonzero (otherwise f is epi, mono+epi → iso in abelian category)
-      have hcok_nz : ¬IsZero (cokernel f : FDRep ℂ G) := by
+      have hcok_nz : ¬IsZero (cokernel f : FDRep k G) := by
         intro hcok0
         haveI : Epi f := (Preadditive.epi_iff_isZero_cokernel f).mpr hcok0
         exact hfni (isIso_of_mono_of_epi f)
       -- finrank Y ≤ n
-      have hfr_eq : finrank ℂ V = finrank ℂ Y + finrank ℂ (cokernel f : FDRep ℂ G) :=
+      have hfr_eq : finrank k V = finrank k Y + finrank k (cokernel f : FDRep k G) :=
         by rw [finrank_iso V (Y ⊞ cokernel f) iso_V, finrank_biprod]
-      have hcok_pos : 0 < finrank ℂ (cokernel f : FDRep ℂ G) := by
+      have hcok_pos : 0 < finrank k (cokernel f : FDRep k G) := by
         by_contra h; push_neg at h
         exact hcok_nz (isZero_of_finrank_zero _ (Nat.eq_zero_of_le_zero h))
-      have hY_le : finrank ℂ Y ≤ n := by omega
+      have hY_le : finrank k Y ≤ n := by omega
       -- By induction, Y has a simple summand
       obtain ⟨S, Y', hSS, ⟨ψ⟩⟩ := ih Y hY hY_le
       -- V ≅ Y ⊞ cok ≅ (S ⊞ Y') ⊞ cok ≅ S ⊞ (Y' ⊞ cok)
@@ -255,18 +273,18 @@ private lemma exists_simple_biprod
         ⟨iso_V.trans ((biprod.mapIso ψ (Iso.refl _)).trans
           (biprod.associator S Y' (cokernel f)))⟩⟩
 
-/-- In a semisimple category (FDRep ℂ G), objects with equal Hom-space dimensions
+/-- In a semisimple category (FDRep k G), objects with equal Hom-space dimensions
 from every object are isomorphic. This is the categorical core: it uses semisimplicity
 (Maschke) and Schur's lemma to match simple constituents. -/
 private lemma iso_of_hom_finrank_eq
     {G : Type} [Group G] [Fintype G]
-    (V W : FDRep ℂ G)
-    (h : ∀ S : FDRep ℂ G, finrank ℂ (S ⟶ V) = finrank ℂ (S ⟶ W)) :
+    (V W : FDRep k G)
+    (h : ∀ S : FDRep k G, finrank k (S ⟶ V) = finrank k (S ⟶ W)) :
     Nonempty (V ≅ W) := by
-  -- Strong induction on finrank ℂ V.
-  suffices key : ∀ (n : ℕ) (V W : FDRep ℂ G),
-      finrank ℂ V ≤ n →
-      (∀ S : FDRep ℂ G, finrank ℂ (S ⟶ V) = finrank ℂ (S ⟶ W)) →
+  -- Strong induction on finrank k V.
+  suffices key : ∀ (n : ℕ) (V W : FDRep k G),
+      finrank k V ≤ n →
+      (∀ S : FDRep k G, finrank k (S ⟶ V) = finrank k (S ⟶ W)) →
       Nonempty (V ≅ W) from
     key _ V W le_rfl h
   intro n
@@ -277,9 +295,9 @@ private lemma iso_of_hom_finrank_eq
     · exact iso_of_hom_finrank_eq_zero V W hV h
     · obtain ⟨S, V', hS, ⟨φ⟩⟩ := exists_simple_biprod V hV
       haveI := hS
-      have : finrank ℂ V = 0 := Nat.eq_zero_of_le_zero hVn
-      have : 0 < finrank ℂ S := finrank_pos_of_simple S
-      have : finrank ℂ S ≤ finrank ℂ V := by
+      have : finrank k V = 0 := Nat.eq_zero_of_le_zero hVn
+      have : 0 < finrank k S := finrank_pos_of_simple S
+      have : finrank k S ≤ finrank k V := by
         rw [finrank_iso V (S ⊞ V') φ, finrank_biprod]
         omega
       omega
@@ -289,41 +307,50 @@ private lemma iso_of_hom_finrank_eq
     · exact iso_of_hom_finrank_eq_zero V W hV h
     · obtain ⟨S, V', hS, ⟨φ⟩⟩ := exists_simple_biprod V hV
       haveI : Simple S := hS
-      have hV_decomp : ∀ T, finrank ℂ (T ⟶ V) = finrank ℂ (T ⟶ S) + finrank ℂ (T ⟶ V') := by
+      have hV_decomp : ∀ T, finrank k (T ⟶ V) = finrank k (T ⟶ S) + finrank k (T ⟶ V') := by
         intro T
         rw [finrank_hom_iso T V (S ⊞ V') φ, finrank_hom_biprod_eq]
-      have hSS : finrank ℂ (S ⟶ S) = 1 := by
+      have hSS : finrank k (S ⟶ S) = 1 := by
         rw [FDRep.finrank_hom_simple_simple]; simp
-      have hSV_pos : 0 < finrank ℂ (S ⟶ V) := by
+      have hSV_pos : 0 < finrank k (S ⟶ V) := by
         rw [hV_decomp S]; omega
-      have hSW_pos : 0 < finrank ℂ (S ⟶ W) := by rw [← h S]; exact hSV_pos
+      have hSW_pos : 0 < finrank k (S ⟶ W) := by rw [← h S]; exact hSV_pos
       have : Nontrivial (S ⟶ W) := by
         rw [nontrivial_iff]
         exact (finrank_pos_iff.mp hSW_pos).exists_pair_ne
       obtain ⟨f, hf⟩ := exists_ne (0 : S ⟶ W)
       obtain ⟨W', ⟨ψ⟩⟩ := biprod_of_nonzero_from_simple S W f hf
-      have hW_decomp : ∀ T, finrank ℂ (T ⟶ W) = finrank ℂ (T ⟶ S) + finrank ℂ (T ⟶ W') := by
+      have hW_decomp : ∀ T, finrank k (T ⟶ W) = finrank k (T ⟶ S) + finrank k (T ⟶ W') := by
         intro T
         rw [finrank_hom_iso T W (S ⊞ W') ψ, finrank_hom_biprod_eq]
-      have hV'W' : ∀ T, finrank ℂ (T ⟶ V') = finrank ℂ (T ⟶ W') := by
+      have hV'W' : ∀ T, finrank k (T ⟶ V') = finrank k (T ⟶ W') := by
         intro T
         have hv := hV_decomp T
         have hw := hW_decomp T
         have := h T
         omega
-      have hV'_le : finrank ℂ V' ≤ n := by
-        have hfr : finrank ℂ V = finrank ℂ S + finrank ℂ V' := by
+      have hV'_le : finrank k V' ≤ n := by
+        have hfr : finrank k V = finrank k S + finrank k V' := by
           rw [finrank_iso V (S ⊞ V') φ, finrank_biprod]
-        have hS_pos : 0 < finrank ℂ S := finrank_pos_of_simple S
+        have hS_pos : 0 < finrank k S := finrank_pos_of_simple S
         omega
       obtain ⟨θ⟩ := ih V' W' hV'_le hV'W'
       exact ⟨φ.trans ((biprod.mapIso (Iso.refl S) θ).trans ψ.symm)⟩
 
-/-- In characteristic 0, representations are determined by their characters.
+/-- Over an algebraically closed field of characteristic zero, finite-dimensional
+representations of a finite group are determined by their characters.
 (Etingof Corollary 4.2.4) -/
 theorem Etingof.Corollary4_2_4
+    (G : Type) [Group G] [Fintype G] [DecidableEq G]
+    (V W : FDRep k G)
+    (h : FDRep.character V = FDRep.character W) :
+    Nonempty (V ≅ W) :=
+  iso_of_hom_finrank_eq V W (hom_finrank_eq_of_char_eq V W h)
+
+/-- The classical special case `k = ℂ` of `Etingof.Corollary4_2_4`. -/
+theorem Etingof.Corollary4_2_4_complex
     (G : Type) [Group G] [Fintype G] [DecidableEq G]
     (V W : FDRep ℂ G)
     (h : FDRep.character V = FDRep.character W) :
     Nonempty (V ≅ W) :=
-  iso_of_hom_finrank_eq V W (hom_finrank_eq_of_char_eq V W h)
+  Etingof.Corollary4_2_4 G V W h

--- a/progress/2026-07-24T06-37-38Z_77ee01ed.md
+++ b/progress/2026-07-24T06-37-38Z_77ee01ed.md
@@ -1,0 +1,50 @@
+## Accomplished
+
+Resolved issue #7433 (feature / completeness-audit): generalized Corollary 4.2.4
+("finite-dimensional representations of a finite group are determined by their
+characters in characteristic zero") from the complex field `ℂ` to an arbitrary
+algebraically closed characteristic-zero field `k`, matching the book-wide
+convention and the source hypotheses.
+
+- Rewrote `EtingofRepresentationTheory/Chapter4/Corollary4_2_4.lean` to work over
+  `variable {k : Type} [Field k] [IsAlgClosed k] [CharZero k]`, replacing every
+  occurrence of `ℂ`. The supporting Mathlib lemmas all generalize cleanly:
+  `scalar_product_char_eq_finrank_equivariant` needs `Invertible (Fintype.card G : k)`
+  (built from `CharZero`), `FDRep.finrank_hom_simple_simple` needs `IsAlgClosed k`,
+  and Maschke injectivity needs `NeZero (Nat.card G : k)` (from `CharZero`).
+- Public endpoint `Etingof.Corollary4_2_4` now carries the general `k` (implicit,
+  inferred at call sites), with explicit argument order `G V W h` unchanged, so all
+  existing ℂ call sites still elaborate.
+- Added `Etingof.Corollary4_2_4_complex` recording the classical `k = ℂ` case.
+- Added `omit [IsAlgClosed k]`/`omit [CharZero k]` clauses on the helper lemmas that
+  do not use those instances, clearing all `unusedSectionVars` linter warnings.
+- Updated the file header docstring and `progress/items.json` (item
+  `Chapter4/Corollary4.2.4`: `covered_partial` → `covered`, dropped `followup_issue`).
+
+Verification:
+- `lake env lean` and `lake build` of the module: exit 0, no sorries.
+- `#print axioms Etingof.Corollary4_2_4` and `..._complex` =
+  `[propext, Classical.choice, Quot.sound]` (no `sorryAx`).
+- Downstream importers build: `Problem4_12_1`, `Discussion_4_4`, `Theorem5_25_2`
+  (both real call sites over ℂ still typecheck with `k` inferred).
+
+## Current frontier
+
+Issue #7433 complete. Remaining `unusedFintypeInType`, `show`-tactic, and
+line-length warnings under `lake build` are pre-existing (present in the original
+ℂ file, non-fatal, CI-accepted) and were left untouched to keep the diff focused.
+
+## Overall project progress
+
+Stage 3 formalization ongoing; a large completeness-audit queue of `feature`
+issues remains unclaimed. This turn closed one audit item (character-determination
+generality). No pipeline stage transition.
+
+## Next step
+
+Pick another unclaimed `feature` / `completeness-audit` issue. Clean, self-contained
+generalization or "restore" items are good candidates for a single session.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3222,10 +3222,9 @@
     "start_line": 15,
     "end_line": 16,
     "status": "sorry_free",
-    "coverage": "covered_partial",
-    "coverage_note": "The character-determines-representation theorem is proved only for FDRep ℂ G. Under the book-wide algebraically-closed-field convention, the source states it for arbitrary algebraically closed characteristic-zero k; that generalization is #7433.",
-    "followup_issue": 7433,
-    "last_updated": "2026-07-22",
+    "coverage": "covered",
+    "coverage_note": "Etingof.Corollary4_2_4 now proves the character-determines-representation theorem for FDRep k G over an arbitrary algebraically closed characteristic-zero field k ([Field k] [IsAlgClosed k] [CharZero k]), matching the book-wide convention and the source hypotheses. Etingof.Corollary4_2_4_complex records the classical k=ℂ special case. sorry-free (#print axioms = [propext, Classical.choice, Quot.sound]).",
+    "last_updated": "2026-07-24",
     "sorry_free": true
   },
   {


### PR DESCRIPTION
Closes #7433

Session: `77ee01ed-2e94-4eca-8225-41c19091944a`

ee88686b feat(Ch4 #7433): generalize Corollary 4.2.4 character determination to alg-closed char-0 k

🤖 Prepared with Claude Code