### PR TITLE
feat(Ch3 #7517): transpose/dual-route ingredients for Theorem 3.3.1

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -6353,3 +6353,18 @@ finrank bookkeeping (`Submodule.finrank_add_eq_of_isCompl` + `Submodule.finrank_
 submodules of the zero carrier are `⊥` via a one-line
 `submodule_eq_bot_of_subsingleton` (`eq_bot_iff`; `Subsingleton.elim`), avoiding a fresh
 `finrank (rep_ker k).V₂` that would re-trigger trap 1.
+
+## Trap: `Pi.module'` shadows `Pi.module` on product-ring representations
+
+When the acting algebra is a **product ring** `A = ∀ i, Rᵢ` (e.g. `MatProd k d = ∀ i, Matrix (Fin (dᵢ)) (Fin (dᵢ)) k`) and you write an `A`-module whose carrier is itself a product `∀ i, gᵢ`, Mathlib has **two** competing `Module A (∀ i, gᵢ)` instances:
+
+- `Pi.module` (generic): `A` acts on each `gᵢ` through the module structure you intend (e.g. via a projection `A → Rᵢ`);
+- `Pi.module'` (in `Mathlib/Algebra/Module/Pi.lean`): the product ring acts **factorwise**, `(N • w) i = N i • w i`, using whatever `Module Rᵢ gᵢ` exists — a *different, often column-mixing* action.
+
+A bare type annotation `A →ₗ[A] (∀ i, gᵢ)` picks `Pi.module'` (higher priority), while `LinearMap.pi`, `DirectSum.linearEquivFunOnFintype`, and `Proposition 3.1.4`'s ambient use `Pi.module`. Symptoms: `Pi.smul_apply` / `Matrix.Module.smul_apply` silently refuse to fire (reported "unused" by `simp only`), and `rw`/`exact` fail with `Pi.smul'` vs `DistribMulAction.toDistribSMul.toSMul` mismatches, or `Type mismatch … Pi.module vs Pi.module'`. Do **not** try to grind the `map_smul'` by hand — you cannot win the diamond that way.
+
+Fixes, in order of preference:
+1. **Target `⨁ i, gᵢ` (a `DirectSum`) instead of `∀ i, gᵢ`.** `Pi.module'` only matches products, so the `⨁` annotation is safe, and it matches `Etingof.subrepresentation_of_semisimple` (the `⨁` form of Proposition 3.1.4). Build the map into the product with `LinearMap.pi` (unannotated, so it keeps `Pi.module`), wrap with `LinearEquiv.ofBijective` (mark `noncomputable`), then `.trans (DirectSum.linearEquivFunOnFintype A ι g).symm`.
+2. **Let Mathlib supply Pi-linearity.** `LinearMap.pi (fun i => fᵢ)` discharges linearity into `∀ i, gᵢ` for free — you only prove `map_smul'` for the single-index building block `fᵢ`, where there is no nested-Pi diamond. Assemble the equiv with `LinearEquiv.ofBijective` + `Function.bijective_iff_has_inverse` (the two inverse laws are `fun _ => rfl`), avoiding a reverse `map_smul'` for the inverse.
+
+Also: a `local instance` module action (e.g. `vModuleProd`) is **not** available downstream. In `_Test.lean` files, pin such a decl's signature with `#check @name`, not a type-ascribed `example`, which would fail to synthesize the unexported instance.

--- a/EtingofRepresentationTheory/Chapter3.lean
+++ b/EtingofRepresentationTheory/Chapter3.lean
@@ -8,6 +8,7 @@ import EtingofRepresentationTheory.Chapter3.Corollary3_2_1
 import EtingofRepresentationTheory.Chapter3.Theorem3_2_2
 import EtingofRepresentationTheory.Chapter3.Definition3_3_2
 import EtingofRepresentationTheory.Chapter3.Theorem3_3_1
+import EtingofRepresentationTheory.Chapter3.Theorem3_3_1_Test
 import EtingofRepresentationTheory.Chapter3.Problem3_3_3
 import EtingofRepresentationTheory.Chapter3.Remark3_3_4
 import EtingofRepresentationTheory.Chapter3.Definition3_4_1

--- a/EtingofRepresentationTheory/Chapter3/Theorem3_3_1.lean
+++ b/EtingofRepresentationTheory/Chapter3/Theorem3_3_1.lean
@@ -5,6 +5,7 @@ import Mathlib.LinearAlgebra.Matrix.ToLin
 import Mathlib.LinearAlgebra.Matrix.Module
 import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 import Mathlib.Algebra.DirectSum.Module
+import Mathlib.LinearAlgebra.Dual.Lemmas
 
 /-!
 # Theorem 3.3.1: Irreducible Representations of Direct Sums of Matrix Algebras
@@ -297,3 +298,52 @@ noncomputable def regularDecomp :
     regularDecomp M i c j = M i j c := rfl
 
 end Product
+
+/-! ## Transpose self-duality and the dual-of-surjection bridge
+
+Two further ingredients of the book's proof of Theorem 3.3.1:
+
+* the matrix transpose realizes `Mat_d(k) ≅ Mat_d(k)ᵒᵖ`, hence `A ≅ Aᵒᵖ`, which is what lets
+  the `k`-dual `X*` (a priori an `Aᵒᵖ`-module) be viewed as an `A`-module;
+* the `k`-dual of a surjection is an injection, which turns the surjection `Aⁿ ↠ X*` into the
+  injection `X ↪ Aⁿ*`.
+-/
+
+section Duality
+
+variable {k : Type*} [Field k]
+
+/-- **Transpose self-duality of a matrix algebra.** `Matrix.transpose` realizes
+`Mat_d(k) ≅ Mat_d(k)ᵐᵒᵖ` as `k`-algebras (equivalently `Mat_d(k)ᵒᵖ ≅ Mat_d(k)`), since
+`(BC)ᵀ = CᵀBᵀ`. This is the isomorphism `A ≅ Aᵒᵖ` used in the proof of Theorem 3.3.1 to
+turn the dual `X*` (a priori an `Aᵒᵖ`-module) into an `A`-module. -/
+abbrev matrixTransposeSelfDuality (k : Type*) [Field k] (D : ℕ) :
+    Matrix (Fin D) (Fin D) k ≃ₐ[k] (Matrix (Fin D) (Fin D) k)ᵐᵒᵖ :=
+  Matrix.transposeAlgEquiv (Fin D) k k
+
+/-- The opposite of a finite product of rings is the product of the opposites. -/
+def piMulOppositeRingEquiv {ι : Type*} (R : ι → Type*) [∀ i, Semiring (R i)] :
+    (∀ i, (R i)ᵐᵒᵖ) ≃+* (∀ i, R i)ᵐᵒᵖ where
+  toFun f := MulOpposite.op fun i => (f i).unop
+  invFun g := fun i => MulOpposite.op ((MulOpposite.unop g) i)
+  left_inv f := by funext i; simp
+  right_inv g := by simp
+  map_mul' f g := MulOpposite.unop_injective <| funext fun i => by simp [MulOpposite.unop_mul]
+  map_add' f g := MulOpposite.unop_injective <| funext fun i => by simp
+
+/-- **Transpose self-duality of `A = ⊕ᵢ Mat_{dᵢ}(k)`**: `A ≅ Aᵐᵒᵖ` as rings, applying the
+matrix transpose factorwise. -/
+def matProdTransposeSelfDuality {r : ℕ} (d : Fin r → ℕ) :
+    MatProd k d ≃+* (MatProd k d)ᵐᵒᵖ :=
+  (RingEquiv.piCongrRight fun i => Matrix.transposeRingEquiv (Fin (d i)) k).trans
+    (piMulOppositeRingEquiv _)
+
+/-- **Dual of a surjection is an injection.** If `φ : M → N` is a surjective `k`-linear map,
+its transpose `φ.dualMap : N* → M*` is injective. This is the step in the proof of Theorem
+3.3.1 turning the surjection `Aⁿ ↠ X*` into the injection `X ↪ Aⁿ*`. -/
+theorem dualMap_injective_of_surjective {M N : Type*} [AddCommGroup M] [Module k M]
+    [AddCommGroup N] [Module k N] {φ : M →ₗ[k] N} (hφ : Function.Surjective φ) :
+    Function.Injective φ.dualMap :=
+  LinearMap.dualMap_injective_of_surjective hφ
+
+end Duality

--- a/EtingofRepresentationTheory/Chapter3/Theorem3_3_1.lean
+++ b/EtingofRepresentationTheory/Chapter3/Theorem3_3_1.lean
@@ -4,6 +4,7 @@ import Mathlib.RingTheory.Artinian.Module
 import Mathlib.LinearAlgebra.Matrix.ToLin
 import Mathlib.LinearAlgebra.Matrix.Module
 import Mathlib.LinearAlgebra.FiniteDimensional.Defs
+import Mathlib.Algebra.DirectSum.Module
 
 /-!
 # Theorem 3.3.1: Irreducible Representations of Direct Sums of Matrix Algebras
@@ -19,6 +20,8 @@ algebras are exactly the irreducible representations of the individual factors.
 -/
 
 open Matrix.Module Finset
+
+open scoped DirectSum
 
 private theorem matrix_single_smul_vec {k : Type*} [Field k] {d : ℕ}
     (j i : Fin d) (c : k) (v : Fin d → k) :
@@ -244,5 +247,53 @@ theorem Etingof.irreducible_reps_of_matrix_algebra :
     (∀ (X : Type*) [AddCommGroup X] [Module (MatProd k d) X], IsSemisimpleModule (MatProd k d) X) :=
   ⟨isSimpleModule_vModuleProd, fun W => exists_iso_vModuleProd W,
     isSemisimpleModule_of_matrixProd⟩
+
+/-! ## Regular-module decomposition `A ≅ ⊕ᵢ dᵢ Vᵢ`
+
+The book's proof of Theorem 3.3.1 uses the identity `Mat_{dᵢ}(k) = dᵢ Vᵢ`, hence
+`A = ⊕ᵢ dᵢ Vᵢ` and `Aⁿ = ⊕ᵢ (n dᵢ) Vᵢ` as representations of `A`. Concretely, viewing the
+left regular module `A = ⊕ᵢ Mat_{dᵢ}(k)` over itself, within the `i`-th matrix factor the
+`dᵢ` columns each span a copy of the standard representation `Vᵢ = k^{dᵢ}`, and the columns
+transform independently under left multiplication. -/
+
+/-- The `A`-linear map extracting the `c`-th column of the `i`-th matrix factor:
+`M ↦ (fun j => (M i) j c)`, landing in `Vᵢ = k^{dᵢ}`. This is the single-factor,
+single-column building block of the regular decomposition; it is `A`-linear because within
+the `i`-th factor, left multiplication acts columnwise by `mulVec`. -/
+def colVec (i : Fin r) (c : Fin (d i)) :
+    MatProd k d →ₗ[MatProd k d] (Fin (d i) → k) where
+  toFun M := fun j => M i j c
+  map_add' M N := by funext j; simp
+  map_smul' N M := by
+    funext j
+    rw [RingHom.id_apply, vModuleProd_smul, Matrix.Module.smul_apply, smul_eq_mul, Pi.mul_apply,
+      Matrix.mul_apply]
+    simp [smul_eq_mul]
+
+/-- The columns of the `i`-th matrix factor, packaged as an `A`-linear map into
+`Fin (dᵢ) → Vᵢ`. -/
+def colMap (i : Fin r) : MatProd k d →ₗ[MatProd k d] (Fin (d i) → (Fin (d i) → k)) :=
+  LinearMap.pi fun c => colVec i c
+
+/-- **Regular-module decomposition** (`A ≅ ⊕ᵢ dᵢ Vᵢ`). As a module over itself,
+`A = ⊕ᵢ Mat_{dᵢ}(k)` is isomorphic to `⊕ᵢ dᵢ Vᵢ`, realized as the direct sum
+`⨁ i, (Fin (dᵢ) → Vᵢ)` (each `Fin (dᵢ) → Vᵢ` is `dᵢ` copies of `Vᵢ = k^{dᵢ}`, with `A`
+acting through its `i`-th projection). The isomorphism sends a tuple of matrices to its
+columns, `M ↦ fun i c j => (M i) j c`, packaged in the direct sum.
+
+The direct-sum target (rather than the product `∀ i, …`) is deliberate: it matches the
+ambient of `Etingof.subrepresentation_of_semisimple` (Proposition 3.1.4) and avoids the
+`Pi.module'` instance (product ring acting factorwise), which would otherwise supply a
+different, column-mixing action on `∀ i, Fin (dᵢ) → Fin (dᵢ) → k`. -/
+noncomputable def regularDecomp :
+    MatProd k d ≃ₗ[MatProd k d] (⨁ i, (Fin (d i) → (Fin (d i) → k))) :=
+  (LinearEquiv.ofBijective (LinearMap.pi colMap)
+      (Function.bijective_iff_has_inverse.mpr
+        ⟨fun w i j c => w i c j, fun _ => rfl, fun _ => rfl⟩)).trans
+    (DirectSum.linearEquivFunOnFintype (MatProd k d) (Fin r)
+      (fun i => Fin (d i) → (Fin (d i) → k))).symm
+
+@[simp] theorem regularDecomp_apply (M : MatProd k d) (i : Fin r) (c j : Fin (d i)) :
+    regularDecomp M i c j = M i j c := rfl
 
 end Product

--- a/EtingofRepresentationTheory/Chapter3/Theorem3_3_1_Test.lean
+++ b/EtingofRepresentationTheory/Chapter3/Theorem3_3_1_Test.lean
@@ -1,0 +1,51 @@
+import EtingofRepresentationTheory.Chapter3.Theorem3_3_1
+
+/-!
+# Downstream import/`#check` test for the Theorem 3.3.1 transpose/dual route
+
+This file imports `Chapter3/Theorem3_3_1.lean` and pins the public signatures of the
+transpose/dual-route ingredients added for Etingof Theorem 3.3.1:
+
+* `regularDecomp` — the regular-module decomposition `A ≅ ⊕ᵢ dᵢ Vᵢ`;
+* `colVec` / `colMap` — the single-factor column building blocks;
+* `matrixTransposeSelfDuality` / `matProdTransposeSelfDuality` — the transpose self-duality
+  `Mat_d(k) ≅ Mat_d(k)ᵐᵒᵖ` and its product form `A ≅ Aᵐᵒᵖ`;
+* `dualMap_injective_of_surjective` — the dual-of-surjection bridge.
+
+Because this file re-elaborates the endpoint statements, it forces a fresh check of their
+public API even when cached oleans would otherwise hide a source regression.
+
+See issue #7517.
+-/
+
+open scoped DirectSum
+
+-- The public endpoints must remain importable under these names.
+#check @regularDecomp
+#check @regularDecomp_apply
+#check @colVec
+#check @colMap
+#check @matrixTransposeSelfDuality
+#check @matProdTransposeSelfDuality
+#check @piMulOppositeRingEquiv
+#check @dualMap_injective_of_surjective
+
+-- Signature locks: each `example` fails to elaborate if the corresponding statement drifts.
+-- (`regularDecomp`/`regularDecomp_apply` reference the file-local `vModuleProd` action, which
+-- is not exported, so they are pinned via `#check` above rather than re-ascribed here.)
+
+/-- Transpose self-duality of a single matrix algebra, as a `k`-algebra isomorphism to the
+opposite algebra. -/
+example (k : Type*) [Field k] (D : ℕ) :
+    Matrix (Fin D) (Fin D) k ≃ₐ[k] (Matrix (Fin D) (Fin D) k)ᵐᵒᵖ :=
+  matrixTransposeSelfDuality k D
+
+/-- Transpose self-duality of `A = ⊕ᵢ Mat_{dᵢ}(k)`, as a ring isomorphism `A ≅ Aᵐᵒᵖ`. -/
+example {k : Type*} [Field k] {r : ℕ} (d : Fin r → ℕ) :
+    MatProd k d ≃+* (MatProd k d)ᵐᵒᵖ :=
+  matProdTransposeSelfDuality d
+
+/-- The `k`-dual of a surjection is an injection. -/
+example {k M N : Type*} [Field k] [AddCommGroup M] [Module k M] [AddCommGroup N] [Module k N]
+    {φ : M →ₗ[k] N} (hφ : Function.Surjective φ) : Function.Injective φ.dualMap :=
+  dualMap_injective_of_surjective hφ

--- a/progress/2026-07-24T08-17-37Z_1c1fc6ab.md
+++ b/progress/2026-07-24T08-17-37Z_1c1fc6ab.md
@@ -1,0 +1,42 @@
+## Accomplished
+
+Worked issue #7517 (formalize the transpose/self-duality proof route after Theorem 3.3.1).
+Landed the self-contained ingredients of the book's dual route in
+`EtingofRepresentationTheory/Chapter3/Theorem3_3_1.lean` (no `sorry`/`admit`/axiom):
+
+- **Regular-module decomposition** `regularDecomp : MatProd k d ≃ₗ[MatProd k d] ⨁ i, (Fin dᵢ → Vᵢ)`
+  (i.e. `A ≅ ⊕ᵢ dᵢVᵢ`), with building blocks `colVec` (single column) and `colMap` (one factor's
+  columns), and `regularDecomp_apply`.
+- **Transpose self-duality** `matrixTransposeSelfDuality` (`Mat_d(k) ≅ Mat_d(k)ᵐᵒᵖ` as a
+  `k`-algebra iso) and `matProdTransposeSelfDuality` (`A ≅ Aᵐᵒᵖ` factorwise), plus the helper
+  `piMulOppositeRingEquiv` (`∏ Rᵢᵐᵒᵖ ≅ (∏ Rᵢ)ᵐᵒᵖ`).
+- **Dual-of-surjection bridge** `dualMap_injective_of_surjective`.
+- Downstream test `Chapter3/Theorem3_3_1_Test.lean` pinning the public signatures, added to the
+  `Chapter3` aggregate.
+
+Three commits; `lake build EtingofRepresentationTheory.Chapter3` succeeds (8681 jobs).
+
+## Current frontier
+
+The end-to-end dual-route embedding `X ↪ Aⁿ ⟹ X ≅ ⊕ᵢ mᵢVᵢ` (the "advertised route") is NOT
+done. It requires `Module A (Dual k X)` via the transpose anti-automorphism, a surjection
+`Aⁿ ↠ X*`, the module self-duality `Aⁿ* ≅ Aⁿ`, and application of Proposition 3.1.4. Split out
+as issue **#7662**.
+
+## Overall project progress
+
+Phase 3 (formalization) ongoing. This turn advanced Theorem 3.3.1's completeness audit: the
+transpose/dual helpers are now public; the full route is decomposed.
+
+## Next step
+
+Pick up **#7662**. Key technical note carried there: the product representation lives on
+`∀ i, …` over the product ring `MatProd`, where Mathlib's `Pi.module'` (product-ring factorwise
+action) shadows the intended generic `Pi.module` with a *column-mixing* action. `regularDecomp`
+deliberately targets `⨁` to avoid this; the dual route must stay in the `⨁` world or pin
+`Pi.module` explicitly. Also `vModuleProd` is a `local instance`, so the `Vᵢ` action is not
+available downstream without re-declaration (do the work in the same file).
+
+## Blockers
+
+None. #7517 landed as a partial PR (helpers only); remainder tracked in #7662.


### PR DESCRIPTION
Partial progress on #7517

Session: `1c1fc6ab-a619-46f9-aa94-4418494559b7`

e42fcb4b docs(#7517): progress file for Theorem 3.3.1 transpose/dual route (partial)
3c1f18c9 test(Ch3 #7517): downstream import/signature test for Theorem 3.3.1 route
f5989116 feat(Ch3 #7517): transpose self-duality and dual-of-surjection bridge
85c95e1e feat(Ch3 #7517): regular-module decomposition A ≅ ⊕ᵢ dᵢVᵢ (Theorem 3.3.1 route)

🤖 Prepared with Claude Code