### PR TITLE
Prove the toy categories in Section 7.4 are not strictly isomorphic

### DIFF
--- a/EtingofRepresentationTheory/Chapter7/Introduction_7_4.lean
+++ b/EtingofRepresentationTheory/Chapter7/Introduction_7_4.lean
@@ -1,5 +1,6 @@
 import Mathlib.CategoryTheory.IsomorphismClasses
 import Mathlib.CategoryTheory.Equivalence
+import Mathlib.CategoryTheory.IsoCat
 import EtingofRepresentationTheory.Chapter7.Discussion_after_Definition7_4_1
 
 /-!
@@ -28,6 +29,15 @@ We show:
 * `functorIsoClassesEquiv`: applying this to the equivalence `C₁ ≌ C₂` precomposed into
   the functor category (`Equivalence.congrLeft`) gives the natural bijection between
   isomorphism classes of functors `C₁ → D` and `C₂ → D`.
+
+The text stresses that this bijection is the sense in which `C₁` and `C₂` are "the same",
+*even though* they are not isomorphic as categories: a strict isomorphism of categories
+would require a bijection between their object types, which is impossible since `C₁` has one
+object and `C₂` has two. Mathlib's strict (on-the-nose) notion of isomorphism of categories
+is `CategoryTheory.IsoCat`. We record the negative claim:
+
+* `isEmpty_isoCat_cat₁_cat₂`: there is no `IsoCat Cat₁ Cat₂`, i.e. `C₁` and `C₂` are *not*
+  isomorphic as categories.
 -/
 
 open CategoryTheory
@@ -52,5 +62,22 @@ which `C₁` and `C₂` are "the same for all practical purposes". -/
 def functorIsoClassesEquiv (D : Type*) [Category D] :
     Quotient (isIsomorphicSetoid (Cat₁ ⥤ D)) ≃ Quotient (isIsomorphicSetoid (Cat₂ ⥤ D)) :=
   isoClassesEquivOfEquivalence (cat₁EquivCat₂.congrLeft (E := D))
+
+/-- Introduction to Section 7.4: although `C₁` and `C₂` are equivalent (`cat₁EquivCat₂`) and
+have the "same" functor-isomorphism classes into any `D` (`functorIsoClassesEquiv`), they are
+**not isomorphic as categories**. A strict isomorphism of categories (`CategoryTheory.IsoCat`)
+has a forward functor that is bijective on objects, hence would give a bijection `Cat₁ ≃ Cat₂`;
+but `Cat₁` (one object) is a subsingleton while `Cat₂` (two objects) is not. This is the
+contrast between equivalence and the naive strict notion of isomorphism the text draws. -/
+theorem isEmpty_isoCat_cat₁_cat₂ : IsEmpty (IsoCat Cat₁ Cat₂) := by
+  refine ⟨fun e => ?_⟩
+  -- The forward functor of an isomorphism of categories is bijective on objects, so it
+  -- induces an equivalence of object types `Cat₁ ≃ Cat₂`, i.e. `PUnit ≃ Bool`.
+  let f : PUnit ≃ Bool := e.functor.objEquiv
+  -- `PUnit` is a subsingleton, so `f.symm` collapses `true` and `false`; injectivity of
+  -- `f.symm` then forces `true = false`, a contradiction.
+  have : (true : Bool) = false :=
+    f.symm.injective (Subsingleton.elim (f.symm true) (f.symm false))
+  exact absurd this (by decide)
 
 end Etingof

--- a/progress/2026-07-24T08-26-21Z_d9c14e3f.md
+++ b/progress/2026-07-24T08-26-21Z_d9c14e3f.md
@@ -1,0 +1,34 @@
+## Accomplished
+
+Completed issue #7480 — "Prove the toy categories in Section 7.4 are not strictly isomorphic".
+
+- Added `Etingof.isEmpty_isoCat_cat₁_cat₂ : IsEmpty (CategoryTheory.IsoCat Cat₁ Cat₂)`
+  to `EtingofRepresentationTheory/Chapter7/Introduction_7_4.lean`.
+- Used Mathlib's `CategoryTheory.IsoCat` (the strict, inverse-on-the-nose isomorphism of
+  categories) as instructed — no duplicate strict-isomorphism structure introduced.
+- Proof: the forward functor of an `IsoCat` is bijective on objects (`IsoCat.isIso_functor`
+  → `Functor.objEquiv`), giving `Cat₁ ≃ Cat₂`, i.e. `PUnit ≃ Bool`. `PUnit` is a
+  subsingleton while `Bool` is not, so the induced bijection forces `true = false`.
+- Kept the positive equivalence (`cat₁EquivCat₂`) and functor-iso-class bijection
+  (`functorIsoClassesEquiv`) referenced in the docstring so the equivalence-vs-strict-iso
+  contrast the text draws is explicit.
+- Updated coverage metadata for `Chapter7/Introduction_7.4` in `progress/items.json`:
+  `fidelity partial → full`, `coverage covered_partial → covered_full`, removed
+  `fidelity_issue: 7480`, refreshed `coverage_note` and `last_updated`.
+
+## Current frontier
+
+Issue #7480 complete. No `sorry`/`axiom` introduced. `lake build` of the target module
+succeeds (762 jobs).
+
+## Overall project progress
+
+Stage 3 formalization ongoing; this closes one Chapter 7 completeness-audit gap.
+
+## Next step
+
+Open the PR for #7480; pick up another unclaimed feature/fix issue in the next session.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -8291,12 +8291,11 @@
     "start_line": 1,
     "end_line": 13,
     "status": "sorry_free",
-    "fidelity": "partial",
+    "fidelity": "full",
     "sorry_free": true,
-    "coverage": "covered_partial",
-    "coverage_note": "The equivalence C₁ ≌ C₂ and induced bijection on functor isomorphism classes are public, but the source's contrasting claim that the categories are not strictly inverse-on-the-nose isomorphic is absent; follow-up #7480.",
-    "fidelity_issue": 7480,
-    "last_updated": "2026-07-22",
+    "coverage": "covered_full",
+    "coverage_note": "The equivalence C₁ ≌ C₂ and induced bijection on functor isomorphism classes are public; the source's contrasting claim that the categories are not strictly (on-the-nose) isomorphic is now formalized as isEmpty_isoCat_cat₁_cat₂ via CategoryTheory.IsoCat.",
+    "last_updated": "2026-07-24",
     "coverage_swept": {
       "wave": 1,
       "result": "covered"


### PR DESCRIPTION
Closes #7480

Session: `d9c14e3f-f7a5-4fbb-821a-70bd660b9e34`

7d026a74 feat(Ch7 #7480): prove Cat₁ and Cat₂ are not strictly isomorphic

🤖 Prepared with Claude Code