### PR TITLE
complete Example 4.3(1): finite abelian character-group duality and canonical double dual

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Example4_3_FiniteAbelianGroups.lean
+++ b/EtingofRepresentationTheory/Chapter4/Example4_3_FiniteAbelianGroups.lean
@@ -45,3 +45,101 @@ theorem Etingof.Example4_3_FiniteAbelianGroups
     IsSimpleModule.finrank_eq_one_of_isMulCommutative
       (k := k) (A := MonoidAlgebra k G) (V := ρ.asModule)
   rwa [ρ.asModuleEquiv.finrank_eq] at h
+
+/-!
+## The dual (character) group
+
+The book's second half of Example 4.3(1) develops the **dual group** (character group)
+`G^∨` of a finite abelian group `G`. Since every irreducible representation of an abelian
+group over `ℂ` is one-dimensional (the theorem above, plus that a line carries the same data
+as a homomorphism to scalars), `G^∨` is the same as the group of complex-valued *characters*
+`G →* ℂˣ`, and pointwise multiplication and inversion of characters make it an abelian group.
+We formalize `G^∨` as `G →* ℂˣ`.
+
+The three claims of the book are:
+
+* duality respects products, `(G₁ × ⋯ × Gₙ)^∨ ≅ G₁^∨ × ⋯ × Gₙ^∨`
+  (`Etingof.characterGroupProdEquiv`, `Etingof.characterGroupPiEquiv`);
+* `G^∨ ≅ G` noncanonically (`Etingof.nonempty_mulEquiv_characterGroup`), the choice hidden in
+  the decomposition of `G` into cyclic factors;
+* `G ≅ (G^∨)^∨` **canonically** via evaluation `φ(g)(χ) = χ(g)`
+  (`Etingof.characterDoubleDualEquiv` and `Etingof.characterDoubleDualEquiv_apply_apply`).
+
+For a finite abelian group these follow from Mathlib's duality theory of finite commutative
+groups, `Mathlib.GroupTheory.FiniteAbelian.Duality`, taking the coefficient monoid to be `ℂ`,
+which has enough roots of unity because it is algebraically (hence separably) closed of
+characteristic zero.
+-/
+
+namespace Etingof
+
+/-- The **dual group** (character group) `G^∨ = G →* ℂˣ` of a group `G`: the group of
+complex-valued multiplicative characters, an abelian group under pointwise multiplication.
+For a finite abelian group these are exactly the (one-dimensional) irreducible representations
+of `G`. (Etingof Example 4.3(1)) -/
+abbrev CharacterGroup (G : Type*) [CommGroup G] : Type _ := G →* ℂˣ
+
+/-- The character group is an abelian group, recording the book's observation that the product
+`χ₁χ₂` and inverse `χ⁻¹` of characters are again characters. -/
+example (G : Type*) [CommGroup G] : CommGroup (CharacterGroup G) := inferInstance
+
+/-- `ℂ` has enough roots of unity of every order coming from a finite group: it is
+algebraically (hence separably) closed of characteristic zero, so the exponent of any finite
+group is invertible in `ℂ`. This is the hypothesis Mathlib's finite-abelian duality needs. -/
+instance instHasEnoughRootsOfUnityComplexExponent (G : Type*) [Group G] [Finite G] :
+    HasEnoughRootsOfUnity ℂ (Monoid.exponent G) :=
+  have : NeZero ((Monoid.exponent G : ℕ) : ℂ) :=
+    ⟨by exact_mod_cast Monoid.exponent_ne_zero_of_finite (G := G)⟩
+  inferInstance
+
+/-- **Duality respects binary products**: `(G₁ × G₂)^∨ ≅ G₁^∨ × G₂^∨`. A character of a
+product is the same data as a pair of characters, via restriction to the two factors.
+(Etingof Example 4.3(1)) -/
+def characterGroupProdEquiv (G₁ G₂ : Type*) [CommGroup G₁] [CommGroup G₂] :
+    CharacterGroup (G₁ × G₂) ≃* CharacterGroup G₁ × CharacterGroup G₂ where
+  toFun φ := (φ.comp (.inl G₁ G₂), φ.comp (.inr G₁ G₂))
+  invFun p := p.1.comp (.fst G₁ G₂) * p.2.comp (.snd G₁ G₂)
+  left_inv φ := by
+    refine DFunLike.ext _ _ fun x => ?_
+    obtain ⟨a, b⟩ := x
+    change φ (a, 1) * φ (1, b) = φ (a, b)
+    rw [← map_mul, Prod.mk_mul_mk, mul_one, one_mul]
+  right_inv p := by
+    refine Prod.ext (DFunLike.ext _ _ fun a => ?_) (DFunLike.ext _ _ fun a => ?_)
+    · change p.1 a * p.2 1 = p.1 a
+      rw [map_one, mul_one]
+    · change p.1 1 * p.2 a = p.2 a
+      rw [map_one, one_mul]
+  map_mul' φ ψ := Prod.ext rfl rfl
+
+/-- **Duality respects finite products**: `(∏ᵢ Gᵢ)^∨ ≅ ∏ᵢ Gᵢ^∨`. This is the book's displayed
+`(G₁ × ⋯ × Gₙ)^∨ = G₁^∨ × ⋯ × Gₙ^∨` for an arbitrary finite index set. (Etingof Example 4.3(1)) -/
+def characterGroupPiEquiv {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (G : ι → Type*) [∀ i, CommGroup (G i)] :
+    CharacterGroup (∀ i, G i) ≃* ∀ i, CharacterGroup (G i) :=
+  Pi.monoidHomMulEquiv G ℂˣ
+
+/-- **Noncanonical self-duality**: a finite abelian group is isomorphic to its dual group,
+`G ≅ G^∨`. As the book stresses, this isomorphism is not canonical: it depends on a choice of
+decomposition of `G` into cyclic factors, so it is stated as mere nonemptiness of the type of
+isomorphisms rather than a chosen map. (Etingof Example 4.3(1)) -/
+theorem nonempty_mulEquiv_characterGroup (G : Type*) [CommGroup G] [Finite G] :
+    Nonempty (G ≃* CharacterGroup G) :=
+  (CommGroup.monoidHom_mulEquiv_of_hasEnoughRootsOfUnity G ℂ).map MulEquiv.symm
+
+/-- **Canonical double duality**: a finite abelian group is *canonically* isomorphic to its
+double dual, `G ≅ (G^∨)^∨`. The isomorphism is the evaluation map `φ(g)(χ) = χ(g)`; see
+`characterDoubleDualEquiv_apply_apply`. (Etingof Example 4.3(1)) -/
+noncomputable def characterDoubleDualEquiv (G : Type*) [CommGroup G] [Finite G] :
+    G ≃* CharacterGroup (CharacterGroup G) :=
+  (CommGroup.monoidHomMonoidHomEquiv G ℂ).symm
+
+/-- The canonical double-dual isomorphism is evaluation: `φ(g)(χ) = χ(g)`, exactly the book's
+formula. Here `χ = φ` ranges over `G^∨ = G →* ℂˣ`. -/
+@[simp]
+theorem characterDoubleDualEquiv_apply_apply (G : Type*) [CommGroup G] [Finite G]
+    (g : G) (χ : CharacterGroup G) :
+    characterDoubleDualEquiv G g χ = χ g :=
+  CommGroup.monoidHomMonoidHomEquiv_symm_apply_apply G ℂ g χ
+
+end Etingof

--- a/progress/2026-07-24T09-53-46Z_5bf2cb93.md
+++ b/progress/2026-07-24T09-53-46Z_5bf2cb93.md
@@ -1,0 +1,45 @@
+## Accomplished
+
+Completed the dual-group half of **Example 4.3(1)** (issue #7412), which was previously
+`covered_partial` (only one-dimensionality of irreps was proved).
+
+Added to `EtingofRepresentationTheory/Chapter4/Example4_3_FiniteAbelianGroups.lean`:
+
+- `Etingof.CharacterGroup G := G →* ℂˣ` — the dual/character group `G^∨`, an abelian group
+  by the existing `MonoidHom.instCommGroup` instance (noted with an `example`).
+- `instHasEnoughRootsOfUnityComplexExponent` — `HasEnoughRootsOfUnity ℂ (Monoid.exponent G)`
+  for finite `G`, the hypothesis Mathlib's finite-abelian duality needs. Provided via
+  `IsSepClosed.hasEnoughRootsOfUnity` (ℂ is alg-closed ⟹ sep-closed) plus a local
+  `NeZero ((exponent G : ℕ) : ℂ)` from `Monoid.exponent_ne_zero_of_finite` and char zero.
+- `characterGroupProdEquiv` — binary product duality `(G₁ × G₂)^∨ ≅ G₁^∨ × G₂^∨`
+  (hand-built `MulEquiv` from restriction along `inl`/`inr`).
+- `characterGroupPiEquiv` — n-fold product duality `(∏ᵢ Gᵢ)^∨ ≅ ∏ᵢ Gᵢ^∨`, the book's general
+  displayed formula, from `Pi.monoidHomMulEquiv`.
+- `nonempty_mulEquiv_characterGroup` — noncanonical `G ≅ G^∨`, stated as `Nonempty` because the
+  isomorphism depends on the cyclic decomposition (from
+  `CommGroup.monoidHom_mulEquiv_of_hasEnoughRootsOfUnity`).
+- `characterDoubleDualEquiv` + `characterDoubleDualEquiv_apply_apply` — canonical
+  `G ≅ (G^∨)^∨` with the explicit evaluation formula `φ(g)(χ) = χ(g)`, from
+  `CommGroup.monoidHomMonoidHomEquiv`.
+
+Updated `progress/items.json` for `Chapter4/Example4.3_FiniteAbelianGroups`: coverage
+`covered_partial` → `covered_full`, refreshed `fidelity_note`, removed `fidelity_issue`.
+
+## Current frontier
+
+Item complete. Build of the file is clean; `#print axioms` on all new declarations shows only
+`[propext, Classical.choice, Quot.sound]`. No new `sorry`/`axiom`.
+
+## Overall project progress
+
+Phase 3 formalization, filling fidelity gaps. One item (Example 4.3(1) dual-group claims)
+upgraded from partial to full coverage this turn.
+
+## Next step
+
+Open a PR closing #7412 with auto-merge. Next worker: pick the next unclaimed issue
+(`coordination list-unclaimed`).
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3250,13 +3250,12 @@
     "start_line": 21,
     "end_line": 2,
     "status": "sorry_free",
-    "coverage": "covered_partial",
+    "coverage": "covered_full",
     "fidelity": "verified",
     "sorry_free": true,
     "fidelity_decl": "Etingof.Example4_3_FiniteAbelianGroups",
-    "fidelity_note": "The one-dimensionality of irreducible representations is proved. The source's character-group product duality, noncanonical G ≅ G∨, and canonical evaluation isomorphism G ≅ (G∨)∨ are absent; follow-up #7412.",
-    "fidelity_issue": 7412,
-    "last_updated": "2026-07-22"
+    "fidelity_note": "The one-dimensionality of irreducible representations is proved (Etingof.Example4_3_FiniteAbelianGroups). The dual-group half of Example 4.3(1) is now formalized with G∨ = G →* ℂˣ (Etingof.CharacterGroup): product duality (characterGroupProdEquiv, characterGroupPiEquiv), noncanonical G ≅ G∨ (nonempty_mulEquiv_characterGroup), and the canonical evaluation double-dual isomorphism G ≅ (G∨)∨ with φ(g)(χ)=χ(g) (characterDoubleDualEquiv, characterDoubleDualEquiv_apply_apply), via Mathlib finite-abelian duality over ℂ. Closes #7412.",
+    "last_updated": "2026-07-24"
   },
   {
     "id": "Chapter4/Example4.3_S3",


### PR DESCRIPTION
Closes #7412

Session: `5bf2cb93-6b6b-4b22-bbf5-26a3666aefb1`

9d7beadf feat(Ch4 #7412): formalize the dual-group half of Example 4.3(1)

🤖 Prepared with Claude Code