### PR TITLE
fix(Ch5 Exercise 5.3.3): restore the odd-order complex-type theorem

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Exercise5_3_3.lean
+++ b/EtingofRepresentationTheory/Chapter5/Exercise5_3_3.lean
@@ -107,7 +107,7 @@ private def stableSubmodule (ρ : Representation ℂ G V) (P : Submodule ℂ ρ.
     | single g a =>
         have hsingle : (MonoidAlgebra.single g a : MonoidAlgebra ℂ G) =
             a • MonoidAlgebra.single g (1 : ℂ) := by
-          rw [Finsupp.smul_single, smul_eq_mul, mul_one]
+          rw [MonoidAlgebra.smul_single', mul_one]
         rw [hsingle, smul_assoc]
         apply P.smul_mem
         rw [Representation.single_smul, one_smul]

--- a/progress/2026-07-24T11-12-52Z_c1d958d7.md
+++ b/progress/2026-07-24T11-12-52Z_c1d958d7.md
@@ -1,0 +1,37 @@
+## Accomplished
+
+Fixed the source regression in `EtingofRepresentationTheory/Chapter5/Exercise5_3_3.lean`
+(issue #7553, `fix(Ch5 Exercise 5.3.3): restore the odd-order complex-type theorem`).
+
+The failure was at line 110 inside the private `stableSubmodule` construction: the rewrite
+`Finsupp.smul_single` could not match the goal `MonoidAlgebra.single g a = a • MonoidAlgebra.single g 1`,
+because `MonoidAlgebra.single` no longer displays as the `fun₀ | a => b` Finsupp pattern the
+lemma expects. Replaced the rewrite with `MonoidAlgebra.smul_single'` (`r' • single m r = single m (r' * r)`)
+followed by `mul_one`, which matches the `MonoidAlgebra.single` form directly.
+
+No hypotheses or conclusions were weakened; no `sorry`, `admit`, or replacement axiom was
+introduced.
+
+## Current frontier
+
+Done. Verification:
+- `lake env lean EtingofRepresentationTheory/Chapter5/Exercise5_3_3.lean` elaborates from source
+  (only pre-existing style/unused-variable linter warnings remain).
+- `lake build EtingofRepresentationTheory.Chapter5.Exercise5_3_3` completes successfully
+  (8589 jobs), confirming the whole dependency chain — including the now-merged #7527
+  quaternionic even-dimension endpoint — builds from source rather than a stale `.olean`.
+- `#print axioms isComplexType_of_odd_order_of_nontrivial_irreducible` reports only
+  `propext, Classical.choice, Quot.sound` — no `sorryAx`.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. One source regression restored this turn.
+
+## Next step
+
+Other unclaimed source regressions remain (e.g. #7555 Exercise 5.8.5, #7542/#7543 Ch5).
+A follow-up worker can claim the next one.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7553

Session: `c1d958d7-0160-4fb2-970a-2af9b51ad9a1`

4394a148 fix(Ch5 Exercise5.3.3 #7553): restore odd-order complex-type theorem

🤖 Prepared with Claude Code