### PR TITLE
Restore the importable Hilbert-syzygy endpoint of Example 9.4.4

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -100,7 +100,16 @@ fails spuriously. **A "restore/regression" issue whose reproduction is `lake env
 <file>` and whose errors are `synthInstanceFailed` / `Module k (DirectSum …)` is very
 likely a false positive — verify the premise with `lake build <Module>` before doing any
 work.** (2026-07: issue #7490 was filed this way; all four files build clean under `lake
-build` and the endpoints are axiom-clean.)
+build` and the endpoints are axiom-clean.) The *same* missing option produces a second,
+different symptom on change-of-scalars / adjunction proofs: `rw`/`simp` reporting "did not
+find … the pattern" together with a "target expression is not type-correct under the
+`instances` transparency level" note, because terms mixing `F.obj (G.obj M)` with
+`(G ⋙ F).obj M` (or a let-bound `C` with `Polynomial.C`) stop matching. If closing as a
+false positive is undesirable (you want the file to also pass bare `lake env lean`), pin
+`set_option backward.isDefEq.respectTransparency false in` on just the affected
+declarations — the same idiom Mathlib uses on `ExtendRestrictScalarsAdj.counit`. (2026-07:
+#7491, `Chapter9/Example9_4_4.lean` — pristine file built clean under `lake build`; three
+per-declaration pins made it pass `lake env lean` too, no proof changes.)
 
 **Two Mathlib lemmas can produce the *same* `1`/`0`/`Pi.single i 1` through *different*
 typeclass paths — `rw` then fails syntactically, `exact` succeeds by defeq.** Classic case

--- a/EtingofRepresentationTheory/Chapter9/Example9_4_4.lean
+++ b/EtingofRepresentationTheory/Chapter9/Example9_4_4.lean
@@ -162,6 +162,7 @@ private noncomputable def xActionAsRLinear {R : Type u} [CommRing R]
   (ModuleCat.restrictScalars (Polynomial.C (R := R))).map
     ((Polynomial.X : Polynomial R) • (𝟙 M))
 
+set_option backward.isDefEq.respectTransparency false in
 set_option maxHeartbeats 800000 in
 /-- The Koszul short exact sequence for an R[X]-module M:
   0 → R[X] ⊗_R M|_R →^d R[X] ⊗_R M|_R →^ε M → 0
@@ -584,6 +585,7 @@ private theorem Polynomial.divX_X_mul (R : Type u) [CommRing R] (p : R[X]) :
   ext n
   simp [coeff_divX, coeff_X_mul]
 
+set_option backward.isDefEq.respectTransparency false in
 /-- X-multiplication on R[X] ⊗_R M is injective: X· has a left inverse (divX ⊗ id),
 since divX is a left inverse of X· on R[X] as an R-linear map. -/
 private theorem polynomial_X_mul_mono_extendScalars (R : Type u) [CommRing R]
@@ -687,6 +689,7 @@ private theorem ext_eq_zero_of_X_action_vanishing
   -- Combine: e = f*(e₂) = X • e₂ = 0
   rw [← he₂, h_precomp, h_smul_zero]
 
+set_option backward.isDefEq.respectTransparency false in
 /-- The Shapiro transfer: for any R-module N, Ext vanishing for R[X]-modules with
 trivial X-action transfers to Ext vanishing over R via the extension-restriction
 adjunction. This combines ext_subsingleton_of_extendScalars with the observation

--- a/progress/2026-07-24T11-32-00Z_a544d4c9.md
+++ b/progress/2026-07-24T11-32-00Z_a544d4c9.md
@@ -1,0 +1,47 @@
+## Accomplished
+
+Fixed regression #7491: `EtingofRepresentationTheory/Chapter9/Example9_4_4.lean`
+failed a fresh Lean check on the current toolchain and could not be imported.
+
+Root cause: a toolchain migration made the elaborator stricter about
+type-correctness "under instances transparency". The change-of-scalars morphism
+proofs (Koszul differential `d = X·𝟙 - F.map(xAct)`, the `X·`-mono argument, and
+the Shapiro transfer) rely on definitional equalities between `F.obj (G.obj M)`
+and `(G ⋙ F).obj M`, and between the let-bound `C` and `Polynomial.C`. Under the
+new elaborator, `rw`/`simp` produced terms flagged as type-incorrect at instances
+transparency, so the tactics no longer matched.
+
+Fix: three `set_option backward.isDefEq.respectTransparency false in` annotations
+on `koszulSES_shortExact`, `polynomial_X_mul_mono_extendScalars`, and
+`ext_subsingleton_of_polynomial_trivial_action`. This restores the pre-migration
+defeq behavior the proofs were written against — the same option Mathlib itself
+uses on `ExtendRestrictScalarsAdj.counit`. No proof logic changed, no axioms, no
+`sorry`.
+
+- `lake env lean EtingofRepresentationTheory/Chapter9/Example9_4_4.lean`: no errors, no `sorry`.
+- `lake build EtingofRepresentationTheory.Chapter9.Example9_4_4`: completed successfully (2454 jobs).
+- Public endpoint preserved verbatim:
+  `Etingof.Example_9_4_4 (k) [Field k] (n) : Etingof.homologicalDimension (MvPolynomial (Fin n) k) = n`.
+- Updated `progress/items.json` entry `Chapter9/Example9.4.4` to `proved` / `full` /
+  `covered_full`, cleared `attention_needed` and `fidelity_issue`.
+
+## Current frontier
+
+Issue #7491 complete. Only pre-existing style/deprecation warnings remain in the
+file (`push_neg` deprecation, `linter.style.show`, `linter.defProp` on
+`polynomialExtensionSES`); these are unrelated to the regression and out of scope.
+
+## Overall project progress
+
+Stage 3 formalization ongoing across chapters. This turn restored one broken
+Chapter 9 file to a clean, importable, sorry-free state.
+
+## Next step
+
+Pick the next unclaimed issue via `coordination list-unclaimed`. The many
+`fix(Ch5)`/`fix(Ch4) restore ...` issues look like similar regressions worth
+batching; some may share this same `respectTransparency` root cause.
+
+## Blockers
+
+None.

--- a/progress/2026-07-24T11-32-00Z_a544d4c9.md
+++ b/progress/2026-07-24T11-32-00Z_a544d4c9.md
@@ -1,22 +1,32 @@
 ## Accomplished
 
-Fixed regression #7491: `EtingofRepresentationTheory/Chapter9/Example9_4_4.lean`
-failed a fresh Lean check on the current toolchain and could not be imported.
+Resolved #7491 for `EtingofRepresentationTheory/Chapter9/Example9_4_4.lean`.
 
-Root cause: a toolchain migration made the elaborator stricter about
-type-correctness "under instances transparency". The change-of-scalars morphism
-proofs (Koszul differential `d = X·𝟙 - F.map(xAct)`, the `X·`-mono argument, and
-the Shapiro transfer) rely on definitional equalities between `F.obj (G.obj M)`
-and `(G ⋙ F).obj M`, and between the let-bound `C` and `Polynomial.C`. Under the
-new elaborator, `rw`/`simp` produced terms flagged as type-incorrect at instances
-transparency, so the tactics no longer matched.
+Important finding: this was a **false-positive-style regression**. The issue was
+reproduced with bare `lake env lean <file>`, which does NOT apply the lakefile's
+global `[leanOptions] weak.backward.isDefEq.respectTransparency = false`. Under
+`lake build` (i.e. CI) the pristine file already compiled cleanly — I verified
+this by building `origin/main`'s version of the file: `NO ERRORS`. So CI was
+never broken. This matches the warning already in the `lean-formalization` skill
+(lines 94-103): a "restore/regression" issue reproduced via `lake env lean` is
+likely a false positive; verify with `lake build <Module>` first.
 
-Fix: three `set_option backward.isDefEq.respectTransparency false in` annotations
-on `koszulSES_shortExact`, `polynomial_X_mul_mono_extendScalars`, and
-`ext_subsingleton_of_polynomial_trivial_action`. This restores the pre-migration
-defeq behavior the proofs were written against — the same option Mathlib itself
-uses on `ExtendRestrictScalarsAdj.counit`. No proof logic changed, no axioms, no
-`sorry`.
+Why bare `lean` fails: the migrated elaborator is stricter about type-correctness
+"under instances transparency". The change-of-scalars morphism proofs (Koszul
+differential `d = X·𝟙 - F.map(xAct)`, the `X·`-mono argument, the Shapiro
+transfer) rely on defeq between `F.obj (G.obj M)` and `(G ⋙ F).obj M` and between
+the let-bound `C` and `Polynomial.C`; without the option, `rw`/`simp` produce
+terms flagged type-incorrect and stop matching.
+
+Fix chosen: rather than just closing as a false positive (which would leave the
+file failing bare `lean` and the issue liable to recur), I pinned
+`set_option backward.isDefEq.respectTransparency false in` at the three affected
+declarations (`koszulSES_shortExact`, `polynomial_X_mul_mono_extendScalars`,
+`ext_subsingleton_of_polynomial_trivial_action`). This makes the file
+self-contained — it now passes both `lake env lean` and `lake build` — using the
+same idiom Mathlib applies to `ExtendRestrictScalarsAdj.counit`. No proof logic
+changed, no axioms, no `sorry`. The literal deliverable of #7491 (fresh
+`lake env lean` check passes) is satisfied.
 
 - `lake env lean EtingofRepresentationTheory/Chapter9/Example9_4_4.lean`: no errors, no `sorry`.
 - `lake build EtingofRepresentationTheory.Chapter9.Example9_4_4`: completed successfully (2454 jobs).

--- a/progress/items.json
+++ b/progress/items.json
@@ -9486,14 +9486,13 @@
     "end_page": "217",
     "start_line": 5,
     "end_line": 6,
-    "status": "partially_proved",
-    "fidelity": "partial",
+    "status": "proved",
+    "fidelity": "full",
     "needs_statement": false,
-    "attention_needed": true,
-    "notes": "The file has the exact Hilbert-syzygy endpoint, but its current implementation fails a fresh Lean check and cannot be imported. The failures occur in the exact-sequence, change-of-rings, and Koszul support used by the upper and lower bounds; regression #7491.",
-    "coverage": "covered_partial",
-    "fidelity_issue": 7491,
-    "last_updated": "2026-07-22"
+    "attention_needed": false,
+    "notes": "The file has the exact Hilbert-syzygy endpoint `Etingof.Example_9_4_4` and checks cleanly (sorry-free, importable) on the current toolchain. Regression #7491 (fresh-check failures in the exact-sequence, change-of-rings, and Koszul support) was fixed by restoring `backward.isDefEq.respectTransparency false` on the change-of-scalars morphism proofs, which the stricter migrated elaborator otherwise rejects.",
+    "coverage": "covered_full",
+    "last_updated": "2026-07-24"
   },
   {
     "id": "Chapter9/Problem9.4.5",

--- a/progress/items.json
+++ b/progress/items.json
@@ -9490,7 +9490,7 @@
     "fidelity": "full",
     "needs_statement": false,
     "attention_needed": false,
-    "notes": "The file has the exact Hilbert-syzygy endpoint `Etingof.Example_9_4_4` and checks cleanly (sorry-free, importable) on the current toolchain. Regression #7491 (fresh-check failures in the exact-sequence, change-of-rings, and Koszul support) was fixed by restoring `backward.isDefEq.respectTransparency false` on the change-of-scalars morphism proofs, which the stricter migrated elaborator otherwise rejects.",
+    "notes": "The file has the exact Hilbert-syzygy endpoint `Etingof.Example_9_4_4` and checks cleanly (sorry-free) under `lake build` (2454 jobs). Regression #7491 was reproduced only via bare `lake env lean`, which does not apply the lakefile's global `weak.backward.isDefEq.respectTransparency = false`; under that stricter elaborator the change-of-scalars morphism proofs fail as `rw`/`simp` no longer match defeq `F.obj (G.obj M)` vs `(G ⋙ F).obj M`. Pinned `backward.isDefEq.respectTransparency false` at the three affected declarations so the file also passes bare `lake env lean` (mirroring Mathlib's own usage on ExtendRestrictScalarsAdj.counit). CI was never broken.",
     "coverage": "covered_full",
     "last_updated": "2026-07-24"
   },


### PR DESCRIPTION
This PR restores a clean bare `lake env lean` check for `EtingofRepresentationTheory/Chapter9/Example9_4_4.lean` (issue #7491) by pinning `set_option backward.isDefEq.respectTransparency false in` at the three change-of-scalars morphism declarations (`koszulSES_shortExact`, `polynomial_X_mul_mono_extendScalars`, `ext_subsingleton_of_polynomial_trivial_action`), mirroring the idiom Mathlib itself applies to `ExtendRestrictScalarsAdj.counit`. No proof logic changes, no axioms, no `sorry`; the public endpoint `Etingof.Example_9_4_4 (k) [Field k] (n) : Etingof.homologicalDimension (MvPolynomial (Fin n) k) = n` is preserved verbatim.

Note on the regression: the failure was reproduced only with bare `lake env lean`, which does not apply the lakefile's global `[leanOptions] weak.backward.isDefEq.respectTransparency = false`. Building `origin/main`'s pristine version under `lake build` reports no errors, so CI was never broken. Under the migrated (stricter) elaborator, `rw`/`simp` in these proofs stop matching because terms mixing `F.obj (G.obj M)` with `(G ⋙ F).obj M` (and the let-bound `C` with `Polynomial.C`) are flagged type-incorrect at instances transparency. Pinning the option per declaration makes the file self-contained: it now passes both `lake env lean` and `lake build` (2454 jobs).

Closes #7491

🤖 Prepared with Claude Code