### PR TITLE
feat(Ch5 #7398): prove the Frobenius-Schur type trichotomy

### DIFF
--- a/EtingofRepresentationTheory/Chapter5.lean
+++ b/EtingofRepresentationTheory/Chapter5.lean
@@ -5,6 +5,7 @@ import EtingofRepresentationTheory.Chapter5.Definition5_1_4
 import EtingofRepresentationTheory.Chapter5.Theorem5_1_5
 import EtingofRepresentationTheory.Chapter5.FrobeniusSchurRealType
 import EtingofRepresentationTheory.Chapter5.FrobeniusSchurTraceIdentity
+import EtingofRepresentationTheory.Chapter5.FrobeniusSchurTrichotomy
 import EtingofRepresentationTheory.Chapter5.Corollary5_1_6
 
 -- Section 5.2: Algebraic Numbers and Integers

--- a/EtingofRepresentationTheory/Chapter5/FrobeniusSchurTraceIdentity.lean
+++ b/EtingofRepresentationTheory/Chapter5/FrobeniusSchurTraceIdentity.lean
@@ -96,22 +96,25 @@ private lemma trace_involution_eq_pm_one {W : Type*} [AddCommGroup W] [Module �
   rw [htr]
   exact mul_self_eq_one_iff.mp hsq
 
-/-- **Frobenius-Schur dichotomy (numerical form).** A simple complex representation with
-self-dual character (`χ(g⁻¹) = χ(g)`) has Frobenius-Schur indicator `±1`.
+/-- **The Frobenius-Schur indicator as an involution trace (dimension-free core).**
 
-This is the trace identity `FS = dim(Sym²)^G − dim(Λ²)^G` together with the Schur
-bound `dim(Bil)^G = 1` for self-dual simple representations. -/
-theorem frobeniusSchurIndicator_eq_pm_one_of_self_dual_simple
+For *any* complex representation `ρ`, working on `V ⊗ V` with the diagonal
+representation `T = tprod ρ ρ` and the swap involution `cm = TensorProduct.comm`,
+the Frobenius-Schur indicator equals the trace of an involution `g₀` on the
+invariants `T.invariants`: `g₀` is the swap restricted to `(V ⊗ V)^G` (where the
+averaging projector acts as the identity). This is the shared core of both the
+`±1` case (`dim (V ⊗ V)^G = 1`, self-dual simple) and the `0` case
+(`dim (V ⊗ V)^G = 0`, non-self-dual simple). No simplicity hypothesis is used. -/
+private lemma exists_involution_trace_eq_frobeniusSchur
     [NeZero (Nat.card G : ℂ)] [Invertible (Fintype.card G : ℂ)]
-    (ρ : Representation ℂ G V)
-    (hρ : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule)
-    (hsd : ∀ g, ρ.character g⁻¹ = ρ.character g) :
-    Etingof.frobeniusSchurIndicator ρ = 1 ∨ Etingof.frobeniusSchurIndicator ρ = -1 := by
+    (ρ : Representation ℂ G V) :
+    ∃ g₀ : (Representation.tprod ρ ρ).invariants →ₗ[ℂ] (Representation.tprod ρ ρ).invariants,
+      g₀ ∘ₗ g₀ = LinearMap.id ∧
+      Etingof.frobeniusSchurIndicator ρ
+        = LinearMap.trace ℂ (Representation.tprod ρ ρ).invariants g₀ := by
   classical
   haveI : Invertible (Nat.card G : ℂ) := by
     rw [Nat.card_eq_fintype_card]; infer_instance
-  haveI : Representation.IsIrreducible ρ :=
-    (Representation.irreducible_iff_isSimpleModule_asModule ρ).mpr hρ
   -- The diagonal representation `T` on `V ⊗ V`, the swap `cm`, and the projector `P`.
   set T : Representation ℂ G (V ⊗[ℂ] V) := Representation.tprod ρ ρ with hT
   set cm : V ⊗[ℂ] V →ₗ[ℂ] V ⊗[ℂ] V :=
@@ -134,21 +137,6 @@ theorem frobeniusSchurIndicator_eq_pm_one_of_self_dual_simple
     have key : (T g ∘ₗ cm) x = (cm ∘ₗ T g) x := by rw [hequiv]
     have hxg : T g x = x := hx g
     simpa [hxg] using key
-  -- The dimension of the invariants is `1`.
-  have hdim : Module.finrank ℂ (T.invariants) = 1 := by
-    have hkey := Representation.card_inv_mul_sum_char_eq_finrank T
-    have hortho := Representation.char_orthonormal ρ ρ
-    rw [if_pos ⟨Representation.Equiv.refl ρ⟩] at hortho
-    have hchar : ∀ g, T.character g = ρ.character g * ρ.character g := by
-      intro g; rw [hT, Representation.char_tensor]; rfl
-    have hsum : (Nat.card G : ℂ)⁻¹ * ∑ g : G, T.character g = 1 := by
-      rw [Finset.sum_congr rfl (fun g _ => hchar g)]
-      rw [show (∑ g : G, ρ.character g * ρ.character g)
-            = ∑ g : G, ρ.character g * ρ.character g⁻¹ from
-          Finset.sum_congr rfl (fun g _ => by rw [hsd g])]
-      exact hortho
-    rw [hkey] at hsum
-    exact_mod_cast hsum
   -- `FS(ρ) = trace (cm ∘ averageMap T)`.
   have hP : T.averageMap = ⅟(Fintype.card G : ℂ) • ∑ g : G, T g := by
     simp only [Representation.averageMap, GroupAlgebra.average, map_smul, map_sum,
@@ -170,7 +158,7 @@ theorem frobeniusSchurIndicator_eq_pm_one_of_self_dual_simple
     rw [hR, Etingof.frobeniusSchurIndicator]
     exact congrArg (fun s => (Fintype.card G : ℂ)⁻¹ * s)
       (Finset.sum_congr rfl (fun g _ => hterm g))
-  -- Restrict to the invariants and apply the involution argument.
+  -- Restrict to the invariants and package the involution.
   have hmaps : ∀ x, (cm ∘ₗ T.averageMap) x ∈ T.invariants := by
     intro x
     exact hpres _ (T.averageMap_invariant x)
@@ -178,7 +166,6 @@ theorem frobeniusSchurIndicator_eq_pm_one_of_self_dual_simple
     fun x _ => hmaps x
   have htr := LinearMap.trace_restrict_eq_of_forall_mem T.invariants
     (cm ∘ₗ T.averageMap) hmaps hmaps'
-  -- The restricted map is an involution on the 1-dimensional invariants.
   set g₀ := (cm ∘ₗ T.averageMap).restrict hmaps' with hg₀
   have hg₀sq : g₀ ∘ₗ g₀ = LinearMap.id := by
     refine LinearMap.ext fun x => Subtype.ext ?_
@@ -194,7 +181,110 @@ theorem frobeniusSchurIndicator_eq_pm_one_of_self_dual_simple
       simpa using hinv
     rw [LinearMap.comp_apply, e2]
     simp
-  rw [hFS, ← htr]
+  exact ⟨g₀, hg₀sq, hFS.trans htr.symm⟩
+
+/-- **Frobenius-Schur dichotomy (numerical form).** A simple complex representation with
+self-dual character (`χ(g⁻¹) = χ(g)`) has Frobenius-Schur indicator `±1`.
+
+This is the trace identity `FS = dim(Sym²)^G − dim(Λ²)^G` together with the Schur
+bound `dim(Bil)^G = 1` for self-dual simple representations. -/
+theorem frobeniusSchurIndicator_eq_pm_one_of_self_dual_simple
+    [NeZero (Nat.card G : ℂ)] [Invertible (Fintype.card G : ℂ)]
+    (ρ : Representation ℂ G V)
+    (hρ : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule)
+    (hsd : ∀ g, ρ.character g⁻¹ = ρ.character g) :
+    Etingof.frobeniusSchurIndicator ρ = 1 ∨ Etingof.frobeniusSchurIndicator ρ = -1 := by
+  classical
+  haveI : Invertible (Nat.card G : ℂ) := by
+    rw [Nat.card_eq_fintype_card]; infer_instance
+  haveI : Representation.IsIrreducible ρ :=
+    (Representation.irreducible_iff_isSimpleModule_asModule ρ).mpr hρ
+  obtain ⟨g₀, hg₀sq, hfs⟩ := exists_involution_trace_eq_frobeniusSchur ρ
+  -- The dimension of the invariants is `1`.
+  have hdim : Module.finrank ℂ ((Representation.tprod ρ ρ).invariants) = 1 := by
+    have hkey := Representation.card_inv_mul_sum_char_eq_finrank (Representation.tprod ρ ρ)
+    have hortho := Representation.char_orthonormal ρ ρ
+    rw [if_pos ⟨Representation.Equiv.refl ρ⟩] at hortho
+    have hchar : ∀ g, (Representation.tprod ρ ρ).character g = ρ.character g * ρ.character g := by
+      intro g; rw [Representation.char_tensor]; rfl
+    have hsum : (Nat.card G : ℂ)⁻¹ * ∑ g : G, (Representation.tprod ρ ρ).character g = 1 := by
+      rw [Finset.sum_congr rfl (fun g _ => hchar g)]
+      rw [show (∑ g : G, ρ.character g * ρ.character g)
+            = ∑ g : G, ρ.character g * ρ.character g⁻¹ from
+          Finset.sum_congr rfl (fun g _ => by rw [hsd g])]
+      exact hortho
+    rw [hkey] at hsum
+    exact_mod_cast hsum
+  rw [hfs]
   exact trace_involution_eq_pm_one hdim g₀ hg₀sq
+
+/-- **Frobenius-Schur vanishing (complex type).** A simple complex representation whose
+character is *not* self-dual (`χ(g⁻¹) ≠ χ(g)` for some `g`, i.e. `V ≇ V*`) has
+Frobenius-Schur indicator `0`.
+
+The invariant bilinear forms `(V ⊗ V)^G ≅ Hom_G(V*, V)` vanish by Schur's lemma
+(`V*` is not isomorphic to `V`), so the swap involution acts on a zero-dimensional
+space and its trace `FS(ρ)` is `0`. -/
+theorem frobeniusSchurIndicator_eq_zero_of_not_self_dual_simple
+    [NeZero (Nat.card G : ℂ)] [Invertible (Fintype.card G : ℂ)]
+    (ρ : Representation ℂ G V)
+    (hρ : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule)
+    (hnsd : ¬ ∀ g, ρ.character g⁻¹ = ρ.character g) :
+    Etingof.frobeniusSchurIndicator ρ = 0 := by
+  classical
+  haveI : Invertible (Nat.card G : ℂ) := by
+    rw [Nat.card_eq_fintype_card]; infer_instance
+  haveI : Representation.IsIrreducible ρ :=
+    (Representation.irreducible_iff_isSimpleModule_asModule ρ).mpr hρ
+  obtain ⟨g₀, _, hfs⟩ := exists_involution_trace_eq_frobeniusSchur ρ
+  -- No `G`-equivariant iso `V ≅ V*` (else the characters would agree, contradicting `hnsd`).
+  have hempty : IsEmpty (ρ.Equiv ρ.dual) := by
+    rw [isEmpty_iff]
+    intro φ
+    refine hnsd (fun g => ?_)
+    have hc := congrFun (Representation.char_iso φ) g
+    rw [Representation.char_dual] at hc
+    exact hc.symm
+  -- `Hom_G(V, V*)` is a subsingleton: a nonzero intertwiner is injective (Schur), hence
+  -- bijective (equal dimension), giving an equivalence `V ≅ V*`, which is impossible.
+  haveI hsub : Subsingleton (Representation.IntertwiningMap ρ ρ.dual) := by
+    refine ⟨fun f h => ?_⟩
+    suffices hz : ∀ e : Representation.IntertwiningMap ρ ρ.dual, e = 0 by rw [hz f, hz h]
+    intro e
+    rcases Representation.IsIrreducible.injective_or_eq_zero e with hinj | h0
+    · exfalso
+      have hdimeq : Module.finrank ℂ V = Module.finrank ℂ (Module.Dual ℂ V) :=
+        (Subspace.dual_finrank_eq).symm
+      have hsurj : Function.Surjective ⇑e :=
+        (LinearMap.injective_iff_surjective_of_finrank_eq_finrank hdimeq
+          (f := e.toLinearMap)).mp hinj
+      exact hempty.false (e.ofBijective ⟨hinj, hsurj⟩)
+    · exact h0
+  -- The dimension of the invariants is `0`: `(V ⊗ V)^G ≅ Hom_G(V, V*) = 0` by the above.
+  have hdim : Module.finrank ℂ ((Representation.tprod ρ ρ).invariants) = 0 := by
+    have hkey := Representation.card_inv_mul_sum_char_eq_finrank (Representation.tprod ρ ρ)
+    have hInt := Representation.card_inv_mul_sum_char_mul_char_eq_finrank ρ ρ.dual
+    -- `∑ T.character g = ∑ ρ.dual.character g * ρ.character g⁻¹` (reindex `g ↦ g⁻¹`).
+    have hsum : (∑ g : G, (Representation.tprod ρ ρ).character g)
+        = ∑ g : G, ρ.dual.character g * ρ.character g⁻¹ := by
+      rw [Finset.sum_congr rfl
+            (fun g _ => by rw [Representation.char_tensor, Pi.mul_apply] :
+              ∀ g ∈ Finset.univ, (Representation.tprod ρ ρ).character g
+                = ρ.character g * ρ.character g),
+          Finset.sum_congr rfl
+            (fun g _ => by rw [Representation.char_dual] :
+              ∀ g ∈ Finset.univ, ρ.dual.character g * ρ.character g⁻¹
+                = ρ.character g⁻¹ * ρ.character g⁻¹)]
+      exact (Equiv.sum_comp (Equiv.inv G) (fun g => ρ.character g * ρ.character g)).symm
+    rw [hsum, hInt] at hkey
+    have hInt0 : Module.finrank ℂ (Representation.IntertwiningMap ρ ρ.dual) = 0 :=
+      (finrank_zero_iff_forall_zero (K := ℂ)).mpr fun x => Subsingleton.elim x 0
+    rw [hInt0] at hkey
+    exact_mod_cast hkey.symm
+  -- Zero-dimensional invariants force `g₀ = 0`, hence `FS(ρ) = trace g₀ = 0`.
+  haveI : Subsingleton ((Representation.tprod ρ ρ).invariants) :=
+    ⟨fun a b => ((finrank_zero_iff_forall_zero (K := ℂ)).mp hdim a).trans
+      ((finrank_zero_iff_forall_zero (K := ℂ)).mp hdim b).symm⟩
+  rw [hfs, Subsingleton.elim g₀ 0, map_zero]
 
 end Etingof

--- a/EtingofRepresentationTheory/Chapter5/FrobeniusSchurTrichotomy.lean
+++ b/EtingofRepresentationTheory/Chapter5/FrobeniusSchurTrichotomy.lean
@@ -1,0 +1,266 @@
+import Mathlib
+import EtingofRepresentationTheory.Chapter5.Definition5_1_1
+import EtingofRepresentationTheory.Chapter5.Definition5_1_4
+import EtingofRepresentationTheory.Chapter5.FrobeniusSchurRealType
+import EtingofRepresentationTheory.Chapter5.FrobeniusSchurTraceIdentity
+
+/-!
+# Definition 5.1.4: the Frobenius-Schur type trichotomy
+
+For a *simple* finite-dimensional complex representation `ρ` of a finite group, the
+Frobenius-Schur indicator `FS(ρ) = |G|⁻¹ ∑_g χ(g²)` (Definition 5.1.4) determines and is
+determined by the complex / real / quaternionic type of `ρ` (Definition 5.1.1):
+
+* `IsComplexType ρ ↔ FS(ρ) = 0`;
+* `IsRealType ρ ↔ FS(ρ) = 1`;
+* `IsQuaternionicType ρ ↔ FS(ρ) = -1`.
+
+The three types are **exhaustive** (every simple `ρ` is of exactly one type) and
+**pairwise exclusive**, and in particular `FS(ρ) ∈ {0, 1, -1}`.
+
+## Proof ingredients
+
+Everything is assembled from previously established results:
+
+* real ⟺ `FS = 1`: `isRealType_of_frobeniusSchurIndicator_eq_one` /
+  `frobeniusSchurIndicator_eq_one_of_isRealType` (Frobenius-Schur real-type file);
+* self-dual character ⟹ `FS = ±1`: `frobeniusSchurIndicator_eq_pm_one_of_self_dual_simple`;
+* non-self-dual character ⟹ `FS = 0`: `frobeniusSchurIndicator_eq_zero_of_not_self_dual_simple`;
+* self-dual character ⟹ real or quaternionic: `isRealType_or_isQuaternionicType_of_self_dual`;
+* real / quaternionic ⟹ not complex: `not_isComplexType_of_isRealType` /
+  `not_isComplexType_of_isQuaternionicType`.
+
+Two bridging facts are proved here: a non-complex simple representation has self-dual
+character (`selfDualChar_of_not_isComplexType`), and no simple representation is
+simultaneously of real and quaternionic type (`not_isRealType_and_isQuaternionicType`),
+because the space of invariant bilinear forms is one-dimensional and cannot contain both a
+nonzero symmetric and a nonzero skew-symmetric form.
+-/
+
+open scoped MonoidAlgebra
+
+namespace Etingof
+
+variable {G : Type*} [Group G] [Fintype G] [DecidableEq G]
+variable {V : Type*} [AddCommGroup V] [Module ℂ V] [Module.Finite ℂ V]
+
+/-- Over `ℂ`, a finite group has invertible/nonzero order; supply the instances required by
+the numerical Frobenius-Schur results. -/
+private lemma cardCastNeZero : (Fintype.card G : ℂ) ≠ 0 := by
+  exact_mod_cast Fintype.card_pos.ne'
+
+/-- **Bridge: not complex ⟹ self-dual character.** If a representation is not of complex
+type, i.e. it admits a `G`-equivariant isomorphism `V ≅ V*`, then its character is self-dual
+(`χ(g⁻¹) = χ(g)`): the isomorphism conjugates `ρ g` to `ρ.dual g`, and trace is a conjugation
+invariant, while `χ_{V*}(g) = χ(g⁻¹)`. -/
+theorem selfDualChar_of_not_isComplexType (ρ : Representation ℂ G V)
+    (h : ¬ Etingof.IsComplexType ρ) :
+    ∀ g, ρ.character g⁻¹ = ρ.character g := by
+  have hex : ∃ e : V ≃ₗ[ℂ] Module.Dual ℂ V, ∀ g v, e (ρ g v) = ρ.dual g (e v) := by
+    by_contra hc; exact h hc
+  obtain ⟨e, he⟩ := hex
+  intro g
+  have hconj : ρ.dual g = e.conj (ρ g) := by
+    ext w
+    rw [LinearEquiv.conj_apply_apply, he g (e.symm w), LinearEquiv.apply_symm_apply]
+  calc ρ.character g⁻¹
+      = ρ.dual.character g := (ρ.char_dual g).symm
+    _ = LinearMap.trace ℂ (Module.Dual ℂ V) (e.conj (ρ g)) := by
+          rw [Representation.character, hconj]
+    _ = LinearMap.trace ℂ V (ρ g) := LinearMap.trace_conj' (ρ g) e
+    _ = ρ.character g := rfl
+
+/-- **Real and quaternionic type are exclusive.** For a simple representation the space of
+`G`-invariant bilinear forms is one-dimensional (Schur, self-dual), so it cannot contain both
+a nonzero symmetric form (real type) and a nonzero skew-symmetric form (quaternionic type):
+these would be proportional, forcing a nonzero form to be both symmetric and skew, hence
+zero. -/
+theorem not_isRealType_and_isQuaternionicType (ρ : Representation ℂ G V)
+    (hρ : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule) :
+    ¬ (Etingof.IsRealType ρ ∧ Etingof.IsQuaternionicType ρ) := by
+  classical
+  rintro ⟨⟨Bs, hBs_sym, hBs_nd, hBs_inv⟩, ⟨Bq, hBq_skew, hBq_nd, hBq_inv⟩⟩
+  haveI : Representation.IsIrreducible ρ :=
+    (Representation.irreducible_iff_isSimpleModule_asModule ρ).mpr hρ
+  haveI : Nonempty G := ⟨1⟩
+  haveI : Invertible (Nat.card G : ℂ) :=
+    invertibleOfNonzero (by simp only [ne_eq, Nat.cast_eq_zero]; exact Nat.card_pos.ne')
+  haveI hNT : Nontrivial V := IsSimpleModule.nontrivial (MonoidAlgebra ℂ G) ρ.asModule
+  -- Self-dual character from the nondegenerate invariant symmetric form `Bs`.
+  have hchar_sd : ∀ g, ρ.character g⁻¹ = ρ.character g := by
+    obtain ⟨e, he⟩ :=
+      Etingof.exists_equivariant_dual_equiv_of_invariant_nondegenerate ρ Bs hBs_nd hBs_inv
+    intro g
+    have hconj : ρ.dual g = e.conj (ρ g) := by
+      ext w; rw [LinearEquiv.conj_apply_apply, he g (e.symm w), LinearEquiv.apply_symm_apply]
+    calc ρ.character g⁻¹
+        = ρ.dual.character g := (ρ.char_dual g).symm
+      _ = LinearMap.trace ℂ (Module.Dual ℂ V) (e.conj (ρ g)) := by
+            rw [Representation.character, hconj]
+      _ = LinearMap.trace ℂ V (ρ g) := LinearMap.trace_conj' (ρ g) e
+      _ = ρ.character g := rfl
+  -- The space of invariant bilinear forms is one-dimensional.
+  have hd1 : Module.finrank ℂ ((Representation.linHom ρ ρ.dual).invariants) = 1 := by
+    have hkey := Representation.card_inv_mul_sum_char_eq_finrank (Representation.linHom ρ ρ.dual)
+    have hortho := Representation.char_orthonormal ρ ρ
+    rw [if_pos ⟨Representation.Equiv.refl ρ⟩] at hortho
+    have hchar : ∀ g, (Representation.linHom ρ ρ.dual).character g
+        = ρ.character g * ρ.character g⁻¹ := fun g => by
+      rw [Representation.char_linHom, Representation.char_dual, hchar_sd g]
+    rw [Finset.sum_congr rfl (fun g _ => hchar g), hortho] at hkey
+    exact_mod_cast hkey.symm
+  -- `Bs` and `Bq`, read as maps `V →ₗ Module.Dual ℂ V`, are invariant.
+  have hmem : ∀ B : V →ₗ[ℂ] Module.Dual ℂ V, (∀ g v w, B (ρ g v) (ρ g w) = B v w) →
+      B ∈ (Representation.linHom ρ ρ.dual).invariants := by
+    intro B hB
+    rw [Representation.mem_invariants]
+    intro g
+    ext v w
+    rw [Representation.linHom_apply]
+    simp only [LinearMap.comp_apply, Representation.dual_apply, Module.Dual.transpose_apply]
+    exact hB g⁻¹ v w
+  have memS : (Bs : V →ₗ[ℂ] Module.Dual ℂ V) ∈ (Representation.linHom ρ ρ.dual).invariants :=
+    hmem Bs hBs_inv
+  have memQ : (Bq : V →ₗ[ℂ] Module.Dual ℂ V) ∈ (Representation.linHom ρ ρ.dual).invariants :=
+    hmem Bq hBq_inv
+  obtain ⟨v0, hv0⟩ := exists_ne (0 : V)
+  have hBsne : (⟨Bs, memS⟩ : (Representation.linHom ρ ρ.dual).invariants) ≠ 0 := by
+    intro h0
+    have hBs0 : Bs = 0 := by simpa using congrArg Subtype.val h0
+    exact hv0 (hBs_nd v0 (fun w => by simp [hBs0]))
+  -- Proportionality: `Bq = c • Bs` for some scalar `c`.
+  obtain ⟨c, hc⟩ :=
+    (finrank_eq_one_iff_of_nonzero' (⟨Bs, memS⟩ : (Representation.linHom ρ ρ.dual).invariants)
+      hBsne).mp hd1 ⟨Bq, memQ⟩
+  have hcoe : c • Bs = Bq := by simpa using congrArg Subtype.val hc
+  -- A symmetric multiple that is also skew must vanish.
+  have hBqzero : Bq = 0 := by
+    ext v w
+    have hxvw : Bq v w = c * Bs v w := by rw [← hcoe]; simp
+    have hxwv : Bq w v = c * Bs v w := by rw [← hcoe]; simp [hBs_sym w v]
+    have hz : Bq v w = 0 := by
+      linear_combination (1 / 2 : ℂ) * hxvw - (1 / 2 : ℂ) * hxwv + (1 / 2 : ℂ) * hBq_skew v w
+    simpa using hz
+  exact hv0 (hBq_nd v0 (fun w => by simp [hBqzero]))
+
+/-- The nonzero-order instances required by the numerical Frobenius-Schur results, always
+available over `ℂ` for a finite group. -/
+private noncomputable def invertibleCardCast : Invertible (Fintype.card G : ℂ) :=
+  invertibleOfNonzero cardCastNeZero
+
+private theorem neZeroNatCardCast : NeZero (Nat.card G : ℂ) :=
+  ⟨by rw [Nat.card_eq_fintype_card]; exact cardCastNeZero⟩
+
+/-- **Real type ⟺ indicator `1`.** (Etingof, Definition 5.1.4, real case.) -/
+theorem isRealType_iff_frobeniusSchurIndicator_eq_one (ρ : Representation ℂ G V)
+    (hρ : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule) :
+    Etingof.IsRealType ρ ↔ Etingof.frobeniusSchurIndicator ρ = 1 :=
+  ⟨Etingof.frobeniusSchurIndicator_eq_one_of_isRealType ρ hρ,
+    Etingof.isRealType_of_frobeniusSchurIndicator_eq_one ρ hρ⟩
+
+/-- **Quaternionic type ⟹ indicator `-1`.** A quaternionic simple representation is
+self-dual, so `FS = ±1`; it cannot be `1` (that would make it real too, contradicting
+`not_isRealType_and_isQuaternionicType`), hence `FS = -1`. -/
+theorem frobeniusSchurIndicator_eq_neg_one_of_isQuaternionicType (ρ : Representation ℂ G V)
+    (hρ : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule)
+    (hq : Etingof.IsQuaternionicType ρ) :
+    Etingof.frobeniusSchurIndicator ρ = -1 := by
+  haveI := invertibleCardCast (G := G)
+  haveI := neZeroNatCardCast (G := G)
+  have hsd := selfDualChar_of_not_isComplexType ρ (not_isComplexType_of_isQuaternionicType hq)
+  rcases Etingof.frobeniusSchurIndicator_eq_pm_one_of_self_dual_simple ρ hρ hsd with h1 | hm1
+  · exact absurd ⟨Etingof.isRealType_of_frobeniusSchurIndicator_eq_one ρ hρ h1, hq⟩
+      (not_isRealType_and_isQuaternionicType ρ hρ)
+  · exact hm1
+
+/-- **Indicator `-1` ⟹ quaternionic type.** If `FS = -1` the character is self-dual (else
+`FS = 0`), so `ρ` is real or quaternionic; real would give `FS = 1`, so `ρ` is
+quaternionic. -/
+theorem isQuaternionicType_of_frobeniusSchurIndicator_eq_neg_one (ρ : Representation ℂ G V)
+    (hρ : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule)
+    (h : Etingof.frobeniusSchurIndicator ρ = -1) :
+    Etingof.IsQuaternionicType ρ := by
+  haveI := invertibleCardCast (G := G)
+  haveI := neZeroNatCardCast (G := G)
+  by_cases hsd : ∀ g, ρ.character g⁻¹ = ρ.character g
+  · rcases Etingof.isRealType_or_isQuaternionicType_of_self_dual ρ hρ hsd with hr | hq
+    · exact absurd (Etingof.frobeniusSchurIndicator_eq_one_of_isRealType ρ hρ hr)
+        (by rw [h]; norm_num)
+    · exact hq
+  · exact absurd (Etingof.frobeniusSchurIndicator_eq_zero_of_not_self_dual_simple ρ hρ hsd)
+      (by rw [h]; norm_num)
+
+/-- **Quaternionic type ⟺ indicator `-1`.** (Etingof, Definition 5.1.4, quaternionic case.) -/
+theorem isQuaternionicType_iff_frobeniusSchurIndicator_eq_neg_one (ρ : Representation ℂ G V)
+    (hρ : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule) :
+    Etingof.IsQuaternionicType ρ ↔ Etingof.frobeniusSchurIndicator ρ = -1 :=
+  ⟨frobeniusSchurIndicator_eq_neg_one_of_isQuaternionicType ρ hρ,
+    isQuaternionicType_of_frobeniusSchurIndicator_eq_neg_one ρ hρ⟩
+
+/-- **The indicator takes the values `0`, `1`, `-1`.** A simple complex representation has
+`FS(ρ) ∈ {0, 1, -1}`: `±1` when the character is self-dual, `0` otherwise. -/
+theorem frobeniusSchurIndicator_eq_zero_or_one_or_neg_one (ρ : Representation ℂ G V)
+    (hρ : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule) :
+    Etingof.frobeniusSchurIndicator ρ = 0 ∨ Etingof.frobeniusSchurIndicator ρ = 1 ∨
+      Etingof.frobeniusSchurIndicator ρ = -1 := by
+  haveI := invertibleCardCast (G := G)
+  haveI := neZeroNatCardCast (G := G)
+  by_cases hsd : ∀ g, ρ.character g⁻¹ = ρ.character g
+  · rcases Etingof.frobeniusSchurIndicator_eq_pm_one_of_self_dual_simple ρ hρ hsd with h | h
+    · exact Or.inr (Or.inl h)
+    · exact Or.inr (Or.inr h)
+  · exact Or.inl (Etingof.frobeniusSchurIndicator_eq_zero_of_not_self_dual_simple ρ hρ hsd)
+
+/-- The indicator belongs to the set `{0, 1, -1}`. -/
+theorem frobeniusSchurIndicator_mem_insert (ρ : Representation ℂ G V)
+    (hρ : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule) :
+    Etingof.frobeniusSchurIndicator ρ ∈ ({0, 1, -1} : Set ℂ) := by
+  rcases frobeniusSchurIndicator_eq_zero_or_one_or_neg_one ρ hρ with h | h | h <;>
+    simp [h]
+
+/-- **Complex type ⟺ indicator `0`.** (Etingof, Definition 5.1.4, complex case.) -/
+theorem isComplexType_iff_frobeniusSchurIndicator_eq_zero (ρ : Representation ℂ G V)
+    (hρ : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule) :
+    Etingof.IsComplexType ρ ↔ Etingof.frobeniusSchurIndicator ρ = 0 := by
+  haveI := invertibleCardCast (G := G)
+  haveI := neZeroNatCardCast (G := G)
+  constructor
+  · intro hc
+    have hnr : ¬ Etingof.IsRealType ρ := fun hr => not_isComplexType_of_isRealType hr hc
+    have hnq : ¬ Etingof.IsQuaternionicType ρ := fun hq =>
+      not_isComplexType_of_isQuaternionicType hq hc
+    rcases frobeniusSchurIndicator_eq_zero_or_one_or_neg_one ρ hρ with h0 | h1 | hm1
+    · exact h0
+    · exact absurd (Etingof.isRealType_of_frobeniusSchurIndicator_eq_one ρ hρ h1) hnr
+    · exact absurd (isQuaternionicType_of_frobeniusSchurIndicator_eq_neg_one ρ hρ hm1) hnq
+  · intro h0
+    by_contra hnc
+    have hsd := selfDualChar_of_not_isComplexType ρ hnc
+    rcases Etingof.frobeniusSchurIndicator_eq_pm_one_of_self_dual_simple ρ hρ hsd with h1 | hm1
+    · rw [h0] at h1; norm_num at h1
+    · rw [h0] at hm1; norm_num at hm1
+
+/-- **Exhaustiveness of the trichotomy.** Every simple complex representation is of complex,
+real, or quaternionic type. -/
+theorem isComplexType_or_isRealType_or_isQuaternionicType (ρ : Representation ℂ G V)
+    (hρ : IsSimpleModule (MonoidAlgebra ℂ G) ρ.asModule) :
+    Etingof.IsComplexType ρ ∨ Etingof.IsRealType ρ ∨ Etingof.IsQuaternionicType ρ := by
+  by_cases hsd : ∀ g, ρ.character g⁻¹ = ρ.character g
+  · rcases Etingof.isRealType_or_isQuaternionicType_of_self_dual ρ hρ hsd with hr | hq
+    · exact Or.inr (Or.inl hr)
+    · exact Or.inr (Or.inr hq)
+  · refine Or.inl ?_
+    by_contra hnc
+    exact hsd (selfDualChar_of_not_isComplexType ρ hnc)
+
+/-- Complex and real type are exclusive. -/
+theorem not_isComplexType_and_isRealType (ρ : Representation ℂ G V) :
+    ¬ (Etingof.IsComplexType ρ ∧ Etingof.IsRealType ρ) :=
+  fun ⟨hc, hr⟩ => not_isComplexType_of_isRealType hr hc
+
+/-- Complex and quaternionic type are exclusive. -/
+theorem not_isComplexType_and_isQuaternionicType (ρ : Representation ℂ G V) :
+    ¬ (Etingof.IsComplexType ρ ∧ Etingof.IsQuaternionicType ρ) :=
+  fun ⟨hc, hq⟩ => not_isComplexType_of_isQuaternionicType hq hc
+
+end Etingof

--- a/progress/2026-07-24T13-22-29Z_ffb70247.md
+++ b/progress/2026-07-24T13-22-29Z_ffb70247.md
@@ -1,0 +1,53 @@
+## Accomplished
+
+Completed issue #7398 — the full Frobenius-Schur type trichotomy for Definition 5.1.4.
+
+- **`FrobeniusSchurTraceIdentity.lean`**: extracted the dimension-free trace-identity
+  core (`exists_involution_trace_eq_frobeniusSchur`, no simplicity hypothesis) from the
+  existing `frobeniusSchurIndicator_eq_pm_one_of_self_dual_simple`, and used it to add
+  `frobeniusSchurIndicator_eq_zero_of_not_self_dual_simple`: a simple complex representation
+  whose character is not self-dual has `FS = 0`. The existing `±1` theorem keeps its exact
+  signature (it now shares the core), so downstream (`Example5_1_3`) is unaffected — verified.
+
+- **`FrobeniusSchurTrichotomy.lean`** (new): assembles the trichotomy for simple complex
+  representations:
+  - `isRealType_iff_frobeniusSchurIndicator_eq_one`
+  - `isQuaternionicType_iff_frobeniusSchurIndicator_eq_neg_one`
+  - `isComplexType_iff_frobeniusSchurIndicator_eq_zero`
+  - `isComplexType_or_isRealType_or_isQuaternionicType` (exhaustive)
+  - `not_isComplexType_and_isRealType`, `not_isComplexType_and_isQuaternionicType`,
+    `not_isRealType_and_isQuaternionicType` (pairwise exclusive)
+  - `frobeniusSchurIndicator_eq_zero_or_one_or_neg_one` and `..._mem_insert` (`FS ∈ {0,1,-1}`)
+  - Bridge lemmas: `selfDualChar_of_not_isComplexType` (not-complex ⟹ self-dual character)
+    and `not_isRealType_and_isQuaternionicType` (invariant-form space is 1-dimensional).
+
+- Registered the new file in `Chapter5.lean`; updated `progress/items.json` coverage for
+  Definition 5.1.4 to `covered_full`.
+
+## Current frontier
+
+Issue #7398 is fully done. No new `sorry` or axioms. Each new file builds; the downstream
+importer `Example5_1_3` builds unchanged.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. Definition 5.1.4 (Frobenius-Schur indicator) now has its
+complete source trichotomy, closing the last fidelity gap for that item.
+
+## Next step
+
+Open the PR for #7398 with auto-merge. Other agents can pick up remaining unclaimed
+Chapter 5 items (e.g. #7399, #7400, #7405, #7406).
+
+## Blockers
+
+None.
+
+## Key patterns discovered
+
+- The dual of a simple representation being simple is **not** in Mathlib. Avoided needing
+  it: `Subsingleton (IntertwiningMap ρ ρ.dual)` was proved directly from `IsIrreducible ρ`
+  (source only) via `injective_or_eq_zero` + `injective_iff_surjective_of_finrank_eq_finrank`
+  + `IsEmpty (Equiv ρ ρ.dual)`, rather than the two-sided Schur instance.
+- `FS = 0` for the complex/non-self-dual case reuses the same swap-involution trace machinery
+  as the `±1` case; the only difference is `dim (V⊗V)^G = 0` vs `1`.

--- a/progress/items.json
+++ b/progress/items.json
@@ -4401,13 +4401,12 @@
     "start_line": 7,
     "end_line": 8,
     "status": "sorry_free",
-    "coverage": "covered_partial",
+    "coverage": "covered_full",
     "fidelity": "verified",
     "sorry_free": true,
-    "fidelity_note": "The definition constructs the genuine FS indicator via (1/|G|) sum_g chi_V(g^2), and the real/+1 case is connected downstream. The full source trichotomy is not: complex/0 and quaternionic/-1 equivalences, exhaustiveness, and mutual exclusivity remain #7398.",
+    "fidelity_note": "The definition constructs the genuine FS indicator via (1/|G|) sum_g chi_V(g^2), and the full source trichotomy is now proved for simple complex representations in FrobeniusSchurTrichotomy.lean: IsRealType ↔ FS=1, IsQuaternionicType ↔ FS=-1, IsComplexType ↔ FS=0, exhaustiveness (isComplexType_or_isRealType_or_isQuaternionicType), pairwise exclusivity, and FS ∈ {0,1,-1} (frobeniusSchurIndicator_eq_zero_or_one_or_neg_one).",
     "fidelity_decl": "Etingof.frobeniusSchurIndicator",
-    "fidelity_issue": 7398,
-    "last_updated": "2026-07-22"
+    "last_updated": "2026-07-24"
   },
   {
     "id": "Chapter5/Theorem5.1.5",


### PR DESCRIPTION
Closes #7398

Session: `ffb70247-6f35-4983-b5be-1bd331592554`

c4569e58 docs(Ch5 #7398): progress handoff for Frobenius-Schur trichotomy
7abb93aa chore(Ch5 #7398): mark Definition 5.1.4 trichotomy coverage as full
97f61718 feat(Ch5 #7398): prove the Frobenius-Schur type trichotomy
267c4079 feat(Ch5 #7398): expose FS=0 vanishing for non-self-dual simple reps

🤖 Prepared with Claude Code