### PR TITLE
Example 7.7.2: formalize the finite-dimensional module category, not a conditional FGModuleCat substitute

### DIFF
--- a/EtingofRepresentationTheory/Chapter7/Example7_7_2.lean
+++ b/EtingofRepresentationTheory/Chapter7/Example7_7_2.lean
@@ -1,47 +1,94 @@
 import Mathlib.CategoryTheory.Abelian.Basic
 import Mathlib.Algebra.Category.ModuleCat.Abelian
 import Mathlib.Algebra.Category.FGModuleCat.Abelian
+import Mathlib.RingTheory.Noetherian.Basic
+import Mathlib.RingTheory.Finiteness.Basic
 
 /-!
 # Example 7.7.2: Module Categories are Abelian
 
-The category of modules over an algebra A and the category of finite dimensional
-modules over A are abelian categories.
+The category of modules over an algebra `A` and the category of finite dimensional
+modules over `A` are abelian categories.
 
 ## Mathlib correspondence
 
-The book makes two claims:
-(a) the category of all modules over A is abelian, and
-(b) the category of finite dimensional modules over A is abelian.
+The book makes two claims, working with a finite dimensional algebra `A` over a field
+`k`:
+(a) the category of all `A`-modules is abelian, and
+(b) the category of finite dimensional `A`-modules is abelian.
 
 Part (a) is an exact match: `ModuleCat A` is an abelian category in Mathlib via
 `ModuleCat.instAbelian`.
 
-Part (b) is captured by `FGModuleCat A`, the category of finitely generated
-A-modules. Mathlib proves `Abelian (FGModuleCat A)` whenever A is a (left-)
-Noetherian ring (`Mathlib.Algebra.Category.FGModuleCat.Abelian`). In Etingof's
-setting A is a finite dimensional algebra over a field, hence Artinian and so
-Noetherian, and an A-module is finite dimensional (over the base field) exactly
-when it is finitely generated over A. Thus `FGModuleCat A` for Noetherian A is
-the faithful rendering of the finite dimensional module category. Specializing A
-to the base field k recovers the category of finite dimensional vector spaces,
-which is likewise abelian.
+For part (b) the source category consists of the `A`-modules that are finite
+dimensional *over the base field* `k`. Mathlib's `FGModuleCat A` is the category of
+`A`-modules that are finitely generated *over* `A`. The point of Example 7.7.2 is that,
+in the book's setting where `A` is finite dimensional over `k`, these two conditions
+agree, so `FGModuleCat A` is a faithful rendering of the finite dimensional module
+category and it is abelian.
+
+The identification of the two categories is the objectwise bridge
+`module_finite_iff_finiteDimensional`: for an `A`-module `M` with a compatible
+`k`-structure, `M` is finitely generated over `A` iff it is finite dimensional over `k`.
+The abelian endpoint `abelian_fgModuleCat_of_finiteDimensional` states part (b) directly
+under the book's hypotheses (`A` a finite dimensional `k`-algebra); the required
+`IsNoetherianRing A` is *derived* from those hypotheses via
+`isNoetherianRing_of_finiteDimensional`, rather than assumed as in the earlier
+placeholder.
 -/
 
 open CategoryTheory
 
-/-- The category of modules over a ring A is an abelian category.
+/-- The category of modules over a ring `A` is an abelian category.
 (Etingof Example 7.7.2, part (a)) -/
 example (A : Type*) [Ring A] : Abelian (ModuleCat A) := inferInstance
 
-/-- The category of finite dimensional modules over A is an abelian category.
-For a finite dimensional algebra A over a field, A is Noetherian and the finitely
-generated A-modules are exactly the finite dimensional ones, so this is Mathlib's
-`Abelian (FGModuleCat A)`.
+section FiniteDimensionalAlgebra
+
+variable (k A : Type*) [Field k] [Ring A] [Algebra k A]
+
+/-- A finite dimensional algebra over a field is a Noetherian ring.
+
+This is the honest hypothesis behind `Abelian (FGModuleCat A)`: in Etingof's setting `A`
+is finite dimensional over the field `k`, hence Artinian and in particular a Noetherian
+ring. -/
+theorem isNoetherianRing_of_finiteDimensional [FiniteDimensional k A] :
+    IsNoetherianRing A :=
+  IsNoetherianRing.of_finite k A
+
+/-- Bridge between the two notions of finiteness for a module over a finite dimensional
+`k`-algebra `A`.
+
+For an `A`-module `M` carrying a compatible `k`-module structure (an object of the
+category the book calls the finite dimensional `A`-modules), `M` is finitely generated
+over `A` iff it is finite dimensional over the base field `k`.
+
+The forward direction is `Module.Finite.trans` (`A` is finite over `k` and `M` is finite
+over `A`, so `M` is finite over `k`); the reverse is
+`Module.Finite.of_restrictScalars_finite` (a `k`-spanning set of `M` also spans over `A`,
+since the `k`-action factors through `A`). -/
+theorem module_finite_iff_finiteDimensional [FiniteDimensional k A]
+    (M : Type*) [AddCommGroup M] [Module A M] [Module k M] [IsScalarTower k A M] :
+    Module.Finite A M ↔ FiniteDimensional k M :=
+  ⟨fun _ => Module.Finite.trans A M, fun _ => Module.Finite.of_restrictScalars_finite k A M⟩
+
+/-- The category of finite dimensional modules over a finite dimensional `k`-algebra `A`
+is abelian.
+
+By `module_finite_iff_finiteDimensional`, `FGModuleCat A` — the finitely generated
+`A`-modules — is exactly the category of `A`-modules that are finite dimensional over the
+base field `k`, i.e. the finite dimensional module category of Example 7.7.2. It is
+abelian because `A` is Noetherian (`isNoetherianRing_of_finiteDimensional`), which here is
+derived from the book's hypotheses rather than assumed.
 (Etingof Example 7.7.2, part (b)) -/
-example (A : Type*) [Ring A] [IsNoetherianRing A] : Abelian (FGModuleCat A) :=
+@[reducible] noncomputable def abelian_fgModuleCat_of_finiteDimensional
+    [FiniteDimensional k A] : Abelian (FGModuleCat A) :=
+  haveI : IsNoetherianRing A := isNoetherianRing_of_finiteDimensional k A
   inferInstance
 
-/-- Specializing to the base field k: the category of finite dimensional vector
-spaces is abelian. -/
-example (k : Type*) [Field k] : Abelian (FGModuleCat k) := inferInstance
+end FiniteDimensionalAlgebra
+
+/-- Specializing to the base field `k` itself (`A = k`): the category of finite dimensional
+`k`-vector spaces is abelian. -/
+noncomputable example (k : Type*) [Field k] : Abelian (FGModuleCat k) :=
+  abelian_fgModuleCat_of_finiteDimensional k k

--- a/progress/2026-07-24T13-43-03Z_c9c86494.md
+++ b/progress/2026-07-24T13-43-03Z_c9c86494.md
@@ -1,0 +1,50 @@
+## Accomplished
+
+Resolved issue #7429 (Example 7.7.2: formalize the finite-dimensional module
+category, not a conditional FGModuleCat substitute).
+
+Rewrote `EtingofRepresentationTheory/Chapter7/Example7_7_2.lean` to give a
+source-faithful rendering of both halves of Example 7.7.2, working in the book's
+setting of a finite dimensional algebra `A` over a field `k`:
+
+- `isNoetherianRing_of_finiteDimensional` — a finite dimensional `k`-algebra is a
+  Noetherian ring (`IsNoetherianRing.of_finite`). This replaces the previous
+  *assumed* `[IsNoetherianRing A]` hypothesis with one *derived* from the book's
+  finite-dimensional-`k`-algebra hypothesis.
+- `module_finite_iff_finiteDimensional` — the bridge the old file only asserted in
+  prose: for an `A`-module `M` with a compatible `k`-structure, `Module.Finite A M ↔
+  FiniteDimensional k M`. Forward is `Module.Finite.trans`, reverse is
+  `Module.Finite.of_restrictScalars_finite`. This is the objectwise identification of
+  `FGModuleCat A` with the category of `A`-modules finite dimensional over `k`.
+- `abelian_fgModuleCat_of_finiteDimensional` — the honest endpoint: `Abelian
+  (FGModuleCat A)` under `[Field k] [Ring A] [Algebra k A] [FiniteDimensional k A]`,
+  with the Noetherian instance supplied internally. Marked `@[reducible] noncomputable
+  def` because `Abelian` is data, not a proposition.
+- Retained part (a) `Abelian (ModuleCat A)` and a specialization to `A = k` (finite
+  dimensional vector spaces).
+
+Updated `progress/items.json` for `Chapter7/Example7.7.2`: coverage
+`covered_partial` → `covered`, refreshed coverage/fidelity notes, dropped the
+follow-up-issue pointer.
+
+## Current frontier
+
+Issue #7429 complete. File builds cleanly (`lake build
+EtingofRepresentationTheory.Chapter7.Example7_7_2`, exit 0, no warnings, no sorry).
+
+## Overall project progress
+
+Stage 3 formalization ongoing. This turn closed one Chapter 7 fidelity gap. Many
+`complete`/`fix`/`formalize` feature issues remain unclaimed (see `coordination
+orient`), plus definition-level items #7430 (Weyl-algebra counterexample) and #7431
+(Weyl group finiteness).
+
+## Next step
+
+Pick another unclaimed feature issue. The remaining definition-level items #7430 and
+#7431 are the highest-priority-by-policy but are substantial; the `fix(ChX): restore
+...` issues address correctness regressions and are also high value.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -8505,11 +8505,10 @@
     "start_line": 1,
     "end_line": 2,
     "status": "sorry_free",
-    "coverage": "covered_partial",
-    "coverage_note": "The all-modules half is exact. The finite-dimensional-module half is represented only by an Abelian (FGModuleCat A) instance under an assumed Noetherian-ring hypothesis; the asserted finite-dimensional-k-algebra bridge and a source-faithful finite-dimensional module category endpoint are absent. Follow-up #7429.",
-    "followup_issue": 7429,
-    "last_updated": "2026-07-22",
-    "fidelity_note": "The `ModuleCat A` half is faithful. The finite-dimensional-module half changes the category to `FGModuleCat A` and leaves the required finite-dimensional-algebra bridge only in prose; #7429.",
+    "coverage": "covered",
+    "coverage_note": "The all-modules half is exact (Abelian (ModuleCat A)). The finite-dimensional-module half is now source-faithful: `module_finite_iff_finiteDimensional` proves the finite-dimensional-k-algebra bridge (an A-module is finitely generated over A iff finite dimensional over the base field k), and `abelian_fgModuleCat_of_finiteDimensional` states Abelian (FGModuleCat A) under the book's hypotheses ([Field k] [Algebra k A] [FiniteDimensional k A]), deriving IsNoetherianRing A internally via `isNoetherianRing_of_finiteDimensional` rather than assuming it. Resolves #7429.",
+    "last_updated": "2026-07-24",
+    "fidelity_note": "Both halves faithful: `ModuleCat A` for all modules, and `FGModuleCat A` identified with the finite-dimensional-over-k module category via the proved bridge `module_finite_iff_finiteDimensional`, with the Noetherian hypothesis derived from A being a finite dimensional k-algebra.",
     "sorry_free": true
   },
   {


### PR DESCRIPTION
Closes #7429

Session: `c9c86494-ffa0-45de-909d-185794227613`

23576df2 feat(Ch7 #7429): make Example 7.7.2 finite-dimensional module category source-faithful

🤖 Prepared with Claude Code