### PR TITLE
fix(Ch5 Exercise 5.8.5): restore the character-left-ideal isomorphism

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Exercise5_8_5.lean
+++ b/EtingofRepresentationTheory/Chapter5/Exercise5_8_5.lean
@@ -62,9 +62,10 @@ section Proof
 variable (χ : K →* ℂˣ)
 
 /-- Abbreviation for the underlying `K`-representation on `ℂ[G] ⊗ ℂ` whose coinvariants form
-`Ind_K^G ℂ_χ`. -/
-private noncomputable abbrev indRep :
-    Representation ℂ K (TensorProduct ℂ (G →₀ ℂ) ℂ) :=
+`Ind_K^G ℂ_χ`. The type ascription is deliberately omitted: writing it out wraps the term so
+that the defeq `Coinvariants (indRep K χ) = Representation.IndV K.subtype (chiRep K χ)` forces
+Lean to fully reduce the tensor-product representation, blowing the `whnf` heartbeat budget. -/
+private noncomputable abbrev indRep :=
   Representation.tprod ((leftRegular ℂ G).comp K.subtype) (chiRep K χ)
 
 private lemma chiRep_apply (k : K) (z : ℂ) : chiRep K χ k z = ((χ k : ℂˣ) : ℂ) • z := rfl
@@ -223,13 +224,14 @@ private lemma bwd_of_inv_mul_idem (h : G) :
 /-- The composite `fwd ∘ bwd` is right multiplication by `e_χ`. -/
 private lemma fwd_bwd (x : MonoidAlgebra ℂ G) :
     fwd K χ (bwd K χ x) = x * idempotentOfChar K χ := by
-  induction x using Finsupp.induction_linear with
-  | zero => simp
-  | add p q hp hq => simp only [map_add, hp, hq, add_mul]
-  | single g c =>
-    rw [show (Finsupp.single g c : MonoidAlgebra ℂ G) = c • MonoidAlgebra.of ℂ G g by
-          rw [MonoidAlgebra.of_apply, Finsupp.smul_single, smul_eq_mul, mul_one],
-      map_smul, map_smul, bwd_of, fwd_mk, inv_inv, one_smul, smul_mul_assoc]
+  -- Induct with `MonoidAlgebra.induction_on` (not `Finsupp.induction_linear`): its case
+  -- variables stay in `ℂ[G]`, whereas the `Finsupp` principle types them as `G →₀ ℂ`, and the
+  -- resulting `ℂ[G] = G →₀ ℂ` mismatch is only defeq at default (not `instances`) transparency,
+  -- which breaks the `map_add`/`map_smul` rewrites into `bwd`/`fwd`.
+  induction x using MonoidAlgebra.induction_on with
+  | hM g => rw [bwd_of, fwd_mk, inv_inv, one_smul]
+  | hadd p q hp hq => rw [map_add, map_add, hp, hq, add_mul]
+  | hsmul r p hp => rw [map_smul, map_smul, hp, smul_mul_assoc]
 
 end Proof
 

--- a/progress/2026-07-24T14-57-03Z_b9cd8a8f.md
+++ b/progress/2026-07-24T14-57-03Z_b9cd8a8f.md
@@ -1,0 +1,49 @@
+## Accomplished
+
+Repaired **#7555** (fix Ch5 Exercise 5.8.5): `EtingofRepresentationTheory/Chapter5/Exercise5_8_5.lean`
+now elaborates from source (`lake env lean … Exercise5_8_5.lean` exits 0), with no `sorry`,
+`admit`, or `sorryAx` in any endpoint. `#print axioms` on `chiRep`, `idempotentOfChar`,
+`charLeftIdeal`, and `ind_chiRep_iso_charLeftIdeal` reports only
+`propext, Classical.choice, Quot.sound`.
+
+Two independent Mathlib-bump regressions, both masked before because the first one aborted
+the file:
+
+1. **`whnf`/`isDefEq` heartbeat blowup at `fwd` (and `fwd_mem`).** The private abbrev `indRep`
+   carried an explicit type ascription `: Representation ℂ K (TensorProduct ℂ (G →₀ ℂ) ℂ)`.
+   Under the new `@[expose] public section` module system in `Mathlib.RepresentationTheory`,
+   that ascription wraps the term so the defeq
+   `Coinvariants (indRep K χ) = Representation.IndV K.subtype (chiRep K χ)` no longer closes by
+   congruence and instead fully reduces the tensor-product representation (154k `DFunLike.coe`,
+   24k `Representation.tprod` unfolds — confirmed with `set_option diagnostics true`). It failed
+   even at 1,000,000 heartbeats. **Fix:** drop the ascription (`abbrev indRep := …`); the body's
+   type is then syntactically what `IndV` unfolds to, so the defeq is trivial.
+
+2. **`map_add`/`map_smul` rewrites failing in `fwd_bwd`.** `Finsupp.induction_linear` types its
+   case variables as `G →₀ ℂ`, but `bwd`/`fwd` expect `ℂ[G]` (`MonoidAlgebra ℂ G`). These are
+   defeq only at default, not `instances`, transparency, so `rw`'s type-correctness check
+   rejected `?f 0` / `?f (?x+?y)` ("target not type-correct under `instances` transparency").
+   **Fix:** induct with `MonoidAlgebra.induction_on` instead, whose case variables stay in `ℂ[G]`.
+
+## Current frontier
+
+Exercise 5.8.5 is fully restored. The construction is unchanged: normalized idempotent `e_χ`, its
+idempotence, the honest left ideal `ℂ[G]·e_χ`, and the genuine `G`-equivariant isomorphism
+`Ind_K^G ℂ_χ ≅ ℂ[G] e_χ` are all intact and axiom-clean.
+
+## Overall project progress
+
+Stage 3 (formalization) ongoing. This was a completeness-audit repair, not new content.
+
+## Next step
+
+Other `completeness-audit` "restore" issues (#7540, #7537, #7539, #7544, #7545, #7547, #7548,
+#7556, #7557) remain. Several share the same two failure patterns seen here: (a) an
+`abbrev`/`def` type ascription forcing an expensive `Coinvariants`/tensor defeq under the new
+module system, and (b) `Finsupp.induction_linear` vs `MonoidAlgebra`/`instances`-transparency
+`rw` failures. The two fixes here (drop the ascription; prefer `MonoidAlgebra.induction_on`) are
+worth trying first on those.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7555

Session: `b9cd8a8f-64c8-42af-9d68-45f30bcd1265`

c466cab2 fix(Ch5 Exercise 5.8.5): restore elaboration from source

🤖 Prepared with Claude Code