### PR TITLE
docs(agent-worker-flow): flag lake env lean restore false positives

### DIFF
--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -190,6 +190,16 @@ Check that the plan's assumptions still hold:
   discover this. If it already exists, reuse it: the task shrinks to a thin
   bridge/assembly (or, for audits, a tracking reconciliation — flip `items.json`,
   repoint `lean_ref`, drop the residual issue), not new infrastructure.
+- **A "restore/regression" issue whose reproduction is `lake env lean <file>` may
+  be a false positive — reconfirm the failure with `lake build <Module>` before any
+  work.** `lake env lean` drops the lakefile's `[leanOptions]` (`maxSynthPendingDepth
+  = 3`, `backward.isDefEq.respectTransparency = false`), so files with deep instance
+  chains or `isDefEq` diamonds throw spurious `synthInstanceFailed` / instance-path
+  errors under it that never occur under `lake build`. See `lean-formalization`
+  ("Typecheck with `lake build`, NOT `lake env lean`") for the full account. If
+  `lake build <Module>` is green and `#print axioms` on the endpoints is clean, the
+  issue is already resolved (often by a since-merged dependency fix) — close it with
+  the build evidence rather than editing a working file. (2026-07: #7490, #7547.)
 
 If stale:
 ```

--- a/progress/2026-07-24T15-24-30Z_1f03cca4.md
+++ b/progress/2026-07-24T15-24-30Z_1f03cca4.md
@@ -1,0 +1,53 @@
+## Accomplished
+
+Investigated issue #7547 ("fix(Ch5): restore the determinant-shift endpoints of
+Proposition 5.22.2"). **Determined it is a false positive** and closed it — no code
+change needed.
+
+The issue's reproduction command was `lake env lean
+EtingofRepresentationTheory/Chapter5/Proposition5_22_2.lean`, which reported instance
+mismatches around lines 225/305/404/486 and an "unknown identifier
+`schurModule_shift_iso_detTwist`" at 506. These are **spurious**: `lake env lean` does
+not apply the lakefile's `[leanOptions]`. This file needs both `maxSynthPendingDepth = 3`
+and `weak.backward.isDefEq.respectTransparency = false` to elaborate; without them the
+`FDRep.of (detTwistedSchurModuleRep …)` applications fail instance unification.
+
+Evidence gathered:
+- `lake build EtingofRepresentationTheory.Chapter5.Proposition5_22_2` → exit 0
+  (recompiled from source after deleting the olean; not a cache artifact).
+- Full `lake build` of the whole project → exit 0 (9272 jobs).
+- `lake env lean -DmaxSynthPendingDepth=3 -Dbackward.isDefEq.respectTransparency=false
+  <file>` → exit 0, 0 errors. Bisected: `maxSynthPendingDepth=3` alone leaves 1 error;
+  both options together give 0.
+- `#print axioms` on `Proposition5_22_2`, `schurModule_shift_iso_detTwist`,
+  `topExteriorPowerRep_iso_detRep` → only `[propext, Classical.choice, Quot.sound]`.
+- No `sorry`/`admit`/`axiom` in the file. All required endpoints present, and the public
+  `Proposition5_22_2` keeps the honest `L_λ ⊗ ∧^N V` (`topExteriorPowerRep`) conclusion,
+  not merely the determinant-character model.
+
+Root cause of the original report: the file was genuinely un-buildable *at filing time*
+(2026-07-23) because its transitive dependency Proposition 5.21.1 was broken (#7546). That
+fix merged (commit ed2aa46b), so the whole Schur chain builds again. The residual
+`lake env lean` errors are purely the missing-`[leanOptions]` artifact documented in the
+`lean-formalization` skill (precedent: #7490).
+
+## Current frontier
+
+No open work on Proposition 5.22.2; the file is complete and axiom-clean on `main`.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. Proposition 5.22.2 (determinant twist,
+`L_{λ+1^N} ≅ L_λ ⊗ ∧^N V`) confirmed complete and green.
+
+## Next step
+
+The next worker should pick a fresh `feature` issue from `coordination list-unclaimed`.
+Note for planners: verify "restore/regression" premises with
+`lake build <Module>` (or `lake env lean` **with** `-DmaxSynthPendingDepth=3
+-Dbackward.isDefEq.respectTransparency=false`) before filing — a bare `lake env lean`
+reproduction is unreliable for files using deep instance chains or isDefEq diamonds.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR adds a Step 4 check to the `agent-worker-flow` skill directing restore/regression workers to reconfirm a build-failure premise with `lake build <Module>` before investigating, since bare `lake env lean` drops the project's `[leanOptions]` (`maxSynthPendingDepth=3`, `backward.isDefEq.respectTransparency=false`) and yields spurious instance-synthesis errors on files with deep instance chains or isDefEq diamonds.

Prompted by #7547 ("restore the determinant-shift endpoints of Proposition 5.22.2"), which was reproduced via `lake env lean` but builds clean under `lake build` (full project green, 9272 jobs; endpoints depend only on `propext/Classical.choice/Quot.sound`). The real blocker was the since-merged dependency fix #7546. Closed #7547 as a verified false positive with the build evidence; this change helps successors skip the same investigation.

Also includes the per-turn progress entry for the #7547 investigation.

🤖 Prepared with Claude Code