### PR TITLE
feat(Ch2 #7686): central-scalar actions xⁿ=α, yⁿ=βⁿ on the q-Weyl family V(α,β)

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -524,6 +524,22 @@ Same #6852. Fix: open each branch with `change <goal with (0 : Fin 3)/(1 : Fin 3
 restate at the `OfNat` literals (defeq, so `change` accepts), *then* `rw`/`decide`-facts match.
 Prefer `change` over `show` here (the linter flags `show` for non-readability goal changes).
 
+**For a *variable* `N`, `Fin N` with `[NeZero N]` is only an `AddCommGroup` — there is no
+`NatCast (Fin N)` and no `CommRing (Fin N)`** (those exist for the *literal* successor shape
+`Fin (n+1)`). So `(i : Fin N)` for `i : ℕ` does not elaborate, and cyclic index arithmetic must be
+written as the `ℕ`-multiple `i • (1 : Fin N)`. Three helper lemmas make that workable, and the
+proofs are short enough to re-derive:
+`(m • (1 : Fin N)).val = m % N` (induction, `succ_nsmul` + `Fin.val_add` + `Fin.val_one'` +
+`← Nat.add_mod`); `k.val • (1 : Fin N) = k` (`Fin.ext` + `Nat.mod_eq_of_lt k.isLt`); and
+`N • (1 : Fin N) = 0` (`Fin.ext` + `Nat.mod_self`). To turn a product/sum over a full cycle into
+one over `Fin N`, chain `← Fin.prod_univ_eq_prod_range` (moves `Finset.range N` to `Fin N`), then
+`k.val • 1 = k` to expose `k - i`, then `Equiv.prod_comp (Equiv.subLeft k)` to reindex, then
+`Finset.prod_ite_eq'` for a weight that is `1` away from a single index. Worked example:
+`prod_wX_cycle` / `Xlin_pow_orderOf` (#7697, `Chapter2/Problem2_7_5_Family.lean`), where the
+twisted cyclic shift `x·eⱼ = e_{j+1}`, `x·e_{N-1} = α·e₀` satisfies `xᴺ = α`. Switching the model
+to `ZMod N → ℂ` (a `CommRing` index) is the alternative, but it is a real refactor of every
+downstream statement — only worth it if the ring structure is needed pervasively.
+
 **`omega` treats `(⟨c, _⟩ : Fin n).val` as an *opaque* atom (it does NOT reduce `Fin.mk`'s value to
 `c`), so a goal `x = ⟨c, _⟩` — or `x.val = (⟨c, _⟩).val` after `apply Fin.ext` — is unprovable by
 `omega` even when `x.val = c` is derivable.** Tell-tale: the omega counterexample lists a variable

--- a/EtingofRepresentationTheory/Chapter2/Problem2_7_5_Family.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_7_5_Family.lean
@@ -27,6 +27,9 @@ the scalars `α`, `βⁿ` respectively (their common values are the *central cha
 * `Etingof.Problem2_7_5.famRel` — the defining relation `Ylin·Xlin = q•(Xlin·Ylin)`.
 * `Etingof.Problem2_7_5.Xlin_pow_orderOf` / `Ylin_pow_orderOf` — the central-scalar actions
   `Xⁿ = α·1`, `Yⁿ = βⁿ·1`.
+* `Etingof.Problem2_7_5.famModule_xpow_smul` / `famModule_ypow_smul` — the same statements on
+  `V(α,β)`: the central elements `xⁿ`, `yⁿ` act by `α`, `βⁿ`, i.e. `V(α,β)` has central character
+  `(α, βⁿ)`.
 -/
 
 namespace Etingof.Problem2_7_5
@@ -197,6 +200,139 @@ theorem famModule_isScalarTower (hqorder : orderOf q = N) :
     letI := famModule q α β N hqorder
     IsScalarTower ℂ (qWeylAlgebra ℂ q) (Fin N → ℂ) :=
   Etingof.QWeyl.module_isScalarTower q (Xunit α N) (Yunit q β N) (famRel_unit q α β N hqorder)
+
+/-! ### Shifting the index set
+
+`Fin N` carries only an additive group structure here (there is no `NatCast`, since `N` is a
+variable constrained merely by `NeZero N`), so "shift by `m` steps" is written as the `ℕ`-multiple
+`m • (1 : Fin N)`. -/
+
+/-- The `m`-step shift is `m` reduced modulo `N`. -/
+theorem val_nsmul_one (m : ℕ) : ((m • (1 : Fin N) : Fin N) : ℕ) = m % N := by
+  induction m with
+  | zero => simp
+  | succ m ih => rw [succ_nsmul, Fin.val_add, ih, Fin.val_one', ← Nat.add_mod]
+
+/-- Shifting `0` by `k` steps lands on `k`, so every index is reached by the shift. -/
+theorem nsmul_one_val (k : Fin N) : ((k : ℕ) • (1 : Fin N)) = k :=
+  Fin.ext (by rw [val_nsmul_one, Nat.mod_eq_of_lt k.isLt])
+
+/-- Shifting by `N` steps is the identity: the shift orbit is one full cycle. -/
+theorem nsmul_one_card : (N • (1 : Fin N)) = 0 :=
+  Fin.ext (by rw [val_nsmul_one, Nat.mod_self]; rfl)
+
+/-! ### Powers of the generators: the central-scalar actions -/
+
+/-- The weights of the twisted shift multiply to `α` over a full cycle: as `i` runs through
+`range N` the index `k - i` runs through all of `Fin N`, so exactly one factor (the one at index
+`0`) contributes `α` and the rest contribute `1`. -/
+theorem prod_wX_cycle (k : Fin N) :
+    ∏ i ∈ Finset.range N, wX α N (k - i • (1 : Fin N)) = (α : ℂ) := by
+  rw [← Fin.prod_univ_eq_prod_range (fun i : ℕ => wX α N (k - i • (1 : Fin N))) N]
+  have h : ∀ i : Fin N, wX α N (k - (i : ℕ) • (1 : Fin N)) = wX α N (Equiv.subLeft k i) := by
+    intro i; rw [nsmul_one_val]; rfl
+  simp_rw [h]
+  rw [Equiv.prod_comp (Equiv.subLeft k) (wX α N)]
+  simp only [wX]
+  rw [Finset.prod_ite_eq' Finset.univ (0 : Fin N) (fun _ => (α : ℂ))]
+  simp
+
+/-- Closed form for the powers of the twisted shift: `(Xᵐ f) k` is `f` at the index `m` steps
+back from `k`, weighted by the product of the weights along that orbit segment. -/
+theorem Xlin_pow_apply (m : ℕ) (f : Fin N → ℂ) (k : Fin N) :
+    ((Xlin α N) ^ m) f k
+      = (∏ i ∈ Finset.range m, wX α N (k - i • (1 : Fin N))) • f (k - m • (1 : Fin N)) := by
+  induction m generalizing f with
+  | zero => simp
+  | succ m ih =>
+    rw [pow_succ, Module.End.mul_apply, ih (Xlin α N f), Finset.prod_range_succ]
+    simp only [Xlin, LinearMap.coe_mk, AddHom.coe_mk, smul_eq_mul]
+    rw [succ_nsmul, ← sub_sub]
+    ring
+
+/-- **Central scalar action of `xⁿ` on the operators.** The `n`-th power of the twisted cyclic
+shift is the scalar `α`. -/
+theorem Xlin_pow_orderOf : (Xlin α N) ^ N = (α : ℂ) • (1 : Module.End ℂ (Fin N → ℂ)) := by
+  refine LinearMap.ext fun f => ?_
+  funext k
+  rw [Xlin_pow_apply, prod_wX_cycle, nsmul_one_card, sub_zero]
+  simp
+
+omit [NeZero N] in
+/-- Closed form for the powers of the diagonal operator. -/
+theorem Ylin_pow_apply (m : ℕ) (f : Fin N → ℂ) (k : Fin N) :
+    ((Ylin q β N) ^ m) f k = (wY q β N k) ^ m • f k := by
+  induction m generalizing f with
+  | zero => simp
+  | succ m ih =>
+    rw [pow_succ, Module.End.mul_apply, ih (Ylin q β N f)]
+    simp only [Ylin, LinearMap.coe_mk, AddHom.coe_mk, smul_eq_mul, pow_succ]
+    ring
+
+omit [NeZero N] in
+/-- `q` is an `N`-th root of unity, `N` being its order. -/
+theorem q_pow_card (hqorder : orderOf q = N) : (q : ℂ) ^ N = 1 := by
+  have h : q ^ N = 1 := by rw [← hqorder]; exact pow_orderOf_eq_one q
+  have hval := congrArg Units.val h
+  push_cast at hval
+  simpa using hval
+
+omit [NeZero N] in
+/-- **Central scalar action of `yⁿ` on the operators.** The `n`-th power of the diagonal operator
+is the scalar `βⁿ`: the `qᵏ` factors are killed by `qⁿ = 1`. -/
+theorem Ylin_pow_orderOf (hqorder : orderOf q = N) :
+    (Ylin q β N) ^ N = ((β : ℂ) ^ N) • (1 : Module.End ℂ (Fin N → ℂ)) := by
+  refine LinearMap.ext fun f => ?_
+  funext k
+  have hk : ((q : ℂ) ^ (k : ℕ)) ^ N = 1 := by
+    rw [← pow_mul, mul_comm, pow_mul, q_pow_card q N hqorder, one_pow]
+  rw [Ylin_pow_apply]
+  simp [wY, mul_pow, hk]
+
+/-! ### The central character of `V(α,β)`
+
+The elements `xⁿ` and `yⁿ` are central in `qWeylAlgebra ℂ q`; on `V(α,β)` they act by the scalars
+`α` and `βⁿ`, so the central character of `V(α,β)` is `(α, βⁿ)`. -/
+
+/-- The central element `xⁿ = qWeylMono (n, 0)` acts on `V(α,β)` by the scalar `α`. -/
+theorem famModule_xpow_smul (hqorder : orderOf q = N) (f : Fin N → ℂ) :
+    letI := famModule q α β N hqorder
+    (Etingof.QWeyl.qWeylMono q ((N : ℤ), 0)) • f = (α : ℂ) • f := by
+  letI := famModule q α β N hqorder
+  rw [Etingof.QWeyl.module_smul]
+  change Etingof.QWeyl.toEnd q (Xunit α N) (Yunit q β N) _
+    (Etingof.QWeyl.qWeylMono q ((N : ℤ), 0)) f = _
+  rw [Etingof.QWeyl.toEnd_qWeylMono]
+  simp only [Etingof.QWeyl.op, zpow_zero, Units.val_one, mul_one, zpow_natCast,
+    Units.val_pow_eq_pow_val, Xunit_val, Xlin_pow_orderOf]
+  simp
+
+/-- The central element `yⁿ = qWeylMono (0, n)` acts on `V(α,β)` by the scalar `βⁿ`. -/
+theorem famModule_ypow_smul (hqorder : orderOf q = N) (f : Fin N → ℂ) :
+    letI := famModule q α β N hqorder
+    (Etingof.QWeyl.qWeylMono q (0, (N : ℤ))) • f = ((β : ℂ) ^ N) • f := by
+  letI := famModule q α β N hqorder
+  rw [Etingof.QWeyl.module_smul]
+  change Etingof.QWeyl.toEnd q (Xunit α N) (Yunit q β N) _
+    (Etingof.QWeyl.qWeylMono q (0, (N : ℤ))) f = _
+  rw [Etingof.QWeyl.toEnd_qWeylMono]
+  simp only [Etingof.QWeyl.op, zpow_zero, Units.val_one, one_mul, zpow_natCast,
+    Units.val_pow_eq_pow_val, Yunit_val, Ylin_pow_orderOf q β N hqorder]
+  simp
+
+/-- The same statement phrased through the generator `x = qWeylMono (1, 0)`: `xⁿ` acts by `α`. -/
+theorem famModule_x_pow_smul (hqorder : orderOf q = N) (f : Fin N → ℂ) :
+    letI := famModule q α β N hqorder
+    ((Etingof.QWeyl.qWeylMono q (1, 0)) ^ N) • f = (α : ℂ) • f := by
+  rw [Etingof.QWeyl.qWeylMono_x_pow, one_mul]
+  exact famModule_xpow_smul q α β N hqorder f
+
+/-- The same statement phrased through the generator `y = qWeylMono (0, 1)`: `yⁿ` acts by `βⁿ`. -/
+theorem famModule_y_pow_smul (hqorder : orderOf q = N) (f : Fin N → ℂ) :
+    letI := famModule q α β N hqorder
+    ((Etingof.QWeyl.qWeylMono q (0, 1)) ^ N) • f = ((β : ℂ) ^ N) • f := by
+  rw [Etingof.QWeyl.qWeylMono_y_pow, one_mul]
+  exact famModule_ypow_smul q α β N hqorder f
 
 end Family
 

--- a/EtingofRepresentationTheory/Chapter2/QWeylAlgebraUniversal.lean
+++ b/EtingofRepresentationTheory/Chapter2/QWeylAlgebraUniversal.lean
@@ -219,6 +219,29 @@ theorem qWeylMono_mul (p r : ℤ × ℤ) :
   rw [MulMemClass.coe_mul, coe_qWeylMono, coe_qWeylMono, Subalgebra.coe_smul, coe_qWeylMono,
     qMono_mul]
 
+/-- Natural powers of a pure `x`-monomial: `(xⁱ)ᵐ = x^{i·m}`. The reordering scalars all vanish
+because the `y`-exponent is zero. -/
+theorem qWeylMono_x_pow (i : ℤ) (m : ℕ) : qWeylMono q (i, 0) ^ m = qWeylMono q (i * m, 0) := by
+  induction m with
+  | zero => rw [pow_zero, Nat.cast_zero, mul_zero, qWeylMono_zero]
+  | succ m ih =>
+    rw [pow_succ, ih, qWeylMono_mul]
+    simp only [zero_mul, zpow_zero, Units.val_one, one_smul, add_zero]
+    congr 2
+    push_cast
+    ring
+
+/-- Natural powers of a pure `y`-monomial: `(yʲ)ᵐ = y^{j·m}`. -/
+theorem qWeylMono_y_pow (j : ℤ) (m : ℕ) : qWeylMono q (0, j) ^ m = qWeylMono q (0, j * m) := by
+  induction m with
+  | zero => rw [pow_zero, Nat.cast_zero, mul_zero, qWeylMono_zero]
+  | succ m ih =>
+    rw [pow_succ, ih, qWeylMono_mul]
+    simp only [mul_zero, zpow_zero, Units.val_one, one_smul, add_zero]
+    congr 2
+    push_cast
+    ring
+
 theorem qWeylMono_linearIndependent : LinearIndependent k (qWeylMono q) := by
   apply LinearIndependent.of_comp (qWeylAlgebra k q).val.toLinearMap
   have h : (qWeylAlgebra k q).val.toLinearMap ∘ qWeylMono q = qMono k q := rfl

--- a/progress/2026-07-24T23-16-25Z_26a41e66.md
+++ b/progress/2026-07-24T23-16-25Z_26a41e66.md
@@ -1,0 +1,57 @@
+## Accomplished
+
+Issue #7697 (feature, Chapter 2, follow-up to #7686): the central-scalar actions
+`xⁿ = α`, `yⁿ = βⁿ` on the classifying `q`-Weyl module family `V(α,β)`.
+
+In `EtingofRepresentationTheory/Chapter2/Problem2_7_5_Family.lean`:
+
+* `val_nsmul_one`, `nsmul_one_val`, `nsmul_one_card` — arithmetic of the index shift.
+  `Fin N` with only `[NeZero N]` carries an additive group structure but no `NatCast`
+  or ring structure (confirmed: `NatCast (Fin N)` and `CommRing (Fin N)` both fail to
+  synthesize for a variable `N`), so the `m`-step shift is written `m • (1 : Fin N)`.
+  The three lemmas give `(m • 1).val = m % N`, `k.val • 1 = k`, and `N • 1 = 0`.
+* `prod_wX_cycle` — `∏ i ∈ range N, wX α N (k - i • 1) = α`. Proved by transporting
+  `range N` to `Fin N` (`Fin.prod_univ_eq_prod_range`), reindexing along
+  `Equiv.subLeft k`, then `Finset.prod_ite_eq'`.
+* `Xlin_pow_apply` / `Xlin_pow_orderOf` — `(Xlin α N) ^ N = α • 1`.
+* `Ylin_pow_apply` / `Ylin_pow_orderOf` — `(Ylin q β N) ^ N = βⁿ • 1`, via
+  `q_pow_card : (q : ℂ) ^ N = 1` (from `orderOf q = N`).
+* `famModule_xpow_smul` / `famModule_ypow_smul` — the central-character corollaries on
+  `V(α,β)`: `qWeylMono q (N, 0) • f = α • f` and `qWeylMono q (0, N) • f = βⁿ • f`.
+* `famModule_x_pow_smul` / `famModule_y_pow_smul` — the same phrased through the
+  generators, `(qWeylMono q (1,0)) ^ N` and `(qWeylMono q (0,1)) ^ N`.
+
+In `EtingofRepresentationTheory/Chapter2/QWeylAlgebraUniversal.lean`:
+
+* `qWeylMono_x_pow` / `qWeylMono_y_pow` — `(xⁱ)ᵐ = x^{i·m}` and `(yʲ)ᵐ = y^{j·m}`.
+  The reordering scalar `q^(p.2 * r.1)` from `qWeylMono_mul` vanishes in both cases
+  because one of the two exponents is zero. These are the public counterparts of the
+  `private gMono_natpow_x`/`gMono_natpow_y` in `Problem2_7_5.lean`.
+
+## Current frontier
+
+`Problem2_7_5_Family.lean` now has the family `V(α,β)`, the defining relation, the
+dimension, the generator actions, and the central character. What remains for the
+Problem 2.7.5(c) classification chain:
+
+* #7698 — irreducibility of `V(α,β)` (unclaimed).
+* #7699 — isomorphism criterion `V(α,β) ≅ V(α',β') ↔ α = α' ∧ βⁿ = β'ⁿ`
+  (blocked on #7697, so unblocked by this PR).
+* #7700 — exhaustiveness + public classification statement (blocked on #7698).
+
+## Overall project progress
+
+Full `lake build` is clean. No `sorry` in either touched file; all eight new results
+depend only on `propext, Classical.choice, Quot.sound`.
+
+## Next step
+
+Claim #7698 (irreducibility of `V(α,β)`). The pieces added here are what that proof
+needs: `Ylin` is diagonal with pairwise-distinct eigenvalues `β qᵏ` (distinct because
+`q` has order exactly `N`), so the `Ylin`-eigenlines are the coordinate lines, and
+`Xlin` cyclically permutes them, so any nonzero submodule is everything.
+`famModule_x_smul` / `famModule_y_smul` are the interface to use.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7697

Session: `26a41e66-a974-4f6c-84c7-a0035bbc59ef`

616ade3a doc: progress entry for #7697 (central-scalar actions on V(α,β))
6f1de302 feat(Ch2 #7697): central-scalar actions x^n=α, y^n=β^n on the q-Weyl family V(α,β)

🤖 Prepared with Claude Code