### PR TITLE
fix: teach validate_items.py the PLAN Stage 1.6 derived-item overlay

### DIFF
--- a/progress/2026-07-25T00-14-48Z_51d2dfe9.md
+++ b/progress/2026-07-25T00-14-48Z_51d2dfe9.md
@@ -1,0 +1,81 @@
+## Accomplished
+
+Claimed and fixed #7712: `python3 scripts/validate_items.py` exited 1 with ten errors of the form
+`Item '<index 583>': missing fields: {'id', 'title', 'start_page', 'end_page', 'start_line',
+'end_line'}` for entries 583-592 of `progress/items.json`.
+
+The issue proposed nesting those ten entries inside their parents' `derived` arrays, or giving them
+the six required top-level fields. **Both would have been wrong**, and I did neither. The ten
+entries are already correct as written. `PLAN.md` Stage 1.6 (line 200) specifies:
+
+> A formalizable claim discovered *inside* an existing blob is recorded as a `derived` item with
+> extra fields: `derived_from` (the parent item id), `source_span`, `claim`, and a `status`.
+> Derived items are an **overlay on the text partition, not members of it**: the contiguity check
+> below skips `type == "derived"`.
+
+So they are top-level array members by design, keyed by `derived_from` rather than `id`, and they
+carry no line span precisely because they are an overlay. Giving them a span would have introduced
+overlaps in the partition; nesting them under a parent's `derived` array would have conflated them
+with a *different* established convention — the nested `derived` arrays on 18 partition items
+(e.g. `Chapter5/Problem5.11.1`) track multi-part exercise sub-parts with `part` / `coverage` /
+`lean_decl` fields, per PLAN Stage 3.7. Different shape, different purpose.
+
+The actual defect was in the tooling: `scripts/validate_items.py` and `scripts/items_schema.json`
+never implemented the Stage 1.6 overlay. Fixed both.
+
+* `validate_items.py`: derived items get their own required-field set (`type`, `derived_from`,
+  `source_span`, `claim`, `status`); `derived_from` is now checked to name a real partition item
+  (collected in an up-front pass so a parent may appear later in the array); derived items are
+  skipped in the coverage/overlap and gap passes; the summary line reports blob and derived counts
+  separately.
+* `items_schema.json`: rewritten as a two-branch `oneOf` (`partitionItem` | `derivedItem`) in
+  `$defs`, documenting both shapes. The branches are discriminated by `type`
+  (`const: "derived"` vs an enum that excludes it), so exactly one matches.
+
+Zero bytes of `progress/items.json` changed — every `claim` / `note` / `lean_ref` survives.
+
+## Verification
+
+* `python3 scripts/validate_items.py` → exit 0, `Coverage: 5721/5721 lines across 235 pages`,
+  `Items: 583 blobs, 583 unique IDs, 10 derived overlay items`.
+* Negative checks on mutated copies confirm the new branch still rejects bad data: dropping
+  `claim` from a derived item → exit 1 with a `missing fields: {'claim'}` error; pointing
+  `derived_from` at a nonexistent id → exit 1 with a dangling-parent error; appending a
+  well-formed derived item → exit 0.
+
+## Current frontier
+
+`validate_items.py` is green. The 583 pre-existing `unexpected fields` warnings (`status`,
+`coverage`, `fidelity`, `last_updated`, `notes`, …) are untouched and explicitly out of scope per
+the issue; ten of them are now emitted for derived items too, consistently with the rest.
+
+## Overall project progress
+
+Repo-wide items.json validation passes again for the first time since the Stage 3.7 completeness
+audit started appending derived items. Chapter 2 and Chapter 9 formalization work continues in
+parallel sessions (#7707, #7708, #7704, #7705).
+
+## Next step
+
+Pick up the oldest unclaimed `feature` issue. #7707 (irreducibility of the char-p Weyl family
+`V(α,c)`) was claimed by session `7ed06f5f` at 00:11Z, so leave it alone; #7708 (the isomorphism
+criterion for the same family) is unclaimed and is the natural companion.
+
+Worth a planner's attention separately: the `status` values actually in use on derived items
+(`sorry_free`, `accepted`) have drifted from the enum PLAN Stage 1.6 lists (`accepted`,
+`rejected_duplicate`, `rejected_trivial`, `rejected_nonformal`, `rejected_already_covered`). I
+left `status` as an unconstrained string rather than enforce either set, since reconciling them is
+a spec question, not a tooling one, and `PLAN.md` is off-limits to agents.
+
+## Blockers
+
+None.
+
+## Decisions
+
+* Fixed the validator rather than the data. The data matched the spec; the tooling did not. The
+  issue's two proposed remedies both assumed the data was at fault.
+* Did not enforce a `status` enum on derived items (see above) — enforcing PLAN's list would fail
+  eight of the ten current entries.
+* Did not add a test harness for `scripts/`; there is no existing one, and building one is beyond
+  this issue's scope. The negative checks above were run ad hoc against temp copies.

--- a/scripts/items_schema.json
+++ b/scripts/items_schema.json
@@ -1,48 +1,84 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "items.json",
-  "description": "Stage 1.5 structure analysis output: every content blob in the book with line-precise boundaries.",
+  "description": "Stage 1.5 structure analysis output: every content blob in the book with line-precise boundaries, plus the Stage 1.6 `derived` overlay of formalizable claims found inside those blobs.",
   "type": "array",
   "items": {
-    "type": "object",
-    "required": ["id", "type", "title", "start_page", "end_page", "start_line", "end_line"],
-    "properties": {
-      "id": {
-        "type": "string",
-        "description": "Unique identifier, e.g. Chapter3/Theorem3.1 or Frontmatter/Preface"
+    "oneOf": [
+      { "$ref": "#/$defs/partitionItem" },
+      { "$ref": "#/$defs/derivedItem" }
+    ]
+  },
+  "$defs": {
+    "partitionItem": {
+      "type": "object",
+      "description": "A member of the text partition: a contiguous span of book text. Every line of every page belongs to exactly one of these.",
+      "required": ["id", "type", "title", "start_page", "end_page", "start_line", "end_line"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier, e.g. Chapter3/Theorem3.1 or Frontmatter/Preface"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "theorem", "lemma", "proposition", "corollary",
+            "definition", "example", "exercise", "remark",
+            "discussion", "introduction", "preface", "notation",
+            "bibliography", "index"
+          ]
+        },
+        "title": {
+          "type": "string",
+          "description": "Human-readable title or brief description"
+        },
+        "start_page": {
+          "type": "string",
+          "description": "Logical page name matching pages/*.md filename without extension"
+        },
+        "end_page": {
+          "type": "string",
+          "description": "Logical page name matching pages/*.md filename without extension"
+        },
+        "start_line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-based line number within start_page"
+        },
+        "end_line": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "1-based line number within end_page (inclusive)"
+        }
       },
-      "type": {
-        "type": "string",
-        "enum": [
-          "theorem", "lemma", "proposition", "corollary",
-          "definition", "example", "exercise", "remark",
-          "discussion", "introduction", "preface", "notation",
-          "bibliography", "index"
-        ]
-      },
-      "title": {
-        "type": "string",
-        "description": "Human-readable title or brief description"
-      },
-      "start_page": {
-        "type": "string",
-        "description": "Logical page name matching pages/*.md filename without extension"
-      },
-      "end_page": {
-        "type": "string",
-        "description": "Logical page name matching pages/*.md filename without extension"
-      },
-      "start_line": {
-        "type": "integer",
-        "minimum": 1,
-        "description": "1-based line number within start_page"
-      },
-      "end_line": {
-        "type": "integer",
-        "minimum": 1,
-        "description": "1-based line number within end_page (inclusive)"
-      }
+      "additionalProperties": false
     },
-    "additionalProperties": false
+    "derivedItem": {
+      "type": "object",
+      "description": "An overlay on the partition, not a member of it: a formalizable claim discovered inside an existing blob. Keyed by `derived_from` rather than `id`, carries no line span, and is skipped by the contiguity check.",
+      "required": ["type", "derived_from", "source_span", "claim", "status"],
+      "properties": {
+        "type": {
+          "const": "derived"
+        },
+        "derived_from": {
+          "type": "string",
+          "description": "The `id` of the partition item this claim was found inside"
+        },
+        "source_span": {
+          "type": "string",
+          "description": "The exact quoted sentence from the book, for provenance"
+        },
+        "claim": {
+          "type": "string",
+          "description": "One-line normalized statement of the claim"
+        },
+        "status": {
+          "type": "string",
+          "description": "Triage/formalization status, e.g. accepted, sorry_free, rejected_duplicate, rejected_trivial, rejected_nonformal, rejected_already_covered"
+        }
+      },
+      "additionalProperties": false
+    }
   }
 }

--- a/scripts/validate_items.py
+++ b/scripts/validate_items.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 """Validate items.json for Stage 1.5 contiguity: every line of every page
-belongs to exactly one blob, with no gaps and no overlaps."""
+belongs to exactly one blob, with no gaps and no overlaps.
+
+`derived` items (PLAN Stage 1.6) are an overlay on that partition rather than
+members of it: they record a formalizable claim found inside an existing blob,
+are keyed by `derived_from` instead of `id`, carry no line span, and are
+skipped by the contiguity check."""
 
 import json
 import sys
@@ -17,6 +22,12 @@ VALID_TYPES = {
     "discussion", "introduction", "preface", "notation",
     "bibliography", "index",
 }
+
+# Derived items (PLAN Stage 1.6) are an overlay on the text partition, not
+# members of it: they record a formalizable claim found *inside* an existing
+# blob, so they carry no line span and are skipped by the contiguity check.
+DERIVED_TYPE = "derived"
+DERIVED_REQUIRED_FIELDS = {"type", "derived_from", "source_span", "claim", "status"}
 
 # Files in pages/ that are not actual page content
 EXCLUDED_FILES = {"CONVENTIONS.md"}
@@ -156,10 +167,40 @@ def validate(items_path):
     required_fields = {"id", "type", "title", "start_page", "end_page", "start_line", "end_line"}
     seen_ids = set()
 
+    # Every partition id, collected up front so derived items can be checked
+    # against parents that appear later in the array.
+    partition_ids = {
+        item["id"] for item in items
+        if isinstance(item, dict) and "id" in item
+    }
+    derived_count = 0
+
     for i, item in enumerate(items):
         prefix = f"Item [{i}]"
         if not isinstance(item, dict):
             errors.append(f"{prefix}: not an object")
+            continue
+
+        # Derived items are keyed by `derived_from` rather than `id` and carry
+        # no line span, so they get their own required-field set.
+        if item.get("type") == DERIVED_TYPE:
+            derived_count += 1
+            parent = item.get("derived_from", f"<index {i}>")
+            prefix = f"Derived item '{parent}'"
+
+            missing = DERIVED_REQUIRED_FIELDS - set(item.keys())
+            if missing:
+                errors.append(f"{prefix}: missing fields: {missing}")
+                continue
+
+            extra = set(item.keys()) - DERIVED_REQUIRED_FIELDS
+            if extra:
+                warnings.append(f"{prefix}: unexpected fields: {extra}")
+
+            if parent not in partition_ids:
+                errors.append(
+                    f"{prefix}: derived_from '{parent}' does not name any item"
+                )
             continue
 
         item_id = item.get("id", f"<index {i}>")
@@ -191,11 +232,13 @@ def validate(items_path):
         if not isinstance(item["end_line"], int):
             errors.append(f"{prefix}: end_line must be integer, got {type(item['end_line']).__name__}")
 
-    # --- Contiguity check ---
+    # --- Contiguity check (partition items only; derived items are an overlay) ---
     # Build complete coverage map: (page, line) -> item_id
     coverage = {}
     for item in items:
         if not isinstance(item, dict) or "id" not in item:
+            continue
+        if item.get("type") == DERIVED_TYPE:
             continue
         item_id = item["id"]
         covered, item_errors = expand_item_lines(item, page_order)
@@ -213,7 +256,7 @@ def validate(items_path):
     # --- Gap check: every line of every page file must be covered ---
     pages_referenced = set()
     for item in items:
-        if not isinstance(item, dict):
+        if not isinstance(item, dict) or item.get("type") == DERIVED_TYPE:
             continue
         sp = item.get("start_page")
         ep = item.get("end_page")
@@ -272,7 +315,10 @@ def validate(items_path):
         for p in page_order if p in page_files
     )
     print(f"\nCoverage: {len(coverage)}/{total_lines} lines across {len(page_files)} pages")
-    print(f"Items: {len(items)} blobs, {len(seen_ids)} unique IDs")
+    print(
+        f"Items: {len(items) - derived_count} blobs, {len(seen_ids)} unique IDs, "
+        f"{derived_count} derived overlay items"
+    )
     print("VALIDATION PASSED")
     return 0
 


### PR DESCRIPTION
This PR teaches `scripts/validate_items.py` and `scripts/items_schema.json` about the `derived`-item overlay that `PLAN.md` Stage 1.6 specifies, fixing the ten validation errors at indices 583-592 of `progress/items.json` without changing any of that file's content.

The ten entries were already correct. PLAN Stage 1.6 records a formalizable claim found inside an existing blob as a `derived` item that is an overlay on the text partition rather than a member of it: keyed by `derived_from` instead of `id`, carrying no line span, and skipped by the contiguity check. The validator and schema never implemented that part of the spec, so every such entry tripped the partition required-field check. Giving them a line span would have introduced overlaps, and nesting them under a parent's `derived` array would have conflated them with the unrelated Stage 3.7 convention for tracking multi-part exercise sub-parts.

`validate_items.py` now gives derived items their own required-field set (`type`, `derived_from`, `source_span`, `claim`, `status`), checks that `derived_from` names a real partition item (parents are collected in an up-front pass, so a parent may appear later in the array), skips them in the coverage/overlap and gap passes, and reports blob and derived counts separately. `items_schema.json` becomes a two-branch `oneOf` over `$defs`, discriminated by `type`, documenting both shapes.

`python3 scripts/validate_items.py` exits 0: `Coverage: 5721/5721 lines across 235 pages`, `Items: 583 blobs, 583 unique IDs, 10 derived overlay items`. Negative checks against mutated copies confirm the new branch still rejects a derived item missing `claim` and one whose `derived_from` names no item. The 583 pre-existing `unexpected fields` warnings are untouched and out of scope.

Closes #7712

Session: `51d2dfe9-e323-445a-8949-c6f5c373a69e`

🤖 Prepared with Claude Code