### PR TITLE
feat(Ch9 #7704): give P₊ and P₋ distinct carriers and compute the Cartan matrix of the Problem 9.3.2 algebra

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/Problem9_3_2.lean
+++ b/EtingofRepresentationTheory/Chapter9/Problem9_3_2.lean
@@ -13,6 +13,7 @@ import Mathlib.Algebra.Module.Projective
 import Mathlib.Algebra.Category.ModuleCat.Projective
 import Mathlib.Algebra.Algebra.Bilinear
 import EtingofRepresentationTheory.Chapter2.Definition2_3_8
+import EtingofRepresentationTheory.Chapter9.Definition9_3_1
 import EtingofRepresentationTheory.Chapter9.Definition9_5_1
 
 /-!
@@ -1290,5 +1291,377 @@ theorem simple_module_classification (S : Type u) [AddCommGroup S] [Module ℂ S
   · exact Or.inr ⟨h, fun h' => not_linearEquiv_splus_and_sminus S ⟨h', h⟩⟩
 
 end Exhaustive
+
+/-! ## The Cartan matrix of `A` (Definition 9.3.1)
+
+The third question of Problem 9.3.2. Each of the four Hom spaces `Hom_A(P_s, P_t)`,
+`s, t ∈ {+, -}`, is one-dimensional over `ℂ`, so the Cartan matrix of `A` is `!![1, 1; 1, 1]`.
+
+The computation is uniform. Each `P_s` is generated over `A` by `e₀`, since `e₁ = x · e₀`
+(`Pplus.eq_smul_e0`), so an `A`-linear map out of `P_s` is determined by its value on `e₀`
+(`Pplus.hom_ext`). That value is constrained by `g`-equivariance: `g · e₀ = ε e₀` with
+`ε = +1` on `P₊` and `ε = -1` on `P₋`, so `φ e₀` lies in the `ε`-eigenspace of `g` on the
+target. Each eigenspace of the involution `g` on `P_t` is one-dimensional, spanned by `e₀` or
+by `e₁` — that is the content of the four `eq_smul_e*_of_g_smul_eq_*` lemmas. Hence each Hom
+space is `ℂ · T` for a single explicit generator `T`, and the coefficient map `φ ↦ (φ e₀) k` is
+a `ℂ`-linear isomorphism onto `ℂ`. -/
+
+section Cartan
+
+/-! ### `ℂ` is central, so the Hom spaces are `ℂ`-vector spaces -/
+
+instance : SMulCommClass A ℂ Pplus where
+  smul_comm a c v := by
+    rw [← algebraMap_smul A c v, ← algebraMap_smul A c (a • v), smul_smul, smul_smul,
+      Algebra.commutes]
+
+instance : SMulCommClass A ℂ Pminus where
+  smul_comm a c v := by
+    rw [← algebraMap_smul A c v, ← algebraMap_smul A c (a • v), smul_smul, smul_smul,
+      Algebra.commutes]
+
+/-! ### The generators `e₀` generate `P₊` and `P₋` over `A` -/
+
+lemma Pplus.eq_smul_e0 (v : Pplus) :
+    v = (algebraMap ℂ A (v 0) + algebraMap ℂ A (v 1) * x) • Pplus.e0 := by
+  rw [add_smul, mul_smul, Pplus.x_smul]
+  simp only [algebraMap_smul, Pplus.e0_zero]
+  refine Pplus.ext fun i => ?_
+  fin_cases i <;> simp
+
+lemma Pminus.eq_smul_e0 (v : Pminus) :
+    v = (algebraMap ℂ A (v 0) + algebraMap ℂ A (v 1) * x) • Pminus.e0 := by
+  rw [add_smul, mul_smul, Pminus.x_smul]
+  simp only [algebraMap_smul, Pminus.e0_zero]
+  refine Pminus.ext fun i => ?_
+  fin_cases i <;> simp
+
+/-- An `A`-linear map out of `P₊` is determined by its value on the generator `e₀`. -/
+lemma Pplus.hom_ext {M : Type u} [AddCommGroup M] [Module A M] {φ ψ : Pplus →ₗ[A] M}
+    (h : φ Pplus.e0 = ψ Pplus.e0) : φ = ψ := by
+  refine LinearMap.ext fun v => ?_
+  rw [Pplus.eq_smul_e0 v, map_smul, map_smul, h]
+
+/-- An `A`-linear map out of `P₋` is determined by its value on the generator `e₀`. -/
+lemma Pminus.hom_ext {M : Type u} [AddCommGroup M] [Module A M] {φ ψ : Pminus →ₗ[A] M}
+    (h : φ Pminus.e0 = ψ Pminus.e0) : φ = ψ := by
+  refine LinearMap.ext fun v => ?_
+  rw [Pminus.eq_smul_e0 v, map_smul, map_smul, h]
+
+/-! ### The action of the generators on `e₀` and `e₁` -/
+
+lemma Pplus.g_smul_e0 : g • Pplus.e0 = Pplus.e0 := by
+  rw [Pplus.g_smul]; refine Pplus.ext fun i => ?_; fin_cases i <;> simp
+
+lemma Pplus.x_smul_e0 : x • Pplus.e0 = Pplus.e1 := by
+  rw [Pplus.x_smul]; refine Pplus.ext fun i => ?_; fin_cases i <;> simp
+
+lemma Pminus.g_smul_e0 : g • Pminus.e0 = -Pminus.e0 := by
+  rw [Pminus.g_smul]; refine Pminus.ext fun i => ?_; fin_cases i <;> simp
+
+lemma Pminus.x_smul_e0 : x • Pminus.e0 = Pminus.e1 := by
+  rw [Pminus.x_smul]; refine Pminus.ext fun i => ?_; fin_cases i <;> simp
+
+/-- `g` fixes `φ e₀` for any `A`-linear `φ` out of `P₊`, since `g · e₀ = e₀` there. -/
+lemma Pplus.g_smul_apply_e0 {M : Type u} [AddCommGroup M] [Module A M] (φ : Pplus →ₗ[A] M) :
+    g • φ Pplus.e0 = φ Pplus.e0 := by
+  rw [← map_smul, Pplus.g_smul_e0]
+
+/-- `g` negates `φ e₀` for any `A`-linear `φ` out of `P₋`, since `g · e₀ = -e₀` there. -/
+lemma Pminus.g_smul_apply_e0 {M : Type u} [AddCommGroup M] [Module A M] (φ : Pminus →ₗ[A] M) :
+    g • φ Pminus.e0 = -φ Pminus.e0 := by
+  rw [← map_smul, Pminus.g_smul_e0, map_neg]
+
+/-! ### The `g`-eigenspaces of `P₊` and `P₋` are the coordinate lines -/
+
+/-- `g` is an involution, so its eigenvalues are `±1` and the two eigenspaces are transverse:
+a scalar fixed up to sign by `g` and equal to its own negative vanishes (`ℂ` has
+characteristic `0`). -/
+private lemma eq_zero_of_neg_eq {z : ℂ} (h : -z = z) : z = 0 := by
+  have h2 : (2 : ℂ) * z = 0 := by
+    rw [two_mul]
+    calc z + z = -z + z := by rw [h]
+      _ = 0 := neg_add_cancel z
+  exact (mul_eq_zero.mp h2).resolve_left two_ne_zero
+
+/-- The `+1`-eigenspace of `g` on `P₊` is the line spanned by `e₀`. -/
+lemma Pplus.eq_smul_e0_of_g_smul_eq_self {w : Pplus} (h : g • w = w) : w = w 0 • Pplus.e0 := by
+  have h1 : w 1 = 0 := by
+    have h2 : (![w 0, -w 1] : Pplus) 1 = w 1 := by rw [← Pplus.g_smul, h]
+    exact eq_zero_of_neg_eq (z := w 1) h2
+  refine Pplus.ext fun i => ?_
+  fin_cases i <;> simp [h1]
+
+/-- The `-1`-eigenspace of `g` on `P₊` is the line spanned by the socle vector `e₁`. -/
+lemma Pplus.eq_smul_e1_of_g_smul_eq_neg {w : Pplus} (h : g • w = -w) : w = w 1 • Pplus.e1 := by
+  have h0 : w 0 = 0 := by
+    have h2 : (![w 0, -w 1] : Pplus) 0 = (-w) 0 := by rw [← Pplus.g_smul, h]
+    exact eq_zero_of_neg_eq (z := w 0) h2.symm
+  refine Pplus.ext fun i => ?_
+  fin_cases i <;> simp [h0]
+
+/-- The `+1`-eigenspace of `g` on `P₋` is the line spanned by the socle vector `e₁`. -/
+lemma Pminus.eq_smul_e1_of_g_smul_eq_self {w : Pminus} (h : g • w = w) : w = w 1 • Pminus.e1 := by
+  have h0 : w 0 = 0 := by
+    have h2 : (![-w 0, w 1] : Pminus) 0 = w 0 := by rw [← Pminus.g_smul, h]
+    exact eq_zero_of_neg_eq (z := w 0) h2
+  refine Pminus.ext fun i => ?_
+  fin_cases i <;> simp [h0]
+
+/-- The `-1`-eigenspace of `g` on `P₋` is the line spanned by `e₀`. -/
+lemma Pminus.eq_smul_e0_of_g_smul_eq_neg {w : Pminus} (h : g • w = -w) : w = w 0 • Pminus.e0 := by
+  have h1 : w 1 = 0 := by
+    have h2 : (![-w 0, w 1] : Pminus) 1 = (-w) 1 := by rw [← Pminus.g_smul, h]
+    exact eq_zero_of_neg_eq (z := w 1) h2.symm
+  refine Pminus.ext fun i => ?_
+  fin_cases i <;> simp [h1]
+
+/-! ### The generators of the four Hom spaces
+
+`Hom_A(P₊, P₊)` and `Hom_A(P₋, P₋)` are generated by the identity. The two off-diagonal Hom
+spaces are generated by the map `(a, b) ↦ (0, a)`, which sends `e₀` to the socle vector `e₁` and
+kills `e₁`. -/
+
+/-- The `ℂ`-linear map `P₊ → P₋`, `(a, b) ↦ (0, a)`, underlying the generator of
+`Hom_A(P₊, P₋)`. -/
+def φTpm : Pplus →ₗ[ℂ] Pminus where
+  toFun v := ![0, v 0]
+  map_add' u v := by refine Pminus.ext fun i => ?_; fin_cases i <;> simp
+  map_smul' c v := by refine Pminus.ext fun i => ?_; fin_cases i <;> simp
+
+@[simp] lemma φTpm_apply (v : Pplus) : φTpm v = ![0, v 0] := rfl
+
+/-- The `ℂ`-linear map `P₋ → P₊`, `(a, b) ↦ (0, a)`, underlying the generator of
+`Hom_A(P₋, P₊)`. -/
+def φTmp : Pminus →ₗ[ℂ] Pplus where
+  toFun v := ![0, v 0]
+  map_add' u v := by refine Pplus.ext fun i => ?_; fin_cases i <;> simp
+  map_smul' c v := by refine Pplus.ext fun i => ?_; fin_cases i <;> simp
+
+@[simp] lemma φTmp_apply (v : Pminus) : φTmp v = ![0, v 0] := rfl
+
+/-- **The generator of `Hom_A(P₊, P₋)`**: `e₀ ↦ e₁`, `e₁ ↦ 0`. It is `A`-linear because the
+`+1`-eigenline of `g` in `P₋` is spanned by `e₁`, and `x · e₁ = 0`. -/
+noncomputable def Tpm : Pplus →ₗ[A] Pminus :=
+  mkAlgLinear ρP ρPm Pplus.smul_def Pminus.smul_def φTpm
+    (by intro v
+        rw [← Pplus.smul_def, ← Pminus.smul_def, Pplus.g_smul, Pminus.g_smul]
+        refine Pminus.ext fun i => ?_
+        fin_cases i <;> simp)
+    (by intro v
+        rw [← Pplus.smul_def, ← Pminus.smul_def, Pplus.x_smul, Pminus.x_smul]
+        refine Pminus.ext fun i => ?_
+        fin_cases i <;> simp)
+
+/-- **The generator of `Hom_A(P₋, P₊)`**: `e₀ ↦ e₁`, `e₁ ↦ 0`. -/
+noncomputable def Tmp : Pminus →ₗ[A] Pplus :=
+  mkAlgLinear ρPm ρP Pminus.smul_def Pplus.smul_def φTmp
+    (by intro v
+        rw [← Pminus.smul_def, ← Pplus.smul_def, Pminus.g_smul, Pplus.g_smul]
+        refine Pplus.ext fun i => ?_
+        fin_cases i <;> simp)
+    (by intro v
+        rw [← Pminus.smul_def, ← Pplus.smul_def, Pminus.x_smul, Pplus.x_smul]
+        refine Pplus.ext fun i => ?_
+        fin_cases i <;> simp)
+
+@[simp] lemma Tpm_apply (v : Pplus) : Tpm v = ![0, v 0] := rfl
+
+@[simp] lemma Tmp_apply (v : Pminus) : Tmp v = ![0, v 0] := rfl
+
+lemma Tpm_e0 : Tpm Pplus.e0 = Pminus.e1 := by
+  rw [Tpm_apply]; refine Pminus.ext fun i => ?_; fin_cases i <;> simp
+
+lemma Tmp_e0 : Tmp Pminus.e0 = Pplus.e1 := by
+  rw [Tmp_apply]; refine Pplus.ext fun i => ?_; fin_cases i <;> simp
+
+/-! ### The four Hom spaces are one-dimensional
+
+For each pair the coefficient map `φ ↦ (φ e₀) k` is a `ℂ`-linear bijection onto `ℂ`, where `k`
+is the coordinate of the eigenline containing `φ e₀`. -/
+
+/-- The coefficient of `φ ∈ Hom_A(P₊, P₊)` on the generator `id`. -/
+noncomputable def homCoeffPP : (Pplus →ₗ[A] Pplus) →ₗ[ℂ] ℂ where
+  toFun φ := (φ Pplus.e0) 0
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+
+/-- The coefficient of `φ ∈ Hom_A(P₊, P₋)` on the generator `Tpm`. -/
+noncomputable def homCoeffPM : (Pplus →ₗ[A] Pminus) →ₗ[ℂ] ℂ where
+  toFun φ := (φ Pplus.e0) 1
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+
+/-- The coefficient of `φ ∈ Hom_A(P₋, P₊)` on the generator `Tmp`. -/
+noncomputable def homCoeffMP : (Pminus →ₗ[A] Pplus) →ₗ[ℂ] ℂ where
+  toFun φ := (φ Pminus.e0) 1
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+
+/-- The coefficient of `φ ∈ Hom_A(P₋, P₋)` on the generator `id`. -/
+noncomputable def homCoeffMM : (Pminus →ₗ[A] Pminus) →ₗ[ℂ] ℂ where
+  toFun φ := (φ Pminus.e0) 0
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+
+lemma homCoeffPP_bijective : Function.Bijective homCoeffPP := by
+  constructor
+  · intro φ ψ h
+    refine Pplus.hom_ext ?_
+    rw [Pplus.eq_smul_e0_of_g_smul_eq_self (Pplus.g_smul_apply_e0 φ),
+      Pplus.eq_smul_e0_of_g_smul_eq_self (Pplus.g_smul_apply_e0 ψ)]
+    exact congrArg (fun c : ℂ => c • Pplus.e0) h
+  · intro c
+    refine ⟨c • LinearMap.id, ?_⟩
+    show ((c • (LinearMap.id : Pplus →ₗ[A] Pplus)) Pplus.e0) 0 = c
+    simp
+
+lemma homCoeffPM_bijective : Function.Bijective homCoeffPM := by
+  constructor
+  · intro φ ψ h
+    refine Pplus.hom_ext ?_
+    rw [Pminus.eq_smul_e1_of_g_smul_eq_self (Pplus.g_smul_apply_e0 φ),
+      Pminus.eq_smul_e1_of_g_smul_eq_self (Pplus.g_smul_apply_e0 ψ)]
+    exact congrArg (fun c : ℂ => c • Pminus.e1) h
+  · intro c
+    refine ⟨c • Tpm, ?_⟩
+    show ((c • Tpm) Pplus.e0) 1 = c
+    rw [LinearMap.smul_apply, Tpm_e0]
+    simp
+
+lemma homCoeffMP_bijective : Function.Bijective homCoeffMP := by
+  constructor
+  · intro φ ψ h
+    refine Pminus.hom_ext ?_
+    rw [Pplus.eq_smul_e1_of_g_smul_eq_neg (Pminus.g_smul_apply_e0 φ),
+      Pplus.eq_smul_e1_of_g_smul_eq_neg (Pminus.g_smul_apply_e0 ψ)]
+    exact congrArg (fun c : ℂ => c • Pplus.e1) h
+  · intro c
+    refine ⟨c • Tmp, ?_⟩
+    show ((c • Tmp) Pminus.e0) 1 = c
+    rw [LinearMap.smul_apply, Tmp_e0]
+    simp
+
+lemma homCoeffMM_bijective : Function.Bijective homCoeffMM := by
+  constructor
+  · intro φ ψ h
+    refine Pminus.hom_ext ?_
+    rw [Pminus.eq_smul_e0_of_g_smul_eq_neg (Pminus.g_smul_apply_e0 φ),
+      Pminus.eq_smul_e0_of_g_smul_eq_neg (Pminus.g_smul_apply_e0 ψ)]
+    exact congrArg (fun c : ℂ => c • Pminus.e0) h
+  · intro c
+    refine ⟨c • LinearMap.id, ?_⟩
+    show ((c • (LinearMap.id : Pminus →ₗ[A] Pminus)) Pminus.e0) 0 = c
+    simp
+
+/-- `Hom_A(P₊, P₊) ≅ ℂ`, the isomorphism sending `φ` to its coefficient on `id`. -/
+noncomputable def homEquivPP : (Pplus →ₗ[A] Pplus) ≃ₗ[ℂ] ℂ :=
+  LinearEquiv.ofBijective homCoeffPP homCoeffPP_bijective
+
+/-- `Hom_A(P₊, P₋) ≅ ℂ`, the isomorphism sending `φ` to its coefficient on `Tpm`. -/
+noncomputable def homEquivPM : (Pplus →ₗ[A] Pminus) ≃ₗ[ℂ] ℂ :=
+  LinearEquiv.ofBijective homCoeffPM homCoeffPM_bijective
+
+/-- `Hom_A(P₋, P₊) ≅ ℂ`, the isomorphism sending `φ` to its coefficient on `Tmp`. -/
+noncomputable def homEquivMP : (Pminus →ₗ[A] Pplus) ≃ₗ[ℂ] ℂ :=
+  LinearEquiv.ofBijective homCoeffMP homCoeffMP_bijective
+
+/-- `Hom_A(P₋, P₋) ≅ ℂ`, the isomorphism sending `φ` to its coefficient on `id`. -/
+noncomputable def homEquivMM : (Pminus →ₗ[A] Pminus) ≃ₗ[ℂ] ℂ :=
+  LinearEquiv.ofBijective homCoeffMM homCoeffMM_bijective
+
+theorem finrank_hom_Pplus_Pplus : Module.finrank ℂ (Pplus →ₗ[A] Pplus) = 1 := by
+  rw [homEquivPP.finrank_eq, Module.finrank_self]
+
+theorem finrank_hom_Pplus_Pminus : Module.finrank ℂ (Pplus →ₗ[A] Pminus) = 1 := by
+  rw [homEquivPM.finrank_eq, Module.finrank_self]
+
+theorem finrank_hom_Pminus_Pplus : Module.finrank ℂ (Pminus →ₗ[A] Pplus) = 1 := by
+  rw [homEquivMP.finrank_eq, Module.finrank_self]
+
+theorem finrank_hom_Pminus_Pminus : Module.finrank ℂ (Pminus →ₗ[A] Pminus) = 1 := by
+  rw [homEquivMM.finrank_eq, Module.finrank_self]
+
+/-! ### The Cartan matrix
+
+The indexed family `Pfam = ![P₊, P₋]` of the two projective indecomposables. This is the input
+`Etingof.algebraCartanMatrix` (Definition 9.3.1) consumes, and forming it is exactly what the
+distinct carriers of `P₊` and `P₋` make possible. -/
+
+/-- The family of the two projective indecomposables of `A`, indexed as `P₊, P₋`. -/
+def Pfam : Fin 2 → Type
+  | 0 => Pplus
+  | 1 => Pminus
+
+instance : ∀ i, AddCommGroup (Pfam i)
+  | 0 => inferInstanceAs (AddCommGroup Pplus)
+  | 1 => inferInstanceAs (AddCommGroup Pminus)
+
+noncomputable instance : ∀ i, Module A (Pfam i)
+  | 0 => inferInstanceAs (Module A Pplus)
+  | 1 => inferInstanceAs (Module A Pminus)
+
+instance : ∀ i, Module ℂ (Pfam i)
+  | 0 => inferInstanceAs (Module ℂ Pplus)
+  | 1 => inferInstanceAs (Module ℂ Pminus)
+
+instance : ∀ i, SMulCommClass A ℂ (Pfam i)
+  | 0 => inferInstanceAs (SMulCommClass A ℂ Pplus)
+  | 1 => inferInstanceAs (SMulCommClass A ℂ Pminus)
+
+instance : ∀ i, IsScalarTower ℂ A (Pfam i)
+  | 0 => inferInstanceAs (IsScalarTower ℂ A Pplus)
+  | 1 => inferInstanceAs (IsScalarTower ℂ A Pminus)
+
+instance : ∀ i, Module.Finite ℂ (Pfam i)
+  | 0 => inferInstanceAs (Module.Finite ℂ Pplus)
+  | 1 => inferInstanceAs (Module.Finite ℂ Pminus)
+
+instance : ∀ i, Nontrivial (Pfam i)
+  | 0 => inferInstanceAs (Nontrivial Pplus)
+  | 1 => inferInstanceAs (Nontrivial Pminus)
+
+@[simp] lemma Pfam_zero : Pfam 0 = Pplus := rfl
+
+@[simp] lemma Pfam_one : Pfam 1 = Pminus := rfl
+
+/-- The family carries the intended module structures, not merely the intended carriers: the
+off-diagonal entry of the Cartan matrix is *literally* `dim_ℂ Hom_A(P₊, P₋)`, computed with the
+`A`-action of `P₊` on the source and that of `P₋` on the target. This is the statement that
+could not even be formed while `Pplus` and `Pminus` shared a carrier, since the two `Module A`
+instances then collided. -/
+lemma algebraCartanMatrix_Pfam_apply_zero_one :
+    Etingof.algebraCartanMatrix (k := ℂ) (A := A) Pfam 0 1
+      = Module.finrank ℂ (Pplus →ₗ[A] Pminus) := rfl
+
+/-- Every entry of the Cartan matrix of `A` is `1`. -/
+theorem algebraCartanMatrix_Pfam_apply (i j : Fin 2) :
+    Etingof.algebraCartanMatrix (k := ℂ) (A := A) Pfam i j = 1 := by
+  fin_cases i <;> fin_cases j
+  · exact finrank_hom_Pplus_Pplus
+  · exact finrank_hom_Pplus_Pminus
+  · exact finrank_hom_Pminus_Pplus
+  · exact finrank_hom_Pminus_Pminus
+
+/-- **The Cartan matrix of the algebra of Problem 9.3.2 is `!![1, 1; 1, 1]`.**
+
+This is the third and last part of Problem 9.3.2. All four entries are `1`: each Hom space
+`Hom_A(P_s, P_t)` is the line spanned by a single explicit generator. Equivalently (Proposition
+9.2.3) each simple `S_s` occurs exactly once in the Jordan–Hölder series of each `P_t`, which
+matches the composition series `0 ⊂ S₋ ⊂ P₊` and `0 ⊂ S₊ ⊂ P₋`. -/
+theorem algebraCartanMatrix_Pfam :
+    Etingof.algebraCartanMatrix (k := ℂ) (A := A) Pfam = !![1, 1; 1, 1] := by
+  refine Matrix.ext fun i j => ?_
+  rw [algebraCartanMatrix_Pfam_apply]
+  fin_cases i <;> fin_cases j <;> simp
+
+/-- Consistency with Etingof's remark after Definition 9.3.1 that the Cartan matrix has positive
+diagonal entries: the general lemma `Etingof.algebraCartanMatrix_diag_pos` applies to this family
+(the projectives are nonzero and finite dimensional over `ℂ`), and agrees with the computation. -/
+theorem algebraCartanMatrix_Pfam_diag_pos (i : Fin 2) :
+    0 < Etingof.algebraCartanMatrix (k := ℂ) (A := A) Pfam i i :=
+  Etingof.algebraCartanMatrix_diag_pos Pfam i
+
+end Cartan
 
 end Etingof.Problem932

--- a/EtingofRepresentationTheory/Chapter9/Problem9_3_2.lean
+++ b/EtingofRepresentationTheory/Chapter9/Problem9_3_2.lean
@@ -278,44 +278,99 @@ theorem splus_not_iso_sminus : IsEmpty (Splus ≃ₗ[A] Sminus) := by
 
 /-! ## The projective indecomposable `P₊` and the nonsplit extension `0 → S₋ → P₊ → S₊ → 0` -/
 
-/-- Carrier of `P₊`: `ℂ²`, on which `g = diag(1, -1)` and `x = [[0,0],[1,0]]`. -/
-abbrev Pplus : Type := Fin 2 → ℂ
+/-- Carrier of `P₊`: `ℂ²`, on which `g = diag(1, -1)` and `x = [[0,0],[1,0]]`.
+
+This is a `def` rather than an `abbrev` on purpose. `P₊` and `P₋` have the *same* underlying
+vector space `ℂ²` but carry *different* `A`-actions, so their carriers must be distinct types
+for the two `Module A` instances to coexist: with reducible `abbrev`s, instance resolution sees
+one type `Fin 2 → ℂ` with two `Module A` instances and silently picks whichever was declared
+last. Distinct carriers are what makes the indexed family `Pfam` of the two projectives — and
+hence the Cartan matrix of Definition 9.3.1 — expressible at all. -/
+def Pplus : Type := Fin 2 → ℂ
+
+namespace Pplus
+
+instance : AddCommGroup Pplus := inferInstanceAs (AddCommGroup (Fin 2 → ℂ))
+instance : Module ℂ Pplus := inferInstanceAs (Module ℂ (Fin 2 → ℂ))
+instance : Nontrivial Pplus := inferInstanceAs (Nontrivial (Fin 2 → ℂ))
+instance : Module.Finite ℂ Pplus := inferInstanceAs (Module.Finite ℂ (Fin 2 → ℂ))
+
+/-! ### Coordinate API for `P₊`
+
+Because `Pplus` is a semireducible `def`, Mathlib's `Pi.*_apply` simp lemmas no longer fire on
+`P₊`-valued expressions (simp matches up to reducible transparency). These `rfl` lemmas restore
+the pointwise calculus. -/
+
+@[ext] lemma ext {u v : Pplus} (h : ∀ i, u i = v i) : u = v := funext h
+
+@[simp] lemma add_apply (u v : Pplus) (i : Fin 2) : (u + v) i = u i + v i := rfl
+@[simp] lemma sub_apply (u v : Pplus) (i : Fin 2) : (u - v) i = u i - v i := rfl
+@[simp] lemma neg_apply (v : Pplus) (i : Fin 2) : (-v) i = -v i := rfl
+@[simp] lemma zero_apply (i : Fin 2) : (0 : Pplus) i = 0 := rfl
+@[simp] lemma complex_smul_apply (c : ℂ) (v : Pplus) (i : Fin 2) : (c • v) i = c * v i := rfl
+
+/-- The generator `e₀ = (1, 0)` of `P₊`. It generates `P₊` over `A` (its `x`-image is `e₁`)
+and lifts the generator of the top `S₊`. -/
+def e0 : Pplus := ![1, 0]
+
+/-- The socle vector `e₁ = (0, 1)` of `P₊`, spanning the copy of `S₋` inside `P₊`. -/
+def e1 : Pplus := ![0, 1]
+
+@[simp] lemma e0_zero : e0 0 = 1 := rfl
+@[simp] lemma e0_one : e0 1 = 0 := rfl
+@[simp] lemma e1_zero : e1 0 = 0 := rfl
+@[simp] lemma e1_one : e1 1 = 1 := rfl
+
+/-- Coordinate expansion of a vector of `P₊` in the basis `e₀, e₁`. -/
+lemma eq_smul_e0_add_smul_e1 (v : Pplus) : v = v 0 • e0 + v 1 • e1 := by
+  refine ext fun i => ?_
+  fin_cases i <;> simp
+
+end Pplus
 
 /-- The action of `g` on `P₊`, the diagonal matrix `diag(1, -1)`. -/
-noncomputable def PG : Module.End ℂ Pplus := Matrix.toLinAlgEquiv' !![1, 0; 0, -1]
+def PG : Module.End ℂ Pplus where
+  toFun v := ![v 0, -v 1]
+  map_add' u v := by refine Pplus.ext fun i => ?_; fin_cases i <;> simp <;> ring
+  map_smul' c v := by refine Pplus.ext fun i => ?_; fin_cases i <;> simp [mul_neg]
 
 /-- The action of `x` on `P₊`, the nilpotent matrix `[[0,0],[1,0]]`. -/
-noncomputable def PX : Module.End ℂ Pplus := Matrix.toLinAlgEquiv' !![0, 0; 1, 0]
+def PX : Module.End ℂ Pplus where
+  toFun v := ![0, v 0]
+  map_add' u v := by refine Pplus.ext fun i => ?_; fin_cases i <;> simp
+  map_smul' c v := by refine Pplus.ext fun i => ?_; fin_cases i <;> simp
 
-lemma PG_apply (v : Pplus) : PG v = ![v 0, -v 1] := by
-  funext i
-  fin_cases i <;>
-    simp [PG, Matrix.toLinAlgEquiv'_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two]
+lemma PG_apply (v : Pplus) : PG v = ![v 0, -v 1] := rfl
 
-lemma PX_apply (v : Pplus) : PX v = ![0, v 0] := by
-  funext i
-  fin_cases i <;>
-    simp [PX, Matrix.toLinAlgEquiv'_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two]
+lemma PX_apply (v : Pplus) : PX v = ![0, v 0] := rfl
+
+/-- `PG` is the action of the matrix `diag(1, -1)` of the book's presentation. -/
+lemma PG_eq_mulVec (v : Pplus) :
+    PG v = Matrix.mulVec !![(1 : ℂ), 0; 0, -1] (v : Fin 2 → ℂ) := by
+  refine Pplus.ext fun i => ?_
+  fin_cases i <;> simp [PG_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two]
+
+/-- `PX` is the action of the nilpotent matrix `[[0,0],[1,0]]` of the book's presentation. -/
+lemma PX_eq_mulVec (v : Pplus) :
+    PX v = Matrix.mulVec !![(0 : ℂ), 0; 1, 0] (v : Fin 2 → ℂ) := by
+  refine Pplus.ext fun i => ?_
+  fin_cases i <;> simp [PX_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two]
 
 /-- The representation defining `P₊`. -/
 noncomputable def ρP : A →ₐ[ℂ] Module.End ℂ Pplus :=
   repHom PG PX
-    (by simp only [PG, PX, ← map_mul, ← map_add]
-        rw [show !![(1 : ℂ), 0; 0, -1] * !![0, 0; 1, 0] + !![0, 0; 1, 0] * !![1, 0; 0, -1]
-              = (0 : Matrix (Fin 2) (Fin 2) ℂ) by
-            ext i j; fin_cases i <;> fin_cases j <;>
-              simp [Matrix.mul_apply, Fin.sum_univ_two]]
-        rw [map_zero])
-    (by simp only [PX, ← map_mul]
-        rw [show !![(0 : ℂ), 0; 1, 0] * !![0, 0; 1, 0] = (0 : Matrix (Fin 2) (Fin 2) ℂ) by
-            ext i j; fin_cases i <;> fin_cases j <;>
-              simp [Matrix.mul_apply, Fin.sum_univ_two]]
-        rw [map_zero])
-    (by simp only [PG, ← map_mul]
-        rw [show !![(1 : ℂ), 0; 0, -1] * !![1, 0; 0, -1] = (1 : Matrix (Fin 2) (Fin 2) ℂ) by
-            ext i j; fin_cases i <;> fin_cases j <;>
-              simp [Matrix.mul_apply, Fin.sum_univ_two, Matrix.one_apply]]
-        rw [map_one])
+    (by refine LinearMap.ext fun v => ?_
+        simp only [LinearMap.add_apply, Module.End.mul_apply, LinearMap.zero_apply]
+        refine Pplus.ext fun i => ?_
+        fin_cases i <;> simp [PG_apply, PX_apply])
+    (by refine LinearMap.ext fun v => ?_
+        simp only [Module.End.mul_apply, LinearMap.zero_apply]
+        refine Pplus.ext fun i => ?_
+        fin_cases i <;> simp [PX_apply])
+    (by refine LinearMap.ext fun v => ?_
+        simp only [Module.End.mul_apply, Module.End.one_apply]
+        refine Pplus.ext fun i => ?_
+        fin_cases i <;> simp [PG_apply])
 
 noncomputable instance : Module A Pplus := Module.compHom Pplus ρP.toRingHom
 
@@ -468,24 +523,26 @@ lemma x_mul_xeplus : x * xeplus = 0 := by
     rw [hxg, neg_mul, mul_assoc, xsq_rel, mul_zero, neg_zero, sub_zero]
   rw [xeplus, mul_smul_comm, h, smul_zero]
 
-lemma eplus_smul_e0 : eplus • (![1, 0] : Pplus) = ![1, 0] := by
-  have h : eplus • (![1, 0] : Pplus)
-      = (2⁻¹ : ℂ) • ((![1, 0] : Pplus) + g • (![1, 0] : Pplus)) := by
+lemma eplus_smul_e0 : eplus • Pplus.e0 = Pplus.e0 := by
+  have h : eplus • Pplus.e0
+      = (2⁻¹ : ℂ) • (Pplus.e0 + g • Pplus.e0) := by
     rw [eplus, smul_assoc, add_smul, one_smul]
   rw [h, Pplus.g_smul]
-  funext i; fin_cases i <;> simp <;> norm_num
+  refine Pplus.ext fun i => ?_
+  fin_cases i <;> simp <;> norm_num
 
-lemma xeplus_smul_e0 : xeplus • (![1, 0] : Pplus) = ![0, 1] := by
+lemma xeplus_smul_e0 : xeplus • Pplus.e0 = Pplus.e1 := by
   rw [← x_mul_eplus, mul_smul, eplus_smul_e0, Pplus.x_smul]
-  funext i; fin_cases i <;> simp
+  refine Pplus.ext fun i => ?_
+  fin_cases i <;> simp
 
 /-- The `ℂ`-linear map `P₊ → A`, `(a, b) ↦ a • e₊ + b • (x·e₊)`, underlying the section. -/
 noncomputable def φiPlus : Pplus →ₗ[ℂ] A where
   toFun v := v 0 • eplus + v 1 • xeplus
   map_add' u v := by
-    simp only [Pi.add_apply, add_smul]; abel
+    simp only [Pplus.add_apply, add_smul]; abel
   map_smul' c v := by
-    simp only [Pi.smul_apply, smul_eq_mul, mul_smul, RingHom.id_apply, smul_add]
+    simp only [Pplus.complex_smul_apply, RingHom.id_apply, mul_smul, smul_add]
 
 @[simp] lemma φiPlus_apply (v : Pplus) : φiPlus v = v 0 • eplus + v 1 • xeplus := rfl
 
@@ -506,7 +563,7 @@ noncomputable def iPlus : Pplus →ₗ[A] A :=
         rw [mul_add, mul_smul_comm, mul_smul_comm, x_mul_eplus, x_mul_xeplus, smul_zero, add_zero])
 
 /-- The `A`-linear retraction `A ↠ P₊`, `a ↦ a • (1,0)`. -/
-noncomputable def rPlus : A →ₗ[A] Pplus := LinearMap.toSpanSingleton A Pplus (![1, 0] : Pplus)
+noncomputable def rPlus : A →ₗ[A] Pplus := LinearMap.toSpanSingleton A Pplus Pplus.e0
 
 /-- The retraction is split by the section: `rPlus ∘ iPlus = id`, so `P₊` is a summand of `A`. -/
 lemma rPlus_comp_iPlus : rPlus.comp iPlus = LinearMap.id := by
@@ -530,38 +587,41 @@ everything. Both facts follow from `x · (a, b) = (0, a)`. -/
 
 /-- Every nonzero `A`-submodule of `P₊` contains the socle vector `(0, 1)`. -/
 lemma socle_mem_of_ne_bot_Pplus (N : Submodule A Pplus) (hN : N ≠ ⊥) :
-    (![0, 1] : Pplus) ∈ N := by
+    Pplus.e1 ∈ N := by
   obtain ⟨v, hvN, hv⟩ := (Submodule.ne_bot_iff N).mp hN
   by_cases h0 : v 0 = 0
   · have h1 : v 1 ≠ 0 := by
       intro h1
-      exact hv (by funext j; fin_cases j <;> simpa [h0, h1])
-    have := smul_mem_complex N (v 1)⁻¹ hvN
-    convert this using 1
-    funext j; fin_cases j <;> simp [h0, inv_mul_cancel₀ h1]
+      exact hv (Pplus.ext fun j => by fin_cases j <;> simp [h0, h1])
+    have hmem := smul_mem_complex N (v 1)⁻¹ hvN
+    have heq : (v 1)⁻¹ • v = Pplus.e1 := by
+      refine Pplus.ext fun j => ?_
+      fin_cases j <;> simp [h0, inv_mul_cancel₀ h1]
+    rwa [heq] at hmem
   · have hx : x • v ∈ N := N.smul_mem x hvN
-    rw [Pplus.x_smul] at hx
-    have := smul_mem_complex N (v 0)⁻¹ hx
-    convert this using 1
-    funext j; fin_cases j <;> simp [inv_mul_cancel₀ h0]
+    have hmem := smul_mem_complex N (v 0)⁻¹ hx
+    have heq : (v 0)⁻¹ • (x • v) = Pplus.e1 := by
+      rw [Pplus.x_smul]
+      refine Pplus.ext fun j => ?_
+      fin_cases j <;> simp [inv_mul_cancel₀ h0]
+    rwa [heq] at hmem
 
 /-- An `A`-submodule of `P₊` containing a vector with nonzero first coordinate is all of `P₊`. -/
 lemma eq_top_of_mem_Pplus (N : Submodule A Pplus) {v : Pplus} (hvN : v ∈ N) (h0 : v 0 ≠ 0) :
     N = ⊤ := by
-  have hsoc : (![0, 1] : Pplus) ∈ N :=
+  have hsoc : Pplus.e1 ∈ N :=
     socle_mem_of_ne_bot_Pplus N (Submodule.ne_bot_iff N |>.mpr
       ⟨v, hvN, fun h => h0 (by rw [h]; rfl)⟩)
-  have he0 : (![1, 0] : Pplus) ∈ N := by
-    have hsub : v - v 1 • (![0, 1] : Pplus) ∈ N :=
+  have he0 : Pplus.e0 ∈ N := by
+    have hsub : v - v 1 • Pplus.e1 ∈ N :=
       N.sub_mem hvN (smul_mem_complex N (v 1) hsoc)
-    have := smul_mem_complex N (v 0)⁻¹ hsub
-    convert this using 1
-    funext j; fin_cases j <;>
-      simp [Matrix.vecHead, Matrix.vecTail, inv_mul_cancel₀ h0]
+    have hmem := smul_mem_complex N (v 0)⁻¹ hsub
+    have heq : (v 0)⁻¹ • (v - v 1 • Pplus.e1) = Pplus.e0 := by
+      refine Pplus.ext fun j => ?_
+      fin_cases j <;> simp [inv_mul_cancel₀ h0]
+    rwa [heq] at hmem
   refine Submodule.eq_top_iff'.mpr fun w => ?_
-  have hw : w = w 0 • (![1, 0] : Pplus) + w 1 • (![0, 1] : Pplus) := by
-    funext j; fin_cases j <;> simp
-  rw [hw]
+  rw [Pplus.eq_smul_e0_add_smul_e1 w]
   exact N.add_mem (smul_mem_complex N _ he0) (smul_mem_complex N _ hsoc)
 
 /-- **`P₊` is indecomposable.** Every nonzero submodule contains the socle vector `(0, 1)`, so
@@ -570,22 +630,24 @@ theorem isIndecomposable_Pplus : Etingof.IsIndecomposable A Pplus := by
   refine ⟨inferInstance, fun M N hMN => ?_⟩
   by_contra hc
   obtain ⟨hM, hN⟩ := not_or.mp hc
-  have hmem : (![0, 1] : Pplus) ∈ M ⊓ N :=
+  have hmem : Pplus.e1 ∈ M ⊓ N :=
     ⟨socle_mem_of_ne_bot_Pplus M hM, socle_mem_of_ne_bot_Pplus N hN⟩
   rw [hMN.inf_eq_bot, Submodule.mem_bot] at hmem
-  have hone : (![0, 1] : Pplus) 1 = (0 : Pplus) 1 := by rw [hmem]
+  have hone : Pplus.e1 1 = (0 : Pplus) 1 := by rw [hmem]
   simp at hone
 
 /-- The kernel of `P₊ ↠ S₊` is superfluous: no proper submodule of `P₊` complements it. -/
 theorem ker_gSES_superfluous (N : Submodule A Pplus)
     (h : N ⊔ LinearMap.ker gSES = ⊤) : N = ⊤ := by
-  have hmem : (![1, 0] : Pplus) ∈ N ⊔ LinearMap.ker gSES := h ▸ Submodule.mem_top
+  have hmem : Pplus.e0 ∈ N ⊔ LinearMap.ker gSES := h ▸ Submodule.mem_top
   obtain ⟨n, hn, k, hk, hnk⟩ := Submodule.mem_sup.mp hmem
   have hk0 : k 0 = 0 := hk
   refine eq_top_of_mem_Pplus N hn ?_
-  have : n 0 + k 0 = (1 : ℂ) := congrFun hnk 0
-  rw [hk0, add_zero] at this
-  rw [this]
+  have hsum : n 0 + k 0 = (1 : ℂ) := by
+    have := congrArg (fun w : Pplus => w 0) hnk
+    simpa using this
+  rw [hk0, add_zero] at hsum
+  rw [hsum]
   exact one_ne_zero
 
 /-- **`P₊ ↠ S₊` is a projective cover of `S₊`.** `P₊` is projective, the map is surjective, and
@@ -602,44 +664,90 @@ theorem isProjectiveCover_Pplus :
 sequence `0 → S₊ → P₋ → S₋ → 0`. Together with `0 → S₋ → P₊ → S₊ → 0` this exhibits the
 2-periodic syzygies `Ω(S₊) ≅ S₋`, `Ω(S₋) ≅ S₊` used in Problem 9.4.5(ii). -/
 
-/-- Carrier of `P₋`: `ℂ²`, on which `g = diag(-1, 1)` and `x = [[0,0],[1,0]]`. -/
-abbrev Pminus : Type := Fin 2 → ℂ
+/-- Carrier of `P₋`: `ℂ²`, on which `g = diag(-1, 1)` and `x = [[0,0],[1,0]]`.
+
+A `def`, not an `abbrev`, for the same reason as `Pplus`: the two projectives share the
+underlying space `ℂ²` and must be distinct types so that their `Module A` instances coexist. -/
+def Pminus : Type := Fin 2 → ℂ
+
+namespace Pminus
+
+instance : AddCommGroup Pminus := inferInstanceAs (AddCommGroup (Fin 2 → ℂ))
+instance : Module ℂ Pminus := inferInstanceAs (Module ℂ (Fin 2 → ℂ))
+instance : Nontrivial Pminus := inferInstanceAs (Nontrivial (Fin 2 → ℂ))
+instance : Module.Finite ℂ Pminus := inferInstanceAs (Module.Finite ℂ (Fin 2 → ℂ))
+
+/-! ### Coordinate API for `P₋` (see the `Pplus` coordinate API for why these are needed) -/
+
+@[ext] lemma ext {u v : Pminus} (h : ∀ i, u i = v i) : u = v := funext h
+
+@[simp] lemma add_apply (u v : Pminus) (i : Fin 2) : (u + v) i = u i + v i := rfl
+@[simp] lemma sub_apply (u v : Pminus) (i : Fin 2) : (u - v) i = u i - v i := rfl
+@[simp] lemma neg_apply (v : Pminus) (i : Fin 2) : (-v) i = -v i := rfl
+@[simp] lemma zero_apply (i : Fin 2) : (0 : Pminus) i = 0 := rfl
+@[simp] lemma complex_smul_apply (c : ℂ) (v : Pminus) (i : Fin 2) : (c • v) i = c * v i := rfl
+
+/-- The generator `e₀ = (1, 0)` of `P₋`, lifting the generator of the top `S₋`. -/
+def e0 : Pminus := ![1, 0]
+
+/-- The socle vector `e₁ = (0, 1)` of `P₋`, spanning the copy of `S₊` inside `P₋`. -/
+def e1 : Pminus := ![0, 1]
+
+@[simp] lemma e0_zero : e0 0 = 1 := rfl
+@[simp] lemma e0_one : e0 1 = 0 := rfl
+@[simp] lemma e1_zero : e1 0 = 0 := rfl
+@[simp] lemma e1_one : e1 1 = 1 := rfl
+
+/-- Coordinate expansion of a vector of `P₋` in the basis `e₀, e₁`. -/
+lemma eq_smul_e0_add_smul_e1 (v : Pminus) : v = v 0 • e0 + v 1 • e1 := by
+  refine ext fun i => ?_
+  fin_cases i <;> simp
+
+end Pminus
 
 /-- The action of `g` on `P₋`, the diagonal matrix `diag(-1, 1)`. -/
-noncomputable def PGm : Module.End ℂ Pminus := Matrix.toLinAlgEquiv' !![-1, 0; 0, 1]
+def PGm : Module.End ℂ Pminus where
+  toFun v := ![-v 0, v 1]
+  map_add' u v := by refine Pminus.ext fun i => ?_; fin_cases i <;> simp <;> ring
+  map_smul' c v := by refine Pminus.ext fun i => ?_; fin_cases i <;> simp [mul_neg]
 
 /-- The action of `x` on `P₋`, the nilpotent matrix `[[0,0],[1,0]]`. -/
-noncomputable def PXm : Module.End ℂ Pminus := Matrix.toLinAlgEquiv' !![0, 0; 1, 0]
+def PXm : Module.End ℂ Pminus where
+  toFun v := ![0, v 0]
+  map_add' u v := by refine Pminus.ext fun i => ?_; fin_cases i <;> simp
+  map_smul' c v := by refine Pminus.ext fun i => ?_; fin_cases i <;> simp
 
-lemma PGm_apply (v : Pminus) : PGm v = ![-v 0, v 1] := by
-  funext i
-  fin_cases i <;>
-    simp [PGm, Matrix.toLinAlgEquiv'_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two]
+lemma PGm_apply (v : Pminus) : PGm v = ![-v 0, v 1] := rfl
 
-lemma PXm_apply (v : Pminus) : PXm v = ![0, v 0] := by
-  funext i
-  fin_cases i <;>
-    simp [PXm, Matrix.toLinAlgEquiv'_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two]
+lemma PXm_apply (v : Pminus) : PXm v = ![0, v 0] := rfl
+
+/-- `PGm` is the action of the matrix `diag(-1, 1)` of the book's presentation. -/
+lemma PGm_eq_mulVec (v : Pminus) :
+    PGm v = Matrix.mulVec !![(-1 : ℂ), 0; 0, 1] (v : Fin 2 → ℂ) := by
+  refine Pminus.ext fun i => ?_
+  fin_cases i <;> simp [PGm_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two]
+
+/-- `PXm` is the action of the nilpotent matrix `[[0,0],[1,0]]` of the book's presentation. -/
+lemma PXm_eq_mulVec (v : Pminus) :
+    PXm v = Matrix.mulVec !![(0 : ℂ), 0; 1, 0] (v : Fin 2 → ℂ) := by
+  refine Pminus.ext fun i => ?_
+  fin_cases i <;> simp [PXm_apply, Matrix.mulVec, dotProduct, Fin.sum_univ_two]
 
 /-- The representation defining `P₋`. -/
 noncomputable def ρPm : A →ₐ[ℂ] Module.End ℂ Pminus :=
   repHom PGm PXm
-    (by simp only [PGm, PXm, ← map_mul, ← map_add]
-        rw [show !![(-1 : ℂ), 0; 0, 1] * !![0, 0; 1, 0] + !![0, 0; 1, 0] * !![-1, 0; 0, 1]
-              = (0 : Matrix (Fin 2) (Fin 2) ℂ) by
-            ext i j; fin_cases i <;> fin_cases j <;>
-              simp [Matrix.mul_apply, Fin.sum_univ_two]]
-        rw [map_zero])
-    (by simp only [PXm, ← map_mul]
-        rw [show !![(0 : ℂ), 0; 1, 0] * !![0, 0; 1, 0] = (0 : Matrix (Fin 2) (Fin 2) ℂ) by
-            ext i j; fin_cases i <;> fin_cases j <;>
-              simp [Matrix.mul_apply, Fin.sum_univ_two]]
-        rw [map_zero])
-    (by simp only [PGm, ← map_mul]
-        rw [show !![(-1 : ℂ), 0; 0, 1] * !![-1, 0; 0, 1] = (1 : Matrix (Fin 2) (Fin 2) ℂ) by
-            ext i j; fin_cases i <;> fin_cases j <;>
-              simp [Matrix.mul_apply, Fin.sum_univ_two, Matrix.one_apply]]
-        rw [map_one])
+    (by refine LinearMap.ext fun v => ?_
+        simp only [LinearMap.add_apply, Module.End.mul_apply, LinearMap.zero_apply]
+        refine Pminus.ext fun i => ?_
+        fin_cases i <;> simp [PGm_apply, PXm_apply])
+    (by refine LinearMap.ext fun v => ?_
+        simp only [Module.End.mul_apply, LinearMap.zero_apply]
+        refine Pminus.ext fun i => ?_
+        fin_cases i <;> simp [PXm_apply])
+    (by refine LinearMap.ext fun v => ?_
+        simp only [Module.End.mul_apply, Module.End.one_apply]
+        refine Pminus.ext fun i => ?_
+        fin_cases i <;> simp [PGm_apply])
 
 noncomputable instance : Module A Pminus := Module.compHom Pminus ρPm.toRingHom
 
@@ -753,24 +861,26 @@ lemma x_mul_xeminus : x * xeminus = 0 := by
     rw [hxg, neg_mul, mul_assoc, xsq_rel, mul_zero, neg_zero, add_zero]
   rw [xeminus, mul_smul_comm, h, smul_zero]
 
-lemma eminus_smul_e0 : eminus • (![1, 0] : Pminus) = ![1, 0] := by
-  have h : eminus • (![1, 0] : Pminus)
-      = (2⁻¹ : ℂ) • ((![1, 0] : Pminus) - g • (![1, 0] : Pminus)) := by
+lemma eminus_smul_e0 : eminus • Pminus.e0 = Pminus.e0 := by
+  have h : eminus • Pminus.e0
+      = (2⁻¹ : ℂ) • (Pminus.e0 - g • Pminus.e0) := by
     rw [eminus, smul_assoc, sub_smul, one_smul]
   rw [h, Pminus.g_smul]
-  funext i; fin_cases i <;> simp <;> norm_num
+  refine Pminus.ext fun i => ?_
+  fin_cases i <;> simp <;> norm_num
 
-lemma xeminus_smul_e0 : xeminus • (![1, 0] : Pminus) = ![0, 1] := by
+lemma xeminus_smul_e0 : xeminus • Pminus.e0 = Pminus.e1 := by
   rw [← x_mul_eminus, mul_smul, eminus_smul_e0, Pminus.x_smul]
-  funext i; fin_cases i <;> simp
+  refine Pminus.ext fun i => ?_
+  fin_cases i <;> simp
 
 /-- The `ℂ`-linear map `P₋ → A`, `(a, b) ↦ a • e₋ + b • (x·e₋)`, underlying the section. -/
 noncomputable def φiMinus : Pminus →ₗ[ℂ] A where
   toFun v := v 0 • eminus + v 1 • xeminus
   map_add' u v := by
-    simp only [Pi.add_apply, add_smul]; abel
+    simp only [Pminus.add_apply, add_smul]; abel
   map_smul' c v := by
-    simp only [Pi.smul_apply, smul_eq_mul, mul_smul, RingHom.id_apply, smul_add]
+    simp only [Pminus.complex_smul_apply, RingHom.id_apply, mul_smul, smul_add]
 
 @[simp] lemma φiMinus_apply (v : Pminus) : φiMinus v = v 0 • eminus + v 1 • xeminus := rfl
 
@@ -792,7 +902,7 @@ noncomputable def iMinus : Pminus →ₗ[A] A :=
           add_zero])
 
 /-- The `A`-linear retraction `A ↠ P₋`, `a ↦ a • (1,0)`. -/
-noncomputable def rMinus : A →ₗ[A] Pminus := LinearMap.toSpanSingleton A Pminus (![1, 0] : Pminus)
+noncomputable def rMinus : A →ₗ[A] Pminus := LinearMap.toSpanSingleton A Pminus Pminus.e0
 
 /-- The retraction is split by the section: `rMinus ∘ iMinus = id`, so `P₋` is a summand of `A`. -/
 lemma rMinus_comp_iMinus : rMinus.comp iMinus = LinearMap.id := by
@@ -809,10 +919,9 @@ instance projective_Pminus : Module.Projective A Pminus :=
 
 /-- `ses.X₂ = P₊` is a projective object of `ModuleCat A`. Built explicitly (with the
 `Module.Projective` witness placed as a local instance) to sidestep the
-`Projective ↔ Module.Projective` synthesis loop. We phrase it through `ses.X₂` rather than a
-fresh `ModuleCat.of A Pplus`, because `Pplus` and `Pminus` share the carrier `Fin 2 → ℂ`, so a
-fresh `of A Pplus` would pick up the wrong `Module A` instance; `ses.X₂` has the correct one
-baked in at its definition. -/
+`Projective ↔ Module.Projective` synthesis loop. Phrased through `ses.X₂` rather than a fresh
+`ModuleCat.of A Pplus` to keep the statement literally about the middle term of the short exact
+sequence, which is what the downstream `Ext` arguments consume. -/
 theorem projective_ses_X₂ : Projective ses.X₂ :=
   @ModuleCat.projective_of_categoryTheory_projective A _ ses.X₂ projective_Pplus
 
@@ -838,38 +947,41 @@ theorem areLinked :
 
 /-- Every nonzero `A`-submodule of `P₋` contains the socle vector `(0, 1)`. -/
 lemma socle_mem_of_ne_bot_Pminus (N : Submodule A Pminus) (hN : N ≠ ⊥) :
-    (![0, 1] : Pminus) ∈ N := by
+    Pminus.e1 ∈ N := by
   obtain ⟨v, hvN, hv⟩ := (Submodule.ne_bot_iff N).mp hN
   by_cases h0 : v 0 = 0
   · have h1 : v 1 ≠ 0 := by
       intro h1
-      exact hv (by funext j; fin_cases j <;> simpa [h0, h1])
-    have := smul_mem_complex N (v 1)⁻¹ hvN
-    convert this using 1
-    funext j; fin_cases j <;> simp [h0, inv_mul_cancel₀ h1]
+      exact hv (Pminus.ext fun j => by fin_cases j <;> simp [h0, h1])
+    have hmem := smul_mem_complex N (v 1)⁻¹ hvN
+    have heq : (v 1)⁻¹ • v = Pminus.e1 := by
+      refine Pminus.ext fun j => ?_
+      fin_cases j <;> simp [h0, inv_mul_cancel₀ h1]
+    rwa [heq] at hmem
   · have hx : x • v ∈ N := N.smul_mem x hvN
-    rw [Pminus.x_smul] at hx
-    have := smul_mem_complex N (v 0)⁻¹ hx
-    convert this using 1
-    funext j; fin_cases j <;> simp [inv_mul_cancel₀ h0]
+    have hmem := smul_mem_complex N (v 0)⁻¹ hx
+    have heq : (v 0)⁻¹ • (x • v) = Pminus.e1 := by
+      rw [Pminus.x_smul]
+      refine Pminus.ext fun j => ?_
+      fin_cases j <;> simp [inv_mul_cancel₀ h0]
+    rwa [heq] at hmem
 
 /-- An `A`-submodule of `P₋` containing a vector with nonzero first coordinate is all of `P₋`. -/
 lemma eq_top_of_mem_Pminus (N : Submodule A Pminus) {v : Pminus} (hvN : v ∈ N) (h0 : v 0 ≠ 0) :
     N = ⊤ := by
-  have hsoc : (![0, 1] : Pminus) ∈ N :=
+  have hsoc : Pminus.e1 ∈ N :=
     socle_mem_of_ne_bot_Pminus N (Submodule.ne_bot_iff N |>.mpr
       ⟨v, hvN, fun h => h0 (by rw [h]; rfl)⟩)
-  have he0 : (![1, 0] : Pminus) ∈ N := by
-    have hsub : v - v 1 • (![0, 1] : Pminus) ∈ N :=
+  have he0 : Pminus.e0 ∈ N := by
+    have hsub : v - v 1 • Pminus.e1 ∈ N :=
       N.sub_mem hvN (smul_mem_complex N (v 1) hsoc)
-    have := smul_mem_complex N (v 0)⁻¹ hsub
-    convert this using 1
-    funext j; fin_cases j <;>
-      simp [Matrix.vecHead, Matrix.vecTail, inv_mul_cancel₀ h0]
+    have hmem := smul_mem_complex N (v 0)⁻¹ hsub
+    have heq : (v 0)⁻¹ • (v - v 1 • Pminus.e1) = Pminus.e0 := by
+      refine Pminus.ext fun j => ?_
+      fin_cases j <;> simp [inv_mul_cancel₀ h0]
+    rwa [heq] at hmem
   refine Submodule.eq_top_iff'.mpr fun w => ?_
-  have hw : w = w 0 • (![1, 0] : Pminus) + w 1 • (![0, 1] : Pminus) := by
-    funext j; fin_cases j <;> simp
-  rw [hw]
+  rw [Pminus.eq_smul_e0_add_smul_e1 w]
   exact N.add_mem (smul_mem_complex N _ he0) (smul_mem_complex N _ hsoc)
 
 /-- **`P₋` is indecomposable.** -/
@@ -877,20 +989,22 @@ theorem isIndecomposable_Pminus : Etingof.IsIndecomposable A Pminus := by
   refine ⟨inferInstance, fun M N hMN => ?_⟩
   by_contra hc
   obtain ⟨hM, hN⟩ := not_or.mp hc
-  have hmem : (![0, 1] : Pminus) ∈ M ⊓ N :=
+  have hmem : Pminus.e1 ∈ M ⊓ N :=
     ⟨socle_mem_of_ne_bot_Pminus M hM, socle_mem_of_ne_bot_Pminus N hN⟩
   rw [hMN.inf_eq_bot, Submodule.mem_bot] at hmem
-  have hone : (![0, 1] : Pminus) 1 = (0 : Pminus) 1 := by rw [hmem]
+  have hone : Pminus.e1 1 = (0 : Pminus) 1 := by rw [hmem]
   simp at hone
 
 /-- The kernel of `P₋ ↠ S₋` is superfluous: no proper submodule of `P₋` complements it. -/
 theorem ker_gSESm_superfluous (N : Submodule A Pminus)
     (h : N ⊔ LinearMap.ker gSESm = ⊤) : N = ⊤ := by
-  have hmem : (![1, 0] : Pminus) ∈ N ⊔ LinearMap.ker gSESm := h ▸ Submodule.mem_top
+  have hmem : Pminus.e0 ∈ N ⊔ LinearMap.ker gSESm := h ▸ Submodule.mem_top
   obtain ⟨n, hn, k, hk, hnk⟩ := Submodule.mem_sup.mp hmem
   have hk0 : k 0 = 0 := hk
   refine eq_top_of_mem_Pminus N hn ?_
-  have hsum : n 0 + k 0 = (1 : ℂ) := congrFun hnk 0
+  have hsum : n 0 + k 0 = (1 : ℂ) := by
+    have := congrArg (fun w : Pminus => w 0) hnk
+    simpa using this
   rw [hk0, add_zero] at hsum
   rw [hsum]
   exact one_ne_zero

--- a/progress/2026-07-25T00-39-44Z_bf3d0ca8.md
+++ b/progress/2026-07-25T00-39-44Z_bf3d0ca8.md
@@ -1,0 +1,91 @@
+## Accomplished
+
+Issue #7704 (feature): the Cartan matrix of the Problem 9.3.2 algebra
+`A = ℂ⟨g, x⟩ / (gx + xg, x², g² - 1)`, plus the carrier refactor it was blocked on.
+
+**Commit 1 — `refactor(Ch9 #7704)`: distinct carriers for `P₊` and `P₋`.**
+`Pplus` and `Pminus` were both `abbrev ... : Type := Fin 2 → ℂ`. Because `abbrev` is
+reducible, `Module A Pplus` and `Module A Pminus` were two instances on the *same* type and
+instance resolution silently picked whichever was declared last; the file coped by ordering
+declarations. Both are now semireducible `def`s with their own
+`AddCommGroup` / `Module ℂ` / `Nontrivial` / `Module.Finite` instances.
+
+Fallout and how it was handled — worth knowing before doing this to another carrier:
+
+- Mathlib's `Pi.add_apply`, `Pi.smul_apply`, … stop firing, because `simp` matches only up to
+  *reducible* transparency and a `def` is semireducible. Fixed by a small coordinate API of
+  `rfl` lemmas (`Pplus.add_apply`, `sub_apply`, `neg_apply`, `zero_apply`,
+  `complex_smul_apply`) plus an `@[ext]` `Pplus.ext`.
+- `funext` and `convert … using 1` fail on `Pplus`-valued goals (`convert` generates a
+  *type*-equality subgoal `(Fin 2 → ℂ) = Pplus`). Replaced by `refine Pplus.ext fun i => ?_`
+  and by explicit `have heq : … = … ; rwa [heq] at hmem` rewrites.
+- A type *ascription* `(![1, 0] : Pplus)` does not stick: the elaborated term keeps type
+  `Fin 2 → ℂ`, so a following `•` fails to find `HSMul A (Fin 2 → ℂ) _`. Fixed by naming the
+  generators — `Pplus.e0`, `Pplus.e1` (and `Pminus.e0`, `Pminus.e1`) — which is also what the
+  Hom computations need.
+- `Matrix.toLinAlgEquiv'` no longer usable directly for `PG`/`PX`/`PGm`/`PXm` (its `_apply`
+  simp lemma is stated at `n → ℂ`). They are now explicit `LinearMap`s, with `*_eq_mulVec`
+  lemmas retaining the book's matrix presentation.
+- `*ᵥ` is scoped notation in the `Matrix` namespace; the file does not `open Matrix`, so the
+  `_eq_mulVec` lemmas spell out `Matrix.mulVec`.
+
+Every public name in the file is unchanged. `Example9_5_2` and `Problem9_4_5` needed no edits.
+
+**Commit 2 — `feat(Ch9 #7704)`: the Cartan matrix.** Each of the four Hom spaces
+`Hom_A(P_s, P_t)` is one-dimensional over `ℂ`, by an explicit `LinearEquiv` to `ℂ`:
+
+- `Pplus.eq_smul_e0` / `Pminus.eq_smul_e0`: `P_s` is generated over `A` by `e₀`, since
+  `e₁ = x · e₀` — so `Pplus.hom_ext` / `Pminus.hom_ext`, an `A`-linear map out of `P_s` is
+  determined by its value on `e₀`.
+- `g`-equivariance pins that value down: `g · e₀ = ε e₀` with `ε = +1` on `P₊`, `ε = -1` on
+  `P₋`, so `φ e₀` lies in the `ε`-eigenline of `g` in the target. The four
+  `eq_smul_e*_of_g_smul_eq_*` lemmas identify each eigenline of the involution `g` as a
+  coordinate line (`e₀` or `e₁`).
+- Hence each Hom space is `ℂ · T`: the identity on the diagonal, and `(a, b) ↦ (0, a)` off it
+  (`Tpm`, `Tmp`). `homCoeff**` (the coefficient functional `φ ↦ (φ e₀) k`) is bijective, giving
+  `finrank_hom_Pplus_Pplus` and its three siblings.
+- Family `Pfam = ![P₊, P₋]` (a `match` on `Fin 2`) with its six instance families, and
+  `algebraCartanMatrix_Pfam : Etingof.algebraCartanMatrix (k := ℂ) (A := A) Pfam = !![1, 1; 1, 1]`.
+
+Two guards against a vacuous endpoint: `algebraCartanMatrix_Pfam_apply_zero_one` records *by
+`rfl`* that the `(0,1)` entry is literally `Module.finrank ℂ (Pplus →ₗ[A] Pminus)` — i.e. the
+family carries the intended *actions*, not just the intended carriers, which is the statement
+that could not be formed before this refactor — and `algebraCartanMatrix_Pfam_diag_pos` derives
+diagonal positivity from the general Definition 9.3.1 lemma, exercising the
+`Module.Finite` / `Nontrivial` / `IsScalarTower` instance families.
+
+`#print axioms` on all six new endpoints: `[propext, Classical.choice, Quot.sound]` only.
+
+## Current frontier
+
+`Chapter9/Problem9_3_2.lean` is sorry-free and builds, as do its two downstream consumers.
+Problem 9.3.2 now has the simple modules (with exhaustiveness), the two projective
+indecomposables (projective, indecomposable, projective covers, submodule lattice), and the
+Cartan matrix. The one remaining piece of the book problem is the *converse* for projectives.
+
+## Overall project progress
+
+Stage 3 formalization. `progress/items.json` entry `Chapter9/Problem9.3.2` stays
+`covered_partial` (status `sorry_free`), with its `coverage_note` updated: the Cartan matrix and
+the shared-carrier blocker are resolved, and the only listed gap is exhaustiveness of the
+indecomposable projectives.
+
+Note: `python3 scripts/validate_items.py` exits 1 with 10 errors on entries 583-592
+(`missing fields: id/title/start_page/…`). This is pre-existing on `main` and is issue #7712 /
+PR #7713 (teaching the validator the PLAN Stage 1.6 derived-item overlay); it is unrelated to
+this change and my edit touches only the `coverage_note` and `last_updated` of one entry.
+
+## Next step
+
+Claim #7705, the other half of #7388: every finitely generated indecomposable projective
+`A`-module is `P₊` or `P₋`. The route in that issue (`A ≅ P₊ ⊕ P₋` via the idempotents
+`eplus`/`eminus`, then Krull-Schmidt from `Chapter3/Theorem3_8_1.lean`) is unaffected by this
+refactor and is in fact easier now: `A ≅ P₊ ⊕ P₋` is statable directly, where before the two
+summands would have collided on one carrier. `Pplus.hom_ext`, `Pplus.eq_smul_e0` and the
+`e₀`/`e₁` generator API added here are the natural tools for it.
+
+Once #7705 lands, `Chapter9/Problem9.3.2` can go to `covered_full` and #7388 can close.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -9413,9 +9413,9 @@
     "end_line": 10,
     "status": "sorry_free",
     "coverage": "covered_partial",
-    "coverage_note": "Splus and Sminus are constructed, proved simple and nonisomorphic; every simple A-module is now proved isomorphic to exactly one of them (simple_module_classification), and Example 9.5.2 (iii) is upgraded to all simple modules via problem_9_3_2_single_block_of_simple. Pplus/Pminus are proved projective, indecomposable (Etingof.IsIndecomposable), and projective covers of Splus/Sminus (surjective with superfluous kernel). Still absent: exhaustiveness of the indecomposable projectives, and the Cartan-matrix computation via Etingof.algebraCartanMatrix (blocked on Pplus and Pminus sharing the carrier Fin 2 -> C, which prevents forming an indexed family of the two projectives). Follow-up: #7388.",
+    "coverage_note": "Splus and Sminus are constructed, proved simple and nonisomorphic; every simple A-module is proved isomorphic to exactly one of them (simple_module_classification), and Example 9.5.2 (iii) is upgraded to all simple modules via problem_9_3_2_single_block_of_simple. Pplus/Pminus are proved projective, indecomposable (Etingof.IsIndecomposable), and projective covers of Splus/Sminus (surjective with superfluous kernel). The Cartan matrix is now computed: Pplus and Pminus have genuinely distinct carriers (both were reducible abbrevs for Fin 2 -> C, so their two Module A instances collided), each of the four Hom spaces is proved one-dimensional over C by an explicit LinearEquiv (finrank_hom_Pplus_Pplus and the three siblings), and algebraCartanMatrix_Pfam gives Etingof.algebraCartanMatrix ![Pplus, Pminus] = !![1, 1; 1, 1]. Still absent: exhaustiveness of the indecomposable projectives (that Pplus and Pminus are the only ones) -- #7705. Follow-up: #7388.",
     "followup_issue": 7388,
-    "last_updated": "2026-07-22"
+    "last_updated": "2026-07-25"
   },
   {
     "id": "Chapter9/Introduction_9.4",


### PR DESCRIPTION
This PR gives `P₊` and `P₋` genuinely distinct carriers and computes the Cartan matrix of the Problem 9.3.2 algebra `A = ℂ⟨g, x⟩ / (gx + xg, x², g² - 1)`, completing the third of the problem's three questions.

`Pplus` and `Pminus` were both `abbrev ... : Type := Fin 2 → ℂ`. Because `abbrev` is reducible, `Module A Pplus` and `Module A Pminus` were two instances on the *same* type and instance resolution silently picked whichever was declared last; the file coped by ordering declarations, but that does not extend to an indexed family of the two projectives, which is what `Etingof.algebraCartanMatrix` (Definition 9.3.1) consumes. Both carriers become semireducible `def`s with their own `AddCommGroup`/`Module ℂ`/`Nontrivial`/`Module.Finite` instances, a coordinate API of `rfl` lemmas and an `@[ext]` lemma replacing the Mathlib `Pi.*_apply` lemmas that no longer fire at reducible transparency, and named generators `e0`, `e1`. `PG`/`PX`/`PGm`/`PXm` become explicit linear maps, with `*_eq_mulVec` lemmas retaining the book's matrix presentation. Every public name in the file is unchanged, and `Example9_5_2` and `Problem9_4_5` needed no edits.

Each of the four Hom spaces `Hom_A(P_s, P_t)` is then shown one-dimensional over `ℂ` by an explicit `LinearEquiv` to `ℂ`. Each `P_s` is generated over `A` by `e₀` since `e₁ = x · e₀`, so an `A`-linear map out of it is determined by its value on `e₀`; `g`-equivariance pins that value to the `ε`-eigenline of `g` in the target (`ε = +1` on `P₊`, `ε = -1` on `P₋`), and each eigenline of the involution `g` is a coordinate line. So each Hom space is `ℂ · T` for one explicit generator: the identity on the diagonal, `(a, b) ↦ (0, a)` off it. Assembling the family `Pfam = ![P₊, P₋]` with its instance families gives `Etingof.algebraCartanMatrix (k := ℂ) (A := A) Pfam = !![1, 1; 1, 1]`.

Two guards against a vacuous endpoint: `algebraCartanMatrix_Pfam_apply_zero_one` records by `rfl` that the off-diagonal entry is literally `Module.finrank ℂ (Pplus →ₗ[A] Pminus)`, so the family carries the intended *actions* and not merely the intended carriers, and `algebraCartanMatrix_Pfam_diag_pos` derives diagonal positivity from the general Definition 9.3.1 lemma. `#print axioms` on all six new endpoints reports `[propext, Classical.choice, Quot.sound]` only; the file remains sorry-free.

The remaining piece of #7388 is the converse for projectives (#7705), which this refactor unblocks in the same way: `A ≅ P₊ ⊕ P₋` is now statable, where before the two summands would have collided on one carrier.

Note on CI: `python3 scripts/validate_items.py` exits 1 with 10 errors on `progress/items.json` entries 583-592. That failure is pre-existing on `main` and is #7712 / PR #7713 (teaching the validator the PLAN Stage 1.6 derived-item overlay); this PR touches only the `coverage_note` and `last_updated` of the `Chapter9/Problem9.3.2` entry.

Two skill updates ride along, both consequences of this session. `lean-formalization` described this very file as still relying on declaration ordering to disambiguate the two `Module A` instances, which this PR makes false; it now records the resolution and the four non-obvious failure modes an `abbrev` -> `def` carrier retype produces. `agent-worker-flow` Step 2 gains the missing case for a reused worktree arriving with *stale* content rather than in-progress work: this worktree had 169 lines of committed skill and command guidance deleted, which unexamined would have shipped as a stealth revert inside this PR.

🤖 Prepared with Claude Code