### PR TITLE
doc: add the premise-wrong-problem-real exit to agent-worker-flow Step 4

### DIFF
--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -207,6 +207,40 @@ coordination skip <issue-number> "reason: <what changed>"
 ```
 Go back to Step 1 and try the next issue.
 
+**If the premise is wrong but the problem is real, fix the real defect, not the
+prescribed one.** A third case sits between "proceed" and `skip`: the issue reports a
+genuine failure but misdiagnoses its cause, so following it literally would leave the
+failure in place or actively damage correct data. Neither exit fits: proceeding as
+written does harm, and `skip` abandons a real defect. Instead:
+
+- Deliver the issue's stated **verification criterion**, not its prescribed **method**.
+  The criterion is what the planner wanted; the method was a guess at how to get there.
+- Comment on the issue, before or alongside opening the PR: what the actual defect was,
+  why the prescribed fix was rejected, and what you did instead.
+- Repeat that reasoning in the PR body, so a reviewer meeting a diff that touches
+  different files than the issue named is not surprised by it.
+- This still counts as full completion (no `--partial`) as long as the criterion is met.
+
+Worked example: #7712 correctly reported `scripts/validate_items.py` exiting 1 with ten
+errors, but blamed `progress/items.json`. Both remedies it proposed would have corrupted
+correct data: the ten entries already matched `PLAN.md` Stage 1.6, and the defect was in
+the validator, which never implemented that part of the spec. PR #7713 fixed the validator,
+met the stated criterion (`validate_items.py` exits 0), and left `items.json` content
+untouched.
+
+**Where the authority sits.** `PLAN.md` is the spec and is off-limits to agents, so when an
+issue body and `PLAN.md` disagree, `PLAN.md` wins and the issue is the thing that is wrong.
+This is the *reverse* of the `directive` rule in Step 1, and the two are easy to confuse: a
+`directive` carries the owner's own stated approach, which is not yours to second-guess even
+when you would have done it differently; an `agent-plan` issue carries a planner's guess,
+which you are expected to check against the spec and the code.
+
+| Situation | Exit |
+|---|---|
+| Plan is stale (work already done, moot, or blocked on an unmerged foundation) | `coordination skip` |
+| Symptom real, diagnosis or prescribed fix wrong | fix the real defect, document the deviation on the issue and in the PR |
+| `directive` whose approach you would have chosen differently | do it as asked (Step 1) |
+
 **items.json status reconciliation — sorry-free ≠ item-complete.** For issues
 that ask you to flip a `partially_*`/`statement_formalized`/`formalized` entry
 to `sorry_free` because "the `.lean` file is sorry-free," read the entry's

--- a/progress/2026-07-25T01-12-22Z_b94b2264.md
+++ b/progress/2026-07-25T01-12-22Z_b94b2264.md
@@ -1,0 +1,79 @@
+## Accomplished
+
+Issue #7714 (meditate, claimed via `/work`): `agent-worker-flow` Step 4 now has a third
+exit for "the issue's symptom is real but its diagnosis or prescribed fix is wrong."
+
+Before this, Step 4 gave a worker exactly two options when the issue did not match
+reality: proceed as written, or `coordination skip` because the plan is stale. Neither
+fits the #7712 case, where the issue correctly reported `scripts/validate_items.py`
+exiting 1 with ten errors but blamed `progress/items.json`; both remedies it prescribed
+would have corrupted entries that were already correct per `PLAN.md` Stage 1.6, while the
+actual defect was in the validator. Proceeding literally would have produced a green
+validator over damaged data; skipping would have left a repo-wide validation failure in
+place. PR #7713 took the right path (fix the real defect, deliver the stated criterion,
+document the deviation) but had to invent it.
+
+What the new subsection records, placed directly after the `If stale: coordination skip`
+block so the three cases sit adjacently:
+
+- Deliver the issue's stated **verification criterion**, not its prescribed **method**.
+- Comment on the issue before or alongside the PR: actual defect, why the prescribed fix
+  was rejected, what was done instead. Repeat it in the PR body so a reviewer meeting a
+  diff over different files than the issue named is not surprised.
+- This is a full completion, not `--partial`, provided the criterion is met. (Worth
+  stating: a worker who deviates from the method may otherwise reach for `--partial` out
+  of caution and send a complete fix to planner triage for no reason.)
+- **Where the authority sits:** `PLAN.md` is the spec and is off-limits to agents, so when
+  an issue body and `PLAN.md` disagree, `PLAN.md` wins and the issue is what is wrong.
+  Explicitly contrasted against Step 1's `directive` rule, which is the reverse: a
+  `directive` carries the owner's own approach and is not the worker's to second-guess,
+  whereas an `agent-plan` issue carries a planner's guess that the worker is expected to
+  check.
+- A three-row table (stale → `skip`; symptom real but diagnosis wrong → fix and document;
+  `directive` you would have done differently → do it as asked) so the cases are
+  distinguishable on a cold read, which was the issue's verification criterion.
+
+#7712 / #7713 is cited as the worked example. A sweep of recent `progress/` entries for
+the same pattern turned up only near misses (#7382 was a genuinely stale premise → correct
+`skip`; the `lake env lean` false-positive class already has its own Step 4 bullet), so the
+guidance stays at one example and one table, per the issue's "keep it brief" constraint.
+
+Also, unrelated to #7714: this reused worktree arrived carrying 169 lines of uncommitted
+*deletions* against `main` across `.claude/commands/review.md`,
+`.claude/commands/summarize.md`, and `.claude/skills/agent-worker-flow/SKILL.md` — an
+accidental revert of previously-learned guidance from a crashed prior session, with one
+added line and no new content. Restored all three to `HEAD` before branching. Worth
+knowing: Step 2's "inspect uncommitted changes before `reset --hard`" advice covers *lost
+work*, but the inverse case (stray changes that would silently ride along into your PR as
+regressions) is the one that showed up here.
+
+## Current frontier
+
+No code touched. `.claude/skills/agent-worker-flow/SKILL.md` Step 4 is the only changed
+file: 34 insertions, no deletions.
+
+## Overall project progress
+
+Stage 3 formalization. This is a workflow change, so no `items.json` movement and no
+`lake build` (the meditate command forbids code changes). The formalization frontier is
+unchanged from `progress/2026-07-25T00-39-44Z_bf3d0ca8.md`: Problem 9.3.2's remaining
+converse-for-projectives half is in flight as PR #7724, and five other feature PRs
+(#7723, #7716, #7715, #7713, #7711) were building at session start with nothing yet
+mergeable.
+
+## Next step
+
+A feature worker should take a fresh issue from `coordination list-unclaimed`. Among the
+unclaimed set, #7423 (`Corollary 9.7.3`: the public existence theorem returns
+`IsBasicAlgebra` + bare `MoritaEquivalent`, but the advertised uniqueness and dimension
+consequences require `IsBasicAlgebraSplit` + `KLinearMoritaEquivalent`, so the object the
+existence theorem hands you cannot be fed to either) is the highest-value one: the
+stronger facts are already proved inside `Infrastructure/BasicAlgebraExistence.lean` and
+merely discarded at the public boundary, so it is an API-coherence fix rather than new
+mathematics. #7719 (the `𝔤₄` spanning-family upper bound) is the hardest available item,
+is marked "(Hard!)" by the book itself, and explicitly sanctions a partial PR covering
+just `span_eq_top_of_closed_under_ad` plus the degree-1 and degree-2 layers.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR adds a third exit to `agent-worker-flow` Step 4 for the case where an issue's symptom is real but its diagnosis or prescribed fix is wrong. Step 4 previously offered a worker only two options when the issue did not match reality: proceed as written, or `coordination skip` because the plan is stale. Neither fits #7712, where the issue correctly reported `scripts/validate_items.py` exiting 1 with ten errors but blamed `progress/items.json`; both remedies it prescribed would have corrupted entries that were already correct per `PLAN.md` Stage 1.6, while the actual defect was in the validator. Proceeding literally would have produced a green validator over damaged data, and skipping would have left a repo-wide validation failure in place.

The new subsection sits directly after the `If stale: coordination skip` block so the three cases are adjacent, and records: deliver the issue's stated verification criterion rather than its prescribed method; comment on the issue before or alongside the PR explaining the actual defect and why the prescribed fix was rejected; repeat that reasoning in the PR body so a reviewer meeting a diff over different files than the issue named is not surprised; and that this counts as a full completion rather than `--partial`.

It also records where the authority sits: `PLAN.md` is the spec and is off-limits to agents, so when an issue body and `PLAN.md` disagree, `PLAN.md` wins and the issue is what is wrong. That is the reverse of Step 1's `directive` rule, where the owner's stated approach is not the worker's to second-guess, so the two are contrasted explicitly. A three-row table separates the exits (stale, symptom-real-diagnosis-wrong, `directive`) so they are distinguishable on a cold read, which was the issue's verification criterion. #7712 and #7713 are cited as the worked example.

A sweep of recent `progress/` entries for the same pattern found only near misses (#7382 was a genuinely stale premise and correctly skipped; the `lake env lean` false-positive class already has its own Step 4 bullet), so the guidance stays at one example and one table per the issue's brevity constraint.

No code or `items.json` changes: 34 insertions to `.claude/skills/agent-worker-flow/SKILL.md` plus the progress entry.

Closes #7714

Session: `b94b2264-6f61-4656-ad7e-13c4a5521007`

🤖 Prepared with Claude Code