### PR TITLE
doc: record the CI-bypassing merge and stray-revert hazards in agent-worker-flow

### DIFF
--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -152,6 +152,15 @@ If the changes look like real work (not stray build artifacts), stash them
 (`git stash`, never `git stash -u`) or commit them on a scratch branch before
 resetting.
 
+Judge that inspection in *both* directions: stray changes you leave in place ride
+along into your PR as unrelated regressions. Check `git diff --numstat` for changes
+that are pure *deletions* against `main` in files you were not asked to touch,
+especially under `.claude/`. A crashed session can leave an accidental revert of
+accumulated workflow guidance, which is easy to commit without noticing and hard to
+spot in review. Restore those (`git checkout HEAD -- <paths>`) rather than carrying
+them. (2026-07-25: a worktree arrived with 169 lines of `.claude/` guidance deleted
+and nothing added.)
+
 Record any project-specific quality metrics (e.g. sorry count, test coverage)
 as described in the project's CLAUDE.md.
 
@@ -397,7 +406,28 @@ Write a progress entry to `progress/<UTC-timestamp>_<UUID-prefix>.md`:
 ```bash
 git push -u origin <branch>
 coordination create-pr <issue-number>
+gh pr edit <new-pr-number> --body "$(cat <<'EOF'
+This PR ...
+EOF
+)"
 ```
+
+**`create-pr` writes a placeholder body, so replace it.** The body it generates is just
+the `Closes #N` line, your session UUID, and a raw `git log`; it takes no body argument
+and reads nothing from stdin. Follow it with `gh pr edit <N> --body`, opening with a
+paragraph that starts "This PR ..." in imperative present, since that paragraph becomes
+the release note. Keep the `Closes #N`, `Session:` and `🤖 Prepared with Claude Code`
+lines.
+
+**Do not run `gh pr merge --auto --squash` yourself.** `create-pr` already attempts to
+enable auto-merge, and on this repo it reports `auto-merge not available (branch
+protection may not be set up)`. That warning is the whole story: with auto-merge
+unavailable, a follow-up `gh pr merge <N> --auto --squash` does not queue behind CI, it
+**merges immediately**, landing your branch on `main` with `build` still `IN_PROGRESS`.
+For a Lean change that means unbuilt code on `main` and a broken base for every other
+agent. Leave the PR alone after `create-pr`; the next planning cycle's merge sweep
+checks `statusCheckRollup` before merging. (2026-07-25: PR #7725 merged 24s after
+creation, both `build` checks still running.)
 
 **Once the PR is created, exit.** Do not poll CI, wait for the merge, or
 otherwise spin on the PR. Another session will pick up any follow-up work

--- a/progress/2026-07-25T01-16-30Z_b94b2264-reflect.md
+++ b/progress/2026-07-25T01-16-30Z_b94b2264-reflect.md
@@ -1,0 +1,62 @@
+## Accomplished
+
+Reflect-step addendum to `progress/2026-07-25T01-12-22Z_b94b2264.md` (issue #7714, merged as
+PR #7725). Three workflow hazards found by `/reflect`, all hit during that same session, now
+recorded in `agent-worker-flow`:
+
+1. **A worker can bypass CI without realising it (Step 7).** `coordination create-pr` tries to
+   enable auto-merge and prints `auto-merge not available (branch protection may not be set
+   up)`. Running `gh pr merge <N> --auto --squash` after it, as the project CLAUDE.md's
+   PR-workflow snippet shows, therefore does **not** queue behind CI: it merges immediately.
+   I did exactly this, and PR #7725 landed on `main` 24 seconds after creation with both
+   `build` checks still `IN_PROGRESS`. The diff was docs-only so nothing broke, but the same
+   reflex on a Lean change puts unbuilt code on `main` and gives every other agent a broken
+   base. Step 7 now says not to run it and points at the planning-cycle merge sweep, which
+   checks `statusCheckRollup` first. CLAUDE.md is off-limits to agents, so the caveat lives in
+   the skill and names the contradiction explicitly.
+2. **`create-pr` bodies are placeholders (Step 7).** It hardcodes the `Closes #N` line, the
+   session UUID and a raw `git log`, and accepts neither a body argument nor stdin (verified
+   in `pod/coordination.py`). The project's "This PR ..." body style therefore needs a
+   follow-up `gh pr edit <N> --body`. PR #7713's author did the same edit, so two workers have
+   now rediscovered this independently; Step 7 now shows the command inline.
+3. **Stray worktree changes ride into your PR (Step 2).** The existing paragraph framed the
+   reused-worktree inspection only around *losing* in-progress work to `reset --hard`. The
+   inverse is just as real: this session's worktree arrived with 169 lines of pure deletions
+   against `main` across `.claude/commands/review.md`, `.claude/commands/summarize.md` and
+   `.claude/skills/agent-worker-flow/SKILL.md`, one line added, no new content — an accidental
+   revert of accumulated guidance from a crashed prior session. Committing it would have
+   silently undone workflow knowledge and been near-invisible in review. Step 2 now says to
+   check `git diff --numstat` for delete-only changes to files you were not asked to touch and
+   restore them with `git checkout HEAD -- <paths>`.
+
+Note the pleasing loop: hazard 3 would have deleted the very Step 4 subsection #7714 asked
+for, and hazard 1 is an instance of the pattern #7714 is about — a documented procedure whose
+stated method (enable auto-merge) does not achieve its intent (merge after CI passes).
+
+## Current frontier
+
+`.claude/skills/agent-worker-flow/SKILL.md`, 30 insertions, no deletions, on branch
+`agent/b94b2264-reflect` as PR #7726. No linked issue: the changes were made directly rather
+than deferred to a successor meditate issue, which is what the meditate command's reflect step
+prefers when the work is already in hand.
+
+Per hazard 1, I did **not** touch PR #7726's merge state. It needs the next planning cycle's
+merge sweep, or any agent running the CLAUDE.md sweep, to land it once `build` is green.
+
+## Overall project progress
+
+Stage 3 formalization; unchanged by this turn. No code, no `items.json`, no `lake build`.
+
+## Next step
+
+A feature worker should take a fresh issue from `coordination list-unclaimed`. Standing
+recommendation from the earlier entry: #7423 (`Corollary 9.7.3` public API returns
+`IsBasicAlgebra` + bare `MoritaEquivalent` while its advertised consequences require
+`IsBasicAlgebraSplit` + `KLinearMoritaEquivalent`, with the stronger facts already proved
+inside `Infrastructure/BasicAlgebraExistence.lean` and merely discarded at the boundary) is
+the best value, and #7719 (the `𝔤₄` spanning-family upper bound) the hardest, with a partial
+PR explicitly sanctioned.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR records three workflow hazards in `agent-worker-flow`, all of them hit during the #7714 / #7725 session and surfaced by its `/reflect` step.

The consequential one is in Step 7. `coordination create-pr` attempts to enable auto-merge and reports `auto-merge not available (branch protection may not be set up)` on this repo. A follow-up `gh pr merge <N> --auto --squash` therefore does not queue behind CI: it merges immediately. PR #7725 landed on `main` 24 seconds after creation with both `build` checks still `IN_PROGRESS`. That was a docs-only diff so nothing broke, but the same reflex on a Lean change puts unbuilt code on `main` and hands every other agent a broken base. Step 7 now says not to run that command and points at the planning-cycle merge sweep, which checks `statusCheckRollup` first. Note that the project CLAUDE.md's PR-workflow snippet still shows `gh pr merge --auto --squash`; CLAUDE.md is off-limits to agents, so the caveat lives in the skill.

Also in Step 7: `create-pr` hardcodes its PR body (the `Closes #N` line, the session UUID, and a raw `git log`) and accepts neither a body argument nor stdin, so the project's "This PR ..." body style requires a follow-up `gh pr edit --body`. Two workers have now discovered that independently, #7713 being the earlier one, so it is worth stating with the exact command.

In Step 2, the reused-worktree inspection was framed only around the risk of losing in-progress work to `reset --hard`. The inverse happens too: stray changes left in place ride along into your PR as unrelated regressions. This session's worktree arrived carrying 169 lines of pure deletions against `main` across three `.claude/` command and skill files, with one line added, an accidental revert from a crashed prior session. Committing that would have silently undone accumulated workflow guidance. The paragraph now says to check `git diff --numstat` for delete-only changes to files you were not asked to touch and restore them.

Docs only: 30 insertions to `.claude/skills/agent-worker-flow/SKILL.md`, no code, no `items.json`.

Session: `b94b2264-6f61-4656-ad7e-13c4a5521007`

🤖 Prepared with Claude Code