### PR TITLE
progress: record replan triage of #7718

### DIFF
--- a/progress/2026-07-25T02-10-18Z_230092b0-replan.md
+++ b/progress/2026-07-25T02-10-18Z_230092b0-replan.md
@@ -1,0 +1,50 @@
+## Accomplished
+
+`/replan` triage session `230092b0`. `coordination list-replan` held exactly one candidate,
+which was disposed of; the queue is now empty.
+
+**#7718 — "basis of the A₂⁽²⁾ loop subalgebra and range matHom₄ = loopPos" — closed as
+worker-decomposed.**
+
+Session `577db32f` claimed it, discovered that #7717 had landed `loopPos k` as an *intrinsic*
+σ-fixed-point subalgebra (`trace P = 0 ∧ sigInv P = twMat P ∧ constMat P ∈ span k {gzero 0}`)
+rather than as the graded span the plan assumed, and split the issue before releasing the claim:
+
+- **#7728** — deliverable 1: the σ-eigenspace characterizations (`mem_span_gzero_of_sigInv_eq`,
+  `mem_span_gone_of_sigInv_eq_neg`, char `≠ 2`), the monomial embedding helper `emb` with its
+  `coeffMat` computation and finite decomposition, and `loopBasis : Module.Basis LoopIdx k
+  (loopPos k)` via `Basis.mk`. Currently labelled `has-pr`.
+- **#7729** — deliverable 2: `range_matHom₄_eq_loopPos` (both inclusions, `h2 : (2 : k) ≠ 0`,
+  `h3 : (3 : k) ≠ 0`). Labelled `blocked` behind #7728, which is right: the `≥` direction wants
+  #7728's `emb` and eigenspace lemmas.
+
+The two sub-issues cover the parent's two deliverables exactly, and the verified structure-constant
+data written up in the parent was carried forward rather than dropped — the five `ad(NY)ⁱ NX`
+values with their `3` and `6` scalars, the `t`-degree-2 bracket table, and
+`[𝔤₀,𝔤₁] = 𝔤₁` (rank 5) / `[𝔤₁,𝔤₁] = 𝔤₀` (rank 3) all appear verbatim in #7729; the eigenspace
+and `emb` route appears in #7728. So there is no residual scope, and per the `/replan` rules the
+parent closes with a forward link rather than being narrowed and returned to the worker queue.
+
+No code was changed and no issues were created this session.
+
+## Current frontier
+
+Step 2 of 4 for #7394 (explicit `Module.Basis` for `𝔤₄`, Problem 2.16.3(b)) is now tracked by
+#7728 + #7729 instead of #7718. The other steps are unaffected: #7719 (the upper bound on `𝔤₄` —
+an `ad x`/`ad y`-closed spanning family, the book's own "(Hard!)") is independent and remains the
+crux; #7720 assembles the basis once #7719 lands.
+
+## Overall project progress
+
+Stage 3 formalization. `replan` queue empty. No stage-level status changed — this session only
+moved one issue from `replan` to `closed`.
+
+## Next step
+
+Pod can release the planner lock and dispatch normally. For workers: #7728 already has a PR, so
+the claimable descendant of this triage is #7729 once #7728 merges and `coordination
+check-blocked` clears its `blocked` label. #7719 is claimable now and is the long pole for #7394.
+
+## Blockers
+
+None. #7729 is `blocked` by design (depends-on #7728), not stalled.


### PR DESCRIPTION
This PR records the `/replan` triage session `230092b0`, which closed #7718 as fully superseded by the worker decomposition into #7728 (the `Module.Basis` for `loopPos`) and #7729 (`range matHom₄ = loopPos`). The two sub-issues cover the parent's two deliverables exactly and carry forward its verified structure-constant data, so no residual scope remained to return to the worker queue. `coordination list-replan` is now empty.

Progress file only — no Lean sources touched, no new planning issues created.

🤖 Prepared with Claude Code