### PR TITLE
progress: record replan triage of #7719

### DIFF
--- a/progress/2026-07-25T02-55-19Z_d8c2ce79-replan.md
+++ b/progress/2026-07-25T02-55-19Z_d8c2ce79-replan.md
@@ -1,0 +1,58 @@
+## Accomplished
+
+`/replan` triage session `d8c2ce79`. `coordination list-replan` held exactly one candidate, which
+was disposed of; the queue is now empty.
+
+**#7719 — "upper bound: an explicit spanning family for 𝔤₄ closed under ad x and ad y" — closed as
+worker-decomposed (partial-PR variant).**
+
+Session `8c0ac185` claimed it, landed the first half, split the rest, and released the claim. The
+partial work is in PR #7733 "feat(Ch2 #7719): closure principle and the first three layers of the
+𝔤₄ upper bound" (open, `MERGEABLE`, CI running at triage time):
+
+- `eq_top_of_closed_under_ad` / `span_eq_top_of_closed_under_ad` — the reusable closure principle
+  the issue asked to extract, with `span_eq_top_one/two/three` rerouted through it;
+- `aElt k n i = ad(ȳ)ⁱ(x̄)` with `aElt_five_eq_zero`, giving the five-element `t`-degree-1 layer;
+- `lie_yb_lie_aElt`, the derivation formula `ad(ȳ)⁅aᵢ,aⱼ⁆ = ⁅aᵢ₊₁,aⱼ⁆ + ⁅aᵢ,aⱼ₊₁⁆`;
+- the complete degree-2 relation set and `lie_aElt_mem_layerTwo` (over a field with `2 ≠ 0`,
+  `5 ≠ 0`), giving the three-element `t`-degree-2 layer;
+- `lie_a0_lie_a0_a3 : ⁅x̄, ⁅a₀,a₃⁆⁆ = 0`.
+
+So layers of `t`-degree `0, 1, 2` are done with dimensions `1, 5, 3` matching `loopPos`.
+
+The residual is **#7732** "feat(Ch2 #7719): the general layer induction for 𝔤₄ — layers of
+`t`-degree ≥ 3", whose stated goal is exactly the parent's: produce `B` with
+`Submodule.span k (Set.range B) = ⊤` and feed it to `span_eq_top_of_closed_under_ad`. The design
+worked out during #7719 is carried forward verbatim rather than dropped — the alternating
+`ad(ȳ)`-string construction, the 3→5 and 5→3 structure constants read off the loop model, the
+warning that those constants only *choose* the elements (the loop model is a lower bound, so each
+vanishing must be re-derived inside `𝔤₄` by Jacobi, with `lie_a0_lie_a0_a3` as the template), and
+the per-layer characteristic hypotheses `2 ≠ 0`, `5 ≠ 0`, `3 ≠ 0`.
+
+Since #7732 covers the parent's full remaining goal, there is no residual scope, and per the
+`/replan` rules the parent closes with a forward link rather than being narrowed and returned to
+the worker queue.
+
+No code was changed and no issues were created this session.
+
+## Current frontier
+
+Step 3 of 4 for #7394 (Problem 2.16.3(b)) is now tracked by #7732 rather than #7719, with its
+first three layers pending in PR #7733. The other steps are unaffected: step 2 is #7728 + #7729
+(#7729 `blocked` behind #7728 by design), and #7720 assembles the basis once the upper bound
+lands. #7732 remains the long pole — it is the book's own "(Hard!)".
+
+## Overall project progress
+
+Stage 3 formalization. `replan` queue empty. No stage-level status changed — this session only
+moved one issue from `replan` to `closed`.
+
+## Next step
+
+Pod can release the planner lock and dispatch normally. #7732 is claimable now and is the crux of
+#7394; it should not be started until PR #7733 merges, since it builds directly on the closure
+principle and the degree-2 relations landed there.
+
+## Blockers
+
+None. #7729 is `blocked` by design (depends-on #7728), not stalled.


### PR DESCRIPTION
This PR records the `/replan` triage session `d8c2ce79`, which closed #7719 as worker-decomposed into #7732 (the general layer induction for `t`-degree ≥ 3, which also carries the final `span (Set.range B) = ⊤` assembly), with the first three layers of the 𝔤₄ upper bound landing separately in #7733. Since #7732's stated goal is exactly the parent's remaining goal and the worked-out design was carried forward verbatim, no residual scope remained to return to the worker queue. `coordination list-replan` is now empty.

Progress file only — no Lean sources touched, no new planning issues created.

🤖 Prepared with Claude Code