### PR TITLE
feat(Ch8 #7381): finite-direct-sum additivity of Tor in the second argument

### DIFF
--- a/EtingofRepresentationTheory/Chapter8/Additivity.lean
+++ b/EtingofRepresentationTheory/Chapter8/Additivity.lean
@@ -1,6 +1,7 @@
 import Mathlib.CategoryTheory.Abelian.LeftDerived
 import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Biproducts
 import Mathlib.Algebra.Category.ModuleCat.Biproducts
+import Mathlib.Algebra.Category.Grp.Biproducts
 import Mathlib.Algebra.Homology.DerivedCategory.Ext.Basic
 import EtingofRepresentationTheory.Chapter8.Definition8_2_3
 import EtingofRepresentationTheory.Chapter8.Definition8_2_4
@@ -245,5 +246,51 @@ noncomputable def torProdIso (n : ℕ) :
         LinearMap.fst_comp_inr, LinearMap.snd_comp_inr]
 
 end SecondArgument
+
+/-! ### `Tor` commutes with finite direct sums in its second argument
+
+The finite-index form of `Etingof.torProdIso`. The direct sum of a finite family of `A`-modules is
+realised as the product type `∀ i, N i`, whose projections and inclusions satisfy
+`∑ i, (single i) ∘ (proj i) = id` and `(proj j) ∘ (single i) = if i = j then id else 0`; these are
+exactly the two identities the biproduct `⨁ i, Torₙᴬ(M, N i)` needs. -/
+
+section FiniteSecondArgument
+
+variable {ι : Type} [Fintype ι] [DecidableEq ι]
+variable (N : ι → Type u) [∀ i, AddCommGroup (N i)] [∀ i, Module A (N i)]
+
+/-- **`Tor` commutes with finite direct sums in its second argument.**
+`Torₙᴬ(M, ⨁ i, N i) ≅ ⨁ i, Torₙᴬ(M, N i)` for a finite index type, with the isomorphism given by
+the maps induced by the projections `LinearMap.proj i` and the inclusions `LinearMap.single A N i`
+of `∀ i, N i`. -/
+noncomputable def torPiIso (M : ModuleCat.{u} Aᵐᵒᵖ) (n : ℕ) :
+    Tor.{u} A (∀ i, N i) M n ≅ ⨁ fun i => Tor.{u} A (N i) M n where
+  hom := biproduct.lift fun i => torSndMap A (LinearMap.proj i) n M
+  inv := biproduct.desc fun i => torSndMap A (LinearMap.single A N i) n M
+  hom_inv_id := by
+    rw [biproduct.lift_desc]
+    have h : ∀ i : ι,
+        torSndMap A (LinearMap.proj (R := A) (φ := N) i) n M ≫
+            torSndMap A (LinearMap.single A N i) n M
+          = torSndAddHom M n ((LinearMap.single A N i).comp (LinearMap.proj i)) :=
+      fun i => (torSndMap_comp M _ _ n).symm
+    simp_rw [h]
+    rw [← map_sum (torSndAddHom M n),
+      show ∑ i : ι, (LinearMap.single A N i).comp (LinearMap.proj i) = LinearMap.id from
+        LinearMap.ext fun x => by
+          simp only [LinearMap.sum_apply, LinearMap.comp_apply, LinearMap.proj_apply,
+            LinearMap.coe_single, LinearMap.id_apply]
+          exact Finset.univ_sum_single x]
+    exact torSndMap_id A (∀ i, N i) n M
+  inv_hom_id := by
+    refine biproduct.hom_ext' _ _ fun i => biproduct.hom_ext _ _ fun j => ?_
+    rw [biproduct.ι_desc_assoc, Category.assoc, biproduct.lift_π, ← torSndMap_comp,
+      Category.comp_id]
+    rcases eq_or_ne i j with rfl | hij
+    · rw [LinearMap.proj_comp_single_same, biproduct.ι_π_self, torSndMap_id]
+    · rw [LinearMap.proj_comp_single_ne A N j i hij.symm, torSndMap_zero,
+        biproduct.ι_π_ne _ hij]
+
+end FiniteSecondArgument
 
 end Etingof

--- a/progress/2026-07-25T04-37-46Z_32ffb8bd.md
+++ b/progress/2026-07-25T04-37-46Z_32ffb8bd.md
@@ -1,0 +1,67 @@
+## Accomplished
+
+Session type: `/work` (meta dispatch), issue #7735 (`feature`, Ch8).
+
+Start-of-cycle housekeeping: merged the three open PRs that were `MERGEABLE` with
+green CI — #7739 (Tor additive in both arguments), #7741 (categorical direct-sum
+decomposition of f.g. modules over `ℤ` and `k[X]`), #7742 (`range matHom₄ = loopPos`).
+Merging #7739 is what put `Chapter8/Additivity.lean` on `main` and made #7735 workable;
+merging #7741 also cleared #7736, one of the two blockers on #7738.
+
+Formalization work (issue #7735), all in `EtingofRepresentationTheory/Chapter8/Additivity.lean`:
+
+* `Etingof.torPiIso {ι : Type} [Fintype ι] [DecidableEq ι] (N : ι → Type u) … (M) (n) :
+  Tor A (∀ i, N i) M n ≅ ⨁ fun i => Tor A (N i) M n` — the finite-index form of
+  `torProdIso`, with `hom := biproduct.lift fun i => torSndMap A (LinearMap.proj i) n M`
+  and `inv := biproduct.desc fun i => torSndMap A (LinearMap.single A N i) n M`,
+  exactly as the issue specified.
+* Added `import Mathlib.Algebra.Category.Grp.Biproducts`.
+
+No sorries, no new axioms. `lake build` is clean (9279 jobs).
+
+## Decisions and notes
+
+* **The `Grp.Biproducts` import was the real obstacle, not the dependent case split.**
+  `Tor` lands in `AddCommGrpCat`, and `HasFiniteBiproducts AddCommGrpCat` lives in
+  `Mathlib.Algebra.Category.Grp.Biproducts`, which the file did not import. The
+  pre-existing `torBiproductIso` compiles without it because `Functor.mapBiproduct`
+  takes its `HasBiproduct` differently, so the gap was invisible until a bare `⨁` was
+  written over an `AddCommGrpCat`-valued family. Anyone adding further `⨁` statements in
+  Chapter 8 will want this import.
+* **`LinearMap.lsum` is not usable here.** The issue suggested routing
+  `∑ i, single i ∘ proj i = id` through `LinearMap.lsum_single` / `lsum_apply`, but
+  `lsum R φ S` needs `SMulCommClass R S M`, and `A` is an arbitrary (noncommutative) ring,
+  so `SMulCommClass A A (∀ i, N i)` does not hold. Replaced with a direct
+  `LinearMap.ext` proof closing on `Finset.univ_sum_single`.
+* The dependent `biproduct.ι_π` case split the issue flagged as the risky part was not
+  painful: `rcases eq_or_ne i j` plus `LinearMap.proj_comp_single_same` /
+  `proj_comp_single_ne` against `biproduct.ι_π_self` / `ι_π_ne` closes both branches
+  directly. The `torProdIso`-by-`Fin n`-induction fallback was not needed.
+* Cleared stale uncommitted deletions in `.claude/commands/{review,summarize}.md` and
+  `.claude/skills/agent-worker-flow/SKILL.md` left over in this reused worktree by an
+  earlier session (they reverted committed content). Backed up to
+  `/tmp/32ffb8bd-stale-claude-backup/stale.patch` before restoring to `HEAD`.
+
+## Current frontier
+
+Chapter 8's `Tor` additivity API is now complete in both arguments, binary and finite:
+`torBiprodIso` / `torBiproductIso` (first argument) and `torProdIso` / `torPiIso`
+(second argument). This is the input #7738 needs.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. The #7381 chain (Tor/Ext for arbitrary f.g. modules over
+`ℤ` and `k[X]`) now has its additivity and decomposition building blocks on `main`:
+#7735 (this PR), #7736 and the base additivity PR are all landed or in flight.
+
+## Next step
+
+#7738 (`Tor` for arbitrary f.g. modules over `ℤ` and `k[X]`) was blocked on #7735 and
+#7736. #7736 is merged and #7735 has a PR; once it merges, `coordination check-blocked`
+should release #7738, which is the natural next item — it can now consume `torPiIso`
+together with the categorical direct-sum decomposition from #7741. #7737 (the `Ext`
+analogue) was blocked only on #7736 and should already be unblocked.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7735

Session: `32ffb8bd-d693-4d1e-b08b-5c10a0f9b46a`

b9a29530 doc: progress entry for #7735 (torPiIso)
1216ef3d feat(Ch8 #7735): finite-direct-sum additivity of Tor in the second argument

🤖 Prepared with Claude Code