### PR TITLE
feat(Ch8 #7381): Ext for arbitrary finitely generated modules over Z and k[X]

### DIFF
--- a/EtingofRepresentationTheory/Chapter8.lean
+++ b/EtingofRepresentationTheory/Chapter8.lean
@@ -50,6 +50,7 @@ import EtingofRepresentationTheory.Chapter8.HomComplexHomologyK
 import EtingofRepresentationTheory.Chapter8.ExtAbelianComparison
 import EtingofRepresentationTheory.Chapter8.PIDDecomposition
 import EtingofRepresentationTheory.Chapter8.Problem8_2_7_ExtFG
+import EtingofRepresentationTheory.Chapter8.Problem8_2_7_ExtInt
 
 /-!
 # Chapter 8: Homological Algebra

--- a/EtingofRepresentationTheory/Chapter8.lean
+++ b/EtingofRepresentationTheory/Chapter8.lean
@@ -49,6 +49,7 @@ import EtingofRepresentationTheory.Chapter8.BarResolution
 import EtingofRepresentationTheory.Chapter8.HomComplexHomologyK
 import EtingofRepresentationTheory.Chapter8.ExtAbelianComparison
 import EtingofRepresentationTheory.Chapter8.PIDDecomposition
+import EtingofRepresentationTheory.Chapter8.Problem8_2_7_ExtFG
 
 /-!
 # Chapter 8: Homological Algebra

--- a/EtingofRepresentationTheory/Chapter8.lean
+++ b/EtingofRepresentationTheory/Chapter8.lean
@@ -51,6 +51,7 @@ import EtingofRepresentationTheory.Chapter8.ExtAbelianComparison
 import EtingofRepresentationTheory.Chapter8.PIDDecomposition
 import EtingofRepresentationTheory.Chapter8.Problem8_2_7_ExtFG
 import EtingofRepresentationTheory.Chapter8.Problem8_2_7_ExtInt
+import EtingofRepresentationTheory.Chapter8.Problem8_2_7_ExtPoly
 
 /-!
 # Chapter 8: Homological Algebra

--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_7.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_7.lean
@@ -29,9 +29,8 @@ import EtingofRepresentationTheory.Chapter8.Problem8_2_6
 
 A finitely generated module over the PID `ℤ` (resp. `k[x]`) is a direct sum of a free module
 and cyclic torsion modules, and `Tor`/`Ext` are additive in each argument, so the whole
-computation reduces to two cases: a **free** generator and a pair of **cyclic** modules. We
-formalize exactly these building blocks, the content the book's "reduce to cyclic groups" hint
-points at:
+computation reduces to two cases: a **free** generator and a pair of **cyclic** modules. This file
+formalizes those building blocks, the content the book's "reduce to cyclic groups" hint points at:
 
 * **Cyclic pair.** For `a, b ≠ 0` (finite cyclic groups `ℤ/a`, `ℤ/b`):
   `Tor₀ ≅ Tor₁ ≅ ℤ/gcd(a,b)` and `Extⁿ⁺² = Ext¹ ≅ Ext⁰ ≅ ℤ/gcd(a,b)`, with `Torᵢ = Extⁱ = 0`
@@ -47,6 +46,24 @@ ring hom (`local instance`s below).
 The reusable number theory is packaged in the `ZModGcd` namespace below: the kernel and
 cokernel of multiplication by `a` on `ZMod b` are both `ZMod (gcd a b)`, giving the tensor and
 Hom isomorphisms `ZMod a ⊗_ℤ ZMod b ≅ ZMod (gcd a b)` and `Hom_ℤ(ZMod a, ZMod b) ≅ ZMod (gcd a b)`.
+
+## Where the arbitrary finitely generated case lives
+
+The building blocks below are *not* the whole exercise: they are the summand-level input to it. The
+reduction of arbitrary finitely generated `M`, `N` to these summands, and the resulting formulas
+for `Extⁱ(M, N)`, are in three further files:
+
+* `Chapter8/PIDDecomposition.lean` — the structure theorem as a biproduct decomposition;
+* `Chapter8/Problem8_2_7_ExtFG.lean` — additivity of `Ext` along a decomposition
+  (`Etingof.extPIDDecompositionAddEquiv` and its one-variable forms), and projective dimension
+  `< 2` for every finitely generated module over a PID (`Etingof.fg_hasProjectiveDimensionLT_two`),
+  which gives `Extⁱ = 0` for `i ≥ 2`;
+* `Chapter8/Problem8_2_7_ExtInt.lean` (part (i)) and `Chapter8/Problem8_2_7_ExtPoly.lean`
+  (part (ii)) — the completed summand tables and the assembled answers
+  `Etingof.Problem_8_2_7_i_ext_fg` and `Etingof.Problem_8_2_7_ii_ext_fg`.
+
+The `Tor` half of the arbitrary finitely generated case uses `Chapter8/Additivity.lean` and is
+tracked separately.
 
 For part (i), the degree-`0` identifications (`Tor₀`, `Ext⁰`), the degree-`1`
 identifications (`Tor₁`, `Ext¹`), and all higher-degree vanishing are established. The degree-`1`

--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_7.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_7.lean
@@ -197,8 +197,25 @@ def zmodCokerEquiv (a b : ℕ) [NeZero b] :
 
 /-! ### Kernel of multiplication by `a` on `ZMod b` -/
 
+/-- Multiplication-by-`a` endomorphism of an arbitrary abelian group, as a ℤ-linear map. Its
+cokernel is what `Ext¹(ℤ/a, -)` computes and its kernel (the `a`-torsion) is what `Hom(ℤ/a, -)`
+computes; both are needed for arbitrary targets, not just for `ZMod b`. -/
+def mulBy (a : ℕ) (Y : Type*) [AddCommGroup Y] : Y →ₗ[ℤ] Y := (a : ℤ) • LinearMap.id
+
+@[simp] lemma mulBy_apply (a : ℕ) {Y : Type*} [AddCommGroup Y] (x : Y) :
+    mulBy a Y x = (a : ℤ) • x := rfl
+
+/-- The image of multiplication by `a` is the submodule `(a) • ⊤`, the denominator of the
+cokernel. -/
+lemma range_mulBy (a : ℕ) (Y : Type*) [AddCommGroup Y] :
+    LinearMap.range (mulBy a Y) = Ideal.span {(a : ℤ)} • (⊤ : Submodule ℤ Y) := by
+  rw [Submodule.ideal_span_singleton_smul]
+  ext x
+  simp only [LinearMap.mem_range, mulBy_apply, Submodule.mem_smul_pointwise_iff_exists]
+  exact ⟨fun ⟨y, hy⟩ => ⟨y, Submodule.mem_top, hy⟩, fun ⟨y, _, hy⟩ => ⟨y, hy⟩⟩
+
 /-- Multiplication-by-`a` endomorphism of `ZMod b`, as a ℤ-linear map. -/
-def mulByCast (a b : ℕ) : ZMod b →ₗ[ℤ] ZMod b := (a : ℤ) • LinearMap.id
+def mulByCast (a b : ℕ) : ZMod b →ₗ[ℤ] ZMod b := mulBy a (ZMod b)
 
 @[simp] lemma mulByCast_apply (a b : ℕ) (x : ZMod b) : mulByCast a b x = (a : ℤ) • x := rfl
 
@@ -280,18 +297,18 @@ def tensorEquiv (a b : ℕ) [NeZero b] :
     (TensorProduct.quotTensorEquivQuotSMul (ZMod b) (Ideal.span {(a : ℤ)})) ≪≫ₗ
     zmodCokerEquiv a b
 
-/-- The `a`-torsion element `f 1` of a ℤ-linear map `ZMod a → ZMod b`, packaged as an
-additive isomorphism `Hom(ZMod a, ZMod b) ≃+ ker(·a)`. -/
-def homToKer (a b : ℕ) [NeZero a] :
-    (ZMod a →ₗ[ℤ] ZMod b) ≃+ LinearMap.ker (mulByCast a b) where
+/-- The `a`-torsion element `f 1` of a ℤ-linear map `ZMod a → Y`, packaged as an additive
+isomorphism `Hom(ZMod a, Y) ≃+ ker(·a)` for an arbitrary abelian group `Y`. -/
+def homToKer (a : ℕ) (Y : Type*) [AddCommGroup Y] [NeZero a] :
+    (ZMod a →ₗ[ℤ] Y) ≃+ LinearMap.ker (mulBy a Y) where
   toFun f := ⟨f 1, by
-    rw [LinearMap.mem_ker, mulByCast_apply, ← map_smul]
+    rw [LinearMap.mem_ker, mulBy_apply, ← map_smul]
     have h1 : (a : ℤ) • (1 : ZMod a) = 0 := by
       rw [zsmul_eq_mul, mul_one, Int.cast_natCast, ZMod.natCast_self]
     rw [h1, map_zero]⟩
-  invFun x := (ZMod.lift a ⟨zmultiplesHom (ZMod b) (x : ZMod b), by
+  invFun x := (ZMod.lift a ⟨zmultiplesHom Y (x : Y), by
     have hx := LinearMap.mem_ker.mp x.2
-    rw [mulByCast_apply] at hx
+    rw [mulBy_apply] at hx
     simpa only [zmultiplesHom_apply] using hx⟩).toIntLinearMap
   left_inv f := by
     ext z
@@ -302,7 +319,7 @@ def homToKer (a b : ℕ) [NeZero a] :
     rw [← zsmul_one n, map_zsmul]
   right_inv x := by
     apply Subtype.ext
-    change (ZMod.lift a ⟨zmultiplesHom (ZMod b) (x : ZMod b), _⟩).toIntLinearMap 1 = (x : ZMod b)
+    change (ZMod.lift a ⟨zmultiplesHom Y (x : Y), _⟩).toIntLinearMap 1 = (x : Y)
     rw [AddMonoidHom.coe_toIntLinearMap,
       show (1 : ZMod a) = ((1 : ℤ) : ZMod a) by push_cast; rfl, ZMod.lift_coe]
     simp only [zmultiplesHom_apply, one_zsmul]
@@ -311,7 +328,20 @@ def homToKer (a b : ℕ) [NeZero a] :
 /-- **`Hom_ℤ(ZMod a, ZMod b) ≃ ZMod (gcd a b)`.** -/
 def homEquiv (a b : ℕ) [NeZero a] [NeZero b] :
     (ZMod a →ₗ[ℤ] ZMod b) ≃+ ZMod (Nat.gcd a b) :=
-  (homToKer a b).trans (zmodKerEquiv a b).toAddEquiv
+  (homToKer a (ZMod b)).trans (zmodKerEquiv a b).toAddEquiv
+
+/-- **`Hom_ℤ(ZMod a, ℤ) = 0`** for `a ≠ 0`: a torsion group has no nonzero map to a torsion-free
+one. This is the degree-`0` value at a torsion summand of `M` paired with a *free* summand of `N`,
+the one place where the uniform `ZMod (gcd a b)` answer fails (`gcd a 0 = a ≠ 0`). -/
+lemma subsingleton_hom_zmod_int (a : ℕ) [NeZero a] : Subsingleton (ZMod a →ₗ[ℤ] ℤ) := by
+  have hker : ∀ z : LinearMap.ker (mulBy a ℤ), (z : ℤ) = 0 := by
+    intro z
+    have hz : (a : ℤ) • (z : ℤ) = 0 := LinearMap.mem_ker.mp z.2
+    rw [smul_eq_mul, mul_eq_zero] at hz
+    exact hz.resolve_left (Int.natCast_ne_zero.mpr (NeZero.ne a))
+  haveI : Subsingleton (LinearMap.ker (mulBy a ℤ)) :=
+    ⟨fun x y => Subtype.ext (by rw [hker x, hker y])⟩
+  exact (homToKer a ℤ).toEquiv.subsingleton
 
 end
 
@@ -604,12 +634,19 @@ theorem Problem_8_2_7_i_ext_zero (a b : ℕ) (ha : a ≠ 0) (hb : b ≠ 0) :
   obtain ⟨e₀⟩ := Problem_8_2_6_i_ext ℤ (ModuleCat.of ℤ (ZMod a)) (ModuleCat.of ℤ (ZMod b))
   exact ⟨e₀.trans (ModuleCat.homAddEquiv.trans (ZModGcd.homEquiv a b))⟩
 
-/-- **Problem 8.2.7(i), `Ext¹`.** `Ext¹(ℤ/a, ℤ/b) ≅ ℤ/gcd(a,b)` for `a, b ≠ 0`. -/
-theorem Problem_8_2_7_i_ext_one (a b : ℕ) (ha : a ≠ 0) (hb : b ≠ 0) :
-    Nonempty (Etingof.Ext (ModuleCat.of ℤ (ZMod a)) (ModuleCat.of ℤ (ZMod b)) 1
-      ≃+ ZMod (Nat.gcd a b)) := by
+/-- **`Ext¹(ℤ/a, Y)` is the cokernel of multiplication by `a` on `Y`**, for `a ≠ 0` and an
+arbitrary abelian group `Y`. This is the whole degree-`1` content of Problem 8.2.7(i), read off the
+length-`1` free resolution `0 → ℤ →(·a) ℤ → ℤ/a → 0` via the contravariant six-term sequence: the
+connecting map `Ext⁰(ℤ, Y) → Ext¹(ℤ/a, Y)` is surjective because `Ext¹(ℤ, Y) = 0`, and its kernel
+is the image of precomposition by `·a`, which under `Ext⁰(ℤ, Y) ≅ Hom_ℤ(ℤ, Y) ≅ Y` is
+multiplication by `a` on `Y`.
+
+`Problem_8_2_7_i_ext_one` is the case `Y = ZMod b`, where the cokernel is `ZMod (gcd a b)`; the
+case `Y = ℤ` (a *free* summand of `N`) gives `Ext¹(ℤ/a, ℤ) ≅ ZMod a`. -/
+theorem ext_one_zmod_quotSMul (a : ℕ) (ha : a ≠ 0) (Y : Type) [AddCommGroup Y] :
+    Nonempty (Etingof.Ext (ModuleCat.of ℤ (ZMod a)) (ModuleCat.of ℤ Y) 1
+      ≃+ (Y ⧸ Ideal.span {(a : ℤ)} • (⊤ : Submodule ℤ Y))) := by
   haveI : NeZero a := ⟨ha⟩
-  haveI : NeZero b := ⟨hb⟩
   have ha' : (a : ℤ) ≠ 0 := by exact_mod_cast ha
   -- Length-`1` resolution `0 → ℤ →(·a) ℤ → ℤ/a → 0` over `ModuleCat ℤ`, inline for access to `S.f`.
   let f : ℤ →ₗ[ℤ] ℤ := (a : ℤ) • LinearMap.id
@@ -633,27 +670,28 @@ theorem Problem_8_2_7_i_ext_one (a b : ℕ) (ha : a ≠ 0) (hb : b ≠ 0) :
     intro z; obtain ⟨y, rfl⟩ := ZMod.intCast_surjective z; exact ⟨y, hg y⟩
   set S := ModuleCat.shortComplexOfCompEqZero f g eq0 with hSdef
   have hS : S.ShortExact := ModuleCat.shortComplex_shortExact S hexact hinjf hsurjg
-  set Y := ModuleCat.of ℤ (ZMod b) with hY
+  set Yc := ModuleCat.of ℤ Y with hY
   -- Contravariant six-term window `Ext⁰(ℤ/a) → Ext⁰(ℤ) →[·a] Ext⁰(ℤ) →[δ] Ext¹(ℤ/a) → 0 → 0`.
-  have hExactCS := Abelian.Ext.contravariantSequence_exact hS Y 0 1 (by norm_num)
-  -- Connecting map `δ : Ext⁰(ℤ, ℤ/b) → Ext¹(ℤ/a, ℤ/b)`, and precomposition-by-`·a` map.
-  let dhom : Etingof.Ext S.X₁ Y 0 →+ Etingof.Ext S.X₃ Y 1 := hS.extClass.precomp Y (by norm_num)
-  let m12 : Etingof.Ext S.X₂ Y 0 →+ Etingof.Ext S.X₁ Y 0 :=
-    (Abelian.Ext.mk₀ S.f).precomp Y (zero_add 0)
-  -- `Ext¹(ℤ, ℤ/b) = 0`, so `δ` is surjective; and `ker δ = range(·a)`.
+  have hExactCS := Abelian.Ext.contravariantSequence_exact hS Yc 0 1 (by norm_num)
+  -- Connecting map `δ : Ext⁰(ℤ, Y) → Ext¹(ℤ/a, Y)`, and precomposition-by-`·a` map.
+  let dhom : Etingof.Ext S.X₁ Yc 0 →+ Etingof.Ext S.X₃ Yc 1 :=
+    hS.extClass.precomp Yc (by norm_num)
+  let m12 : Etingof.Ext S.X₂ Yc 0 →+ Etingof.Ext S.X₁ Yc 0 :=
+    (Abelian.Ext.mk₀ S.f).precomp Yc (zero_add 0)
+  -- `Ext¹(ℤ, Y) = 0`, so `δ` is surjective; and `ker δ = range(·a)`.
   have hsurjδ : Function.Surjective dhom := by
     rw [← AddMonoidHom.range_eq_top,
       show dhom.range = _ from (hExactCS.exact' 2 3 4).ab_range_eq_ker]
     ext x
     simp only [AddSubgroup.mem_top, iff_true, AddMonoidHom.mem_ker]
-    exact (Abelian.Ext.subsingleton_of_projective S.X₂ Y 0).elim _ _
+    exact (Abelian.Ext.subsingleton_of_projective S.X₂ Yc 0).elim _ _
   have hkerδ : dhom.ker = m12.range := ((hExactCS.exact' 1 2 3).ab_range_eq_ker).symm
-  -- `Ext⁰(ℤ, ℤ/b) ≅ Hom_ℤ(ℤ, ℤ/b) ≅ ℤ/b`, sending `α ↦ (addEquiv₀ α)(1)`.
-  let e0 : (Etingof.Ext S.X₁ Y 0) ≃+ ZMod b :=
+  -- `Ext⁰(ℤ, Y) ≅ Hom_ℤ(ℤ, Y) ≅ Y`, sending `α ↦ (addEquiv₀ α)(1)`.
+  let e0 : (Etingof.Ext S.X₁ Yc 0) ≃+ Y :=
     (Abelian.Ext.addEquiv₀).trans (ModuleCat.homAddEquiv.trans
-      (LinearMap.ringLmapEquivSelf ℤ ℤ (ZMod b)).toAddEquiv)
-  -- The precomposition map `·a` on `Ext⁰(ℤ)` is multiplication by `a` on `ℤ/b`.
-  have hconj : ∀ β, e0 (m12 β) = ZModGcd.mulByCast a b (e0 β) := by
+      (LinearMap.ringLmapEquivSelf ℤ ℤ Y).toAddEquiv)
+  -- The precomposition map `·a` on `Ext⁰(ℤ)` is multiplication by `a` on `Y`.
+  have hconj : ∀ β, e0 (m12 β) = ZModGcd.mulBy a Y (e0 β) := by
     intro β
     have hred : m12 β = (Abelian.Ext.mk₀ S.f).comp β (zero_add 0) := rfl
     have step1 : Abelian.Ext.addEquiv₀ (m12 β) = S.f ≫ Abelian.Ext.addEquiv₀ β := by
@@ -661,33 +699,23 @@ theorem Problem_8_2_7_i_ext_one (a b : ℕ) (ha : a ≠ 0) (hb : b ≠ 0) :
       apply Abelian.Ext.addEquiv₀.symm.injective
       rw [AddEquiv.symm_apply_apply, Abelian.Ext.addEquiv₀_symm_apply, ← Abelian.Ext.mk₀_comp_mk₀,
         Abelian.Ext.mk₀_addEquiv₀_apply]
-    change (LinearMap.ringLmapEquivSelf ℤ ℤ (ZMod b))
+    change (LinearMap.ringLmapEquivSelf ℤ ℤ Y)
         (ModuleCat.homAddEquiv (Abelian.Ext.addEquiv₀ (m12 β)))
-      = ZModGcd.mulByCast a b ((LinearMap.ringLmapEquivSelf ℤ ℤ (ZMod b))
+      = ZModGcd.mulBy a Y ((LinearMap.ringLmapEquivSelf ℤ ℤ Y)
         (ModuleCat.homAddEquiv (Abelian.Ext.addEquiv₀ β)))
     rw [step1]
     simp only [ModuleCat.homAddEquiv_apply, ModuleCat.hom_comp,
-      LinearMap.ringLmapEquivSelf_apply, ZModGcd.mulByCast_apply]
+      LinearMap.ringLmapEquivSelf_apply, ZModGcd.mulBy_apply]
     change (Abelian.Ext.addEquiv₀ β).hom (S.f.hom 1) = (a : ℤ) • (Abelian.Ext.addEquiv₀ β).hom 1
     rw [show S.f.hom (1 : ℤ) = (a : ℤ) • (1 : ℤ) from rfl, map_smul]
-  -- `range(mulByCast) = (a) • ⊤`, matching the domain of `zmodCokerEquiv`.
-  have hrange : LinearMap.range (ZModGcd.mulByCast a b)
-      = Ideal.span {(a : ℤ)} • (⊤ : Submodule ℤ (ZMod b)) := by
-    rw [Submodule.ideal_span_singleton_smul]
-    ext x
-    simp only [LinearMap.mem_range, ZModGcd.mulByCast_apply,
-      Submodule.mem_smul_pointwise_iff_exists]
-    constructor
-    · rintro ⟨y, rfl⟩; exact ⟨y, Submodule.mem_top, rfl⟩
-    · rintro ⟨y, _, rfl⟩; exact ⟨y, rfl⟩
-  -- Assemble: `Ext¹ ≃ Ext⁰(ℤ)/ker δ ≃ ℤ/b / (a)•⊤ ≃ ℤ/gcd`.
+  -- Assemble: `Ext¹ ≃ Ext⁰(ℤ)/ker δ ≃ Y / (a)•⊤`.
   let δL := dhom.toIntLinearMap
   have hsurjδL : Function.Surjective δL := hsurjδ
-  let e0L : (Etingof.Ext S.X₁ Y 0) ≃ₗ[ℤ] ZMod b := e0.toIntLinearEquiv
-  have he0L : ∀ x, (e0L : (Etingof.Ext S.X₁ Y 0) →ₗ[ℤ] ZMod b) x = e0 x := fun _ => rfl
-  have hmap : Submodule.map (e0L : (Etingof.Ext S.X₁ Y 0) →ₗ[ℤ] ZMod b) (LinearMap.ker δL)
-      = Ideal.span {(a : ℤ)} • (⊤ : Submodule ℤ (ZMod b)) := by
-    rw [← hrange]
+  let e0L : (Etingof.Ext S.X₁ Yc 0) ≃ₗ[ℤ] Y := e0.toIntLinearEquiv
+  have he0L : ∀ x, (e0L : (Etingof.Ext S.X₁ Yc 0) →ₗ[ℤ] Y) x = e0 x := fun _ => rfl
+  have hmap : Submodule.map (e0L : (Etingof.Ext S.X₁ Yc 0) →ₗ[ℤ] Y) (LinearMap.ker δL)
+      = Ideal.span {(a : ℤ)} • (⊤ : Submodule ℤ Y) := by
+    rw [← ZModGcd.range_mulBy a Y]
     ext z
     simp only [Submodule.mem_map, LinearMap.mem_ker, LinearMap.mem_range, he0L]
     constructor
@@ -702,9 +730,18 @@ theorem Problem_8_2_7_i_ext_one (a b : ℕ) (ha : a ≠ 0) (hb : b ≠ 0) :
           hkerδ.symm ▸ AddMonoidHom.mem_range.mpr ⟨e0.symm w, rfl⟩
         exact AddMonoidHom.mem_ker.mp this
       · rw [hconj, e0.apply_symm_apply]
-  exact ⟨(((LinearMap.quotKerEquivOfSurjective δL hsurjδL).symm.trans
-    (Submodule.Quotient.equiv (LinearMap.ker δL) _ e0L hmap)).trans
-    (ZModGcd.zmodCokerEquiv a b)).toAddEquiv⟩
+  exact ⟨((LinearMap.quotKerEquivOfSurjective δL hsurjδL).symm.trans
+    (Submodule.Quotient.equiv (LinearMap.ker δL) _ e0L hmap)).toAddEquiv⟩
+
+/-- **Problem 8.2.7(i), `Ext¹`.** `Ext¹(ℤ/a, ℤ/b) ≅ ℤ/gcd(a,b)` for `a, b ≠ 0`: the cokernel of
+multiplication by `a` on `ℤ/b` (`Etingof.ext_one_zmod_quotSMul`) is `ℤ/gcd(a,b)`
+(`ZModGcd.zmodCokerEquiv`). -/
+theorem Problem_8_2_7_i_ext_one (a b : ℕ) (ha : a ≠ 0) (hb : b ≠ 0) :
+    Nonempty (Etingof.Ext (ModuleCat.of ℤ (ZMod a)) (ModuleCat.of ℤ (ZMod b)) 1
+      ≃+ ZMod (Nat.gcd a b)) := by
+  haveI : NeZero b := ⟨hb⟩
+  obtain ⟨e⟩ := ext_one_zmod_quotSMul a ha (ZMod b)
+  exact ⟨e.trans (ZModGcd.zmodCokerEquiv a b).toAddEquiv⟩
 
 /-- `ℤ/a` has projective dimension `< 2` as a `ℤ`-module. For `a ≠ 0` the length-`1` free
 resolution `0 → ℤ →(·a) ℤ → ℤ/a → 0` exhibits this; for `a = 0`, `ℤ/0 = ℤ` is projective. -/

--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_7.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_7.lean
@@ -106,7 +106,7 @@ open Limits in
 /-- If `Q = S.X₃` fits in a short exact sequence `0 → S.X₁ → S.X₂ → Q → 0` with `S.X₁`, `S.X₂`
 projective, then `Q` has projective dimension `< 2`. (Categorical form of "a length-`1` projective
 resolution bounds the projective dimension by `1`".) -/
-private lemma hasProjectiveDimensionLT_two_of_shortExact
+lemma hasProjectiveDimensionLT_two_of_shortExact
     {R : Type u} [Ring R] [Small.{u} R] {S : ShortComplex (ModuleCat.{u} R)}
     (hS : S.ShortExact) (h₁ : Projective S.X₁) (h₂ : Projective S.X₂) :
     HasProjectiveDimensionLT S.X₃ 2 := by

--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_7_ExtFG.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_7_ExtFG.lean
@@ -1,0 +1,186 @@
+import EtingofRepresentationTheory.Chapter8.PIDDecomposition
+
+/-!
+# Problem 8.2.7: `Ext` for arbitrary finitely generated modules over a PID
+
+`Problem8_2_7.lean` computes `Extⁱ` for the two *building blocks* of the structure theorem over a
+PID — a free generator and a pair of cyclic modules — and `PIDDecomposition.lean` packages the
+structure theorem as a biproduct decomposition. This file performs the reduction the book's hint
+asks for ("reduce to the case of cyclic groups using the classification theorem") and supplies the
+base-ring-independent half of the computation of `Extⁱ(M, N)` for **arbitrary** finitely generated
+`M`, `N`.
+
+## Main results
+
+* `Etingof.extCongr`: `Ext` transported along isomorphisms in both variables.
+* `Etingof.extPIDDecompositionAddEquiv`: **the reduction.** Given decompositions `D` of `M` and
+  `E` of `N`,
+  `Extⁱ(M, N) ≃+ Π (j : D.index) (l : E.index), Extⁱ(D.summand j, E.summand l)`,
+  i.e. `Ext` of a pair of finitely generated modules is the product of the `Ext` groups of the
+  pairs of free/cyclic summands. This is Mathlib's additivity of `Ext` in both variables
+  (`Abelian.Ext.biproductAddEquiv`, `Abelian.Ext.addEquivBiproduct`) applied to
+  `PIDDecomposition.biproductIso`.
+* `Etingof.hasProjectiveDimensionLT_biproduct`: a finite biproduct of objects of projective
+  dimension `< n` has projective dimension `< n` (Mathlib has only the binary case).
+* `Etingof.cyclic_hasProjectiveDimensionLT_two`: over a domain, `A ⧸ (d)` has projective
+  dimension `< 2` — from `0 → A →(·d) A → A ⧸ (d) → 0` when `d ≠ 0`, and from projectivity of
+  `A ⧸ (0) ≅ A` when `d = 0`.
+* `Etingof.fg_hasProjectiveDimensionLT_two`: **every** finitely generated module over a PID has
+  projective dimension `< 2`, hence `Extⁱ(M, N) = 0` for `i ≥ 2` and *arbitrary* `N`.
+
+Everything here is proved for an arbitrary PID; the `ℤ` and `k[X]` statements of Problem 8.2.7 are
+instances. The degree-`0` and degree-`1` computations, which depend on the base ring through the
+`ZModGcd` / `PolyGcd` isomorphisms of `Problem8_2_7.lean`, are assembled in
+`Problem8_2_7_ExtInt.lean` and `Problem8_2_7_ExtPoly.lean`.
+-/
+
+universe w v u
+
+namespace Etingof
+
+open CategoryTheory Limits
+
+/-! ### Transporting `Ext` along isomorphisms -/
+
+section ExtCongr
+
+variable {C : Type u} [Category.{v} C] [Abelian C] [HasExt.{w} C]
+
+/-- **`Ext` is invariant under isomorphism in both variables.** `Extⁿ(X, Y) ≃+ Extⁿ(X', Y')` for
+`e : X ≅ X'` and `f : Y ≅ Y'`, by pre-composing with `e.inv` and post-composing with `f.hom`. -/
+noncomputable def extCongr {X X' Y Y' : C} (e : X ≅ X') (f : Y ≅ Y') (n : ℕ) :
+    Abelian.Ext.{w} X Y n ≃+ Abelian.Ext.{w} X' Y' n where
+  toFun α :=
+    (Abelian.Ext.mk₀ e.inv).comp (α.comp (Abelian.Ext.mk₀ f.hom) (add_zero n)) (zero_add n)
+  invFun β :=
+    (Abelian.Ext.mk₀ e.hom).comp (β.comp (Abelian.Ext.mk₀ f.inv) (add_zero n)) (zero_add n)
+  left_inv α := by
+    simp only [Abelian.Ext.comp_assoc_of_second_deg_zero, Abelian.Ext.mk₀_comp_mk₀,
+      Abelian.Ext.comp_assoc_of_third_deg_zero, Iso.hom_inv_id, Abelian.Ext.comp_mk₀_id,
+      Abelian.Ext.mk₀_comp_mk₀_assoc, Abelian.Ext.mk₀_id_comp]
+  right_inv β := by
+    simp only [Abelian.Ext.comp_assoc_of_second_deg_zero, Abelian.Ext.mk₀_comp_mk₀,
+      Abelian.Ext.comp_assoc_of_third_deg_zero, Iso.inv_hom_id, Abelian.Ext.comp_mk₀_id,
+      Abelian.Ext.mk₀_comp_mk₀_assoc, Abelian.Ext.mk₀_id_comp]
+  map_add' α₁ α₂ := by
+    simp only [Abelian.Ext.add_comp, Abelian.Ext.comp_add]
+
+end ExtCongr
+
+/-! ### Projective dimension of a finite biproduct -/
+
+section ProjectiveDimension
+
+variable {C : Type u} [Category.{v} C] [Abelian C] [HasExt.{w} C]
+
+/-- **A finite biproduct of objects of projective dimension `< n` has projective dimension `< n`.**
+Mathlib has the binary case as an instance; the finite-family case follows from additivity of `Ext`
+in its first variable, `Abelian.Ext.biproductAddEquiv`. -/
+lemma hasProjectiveDimensionLT_biproduct {ι : Type*} [Finite ι] (X : ι → C) [HasBiproduct X]
+    (n : ℕ) (h : ∀ i, HasProjectiveDimensionLT (X i) n) :
+    HasProjectiveDimensionLT (⨁ X) n :=
+  HasProjectiveDimensionLT.mk fun i hi Y e => by
+    haveI := Fintype.ofFinite ι
+    haveI : ∀ j, Subsingleton (Abelian.Ext.{w} (X j) Y i) := fun j =>
+      have := h j
+      HasProjectiveDimensionLT.subsingleton (X j) n i hi Y
+    haveI : Subsingleton (∀ j, Abelian.Ext.{w} (X j) Y i) :=
+      ⟨fun _ _ => funext fun _ => Subsingleton.elim _ _⟩
+    exact (Abelian.Ext.biproductAddEquiv (biproduct.isBilimit X) Y i).subsingleton.elim _ _
+
+end ProjectiveDimension
+
+/-! ### The reduction to summand pairs -/
+
+section Reduction
+
+variable {A : Type u} [CommRing A] {M N : Type u} [AddCommGroup M] [Module A M]
+  [AddCommGroup N] [Module A N]
+
+/-- **The reduction of Problem 8.2.7 to the free and cyclic building blocks.** For decompositions
+`D` of `M` and `E` of `N` into a free part and cyclic parts, `Extⁿ(M, N)` is the product, over
+pairs of summands, of the `Extⁿ` groups of those summands. Together with the summand-level
+computations of `Problem8_2_7.lean` this *is* the book's "reduce to the case of cyclic groups". -/
+noncomputable def extPIDDecompositionAddEquiv (D : PIDDecomposition A M) (E : PIDDecomposition A N)
+    (n : ℕ) :
+    Etingof.Ext (ModuleCat.of A M) (ModuleCat.of A N) n ≃+
+      ∀ (j : D.index) (l : E.index), Etingof.Ext (D.summand j) (E.summand l) n :=
+  (extCongr D.biproductIso E.biproductIso n).trans
+    ((Abelian.Ext.biproductAddEquiv (biproduct.isBilimit D.summand) _ n).trans
+      (AddEquiv.piCongrRight fun _ =>
+        Abelian.Ext.addEquivBiproduct _ (biproduct.isBilimit E.summand) n))
+
+end Reduction
+
+/-! ### Projective dimension `< 2` for finitely generated modules over a PID -/
+
+section PIDProjectiveDimension
+
+variable (A : Type u) [CommRing A]
+
+/-- The multiplication-by-`d` endomorphism of `A`, as an `A`-linear map. -/
+private noncomputable def mulByGen (d : A) : A →ₗ[A] A := d • LinearMap.id
+
+private lemma mulByGen_apply (d x : A) : mulByGen A d x = d * x := by
+  simp [mulByGen]
+
+private lemma range_mulByGen (d : A) :
+    LinearMap.range (mulByGen A d) = Ideal.span {d} := by
+  ext x
+  simp only [LinearMap.mem_range, mulByGen_apply, Ideal.mem_span_singleton]
+  exact ⟨fun ⟨c, hc⟩ => ⟨c, hc.symm⟩, fun ⟨c, hc⟩ => ⟨c, hc.symm⟩⟩
+
+/-- **A cyclic module over a domain has projective dimension `< 2`.** For `d ≠ 0` this is the
+length-`1` free resolution `0 → A →(·d) A → A ⧸ (d) → 0`; for `d = 0` the module `A ⧸ (0)` is
+isomorphic to the projective module `A`. -/
+lemma cyclic_hasProjectiveDimensionLT_two [IsDomain A] (d : A) :
+    HasProjectiveDimensionLT (ModuleCat.of A (A ⧸ Ideal.span {d})) 2 := by
+  haveI : HasProjectiveDimensionLT (ModuleCat.of A A) 2 :=
+    hasProjectiveDimensionLT_of_ge (ModuleCat.of A A) 1 2 (by omega)
+  rcases eq_or_ne d 0 with rfl | hd
+  · -- `A ⧸ (0) ≅ A` is projective
+    have hbot : (Ideal.span {(0 : A)} : Ideal A) = ⊥ := Ideal.span_singleton_eq_bot.mpr rfl
+    exact hasProjectiveDimensionLT_of_iso
+      (LinearEquiv.toModuleIso (Submodule.quotEquivOfEqBot _ hbot).symm) 2
+  · -- the length-`1` free resolution `0 → A →(·d) A → A ⧸ (d) → 0`
+    let f : A →ₗ[A] A := mulByGen A d
+    let g : A →ₗ[A] (A ⧸ Ideal.span {d}) := (Ideal.span {d} : Ideal A).mkQ
+    have eq0 : g.comp f = 0 := LinearMap.ext fun x => by
+      simpa only [LinearMap.comp_apply, Submodule.mkQ_apply, Submodule.Quotient.mk_eq_zero,
+        LinearMap.zero_apply, mulByGen_apply, f, g] using Ideal.mem_span_singleton.mpr ⟨x, rfl⟩
+    have hexact : Function.Exact f g := by
+      rw [LinearMap.exact_iff, Submodule.ker_mkQ]
+      exact (range_mulByGen A d).symm
+    have hinj : Function.Injective f := fun x y hxy =>
+      mul_left_cancel₀ hd (by rw [← mulByGen_apply A d x, ← mulByGen_apply A d y]; exact hxy)
+    have hsurj : Function.Surjective g := Submodule.mkQ_surjective _
+    let S := ModuleCat.shortComplexOfCompEqZero f g eq0
+    have hS : S.ShortExact := ModuleCat.shortComplex_shortExact S hexact hinj hsurj
+    exact hasProjectiveDimensionLT_two_of_shortExact hS inferInstance inferInstance
+
+/-- **A module with a PID decomposition has projective dimension `< 2`.** Its summands are free or
+cyclic, and both have projective dimension `< 2`
+(`Etingof.cyclic_hasProjectiveDimensionLT_two`); projective dimension is additive over finite
+biproducts (`Etingof.hasProjectiveDimensionLT_biproduct`). -/
+lemma hasProjectiveDimensionLT_two_of_pidDecomposition [IsDomain A] {M : Type u} [AddCommGroup M]
+    [Module A M] (D : PIDDecomposition A M) :
+    HasProjectiveDimensionLT (ModuleCat.of A M) 2 := by
+  haveI : HasProjectiveDimensionLT (ModuleCat.of A A) 2 :=
+    hasProjectiveDimensionLT_of_ge (ModuleCat.of A A) 1 2 (by omega)
+  haveI : HasProjectiveDimensionLT (⨁ D.summand) 2 :=
+    hasProjectiveDimensionLT_biproduct D.summand 2 fun j => by
+      cases j with
+      | inl i => exact ‹HasProjectiveDimensionLT (ModuleCat.of A A) 2›
+      | inr i => exact cyclic_hasProjectiveDimensionLT_two A (D.gen i)
+  exact hasProjectiveDimensionLT_of_iso D.biproductIso.symm 2
+
+/-- **Every finitely generated module over a PID has projective dimension `< 2`**, hence
+`Extⁱ(M, N) = 0` for `i ≥ 2` and *arbitrary* `N` (`HasProjectiveDimensionLT.subsingleton`). -/
+lemma fg_hasProjectiveDimensionLT_two [IsDomain A] [IsPrincipalIdealRing A] (M : Type u)
+    [AddCommGroup M] [Module A M] [Module.Finite A M] :
+    HasProjectiveDimensionLT (ModuleCat.of A M) 2 :=
+  (exists_pidDecomposition A M).elim (hasProjectiveDimensionLT_two_of_pidDecomposition A)
+
+end PIDProjectiveDimension
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_7_ExtFG.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_7_ExtFG.lean
@@ -90,12 +90,65 @@ lemma hasProjectiveDimensionLT_biproduct {ι : Type*} [Finite ι] (X : ι → C)
 
 end ProjectiveDimension
 
+/-! ### Splitting a product indexed by a sum -/
+
+/-- `Π (j : α ⊕ β), f j ≃+ (Π a, f (inl a)) × (Π b, f (inr b))`: the additive form of
+`Equiv.sumPiEquivProdPi`, used to split the free and cyclic blocks of a decomposition apart. -/
+@[simps]
+def piSumAddEquiv {α β : Type*} (f : α ⊕ β → Type*) [∀ j, AddCommGroup (f j)] :
+    (∀ j, f j) ≃+ (∀ a, f (Sum.inl a)) × (∀ b, f (Sum.inr b)) where
+  toFun g := (fun a => g (Sum.inl a), fun b => g (Sum.inr b))
+  invFun p := Sum.rec p.1 p.2
+  left_inv g := funext fun j => by cases j <;> rfl
+  right_inv _ := rfl
+  map_add' _ _ := rfl
+
+/-- A product of trivial groups is trivial: the block of a decomposition on which `Ext` vanishes
+contributes nothing. -/
+lemma subsingleton_pi {α : Type*} (f : α → Type*) [∀ a, Subsingleton (f a)] :
+    Subsingleton (∀ a, f a) :=
+  ⟨fun _ _ => funext fun _ => Subsingleton.elim _ _⟩
+
+/-- Drop a trivial first factor: `X × Y ≃+ Y` when `X` is trivial. -/
+noncomputable def subsingletonProdAddEquiv (X Y : Type*) [AddCommGroup X] [AddCommGroup Y]
+    [Subsingleton X] : (X × Y) ≃+ Y where
+  toFun p := p.2
+  invFun y := (0, y)
+  left_inv _ := Prod.ext (Subsingleton.elim _ _) rfl
+  right_inv _ := rfl
+  map_add' _ _ := rfl
+
+/-- Drop a trivial second factor: `X × Y ≃+ X` when `Y` is trivial. -/
+noncomputable def prodSubsingletonAddEquiv (X Y : Type*) [AddCommGroup X] [AddCommGroup Y]
+    [Subsingleton Y] : (X × Y) ≃+ X where
+  toFun p := p.1
+  invFun x := (x, 0)
+  left_inv _ := Prod.ext rfl (Subsingleton.elim _ _)
+  right_inv _ := rfl
+  map_add' _ _ := rfl
+
 /-! ### The reduction to summand pairs -/
 
 section Reduction
 
 variable {A : Type u} [CommRing A] {M N : Type u} [AddCommGroup M] [Module A M]
   [AddCommGroup N] [Module A N]
+
+/-- **Additivity of `Ext` in the first variable, along a decomposition.**
+`Extⁿ(M, Y) ≃+ Π j, Extⁿ(D.summand j, Y)` for an arbitrary second argument `Y`. -/
+noncomputable def extFstDecompositionAddEquiv (D : PIDDecomposition A M) (Y : ModuleCat.{u} A)
+    (n : ℕ) :
+    Etingof.Ext (ModuleCat.of A M) Y n ≃+ ∀ j : D.index, Etingof.Ext (D.summand j) Y n :=
+  (extCongr D.biproductIso (Iso.refl Y) n).trans
+    (Abelian.Ext.biproductAddEquiv (biproduct.isBilimit D.summand) Y n)
+
+/-- **Additivity of `Ext` in the second variable, along a decomposition.**
+`Extⁿ(X, N) ≃+ Π l, Extⁿ(X, E.summand l)` for an arbitrary first argument `X`. -/
+noncomputable def extSndDecompositionAddEquiv (X : ModuleCat.{u} A) (E : PIDDecomposition A N)
+    (n : ℕ) :
+    Etingof.Ext X (ModuleCat.of A N) n ≃+ ∀ l : E.index, Etingof.Ext X (E.summand l) n :=
+  (extCongr (Iso.refl X) E.biproductIso n).trans
+    (Abelian.Ext.addEquivBiproduct X (biproduct.isBilimit E.summand) n)
 
 /-- **The reduction of Problem 8.2.7 to the free and cyclic building blocks.** For decompositions
 `D` of `M` and `E` of `N` into a free part and cyclic parts, `Extⁿ(M, N)` is the product, over
@@ -109,6 +162,32 @@ noncomputable def extPIDDecompositionAddEquiv (D : PIDDecomposition A M) (E : PI
     ((Abelian.Ext.biproductAddEquiv (biproduct.isBilimit D.summand) _ n).trans
       (AddEquiv.piCongrRight fun _ =>
         Abelian.Ext.addEquivBiproduct _ (biproduct.isBilimit E.summand) n))
+
+/-! ### The summands, uniformly as cyclic modules
+
+A free summand `A` is the cyclic module `A ⧸ (0)`, so *every* summand of a decomposition is
+`A ⧸ (d)` for a suitable `d` — `0` for the free ones. This uniformity is what makes the degree-`1`
+answer of Problem 8.2.7 a single formula (over `ℤ`: `ZMod (gcd aᵢ c_l)` with `c_l = 0` for the free
+summands of `N`, since `gcd a 0 = a`). -/
+
+/-- The generator of the annihilator of the `j`-th summand, uniformly: `0` on the free summands. -/
+def PIDDecomposition.genOf (D : PIDDecomposition A M) : D.index → A :=
+  Sum.elim (fun _ => 0) D.gen
+
+@[simp] lemma PIDDecomposition.genOf_inl (D : PIDDecomposition A M) (i : Fin D.freeRank) :
+    D.genOf (Sum.inl i) = 0 := rfl
+
+@[simp] lemma PIDDecomposition.genOf_inr (D : PIDDecomposition A M) (i : D.torsionIndex) :
+    D.genOf (Sum.inr i) = D.gen i := rfl
+
+/-- **Every summand is a cyclic module `A ⧸ (genOf j)`**, the free ones being `A ⧸ (0) ≅ A`. -/
+noncomputable def PIDDecomposition.summandIso (D : PIDDecomposition A M) (j : D.index) :
+    D.summand j ≅ ModuleCat.of A (A ⧸ Ideal.span {D.genOf j}) := by
+  cases j with
+  | inl i =>
+    exact LinearEquiv.toModuleIso
+      (Submodule.quotEquivOfEqBot _ (Ideal.span_singleton_eq_bot.mpr rfl)).symm
+  | inr i => exact Iso.refl _
 
 end Reduction
 
@@ -182,5 +261,30 @@ lemma fg_hasProjectiveDimensionLT_two [IsDomain A] [IsPrincipalIdealRing A] (M :
   (exists_pidDecomposition A M).elim (hasProjectiveDimensionLT_two_of_pidDecomposition A)
 
 end PIDProjectiveDimension
+
+/-! ### Decompositions with nonzero torsion generators
+
+The degree-`0` computation distinguishes a *genuinely torsion* cyclic summand `A ⧸ (d)`, `d ≠ 0`,
+from a free one (`Hom(A ⧸ (d), A) = 0` for `d ≠ 0`, whereas `Hom(A, A) = A`). The structure theorem
+produces prime-power generators, which are nonzero, so this costs nothing — but
+`Etingof.PIDDecomposition` itself does not record it, so we strengthen the existence statement. -/
+
+/-- **Structure theorem, with nonzero torsion generators.** Every finitely generated module over a
+PID admits a decomposition whose cyclic summands `A ⧸ (gen i)` are genuinely torsion, i.e.
+`gen i ≠ 0`: the structure theorem produces `gen i = pᵢ ^ eᵢ` with `pᵢ` irreducible. -/
+theorem exists_pidDecomposition_gen_ne_zero (A : Type u) [CommRing A] [IsDomain A]
+    [IsPrincipalIdealRing A] (M : Type u) [AddCommGroup M] [Module A M] [Module.Finite A M] :
+    ∃ D : PIDDecomposition A M, ∀ i, D.gen i ≠ 0 := by
+  classical
+  obtain ⟨n, ι, hι, p, hp, e, ⟨f⟩⟩ := Module.equiv_free_prod_directSum A M
+  refine ⟨{ freeRank := n
+            torsionIndex := ι
+            torsionFintype := hι
+            torsionDecEq := Classical.decEq ι
+            gen := fun i => p i ^ e i
+            equivProd := f ≪≫ₗ LinearEquiv.prodCongr
+              (Finsupp.linearEquivFunOnFinite A A (Fin n))
+              (DirectSum.linearEquivFunOnFintype A ι fun i => A ⧸ Ideal.span {p i ^ e i}) },
+    fun i => pow_ne_zero _ (hp i).ne_zero⟩
 
 end Etingof

--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_7_ExtFG.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_7_ExtFG.lean
@@ -163,6 +163,15 @@ noncomputable def extPIDDecompositionAddEquiv (D : PIDDecomposition A M) (E : PI
       (AddEquiv.piCongrRight fun _ =>
         Abelian.Ext.addEquivBiproduct _ (biproduct.isBilimit E.summand) n))
 
+/-- `Hom_A(A, Z) ≅ Z`, evaluation at `1`: the degree-`0` value of `Ext` at a *free* summand. -/
+noncomputable def homSelfAddEquiv (A : Type u) [CommRing A] (Z : Type u) [AddCommGroup Z]
+    [Module A Z] : (A →ₗ[A] Z) ≃+ Z where
+  toFun f := f 1
+  invFun z := LinearMap.toSpanSingleton A Z z
+  left_inv f := by ext; simp [LinearMap.toSpanSingleton_apply]
+  right_inv z := by simp [LinearMap.toSpanSingleton_apply]
+  map_add' _ _ := rfl
+
 /-! ### The summands, uniformly as cyclic modules
 
 A free summand `A` is the cyclic module `A ⧸ (0)`, so *every* summand of a decomposition is

--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_7_ExtInt.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_7_ExtInt.lean
@@ -1,0 +1,246 @@
+import EtingofRepresentationTheory.Chapter8.Problem8_2_7_ExtFG
+
+/-!
+# Problem 8.2.7(i): `Extⁱ(M, N)` for arbitrary finitely generated abelian groups
+
+`Problem8_2_7.lean` computes `Extⁱ` for a pair of cyclic groups and for a free generator, and
+`Problem8_2_7_ExtFG.lean` reduces the general case to those building blocks. This file completes
+part (i) of the exercise: it fills in the summand-level table over `ℤ` and assembles the answer for
+**arbitrary** finitely generated `M`, `N`.
+
+## The summand table
+
+Every summand of a decomposition is `ℤ ⧸ (d) ≅ ZMod d.natAbs` (`Etingof.intSummandIso`), the free
+ones being `d = 0`, i.e. `ZMod 0 = ℤ`. Writing `a` for the first argument's modulus and `c` for the
+second's:
+
+| | `Ext⁰` | `Ext¹` | `Extⁿ⁺²` |
+|---|---|---|---|
+| `a = 0` (free) | `ZMod c` | `0` | `0` |
+| `a ≠ 0`, `c = 0` | `0` | `ZMod a` | `0` |
+| `a ≠ 0`, `c ≠ 0` | `ZMod (gcd a c)` | `ZMod (gcd a c)` | `0` |
+
+In degree `1` the three rows are the *single* formula `ZMod (gcd a c)` for `a ≠ 0` (note
+`gcd a 0 = a`), which is why `Problem_8_2_7_i_ext_one_fg` below has no case split over the free
+summands of `N`. In degree `0` the entry at `a ≠ 0`, `c = 0` genuinely breaks the pattern:
+`Hom(ℤ/a, ℤ) = 0` while `gcd a 0 = a ≠ 0`.
+
+## Main results
+
+* `Etingof.Problem_8_2_7_i_ext_zero_fg`:
+  `Hom(M, N) = Ext⁰(M, N) ≅ N^p ⊕ ⨁_{i,l} ℤ/gcd(aᵢ, b_l)`, where `p` is the free rank of `M` and
+  the `aᵢ`, `b_l` are the torsion generators of `M` and `N`.
+* `Etingof.Problem_8_2_7_i_ext_one_fg`:
+  `Ext¹(M, N) ≅ ⨁_{i, l} ℤ/gcd(aᵢ, c_l)`, the product running over the torsion summands of `M` and
+  **all** summands of `N` (`c_l = 0` on the free ones, contributing `ℤ/aᵢ`).
+* `Etingof.Problem_8_2_7_i_ext_fg_vanish`: `Extⁱ(M, N) = 0` for `i ≥ 2`, with `N` arbitrary.
+* `Etingof.Problem_8_2_7_i_ext_one_intrinsic`: the coordinate-free form of the degree-`1` answer,
+  `Ext¹(M, N) ≅ Π i, N / aᵢN`, valid for arbitrary (not necessarily finitely generated) `N`.
+-/
+
+universe u
+
+namespace Etingof
+
+open CategoryTheory Limits
+
+/-! ### Identifying the summands with `ZMod` -/
+
+/-- `ℤ ⧸ (d) ≅ ZMod d.natAbs`, for an arbitrary integer `d` — including `d = 0`, where both sides
+are `ℤ`. This extends `Etingof.intCyclicIso`, which is stated for a natural-number generator. -/
+noncomputable def intCyclicIsoNatAbs (d : ℤ) :
+    ModuleCat.of ℤ (ℤ ⧸ Ideal.span {d}) ≅ ModuleCat.of ℤ (ZMod d.natAbs) :=
+  have hspan : Ideal.span {d} = Ideal.span {(d.natAbs : ℤ)} :=
+    le_antisymm
+      (Ideal.span_le.mpr (by
+        simp only [Set.singleton_subset_iff, SetLike.mem_coe]
+        exact Ideal.mem_span_singleton.mpr (Int.natAbs_dvd.mpr dvd_rfl)))
+      (Ideal.span_le.mpr (by
+        simp only [Set.singleton_subset_iff, SetLike.mem_coe]
+        exact Ideal.mem_span_singleton.mpr (Int.dvd_natAbs.mpr dvd_rfl)))
+  LinearEquiv.toModuleIso (Submodule.quotEquivOfEq _ _ hspan) ≪≫ intCyclicIso d.natAbs
+
+/-- **Every summand of a decomposition of a finitely generated abelian group is a `ZMod`.** The
+free summands are `ZMod 0 = ℤ`; this is the uniform shape the `ZModGcd` building blocks of
+`Problem8_2_7.lean` are stated for. -/
+noncomputable def intSummandIso {M : Type} [AddCommGroup M] (D : PIDDecomposition ℤ M)
+    (j : D.index) : D.summand j ≅ ModuleCat.of ℤ (ZMod (D.genOf j).natAbs) :=
+  D.summandIso j ≪≫ intCyclicIsoNatAbs (D.genOf j)
+
+/-! ### The summand table -/
+
+/-- `Ext⁰(ℤ, Z) = Hom(ℤ, Z) ≅ Z` for any abelian group `Z`: the degree-`0` value at a free summand
+of `M`. -/
+theorem Problem_8_2_7_i_ext_free_zero (Z : ModuleCat.{0} ℤ) :
+    Nonempty (Etingof.Ext (ModuleCat.of ℤ ℤ) Z 0 ≃+ Z) := by
+  obtain ⟨e⟩ := Problem_8_2_6_i_ext ℤ (ModuleCat.of ℤ ℤ) Z
+  exact ⟨e.trans (ModuleCat.homAddEquiv.trans (homSelfAddEquiv ℤ Z))⟩
+
+/-- `Ext⁰(ℤ/a, ℤ) = Hom(ℤ/a, ℤ) = 0` for `a ≠ 0`: the degree-`0` value at a torsion summand of `M`
+paired with a *free* summand of `N`. This is the one entry of the table where the uniform
+`ZMod (gcd a c)` answer fails. -/
+theorem Problem_8_2_7_i_ext_cyclic_free_zero (a : ℕ) (ha : a ≠ 0) :
+    Subsingleton (Etingof.Ext (ModuleCat.of ℤ (ZMod a)) (ModuleCat.of ℤ ℤ) 0) := by
+  haveI : NeZero a := ⟨ha⟩
+  haveI := ZModGcd.subsingleton_hom_zmod_int a
+  obtain ⟨e⟩ := Problem_8_2_6_i_ext ℤ (ModuleCat.of ℤ (ZMod a)) (ModuleCat.of ℤ ℤ)
+  exact (e.trans ModuleCat.homAddEquiv).toEquiv.subsingleton
+
+/-- **`Ext¹(ℤ/a, ℤ/c) ≅ ℤ/gcd(a, c)` for `a ≠ 0` and every `c`, including `c = 0`.** For `c ≠ 0`
+this is `Problem_8_2_7_i_ext_one`; for `c = 0` it says `Ext¹(ℤ/a, ℤ) ≅ ℤ/a`, which is the same
+cokernel computation (`Etingof.ext_one_zmod_quotSMul`) with `ℤ ⧸ (a) ≅ ZMod a` at the end, and
+`gcd a 0 = a`. -/
+theorem Problem_8_2_7_i_ext_one_cyclic (a c : ℕ) (ha : a ≠ 0) :
+    Nonempty (Etingof.Ext (ModuleCat.of ℤ (ZMod a)) (ModuleCat.of ℤ (ZMod c)) 1
+      ≃+ ZMod (Nat.gcd a c)) := by
+  rcases eq_or_ne c 0 with rfl | hc
+  · rw [Nat.gcd_zero_right]
+    obtain ⟨e⟩ := ext_one_zmod_quotSMul a ha ℤ
+    have h : Ideal.span {(a : ℤ)} • (⊤ : Submodule ℤ ℤ) = (Ideal.span {(a : ℤ)} : Ideal ℤ) := by
+      rw [Ideal.smul_eq_mul, Ideal.mul_top]
+    exact ⟨e.trans ((Submodule.quotEquivOfEq _ _ h).toAddEquiv.trans
+      (Int.quotientSpanNatEquivZMod a).toAddEquiv)⟩
+  · exact Problem_8_2_7_i_ext_one a c ha hc
+
+/-! ### The assembled answers -/
+
+variable {M N : Type} [AddCommGroup M] [AddCommGroup N]
+
+/-- **Problem 8.2.7(i), higher `Ext`.** `Extⁱ(M, N) = 0` for `i ≥ 2`, for `M` a finitely generated
+abelian group and `N` an *arbitrary* one: every finitely generated abelian group has projective
+dimension `≤ 1` (`Etingof.fg_hasProjectiveDimensionLT_two`). -/
+theorem Problem_8_2_7_i_ext_fg_vanish [Module.Finite ℤ M] (Z : ModuleCat.{0} ℤ) (n : ℕ) :
+    Subsingleton (Etingof.Ext (ModuleCat.of ℤ M) Z (n + 2)) := by
+  haveI := fg_hasProjectiveDimensionLT_two ℤ M
+  exact HasProjectiveDimensionLT.subsingleton (ModuleCat.of ℤ M) 2 (n + 2) (by omega) Z
+
+/-- **Problem 8.2.7(i), `Ext¹`, coordinate-free form.** `Ext¹(M, N) ≅ Π i, N / aᵢN`, where the
+`aᵢ` are the torsion generators of a decomposition of `M`. `N` is arbitrary — it need not be
+finitely generated, since only `M` is decomposed. -/
+theorem Problem_8_2_7_i_ext_one_intrinsic (D : PIDDecomposition ℤ M) (hD : ∀ i, D.gen i ≠ 0) :
+    Nonempty (Etingof.Ext (ModuleCat.of ℤ M) (ModuleCat.of ℤ N) 1 ≃+
+      ∀ i : D.torsionIndex,
+        (N ⧸ Ideal.span {((D.gen i).natAbs : ℤ)} • (⊤ : Submodule ℤ N))) := by
+  -- Split off the free summands of `M`, on which `Ext¹` vanishes.
+  haveI : ∀ i : Fin D.freeRank,
+      Subsingleton (Etingof.Ext (D.summand (Sum.inl i)) (ModuleCat.of ℤ N) 1) := fun _ =>
+    Problem_8_2_7_i_ext_free_vanish (ModuleCat.of ℤ N) 0
+  haveI := subsingleton_pi fun i : Fin D.freeRank =>
+    Etingof.Ext (D.summand (Sum.inl i)) (ModuleCat.of ℤ N) 1
+  -- On a torsion summand `ℤ/aᵢ`, `Ext¹(ℤ/aᵢ, N)` is the cokernel of multiplication by `aᵢ`.
+  refine ⟨(extFstDecompositionAddEquiv D (ModuleCat.of ℤ N) 1).trans
+    (((piSumAddEquiv _).trans (subsingletonProdAddEquiv _ _)).trans
+      (AddEquiv.piCongrRight fun i => ?_))⟩
+  have hne : (D.gen i).natAbs ≠ 0 := Int.natAbs_ne_zero.mpr (hD i)
+  exact (extCongr (intSummandIso D (Sum.inr i)) (Iso.refl _) 1).trans
+    (ext_one_zmod_quotSMul (D.gen i).natAbs hne N).some
+
+/-- **Problem 8.2.7(i), `Ext¹`.** `Ext¹(M, N) ≅ ⨁_{i, l} ℤ/gcd(aᵢ, c_l)` for finitely generated
+abelian groups `M`, `N`: the product runs over the torsion summands `ℤ/aᵢ` of `M` and over **all**
+summands of `N`, the free ones contributing `c_l = 0` and hence `ℤ/gcd(aᵢ, 0) = ℤ/aᵢ`. So in the
+notation of the exercise, with `N ≅ ℤ^q ⊕ ⨁_l ℤ/b_l`,
+`Ext¹(M, N) ≅ (⨁_{i,l} ℤ/gcd(aᵢ, b_l)) ⊕ (⨁_i ℤ/aᵢ)^q`. -/
+theorem Problem_8_2_7_i_ext_one_fg (D : PIDDecomposition ℤ M) (E : PIDDecomposition ℤ N)
+    (hD : ∀ i, D.gen i ≠ 0) :
+    Nonempty (Etingof.Ext (ModuleCat.of ℤ M) (ModuleCat.of ℤ N) 1 ≃+
+      ∀ (i : D.torsionIndex) (l : E.index),
+        ZMod (Nat.gcd (D.gen i).natAbs (E.genOf l).natAbs)) := by
+  haveI : ∀ i : Fin D.freeRank,
+      Subsingleton (Etingof.Ext (D.summand (Sum.inl i)) (ModuleCat.of ℤ N) 1) := fun _ =>
+    Problem_8_2_7_i_ext_free_vanish (ModuleCat.of ℤ N) 0
+  haveI := subsingleton_pi fun i : Fin D.freeRank =>
+    Etingof.Ext (D.summand (Sum.inl i)) (ModuleCat.of ℤ N) 1
+  refine ⟨(extFstDecompositionAddEquiv D (ModuleCat.of ℤ N) 1).trans
+    (((piSumAddEquiv _).trans (subsingletonProdAddEquiv _ _)).trans
+      (AddEquiv.piCongrRight fun i => ?_))⟩
+  have hne : (D.gen i).natAbs ≠ 0 := Int.natAbs_ne_zero.mpr (hD i)
+  -- Identify the source with `ZMod aᵢ`, then decompose the second argument.
+  refine (extCongr (intSummandIso D (Sum.inr i)) (Iso.refl _) 1).trans
+    ((extSndDecompositionAddEquiv (ModuleCat.of ℤ (ZMod (D.gen i).natAbs)) E 1).trans
+      (AddEquiv.piCongrRight fun l => ?_))
+  exact (extCongr (Iso.refl _) (intSummandIso E l) 1).trans
+    (Problem_8_2_7_i_ext_one_cyclic (D.gen i).natAbs (E.genOf l).natAbs hne).some
+
+/-- **Problem 8.2.7(i), `Ext⁰`.** `Ext⁰(M, N) = Hom(M, N) ≅ N^p ⊕ ⨁_{i,l} ℤ/gcd(aᵢ, b_l)`, where
+`p` is the free rank of `M`, the `aᵢ` are the torsion generators of `M` and the `b_l` those of `N`.
+Unlike in degree `1`, the free summands of `N` do *not* contribute to the torsion block:
+`Hom(ℤ/aᵢ, ℤ) = 0` (`Problem_8_2_7_i_ext_cyclic_free_zero`); their contribution is inside the `N^p`
+factor coming from `Hom(ℤ, N) ≅ N`. -/
+theorem Problem_8_2_7_i_ext_zero_fg (D : PIDDecomposition ℤ M) (E : PIDDecomposition ℤ N)
+    (hD : ∀ i, D.gen i ≠ 0) (hE : ∀ l, E.gen l ≠ 0) :
+    Nonempty (Etingof.Ext (ModuleCat.of ℤ M) (ModuleCat.of ℤ N) 0 ≃+
+      (Fin D.freeRank → N) ×
+        ∀ (i : D.torsionIndex) (l : E.torsionIndex),
+          ZMod (Nat.gcd (D.gen i).natAbs (E.gen l).natAbs)) := by
+  refine ⟨(extFstDecompositionAddEquiv D (ModuleCat.of ℤ N) 0).trans
+    ((piSumAddEquiv _).trans (AddEquiv.prodCongr (AddEquiv.piCongrRight fun _ => ?_)
+      (AddEquiv.piCongrRight fun i => ?_)))⟩
+  · -- free summand of `M`: `Hom(ℤ, N) ≅ N`
+    exact (Problem_8_2_7_i_ext_free_zero (ModuleCat.of ℤ N)).some
+  · -- torsion summand `ℤ/aᵢ` of `M`: decompose `N` and drop the free block
+    have hne : (D.gen i).natAbs ≠ 0 := Int.natAbs_ne_zero.mpr (hD i)
+    haveI : NeZero (D.gen i).natAbs := ⟨hne⟩
+    haveI : ∀ l : Fin E.freeRank,
+        Subsingleton (Etingof.Ext (ModuleCat.of ℤ (ZMod (D.gen i).natAbs))
+          (E.summand (Sum.inl l)) 0) := fun _ =>
+      Problem_8_2_7_i_ext_cyclic_free_zero (D.gen i).natAbs hne
+    haveI := subsingleton_pi fun l : Fin E.freeRank =>
+      Etingof.Ext (ModuleCat.of ℤ (ZMod (D.gen i).natAbs)) (E.summand (Sum.inl l)) 0
+    refine (extCongr (intSummandIso D (Sum.inr i)) (Iso.refl _) 0).trans
+      ((extSndDecompositionAddEquiv (ModuleCat.of ℤ (ZMod (D.gen i).natAbs)) E 0).trans
+        (((piSumAddEquiv _).trans (subsingletonProdAddEquiv _ _)).trans
+          (AddEquiv.piCongrRight fun l => ?_)))
+    exact (extCongr (Iso.refl _) (intSummandIso E (Sum.inr l)) 0).trans
+      (Problem_8_2_7_i_ext_zero (D.gen i).natAbs (E.gen l).natAbs hne
+        (Int.natAbs_ne_zero.mpr (hE l))).some
+
+/-- **Problem 8.2.7(i), packaged.** For any two finitely generated abelian groups `M`, `N` there
+are decompositions `M ≅ ℤ^p ⊕ ⨁ᵢ ℤ/aᵢ` and `N ≅ ℤ^q ⊕ ⨁_l ℤ/b_l` (with all `aᵢ`, `b_l` nonzero)
+for which
+
+* `Ext⁰(M, N) = Hom(M, N) ≅ N^p ⊕ ⨁_{i,l} ℤ/gcd(aᵢ, b_l)`,
+* `Ext¹(M, N) ≅ ⨁_{i} ⨁_{l ∈ all summands of N} ℤ/gcd(aᵢ, c_l)`
+  `= (⨁_{i,l} ℤ/gcd(aᵢ, b_l)) ⊕ (⨁ᵢ ℤ/aᵢ)^q`,
+* `Extⁱ(M, N) = 0` for `i ≥ 2`.
+
+This is the answer the exercise asks for. -/
+theorem Problem_8_2_7_i_ext_fg [Module.Finite ℤ M] [Module.Finite ℤ N] :
+    ∃ (D : PIDDecomposition ℤ M) (E : PIDDecomposition ℤ N),
+      Nonempty (Etingof.Ext (ModuleCat.of ℤ M) (ModuleCat.of ℤ N) 0 ≃+
+        (Fin D.freeRank → N) ×
+          ∀ (i : D.torsionIndex) (l : E.torsionIndex),
+            ZMod (Nat.gcd (D.gen i).natAbs (E.gen l).natAbs)) ∧
+      Nonempty (Etingof.Ext (ModuleCat.of ℤ M) (ModuleCat.of ℤ N) 1 ≃+
+        ∀ (i : D.torsionIndex) (l : E.index),
+          ZMod (Nat.gcd (D.gen i).natAbs (E.genOf l).natAbs)) ∧
+      ∀ n : ℕ, Subsingleton (Etingof.Ext (ModuleCat.of ℤ M) (ModuleCat.of ℤ N) (n + 2)) := by
+  obtain ⟨D, hD⟩ := exists_pidDecomposition_gen_ne_zero ℤ M
+  obtain ⟨E, hE⟩ := exists_pidDecomposition_gen_ne_zero ℤ N
+  exact ⟨D, E, Problem_8_2_7_i_ext_zero_fg D E hD hE, Problem_8_2_7_i_ext_one_fg D E hD,
+    fun n => Problem_8_2_7_i_ext_fg_vanish (ModuleCat.of ℤ N) n⟩
+
+/-! ### Non-vacuity checks
+
+The summand-level degree-`1` formula gives `Ext¹(ℤ/6, ℤ/4) ≅ ℤ/2` and, at a free second argument,
+`Ext¹(ℤ/6, ℤ) ≅ ℤ/6` (`ZMod 0 = ℤ`, `gcd 6 0 = 6`); and the packaged endpoint elaborates for a
+concrete pair of finitely generated groups, so its hypotheses are satisfiable. -/
+
+section Examples
+
+example : Nonempty (Etingof.Ext (ModuleCat.of ℤ (ZMod 6)) (ModuleCat.of ℤ (ZMod 4)) 1
+    ≃+ ZMod 2) := by
+  have h := Problem_8_2_7_i_ext_one_cyclic 6 4 (by norm_num)
+  rwa [show Nat.gcd 6 4 = 2 from by norm_num] at h
+
+example : Nonempty (Etingof.Ext (ModuleCat.of ℤ (ZMod 6)) (ModuleCat.of ℤ (ZMod 0)) 1
+    ≃+ ZMod 6) := by
+  have h := Problem_8_2_7_i_ext_one_cyclic 6 0 (by norm_num)
+  rwa [Nat.gcd_zero_right] at h
+
+example : True := by
+  have := Problem_8_2_7_i_ext_fg (M := ZMod 6) (N := ℤ × ZMod 4)
+  trivial
+
+end Examples
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_7_ExtPoly.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_7_ExtPoly.lean
@@ -1,0 +1,170 @@
+import EtingofRepresentationTheory.Chapter8.Problem8_2_7_ExtFG
+
+/-!
+# Problem 8.2.7(ii): `Extⁱ(M, N)` for arbitrary finitely generated `k[x]`-modules
+
+This is the `k[x]` counterpart of `Problem8_2_7_ExtInt.lean`. `Problem8_2_7.lean` computes `Extⁱ`
+for a pair of cyclic `k[x]`-modules and for a free generator, `Problem8_2_7_ExtFG.lean` reduces the
+general case to those building blocks, and this file fills in the summand table over `k[x]` and
+assembles the answer for **arbitrary** finitely generated `M`, `N`.
+
+## The summand table
+
+Every summand of a decomposition is `k[x] ⧸ (d)` (`Etingof.PIDDecomposition.summandIso`), the free
+ones being `d = 0`. Writing `f` for the first argument's generator and `g` for the second's, and
+`(f, g)` for the sum ideal `(f) ⊔ (g)` (which is `(gcd f g)`, since `k[x]` is a PID):
+
+| | `Ext⁰` | `Ext¹` | `Extⁿ⁺²` |
+|---|---|---|---|
+| `f = 0` (free) | `k[x] ⧸ (g)` | `0` | `0` |
+| `f ≠ 0`, `g = 0` | `0` | `k[x] ⧸ (f)` | `0` |
+| `f ≠ 0`, `g ≠ 0` | `k[x] ⧸ (f, g)` | `k[x] ⧸ (f, g)` | `0` |
+
+As over `ℤ`, the degree-`1` column is a *single* formula `k[x] ⧸ (f, g)` for `f ≠ 0` — indeed
+`Problem_8_2_7_ii_ext_one` already has no hypothesis on `g`, since `(f, 0) = (f)`. In degree `0` the
+entry at `f ≠ 0`, `g = 0` breaks the pattern: `Hom(k[x] ⧸ (f), k[x]) = 0` while `(f, 0) = (f)`.
+
+## Main results
+
+* `Etingof.Problem_8_2_7_ii_ext_zero_fg`:
+  `Hom(M, N) = Ext⁰(M, N) ≅ N^p ⊕ ⨁_{i,l} k[x] ⧸ (fᵢ, g_l)`.
+* `Etingof.Problem_8_2_7_ii_ext_one_fg`:
+  `Ext¹(M, N) ≅ ⨁_{i,l} k[x] ⧸ (fᵢ, g_l)`, the product running over the torsion summands of `M` and
+  **all** summands of `N` (the free ones contributing `k[x] ⧸ (fᵢ)`).
+* `Etingof.Problem_8_2_7_ii_ext_fg_vanish`: `Extⁱ(M, N) = 0` for `i ≥ 2`, `N` arbitrary.
+* `Etingof.Problem_8_2_7_ii_ext_fg`: the three answers packaged with the existence of suitable
+  decompositions.
+-/
+
+universe u
+
+namespace Etingof
+
+open CategoryTheory Limits Polynomial
+
+variable {k : Type u} [Field k]
+
+/-! ### The summand table -/
+
+/-- `Ext⁰(k[x], Z) = Hom(k[x], Z) ≅ Z`: the degree-`0` value at a free summand of `M`. -/
+theorem Problem_8_2_7_ii_ext_free_zero (Z : ModuleCat.{u} k[X]) :
+    Nonempty (Etingof.Ext (ModuleCat.of k[X] k[X]) Z 0 ≃+ Z) := by
+  obtain ⟨e⟩ := Problem_8_2_6_i_ext k[X] (ModuleCat.of k[X] k[X]) Z
+  exact ⟨e.trans (ModuleCat.homAddEquiv.trans (homSelfAddEquiv k[X] Z))⟩
+
+/-- `Hom_{k[x]}(k[x] ⧸ (f), k[x]) = 0` for `f ≠ 0`: a torsion module has no nonzero map to a
+torsion-free one. A map `ψ` is determined by `ψ [1]`, and `f • ψ [1] = ψ [f] = 0` forces
+`ψ [1] = 0` because `k[x]` is a domain. -/
+lemma subsingleton_hom_polyQuot_self (f : k[X]) (hf : f ≠ 0) :
+    Subsingleton ((k[X] ⧸ Ideal.span {f}) →ₗ[k[X]] k[X]) := by
+  have hzero : ∀ ψ : (k[X] ⧸ Ideal.span {f}) →ₗ[k[X]] k[X], ψ = 0 := by
+    intro ψ
+    have h1 : ψ (Submodule.Quotient.mk (1 : k[X])) = 0 := by
+      have hf1 : f • ψ (Submodule.Quotient.mk (1 : k[X])) = 0 := by
+        rw [← map_smul, ← Submodule.Quotient.mk_smul, smul_eq_mul, mul_one,
+          (Submodule.Quotient.mk_eq_zero _).2 (Ideal.mem_span_singleton_self f), map_zero]
+      exact (smul_eq_zero.mp hf1).resolve_left hf
+    refine LinearMap.ext fun x => ?_
+    obtain ⟨y, rfl⟩ := Submodule.Quotient.mk_surjective (Ideal.span {f}) x
+    rw [show (Submodule.Quotient.mk y : k[X] ⧸ Ideal.span {f})
+          = y • Submodule.Quotient.mk (1 : k[X]) from by
+        rw [← Submodule.Quotient.mk_smul, smul_eq_mul, mul_one], map_smul, h1, smul_zero,
+      LinearMap.zero_apply]
+  exact ⟨fun ψ φ => by rw [hzero ψ, hzero φ]⟩
+
+/-- `Ext⁰(k[x] ⧸ (f), k[x]) = 0` for `f ≠ 0`: the degree-`0` value at a torsion summand of `M`
+paired with a *free* summand of `N`. This is the one entry of the table where the uniform
+`k[x] ⧸ (f, g)` answer fails. -/
+theorem Problem_8_2_7_ii_ext_cyclic_free_zero (f : k[X]) (hf : f ≠ 0) :
+    Subsingleton (Etingof.Ext (ModuleCat.of k[X] (k[X] ⧸ Ideal.span {f}))
+      (ModuleCat.of k[X] k[X]) 0) := by
+  haveI := subsingleton_hom_polyQuot_self f hf
+  obtain ⟨e⟩ := Problem_8_2_6_i_ext k[X] (ModuleCat.of k[X] (k[X] ⧸ Ideal.span {f}))
+    (ModuleCat.of k[X] k[X])
+  exact (e.trans ModuleCat.homAddEquiv).toEquiv.subsingleton
+
+/-! ### The assembled answers -/
+
+variable {M N : Type u} [AddCommGroup M] [Module k[X] M] [AddCommGroup N] [Module k[X] N]
+
+/-- **Problem 8.2.7(ii), higher `Ext`.** `Extⁱ(M, N) = 0` for `i ≥ 2`, for `M` a finitely generated
+`k[x]`-module and `N` an *arbitrary* one: `k[x]` is a PID, so every finitely generated module has
+projective dimension `≤ 1` (`Etingof.fg_hasProjectiveDimensionLT_two`). -/
+theorem Problem_8_2_7_ii_ext_fg_vanish [Module.Finite k[X] M] (Z : ModuleCat.{u} k[X]) (n : ℕ) :
+    Subsingleton (Etingof.Ext (ModuleCat.of k[X] M) Z (n + 2)) := by
+  haveI := fg_hasProjectiveDimensionLT_two k[X] M
+  exact HasProjectiveDimensionLT.subsingleton (ModuleCat.of k[X] M) 2 (n + 2) (by omega) Z
+
+/-- **Problem 8.2.7(ii), `Ext¹`.** `Ext¹(M, N) ≅ ⨁_{i,l} k[x] ⧸ (fᵢ, g_l)`, the product running
+over the torsion summands `k[x] ⧸ (fᵢ)` of `M` and over **all** summands of `N`, the free ones
+having `g_l = 0` and hence contributing `k[x] ⧸ (fᵢ, 0) = k[x] ⧸ (fᵢ)`. -/
+theorem Problem_8_2_7_ii_ext_one_fg (D : PIDDecomposition k[X] M) (E : PIDDecomposition k[X] N)
+    (hD : ∀ i, D.gen i ≠ 0) :
+    Nonempty (Etingof.Ext (ModuleCat.of k[X] M) (ModuleCat.of k[X] N) 1 ≃+
+      ∀ (i : D.torsionIndex) (l : E.index), (k[X] ⧸ Ideal.span {D.gen i, E.genOf l})) := by
+  haveI : ∀ i : Fin D.freeRank,
+      Subsingleton (Etingof.Ext (D.summand (Sum.inl i)) (ModuleCat.of k[X] N) 1) := fun _ =>
+    Problem_8_2_7_ii_ext_free_vanish k (ModuleCat.of k[X] N) 0
+  haveI := subsingleton_pi fun i : Fin D.freeRank =>
+    Etingof.Ext (D.summand (Sum.inl i)) (ModuleCat.of k[X] N) 1
+  refine ⟨(extFstDecompositionAddEquiv D (ModuleCat.of k[X] N) 1).trans
+    (((piSumAddEquiv _).trans (subsingletonProdAddEquiv _ _)).trans
+      (AddEquiv.piCongrRight fun i => ?_))⟩
+  -- `D.summand (Sum.inr i)` *is* `k[x] ⧸ (fᵢ)`; only `N` has to be decomposed.
+  refine (extSndDecompositionAddEquiv (ModuleCat.of k[X] (k[X] ⧸ Ideal.span {D.gen i})) E 1).trans
+    (AddEquiv.piCongrRight fun l => ?_)
+  exact (extCongr (Iso.refl _) (E.summandIso l) 1).trans
+    (Problem_8_2_7_ii_ext_one k (D.gen i) (E.genOf l) (hD i)).some
+
+/-- **Problem 8.2.7(ii), `Ext⁰`.** `Ext⁰(M, N) = Hom(M, N) ≅ N^p ⊕ ⨁_{i,l} k[x] ⧸ (fᵢ, g_l)`, where
+`p` is the free rank of `M` and the `fᵢ`, `g_l` are the torsion generators of `M` and `N`. The free
+summands of `N` do not contribute to the torsion block, since
+`Hom(k[x] ⧸ (fᵢ), k[x]) = 0`; their contribution sits in the `N^p` factor. -/
+theorem Problem_8_2_7_ii_ext_zero_fg (D : PIDDecomposition k[X] M) (E : PIDDecomposition k[X] N)
+    (hD : ∀ i, D.gen i ≠ 0) (hE : ∀ l, E.gen l ≠ 0) :
+    Nonempty (Etingof.Ext (ModuleCat.of k[X] M) (ModuleCat.of k[X] N) 0 ≃+
+      (Fin D.freeRank → N) ×
+        ∀ (i : D.torsionIndex) (l : E.torsionIndex),
+          (k[X] ⧸ Ideal.span {D.gen i, E.gen l})) := by
+  refine ⟨(extFstDecompositionAddEquiv D (ModuleCat.of k[X] N) 0).trans
+    ((piSumAddEquiv _).trans (AddEquiv.prodCongr (AddEquiv.piCongrRight fun _ => ?_)
+      (AddEquiv.piCongrRight fun i => ?_)))⟩
+  · exact (Problem_8_2_7_ii_ext_free_zero (ModuleCat.of k[X] N)).some
+  · haveI : ∀ l : Fin E.freeRank,
+        Subsingleton (Etingof.Ext (ModuleCat.of k[X] (k[X] ⧸ Ideal.span {D.gen i}))
+          (E.summand (Sum.inl l)) 0) := fun _ =>
+      Problem_8_2_7_ii_ext_cyclic_free_zero (D.gen i) (hD i)
+    haveI := subsingleton_pi fun l : Fin E.freeRank =>
+      Etingof.Ext (ModuleCat.of k[X] (k[X] ⧸ Ideal.span {D.gen i})) (E.summand (Sum.inl l)) 0
+    refine (extSndDecompositionAddEquiv (ModuleCat.of k[X] (k[X] ⧸ Ideal.span {D.gen i})) E 0).trans
+      (((piSumAddEquiv _).trans (subsingletonProdAddEquiv _ _)).trans
+        (AddEquiv.piCongrRight fun l => ?_))
+    exact (Problem_8_2_7_ii_ext_zero k (D.gen i) (E.gen l) (hE l)).some
+
+/-- **Problem 8.2.7(ii), packaged.** For any two finitely generated `k[x]`-modules `M`, `N` there
+are decompositions `M ≅ k[x]^p ⊕ ⨁ᵢ k[x] ⧸ (fᵢ)` and `N ≅ k[x]^q ⊕ ⨁_l k[x] ⧸ (g_l)` (with all
+`fᵢ`, `g_l` nonzero) for which `Ext⁰`, `Ext¹` are as above and `Extⁱ = 0` for `i ≥ 2`. -/
+theorem Problem_8_2_7_ii_ext_fg [Module.Finite k[X] M] [Module.Finite k[X] N] :
+    ∃ (D : PIDDecomposition k[X] M) (E : PIDDecomposition k[X] N),
+      Nonempty (Etingof.Ext (ModuleCat.of k[X] M) (ModuleCat.of k[X] N) 0 ≃+
+        (Fin D.freeRank → N) ×
+          ∀ (i : D.torsionIndex) (l : E.torsionIndex),
+            (k[X] ⧸ Ideal.span {D.gen i, E.gen l})) ∧
+      Nonempty (Etingof.Ext (ModuleCat.of k[X] M) (ModuleCat.of k[X] N) 1 ≃+
+        ∀ (i : D.torsionIndex) (l : E.index), (k[X] ⧸ Ideal.span {D.gen i, E.genOf l})) ∧
+      ∀ n : ℕ, Subsingleton (Etingof.Ext (ModuleCat.of k[X] M) (ModuleCat.of k[X] N) (n + 2)) := by
+  obtain ⟨D, hD⟩ := exists_pidDecomposition_gen_ne_zero k[X] M
+  obtain ⟨E, hE⟩ := exists_pidDecomposition_gen_ne_zero k[X] N
+  exact ⟨D, E, Problem_8_2_7_ii_ext_zero_fg D E hD hE, Problem_8_2_7_ii_ext_one_fg D E hD,
+    fun n => Problem_8_2_7_ii_ext_fg_vanish (ModuleCat.of k[X] N) n⟩
+
+/-! ### Non-vacuity check
+
+The packaged endpoint elaborates for a concrete pair of finitely generated `ℚ[x]`-modules, so its
+hypotheses are satisfiable. -/
+
+example : True := by
+  have := Problem_8_2_7_ii_ext_fg (k := ℚ) (M := ℚ[X]) (N := ℚ[X])
+  trivial
+
+end Etingof

--- a/progress/2026-07-25T05-20-57Z_0ef4e369.md
+++ b/progress/2026-07-25T05-20-57Z_0ef4e369.md
@@ -1,0 +1,82 @@
+## Accomplished
+
+Closed #7737: `Extⁱ(M, N)` for **arbitrary** finitely generated modules over `ℤ` and `k[x]`
+(Problem 8.2.7, the `Ext` half). Three new files plus a refactor of `Problem8_2_7.lean`.
+
+`Chapter8/Problem8_2_7_ExtFG.lean` — base-ring-independent machinery, all for an arbitrary PID:
+
+* `extCongr` — transport `Ext` along isomorphisms in both variables (Mathlib has the biproduct
+  additivity but no iso-invariance lemma).
+* `extFstDecompositionAddEquiv`, `extSndDecompositionAddEquiv`, `extPIDDecompositionAddEquiv` — the
+  book's "reduce to the case of cyclic groups": `Extⁿ(M, N) ≃+ Π_{j,l} Extⁿ(summand j, summand l)`,
+  and the two one-variable forms that leave the other argument arbitrary.
+* `hasProjectiveDimensionLT_biproduct` — finite-family version of Mathlib's binary instance.
+* `cyclic_hasProjectiveDimensionLT_two`, `fg_hasProjectiveDimensionLT_two` — **every** finitely
+  generated module over a PID has projective dimension `< 2`. This gives `Extⁱ(M, N) = 0` for
+  `i ≥ 2` with `N` completely arbitrary, which is stronger than going through the reduction.
+* `PIDDecomposition.genOf` / `summandIso` — every summand is `A ⧸ (d)`, free ones having `d = 0`.
+* `exists_pidDecomposition_gen_ne_zero` — the structure theorem with prime-power (hence nonzero)
+  torsion generators, which the degree-`0` formula needs.
+
+`Chapter8/Problem8_2_7_ExtInt.lean` (part i) and `Chapter8/Problem8_2_7_ExtPoly.lean` (part ii) —
+the summand tables and the assembled answers, ending in `Problem_8_2_7_i_ext_fg` /
+`Problem_8_2_7_ii_ext_fg`, which package all three degrees with the existence of suitable
+decompositions.
+
+### Two things worth recording
+
+**The degree-`1` answer is uniform, the degree-`0` answer is not.** With `c = 0` standing for a free
+summand of `N`, `Ext¹(ℤ/a, ℤ/c) ≅ ℤ/gcd(a, c)` holds for *every* `c` including `0`, because
+`gcd a 0 = a` and `ℤ/0 = ℤ`. So `Problem_8_2_7_i_ext_one_fg` has a single product over all summands
+of `N` with no case split, and the exercise's `(⨁ᵢ ℤ/aᵢ)^q` block is just the free-`l` part of it.
+Degree `0` genuinely breaks: `Hom(ℤ/a, ℤ) = 0` while `gcd a 0 = a ≠ 0`, so the free summands of `N`
+are excluded from the torsion block and appear instead in the `N^p` factor via `Hom(ℤ, N) ≅ N`.
+Same story over `k[x]` with `(f, g) = (f) ⊔ (g)` in place of `gcd`; there
+`Problem_8_2_7_ii_ext_one` already had no hypothesis on `g`, so it was usable as-is.
+
+**Generalizing beat duplicating.** The `ℤ` degree-`1` value at a free summand of `N`
+(`Ext¹(ℤ/a, ℤ) ≅ ℤ/a`) was not among the existing building blocks, and the existing
+`Problem_8_2_7_i_ext_one` needed `b ≠ 0` — but *only* for the final `ZModGcd.zmodCokerEquiv` step.
+Rather than copy the 100-line six-term-sequence argument, I generalized its target from `ZMod b` to
+an arbitrary abelian group `Y`, giving `Etingof.ext_one_zmod_quotSMul`:
+`Ext¹(ℤ/a, Y) ≅ Y / aY` for any `Y`. `Problem_8_2_7_i_ext_one` is now a three-line corollary with
+its statement unchanged, and the free case is the instance `Y = ℤ`. The same generalization applied
+to `ZModGcd.homToKer` and `mulByCast`/`mulBy`. This also yielded a bonus endpoint,
+`Problem_8_2_7_i_ext_one_intrinsic`: `Ext¹(M, N) ≅ Π i, N / aᵢN` for `M` finitely generated and `N`
+**arbitrary**.
+
+## Current frontier
+
+`lake build` is clean: 9283 jobs, exit 0, zero `error:`, zero `declaration uses 'sorry'`. All new
+endpoints depend only on `propext`, `Classical.choice`, `Quot.sound` (checked with
+`#print axioms`). Non-vacuity is checked in-file: `Ext¹(ℤ/6, ℤ/4) ≅ ℤ/2`, `Ext¹(ℤ/6, ℤ) ≅ ℤ/6`, and
+the packaged endpoints elaborate for concrete pairs (`ZMod 6`, `ℤ × ZMod 4` over `ℤ`; `ℚ[X]` over
+`ℚ[X]`).
+
+`progress/items.json`: `Chapter8/Problem8.2.7` stays `covered_partial` with an updated coverage note
+and file list — per the issue, it may only be marked fully covered once the `Tor` half (#7738) lands
+too.
+
+## Overall project progress
+
+Stage 3 formalization. This turn completes the `Ext` half of Problem 8.2.7 for arbitrary finitely
+generated modules, one of the two halves of #7381.
+
+## Next step
+
+#7738 (`Tor` for arbitrary finitely generated modules over `ℤ` and `k[x]`) is the direct successor
+and is now unblocked in substance: it can reuse `PIDDecomposition.genOf`/`summandIso`,
+`piSumAddEquiv`, `subsingletonProdAddEquiv` and `exists_pidDecomposition_gen_ne_zero` from
+`Problem8_2_7_ExtFG.lean`, and the additivity of `Tor` in both arguments already sits in
+`Chapter8/Additivity.lean` (`torBiproductIso`, `torPiIso`). Note the extra wrinkle on the `Tor` side:
+its first argument is a *right* module, so the decomposition has to be transported into
+`ModuleCat k[X]ᵐᵒᵖ` via `PIDDecomposition.mopBiproductIso`. Once it lands, flip
+`Chapter8/Problem8.2.7` to `covered_full` in `progress/items.json`.
+
+A smaller optional follow-up: `Problem_8_2_7_ii_ext_one` could be generalized to an arbitrary target
+module the way `ext_one_zmod_quotSMul` generalizes the `ℤ` case, which would give the `k[x]`
+counterpart of `Problem_8_2_7_i_ext_one_intrinsic`. Not needed for the exercise.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -9206,13 +9206,18 @@
     "start_line": 23,
     "end_line": 26,
     "status": "sorry_free",
-    "coverage_note": "Partially formalized in EtingofRepresentationTheory/Chapter8/Problem8_2_7.lean. The file proves the cyclic-pair Tor/Ext computations and higher vanishing over Z and k[X], plus the free-generator vanishing results. It does not yet assemble those building blocks, via the structure theorem and additivity, into formulas for arbitrary finitely generated modules M and N as the exercise asks.",
+    "coverage_note": "The Ext half of the exercise is complete for arbitrary finitely generated modules. Problem8_2_7.lean has the summand-level building blocks (cyclic-pair and free-generator Tor/Ext over Z and k[X]); PIDDecomposition.lean packages the structure theorem as a biproduct decomposition; Problem8_2_7_ExtFG.lean supplies additivity of Ext along a decomposition and projective dimension < 2 for every f.g. module over a PID; Problem8_2_7_ExtInt.lean and Problem8_2_7_ExtPoly.lean assemble Ext^0, Ext^1 and the vanishing in degrees >= 2 for arbitrary f.g. M, N (Problem_8_2_7_i_ext_fg, Problem_8_2_7_ii_ext_fg). The Tor half for arbitrary f.g. modules is still open (#7738), so this item stays covered_partial.",
     "followup_issue": 7381,
     "coverage": "covered_partial",
     "lean_file": [
-      "EtingofRepresentationTheory/Chapter8/Problem8_2_7.lean"
+      "EtingofRepresentationTheory/Chapter8/Problem8_2_7.lean",
+      "EtingofRepresentationTheory/Chapter8/PIDDecomposition.lean",
+      "EtingofRepresentationTheory/Chapter8/Additivity.lean",
+      "EtingofRepresentationTheory/Chapter8/Problem8_2_7_ExtFG.lean",
+      "EtingofRepresentationTheory/Chapter8/Problem8_2_7_ExtInt.lean",
+      "EtingofRepresentationTheory/Chapter8/Problem8_2_7_ExtPoly.lean"
     ],
-    "last_updated": "2026-07-22"
+    "last_updated": "2026-07-25"
   },
   {
     "id": "Chapter8/Problem8.2.8",


### PR DESCRIPTION
This PR completes the `Ext` half of Problem 8.2.7: it computes `Extⁱ(M, N)` for arbitrary finitely generated modules over `ℤ` and over `k[x]`, not just for the free and cyclic building blocks. `Problem8_2_7_ExtFG.lean` carries out the reduction the book's hint asks for, over an arbitrary PID: `extCongr` transports `Ext` along isomorphisms in both variables, `extPIDDecompositionAddEquiv` (with one-variable forms `extFstDecompositionAddEquiv`/`extSndDecompositionAddEquiv`) turns `Extⁿ(M, N)` into the product of the `Extⁿ` groups of the summand pairs of two `PIDDecomposition`s, and `fg_hasProjectiveDimensionLT_two` shows every finitely generated module over a PID has projective dimension `< 2`, which gives `Extⁱ(M, N) = 0` for `i ≥ 2` with `N` arbitrary. `Problem8_2_7_ExtInt.lean` and `Problem8_2_7_ExtPoly.lean` fill in the summand tables and assemble the answers, ending in `Problem_8_2_7_i_ext_fg` and `Problem_8_2_7_ii_ext_fg`.

The degree-`1` answer turns out to be a single formula: with `c = 0` standing for a free summand of `N`, `Ext¹(ℤ/a, ℤ/c) ≅ ℤ/gcd(a, c)` holds for every `c` (since `gcd a 0 = a` and `ℤ/0 = ℤ`), so the exercise's `(⨁ᵢ ℤ/aᵢ)^q` block is just the free part of one product. Degree `0` genuinely breaks the pattern — `Hom(ℤ/a, ℤ) = 0` while `gcd a 0 = a` — so there the free summands of `N` sit in an `N^p` factor coming from `Hom(ℤ, N) ≅ N`.

Rather than duplicate the existing 100-line six-term-sequence argument to reach the missing free-target case, this generalizes it: `ext_one_zmod_quotSMul` computes `Ext¹(ℤ/a, Y) ≅ Y / aY` for an arbitrary abelian group `Y`, and `Problem_8_2_7_i_ext_one` becomes a three-line corollary with its statement unchanged. `ZModGcd.mulBy`/`homToKer` are generalized to arbitrary targets for the same reason, and the generalization yields `Problem_8_2_7_i_ext_one_intrinsic`: `Ext¹(M, N) ≅ Π i, N / aᵢN` for `M` finitely generated and `N` arbitrary.

`lake build` is clean (9283 jobs, no errors, no sorries); the new endpoints depend only on `propext`, `Classical.choice` and `Quot.sound`. Non-vacuity is checked in-file. `progress/items.json` keeps `Chapter8/Problem8.2.7` at `covered_partial` — per issue #7737 it may only be marked fully covered once the `Tor` half (#7738) lands.

Closes #7737

Session: \`0ef4e369-3bf7-49a3-a4c8-e42475c66c1a\`

🤖 Prepared with Claude Code