### PR TITLE
feat(Ch8 #7381): Tor for arbitrary finitely generated modules over Z and k[X]

### DIFF
--- a/EtingofRepresentationTheory/Chapter8.lean
+++ b/EtingofRepresentationTheory/Chapter8.lean
@@ -52,6 +52,9 @@ import EtingofRepresentationTheory.Chapter8.PIDDecomposition
 import EtingofRepresentationTheory.Chapter8.Problem8_2_7_ExtFG
 import EtingofRepresentationTheory.Chapter8.Problem8_2_7_ExtInt
 import EtingofRepresentationTheory.Chapter8.Problem8_2_7_ExtPoly
+import EtingofRepresentationTheory.Chapter8.Problem8_2_7_TorFG
+import EtingofRepresentationTheory.Chapter8.Problem8_2_7_TorInt
+import EtingofRepresentationTheory.Chapter8.Problem8_2_7_TorPoly
 
 /-!
 # Chapter 8: Homological Algebra

--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_7.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_7.lean
@@ -347,17 +347,23 @@ def homEquiv (a b : ℕ) [NeZero a] [NeZero b] :
     (ZMod a →ₗ[ℤ] ZMod b) ≃+ ZMod (Nat.gcd a b) :=
   (homToKer a (ZMod b)).trans (zmodKerEquiv a b).toAddEquiv
 
-/-- **`Hom_ℤ(ZMod a, ℤ) = 0`** for `a ≠ 0`: a torsion group has no nonzero map to a torsion-free
-one. This is the degree-`0` value at a torsion summand of `M` paired with a *free* summand of `N`,
-the one place where the uniform `ZMod (gcd a b)` answer fails (`gcd a 0 = a ≠ 0`). -/
-lemma subsingleton_hom_zmod_int (a : ℕ) [NeZero a] : Subsingleton (ZMod a →ₗ[ℤ] ℤ) := by
+/-- **`ℤ` is torsion-free**: the kernel of multiplication by `a ≠ 0` on `ℤ` is trivial. This is
+what makes both `Hom(ℤ/a, ℤ) = 0` and `Tor₁(ℤ/a, ℤ) = 0`, since the first is the `a`-torsion of `ℤ`
+(`Etingof.ZModGcd.homToKer`) and so is the second (`Etingof.tor_one_zmod_kerSMul`). -/
+lemma subsingleton_ker_mulBy_int (a : ℕ) [NeZero a] :
+    Subsingleton (LinearMap.ker (mulBy a ℤ)) := by
   have hker : ∀ z : LinearMap.ker (mulBy a ℤ), (z : ℤ) = 0 := by
     intro z
     have hz : (a : ℤ) • (z : ℤ) = 0 := LinearMap.mem_ker.mp z.2
     rw [smul_eq_mul, mul_eq_zero] at hz
     exact hz.resolve_left (Int.natCast_ne_zero.mpr (NeZero.ne a))
-  haveI : Subsingleton (LinearMap.ker (mulBy a ℤ)) :=
-    ⟨fun x y => Subtype.ext (by rw [hker x, hker y])⟩
+  exact ⟨fun x y => Subtype.ext (by rw [hker x, hker y])⟩
+
+/-- **`Hom_ℤ(ZMod a, ℤ) = 0`** for `a ≠ 0`: a torsion group has no nonzero map to a torsion-free
+one. This is the degree-`0` value at a torsion summand of `M` paired with a *free* summand of `N`,
+the one place where the uniform `ZMod (gcd a b)` answer fails (`gcd a 0 = a ≠ 0`). -/
+lemma subsingleton_hom_zmod_int (a : ℕ) [NeZero a] : Subsingleton (ZMod a →ₗ[ℤ] ℤ) := by
+  haveI := subsingleton_ker_mulBy_int a
   exact (homToKer a ℤ).toEquiv.subsingleton
 
 end
@@ -373,6 +379,37 @@ coincide because `ℤ` is commutative). Needed to supply `ZMod a` as a right mod
 noncomputable local instance mopZMod (a : ℕ) : Module ℤᵐᵒᵖ (ZMod a) :=
   Module.compHom (ZMod a) ((RingHom.id ℤ).fromOpposite fun x y => mul_comm x y)
 
+/-- Over the commutative base `ℤ`, the balancing subgroup of `ZMod a ⊗_ℤ N` is trivial, for any
+abelian group `N`: the right action `op r • m` on `ZMod a` *is* the left action `r • m`. -/
+private lemma balancedSubgroup_zmod_eq_bot (a : ℕ) (N : Type) [AddCommGroup N] :
+    balancedSubgroup ℤ N (ZMod a) = ⊥ := by
+  rw [balancedSubgroup]
+  apply le_antisymm _ bot_le
+  rw [AddSubgroup.closure_le]
+  rintro x ⟨r, m, n, rfl⟩
+  simp only [SetLike.mem_coe, AddSubgroup.mem_bot]
+  have hop : (MulOpposite.op r • m : ZMod a) = r • m := rfl
+  rw [hop, sub_eq_zero]
+  exact TensorProduct.smul_tmul r m n
+
+/-- **`Tor₀(ℤ/a, N) ≅ N / aN`** for an *arbitrary* abelian group `N` and every `a` (including
+`a = 0`, where `ZMod 0 = ℤ` and the right-hand side is `N`). `Tor₀` is the tensor product
+(Problem 8.2.6(i)), and `(ℤ ⧸ (a)) ⊗_ℤ N ≅ N ⧸ aN` is Mathlib's
+`TensorProduct.quotTensorEquivQuotSMul`. This is the `Tor` counterpart of
+`Etingof.ext_one_zmod_quotSMul`, and specialising `N` gives every entry of the degree-`0` row of
+the summand table for Problem 8.2.7(i). -/
+theorem tor_zero_zmod_quotSMul (a : ℕ) (N : Type) [AddCommGroup N] :
+    Nonempty (Etingof.Tor ℤ N (ModuleCat.of ℤᵐᵒᵖ (ZMod a)) 0
+      ≅ AddCommGrpCat.of (N ⧸ (Ideal.span {(a : ℤ)} • (⊤ : Submodule ℤ N)))) := by
+  obtain ⟨e₀⟩ := Problem_8_2_6_i_tor ℤ N (ModuleCat.of ℤᵐᵒᵖ (ZMod a))
+  refine ⟨e₀ ≪≫ AddEquiv.toAddCommGrpIso ?_⟩
+  let e_a : ZMod a ≃ₗ[ℤ] (ℤ ⧸ Ideal.span {(a : ℤ)}) :=
+    ((Int.quotientSpanNatEquivZMod a).symm.toAddEquiv).toIntLinearEquiv
+  exact ((QuotientAddGroup.quotientAddEquivOfEq (balancedSubgroup_zmod_eq_bot a N)).trans
+    QuotientAddGroup.quotientBot).trans
+    (((TensorProduct.congr e_a (LinearEquiv.refl ℤ N)).trans
+      (TensorProduct.quotTensorEquivQuotSMul N (Ideal.span {(a : ℤ)}))).toAddEquiv)
+
 /-- **Problem 8.2.7(i), `Tor₀`.** For finite cyclic groups `ℤ/a`, `ℤ/b` (`a, b ≠ 0`),
 `Tor₀(ℤ/a, ℤ/b) ≅ ℤ/gcd(a,b)`. (This is `ℤ/a ⊗_ℤ ℤ/b`, Problem 8.2.6(i).) -/
 theorem Problem_8_2_7_i_tor_zero (a b : ℕ) (ha : a ≠ 0) (hb : b ≠ 0) :
@@ -383,18 +420,8 @@ theorem Problem_8_2_7_i_tor_zero (a b : ℕ) (ha : a ≠ 0) (hb : b ≠ 0) :
   -- `Tor₀ ≅ ZMod a ⊗_ℤ ZMod b`, and the latter is `ZMod (gcd a b)`.
   obtain ⟨e₀⟩ := Problem_8_2_6_i_tor ℤ (ZMod b) (ModuleCat.of ℤᵐᵒᵖ (ZMod a))
   refine ⟨e₀ ≪≫ AddEquiv.toAddCommGrpIso ?_⟩
-  -- the balancing subgroup is trivial over the commutative base `ℤ`
-  have hbot : balancedSubgroup ℤ (ZMod b) (ZMod a) = ⊥ := by
-    rw [balancedSubgroup]
-    apply le_antisymm _ bot_le
-    rw [AddSubgroup.closure_le]
-    rintro x ⟨r, m, n, rfl⟩
-    simp only [SetLike.mem_coe, AddSubgroup.mem_bot]
-    have hop : (MulOpposite.op r • m : ZMod a) = r • m := rfl
-    rw [hop, sub_eq_zero]
-    exact TensorProduct.smul_tmul r m n
-  exact ((QuotientAddGroup.quotientAddEquivOfEq hbot).trans QuotientAddGroup.quotientBot).trans
-    (ZModGcd.tensorEquiv a b).toAddEquiv
+  exact ((QuotientAddGroup.quotientAddEquivOfEq (balancedSubgroup_zmod_eq_bot a (ZMod b))).trans
+    QuotientAddGroup.quotientBot).trans (ZModGcd.tensorEquiv a b).toAddEquiv
 
 /-! ### The degree-`0` tensor `ℤ ⊗_ℤ N ≅ N`, for the `Tor₁` connecting-map identification
 
@@ -431,13 +458,19 @@ open scoped TensorProduct in
   rfl
 
 open scoped TensorProduct in
-/-- **Problem 8.2.7(i), `Tor₁`.** For finite cyclic groups `ℤ/a`, `ℤ/b` (`a, b ≠ 0`),
-`Tor₁(ℤ/a, ℤ/b) ≅ ℤ/gcd(a,b)`. -/
-theorem Problem_8_2_7_i_tor_one (a b : ℕ) (ha : a ≠ 0) (hb : b ≠ 0) :
-    Nonempty (Etingof.Tor ℤ (ZMod b) (ModuleCat.of ℤᵐᵒᵖ (ZMod a)) 1
-      ≅ AddCommGrpCat.of (ZMod (Nat.gcd a b))) := by
+/-- **`Tor₁(ℤ/a, N)` is the `a`-torsion of `N`**, i.e. the kernel of multiplication by `a`, for
+`a ≠ 0` and an *arbitrary* abelian group `N`. This is read off the length-`1` free resolution
+`0 → ℤ →(·a) ℤ → ℤ/a → 0` through the six-term sequence: `Tor₁` is the kernel of the map induced
+on `Tor₀(ℤ, N) = ℤ ⊗_ℤ N ≅ N`, which is multiplication by `a`.
+
+This is the exact `Tor` mirror of `Etingof.ext_one_zmod_quotSMul` (`Ext¹(ℤ/a, N) ≅ N / aN`):
+`Ext¹` is the cokernel of `·a`, `Tor₁` its kernel. Specialising `N` gives the degree-`1` row of the
+summand table for Problem 8.2.7(i) — `N = ZMod b` gives `ℤ/gcd(a, b)`
+(`Problem_8_2_7_i_tor_one`), and `N = ℤ` gives `0`, since `ℤ` is torsion-free. -/
+theorem tor_one_zmod_kerSMul (a : ℕ) (ha : a ≠ 0) (N : Type) [AddCommGroup N] :
+    Nonempty (Etingof.Tor ℤ N (ModuleCat.of ℤᵐᵒᵖ (ZMod a)) 1
+      ≅ AddCommGrpCat.of (LinearMap.ker (ZModGcd.mulBy a N))) := by
   haveI : NeZero a := ⟨ha⟩
-  haveI : NeZero b := ⟨hb⟩
   have ha' : (a : ℤ) ≠ 0 := by exact_mod_cast ha
   -- Length-`1` resolution `0 → ℤ →(·a) ℤ → ℤ/a → 0` over `ℤᵐᵒᵖ`, inline for access to `S.f`.
   let f : ℤ →ₗ[ℤᵐᵒᵖ] ℤ :=
@@ -472,7 +505,7 @@ theorem Problem_8_2_7_i_tor_one (a b : ℕ) (ha : a ≠ 0) (hb : b ≠ 0) :
     intro z; obtain ⟨y, rfl⟩ := ZMod.intCast_surjective z; exact ⟨y, rfl⟩
   set S := ModuleCat.shortComplexOfCompEqZero f g eq0 with hSdef
   have hS : S.ShortExact := ModuleCat.shortComplex_shortExact S hexact hinjf hsurjg
-  set F := tensorRightFunctor ℤ (ZMod b) with hF
+  set F := tensorRightFunctor ℤ N with hF
   -- Six-term window `0 = L₁X₁ → 0 = L₁X₂ → Tor₁ →[δ] Tor₀ℤ →[φ] Tor₀ℤ → …`.
   obtain ⟨δ, hExact⟩ := Etingof.Functor.leftDerived_sixTerm_exact F hS 0 1 rfl
   let φ : (F.leftDerived 0).obj S.X₁ ⟶ (F.leftDerived 0).obj S.X₂ := (F.leftDerived 0).map S.f
@@ -486,50 +519,50 @@ theorem Problem_8_2_7_i_tor_one (a b : ℕ) (ha : a ≠ 0) (hb : b ≠ 0) :
   -- Exactness at `Tor₀ℤ`: `range δ = ker φ`.
   have hrk : δ.hom.range = φ.hom.ker := (hExact.exact' 2 3 4).ab_range_eq_ker
   have hcompl : δ ≫ φ = 0 := hExact.toIsComplex.zero' 2 3 4
-  -- `Tor₀(ℤ) = ℤ ⊗_ℤ (ZMod b) ≅ ZMod b`, natural in the argument (`leftDerivedZeroIsoSelf`).
+  -- `Tor₀(ℤ) = ℤ ⊗_ℤ N ≅ N`, natural in the argument (`leftDerivedZeroIsoSelf`).
   let ζ := F.leftDerivedZeroIsoSelf
-  let τ₁ : ((F.leftDerived 0).obj S.X₁) ≃+ ZMod b :=
-    (ζ.app S.X₁).addCommGroupIsoToAddEquiv.trans (intTensorOverEquiv (ZMod b))
-  let τ₂ : ((F.leftDerived 0).obj S.X₂) ≃+ ZMod b :=
-    (ζ.app S.X₂).addCommGroupIsoToAddEquiv.trans (intTensorOverEquiv (ZMod b))
+  let τ₁ : ((F.leftDerived 0).obj S.X₁) ≃+ N :=
+    (ζ.app S.X₁).addCommGroupIsoToAddEquiv.trans (intTensorOverEquiv N)
+  let τ₂ : ((F.leftDerived 0).obj S.X₂) ≃+ N :=
+    (ζ.app S.X₂).addCommGroupIsoToAddEquiv.trans (intTensorOverEquiv N)
   -- The induced map `φ` on `Tor₀(ℤ)` is multiplication by `a`.
-  have key : ∀ w : tensorOver ℤ (ZMod b) S.X₁,
-      intTensorOverEquiv (ZMod b) (tensorRightMap ℤ (ZMod b) S.f w)
-        = ZModGcd.mulByCast a b (intTensorOverEquiv (ZMod b) w) := by
+  have key : ∀ w : tensorOver ℤ N S.X₁,
+      intTensorOverEquiv N (tensorRightMap ℤ N S.f w)
+        = ZModGcd.mulBy a N (intTensorOverEquiv N w) := by
     intro w
     induction w using QuotientAddGroup.induction_on with
     | _ y =>
       induction y using TensorProduct.induction_on with
       | zero => simp
       | tmul m n =>
-        change intTensorOverEquiv (ZMod b)
-            (tensorRightMap ℤ (ZMod b) S.f (TensorProduct.tmul ℤ m n : tensorOver ℤ (ZMod b) S.X₁))
-          = ZModGcd.mulByCast a b
-            (intTensorOverEquiv (ZMod b) (TensorProduct.tmul ℤ m n : tensorOver ℤ (ZMod b) S.X₁))
-        rw [show tensorRightMap ℤ (ZMod b) S.f
-              (TensorProduct.tmul ℤ m n : tensorOver ℤ (ZMod b) S.X₁)
-            = (TensorProduct.tmul ℤ (S.f.hom m) n : tensorOver ℤ (ZMod b) S.X₂) from rfl,
-          intTensorOverEquiv_mk, intTensorOverEquiv_mk, ZModGcd.mulByCast_apply, smul_smul]
+        change intTensorOverEquiv N
+            (tensorRightMap ℤ N S.f (TensorProduct.tmul ℤ m n : tensorOver ℤ N S.X₁))
+          = ZModGcd.mulBy a N
+            (intTensorOverEquiv N (TensorProduct.tmul ℤ m n : tensorOver ℤ N S.X₁))
+        rw [show tensorRightMap ℤ N S.f
+              (TensorProduct.tmul ℤ m n : tensorOver ℤ N S.X₁)
+            = (TensorProduct.tmul ℤ (S.f.hom m) n : tensorOver ℤ N S.X₂) from rfl,
+          intTensorOverEquiv_mk, intTensorOverEquiv_mk, ZModGcd.mulBy_apply, smul_smul]
         rfl
       | add p q hp hq =>
-        rw [show ((p + q : TensorProduct ℤ S.X₁ (ZMod b)) : tensorOver ℤ (ZMod b) S.X₁)
-              = ((p : tensorOver ℤ (ZMod b) S.X₁) + (q : tensorOver ℤ (ZMod b) S.X₁))
+        rw [show ((p + q : TensorProduct ℤ S.X₁ N) : tensorOver ℤ N S.X₁)
+              = ((p : tensorOver ℤ N S.X₁) + (q : tensorOver ℤ N S.X₁))
             from map_add (QuotientAddGroup.mk' _) p q,
           map_add, map_add, map_add, map_add, hp, hq]
-  have hconj : ∀ x, τ₂ (φ.hom x) = ZModGcd.mulByCast a b (τ₁ x) := by
+  have hconj : ∀ x, τ₂ (φ.hom x) = ZModGcd.mulBy a N (τ₁ x) := by
     intro x
     have hn := congrArg (fun (m : (F.leftDerived 0).obj S.X₁ ⟶ F.obj S.X₂) => m.hom x)
       (ζ.hom.naturality S.f)
     simp only [AddCommGrpCat.hom_comp, AddMonoidHom.comp_apply] at hn
     simp only [τ₁, τ₂, AddEquiv.trans_apply, Iso.addCommGroupIsoToAddEquiv_apply]
-    calc intTensorOverEquiv (ZMod b) ((ζ.app S.X₂).hom (φ.hom x))
-        = intTensorOverEquiv (ZMod b)
-            (tensorRightMap ℤ (ZMod b) S.f ((ζ.app S.X₁).hom x)) :=
-          congrArg (intTensorOverEquiv (ZMod b)) hn
-      _ = ZModGcd.mulByCast a b (intTensorOverEquiv (ZMod b) ((ζ.app S.X₁).hom x)) :=
+    calc intTensorOverEquiv N ((ζ.app S.X₂).hom (φ.hom x))
+        = intTensorOverEquiv N
+            (tensorRightMap ℤ N S.f ((ζ.app S.X₁).hom x)) :=
+          congrArg (intTensorOverEquiv N) hn
+      _ = ZModGcd.mulBy a N (intTensorOverEquiv N ((ζ.app S.X₁).hom x)) :=
           key _
-  -- Assemble: `Tor₁ = W.obj 2 ≃+ ker(mulByCast) ≃+ ZMod (gcd a b)`.
-  have mem : ∀ x, τ₁ (δ.hom x) ∈ LinearMap.ker (ZModGcd.mulByCast a b) := by
+  -- Assemble: `Tor₁ = W.obj 2 ≃+ ker(·a)`.
+  have mem : ∀ x, τ₁ (δ.hom x) ∈ LinearMap.ker (ZModGcd.mulBy a N) := by
     intro x
     rw [LinearMap.mem_ker, ← hconj (δ.hom x)]
     have : φ.hom (δ.hom x) = 0 := by
@@ -538,7 +571,7 @@ theorem Problem_8_2_7_i_tor_one (a b : ℕ) (ha : a ≠ 0) (hb : b ≠ 0) :
       simpa only [AddCommGrpCat.hom_comp, AddMonoidHom.comp_apply, AddCommGrpCat.hom_zero,
         AddMonoidHom.zero_apply] using this
     rw [this, map_zero]
-  let κ : ((F.leftDerived 1).obj S.X₃) →+ LinearMap.ker (ZModGcd.mulByCast a b) :=
+  let κ : ((F.leftDerived 1).obj S.X₃) →+ LinearMap.ker (ZModGcd.mulBy a N) :=
     { toFun := fun x => ⟨τ₁ (δ.hom x), mem x⟩
       map_zero' := by apply Subtype.ext; simp
       map_add' := fun x y => by apply Subtype.ext; simp }
@@ -556,10 +589,30 @@ theorem Problem_8_2_7_i_tor_one (a b : ℕ) (ha : a ≠ 0) (hb : b ≠ 0) :
         exact (LinearMap.mem_ker.mp hz)
       rw [← hrk] at hwker
       obtain ⟨x, hx⟩ := hwker
-      exact ⟨x, Subtype.ext (by rw [show ((κ x : _) : ZMod b) = τ₁ (δ.hom x) from rfl, hx,
+      exact ⟨x, Subtype.ext (by rw [show ((κ x : _) : N) = τ₁ (δ.hom x) from rfl, hx,
         τ₁.apply_symm_apply])⟩
-  exact ⟨((AddEquiv.ofBijective κ hκbij).trans
-    (ZModGcd.zmodKerEquiv a b).toAddEquiv).toAddCommGrpIso⟩
+  exact ⟨(AddEquiv.ofBijective κ hκbij).toAddCommGrpIso⟩
+
+/-- **Problem 8.2.7(i), `Tor₁`.** For finite cyclic groups `ℤ/a`, `ℤ/b` (`a, b ≠ 0`),
+`Tor₁(ℤ/a, ℤ/b) ≅ ℤ/gcd(a,b)`: the `a`-torsion of `ℤ/b` (`Etingof.tor_one_zmod_kerSMul`) is
+`ℤ/gcd(a, b)` (`Etingof.ZModGcd.zmodKerEquiv`). -/
+theorem Problem_8_2_7_i_tor_one (a b : ℕ) (ha : a ≠ 0) (hb : b ≠ 0) :
+    Nonempty (Etingof.Tor ℤ (ZMod b) (ModuleCat.of ℤᵐᵒᵖ (ZMod a)) 1
+      ≅ AddCommGrpCat.of (ZMod (Nat.gcd a b))) := by
+  haveI : NeZero b := ⟨hb⟩
+  obtain ⟨e⟩ := tor_one_zmod_kerSMul a ha (ZMod b)
+  exact ⟨e ≪≫ (ZModGcd.zmodKerEquiv a b).toAddEquiv.toAddCommGrpIso⟩
+
+/-- **`Tor₁(ℤ/a, ℤ) = 0`** for `a ≠ 0`: `ℤ` is torsion-free, so the `a`-torsion subgroup that
+`Etingof.tor_one_zmod_kerSMul` computes is trivial. This is the degree-`1` entry at a torsion
+summand of `M` paired with a *free* summand of `N` — the place where the uniform
+`ℤ/gcd(a, c)` answer of degree `0` fails on the `Tor` side (`gcd a 0 = a ≠ 0`). -/
+theorem Problem_8_2_7_i_tor_cyclic_free_one (a : ℕ) (ha : a ≠ 0) :
+    Limits.IsZero (Etingof.Tor ℤ ℤ (ModuleCat.of ℤᵐᵒᵖ (ZMod a)) 1) := by
+  haveI : NeZero a := ⟨ha⟩
+  haveI := ZModGcd.subsingleton_ker_mulBy_int a
+  obtain ⟨e⟩ := tor_one_zmod_kerSMul a ha ℤ
+  exact (AddCommGrpCat.isZero_of_subsingleton _).of_iso e
 
 /-- The right-module length-`1` free resolution `0 → ℤ →(·a) ℤ → ℤ/a → 0` over `ℤᵐᵒᵖ`
 (`a ≠ 0`): `ℤ` and `ℤ/a` as right `ℤ`-modules, with `·a` and the quotient map made `ℤᵐᵒᵖ`-linear.
@@ -609,20 +662,23 @@ private noncomputable def zmodZeroOpEquiv : ℤ ≃ₗ[ℤᵐᵒᵖ] (ZMod 0) :=
       rw [smul_eq_mul, mul_comm] }
 
 open Limits in
-/-- **Problem 8.2.7(i), higher `Tor` vanishes.** `Torᵢ(ℤ/a, ℤ/b) = 0` for `i ≥ 2`, because
-`ℤ/a` has a length-`1` free resolution over the PID `ℤ`. For `i ≥ 2` the `Tor` is squeezed
-between the vanishing `Tor` of the two free terms in the six-term long exact sequence. -/
-theorem Problem_8_2_7_i_tor_vanish (a b : ℕ) (n : ℕ) :
-    Limits.IsZero (Etingof.Tor ℤ (ZMod b) (ModuleCat.of ℤᵐᵒᵖ (ZMod a)) (n + 2)) := by
+/-- **Higher `Tor` out of a cyclic group vanishes, for an arbitrary second argument.**
+`Torᵢ(ℤ/a, N) = 0` for `i ≥ 2` and any abelian group `N`, because `ℤ/a` has a length-`1` free
+resolution over the PID `ℤ`: for `i ≥ 2` the `Tor` is squeezed between the vanishing `Tor` of the
+two free terms in the six-term long exact sequence. Since `ZMod 0 = ℤ`, the `a = 0` case covers the
+free summands too, which is what lets the finitely-generated statement treat all summands
+uniformly. -/
+theorem tor_vanish_zmod (a : ℕ) (N : Type) [AddCommGroup N] (n : ℕ) :
+    Limits.IsZero (Etingof.Tor ℤ N (ModuleCat.of ℤᵐᵒᵖ (ZMod a)) (n + 2)) := by
   rcases eq_or_ne a 0 with rfl | ha
   · -- `ZMod 0 = ℤ` is a projective (free rank-one) right module
     have hz := Functor.isZero_leftDerived_obj_projective_succ
-      (tensorRightFunctor ℤ (ZMod b)) (n + 1) (ModuleCat.of ℤᵐᵒᵖ ℤ)
+      (tensorRightFunctor ℤ N) (n + 1) (ModuleCat.of ℤᵐᵒᵖ ℤ)
     exact hz.of_iso
-      (((tensorRightFunctor ℤ (ZMod b)).leftDerived (n + 2)).mapIso
+      (((tensorRightFunctor ℤ N).leftDerived (n + 2)).mapIso
         zmodZeroOpEquiv.symm.toModuleIso)
   · obtain ⟨S, hS, hX₁, hX₂, hX₃⟩ := zmodMopResolution a ha
-    set F := tensorRightFunctor ℤ (ZMod b) with hF
+    set F := tensorRightFunctor ℤ N with hF
     obtain ⟨δ, hExact⟩ := Etingof.Functor.leftDerived_sixTerm_exact F hS (n + 1) (n + 2) rfl
     have h1 : IsZero ((F.leftDerived (n + 2)).obj S.X₂) := by
       rw [hX₂]; exact Functor.isZero_leftDerived_obj_projective_succ F (n + 1) _
@@ -632,6 +688,12 @@ theorem Problem_8_2_7_i_tor_vanish (a b : ℕ) (n : ℕ) :
       isZero_obj_two_of_sixTerm_exact hExact h1 h3
     rw [hX₃] at hgoal
     exact hgoal
+
+/-- **Problem 8.2.7(i), higher `Tor` vanishes.** `Torᵢ(ℤ/a, ℤ/b) = 0` for `i ≥ 2`, because
+`ℤ/a` has a length-`1` free resolution over the PID `ℤ`. -/
+theorem Problem_8_2_7_i_tor_vanish (a b : ℕ) (n : ℕ) :
+    Limits.IsZero (Etingof.Tor ℤ (ZMod b) (ModuleCat.of ℤᵐᵒᵖ (ZMod a)) (n + 2)) :=
+  tor_vanish_zmod a (ZMod b) n
 
 /-- **Problem 8.2.7(i), free generator.** `ℤ` is projective as a `ℤ`-module, so
 `Torᵢ₊₁(ℤ, N) = 0` for every abelian group `N`. -/
@@ -826,12 +888,33 @@ noncomputable section
 
 variable {k : Type*} [Field k]
 
+/-- Multiplication-by-`f` endomorphism of an arbitrary `k[X]`-module, as a `k[X]`-linear map. Its
+kernel is what `Tor₁(k[X]/(f), -)` computes and its cokernel is what `Ext¹(k[X]/(f), -)` computes;
+both are needed for arbitrary targets, not just for `k[X]/(g)`. -/
+def mulByOn (f : k[X]) (N : Type*) [AddCommGroup N] [Module k[X] N] : N →ₗ[k[X]] N :=
+  f • LinearMap.id
+
+@[simp] lemma mulByOn_apply (f : k[X]) {N : Type*} [AddCommGroup N] [Module k[X] N] (x : N) :
+    mulByOn f N x = f • x := rfl
+
 /-- Multiplication-by-`f` endomorphism of `k[X]/(g)`, as a `k[X]`-linear map. -/
 def mulBy (f g : k[X]) : (k[X] ⧸ Ideal.span {g}) →ₗ[k[X]] (k[X] ⧸ Ideal.span {g}) :=
-  f • LinearMap.id
+  mulByOn f _
 
 @[simp] lemma mulBy_apply (f g : k[X]) (x : k[X] ⧸ Ideal.span {g}) :
     mulBy f g x = f • x := rfl
+
+/-- **`k[X]` is torsion-free**: the kernel of multiplication by `f ≠ 0` on `k[X]` is trivial,
+since `k[X]` is a domain. This is what makes both `Hom(k[X]/(f), k[X]) = 0` and
+`Tor₁(k[X]/(f), k[X]) = 0`. -/
+lemma subsingleton_ker_mulByOn_self (f : k[X]) (hf : f ≠ 0) :
+    Subsingleton (LinearMap.ker (mulByOn f k[X])) := by
+  refine ⟨fun x y => Subtype.ext ?_⟩
+  have h : ∀ z : LinearMap.ker (mulByOn f k[X]), (z : k[X]) = 0 := fun z => by
+    have hz : f • (z : k[X]) = 0 := LinearMap.mem_ker.mp z.2
+    rw [smul_eq_mul, mul_eq_zero] at hz
+    exact hz.resolve_left hf
+  rw [h x, h y]
 
 /-- The `k[X]`-linear projection `k[X]/(g) → k[X]/(f,g)` induced by the identity
 (well-defined since `(g) ≤ (f,g)`). -/
@@ -1070,11 +1153,17 @@ open scoped TensorProduct in
     LinearEquiv.coe_toAddEquiv]
   exact TensorProduct.lid_tmul n m
 
-/-- **Problem 8.2.7(ii), `Tor₁`.** `Tor₁(k[x]/(f), k[x]/(g)) ≅ k[x]/(gcd(f,g))` for `f, g ≠ 0`. -/
-theorem Problem_8_2_7_ii_tor_one (k : Type*) [Field k] (f g : k[X]) (hf : f ≠ 0) (hg : g ≠ 0) :
-    Nonempty (Etingof.Tor k[X] (k[X] ⧸ Ideal.span {g})
-        (ModuleCat.of (k[X])ᵐᵒᵖ (k[X] ⧸ Ideal.span {f})) 1
-      ≅ AddCommGrpCat.of (k[X] ⧸ Ideal.span {f, g})) := by
+/-- **`Tor₁(k[x]/(f), N)` is the `f`-torsion of `N`**, i.e. the kernel of multiplication by `f`,
+for `f ≠ 0` and an *arbitrary* `k[x]`-module `N`. This is the `k[x]` analogue of
+`Etingof.tor_one_zmod_kerSMul`: read off the length-`1` free resolution
+`0 → k[x] →(·f) k[x] → k[x]/(f) → 0` through the six-term sequence, `Tor₁` is the kernel of the map
+induced on `Tor₀(k[x], N) = k[x] ⊗ N ≅ N`, which is multiplication by `f`. Specialising `N` gives
+the degree-`1` row of the summand table: `N = k[x]/(g)` gives `k[x]/(f, g)`
+(`Problem_8_2_7_ii_tor_one`), and `N = k[x]` gives `0`. -/
+theorem tor_one_polyQuot_kerSMul {k : Type u} [Field k] (f : k[X]) (hf : f ≠ 0)
+    (N : Type u) [AddCommGroup N] [Module k[X] N] :
+    Nonempty (Etingof.Tor k[X] N (ModuleCat.of (k[X])ᵐᵒᵖ (k[X] ⧸ Ideal.span {f})) 1
+      ≅ AddCommGrpCat.of (LinearMap.ker (PolyGcd.mulByOn f N))) := by
   -- Length-`1` resolution `0 → k[x] →(·f) k[x] → k[x]/f → 0` over `k[x]ᵐᵒᵖ`, inline for `S.f`.
   let mfL : k[X] →ₗ[(k[X])ᵐᵒᵖ] k[X] :=
     { toFun := fun x => f * x
@@ -1109,7 +1198,7 @@ theorem Problem_8_2_7_ii_tor_one (k : Type*) [Field k] (f g : k[X]) (hf : f ≠ 
   have hsurjg : Function.Surjective pfL := (Ideal.span {f}).mkQ_surjective
   set S := ModuleCat.shortComplexOfCompEqZero mfL pfL eq0 with hSdef
   have hS : S.ShortExact := ModuleCat.shortComplex_shortExact S hexact hinjf hsurjg
-  set F := tensorRightFunctor k[X] (k[X] ⧸ Ideal.span {g}) with hF
+  set F := tensorRightFunctor k[X] N with hF
   -- Six-term window `0 = L₁X₁ → 0 = L₁X₂ → Tor₁ →[δ] Tor₀ k[x] →[φ] Tor₀ k[x] → …`.
   obtain ⟨δ, hExact⟩ := Etingof.Functor.leftDerived_sixTerm_exact F hS 0 1 rfl
   let φ : (F.leftDerived 0).obj S.X₁ ⟶ (F.leftDerived 0).obj S.X₂ := (F.leftDerived 0).map S.f
@@ -1123,51 +1212,46 @@ theorem Problem_8_2_7_ii_tor_one (k : Type*) [Field k] (f g : k[X]) (hf : f ≠ 
   -- Exactness at `Tor₀ k[x]`: `range δ = ker φ`.
   have hrk : δ.hom.range = φ.hom.ker := (hExact.exact' 2 3 4).ab_range_eq_ker
   have hcompl : δ ≫ φ = 0 := hExact.toIsComplex.zero' 2 3 4
-  -- `Tor₀(k[x]) = k[x] ⊗_{k[x]} (k[x]/g) ≅ k[x]/g`, natural in the argument.
+  -- `Tor₀(k[x]) = k[x] ⊗_{k[x]} N ≅ N`, natural in the argument.
   let ζ := F.leftDerivedZeroIsoSelf
-  let τ₁ : ((F.leftDerived 0).obj S.X₁) ≃+ (k[X] ⧸ Ideal.span {g}) :=
-    (ζ.app S.X₁).addCommGroupIsoToAddEquiv.trans (polyTensorOverEquiv (k[X] ⧸ Ideal.span {g}))
-  let τ₂ : ((F.leftDerived 0).obj S.X₂) ≃+ (k[X] ⧸ Ideal.span {g}) :=
-    (ζ.app S.X₂).addCommGroupIsoToAddEquiv.trans (polyTensorOverEquiv (k[X] ⧸ Ideal.span {g}))
+  let τ₁ : ((F.leftDerived 0).obj S.X₁) ≃+ N :=
+    (ζ.app S.X₁).addCommGroupIsoToAddEquiv.trans (polyTensorOverEquiv N)
+  let τ₂ : ((F.leftDerived 0).obj S.X₂) ≃+ N :=
+    (ζ.app S.X₂).addCommGroupIsoToAddEquiv.trans (polyTensorOverEquiv N)
   -- The induced map `φ` on `Tor₀(k[x])` is multiplication by `f`.
-  have key : ∀ w : tensorOver k[X] (k[X] ⧸ Ideal.span {g}) S.X₁,
-      polyTensorOverEquiv (k[X] ⧸ Ideal.span {g})
-          (tensorRightMap k[X] (k[X] ⧸ Ideal.span {g}) S.f w)
-        = PolyGcd.mulBy f g (polyTensorOverEquiv (k[X] ⧸ Ideal.span {g}) w) := by
+  have key : ∀ w : tensorOver k[X] N S.X₁,
+      polyTensorOverEquiv N (tensorRightMap k[X] N S.f w)
+        = PolyGcd.mulByOn f N (polyTensorOverEquiv N w) := by
     intro w
     induction w using QuotientAddGroup.induction_on with
     | _ y =>
       induction y using TensorProduct.induction_on with
       | zero => simp
       | tmul m n =>
-        rw [show tensorRightMap k[X] (k[X] ⧸ Ideal.span {g}) S.f
-              (TensorProduct.tmul ℤ m n : tensorOver k[X] (k[X] ⧸ Ideal.span {g}) S.X₁)
-            = (TensorProduct.tmul ℤ (S.f.hom m) n :
-                tensorOver k[X] (k[X] ⧸ Ideal.span {g}) S.X₂) from rfl,
-          polyTensorOverEquiv_mk, polyTensorOverEquiv_mk, PolyGcd.mulBy_apply]
+        rw [show tensorRightMap k[X] N S.f
+              (TensorProduct.tmul ℤ m n : tensorOver k[X] N S.X₁)
+            = (TensorProduct.tmul ℤ (S.f.hom m) n : tensorOver k[X] N S.X₂) from rfl,
+          polyTensorOverEquiv_mk, polyTensorOverEquiv_mk, PolyGcd.mulByOn_apply]
         change (f * m) • n = f • (m • n)
         rw [mul_smul]
       | add p q hp hq =>
-        rw [show ((p + q : TensorProduct ℤ S.X₁ (k[X] ⧸ Ideal.span {g})) :
-              tensorOver k[X] (k[X] ⧸ Ideal.span {g}) S.X₁)
-              = ((p : tensorOver k[X] (k[X] ⧸ Ideal.span {g}) S.X₁)
-                  + (q : tensorOver k[X] (k[X] ⧸ Ideal.span {g}) S.X₁))
+        rw [show ((p + q : TensorProduct ℤ S.X₁ N) : tensorOver k[X] N S.X₁)
+              = ((p : tensorOver k[X] N S.X₁) + (q : tensorOver k[X] N S.X₁))
             from map_add (QuotientAddGroup.mk' _) p q,
           map_add, map_add, map_add, map_add, hp, hq]
-  have hconj : ∀ x, τ₂ (φ.hom x) = PolyGcd.mulBy f g (τ₁ x) := by
+  have hconj : ∀ x, τ₂ (φ.hom x) = PolyGcd.mulByOn f N (τ₁ x) := by
     intro x
     have hn := congrArg (fun (m : (F.leftDerived 0).obj S.X₁ ⟶ F.obj S.X₂) => m.hom x)
       (ζ.hom.naturality S.f)
     simp only [AddCommGrpCat.hom_comp, AddMonoidHom.comp_apply] at hn
     simp only [τ₁, τ₂, AddEquiv.trans_apply, Iso.addCommGroupIsoToAddEquiv_apply]
-    calc polyTensorOverEquiv (k[X] ⧸ Ideal.span {g}) ((ζ.app S.X₂).hom (φ.hom x))
-        = polyTensorOverEquiv (k[X] ⧸ Ideal.span {g})
-            (tensorRightMap k[X] (k[X] ⧸ Ideal.span {g}) S.f ((ζ.app S.X₁).hom x)) :=
-          congrArg (polyTensorOverEquiv (k[X] ⧸ Ideal.span {g})) hn
-      _ = PolyGcd.mulBy f g
-            (polyTensorOverEquiv (k[X] ⧸ Ideal.span {g}) ((ζ.app S.X₁).hom x)) := key _
-  -- Assemble: `Tor₁ ≃+ ker(mulBy) ≃+ k[x]/(f,g)`.
-  have mem : ∀ x, τ₁ (δ.hom x) ∈ LinearMap.ker (PolyGcd.mulBy f g) := by
+    calc polyTensorOverEquiv N ((ζ.app S.X₂).hom (φ.hom x))
+        = polyTensorOverEquiv N
+            (tensorRightMap k[X] N S.f ((ζ.app S.X₁).hom x)) :=
+          congrArg (polyTensorOverEquiv N) hn
+      _ = PolyGcd.mulByOn f N (polyTensorOverEquiv N ((ζ.app S.X₁).hom x)) := key _
+  -- Assemble: `Tor₁ ≃+ ker(·f)`.
+  have mem : ∀ x, τ₁ (δ.hom x) ∈ LinearMap.ker (PolyGcd.mulByOn f N) := by
     intro x
     rw [LinearMap.mem_ker, ← hconj (δ.hom x)]
     have : φ.hom (δ.hom x) = 0 := by
@@ -1176,7 +1260,7 @@ theorem Problem_8_2_7_ii_tor_one (k : Type*) [Field k] (f g : k[X]) (hf : f ≠ 
       simpa only [AddCommGrpCat.hom_comp, AddMonoidHom.comp_apply, AddCommGrpCat.hom_zero,
         AddMonoidHom.zero_apply] using this
     rw [this, map_zero]
-  let κ : ((F.leftDerived 1).obj S.X₃) →+ LinearMap.ker (PolyGcd.mulBy f g) :=
+  let κ : ((F.leftDerived 1).obj S.X₃) →+ LinearMap.ker (PolyGcd.mulByOn f N) :=
     { toFun := fun x => ⟨τ₁ (δ.hom x), mem x⟩
       map_zero' := by apply Subtype.ext; simp
       map_add' := fun x y => by apply Subtype.ext; simp }
@@ -1195,10 +1279,27 @@ theorem Problem_8_2_7_ii_tor_one (k : Type*) [Field k] (f g : k[X]) (hf : f ≠ 
       rw [← hrk] at hwker
       obtain ⟨x, hx⟩ := hwker
       refine ⟨x, Subtype.ext ?_⟩
-      rw [show ((κ x : _) : k[X] ⧸ Ideal.span {g}) = τ₁ (δ.hom x) from rfl, hx,
-        τ₁.apply_symm_apply]
-  exact ⟨((AddEquiv.ofBijective κ hκbij).trans
-    (PolyGcd.kerEquiv f g hg).toAddEquiv).toAddCommGrpIso⟩
+      rw [show ((κ x : _) : N) = τ₁ (δ.hom x) from rfl, hx, τ₁.apply_symm_apply]
+  exact ⟨(AddEquiv.ofBijective κ hκbij).toAddCommGrpIso⟩
+
+/-- **Problem 8.2.7(ii), `Tor₁`.** `Tor₁(k[x]/(f), k[x]/(g)) ≅ k[x]/(f, g)` for `f, g ≠ 0`: the
+`f`-torsion of `k[x]/(g)` (`Etingof.tor_one_polyQuot_kerSMul`) is `k[x]/(f, g)`
+(`Etingof.PolyGcd.kerEquiv`). -/
+theorem Problem_8_2_7_ii_tor_one {k : Type u} [Field k] (f g : k[X]) (hf : f ≠ 0) (hg : g ≠ 0) :
+    Nonempty (Etingof.Tor k[X] (k[X] ⧸ Ideal.span {g})
+        (ModuleCat.of (k[X])ᵐᵒᵖ (k[X] ⧸ Ideal.span {f})) 1
+      ≅ AddCommGrpCat.of (k[X] ⧸ Ideal.span {f, g})) := by
+  obtain ⟨e⟩ := tor_one_polyQuot_kerSMul f hf (k[X] ⧸ Ideal.span {g})
+  exact ⟨e ≪≫ (PolyGcd.kerEquiv f g hg).toAddEquiv.toAddCommGrpIso⟩
+
+/-- **`Tor₁(k[x]/(f), k[x]) = 0`** for `f ≠ 0`: `k[x]` is torsion-free, so the `f`-torsion that
+`Etingof.tor_one_polyQuot_kerSMul` computes is trivial. This is the degree-`1` entry at a torsion
+summand of `M` paired with a *free* summand of `N`. -/
+theorem Problem_8_2_7_ii_tor_cyclic_free_one {k : Type u} [Field k] (f : k[X]) (hf : f ≠ 0) :
+    Limits.IsZero (Etingof.Tor k[X] k[X] (ModuleCat.of (k[X])ᵐᵒᵖ (k[X] ⧸ Ideal.span {f})) 1) := by
+  haveI := PolyGcd.subsingleton_ker_mulByOn_self f hf
+  obtain ⟨e⟩ := tor_one_polyQuot_kerSMul f hf k[X]
+  exact (AddCommGrpCat.isZero_of_subsingleton _).of_iso e
 
 /-- The right-module length-`1` free resolution `0 → k[x] →(·p) k[x] → k[x]/(p) → 0` over
 `k[x]ᵐᵒᵖ` (`p ≠ 0`), the `k[x]` analogue of `zmodMopResolution`. -/
@@ -1251,20 +1352,23 @@ private noncomputable def polyZeroOpEquiv (k : Type u) [Field k] :
       rw [map_smul, smul_eq_mul, mul_comm] }
 
 open Limits in
-/-- **Problem 8.2.7(ii), higher `Tor` vanishes.** `Torᵢ(k[x]/(f), k[x]/(g)) = 0` for `i ≥ 2`,
-by the same six-term long-exact-sequence squeeze as part (i), over the PID `k[x]`. -/
-theorem Problem_8_2_7_ii_tor_vanish (k : Type*) [Field k] (f g : k[X]) (n : ℕ) :
-    Limits.IsZero (Etingof.Tor k[X] (k[X] ⧸ Ideal.span {g})
+/-- **Higher `Tor` out of a cyclic `k[x]`-module vanishes, for an arbitrary second argument.**
+`Torᵢ(k[x]/(f), N) = 0` for `i ≥ 2` and any `k[x]`-module `N`, by the same six-term
+long-exact-sequence squeeze as part (i), over the PID `k[x]`. The `f = 0` case is
+`k[x]/(0) ≅ k[x]`, so this covers the free summands too, which is what lets the finitely-generated
+statement treat all summands uniformly. -/
+theorem tor_vanish_polyQuot {k : Type u} [Field k] (f : k[X]) (N : Type u) [AddCommGroup N]
+    [Module k[X] N] (n : ℕ) :
+    Limits.IsZero (Etingof.Tor k[X] N
       (ModuleCat.of (k[X])ᵐᵒᵖ (k[X] ⧸ Ideal.span {f})) (n + 2)) := by
   rcases eq_or_ne f 0 with rfl | hf
   · -- `k[x]/(0) ≅ k[x]` is a projective (free rank-one) right module
     have hz := Functor.isZero_leftDerived_obj_projective_succ
-      (tensorRightFunctor k[X] (k[X] ⧸ Ideal.span {g})) (n + 1) (ModuleCat.of (k[X])ᵐᵒᵖ k[X])
+      (tensorRightFunctor k[X] N) (n + 1) (ModuleCat.of (k[X])ᵐᵒᵖ k[X])
     exact hz.of_iso
-      (((tensorRightFunctor k[X] (k[X] ⧸ Ideal.span {g})).leftDerived (n + 2)).mapIso
-        (polyZeroOpEquiv k).toModuleIso)
+      (((tensorRightFunctor k[X] N).leftDerived (n + 2)).mapIso (polyZeroOpEquiv k).toModuleIso)
   · obtain ⟨S, hS, hX₁, hX₂, hX₃⟩ := polyMopResolution k f hf
-    set F := tensorRightFunctor k[X] (k[X] ⧸ Ideal.span {g}) with hF
+    set F := tensorRightFunctor k[X] N with hF
     obtain ⟨δ, hExact⟩ := Etingof.Functor.leftDerived_sixTerm_exact F hS (n + 1) (n + 2) rfl
     have h1 : IsZero ((F.leftDerived (n + 2)).obj S.X₂) := by
       rw [hX₂]; exact Functor.isZero_leftDerived_obj_projective_succ F (n + 1) _
@@ -1274,6 +1378,12 @@ theorem Problem_8_2_7_ii_tor_vanish (k : Type*) [Field k] (f g : k[X]) (n : ℕ)
       isZero_obj_two_of_sixTerm_exact hExact h1 h3
     rw [hX₃] at hgoal
     exact hgoal
+
+/-- **Problem 8.2.7(ii), higher `Tor` vanishes.** `Torᵢ(k[x]/(f), k[x]/(g)) = 0` for `i ≥ 2`. -/
+theorem Problem_8_2_7_ii_tor_vanish {k : Type u} [Field k] (f g : k[X]) (n : ℕ) :
+    Limits.IsZero (Etingof.Tor k[X] (k[X] ⧸ Ideal.span {g})
+      (ModuleCat.of (k[X])ᵐᵒᵖ (k[X] ⧸ Ideal.span {f})) (n + 2)) :=
+  tor_vanish_polyQuot f (k[X] ⧸ Ideal.span {g}) n
 
 /-- **Problem 8.2.7(ii), free generator.** `k[x]` is projective, so `Torᵢ₊₁(k[x], N) = 0` for
 every `k[x]`-module `N`. -/

--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_7_TorFG.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_7_TorFG.lean
@@ -1,0 +1,160 @@
+import EtingofRepresentationTheory.Chapter8.Problem8_2_7_ExtFG
+import EtingofRepresentationTheory.Chapter8.Additivity
+
+/-!
+# Problem 8.2.7: `Tor` for arbitrary finitely generated modules over a PID
+
+`Problem8_2_7.lean` computes `Torᵢ` for the two *building blocks* of the structure theorem over a
+PID — a free generator and a pair of cyclic modules — `PIDDecomposition.lean` packages the
+structure theorem as a biproduct decomposition, and `Additivity.lean` proves that `Tor` commutes
+with finite direct sums in each argument. This file performs the reduction the book's hint asks for
+("reduce to the case of cyclic groups using the classification theorem") on the `Tor` side, and
+supplies the base-ring-independent half of the computation of `Torᵢ(M, N)` for **arbitrary**
+finitely generated `M`, `N`. It is the exact counterpart of `Problem8_2_7_ExtFG.lean`.
+
+## Main results
+
+* `Etingof.torSndCongr`: `Tor` transported along a linear isomorphism in its second variable
+  (in the first variable this is just `(TorFunctor A N n).mapIso`).
+* `Etingof.PIDDecomposition.equivPi`, `Etingof.PIDDecomposition.mopSummandIso`: a decomposition as
+  an isomorphism onto the *product* of its summands, and the identification of each summand, as a
+  **right** module, with the cyclic right module `A ⧸ (genOf j)`.
+* `Etingof.torFstDecompositionAddEquiv`, `Etingof.torSndDecompositionAddEquiv`,
+  `Etingof.torPIDDecompositionAddEquiv`: **the reduction.** Given decompositions `D` of `M` and `E`
+  of `N`,
+  `Torₙ(M, N) ≃+ Π (j : D.index) (l : E.index), Torₙ(D.summand j, E.summand l)`,
+  together with the two one-variable forms that leave the other argument arbitrary.
+
+## Two asymmetries with the `Ext` side
+
+**The first argument has to be transported into `ModuleCat Aᵐᵒᵖ`.** `Etingof.Tor` takes its first
+argument as a *right* `A`-module, so the reduction uses `PIDDecomposition.mopBiproductIso` rather
+than `PIDDecomposition.biproductIso`. Over the commutative rings `ℤ` and `k[X]` the two carry the
+same information, via the ring isomorphism `Aᵐᵒᵖ ≃+* A` of `Etingof.mopRingEquiv`.
+
+**Everything here lives in `Type 0`.** `Etingof.torBiproductIso` and `Etingof.torPiIso` are stated
+for an index type in `Type 0` (Mathlib's `PreservesBiproduct` instances for additive functors, and
+`AddCommGrpCat.biproductIsoPi`, are `Type 0`-indexed), and a `PIDDecomposition A M` for
+`A M : Type u` has its summands indexed by a `Type u`. So the finitely-generated `Tor` statements
+are for `A M N : Type`, which is automatic over `ℤ` and amounts to taking `k : Type` over `k[X]`.
+The `Ext` side has no such restriction, since Mathlib's `Abelian.Ext.biproductAddEquiv` is
+universe-polymorphic in the index.
+-/
+
+universe u
+
+namespace Etingof
+
+open CategoryTheory Limits
+
+/-! ### Biproducts of abelian groups as products -/
+
+/-- `⨁ f ≃+ Π j, f j` for a finite family of abelian groups: the additive form of
+`AddCommGrpCat.biproductIsoPi`. The `Tor` additivity lemmas produce categorical biproducts; the
+answers of Problem 8.2.7 are more readable as products, which is also the shape the `Ext` side
+uses. -/
+noncomputable def biproductPiAddEquiv {J : Type} [Finite J] (f : J → AddCommGrpCat.{u}) :
+    (⨁ f : AddCommGrpCat.{u}) ≃+ ∀ j, f j :=
+  (AddCommGrpCat.biproductIsoPi f).addCommGroupIsoToAddEquiv
+
+/-! ### Transporting `Tor` along isomorphisms -/
+
+section TorCongr
+
+variable {A : Type u} [Ring A]
+
+/-- **`Tor` is invariant under isomorphism in its first variable**, since `Torₙ(-, N)` is a
+functor. -/
+noncomputable abbrev torFstCongr (N : Type u) [AddCommGroup N] [Module A N]
+    {M₁ M₂ : ModuleCat.{u} Aᵐᵒᵖ} (e : M₁ ≅ M₂) (n : ℕ) :
+    Tor.{u} A N M₁ n ≅ Tor.{u} A N M₂ n :=
+  (TorFunctor.{u} A N n).mapIso e
+
+/-- **`Tor` is invariant under isomorphism in its second variable.** The second argument is not a
+functor argument in the present set-up, so this is assembled from the functoriality `torSndMap` of
+Problem 8.2.6 and its identity/composition laws. -/
+noncomputable def torSndCongr {N₁ N₂ : Type u} [AddCommGroup N₁] [Module A N₁] [AddCommGroup N₂]
+    [Module A N₂] (e : N₁ ≃ₗ[A] N₂) (M : ModuleCat.{u} Aᵐᵒᵖ) (n : ℕ) :
+    Tor.{u} A N₁ M n ≅ Tor.{u} A N₂ M n where
+  hom := torSndMap A (e : N₁ →ₗ[A] N₂) n M
+  inv := torSndMap A (e.symm : N₂ →ₗ[A] N₁) n M
+  hom_inv_id := by
+    rw [← torSndMap_comp M (e : N₁ →ₗ[A] N₂) (e.symm : N₂ →ₗ[A] N₁) n,
+      show (e.symm : N₂ →ₗ[A] N₁).comp (e : N₁ →ₗ[A] N₂) = LinearMap.id from
+        LinearMap.ext fun x => e.symm_apply_apply x]
+    exact torSndMap_id A N₁ n M
+  inv_hom_id := by
+    rw [← torSndMap_comp M (e.symm : N₂ →ₗ[A] N₁) (e : N₁ →ₗ[A] N₂) n,
+      show (e : N₁ →ₗ[A] N₂).comp (e.symm : N₂ →ₗ[A] N₁) = LinearMap.id from
+        LinearMap.ext fun x => e.apply_symm_apply x]
+    exact torSndMap_id A N₂ n M
+
+end TorCongr
+
+/-! ### The reduction to summand pairs
+
+Everything below is in `Type 0`; see the module docstring. -/
+
+section Reduction
+
+variable {A : Type} [CommRing A] {M N : Type} [AddCommGroup M] [Module A M]
+  [AddCommGroup N] [Module A N]
+
+/-- A decomposition as a linear isomorphism onto the **product** of its summands. This is the
+`Pi`-shaped form of `Etingof.PIDDecomposition.equivDirectSum`, which is what
+`Etingof.torPiIso` — additivity of `Tor` in its second argument — is stated for. -/
+noncomputable def PIDDecomposition.equivPi (D : PIDDecomposition A M) :
+    M ≃ₗ[A] ∀ j : D.index, (D.summand j : Type) :=
+  D.equivProd ≪≫ₗ
+    (LinearEquiv.sumPiEquivProdPi A (Fin D.freeRank) D.torsionIndex
+      (fun j => (D.summand j : Type))).symm
+
+/-- **Every summand of a decomposition, viewed as a right module, is the cyclic right module
+`A ⧸ (genOf j)`**, the free ones being `A ⧸ (0) ≅ A`. This is `PIDDecomposition.summandIso`
+transported along the equivalence `mopFunctor A : ModuleCat A ≌ ModuleCat Aᵐᵒᵖ`. -/
+noncomputable def PIDDecomposition.mopSummandIso (D : PIDDecomposition A M) (j : D.index) :
+    D.mopSummand j ≅ mopOf A (A ⧸ Ideal.span {D.genOf j}) :=
+  (mopFunctor A).mapIso (D.summandIso j)
+
+/-- **Additivity of `Tor` in the first variable, along a decomposition.**
+`Torₙ(M, Y) ≃+ Π j, Torₙ(D.summand j, Y)` for an arbitrary second argument `Y`. -/
+noncomputable def torFstDecompositionAddEquiv (D : PIDDecomposition A M) (Y : Type)
+    [AddCommGroup Y] [Module A Y] (n : ℕ) :
+    Tor A Y (mopOf A M) n ≃+ ∀ j : D.index, Tor A Y (D.mopSummand j) n :=
+  (torFstCongr Y D.mopBiproductIso n).addCommGroupIsoToAddEquiv.trans
+    (((torBiproductIso A Y n D.mopSummand).addCommGroupIsoToAddEquiv).trans
+      (biproductPiAddEquiv _))
+
+/-- **Additivity of `Tor` in the second variable, along a decomposition.**
+`Torₙ(X, N) ≃+ Π l, Torₙ(X, E.summand l)` for an arbitrary first argument `X`. -/
+noncomputable def torSndDecompositionAddEquiv (E : PIDDecomposition A N)
+    (X : ModuleCat.{0} Aᵐᵒᵖ) (n : ℕ) :
+    Tor A N X n ≃+ ∀ l : E.index, Tor A (E.summand l) X n :=
+  (torSndCongr E.equivPi X n).addCommGroupIsoToAddEquiv.trans
+    (((torPiIso A (fun l : E.index => (E.summand l : Type)) X n).addCommGroupIsoToAddEquiv).trans
+      (biproductPiAddEquiv _))
+
+/-- **The reduction of the `Tor` half of Problem 8.2.7 to the free and cyclic building blocks.**
+For decompositions `D` of `M` and `E` of `N` into a free part and cyclic parts, `Torₙ(M, N)` is the
+product, over pairs of summands, of the `Torₙ` groups of those summands. Together with the
+summand-level computations of `Problem8_2_7.lean` this *is* the book's "reduce to the case of
+cyclic groups". -/
+noncomputable def torPIDDecompositionAddEquiv (D : PIDDecomposition A M) (E : PIDDecomposition A N)
+    (n : ℕ) :
+    Tor A N (mopOf A M) n ≃+
+      ∀ (j : D.index) (l : E.index), Tor A (E.summand l) (D.mopSummand j) n :=
+  (torFstDecompositionAddEquiv D N n).trans
+    (AddEquiv.piCongrRight fun j => torSndDecompositionAddEquiv E (D.mopSummand j) n)
+
+/-- **`Tor` vanishes on a decomposed module as soon as it vanishes on every summand.** The form in
+which the higher-degree vanishing of Problem 8.2.7 is assembled: each summand is cyclic, and higher
+`Tor` out of a cyclic module over a PID vanishes for an arbitrary second argument. -/
+lemma subsingleton_tor_of_summands (D : PIDDecomposition A M) (Y : Type) [AddCommGroup Y]
+    [Module A Y] (n : ℕ) (h : ∀ j, Subsingleton (Tor A Y (D.mopSummand j) n)) :
+    Subsingleton (Tor A Y (mopOf A M) n) :=
+  haveI := subsingleton_pi fun j : D.index => (Tor A Y (D.mopSummand j) n : Type)
+  (torFstDecompositionAddEquiv D Y n).toEquiv.subsingleton
+
+end Reduction
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_7_TorInt.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_7_TorInt.lean
@@ -1,0 +1,221 @@
+import EtingofRepresentationTheory.Chapter8.Problem8_2_7_TorFG
+import EtingofRepresentationTheory.Chapter8.Problem8_2_7_ExtInt
+
+/-!
+# Problem 8.2.7(i): `Torᵢ(M, N)` for arbitrary finitely generated abelian groups
+
+`Problem8_2_7.lean` computes `Torᵢ` for a pair of cyclic groups and for a free generator, and
+`Problem8_2_7_TorFG.lean` reduces the general case to those building blocks. This file completes
+the `Tor` half of part (i): it fills in the summand-level table over `ℤ` and assembles the answer
+for **arbitrary** finitely generated `M`, `N`.
+
+## The summand table
+
+Every summand of a decomposition is `ℤ ⧸ (d) ≅ ZMod d.natAbs` (`Etingof.intSummandIso`), the free
+ones being `d = 0`, i.e. `ZMod 0 = ℤ`. Writing `a` for the first argument's modulus and `c` for the
+second's:
+
+| | `Tor₀` | `Tor₁` | `Torₙ₊₂` |
+|---|---|---|---|
+| `a = 0` (free) | `ZMod c` | `0` | `0` |
+| `a ≠ 0`, `c = 0` | `ZMod a` | `0` | `0` |
+| `a ≠ 0`, `c ≠ 0` | `ZMod (gcd a c)` | `ZMod (gcd a c)` | `0` |
+
+**Degree `0` is completely uniform**: `Tor₀` is the tensor product, and `ZMod (gcd a c)` is correct
+in all three rows, since `gcd a 0 = a`, `gcd 0 c = c` and `ZMod 0 = ℤ`. So
+`Problem_8_2_7_i_tor_zero_fg` below is a single product over *all* pairs of summands, with no case
+split at all. **Degree `1` is where the free summands drop out**, on either side: `Tor₁(ℤ, N) = 0`
+because `ℤ` is projective, and `Tor₁(ℤ/a, ℤ) = 0` because `ℤ` is torsion-free — even though
+`gcd a 0 = a ≠ 0`.
+
+This is exactly opposite to the `Ext` side (`Problem8_2_7_ExtInt.lean`), where degree `1` is the
+uniform row and degree `0` is the one that breaks: `Ext¹(ℤ/a, -)` is the *cokernel* of `·a` and
+`Tor₁(ℤ/a, -)` its *kernel*, and it is the kernel that vanishes on the torsion-free group `ℤ`.
+
+## Main results
+
+* `Etingof.Problem_8_2_7_i_tor_zero_fg`:
+  `M ⊗ N = Tor₀(M, N) ≅ ⨁_{j,l} ℤ/gcd(aⱼ, c_l)` over all pairs of summands. In the notation of
+  the exercise, with `M ≅ ℤ^m ⊕ ⨁ᵢ ℤ/aᵢ` and `N ≅ ℤ^p ⊕ ⨁ⱼ ℤ/bⱼ`, this is
+  `ℤ^{mp} ⊕ (⨁ᵢ ℤ/aᵢ)^p ⊕ (⨁ⱼ ℤ/bⱼ)^m ⊕ ⨁_{i,j} ℤ/gcd(aᵢ, bⱼ)`.
+* `Etingof.Problem_8_2_7_i_tor_one_fg`: `Tor₁(M, N) ≅ ⨁_{i,j} ℤ/gcd(aᵢ, bⱼ)`, over the *torsion*
+  summands of both arguments only.
+* `Etingof.Problem_8_2_7_i_tor_fg_vanish`: `Torᵢ(M, N) = 0` for `i ≥ 2`, with `N` arbitrary.
+* `Etingof.Problem_8_2_7_i_tor_fg`: the three answers packaged with the existence of suitable
+  decompositions.
+-/
+
+namespace Etingof
+
+open CategoryTheory Limits
+
+attribute [local instance] mopZMod
+
+/-! ### The summand table -/
+
+/-- **`ZMod c ⧸ a·ZMod c ≃+ ZMod (gcd a c)` for every `a` and every `c`**, including `c = 0`, where
+`ZMod 0 = ℤ` and `ℤ ⧸ aℤ = ZMod a = ZMod (gcd a 0)`. This extends `Etingof.ZModGcd.zmodCokerEquiv`,
+which assumes `c ≠ 0`. -/
+theorem zmod_quotSMul_equiv (a c : ℕ) :
+    Nonempty ((ZMod c ⧸ (Ideal.span {(a : ℤ)} • (⊤ : Submodule ℤ (ZMod c))))
+      ≃+ ZMod (Nat.gcd a c)) := by
+  rcases eq_or_ne c 0 with rfl | hc
+  · rw [Nat.gcd_zero_right]
+    have h : Ideal.span {(a : ℤ)} • (⊤ : Submodule ℤ ℤ) = (Ideal.span {(a : ℤ)} : Ideal ℤ) := by
+      rw [Ideal.smul_eq_mul, Ideal.mul_top]
+    exact ⟨(Submodule.quotEquivOfEq _ _ h).toAddEquiv.trans
+      (Int.quotientSpanNatEquivZMod a).toAddEquiv⟩
+  · haveI : NeZero c := ⟨hc⟩
+    exact ⟨(ZModGcd.zmodCokerEquiv a c).toAddEquiv⟩
+
+/-- **`Tor₀(ℤ/a, ℤ/c) ≅ ℤ/gcd(a, c)` for every `a` and `c`**, including the free cases `a = 0` and
+`c = 0` (`ZMod 0 = ℤ`, `gcd a 0 = a`, `gcd 0 c = c`). Degree `0` is the tensor product
+`(ℤ ⧸ (a)) ⊗_ℤ ℤ/c ≅ (ℤ/c) ⧸ a(ℤ/c)` (`Etingof.tor_zero_zmod_quotSMul`), and there the gcd formula
+needs no case split — unlike degree `1`, where a free summand on either side contributes `0`. -/
+theorem Problem_8_2_7_i_tor_zero_cyclic (a c : ℕ) :
+    Nonempty (Etingof.Tor ℤ (ZMod c) (ModuleCat.of ℤᵐᵒᵖ (ZMod a)) 0
+      ≅ AddCommGrpCat.of (ZMod (Nat.gcd a c))) := by
+  obtain ⟨e⟩ := tor_zero_zmod_quotSMul a (ZMod c)
+  obtain ⟨e'⟩ := zmod_quotSMul_equiv a c
+  exact ⟨e ≪≫ e'.toAddCommGrpIso⟩
+
+/-! ### Identifying the summands
+
+The `Tor` groups of Problem 8.2.7 take their first argument in `ModuleCat ℤᵐᵒᵖ` and their second as
+a plain module, so each summand of a decomposition has to be identified in two different shapes. -/
+
+/-- Every summand of a decomposition, viewed as a **right** `ℤ`-module, is `ZMod (genOf j).natAbs`
+— the shape the `Tor` building blocks of `Problem8_2_7.lean` are stated for. The free summands are
+`ZMod 0 = ℤ`. -/
+noncomputable def mopIntSummandIso {M : Type} [AddCommGroup M] (D : PIDDecomposition ℤ M)
+    (j : D.index) : D.mopSummand j ≅ ModuleCat.of ℤᵐᵒᵖ (ZMod (D.genOf j).natAbs) :=
+  (mopFunctor ℤ).mapIso (intSummandIso D j)
+
+/-- Every summand of a decomposition, as a plain `ℤ`-module, is `ZMod (genOf l).natAbs`: the
+`LinearEquiv` form of `Etingof.intSummandIso`, needed because `Tor` takes its second argument as a
+bare module rather than as an object of `ModuleCat ℤ`. -/
+noncomputable def intSummandLinearEquiv {N : Type} [AddCommGroup N] (E : PIDDecomposition ℤ N)
+    (l : E.index) : (E.summand l : Type) ≃ₗ[ℤ] ZMod (E.genOf l).natAbs :=
+  (intSummandIso E l).toLinearEquiv
+
+/-! ### The assembled answers -/
+
+variable {M N : Type} [AddCommGroup M] [AddCommGroup N]
+
+/-- **Problem 8.2.7(i), higher `Tor`.** `Torᵢ(M, N) = 0` for `i ≥ 2`, for `M` a finitely generated
+abelian group and `N` an *arbitrary* one: `M` is a finite direct sum of cyclic groups, and higher
+`Tor` out of a cyclic group vanishes for an arbitrary second argument
+(`Etingof.tor_vanish_zmod`). -/
+theorem Problem_8_2_7_i_tor_fg_vanish [Module.Finite ℤ M] (Y : Type) [AddCommGroup Y] (n : ℕ) :
+    Subsingleton (Etingof.Tor ℤ Y (mopOf ℤ M) (n + 2)) := by
+  obtain ⟨D⟩ := exists_pidDecomposition ℤ M
+  refine subsingleton_tor_of_summands D Y (n + 2) fun j => ?_
+  exact AddCommGrpCat.subsingleton_of_isZero
+    ((tor_vanish_zmod (D.genOf j).natAbs Y n).of_iso (torFstCongr Y (mopIntSummandIso D j) (n + 2)))
+
+/-- **Problem 8.2.7(i), `Tor₀`.** `M ⊗_ℤ N = Tor₀(M, N) ≅ ⨁_{j,l} ℤ/gcd(aⱼ, c_l)`, the product
+running over **all** pairs of summands of `M` and `N` — free ones included, where the generator is
+`0` and `ZMod 0 = ℤ`. With `M ≅ ℤ^m ⊕ ⨁ᵢ ℤ/aᵢ` and `N ≅ ℤ^p ⊕ ⨁ⱼ ℤ/bⱼ`, expanding the four blocks
+of the product gives the form stated in the exercise,
+`ℤ^{mp} ⊕ (⨁ᵢ ℤ/aᵢ)^p ⊕ (⨁ⱼ ℤ/bⱼ)^m ⊕ ⨁_{i,j} ℤ/gcd(aᵢ, bⱼ)`. -/
+theorem Problem_8_2_7_i_tor_zero_fg (D : PIDDecomposition ℤ M) (E : PIDDecomposition ℤ N) :
+    Nonempty (Etingof.Tor ℤ N (mopOf ℤ M) 0 ≃+
+      ∀ (j : D.index) (l : E.index),
+        ZMod (Nat.gcd (D.genOf j).natAbs (E.genOf l).natAbs)) := by
+  refine ⟨(torPIDDecompositionAddEquiv D E 0).trans
+    (AddEquiv.piCongrRight fun j => AddEquiv.piCongrRight fun l => ?_)⟩
+  exact ((torSndCongr (intSummandLinearEquiv E l) (D.mopSummand j) 0) ≪≫
+    (torFstCongr (ZMod (E.genOf l).natAbs) (mopIntSummandIso D j) 0) ≪≫
+    (Problem_8_2_7_i_tor_zero_cyclic (D.genOf j).natAbs
+      (E.genOf l).natAbs).some).addCommGroupIsoToAddEquiv
+
+/-- **Problem 8.2.7(i), `Tor₁`.** `Tor₁(M, N) ≅ ⨁_{i,j} ℤ/gcd(aᵢ, bⱼ)`, the product running over
+the **torsion** summands of `M` and of `N` only. Both free blocks drop out: `Tor₁(ℤ, N) = 0` since
+`ℤ` is projective (`Problem_8_2_7_i_tor_free_vanish`), and `Tor₁(ℤ/aᵢ, ℤ) = 0` since `ℤ` is
+torsion-free (`Problem_8_2_7_i_tor_cyclic_free_one`). -/
+theorem Problem_8_2_7_i_tor_one_fg (D : PIDDecomposition ℤ M) (E : PIDDecomposition ℤ N)
+    (hD : ∀ i, D.gen i ≠ 0) (hE : ∀ l, E.gen l ≠ 0) :
+    Nonempty (Etingof.Tor ℤ N (mopOf ℤ M) 1 ≃+
+      ∀ (i : D.torsionIndex) (l : E.torsionIndex),
+        ZMod (Nat.gcd (D.gen i).natAbs (E.gen l).natAbs)) := by
+  -- Split off the free summands of `M`, on which `Tor₁` vanishes.
+  haveI : ∀ i : Fin D.freeRank,
+      Subsingleton (Etingof.Tor ℤ N (D.mopSummand (Sum.inl i)) 1) := fun _ =>
+    AddCommGrpCat.subsingleton_of_isZero
+      ((Problem_8_2_7_i_tor_free_vanish N 0).of_iso (torFstCongr N (mopSelfIso ℤ) 1))
+  haveI := subsingleton_pi fun i : Fin D.freeRank =>
+    (Etingof.Tor ℤ N (D.mopSummand (Sum.inl i)) 1 : Type)
+  refine ⟨(torFstDecompositionAddEquiv D N 1).trans
+    (((piSumAddEquiv _).trans (subsingletonProdAddEquiv _ _)).trans
+      (AddEquiv.piCongrRight fun i => ?_))⟩
+  have hne : (D.gen i).natAbs ≠ 0 := Int.natAbs_ne_zero.mpr (hD i)
+  -- Identify the first argument with `ZMod aᵢ`, then decompose `N` and drop *its* free block.
+  refine (torFstCongr N (mopIntSummandIso D (Sum.inr i)) 1).addCommGroupIsoToAddEquiv.trans ?_
+  haveI : ∀ l : Fin E.freeRank,
+      Subsingleton (Etingof.Tor ℤ (E.summand (Sum.inl l))
+        (ModuleCat.of ℤᵐᵒᵖ (ZMod (D.genOf (Sum.inr i)).natAbs)) 1) := fun _ =>
+    AddCommGrpCat.subsingleton_of_isZero (Problem_8_2_7_i_tor_cyclic_free_one _ hne)
+  haveI := subsingleton_pi fun l : Fin E.freeRank =>
+    (Etingof.Tor ℤ (E.summand (Sum.inl l))
+      (ModuleCat.of ℤᵐᵒᵖ (ZMod (D.genOf (Sum.inr i)).natAbs)) 1 : Type)
+  refine (torSndDecompositionAddEquiv E _ 1).trans
+    (((piSumAddEquiv _).trans (subsingletonProdAddEquiv _ _)).trans
+      (AddEquiv.piCongrRight fun l => ?_))
+  exact ((torSndCongr (intSummandLinearEquiv E (Sum.inr l)) _ 1) ≪≫
+    (Problem_8_2_7_i_tor_one (D.gen i).natAbs (E.gen l).natAbs hne
+      (Int.natAbs_ne_zero.mpr (hE l))).some).addCommGroupIsoToAddEquiv
+
+/-- **Problem 8.2.7(i), `Tor`, packaged.** For any two finitely generated abelian groups `M`, `N`
+there are decompositions `M ≅ ℤ^m ⊕ ⨁ᵢ ℤ/aᵢ` and `N ≅ ℤ^p ⊕ ⨁ⱼ ℤ/bⱼ` (with all `aᵢ`, `bⱼ` nonzero)
+for which
+
+* `Tor₀(M, N) = M ⊗ N ≅ ⨁_{j,l ∈ all summands} ℤ/gcd(aⱼ, c_l)`
+  `= ℤ^{mp} ⊕ (⨁ᵢ ℤ/aᵢ)^p ⊕ (⨁ⱼ ℤ/bⱼ)^m ⊕ ⨁_{i,j} ℤ/gcd(aᵢ, bⱼ)`,
+* `Tor₁(M, N) ≅ ⨁_{i,j} ℤ/gcd(aᵢ, bⱼ)`,
+* `Torᵢ(M, N) = 0` for `i ≥ 2`.
+
+This is the `Tor` answer the exercise asks for; `Etingof.Problem_8_2_7_i_ext_fg` is the `Ext`
+half. -/
+theorem Problem_8_2_7_i_tor_fg [Module.Finite ℤ M] [Module.Finite ℤ N] :
+    ∃ (D : PIDDecomposition ℤ M) (E : PIDDecomposition ℤ N),
+      Nonempty (Etingof.Tor ℤ N (mopOf ℤ M) 0 ≃+
+        ∀ (j : D.index) (l : E.index),
+          ZMod (Nat.gcd (D.genOf j).natAbs (E.genOf l).natAbs)) ∧
+      Nonempty (Etingof.Tor ℤ N (mopOf ℤ M) 1 ≃+
+        ∀ (i : D.torsionIndex) (l : E.torsionIndex),
+          ZMod (Nat.gcd (D.gen i).natAbs (E.gen l).natAbs)) ∧
+      ∀ n : ℕ, Subsingleton (Etingof.Tor ℤ N (mopOf ℤ M) (n + 2)) := by
+  obtain ⟨D, hD⟩ := exists_pidDecomposition_gen_ne_zero ℤ M
+  obtain ⟨E, hE⟩ := exists_pidDecomposition_gen_ne_zero ℤ N
+  exact ⟨D, E, Problem_8_2_7_i_tor_zero_fg D E, Problem_8_2_7_i_tor_one_fg D E hD hE,
+    fun n => Problem_8_2_7_i_tor_fg_vanish N n⟩
+
+/-! ### Non-vacuity checks
+
+The summand-level table gives `Tor₀(ℤ/6, ℤ/4) ≅ ℤ/2` and, at a free second argument,
+`Tor₀(ℤ/6, ℤ) ≅ ℤ/6` (`ZMod 0 = ℤ`, `gcd 6 0 = 6`) while `Tor₁(ℤ/6, ℤ) = 0`; and the packaged
+endpoint elaborates for a concrete pair of finitely generated groups, so its hypotheses are
+satisfiable. -/
+
+section Examples
+
+example : Nonempty (Etingof.Tor ℤ (ZMod 4) (ModuleCat.of ℤᵐᵒᵖ (ZMod 6)) 0
+    ≅ AddCommGrpCat.of (ZMod 2)) := by
+  have h := Problem_8_2_7_i_tor_zero_cyclic 6 4
+  rwa [show Nat.gcd 6 4 = 2 from by norm_num] at h
+
+example : Nonempty (Etingof.Tor ℤ (ZMod 0) (ModuleCat.of ℤᵐᵒᵖ (ZMod 6)) 0
+    ≅ AddCommGrpCat.of (ZMod 6)) := by
+  have h := Problem_8_2_7_i_tor_zero_cyclic 6 0
+  rwa [Nat.gcd_zero_right] at h
+
+example : Limits.IsZero (Etingof.Tor ℤ ℤ (ModuleCat.of ℤᵐᵒᵖ (ZMod 6)) 1) :=
+  Problem_8_2_7_i_tor_cyclic_free_one 6 (by norm_num)
+
+example : True := by
+  have := Problem_8_2_7_i_tor_fg (M := ZMod 6) (N := ℤ × ZMod 4)
+  trivial
+
+end Examples
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_7_TorPoly.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_7_TorPoly.lean
@@ -1,0 +1,179 @@
+import EtingofRepresentationTheory.Chapter8.Problem8_2_7_TorFG
+import EtingofRepresentationTheory.Chapter8.Problem8_2_7_ExtPoly
+
+/-!
+# Problem 8.2.7(ii): `Torᵢ(M, N)` for arbitrary finitely generated `k[x]`-modules
+
+This is the `k[x]` counterpart of `Problem8_2_7_TorInt.lean`. `Problem8_2_7.lean` computes `Torᵢ`
+for a pair of cyclic `k[x]`-modules and for a free generator, `Problem8_2_7_TorFG.lean` reduces the
+general case to those building blocks, and this file fills in the summand table over `k[x]` and
+assembles the answer for **arbitrary** finitely generated `M`, `N`.
+
+## The summand table
+
+Every summand of a decomposition is `k[x] ⧸ (d)` (`Etingof.PIDDecomposition.summandIso`), the free
+ones being `d = 0`. Writing `f` for the first argument's generator, `g` for the second's, and
+`(f, g)` for the sum ideal `(f) ⊔ (g)` (which is `(gcd f g)`, since `k[x]` is a PID):
+
+| | `Tor₀` | `Tor₁` | `Torₙ₊₂` |
+|---|---|---|---|
+| `f = 0` (free) | `k[x] ⧸ (g)` | `0` | `0` |
+| `f ≠ 0`, `g = 0` | `k[x] ⧸ (f)` | `0` | `0` |
+| `f ≠ 0`, `g ≠ 0` | `k[x] ⧸ (f, g)` | `k[x] ⧸ (f, g)` | `0` |
+
+As over `ℤ`, **degree `0` needs no case split** — `Problem_8_2_7_ii_tor_zero` already has no
+hypothesis on `f` or `g`, since `(f, 0) = (f)` and `(0, g) = (g)` — while **degree `1` loses both
+free blocks**: `Tor₁(k[x], N) = 0` because `k[x]` is projective, and `Tor₁(k[x] ⧸ (f), k[x]) = 0`
+because `k[x]` is a domain, hence torsion-free.
+
+## Universe restriction
+
+The statements below take `k : Type`, not `k : Type u`. `Etingof.torBiproductIso` and
+`Etingof.torPiIso` are indexed by a `Type 0`, so the summands of a `PIDDecomposition` have to live
+there too; see the module docstring of `Problem8_2_7_TorFG.lean`. The `Ext` half
+(`Problem8_2_7_ExtPoly.lean`) is universe-polymorphic in `k`.
+
+## Main results
+
+* `Etingof.Problem_8_2_7_ii_tor_zero_fg`:
+  `M ⊗ N = Tor₀(M, N) ≅ ⨁_{j,l} k[x] ⧸ (dⱼ, e_l)` over **all** pairs of summands.
+* `Etingof.Problem_8_2_7_ii_tor_one_fg`: `Tor₁(M, N) ≅ ⨁_{i,j} k[x] ⧸ (fᵢ, gⱼ)`, over the
+  **torsion** summands of both arguments only.
+* `Etingof.Problem_8_2_7_ii_tor_fg_vanish`: `Torᵢ(M, N) = 0` for `i ≥ 2`, `N` arbitrary.
+* `Etingof.Problem_8_2_7_ii_tor_fg`: the three answers packaged with the existence of suitable
+  decompositions.
+-/
+
+namespace Etingof
+
+open CategoryTheory Limits Polynomial
+
+attribute [local instance] mopPolyQuot
+
+variable {k : Type} [Field k]
+
+/-! ### Identifying the summands
+
+As over `ℤ`, each summand has to be identified in two shapes: as an object of
+`ModuleCat k[X]ᵐᵒᵖ` for the first argument of `Tor`, and as a bare module for the second. -/
+
+/-- Every summand of a decomposition, viewed as a **right** `k[x]`-module, is the cyclic right
+module `k[x] ⧸ (genOf j)` the `Tor` building blocks of `Problem8_2_7.lean` are stated for. The free
+summands are `k[x] ⧸ (0)`. -/
+noncomputable def mopPolySummandIso {M : Type} [AddCommGroup M] [Module k[X] M]
+    (D : PIDDecomposition k[X] M) (j : D.index) :
+    D.mopSummand j ≅ ModuleCat.of (k[X])ᵐᵒᵖ (k[X] ⧸ Ideal.span {D.genOf j}) :=
+  D.mopSummandIso j ≪≫ mopPolyCyclicIso (D.genOf j)
+
+/-- Every summand of a decomposition, as a plain `k[x]`-module, is `k[x] ⧸ (genOf l)`: the
+`LinearEquiv` form of `Etingof.PIDDecomposition.summandIso`, needed because `Tor` takes its second
+argument as a bare module rather than as an object of `ModuleCat k[X]`. -/
+noncomputable def polySummandLinearEquiv {N : Type} [AddCommGroup N] [Module k[X] N]
+    (E : PIDDecomposition k[X] N) (l : E.index) :
+    (E.summand l : Type) ≃ₗ[k[X]] (k[X] ⧸ Ideal.span {E.genOf l}) :=
+  (E.summandIso l).toLinearEquiv
+
+/-! ### The assembled answers -/
+
+variable {M N : Type} [AddCommGroup M] [Module k[X] M] [AddCommGroup N] [Module k[X] N]
+
+/-- **Problem 8.2.7(ii), higher `Tor`.** `Torᵢ(M, N) = 0` for `i ≥ 2`, for `M` a finitely generated
+`k[x]`-module and `N` an *arbitrary* one: `M` is a finite direct sum of cyclic modules, and higher
+`Tor` out of a cyclic module over the PID `k[x]` vanishes for an arbitrary second argument
+(`Etingof.tor_vanish_polyQuot`). -/
+theorem Problem_8_2_7_ii_tor_fg_vanish [Module.Finite k[X] M] (Y : Type) [AddCommGroup Y]
+    [Module k[X] Y] (n : ℕ) :
+    Subsingleton (Etingof.Tor k[X] Y (mopOf k[X] M) (n + 2)) := by
+  obtain ⟨D⟩ := exists_pidDecomposition k[X] M
+  refine subsingleton_tor_of_summands D Y (n + 2) fun j => ?_
+  exact AddCommGrpCat.subsingleton_of_isZero
+    ((tor_vanish_polyQuot (D.genOf j) Y n).of_iso
+      (torFstCongr Y (mopPolySummandIso D j) (n + 2)))
+
+/-- **Problem 8.2.7(ii), `Tor₀`.** `M ⊗_{k[x]} N = Tor₀(M, N) ≅ ⨁_{j,l} k[x] ⧸ (dⱼ, e_l)`, the
+product running over **all** pairs of summands of `M` and `N` — free ones included, where the
+generator is `0` and `k[x] ⧸ (0) ≅ k[x]`. Expanding the four blocks gives the form stated in the
+exercise, with `k[x] ⧸ (f, g)` in place of `ℤ/gcd(a, b)`. -/
+theorem Problem_8_2_7_ii_tor_zero_fg (D : PIDDecomposition k[X] M)
+    (E : PIDDecomposition k[X] N) :
+    Nonempty (Etingof.Tor k[X] N (mopOf k[X] M) 0 ≃+
+      ∀ (j : D.index) (l : E.index), (k[X] ⧸ Ideal.span {D.genOf j, E.genOf l})) := by
+  refine ⟨(torPIDDecompositionAddEquiv D E 0).trans
+    (AddEquiv.piCongrRight fun j => AddEquiv.piCongrRight fun l => ?_)⟩
+  exact ((torSndCongr (polySummandLinearEquiv E l) (D.mopSummand j) 0) ≪≫
+    (torFstCongr (k[X] ⧸ Ideal.span {E.genOf l}) (mopPolySummandIso D j) 0) ≪≫
+    (Problem_8_2_7_ii_tor_zero k (D.genOf j)
+      (E.genOf l)).some).addCommGroupIsoToAddEquiv
+
+/-- **Problem 8.2.7(ii), `Tor₁`.** `Tor₁(M, N) ≅ ⨁_{i,j} k[x] ⧸ (fᵢ, gⱼ)`, the product running
+over the **torsion** summands of `M` and of `N` only. Both free blocks drop out:
+`Tor₁(k[x], N) = 0` since `k[x]` is projective (`Problem_8_2_7_ii_tor_free_vanish`), and
+`Tor₁(k[x] ⧸ (fᵢ), k[x]) = 0` since `k[x]` is torsion-free
+(`Problem_8_2_7_ii_tor_cyclic_free_one`). -/
+theorem Problem_8_2_7_ii_tor_one_fg (D : PIDDecomposition k[X] M) (E : PIDDecomposition k[X] N)
+    (hD : ∀ i, D.gen i ≠ 0) (hE : ∀ l, E.gen l ≠ 0) :
+    Nonempty (Etingof.Tor k[X] N (mopOf k[X] M) 1 ≃+
+      ∀ (i : D.torsionIndex) (l : E.torsionIndex),
+        (k[X] ⧸ Ideal.span {D.gen i, E.gen l})) := by
+  -- Split off the free summands of `M`, on which `Tor₁` vanishes.
+  haveI : ∀ i : Fin D.freeRank,
+      Subsingleton (Etingof.Tor k[X] N (D.mopSummand (Sum.inl i)) 1) := fun _ =>
+    AddCommGrpCat.subsingleton_of_isZero
+      ((Problem_8_2_7_ii_tor_free_vanish k N 0).of_iso (torFstCongr N (mopSelfIso k[X]) 1))
+  haveI := subsingleton_pi fun i : Fin D.freeRank =>
+    (Etingof.Tor k[X] N (D.mopSummand (Sum.inl i)) 1 : Type)
+  refine ⟨(torFstDecompositionAddEquiv D N 1).trans
+    (((piSumAddEquiv _).trans (subsingletonProdAddEquiv _ _)).trans
+      (AddEquiv.piCongrRight fun i => ?_))⟩
+  -- Identify the first argument with `k[x] ⧸ (fᵢ)`, then decompose `N` and drop *its* free block.
+  refine (torFstCongr N (mopPolySummandIso D (Sum.inr i)) 1).addCommGroupIsoToAddEquiv.trans ?_
+  haveI : ∀ l : Fin E.freeRank,
+      Subsingleton (Etingof.Tor k[X] (E.summand (Sum.inl l))
+        (ModuleCat.of (k[X])ᵐᵒᵖ (k[X] ⧸ Ideal.span {D.genOf (Sum.inr i)})) 1) := fun _ =>
+    AddCommGrpCat.subsingleton_of_isZero (Problem_8_2_7_ii_tor_cyclic_free_one _ (hD i))
+  haveI := subsingleton_pi fun l : Fin E.freeRank =>
+    (Etingof.Tor k[X] (E.summand (Sum.inl l))
+      (ModuleCat.of (k[X])ᵐᵒᵖ (k[X] ⧸ Ideal.span {D.genOf (Sum.inr i)})) 1 : Type)
+  refine (torSndDecompositionAddEquiv E _ 1).trans
+    (((piSumAddEquiv _).trans (subsingletonProdAddEquiv _ _)).trans
+      (AddEquiv.piCongrRight fun l => ?_))
+  exact ((torSndCongr (polySummandLinearEquiv E (Sum.inr l)) _ 1) ≪≫
+    (Problem_8_2_7_ii_tor_one (D.gen i) (E.gen l) (hD i) (hE l)).some).addCommGroupIsoToAddEquiv
+
+/-- **Problem 8.2.7(ii), `Tor`, packaged.** For any two finitely generated `k[x]`-modules `M`, `N`
+there are decompositions `M ≅ k[x]^m ⊕ ⨁ᵢ k[x] ⧸ (fᵢ)` and `N ≅ k[x]^p ⊕ ⨁ⱼ k[x] ⧸ (gⱼ)` (with all
+`fᵢ`, `gⱼ` nonzero) for which
+
+* `Tor₀(M, N) = M ⊗ N ≅ ⨁_{j,l ∈ all summands} k[x] ⧸ (dⱼ, e_l)`,
+* `Tor₁(M, N) ≅ ⨁_{i,j} k[x] ⧸ (fᵢ, gⱼ)`,
+* `Torᵢ(M, N) = 0` for `i ≥ 2`.
+
+This is the `Tor` answer part (ii) of the exercise asks for; `Etingof.Problem_8_2_7_ii_ext_fg` is
+the `Ext` half. -/
+theorem Problem_8_2_7_ii_tor_fg [Module.Finite k[X] M] [Module.Finite k[X] N] :
+    ∃ (D : PIDDecomposition k[X] M) (E : PIDDecomposition k[X] N),
+      Nonempty (Etingof.Tor k[X] N (mopOf k[X] M) 0 ≃+
+        ∀ (j : D.index) (l : E.index), (k[X] ⧸ Ideal.span {D.genOf j, E.genOf l})) ∧
+      Nonempty (Etingof.Tor k[X] N (mopOf k[X] M) 1 ≃+
+        ∀ (i : D.torsionIndex) (l : E.torsionIndex),
+          (k[X] ⧸ Ideal.span {D.gen i, E.gen l})) ∧
+      ∀ n : ℕ, Subsingleton (Etingof.Tor k[X] N (mopOf k[X] M) (n + 2)) := by
+  obtain ⟨D, hD⟩ := exists_pidDecomposition_gen_ne_zero k[X] M
+  obtain ⟨E, hE⟩ := exists_pidDecomposition_gen_ne_zero k[X] N
+  exact ⟨D, E, Problem_8_2_7_ii_tor_zero_fg D E, Problem_8_2_7_ii_tor_one_fg D E hD hE,
+    fun n => Problem_8_2_7_ii_tor_fg_vanish N n⟩
+
+/-! ### Non-vacuity check
+
+The packaged endpoint elaborates for a concrete pair of finitely generated `ℚ[X]`-modules, so its
+hypotheses are satisfiable. -/
+
+section Examples
+
+example : True := by
+  have := Problem_8_2_7_ii_tor_fg (k := ℚ) (M := ℚ[X]) (N := ℚ[X])
+  trivial
+
+end Examples
+
+end Etingof

--- a/progress/2026-07-25T05-54-31Z_fde19e67.md
+++ b/progress/2026-07-25T05-54-31Z_fde19e67.md
@@ -1,0 +1,100 @@
+## Accomplished
+
+Closed #7738: `Torᵢ(M, N)` for **arbitrary** finitely generated modules over `ℤ` and `k[x]`
+(Problem 8.2.7, the `Tor` half). This completes Problem 8.2.7 — the `Ext` half landed last turn in
+#7744 — so `progress/items.json` flips `Chapter8/Problem8.2.7` to `covered_full`.
+
+Three new files plus a refactor of `Problem8_2_7.lean`.
+
+`Chapter8/Problem8_2_7_TorFG.lean` — base-ring-independent reduction machinery, the mirror of
+`Problem8_2_7_ExtFG.lean`:
+
+* `torSndCongr` — transport `Tor` along a linear isomorphism in the *second* variable. The first
+  variable is a functor argument, so there `(TorFunctor A N n).mapIso` already does the job
+  (`torFstCongr`); the second is baked into `tensorRightFunctor` before deriving, so it has to be
+  assembled from `torSndMap` and its identity/composition laws.
+* `biproductPiAddEquiv` — `⨁ f ≃+ Π j, f j` for abelian groups, so the answers come out as products
+  rather than categorical biproducts, matching the `Ext` side.
+* `PIDDecomposition.equivPi` (a decomposition as an isomorphism onto the *product* of its summands,
+  which is what `torPiIso` is stated for) and `PIDDecomposition.mopSummandIso` (each summand as a
+  **right** module is `A ⧸ (genOf j)`).
+* `torFstDecompositionAddEquiv`, `torSndDecompositionAddEquiv`, `torPIDDecompositionAddEquiv` — the
+  reduction: `Torₙ(M, N) ≃+ Π (j) (l), Torₙ(summand j, summand l)`, plus the two one-variable forms.
+* `subsingleton_tor_of_summands` — the shape the higher-degree vanishing is assembled in.
+
+`Chapter8/Problem8_2_7_TorInt.lean` (part i) and `Chapter8/Problem8_2_7_TorPoly.lean` (part ii) —
+the summand tables and the assembled answers, ending in `Problem_8_2_7_i_tor_fg` /
+`Problem_8_2_7_ii_tor_fg`, which package all three degrees with the existence of suitable
+decompositions.
+
+### Three things worth recording
+
+**The `Tor` side's uniform degree is `0`, not `1` — exactly opposite to `Ext`.** `Ext¹(ℤ/a, -)` is
+the *cokernel* of `·a` and `Tor₁(ℤ/a, -)` its *kernel*. On the `Ext` side the free summands of `N`
+fit the uniform `ℤ/gcd(a, c)` formula in degree `1` (`gcd a 0 = a`) and break it in degree `0`
+(`Hom(ℤ/a, ℤ) = 0`). On the `Tor` side it is degree `0` — the tensor product — that is uniform
+across *all* pairs of summands including free×free (`gcd 0 0 = 0`, `ZMod 0 = ℤ`), so
+`Problem_8_2_7_i_tor_zero_fg` has no case split at all; and it is degree `1` that loses **both**
+free blocks: `Tor₁(ℤ, N) = 0` by projectivity, and `Tor₁(ℤ/a, ℤ) = 0` because `ℤ` is torsion-free,
+even though `gcd a 0 = a ≠ 0`. So `Tor₁` runs over torsion×torsion only. Same over `k[x]`.
+
+**Generalizing beat duplicating, again.** The reduction needs each summand-level `Tor` for an
+*arbitrary* second argument, but the existing theorems were stated only for a cyclic second
+argument. Rather than reprove the six-term-sequence arguments, I generalized them in place — the
+second argument appears in those proofs only as `F := tensorRightFunctor A N`, never as a cyclic
+module. That gave `tor_zero_zmod_quotSMul` (`Tor₀(ℤ/a, N) ≅ N/aN`, no hypothesis on `a`),
+`tor_one_zmod_kerSMul` (`Tor₁(ℤ/a, N) ≅ ker(·a)`, the exact mirror of the previous turn's
+`ext_one_zmod_quotSMul`), `tor_one_polyQuot_kerSMul`, and `tor_vanish_zmod` /
+`tor_vanish_polyQuot`. `Problem_8_2_7_i_tor_zero`, `_i_tor_one`, `_i_tor_vanish` and their `k[x]`
+counterparts keep their statements and are now short corollaries; two new endpoints
+(`Problem_8_2_7_i_tor_cyclic_free_one`, `Problem_8_2_7_ii_tor_cyclic_free_one`) fall out for free.
+
+**One universe restriction, and it is real.** The general `Tor` statements over `k[x]` take
+`k : Type`, not `k : Type u`. `torBiproductIso` and `torPiIso` (from #7735/#7743) are indexed by a
+`Type 0`, because Mathlib's `PreservesBiproduct` instances for additive functors and
+`AddCommGrpCat.biproductIsoPi` are; a `PIDDecomposition A M` for `A M : Type u` indexes its
+summands by a `Type u`. I tried generalizing both additivity lemmas to a `Type u` index and it
+fails on `PreservesBiproduct M (TorFunctor A N n)` and on `biproduct.lift_desc`, so I reverted that
+and documented the restriction instead of hacking around it. The `Ext` side is unaffected
+(`Abelian.Ext.biproductAddEquiv` is universe-polymorphic in the index). Note this is a restriction
+on the *statement's* generality only: every concrete field lives in `Type 0`.
+
+## Current frontier
+
+`lake build` is clean: 9286 jobs, exit 0, zero `error:`, zero `declaration uses 'sorry'`. All new
+endpoints depend only on `propext`, `Classical.choice`, `Quot.sound` (checked with `#print axioms`
+on all fourteen). Non-vacuity is checked in-file: `Tor₀(ℤ/6, ℤ/4) ≅ ℤ/2`, `Tor₀(ℤ/6, ℤ) ≅ ℤ/6`,
+`Tor₁(ℤ/6, ℤ) = 0`, and the packaged endpoints elaborate for concrete pairs (`ZMod 6`, `ℤ × ZMod 4`
+over `ℤ`; `ℚ[X]` over `ℚ[X]`).
+
+`scripts/validate_items.py` passes (`VALIDATION PASSED`, exit 0); the only warnings are
+pre-existing ones on unrelated `derived` items.
+
+## Overall project progress
+
+Stage 3 formalization. Problem 8.2.7 is now complete in both halves for arbitrary finitely
+generated modules over both base rings, which closes the substance of #7381.
+
+## Next step
+
+`Chapter8/Problem8.2.7` is `covered_full`, so #7381 (the umbrella issue) should be re-read to see
+what, if anything, remains under it beyond 8.2.7.
+
+Two optional follow-ups a later agent could pick up, neither needed for the exercise:
+
+* **Universe polymorphism for the `k[x]` `Tor` statements.** This needs `torBiproductIso` /
+  `torPiIso` at a `Type u` index. The obstruction is upstream (Mathlib's `PreservesBiproduct`
+  instances for additive functors, and `AddCommGrpCat.biproductIsoPi`, are `Type 0`-indexed). The
+  tractable route is to reindex a `PIDDecomposition`'s summands along `Fintype.equivFin` down to
+  `Fin n : Type 0` before applying the additivity lemmas, rather than generalizing them; note that
+  a `Type u`-polymorphic `AddCommGrpCat.biproductIsoPi` *is* provable directly from
+  `AddCommGrpCat.HasLimit.productLimitCone`, which is already universe-general (I verified this in
+  a scratch file), so only the `PreservesBiproduct` side genuinely blocks.
+* `Problem_8_2_7_ii_ext_one` could be generalized to an arbitrary target module the way
+  `ext_one_zmod_quotSMul` generalizes the `ℤ` case, giving the `k[x]` counterpart of
+  `Problem_8_2_7_i_ext_one_intrinsic`. (Carried over from last turn; the `Tor` side of this
+  generalization is now done, as `tor_one_polyQuot_kerSMul`.)
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -9206,16 +9206,19 @@
     "start_line": 23,
     "end_line": 26,
     "status": "sorry_free",
-    "coverage_note": "The Ext half of the exercise is complete for arbitrary finitely generated modules. Problem8_2_7.lean has the summand-level building blocks (cyclic-pair and free-generator Tor/Ext over Z and k[X]); PIDDecomposition.lean packages the structure theorem as a biproduct decomposition; Problem8_2_7_ExtFG.lean supplies additivity of Ext along a decomposition and projective dimension < 2 for every f.g. module over a PID; Problem8_2_7_ExtInt.lean and Problem8_2_7_ExtPoly.lean assemble Ext^0, Ext^1 and the vanishing in degrees >= 2 for arbitrary f.g. M, N (Problem_8_2_7_i_ext_fg, Problem_8_2_7_ii_ext_fg). The Tor half for arbitrary f.g. modules is still open (#7738), so this item stays covered_partial.",
+    "coverage_note": "Both halves are complete for arbitrary finitely generated modules over Z (part i) and k[X] (part ii). Problem8_2_7.lean has the summand-level building blocks, now stated for arbitrary second arguments (tor_zero_zmod_quotSMul, tor_one_zmod_kerSMul, tor_one_polyQuot_kerSMul, tor_vanish_zmod, tor_vanish_polyQuot, ext_one_zmod_quotSMul); PIDDecomposition.lean packages the structure theorem as a biproduct decomposition; Problem8_2_7_ExtFG.lean and Problem8_2_7_TorFG.lean supply additivity along a decomposition in both arguments; Problem8_2_7_ExtInt/ExtPoly and Problem8_2_7_TorInt/TorPoly assemble degrees 0, 1 and the vanishing in degrees >= 2 (Problem_8_2_7_i_ext_fg, Problem_8_2_7_ii_ext_fg, Problem_8_2_7_i_tor_fg, Problem_8_2_7_ii_tor_fg). One scope note: the general Tor statements over k[X] are for k : Type, since Mathlib's PreservesBiproduct instances and AddCommGrpCat.biproductIsoPi are indexed by a Type 0; the Ext statements are universe-polymorphic in k.",
     "followup_issue": 7381,
-    "coverage": "covered_partial",
+    "coverage": "covered_full",
     "lean_file": [
       "EtingofRepresentationTheory/Chapter8/Problem8_2_7.lean",
       "EtingofRepresentationTheory/Chapter8/PIDDecomposition.lean",
       "EtingofRepresentationTheory/Chapter8/Additivity.lean",
       "EtingofRepresentationTheory/Chapter8/Problem8_2_7_ExtFG.lean",
       "EtingofRepresentationTheory/Chapter8/Problem8_2_7_ExtInt.lean",
-      "EtingofRepresentationTheory/Chapter8/Problem8_2_7_ExtPoly.lean"
+      "EtingofRepresentationTheory/Chapter8/Problem8_2_7_ExtPoly.lean",
+      "EtingofRepresentationTheory/Chapter8/Problem8_2_7_TorFG.lean",
+      "EtingofRepresentationTheory/Chapter8/Problem8_2_7_TorInt.lean",
+      "EtingofRepresentationTheory/Chapter8/Problem8_2_7_TorPoly.lean"
     ],
     "last_updated": "2026-07-25"
   },


### PR DESCRIPTION
This PR computes `Torᵢ(M, N)` for arbitrary finitely generated modules over `ℤ` and `k[x]`, completing Problem 8.2.7 (the `Ext` half landed in #7744).

`Chapter8/Problem8_2_7_TorFG.lean` is the base-ring-independent reduction, mirroring `Problem8_2_7_ExtFG.lean`: `torSndCongr` transports `Tor` along an isomorphism in the second variable (the first is a functor argument, so `(TorFunctor A N n).mapIso` suffices there), `PIDDecomposition.equivPi` and `PIDDecomposition.mopSummandIso` present a decomposition in the two shapes `Tor` needs, and `torPIDDecompositionAddEquiv` gives `Torₙ(M, N) ≃+ Π (j) (l), Torₙ(summand j, summand l)` — the book's "reduce to the case of cyclic groups". `Chapter8/Problem8_2_7_TorInt.lean` and `Chapter8/Problem8_2_7_TorPoly.lean` fill in the summand tables and assemble `Problem_8_2_7_i_tor_fg` and `Problem_8_2_7_ii_tor_fg`.

The uniform degree on the `Tor` side is `0`, not `1` — the opposite of `Ext`. Since `Ext¹(ℤ/a, -)` is the cokernel of `·a` and `Tor₁(ℤ/a, -)` its kernel, it is `Tor₀` (the tensor product) that fits `ℤ/gcd(a, c)` across every pair of summands including free ones (`gcd 0 0 = 0`, `ZMod 0 = ℤ`), so the degree-`0` answer has no case split at all; and it is `Tor₁` that loses both free blocks, since `ℤ` is projective and also torsion-free. `Tor₁` therefore runs over torsion×torsion only. Same story over `k[x]`.

The summand-level inputs are generalized rather than duplicated: the existing six-term-sequence proofs never use anything about the second argument beyond `tensorRightFunctor A N`, so they now give `tor_zero_zmod_quotSMul` (`Tor₀(ℤ/a, N) ≅ N/aN`), `tor_one_zmod_kerSMul` (`Tor₁(ℤ/a, N) ≅ ker(·a)`, the exact mirror of `ext_one_zmod_quotSMul`), `tor_one_polyQuot_kerSMul`, and `tor_vanish_zmod` / `tor_vanish_polyQuot`, all for arbitrary `N`. `Problem_8_2_7_i_tor_zero`, `_i_tor_one`, `_i_tor_vanish` and their `k[x]` counterparts keep their statements and become short corollaries.

One documented scope note: the general `Tor` statements over `k[x]` take `k : Type` rather than `k : Type u`, because `torBiproductIso` and `torPiIso` are indexed by a `Type 0` while a `PIDDecomposition A M` for `A M : Type u` indexes its summands by a `Type u`. Generalizing those two lemmas to a `Type u` index fails upstream on `PreservesBiproduct M (TorFunctor A N n)` and on `biproduct.lift_desc`, so the restriction is recorded in the module docstrings instead of worked around. The `Ext` half is unaffected.

`lake build` is clean (9286 jobs, no errors, no sorries) and all fourteen new endpoints depend only on `propext`, `Classical.choice`, `Quot.sound`. `progress/items.json` flips `Chapter8/Problem8.2.7` to `covered_full`; `scripts/validate_items.py` passes.

Closes #7738

Session: fde19e67-ca2e-4530-8d3a-5e06b5198816

🤖 Prepared with Claude Code