### PR TITLE
feat(Ch9 #7367): choose the progenerator internally in the categorical Corollary 9.7.3(i)

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -79,6 +79,15 @@ a bare `lake build` **silently builds Mathlib and reports success** — a green 
 touched your project. If builds report "unknown target" or an unexpected job count, run `pwd`
 and `cd` back to the worktree root before trusting any result.
 
+**Never run two `lake build`s at once in the same worktree.** They share `.lake/build`, and
+the second invocation reads oleans the first is mid-write, producing bogus `failed to open
+file '….olean': No such file or directory` errors on files you never touched. The usual way
+to fall into this: kick off a full `lake build` with `run_in_background`, then start another
+build to "check on it". If you need to wait for a background build, wait for its completion
+notification, or start a *single* foreground `lake build` and let lake's lock queue it — do
+not interleave. When a build fails on a missing olean for an unrelated module, suspect this
+before debugging, and confirm with one clean re-run.
+
 **Typecheck with `lake build EtingofRepresentationTheory.<Module>`, NOT `lake env lean
 <file>`.** `lake env lean` does **not** apply the lakefile's `[leanOptions]` — in
 particular `maxSynthPendingDepth = 3` (lakefile.toml; the Lean default is 2). Deep

--- a/EtingofRepresentationTheory/Chapter9/Corollary9_7_3.lean
+++ b/EtingofRepresentationTheory/Chapter9/Corollary9_7_3.lean
@@ -53,13 +53,12 @@ basic algebra `B(𝒞)`. What is formalized here is the algebra version: the inp
 is a finite-dimensional algebra `A` (Theorem `Etingof.Corollary_9_7_3_i`), not an
 abstract category. The categorical input form is formalized as
 `Etingof.Corollary_9_7_3_i_categorical_fgModule` in `Corollary9_7_3Categorical.lean`:
-for a `k`-linear finite abelian category `𝒞` over an algebraically closed field with a
-progenerator `P`, it produces a basic `k`-algebra `B` together with a single equivalence
-`𝒞 ≌ FGModuleCat B`, the book's part (i) exactly. It composes
-`Etingof.Theorem_9_6_4_corollary` (`𝒞 ≌ FGModuleCat (End P)ᵐᵒᵖ` for the progenerator `P`,
-carried as an explicit hypothesis since the project has no theorem that an abstract finite
-abelian category has a progenerator) with the algebra version applied to
-`A = (End P)ᵐᵒᵖ`. The two conjuncts are combined into `𝒞 ≌ FGModuleCat B` via
+for a `k`-linear finite abelian category `𝒞` over an algebraically closed field, it produces
+a basic `k`-algebra `B` together with a single equivalence `𝒞 ≌ FGModuleCat B`, the book's
+part (i) exactly. It chooses a progenerator `P` of `𝒞` using
+`Etingof.Exercise963.exists_progenerator` (Exercise 9.6.3), then composes
+`Etingof.Theorem_9_6_4_corollary` (`𝒞 ≌ FGModuleCat (End P)ᵐᵒᵖ`) with the algebra version
+applied to `A = (End P)ᵐᵒᵖ`. The two conjuncts are combined into `𝒞 ≌ FGModuleCat B` via
 `Etingof.MoritaEquivalent.fgModuleCatEquiv` (`Infrastructure/MoritaFGRestriction.lean`),
 which restricts a Morita equivalence `ModuleCat A ≌ ModuleCat B` to the finitely
 generated subcategories by proving it preserves finite generation (the image of the

--- a/EtingofRepresentationTheory/Chapter9/Corollary9_7_3Categorical.lean
+++ b/EtingofRepresentationTheory/Chapter9/Corollary9_7_3Categorical.lean
@@ -1,6 +1,7 @@
 import EtingofRepresentationTheory.Chapter9.Corollary9_7_3
 import EtingofRepresentationTheory.Chapter9.Theorem9_6_4
 import EtingofRepresentationTheory.Chapter9.Introduction_9_6
+import EtingofRepresentationTheory.Chapter9.Exercise9_6_3
 import EtingofRepresentationTheory.Infrastructure.BasicAlgebraExistence
 import EtingofRepresentationTheory.Infrastructure.MoritaFGRestriction
 
@@ -11,15 +12,14 @@ The book's Corollary 9.7.3(i) is stated for an abstract `k`-linear finite abelia
 category `𝒞`: any such `𝒞` is equivalent to the finite-dimensional modules over a unique
 basic algebra `B(𝒞)`. The main development in `Corollary9_7_3.lean` formalizes the
 algebra version (input = a finite-dimensional algebra `A`). This file records the
-categorical input form: the input is an abstract `IsFiniteAbelianCategory` together
-with a progenerator, and the output packages both the Morita equivalence with a
-concrete finite-dimensional algebra and the existence of a basic algebra Morita
-equivalent to it.
+categorical input form: the input is an abstract `IsFiniteAbelianCategory`, and the
+output packages both the Morita equivalence with a concrete finite-dimensional algebra
+and the existence of a basic algebra Morita equivalent to it.
 
 ## What is proved here
 
 `Etingof.Corollary_9_7_3_i_categorical`: for a `k`-linear finite abelian category `𝒞`
-over an algebraically closed field `k` with a progenerator `P`, there is a basic
+over an algebraically closed field `k`, there are a progenerator `P` of `𝒞` and a basic
 `k`-algebra `B` such that
 
 * `𝒞 ≌ FGModuleCat (End P)ᵐᵒᵖ` (Theorem 9.6.4), and
@@ -29,12 +29,16 @@ Here `(End P)ᵐᵒᵖ` is the finite-dimensional algebra `A` whose finite-dimen
 modules realize `𝒞`. Because `End P = Hom(P, P)` is finite dimensional over `k` in a
 `k`-linear finite abelian category (Etingof §9.6, "check it!"), so is `(End P)ᵐᵒᵖ`.
 
-## The progenerator hypothesis
+## The progenerator
 
-The book asserts that every finite abelian category has a projective generator. The
-project does not prove existence of a progenerator in an abstract finite abelian
-category; matching how Theorem 9.6.4 is stated, the progenerator `P` is carried as an
-explicit hypothesis rather than produced.
+The book asserts that every finite abelian category has a projective generator, and
+`Etingof.Exercise963.exists_progenerator` (Exercise 9.6.3) proves it: the direct sum of
+the projective covers of the finitely many simple objects is a progenerator. The public
+theorems below quantify only over `𝒞` and choose `P` internally through that theorem.
+Since the algebra `(End P)ᵐᵒᵖ` realizing `𝒞` depends on the choice, `P` reappears as an
+existential in the conclusions that mention it. Each public statement has an
+`_of_progenerator` variant taking `P` as a hypothesis, matching how Theorem 9.6.4 is
+stated; those are the forms to use when a specific progenerator is already at hand.
 
 ## The single-equivalence form
 
@@ -55,20 +59,19 @@ open CategoryTheory
 
 universe v u
 
-/-- **Corollary 9.7.3(i), categorical input form.** This form yields the two facts
-separately; for the single equivalence `𝒞 ≌ FGModuleCat B` see
-`Etingof.Corollary_9_7_3_i_categorical_fgModule`. Let `𝒞` be a `k`-linear finite abelian
-category over an algebraically closed field `k`, and let `P` be a progenerator of `𝒞`.
-Then there is a basic `k`-algebra `B` such that `𝒞` is equivalent to the finite-dimensional
-`(End P)ᵐᵒᵖ`-modules, and `(End P)ᵐᵒᵖ`, a finite-dimensional `k`-algebra, is Morita
-equivalent to `B`.
+/-- **Corollary 9.7.3(i), categorical input form, for a chosen progenerator.** The variant of
+`Etingof.Corollary_9_7_3_i_categorical` that takes the progenerator as a hypothesis instead of
+choosing one internally. Let `𝒞` be a `k`-linear finite abelian category over an algebraically
+closed field `k`, and let `P` be a progenerator of `𝒞`. Then there is a basic `k`-algebra `B`
+such that `𝒞` is equivalent to the finite-dimensional `(End P)ᵐᵒᵖ`-modules, and `(End P)ᵐᵒᵖ`,
+a finite-dimensional `k`-algebra, is Morita equivalent to `B`.
 
 The finite-dimensional algebra `A = (End P)ᵐᵒᵖ` whose finite-dimensional modules realize
 `𝒞` comes from Theorem 9.6.4 (`Etingof.Theorem_9_6_4_corollary`); the basic algebra `B`
 Morita equivalent to it comes from the algebra version of Corollary 9.7.3(i)
 (`Etingof.exists_basic_morita_equivalent`).
 (Etingof Corollary 9.7.3(i), categorical form) -/
-theorem Etingof.Corollary_9_7_3_i_categorical
+theorem Etingof.Corollary_9_7_3_i_categorical_of_progenerator
     {k : Type v} [Field k] [IsAlgClosed k]
     (C : Type u) [Category.{v} C]
     [Etingof.IsFiniteAbelianCategory C] [Linear k C]
@@ -91,8 +94,40 @@ theorem Etingof.Corollary_9_7_3_i_categorical
     Etingof.exists_basic_morita_equivalent k (End P)ᵐᵒᵖ
   exact ⟨B, instR, instA, instF, hbasic, hcat, hmor⟩
 
-/-- **Corollary 9.7.3(i), categorical input form, single equivalence.** The two conjuncts
-of `Etingof.Corollary_9_7_3_i_categorical`
+/-- **Corollary 9.7.3(i), categorical input form.** This form yields the two facts
+separately; for the single equivalence `𝒞 ≌ FGModuleCat B` see
+`Etingof.Corollary_9_7_3_i_categorical_fgModule`. Let `𝒞` be a `k`-linear finite abelian
+category over an algebraically closed field `k`. Then `𝒞` has a progenerator `P`, and there
+is a basic `k`-algebra `B` such that `𝒞` is equivalent to the finite-dimensional
+`(End P)ᵐᵒᵖ`-modules, and `(End P)ᵐᵒᵖ`, a finite-dimensional `k`-algebra, is Morita
+equivalent to `B`.
+
+Unlike `Etingof.Corollary_9_7_3_i_categorical_of_progenerator`, the progenerator is not asked
+of the caller: it is produced by `Etingof.Exercise963.exists_progenerator` (Exercise 9.6.3).
+It stays visible as an existential only because the realizing algebra `(End P)ᵐᵒᵖ` is defined
+in terms of it.
+(Etingof Corollary 9.7.3(i), categorical form) -/
+theorem Etingof.Corollary_9_7_3_i_categorical
+    {k : Type v} [Field k] [IsAlgClosed k]
+    (C : Type u) [Category.{v} C]
+    [Etingof.IsFiniteAbelianCategory C] [Linear k C]
+    [Etingof.IsFiniteAbelianCategoryOverField k C] :
+    ∃ (P : C) (_ : Etingof.IsProgenerator P) (B : Type v) (_ : Ring B) (_ : Algebra k B)
+        (_ : Module.Finite k B),
+      Etingof.IsBasicAlgebra k B ∧
+        Nonempty (C ≌ FGModuleCat.{v} (End P)ᵐᵒᵖ) ∧
+          Etingof.MoritaEquivalent (End P)ᵐᵒᵖ B := by
+  -- Exercise 9.6.3: every finite abelian category has a progenerator.
+  obtain ⟨P, ⟨hp⟩⟩ := Etingof.Exercise963.exists_progenerator C
+  haveI : Etingof.IsProgenerator P := hp
+  obtain ⟨B, instR, instA, instF, hbasic, hcat, hmor⟩ :=
+    Etingof.Corollary_9_7_3_i_categorical_of_progenerator (k := k) C P
+  exact ⟨P, hp, B, instR, instA, instF, hbasic, hcat, hmor⟩
+
+/-- **Corollary 9.7.3(i), categorical input form, single equivalence, for a chosen
+progenerator.** The variant of `Etingof.Corollary_9_7_3_i_categorical_fgModule` that takes the
+progenerator as a hypothesis instead of choosing one internally. The two conjuncts of
+`Etingof.Corollary_9_7_3_i_categorical_of_progenerator`
 (`𝒞 ≌ FGModuleCat (End P)ᵐᵒᵖ` and `(End P)ᵐᵒᵖ` Morita equivalent to a basic `B`) are
 combined into the single book statement `𝒞 ≌ FGModuleCat B` with `B` basic.
 
@@ -104,7 +139,7 @@ The Morita equivalence `(End P)ᵐᵒᵖ ≌ B` restricts to the finitely genera
 subcategories via `Etingof.MoritaEquivalent.fgModuleCatEquiv`, and composing with
 Theorem 9.6.4's `𝒞 ≌ FGModuleCat (End P)ᵐᵒᵖ` gives the single equivalence.
 (Etingof Corollary 9.7.3(i), categorical form) -/
-theorem Etingof.Corollary_9_7_3_i_categorical_fgModule
+theorem Etingof.Corollary_9_7_3_i_categorical_fgModule_of_progenerator
     {k : Type v} [Field k] [IsAlgClosed k]
     (C : Type u) [Category.{v} C]
     [Etingof.IsFiniteAbelianCategory C] [Linear k C]
@@ -123,9 +158,32 @@ theorem Etingof.Corollary_9_7_3_i_categorical_fgModule
   obtain ⟨eC⟩ := hcat
   exact ⟨B, instR, instA, instF, hbasic, ⟨eC.trans eFG⟩⟩
 
-/-- **Corollary 9.7.3(i), categorical input form, with uniqueness.** The strong form of
-`Etingof.Corollary_9_7_3_i_categorical_fgModule`: for a `k`-linear finite abelian category `𝒞`
-over an algebraically closed field with a progenerator `P`, the basic algebra `B` realizing
+/-- **Corollary 9.7.3(i), categorical input form, single equivalence.** The book's statement:
+any `k`-linear finite abelian category `𝒞` over an algebraically closed field `k` is the
+category of finite-dimensional modules over a basic `k`-algebra `B`.
+
+The progenerator needed to produce `B` is chosen internally, via
+`Etingof.Exercise963.exists_progenerator` (Exercise 9.6.3); it does not appear in the
+statement at all. For the uniqueness of `B` see
+`Etingof.Corollary_9_7_3_i_categorical_strong`.
+(Etingof Corollary 9.7.3(i), categorical form) -/
+theorem Etingof.Corollary_9_7_3_i_categorical_fgModule
+    {k : Type v} [Field k] [IsAlgClosed k]
+    (C : Type u) [Category.{v} C]
+    [Etingof.IsFiniteAbelianCategory C] [Linear k C]
+    [Etingof.IsFiniteAbelianCategoryOverField k C] :
+    ∃ (B : Type v) (_ : Ring B) (_ : Algebra k B) (_ : Module.Finite k B),
+      Etingof.IsBasicAlgebra k B ∧ Nonempty (C ≌ FGModuleCat.{v} B) := by
+  obtain ⟨P, ⟨hp⟩⟩ := Etingof.Exercise963.exists_progenerator C
+  haveI : Etingof.IsProgenerator P := hp
+  exact Etingof.Corollary_9_7_3_i_categorical_fgModule_of_progenerator (k := k) C P
+
+/-- **Corollary 9.7.3(i), categorical input form, with uniqueness, for a chosen progenerator.**
+The variant of `Etingof.Corollary_9_7_3_i_categorical_strong` that takes the progenerator as a
+hypothesis instead of choosing one internally, and the strong form of
+`Etingof.Corollary_9_7_3_i_categorical_fgModule_of_progenerator`: for a `k`-linear finite abelian
+category `𝒞` over an algebraically closed field with a progenerator `P`, the basic algebra `B`
+realizing
 `𝒞 ≌ FGModuleCat B` is basic in both senses (`IsBasicAlgebraSplit` and the book's literal
 `IsBasicAlgebra`), is `k`-linearly Morita equivalent to the endomorphism algebra
 `A = (End P)ᵐᵒᵖ` of the progenerator, satisfies `dim B ≤ dim A`, and is unique up to
@@ -142,7 +200,7 @@ not yet have (it is the subject of the open converse-bridge item on `Definition 
 Uniqueness relative to `A = (End P)ᵐᵒᵖ` is what the available machinery supports, and it is the
 whole content once that converse bridge lands, since `𝒞 ≌ FGModuleCat A` by Theorem 9.6.4.
 (Etingof Corollary 9.7.3(i), categorical form) -/
-theorem Etingof.Corollary_9_7_3_i_categorical_strong
+theorem Etingof.Corollary_9_7_3_i_categorical_strong_of_progenerator
     {k : Type v} [Field k] [IsAlgClosed k]
     (C : Type u) [Category.{v} C]
     [Etingof.IsFiniteAbelianCategory C] [Linear k C]
@@ -169,6 +227,41 @@ theorem Etingof.Corollary_9_7_3_i_categorical_strong
   -- Restrict the Morita equivalence to the finitely generated subcategories and compose.
   obtain ⟨eFG⟩ := Etingof.MoritaEquivalent.fgModuleCatEquiv hmor.toMoritaEquivalent
   exact ⟨B, instR, instA, instF, hsplit, hbasic, ⟨eC.trans eFG⟩, hmor, hdim, huniq⟩
+
+/-- **Corollary 9.7.3(i), categorical input form, with uniqueness.** The strong form of
+`Etingof.Corollary_9_7_3_i_categorical_fgModule`: a `k`-linear finite abelian category `𝒞` over
+an algebraically closed field has a progenerator `P`, and the basic algebra `B` realizing
+`𝒞 ≌ FGModuleCat B` is basic in both senses (`IsBasicAlgebraSplit` and the book's literal
+`IsBasicAlgebra`), is `k`-linearly Morita equivalent to the endomorphism algebra
+`A = (End P)ᵐᵒᵖ`, satisfies `dim B ≤ dim A`, and is unique up to `k`-algebra isomorphism among
+basic algebras `k`-linearly Morita equivalent to `A`.
+
+The progenerator is produced by `Etingof.Exercise963.exists_progenerator` (Exercise 9.6.3)
+rather than asked of the caller; it remains an existential because uniqueness is stated
+relative to `(End P)ᵐᵒᵖ`, for the reason recorded in
+`Etingof.Corollary_9_7_3_i_categorical_strong_of_progenerator`.
+(Etingof Corollary 9.7.3(i), categorical form) -/
+theorem Etingof.Corollary_9_7_3_i_categorical_strong
+    {k : Type v} [Field k] [IsAlgClosed k]
+    (C : Type u) [Category.{v} C]
+    [Etingof.IsFiniteAbelianCategory C] [Linear k C]
+    [Etingof.IsFiniteAbelianCategoryOverField k C] :
+    ∃ (P : C) (_ : Etingof.IsProgenerator P) (B : Type v) (_ : Ring B) (_ : Algebra k B)
+        (_ : Module.Finite k B),
+      Etingof.IsBasicAlgebraSplit.{v, v, v} k B ∧
+        Etingof.IsBasicAlgebra k B ∧
+          Nonempty (C ≌ FGModuleCat.{v} B) ∧
+            Etingof.KLinearMoritaEquivalent k (End P)ᵐᵒᵖ B ∧
+              Module.finrank k B ≤ Module.finrank k (End P)ᵐᵒᵖ ∧
+                ∀ (B' : Type v) (_ : Ring B') (_ : Algebra k B') (_ : Module.Finite k B'),
+                  Etingof.IsBasicAlgebra k B' →
+                  Etingof.KLinearMoritaEquivalent k (End P)ᵐᵒᵖ B' →
+                    Nonempty (B' ≃ₐ[k] B) := by
+  obtain ⟨P, ⟨hp⟩⟩ := Etingof.Exercise963.exists_progenerator C
+  haveI : Etingof.IsProgenerator P := hp
+  obtain ⟨B, instR, instA, instF, hsplit, hbasic, hequiv, hmor, hdim, huniq⟩ :=
+    Etingof.Corollary_9_7_3_i_categorical_strong_of_progenerator (k := k) C P
+  exact ⟨P, hp, B, instR, instA, instF, hsplit, hbasic, hequiv, hmor, hdim, huniq⟩
 
 /-- **Corollary 9.7.3(i), algebra version, book-faithful `fmod` form.** Any
 finite-dimensional algebra `A` over an algebraically closed field `k` is Morita equivalent

--- a/progress/2026-07-25T06-22-46Z_883594b3.md
+++ b/progress/2026-07-25T06-22-46Z_883594b3.md
@@ -1,0 +1,69 @@
+## Accomplished
+
+Issue #7367: eliminated the chosen-progenerator hypothesis from the categorical form of
+Corollary 9.7.3(i) (`Chapter9/Corollary9_7_3Categorical.lean`).
+
+The three public categorical endpoints now quantify only over the finite abelian category:
+
+- `Etingof.Corollary_9_7_3_i_categorical` — produces a progenerator `P` and a basic `k`-algebra
+  `B` with `𝒞 ≌ FGModuleCat (End P)ᵐᵒᵖ` and `(End P)ᵐᵒᵖ` Morita equivalent to `B`;
+- `Etingof.Corollary_9_7_3_i_categorical_fgModule` — the book's statement, `𝒞 ≌ FGModuleCat B`
+  with `B` basic, with no mention of a progenerator anywhere in the type;
+- `Etingof.Corollary_9_7_3_i_categorical_strong` — the same with both basicness predicates, the
+  `k`-linear Morita witness, the dimension bound and uniqueness.
+
+Each obtains `P` from `Etingof.Exercise963.exists_progenerator` (Exercise 9.6.3, already
+sorry-free) rather than duplicating its proof. The former statements survive verbatim under
+`_of_progenerator` suffixes (`Corollary_9_7_3_i_categorical_of_progenerator`,
+`..._fgModule_of_progenerator`, `..._strong_of_progenerator`) for callers that already have a
+specific progenerator in hand.
+
+`P` still appears as an existential in the first and third statements, because the algebra
+`(End P)ᵐᵒᵖ` they name is defined from it. The `_fgModule` endpoint — the one that matches the
+book's phrasing — is fully progenerator-free.
+
+Documentation: the "The progenerator hypothesis" section of `Corollary9_7_3Categorical.lean`
+and the corresponding caveat in `Corollary9_7_3.lean`'s module docstring are rewritten to
+describe the internal choice. `progress/items.json` for `Chapter9/Corollary9.7.3` no longer
+records the progenerator gap.
+
+## Current frontier
+
+`lake build` green; `#print axioms` on all six categorical endpoints (three new public ones,
+three `_of_progenerator` helpers) reports only `propext, Classical.choice, Quot.sound`. No
+sorries introduced. `scripts/validate_items.py` passes.
+
+## Overall project progress
+
+Stage 3 formalization. `Chapter9/Corollary9.7.3` stays `status: sorry_free`,
+`fidelity: partial`, `coverage: covered_partial`. `fidelity_issue`/`followup_issue` repoint
+from #7367 (now closed by this work) to #7689.
+
+Deliberate call on `fidelity`: it stays `partial` rather than going to `full`. One genuine gap
+remains against the book, distinct from the progenerator one. The book phrases part (i)'s
+uniqueness relative to `𝒞` ("`B(𝒞)` is unique"), whereas
+`Corollary_9_7_3_i_categorical_strong` states it relative to `(End P)ᵐᵒᵖ`. Closing that needs
+the converse of `Etingof.MoritaEquivalent.fgModuleCatEquiv` — promoting an equivalence
+`FGModuleCat A ≌ FGModuleCat B'` back to a `k`-linear Morita equivalence of the full module
+categories — which is open issue #7689.
+
+## Next step
+
+#7689, the `fmod`-to-full-module Morita converse bridge. It is the last thing standing between
+this item and `fidelity: full`: once it lands, `𝒞 ≌ FGModuleCat (End P)ᵐᵒᵖ` (Theorem 9.6.4)
+converts uniqueness-relative-to-`(End P)ᵐᵒᵖ` into uniqueness-relative-to-`𝒞`, and the last
+existential `P` can be dropped from `Corollary_9_7_3_i_categorical_strong` too.
+
+## Blockers
+
+None.
+
+## Worktree note
+
+This worktree started the session with three uncommitted reversions to tracked files
+(`.claude/commands/review.md`, `.claude/commands/summarize.md`,
+`.claude/skills/agent-worker-flow/SKILL.md`) — each strictly *removes* guidance present in
+`main`, so they look like leftovers from a crashed prior session in a reused worktree rather
+than intended edits. They were left untouched and are not part of this PR (`coordination
+create-pr` only pushes committed work). A future session in this worktree should decide
+whether to discard them.

--- a/progress/items.json
+++ b/progress/items.json
@@ -9817,12 +9817,12 @@
     "status": "sorry_free",
     "fidelity": "partial",
     "needs_statement": false,
-    "notes": "The chosen-progenerator categorical form is sorry-free. Exercise963.exists_progenerator now proves that every finite abelian category has a progenerator, but Corollary_9_7_3_i_categorical and its FGModuleCat endpoint still require P from the caller instead of choosing it internally. Follow-up: #7367.",
+    "notes": "The categorical form is sorry-free and no longer asks the caller for a progenerator (#7367): Corollary_9_7_3_i_categorical, _fgModule and _strong quantify only over the category and obtain P internally from Exercise963.exists_progenerator; the chosen-P forms remain as _of_progenerator variants. Remaining gap: uniqueness is stated relative to (End P)ᵐᵒᵖ rather than to the category itself, pending the fmod-to-full-module Morita converse bridge. Follow-up: #7689.",
     "attention_needed": false,
-    "fidelity_note": "The FGModuleCat equivalence, uniqueness, and dimension-bound conclusions are proved. The public-API incoherence is closed (#7423): Corollary_9_7_3_i_strong and the bundled Corollary_9_7_3 return IsBasicAlgebraSplit + IsBasicAlgebra + KLinearMoritaEquivalent, so the constructed B satisfies the hypotheses of Corollary_9_7_3_i_unique and Corollary_9_7_3_ii, and BasicAlgebraSplitBridge proves the two basicness predicates agree over an algebraically closed field. One wiring gap remains: the categorical corollary still asks the caller for a progenerator (#7367).",
+    "fidelity_note": "The FGModuleCat equivalence, uniqueness, and dimension-bound conclusions are proved. The public-API incoherence is closed (#7423): Corollary_9_7_3_i_strong and the bundled Corollary_9_7_3 return IsBasicAlgebraSplit + IsBasicAlgebra + KLinearMoritaEquivalent, so the constructed B satisfies the hypotheses of Corollary_9_7_3_i_unique and Corollary_9_7_3_ii, and BasicAlgebraSplitBridge proves the two basicness predicates agree over an algebraically closed field. The chosen-progenerator wiring gap is closed (#7367): the categorical corollaries now produce the progenerator from Exercise963.exists_progenerator. One gap remains: the book phrases part (i)'s uniqueness relative to the category, which needs the converse of MoritaEquivalent.fgModuleCatEquiv (#7689); uniqueness is therefore stated relative to the endomorphism algebra (End P)ᵐᵒᵖ of the progenerator.",
     "coverage": "covered_partial",
-    "fidelity_issue": 7367,
-    "followup_issue": 7367,
+    "fidelity_issue": 7689,
+    "followup_issue": 7689,
     "last_updated": "2026-07-25"
   },
   {


### PR DESCRIPTION
Closes #7367

Session: `883594b3-1e57-4f1a-bd9a-71af6e986ffd`

132f19ec doc: progress entry for #7367 (progenerator-free categorical Corollary 9.7.3(i))
ed6574e3 feat(Ch9 #7367): choose the progenerator internally in the categorical Corollary 9.7.3(i)

🤖 Prepared with Claude Code