### PR TITLE
docs: correct the stacking note in the #7749 progress file

### DIFF
--- a/progress/2026-07-25T08-40-00Z_87f7f1d6.md
+++ b/progress/2026-07-25T08-40-00Z_87f7f1d6.md
@@ -49,8 +49,13 @@ only ones carrying new information are the six listed above; `serre_x` at `D⁴b
 Non-vacuity checked over `ℚ`: `EvenLayer ℚ (evenTower ℚ 1)` (the degree-`4` layer, the first one
 the new step produces) and `⁅a₁, oddTop (evenTower ℚ 1)⁆ = 0` both elaborate.
 
-This branch is based on `agent/3c6f4ef3-work` (PR #7751, the odd-to-even step), which had not
-merged when the work started; it should be rebased onto `main` once #7751 lands.
+This work was stacked on `agent/3c6f4ef3-work` (PR #7751, the odd-to-even step), whose CI was still
+running 25 minutes after the work was done. Rather than stall, PR #7754 was published on top of it
+and auto-merged first, carrying #7751's three commits to `main` verbatim inside its squash
+(8b92f218). #7751 was therefore closed as subsumed, not abandoned: `main`'s
+`Problem2_16_3_Layers.lean` is a strict superset of that branch's and its progress file is present.
+The ordering hazard (a plain `git rebase origin/main` does *not* drop commits a squash merge has
+absorbed) is now written up in the `agent-worker-flow` skill, PRs #7755 and #7756.
 
 ## Overall project progress
 


### PR DESCRIPTION
This PR corrects the "Current frontier" section of `progress/2026-07-25T08-40-00Z_87f7f1d6.md`, which told the next agent to rebase onto `main` once #7751 landed. The merge went the other way: #7754 auto-merged first and carried #7751's three commits to `main` inside its squash, so #7751 was closed as subsumed. Since this is the most recent handoff file, the stale instruction would have been the first thing the next agent read.

🤖 Prepared with Claude Code