### PR TITLE
docs: replan triage of #7749 — close as partially completed, retarget #7750

### DIFF
--- a/progress/2026-07-25T08-11-02Z_3f59be92.md
+++ b/progress/2026-07-25T08-11-02Z_3f59be92.md
@@ -1,0 +1,63 @@
+## Accomplished
+
+Replan triage session `3f59be92`. `coordination list-replan` reported exactly one candidate:
+
+* **#7749** `feat(Ch2 #7732): the even-to-odd layer step for 𝔤₄` — disposition **partial
+  progress, residual already recorded**, closed with a forward link.
+
+  PR #7754 (`feat(Ch2 #7749): the even-to-odd layer step for 𝔤₄, modulo the centre`) merged at
+  `2026-07-25T08:03:55Z`, landing five of the six `OddLayer` fields plus `EvenLayer.step`. Checked
+  against `origin/main`'s `EtingofRepresentationTheory/Chapter2/Problem2_16_3_Layers.lean` rather
+  than taking the PR body's word for it: `EvenLayer.lie_zero_oddTop`, `lie_one_oddTop`,
+  `lie_two_oddTop`, `dY_five_oddTop`, `EvenLayer.step`, `evenLayer_evenTower`, `evenLayer_deg_four`,
+  `defect`, `central_defect`, and `OddLayer.of_evenLayer_of_center` are all present, no `sorry`.
+
+  The residual — the sixth field `⁅a₄, oddTop c⁆ = 2 D (evenTop (oddTop c))`, reduced during the
+  work to triviality of the centre of `𝔤₄` — is already fully recorded in **#7753**, including the
+  target statement, two candidate routes, and the complete dead-end list. So no replacement issue
+  was created; the parent was closed pointing forward to #7753 and #7754.
+
+### Dependency-graph repair (the non-obvious part)
+
+Closing #7749 would have **spuriously unblocked #7750** (`feat(Ch2 #7394): assemble the
+LoopIdx-indexed spanning family for 𝔤₄`), which carried a machine-read `depends-on: #7749` and the
+`blocked` label. `pod`'s unblock sweep treats a closed dep as satisfied, so a worker would have
+picked up #7750 while the even-to-odd step is still one field short. Retargeted it:
+
+* `coordination add-dep 7750 7753`, then removed the stale `depends-on: #7749` line. #7750 is still
+  `blocked`, now on the issue that actually gates it.
+* Rewrote #7750's "Current state" to say what landed versus what #7753 owes, and surfaced #7753's
+  cheaper alternative there: for the spanning goal it may suffice that
+  `⁅a₄, oddTop c⁆ ∈ span k {c'', D c'', D² c''}`, since `span (Set.range B) + Z(𝔤₄) = ⊤` already
+  follows from what is proved.
+* #7753's own trailing `depends on #7749` was prose, not the machine `depends-on:` form, so it was
+  never labelled `blocked` — but it was stale and misleading. Replaced with a note that its
+  prerequisites are on `main` via #7754. #7753 now appears in `coordination list-unclaimed`.
+
+Two design corrections established while #7754 was proved are carried into #7753 and echoed in the
+closing comment, since #7749's body still asserted the opposite: the induction does **not** need to
+carry the pair `(b, c)` (`serre_x` at `D c` gives `3⁅a₁, b'⁆ = 0` from `EvenLayer c` alone), and the
+remaining gap is a centre statement rather than a computation — so suggestions 1 and 2 in #7749's
+body are both regressions, not leads.
+
+## Current frontier
+
+`coordination list-replan` is empty. The 𝔤₄ layer induction is complete except for
+`center_eq_bot`-style triviality of the centre (#7753, claimable now), which in turn gates #7750 and
+then #7720.
+
+## Overall project progress
+
+Unchanged by this session — replan edits issues, not code. `origin/main` at `e45442ce`.
+
+## Next step
+
+A worker should claim **#7753** (trivial centre of `𝔤₄`). Route 1 in its body — killing `defect c`
+only for the tops `c = evenTower k m`, via a bigrading on `g k n` that the project does not yet have
+— is flagged there as possibly being the real deliverable; route 2 (absorbing central elements into
+the closure principle) is the cheaper packaging and is also what would let #7750 proceed without the
+exact value.
+
+## Blockers
+
+None. #7750 remains correctly blocked on #7753.


### PR DESCRIPTION
This PR adds the handoff file for replan session `3f59be92`, which triaged the single
`coordination list-replan` candidate #7749 (`feat(Ch2 #7732): the even-to-odd layer step for 𝔤₄`).

#7749 was closed as partially completed: PR #7754 merged five of the six `OddLayer` fields plus
`EvenLayer.step` (verified against `origin/main`, no `sorry`), and the residual sixth field — the
triviality of the centre of `𝔤₄` — was already fully recorded in #7753, so no replacement issue was
created. Closing #7749 would have spuriously unblocked #7750, which carried a machine-read
`depends-on: #7749`; that dependency is now retargeted to #7753 and #7750's body records what landed
versus what remains.

No code changes — replan sessions edit issues directly. This is the progress file the project's
CLAUDE.md requires at the end of every turn.

🤖 Prepared with Claude Code