### PR TITLE
feat(Ch2 #7753): collapse the layer defect to one bracket and close the degree-3 odd layer

### DIFF
--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -169,8 +169,12 @@ that are pure *deletions* against `main` in files you were not asked to touch,
 especially under `.claude/`. A crashed session can leave an accidental revert of
 accumulated workflow guidance, which is easy to commit without noticing and hard to
 spot in review. Restore those (`git checkout HEAD -- <paths>`) rather than carrying
-them. (2026-07-25: a worktree arrived with 169 lines of `.claude/` guidance deleted
-and nothing added.)
+them. (2026-07-25: twice, worktrees arrived with 169 and 279 lines of `.claude/`
+guidance deleted and nothing added.)
+
+**If the restored files include this skill or your `/command` file, re-read them.**
+Skills load from the working tree, so a truncated `SKILL.md` means the guidance you
+started the session on was the deleted version and you never saw these instructions.
 
 **If you branched off an unmerged PR's head** (see "Dependency code that lives
 only in an unmerged PR" above), decide at publish time:

--- a/EtingofRepresentationTheory/Chapter2/Problem2_16_3_Layers.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_16_3_Layers.lean
@@ -80,6 +80,11 @@ bottom of the tower is the bracket of an element with itself, so it vanishes
 (`defect_evenTower_zero`) and the layer of `t`-degree `3` satisfies the full odd-layer invariant
 unconditionally (`oddLayer_deg_three`).
 
+The tower itself has a compact description: `c₀ = evenTower k 0` commutes with every even top
+(`lie_evenTower_zero_evenTower`) and carries each one to the next,
+`2⁅c₀, D c⁆ = c''` (`two_smul_lie_evenTower_zero_dY_one`), so the whole tower is the orbit of the
+single operator `2 ad(c₀) ∘ D`.
+
 Still missing: `⁅⁅a₁, a₃⁆, D (evenTower k m)⁆ = 0` for `m ≥ 1`, which by
 `oddLayer_evenTower_of_lie_eq_zero` is all that stands between the even tower and the odd layer in
 every degree. Both factors lie in the tower, so this is a statement about the bracket of two
@@ -806,6 +811,50 @@ theorem central_defect (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0) (h5 : (5 : k) �
   have : v ∈ M := by rw [hM]; trivial
   exact this
 
+/-! ### The tower is the orbit of `2 ad(c₀) ∘ D`
+
+The top of the degree-`2` layer, `c₀ = -⁅a₀, a₃⁆`, commutes with every even top and carries each
+even top to the next one. -/
+
+/-- `2⁅a₃, D c⁆ = -D³ b'`. -/
+theorem two_smul_lie_three_dY_one (h2 : (2 : k) ≠ 0) (h : EvenLayer k c) :
+    (2 : k) • ⁅aElt k 4 3, dY k 1 c⁆ = -dY k 3 (oddTop c) := by
+  have e := lie_aElt_dY_one k 3 c
+  simp only [Nat.reduceAdd] at e
+  have hD : dY k 1 ((2 : k) • ⁅aElt k 4 3, c⁆) = (3 : k) • dY k 3 ⁅aElt k 4 1, c⁆ := by
+    rw [h.two_smul_lie_three, dY_smul_elt, dY_one_dY]
+  rw [dY_smul_elt] at hD
+  have hb : dY k 3 (oddTop c) = -dY k 3 ⁅aElt k 4 1, c⁆ := by rw [oddTop_eq, dY_neg_elt]
+  linear_combination (norm := module) (2 : k) • e + hD - (2 : k) • h.lie_four h2 + hb
+
+/-- **`⁅c₀, c⁆ = 0`**: the top of the degree-`2` layer commutes with every even top. Both
+`⁅x̄, c⁆ = 0` and `⁅a₂, b'⁆ = 0` go into this. -/
+theorem lie_lie_a0_a3_self (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0) (h : EvenLayer k c) :
+    ⁅⁅aElt k 4 0, aElt k 4 3⁆, c⁆ = 0 := by
+  have hjac : ⁅⁅aElt k 4 0, aElt k 4 3⁆, c⁆
+      = ⁅aElt k 4 0, ⁅aElt k 4 3, c⁆⁆ - ⁅aElt k 4 3, ⁅aElt k 4 0, c⁆⁆ := lie_lie _ _ _
+  rw [h.lie_zero, _root_.lie_zero, sub_zero] at hjac
+  refine eq_zero_of_smul₀ h2 ?_
+  rw [hjac, ← lie_smul, h.two_smul_lie_three, lie_smul, lie_one_eq_neg_oddTop, dY_neg_elt,
+    lie_neg, h.lie_zero_dY_two_oddTop h3, h.lie_two_oddTop h2 h3]
+  module
+
+/-- **`2⁅c₀, D c⁆ = c''`**: bracketing with `c₀` after one `D` sends each even top to the next.
+Stated with `⁅a₀, a₃⁆ = -c₀`, so the sign is on the right. -/
+theorem two_smul_lie_a0_a3_dY_one (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0) (h : EvenLayer k c) :
+    (2 : k) • ⁅⁅aElt k 4 0, aElt k 4 3⁆, dY k 1 c⁆ = -evenTop (oddTop c) := by
+  have hjac : ⁅aElt k 4 3, oddTop c⁆
+      = ⁅⁅aElt k 4 3, aElt k 4 0⁆, dY k 1 c⁆
+        + ⁅aElt k 4 0, ⁅aElt k 4 3, dY k 1 c⁆⁆ := by
+    rw [← h.lie_zero_dY_one]; exact leibniz_lie _ _ _
+  have ha30 : ⁅aElt k 4 3, aElt k 4 0⁆ = -⁅aElt k 4 0, aElt k 4 3⁆ :=
+    (lie_skew (aElt k 4 3) (aElt k 4 0)).symm
+  have h2s : (2 : k) • ⁅aElt k 4 0, ⁅aElt k 4 3, dY k 1 c⁆⁆ = evenTop (oddTop c) := by
+    rw [← lie_smul, h.two_smul_lie_three_dY_one h2, lie_neg,
+      h.lie_zero_dY_three_oddTop h2 h3, neg_neg]
+  rw [ha30, neg_lie, ← evenTop_eq] at hjac
+  linear_combination (norm := module) (2 : k) • hjac + h2s
+
 /-! ### The defect is a single bracket
 
 The three-term expansion of `⁅a₄, b'⁆` obtained by writing `b' = ⁅x̄, D c⁆` and moving `a₄` past
@@ -887,6 +936,20 @@ theorem evenLayer_evenTower (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0) (h5 : (5 :
 theorem evenLayer_deg_four (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0) (h5 : (5 : k) ≠ 0) :
     EvenLayer k (evenTop (oddTop (-⁅aElt k 4 0, aElt k 4 3⁆))) :=
   evenLayer_evenTower h2 h3 h5 1
+
+/-- **The even tower is the orbit of `2 ad(c₀) ∘ D`.** Every even top is obtained from the
+previous one by applying `D` and bracketing with the degree-`2` top `c₀ = evenTower k 0`. -/
+theorem two_smul_lie_evenTower_zero_dY_one (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0)
+    (h5 : (5 : k) ≠ 0) (m : ℕ) :
+    (2 : k) • ⁅evenTower k 0, dY k 1 (evenTower k m)⁆ = evenTower k (m + 1) := by
+  have h := (evenLayer_evenTower h2 h3 h5 m).two_smul_lie_a0_a3_dY_one h2 h3
+  rw [evenTower_zero, evenTower_succ, neg_lie, smul_neg, h, neg_neg]
+
+/-- **`c₀` commutes with the whole even tower.** -/
+theorem lie_evenTower_zero_evenTower (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0) (h5 : (5 : k) ≠ 0)
+    (m : ℕ) : ⁅evenTower k 0, evenTower k m⁆ = 0 := by
+  rw [evenTower_zero, neg_lie,
+    (evenLayer_evenTower h2 h3 h5 m).lie_lie_a0_a3_self h2 h3, neg_zero]
 
 /-! ### The odd layer of `t`-degree `3`
 

--- a/EtingofRepresentationTheory/Chapter2/Problem2_16_3_Layers.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_16_3_Layers.lean
@@ -59,17 +59,34 @@ So the even-layer invariant propagates by itself, two `t`-degrees at a time
 *not* have to be carried: `⁅a₁, b'⁆ = 0` comes from `serre_x` applied to `D c`, not from
 `⁅⁅a₁, a₄⁆, b⁆`.
 
-## What is still missing
+## The defect, and what is still missing
 
-The sixth odd-layer field, `⁅a₄, b'⁆ = 2 D c''`. Its defect
+The sixth odd-layer field, `⁅a₄, b'⁆ = 2 D c''`, does not follow from `EvenLayer c`. Its defect
 
 `EvenLayer.defect c = ⁅a₄, b'⁆ - 2 D c''`
 
 is annihilated by both `ad(x̄)` (`lie_zero_lie_four_oddTop`) and `ad(ȳ)`
-(`dY_one_lie_four_oddTop`), hence is **central** in `𝔤₄` (`EvenLayer.central_defect`). So the
-remaining gap is exactly the triviality of the centre of `𝔤₄`, and
-`OddLayer.of_evenLayer_of_center` derives the full odd-layer invariant from it. Also still open:
-the assembly of the spanning family indexed by `LoopIdx`.
+(`dY_one_lie_four_oddTop`), hence is **central** in `𝔤₄` (`EvenLayer.central_defect`), and
+`OddLayer.of_evenLayer_of_center` derives the full odd-layer invariant from the triviality of the
+centre.
+
+`EvenLayer.defect_eq` collapses the defect to a *single bracket*,
+
+`EvenLayer.defect c = ⁅⁅a₁, a₃⁆, D c⁆`,
+
+by writing `b' = ⁅x̄, D c⁆` and moving `a₄` across the outer bracket, using `⁅a₄, x̄⁆ = 2⁅a₁, a₃⁆`
+(`lie_a4_a0`). Since `⁅a₁, a₃⁆ = D (evenTower k 0)` (`dY_one_evenTower_zero`), the defect at the
+bottom of the tower is the bracket of an element with itself, so it vanishes
+(`defect_evenTower_zero`) and the layer of `t`-degree `3` satisfies the full odd-layer invariant
+unconditionally (`oddLayer_deg_three`).
+
+Still missing: `⁅⁅a₁, a₃⁆, D (evenTower k m)⁆ = 0` for `m ≥ 1`, which by
+`oddLayer_evenTower_of_lie_eq_zero` is all that stands between the even tower and the odd layer in
+every degree. Both factors lie in the tower, so this is a statement about the bracket of two
+explicit elements rather than about all central elements — but it is still equivalent to the
+triviality of the centre of `𝔤₄` in that bidegree, and every Jacobi rearrangement of it is a
+tautology, so it needs an input beyond the commutation relations. Also still open: the assembly of
+the spanning family indexed by `LoopIdx`.
 -/
 
 namespace Etingof.Problem2_16_3
@@ -478,6 +495,13 @@ private theorem smul_cancel₀ {a : k} (ha : a ≠ 0) {v w : g k 4} (hvw : a •
 private theorem eq_zero_of_smul₀ {a : k} (ha : a ≠ 0) {v : g k 4} (hv : a • v = 0) : v = 0 :=
   smul_cancel₀ ha (by rw [hv, smul_zero])
 
+/-- `⁅a₄, x̄⁆ = 2⁅a₁, a₃⁆`. The right-hand side is `D` of the top of the degree-`2` layer
+(`dY_one_evenTower_zero`), which is what makes `defect_eq` below possible. -/
+theorem lie_a4_a0 : ⁅aElt k 4 4, aElt k 4 0⁆ = (2 : k) • ⁅aElt k 4 1, aElt k 4 3⁆ := by
+  have h := lie_a1_a3_add k
+  rw [(lie_skew (aElt k 4 4) (aElt k 4 0)).symm]
+  linear_combination (norm := module) -h
+
 namespace EvenLayer
 
 /-! ### What the even-layer table says about `a₃` and `a₄` -/
@@ -782,6 +806,36 @@ theorem central_defect (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0) (h5 : (5 : k) �
   have : v ∈ M := by rw [hM]; trivial
   exact this
 
+/-! ### The defect is a single bracket
+
+The three-term expansion of `⁅a₄, b'⁆` obtained by writing `b' = ⁅x̄, D c⁆` and moving `a₄` past
+`x̄` collapses the defect to one bracket against the *fixed* degree-`2` element `⁅a₁, a₃⁆`. -/
+
+/-- `⁅a₄, D c⁆ = -D⁴ b'`. -/
+theorem lie_four_dY_one (h2 : (2 : k) ≠ 0) (h : EvenLayer k c) :
+    ⁅aElt k 4 4, dY k 1 c⁆ = -dY k 4 (oddTop c) := by
+  have e := lie_aElt_dY_one k 4 c
+  simp only [Nat.reduceAdd, lie_aElt_five, sub_zero] at e
+  rw [e, h.lie_four h2, dY_one_dY, lie_one_eq_neg_oddTop, dY_neg_elt]
+
+/-- **The defect is a single bracket:** `defect c = ⁅⁅a₁, a₃⁆, D c⁆`.
+
+Write `b' = ⁅x̄, D c⁆` (`lie_zero_dY_one`) and move `a₄` across the outer bracket:
+`⁅a₄, b'⁆ = ⁅⁅a₄, x̄⁆, D c⁆ + ⁅x̄, ⁅a₄, D c⁆⁆`. The first term is `2⁅⁅a₁, a₃⁆, D c⁆` by
+`lie_a4_a0`, and the second is `-⁅x̄, D⁴ b'⁆ = 4 D c'' - ⁅a₄, b'⁆` by
+`lie_zero_dY_four_oddTop`; solving for `⁅a₄, b'⁆` gives `⁅a₄, b'⁆ = ⁅⁅a₁,a₃⁆, D c⁆ + 2 D c''`. -/
+theorem defect_eq (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0) (h : EvenLayer k c) :
+    defect c = ⁅⁅aElt k 4 1, aElt k 4 3⁆, dY k 1 c⁆ := by
+  have hjac : ⁅aElt k 4 4, oddTop c⁆
+      = ⁅⁅aElt k 4 4, aElt k 4 0⁆, dY k 1 c⁆
+        + ⁅aElt k 4 0, ⁅aElt k 4 4, dY k 1 c⁆⁆ := by
+    rw [← h.lie_zero_dY_one]; exact leibniz_lie _ _ _
+  rw [lie_a4_a0, smul_lie, h.lie_four_dY_one h2, lie_neg,
+    h.lie_zero_dY_four_oddTop h2 h3] at hjac
+  rw [defect]
+  refine smul_cancel₀ h2 ?_
+  linear_combination (norm := module) hjac
+
 end EvenLayer
 
 /-! ### The odd layer, modulo the defect -/
@@ -833,6 +887,47 @@ theorem evenLayer_evenTower (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0) (h5 : (5 :
 theorem evenLayer_deg_four (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0) (h5 : (5 : k) ≠ 0) :
     EvenLayer k (evenTop (oddTop (-⁅aElt k 4 0, aElt k 4 3⁆))) :=
   evenLayer_evenTower h2 h3 h5 1
+
+/-! ### The odd layer of `t`-degree `3`
+
+`D (evenTower k 0) = ⁅a₁, a₃⁆` is exactly the element the defect brackets against, so at the
+bottom of the tower the defect is `⁅⁅a₁, a₃⁆, ⁅a₁, a₃⁆⁆ = 0` and the even-to-odd step goes
+through with no hypothesis on the centre. -/
+
+/-- `D(evenTower 0) = ⁅a₁, a₃⁆`: applying `D` to `-⁅a₀, a₃⁆` gives `-⁅a₁,a₃⁆ - ⁅a₀,a₄⁆`, and
+`⁅a₀, a₄⁆ = -2⁅a₁, a₃⁆`. -/
+theorem dY_one_evenTower_zero : dY k 1 (evenTower k 0) = ⁅aElt k 4 1, aElt k 4 3⁆ := by
+  have h := lie_a1_a3_add k
+  rw [evenTower_zero, dY_neg_elt, dY_one, lie_yb_lie_aElt]
+  linear_combination (norm := module) -h
+
+/-- **The defect vanishes at the bottom of the tower.** `defect (evenTower k 0)` is the bracket
+of `⁅a₁, a₃⁆` with itself. -/
+theorem defect_evenTower_zero (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0) (h5 : (5 : k) ≠ 0) :
+    EvenLayer.defect (evenTower k 0) = 0 := by
+  rw [(evenLayer_evenTower h2 h3 h5 0).defect_eq h2 h3, dY_one_evenTower_zero, lie_self]
+
+/-- **The layer of `t`-degree `3` satisfies the odd-layer invariant**, unconditionally: the
+even-to-odd step is not vacuous, and in particular `⁅a₄, b'⁆ = 2 D c''` really does hold there.
+Here `b' = oddTop (evenTower k 0)` is the top of the `t`-degree-`3` layer and
+`evenTop b' = evenTower k 1` the top of the `t`-degree-`4` one. -/
+theorem oddLayer_deg_three (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0) (h5 : (5 : k) ≠ 0) :
+    OddLayer k (oddTop (evenTower k 0)) (evenTop (oddTop (evenTower k 0))) :=
+  OddLayer.of_evenLayer h2 h3 (evenLayer_evenTower h2 h3 h5 0)
+    (defect_evenTower_zero h2 h3 h5)
+
+/-- The remaining gap in the layer induction, in its reduced form: the odd layer above
+`evenTower k m` follows from the single vanishing `⁅⁅a₁, a₃⁆, D (evenTower k m)⁆ = 0`.
+
+By `EvenLayer.defect_eq` this is equivalent to the vanishing of the defect, and by
+`EvenLayer.central_defect` the bracket is central in `𝔤₄`, so the triviality of the centre of
+`𝔤₄` still suffices; but the statement to be proved is now a single bracket of two explicit
+elements of the tower rather than a statement about all central elements. -/
+theorem oddLayer_evenTower_of_lie_eq_zero (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0) (h5 : (5 : k) ≠ 0)
+    (m : ℕ) (hgap : ⁅⁅aElt k 4 1, aElt k 4 3⁆, dY k 1 (evenTower k m)⁆ = 0) :
+    OddLayer k (oddTop (evenTower k m)) (evenTop (oddTop (evenTower k m))) :=
+  OddLayer.of_evenLayer h2 h3 (evenLayer_evenTower h2 h3 h5 m)
+    (by rw [(evenLayer_evenTower h2 h3 h5 m).defect_eq h2 h3, hgap])
 
 end EvenToOdd
 

--- a/progress/2026-07-25T09-15-00Z_1edefb46.md
+++ b/progress/2026-07-25T09-15-00Z_1edefb46.md
@@ -1,0 +1,78 @@
+# 2026-07-25T09:15:00Z — worker session `1edefb46` (issue #7753)
+
+## Accomplished
+
+Worked on #7753, "trivial centre of `𝔤₄` — the last field of the even-to-odd layer step".
+All work is in `EtingofRepresentationTheory/Chapter2/Problem2_16_3_Layers.lean`.
+
+The issue asked for the triviality of the centre of `𝔤₄`. That did not fall, but the gap it
+guards collapsed a long way, and the first new degree closed outright.
+
+**The defect is a single bracket.** `EvenLayer.defect_eq`:
+
+```
+EvenLayer.defect c = ⁅⁅a₁, a₃⁆, D c⁆
+```
+
+Proof: `b' = ⁅x̄, D c⁆` (`lie_zero_dY_one`), so moving `a₄` across the outer bracket gives
+`⁅a₄, b'⁆ = ⁅⁅a₄, x̄⁆, D c⁆ + ⁅x̄, ⁅a₄, D c⁆⁆`. The first term is `2⁅⁅a₁,a₃⁆, D c⁆` by the new
+`lie_a4_a0` (from `lie_a1_a3_add`), the second is `-⁅x̄, D⁴ b'⁆ = 4 D c'' - ⁅a₄, b'⁆` by the
+existing `lie_zero_dY_four_oddTop`; solving for `⁅a₄, b'⁆` leaves exactly one bracket.
+
+**The degree-`3` layer is closed.** `dY_one_evenTower_zero` says `D (evenTower k 0) = ⁅a₁, a₃⁆`,
+so at the bottom of the tower the defect is `⁅⁅a₁,a₃⁆, ⁅a₁,a₃⁆⁆ = 0`
+(`defect_evenTower_zero`), and `oddLayer_deg_three` gives
+`OddLayer k (oddTop (evenTower k 0)) (evenTop (oddTop (evenTower k 0)))` with no hypothesis
+beyond `2, 3, 5 ≠ 0`. This is the non-vacuity check the issue asked for at `m = 0`.
+
+**The residual gap, packaged.** `oddLayer_evenTower_of_lie_eq_zero` derives the odd layer above
+`evenTower k m` from the single vanishing `⁅⁅a₁, a₃⁆, D (evenTower k m)⁆ = 0`.
+
+**Structure of the tower.** `two_smul_lie_evenTower_zero_dY_one` : `2⁅c₀, D c⁆ = c''` and
+`lie_evenTower_zero_evenTower` : `⁅c₀, evenTower k m⁆ = 0`, where `c₀ = evenTower k 0`. So the
+whole even tower is the orbit of the single operator `2 ad(c₀) ∘ D`, and `c₀` is central for it.
+Supporting: `EvenLayer.two_smul_lie_three_dY_one`, `EvenLayer.lie_lie_a0_a3_self`,
+`EvenLayer.two_smul_lie_a0_a3_dY_one`, `EvenLayer.lie_four_dY_one`.
+
+Module docstring updated to match.
+
+## Current frontier
+
+`⁅⁅a₁, a₃⁆, D (evenTower k m)⁆ = 0` for `m ≥ 1`. Filed as #7759 with the full record of what was
+checked.
+
+## Overall project progress
+
+The layer induction for `𝔤₄` is now complete except for that one bracket in odd `t`-degrees
+`≥ 5`: `evenLayer_evenTower` gives the even-layer invariant in every even degree unconditionally,
+and `oddLayer_xb` / `oddLayer_deg_three` give the odd-layer invariant in degrees `1` and `3`
+unconditionally. #7750 (the `LoopIdx`-indexed spanning family) remains blocked on the residual
+bracket.
+
+## Next step
+
+#7759. Two routes are recorded there. The honest assessment from this session: every Jacobi
+rearrangement of the target is a tautology, so it needs an input beyond the commutation
+relations — most likely the `ℕ²` grading on `g k n` (which the project does not have and which is
+reusable well beyond this defect), combined with an upper bound on the relevant bidegree. The
+grading alone reproduces `S + Z = ⊤` and is not sufficient by itself; that is stated explicitly
+in #7759 so the next agent does not spend a session rediscovering it.
+
+Dead ends checked *this* session, on top of those already recorded in #7749 and #7753:
+`serre_y` at `D² c` and at `D³ b'`; the induction `defect c = 0 ⟹ defect c'' = 0` routed through
+`c'' = 2⁅c₀, D c⁆`; and the identities `⁅c₀, c⁆ = 0`, `⁅D c₀, c⁆ = -c''/2`, `⁅c₀, D² c⁆`,
+`⁅D² c₀, c⁆`, `ad(c₀)²(D c) = 0` — all consistent, none new.
+
+## Blockers
+
+None for the project. #7753 is partially completed: the reduction and the `m = 0` case landed,
+the general `m` remains and is now #7759.
+
+## Quality metrics
+
+* `lake build` (whole project, 9287 jobs): clean.
+* No `sorry`, `admit`, or added axioms; `#print axioms` on `oddLayer_deg_three`,
+  `defect_evenTower_zero`, `EvenLayer.defect_eq`, `oddLayer_evenTower_of_lie_eq_zero`, `lie_a4_a0`
+  reports only `propext`, `Classical.choice`, `Quot.sound`.
+* Non-vacuity spot-check: `(oddLayer_deg_three h2 h3 h5).lie_four` really does give
+  `⁅a₄, oddTop (evenTower k 0)⁆ = 2 D (evenTop (oddTop (evenTower k 0)))`.


### PR DESCRIPTION
Partial progress on #7753

Session: `1edefb46-479c-4136-9259-79a532119f23`

f8b59d5d docs: progress entry for #7753 (defect reduced to one bracket; degree-3 layer closed)
b7f22875 feat(Ch2 #7753): the even tower is the orbit of 2 ad(c0) . D
f9086177 feat(Ch2 #7753): collapse the layer defect to a single bracket and close the degree-3 odd layer

🤖 Prepared with Claude Code