### PR TITLE
feat(Ch2 #7759): prove the loop model annihilates the centre of 𝔤₄

### DIFF
--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -154,7 +154,14 @@ git rev-parse HEAD      # record starting commit
 **If the branch already exists** (common in reused worktrees): check for an
 open PR on it first (`gh pr list --head agent/<id>`). If a PR exists, create
 a new branch with a suffix (`agent/<id>-v2`). If no PR exists, reset it to
-master: `git checkout agent/<id> && git reset --hard origin/master`.
+the default branch: `git checkout agent/<id> && git reset --hard origin/main`
+(this repo's default branch is `main`, not `master`).
+
+**Do not try to `git checkout main` in a pod worktree.** `main` is checked out
+in the primary worktree, so the checkout fails — and if you chain it as
+`git checkout main || git checkout master` the first failure is silent and you
+only see a confusing "pathspec 'master' did not match" error. Fetch and compare
+against `origin/main` instead: `git fetch origin && git log --oneline -1 origin/main`.
 
 **Before that `git reset --hard`, run `git status --short` and inspect any
 uncommitted changes** (`git diff`). A reused worktree can carry in-progress

--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -6787,3 +6787,29 @@ propositionally but not definitionally equal, and you get an application type mi
 Always take `[Module ℤ Z]` (or `[Module A Z]`) explicitly in helpers destined for `ModuleCat`
 consumers — `Etingof.homSelfAddEquiv` in `Chapter8/Problem8_2_7_ExtFG.lean` is the fixed form.
 Cheaper than the element-level `conv` bridging described earlier.
+
+## A homomorphism can witness non-vanishing, never vanishing (presented algebras, #7759)
+
+For `L = Free ⧸ relIdeal` (path algebras, generators-and-relations Lie algebras, universal
+enveloping quotients, quiver algebras), the *only* way to prove a specific element `u : L` is `0`
+is to derive it from the relations. A map `φ : L → M` into a concrete model can prove `u ≠ 0`
+(exhibit `φ u ≠ 0`), but `φ u = 0` proves nothing unless you separately have `Injective φ` — and
+injectivity is usually the hard theorem the element-vanishing was standing in for.
+
+Symptom that you are in this trap: the vanishing you want and the injectivity you would need are
+the *same* statement, so a spanning argument that consumes the vanishing cannot be used to supply
+the injectivity. Check for that circularity **before** starting to build the concrete model.
+
+The productive move, when a session lands in this position, is to prove the negative explicitly
+and record it, so no successor re-runs the same computation. `Chapter2/Problem2_16_3_Center.lean`
+does this for `𝔤₄`: `gbar_defect_eq_zero` shows the twisted `A₂⁽²⁾` loop model maps the whole
+centre of `𝔤₄` — and hence the layer-induction defect — to `0` unconditionally, so no computation
+in matrices, in `loopPos`, or in the `LoopIdx` basis can settle it. The paired
+`oddLayer_evenTower_of_gbar_injective` restates the residual gap as `Injective gbar`, which is the
+honest target.
+
+Cheap way to get the negative: if the obstruction is known to be central (here
+`EvenLayer.central_defect`), compute the centre of the *image* subalgebra instead. That is a
+finite matrix chase (`centralizer_NX_NY_eq_scalar`: commuting with the two generator images forces
+a scalar matrix; the trace condition then forces `0` when `3 ≠ 0`), and it settles the whole
+family at once rather than one element at a time.

--- a/EtingofRepresentationTheory/Chapter2.lean
+++ b/EtingofRepresentationTheory/Chapter2.lean
@@ -119,6 +119,7 @@ import EtingofRepresentationTheory.Chapter2.Problem2_16_2
 import EtingofRepresentationTheory.Chapter2.Discussion_concrete_Lie_examples_continued
 import EtingofRepresentationTheory.Chapter2.Problem2_16_3
 import EtingofRepresentationTheory.Chapter2.Problem2_16_3_Layers
+import EtingofRepresentationTheory.Chapter2.Problem2_16_3_Center
 import EtingofRepresentationTheory.Chapter2.Problem2_16_4
 import EtingofRepresentationTheory.Chapter2.Problem2_16_5
 

--- a/EtingofRepresentationTheory/Chapter2/Problem2_16_3_Center.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_16_3_Center.lean
@@ -1,0 +1,196 @@
+import EtingofRepresentationTheory.Chapter2.Problem2_16_3_Layers
+
+/-!
+# Problem 2.16.3(b): the centre of `𝔤₄` versus the twisted loop realization
+
+`Problem2_16_3_Layers.lean` reduces the whole layer induction for `𝔤₄` to a single vanishing:
+the *defect* `EvenLayer.defect c = ⁅a₄, oddTop c⁆ - 2 D (evenTop (oddTop c))` is a central element
+of `𝔤₄` (`EvenLayer.central_defect`), and the induction closes exactly when it is `0`.
+
+This file settles what the twisted `A₂⁽²⁾` loop realization
+`matHom₄ : FreeLieAlgebra k (Fin 2) → 𝔤𝔩₃(k[t])` can say about that question, and the answer is a
+sharp *negative*: the loop model kills the entire centre of `𝔤₄`, so it can never exhibit a defect
+as nonzero, and it can only prove a defect zero by way of its own injectivity.
+
+The two matrix facts are:
+
+* `centralizer_NX_NY_eq_scalar` — over any commutative ring, a polynomial matrix commuting with
+  both generator images `NX = E₂₀·t` and `NY = E₀₁ - E₁₂` is a scalar matrix. This is an entry
+  chase: `⁅P, NX⁆ = 0` forces `P₀₂ = P₁₂ = P₀₁ = 0` and `P₂₂ = P₀₀`, and `⁅P, NY⁆ = 0` forces
+  `P₁₀ = P₂₀ = P₂₁ = 0` and `P₀₀ = P₁₁`.
+* `eq_zero_of_mem_loopPos_of_central` — hence the centre of `𝔫₊ = loopPos` is trivial as soon as
+  `3 ≠ 0`: the only traceless scalar matrix is `0`, because `trace (a • 1) = 3a`. The hypothesis is
+  sharp — in characteristic `3` the scalar matrices `a·1` with `a` an odd polynomial do lie in
+  `loopPos` and are central, the same degeneration that collapses `range matHom₄` to four
+  dimensions.
+
+Consequences for the layer induction:
+
+* `gbar_eq_zero_of_central` — every central element of `𝔤₄` is killed by `gbar`, the factored loop
+  map. In particular `gbar_defect_eq_zero`: the defect maps to `0`, so no computation inside the
+  loop model can ever detect it. Any proof of `EvenLayer.defect c = 0` must therefore use an input
+  strictly beyond `matHom₄`.
+* `oddLayer_evenTower_of_gbar_injective` — conversely, injectivity of `gbar` closes the whole layer
+  induction. This is the precise sense in which the remaining gap in Problem 2.16.3(b) is the
+  Gabber–Kac statement that the Serre relators generate *all* relations of `𝔫₊(A₂⁽²⁾)`.
+-/
+
+namespace Etingof.Problem2_16_3
+
+open Polynomial
+
+attribute [local instance] LieRing.ofAssociativeRing
+
+/-! ## The centralizer of the two generator images in `𝔤𝔩₃(k[t])` -/
+
+section Centralizer
+
+variable {k : Type*} [CommRing k]
+
+/-- Entries of the generator image `NX = E₂₀·t`. -/
+theorem NX_apply (i j : Fin 3) :
+    NX k i j = if 2 = i ∧ 0 = j then (X : Polynomial k) else 0 := rfl
+
+/-- Entries of the generator image `NY = E₀₁ - E₁₂`. -/
+theorem NY_apply (i j : Fin 3) :
+    NY k i j = (if 0 = i ∧ 1 = j then (1 : Polynomial k) else 0)
+      - (if 1 = i ∧ 2 = j then (1 : Polynomial k) else 0) := rfl
+
+/-- **A polynomial matrix commuting with both generator images is scalar.**
+
+`⁅P, NX⁆ = 0` pins the last column and the `(0,1)` entry and equates `P₂₂` with `P₀₀`;
+`⁅P, NY⁆ = 0` pins the strictly lower triangle and equates `P₁₁` with `P₀₀`. No hypothesis on the
+base ring is needed: multiplication by `t` is injective on `k[t]` over any commutative ring. -/
+theorem centralizer_NX_NY_eq_scalar (P : Matrix (Fin 3) (Fin 3) (Polynomial k))
+    (hX : ⁅P, NX k⁆ = 0) (hY : ⁅P, NY k⁆ = 0) :
+    P = Matrix.scalar (Fin 3) (P 0 0) := by
+  have eX : ∀ i j : Fin 3, (P * NX k - NX k * P) i j = 0 := by
+    intro i j
+    have := congrFun (congrFun hX i) j
+    simpa [LieRing.of_associative_ring_bracket] using this
+  have eY : ∀ i j : Fin 3, (P * NY k - NY k * P) i j = 0 := by
+    intro i j
+    have := congrFun (congrFun hY i) j
+    simpa [LieRing.of_associative_ring_bracket] using this
+  have h02 : P 0 2 = 0 := by have := eX 0 0; simpa [Matrix.mul_apply, NX_apply] using this
+  have h12 : P 1 2 = 0 := by have := eX 1 0; simpa [Matrix.mul_apply, NX_apply] using this
+  have h01 : P 0 1 = 0 := by have := eX 2 1; simpa [Matrix.mul_apply, NX_apply] using this
+  have h22 : P 2 2 = P 0 0 := by
+    have h : P 2 2 * X = X * P 0 0 := by
+      have := eX 2 0
+      simpa [Matrix.mul_apply, NX_apply, sub_eq_zero] using this
+    have h' : (P 2 2 - P 0 0) * X = 0 := by linear_combination h
+    simpa [sub_eq_zero] using h'
+  have h10 : P 1 0 = 0 := by have := eY 0 0; simpa [Matrix.mul_apply, NY_apply] using this
+  have h20 : P 2 0 = 0 := by have := eY 1 0; simpa [Matrix.mul_apply, NY_apply] using this
+  have h21 : P 2 1 = 0 := by have := eY 2 2; simpa [Matrix.mul_apply, NY_apply] using this
+  have h11 : P 0 0 = P 1 1 := by
+    have := eY 0 1
+    simpa [Matrix.mul_apply, NY_apply, sub_eq_zero] using this
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.scalar_apply, Matrix.diagonal, h02, h12, h01, h22, h10, h20, h21, h11]
+
+end Centralizer
+
+/-! ## The centre of `𝔫₊ = loopPos` is trivial -/
+
+section CentreLoopPos
+
+variable {k : Type*} [Field k]
+
+/-- **The centre of the twisted loop algebra `𝔫₊` is trivial** (for `3 ≠ 0`).
+
+An element of `loopPos` commuting with the two generators is scalar by
+`centralizer_NX_NY_eq_scalar`, and a scalar matrix `a·1` in `𝔤𝔩₃` has trace `3a`, so the trace
+condition defining `loopPos` forces `a = 0`.
+
+The hypothesis `3 ≠ 0` is sharp: in characteristic `3` the identity matrix is traceless, and
+`a·1` with `a` an odd polynomial satisfies the two remaining conditions of `loopPos`, so it is a
+nonzero central element. -/
+theorem eq_zero_of_mem_loopPos_of_central (h3 : (3 : k) ≠ 0)
+    {P : Matrix (Fin 3) (Fin 3) (Polynomial k)} (hP : P ∈ loopPos k)
+    (hX : ⁅P, NX k⁆ = 0) (hY : ⁅P, NY k⁆ = 0) : P = 0 := by
+  have hscal : P = Matrix.scalar (Fin 3) (P 0 0) := centralizer_NX_NY_eq_scalar P hX hY
+  have htr : Matrix.trace P = 0 := hP.1
+  rw [hscal] at htr
+  have h : (3 : Polynomial k) = 0 ∨ P 0 0 = 0 := by
+    simpa [Matrix.trace, Matrix.diag, Matrix.scalar_apply] using htr
+  have hzero : P 0 0 = 0 := by
+    refine h.resolve_left fun hc => h3 ?_
+    simpa using congrArg (fun p : Polynomial k => p.coeff 0) hc
+  rw [hscal, hzero, map_zero]
+
+end CentreLoopPos
+
+/-! ## The loop model kills the centre of `𝔤₄` -/
+
+section Gbar
+
+variable {k : Type*} [Field k]
+
+@[simp] theorem gbar_proj (a : FreeLieAlgebra k (Fin 2)) :
+    gbar k (proj k 4 a) = matHom₄ k a := rfl
+
+@[simp] theorem gbar_xb : gbar k (xb k 4) = NX k := matHom₄_x k
+
+@[simp] theorem gbar_yb : gbar k (yb k 4) = NY k := matHom₄_y k
+
+/-- `gbar` is a Lie algebra map, not merely `k`-linear: brackets are computed on representatives,
+where `matHom₄` is a `LieHom`. -/
+theorem gbar_lie (u v : g k 4) : gbar k ⁅u, v⁆ = ⁅gbar k u, gbar k v⁆ := by
+  obtain ⟨a, rfl⟩ := proj_surjective k 4 u
+  obtain ⟨b, rfl⟩ := proj_surjective k 4 v
+  rw [← LieHom.map_lie, gbar_proj, gbar_proj, gbar_proj, LieHom.map_lie]
+
+theorem gbar_mem_loopPos (u : g k 4) : gbar k u ∈ loopPos k := by
+  obtain ⟨a, rfl⟩ := proj_surjective k 4 u
+  exact range_matHom₄_le_loopPos k ⟨a, rfl⟩
+
+/-- **The loop realization annihilates the centre of `𝔤₄`** (for `3 ≠ 0`).
+
+The image of a central element commutes with the images of both generators and lies in
+`loopPos`, so it is `0` by `eq_zero_of_mem_loopPos_of_central`. -/
+theorem gbar_eq_zero_of_central (h3 : (3 : k) ≠ 0) {z : g k 4} (hz : ∀ v : g k 4, ⁅v, z⁆ = 0) :
+    gbar k z = 0 := by
+  refine eq_zero_of_mem_loopPos_of_central h3 (gbar_mem_loopPos z) ?_ ?_
+  · rw [← gbar_xb (k := k), ← gbar_lie, ← lie_skew, hz, map_neg, map_zero, neg_zero]
+  · rw [← gbar_yb (k := k), ← gbar_lie, ← lie_skew, hz, map_neg, map_zero, neg_zero]
+
+/-- **The loop model cannot detect the defect.** `gbar` sends the obstruction to the even-to-odd
+induction step to `0`, so any proof that `EvenLayer.defect c = 0` needs an input beyond
+`matHom₄`. -/
+theorem gbar_defect_eq_zero (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0) (h5 : (5 : k) ≠ 0)
+    {c : g k 4} (h : EvenLayer k c) : gbar k (EvenLayer.defect c) = 0 :=
+  gbar_eq_zero_of_central h3 (h.central_defect h2 h3 h5)
+
+/-! ## Injectivity of `gbar` closes the layer induction -/
+
+/-- If `gbar` is injective then every defect vanishes: the defect is central, and `gbar` kills the
+centre. -/
+theorem defect_eq_zero_of_gbar_injective (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0) (h5 : (5 : k) ≠ 0)
+    (hinj : Function.Injective (gbar k)) {c : g k 4} (h : EvenLayer k c) :
+    EvenLayer.defect c = 0 :=
+  hinj (by rw [map_zero]; exact gbar_defect_eq_zero h2 h3 h5 h)
+
+/-- **The remaining gap in the layer induction, restated as injectivity of an explicit matrix
+map.** If `gbar : 𝔤₄ → 𝔤𝔩₃(k[t])` is injective then the odd-layer invariant holds in every odd
+`t`-degree, which together with the unconditional `evenLayer_evenTower` closes the whole
+induction. -/
+theorem oddLayer_evenTower_of_gbar_injective (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0)
+    (h5 : (5 : k) ≠ 0) (hinj : Function.Injective (gbar k)) (m : ℕ) :
+    OddLayer k (oddTop (evenTower k m)) (evenTop (oddTop (evenTower k m))) :=
+  OddLayer.of_evenLayer h2 h3 (evenLayer_evenTower h2 h3 h5 m)
+    (defect_eq_zero_of_gbar_injective h2 h3 h5 hinj (evenLayer_evenTower h2 h3 h5 m))
+
+/-- The same conclusion in the reduced bracket form of `oddLayer_evenTower_of_lie_eq_zero`. -/
+theorem lie_a1_a3_dY_one_evenTower_of_gbar_injective (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0)
+    (h5 : (5 : k) ≠ 0) (hinj : Function.Injective (gbar k)) (m : ℕ) :
+    ⁅⁅aElt k 4 1, aElt k 4 3⁆, dY k 1 (evenTower k m)⁆ = 0 := by
+  have h := evenLayer_evenTower h2 h3 h5 m
+  rw [← h.defect_eq h2 h3]
+  exact defect_eq_zero_of_gbar_injective h2 h3 h5 hinj h
+
+end Gbar
+
+end Etingof.Problem2_16_3

--- a/progress/2026-07-25T09-29-25Z_1fcad7cf.md
+++ b/progress/2026-07-25T09-29-25Z_1fcad7cf.md
@@ -1,0 +1,68 @@
+## Accomplished
+
+Session type: `/work` (meta) → feature. Claimed #7759,
+"kill the residual layer defect `⁅⁅a₁,a₃⁆, D (evenTower m)⁆` for `m ≥ 1`".
+
+Landed a new sorry-free module
+`EtingofRepresentationTheory/Chapter2/Problem2_16_3_Center.lean` (also added to
+`Chapter2.lean`):
+
+* `centralizer_NX_NY_eq_scalar` — over any `CommRing`, a matrix in `𝔤𝔩₃(k[t])` commuting with
+  both generator images `NX = E₂₀·t` and `NY = E₀₁ - E₁₂` is scalar. Entry chase:
+  `⁅P, NX⁆ = 0` ⟹ `P₀₂ = P₁₂ = P₀₁ = 0`, `P₂₂ = P₀₀`; `⁅P, NY⁆ = 0` ⟹ `P₁₀ = P₂₀ = P₂₁ = 0`,
+  `P₀₀ = P₁₁`. Multiplication by `X` is injective on `k[t]` over any commutative ring, so no
+  field hypothesis is needed here.
+* `eq_zero_of_mem_loopPos_of_central` — the centre of `𝔫₊ = loopPos` is trivial when `3 ≠ 0`,
+  since `trace (a·1) = 3a`. Sharp in characteristic `3` (odd-polynomial multiples of the identity
+  are then central members of `loopPos`).
+* `gbar_proj`, `gbar_xb`, `gbar_yb`, `gbar_lie`, `gbar_mem_loopPos` — the missing API turning the
+  merely-linear `gbar` into a usable Lie map.
+* `gbar_eq_zero_of_central`, `gbar_defect_eq_zero` — the loop model annihilates the whole centre
+  of `𝔤₄`, so it cannot detect the defect.
+* `defect_eq_zero_of_gbar_injective`, `oddLayer_evenTower_of_gbar_injective`,
+  `lie_a1_a3_dY_one_evenTower_of_gbar_injective` — conversely, injectivity of `gbar` closes the
+  entire layer induction.
+
+`#print axioms` on all six headline results: only `propext`, `Classical.choice`, `Quot.sound`.
+
+Created sub-issue #7764 (the `ℕ²`-bidegree grading on `g k n`) and posted a full analysis comment
+on #7759 recording the decomposition, the negative result, and the residual scope.
+
+## Current frontier
+
+The issue's stated goal — `⁅⁅a₁,a₃⁆, D (evenTower k m)⁆ = 0` — is **not** proved, and this session
+establishes that it cannot be proved by any computation inside the loop realization: the defect's
+image under `gbar` is unconditionally `0`. The remaining gap is exactly `ker gbar = 0`, i.e. that
+the Serre relators generate all relations of `𝔫₊(A₂⁽²⁾)` — Gabber–Kac for this affine type.
+
+Bidegree bookkeeping (checked on paper, recorded in the #7759 comment): `aᵢ = (1, i)`,
+`evenTower k m = (2m+2, 4m+3)`, `D (evenTower k m) = (2m+2, 4m+4)`, and
+`defect (evenTower k m) = (2m+4, 4m+8) = (m+2)·(2,4)` — the same bidegree as
+`D (evenTower k (m+1))`, both imaginary root vectors at `(m+2)δ` with `δ = α₁ + 2α₂`. The layer
+induction supplies only `dim ≤ 2` there (`S + Z = ⊤`); the target needs `≤ 1`.
+
+## Overall project progress
+
+Chapter 2, Problem 2.16.3(b): the even-layer tower is unconditional
+(`evenLayer_evenTower`), the odd layer holds at `t`-degree 1 and 3 unconditionally, and every
+higher odd layer is now reduced to a single explicit hypothesis with two equivalent forms —
+`⁅⁅a₁,a₃⁆, D (evenTower m)⁆ = 0` (old) or `Function.Injective (gbar k)` (new). The infinite
+dimensionality of `𝔤₄` for `char k ≠ 3` is already established independently, so the residual gap
+blocks only the exact basis/spanning statements (#7750, #7720, #7394).
+
+## Next step
+
+For a planner: retarget #7759 to `Function.Injective (gbar k)` / trivial centre of `𝔤₄`, and note
+it needs its own decomposition — it should not go to a worker as one session's work in its
+current form. #7764 (the `ℕ²` grading) is the first genuinely independent piece and is ready to
+claim.
+
+For a worker on #7764: the grading is the prerequisite for any bidegree-wise upper bound. It is
+reusable well beyond this defect. Do **not** attempt to prove the defect vanishes by computing in
+`matHom₄`/`loopPos`/the `LoopIdx` basis — `gbar_defect_eq_zero` proves that route always returns
+`0` and settles nothing.
+
+## Blockers
+
+#7759 as stated is Gabber–Kac for `A₂⁽²⁾`, which is a research-level theorem, not a
+single-session formalization. Landed as a partial PR with the scope analysis on the issue.


### PR DESCRIPTION
This PR adds `EtingofRepresentationTheory/Chapter2/Problem2_16_3_Center.lean`, settling what the
twisted `A₂⁽²⁾` loop realization can contribute to the one remaining gap in the layer induction
for `𝔤₄`, and the answer is a sharp negative.

`centralizer_NX_NY_eq_scalar` shows that over any commutative ring a matrix in `𝔤𝔩₃(k[t])`
commuting with both generator images `NX = E₂₀·t` and `NY = E₀₁ - E₁₂` is scalar, whence
`eq_zero_of_mem_loopPos_of_central`: the centre of `𝔫₊ = loopPos` is trivial whenever `3 ≠ 0`.
The hypothesis is sharp, since in characteristic `3` the odd-polynomial multiples of the identity
are nonzero central members of `loopPos`.

Together with new `gbar_lie` / `gbar_mem_loopPos` API this gives `gbar_eq_zero_of_central`: the
factored loop map annihilates the whole centre of `𝔤₄`. In particular `gbar_defect_eq_zero` says
the defect obstructing the even-to-odd induction step maps to `0` unconditionally, so no
computation inside the loop model can ever detect it. Conversely
`oddLayer_evenTower_of_gbar_injective` shows that injectivity of `gbar` closes the entire layer
induction, which pins the residual gap down to Gabber–Kac for `A₂⁽²⁾`.

Partial completion of #7759: the issue's stated bracket is not proved. The scope analysis, the
bidegree bookkeeping for the imaginary-root components, and the reasons two families of attempts
are now ruled out are recorded on the issue; the reusable `ℕ²`-grading deliverable is split out
as #7764.

Everything is sorry-free; `#print axioms` on all six headline results reports only `propext`,
`Classical.choice`, `Quot.sound`.

🤖 Prepared with Claude Code
