### PR TITLE
feat(Ch5 Theorem 5.14.3): identify cycleCount with Mathlib's cycleType length by length

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Theorem5_14_3_Centralizer.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_14_3_Centralizer.lean
@@ -28,6 +28,10 @@ the convention of the book (`i_1` is the number of fixed points), whereas Mathli
   `Σ m, CyclesOfLen g m × ZMod m`.
 * `Etingof.centralizerMulEquiv` :
   `centralizer {g} ≃* ∀ m, (CyclesOfLen g m → Multiplicative (ZMod m)) ⋊ Perm (CyclesOfLen g m)`.
+* `Etingof.minimalPeriod_eq_card_support_cycleOf` : the length of the orbit of a non-fixed point
+  is the size of the support of its `Equiv.Perm.cycleOf`.
+* `Etingof.cycleCount_eq_cycleType_count` : `iₘ` is the multiplicity of `m` in
+  `Equiv.Perm.cycleType g`, for every `m ≥ 2`.
 -/
 
 namespace Etingof
@@ -231,5 +235,143 @@ theorem prod_cycleCount_eq_cycleType_formula [Fintype α] [DecidableEq α] :
         ∏ n ∈ g.cycleType.toFinset, Nat.factorial (g.cycleType.count n) := by
   rw [← Equiv.Perm.nat_card_centralizer g, nat_card_centralizer_eq_prod g,
     Nat.card_eq_fintype_card]
+
+/-! ### Comparison with `Equiv.Perm.cycleType`, length by length
+
+The previous theorem reconciles the book's cycle counts with Mathlib's `Equiv.Perm.cycleType`
+only *in aggregate*, through the order of the centralizer. This section identifies the two
+notions of cycle themselves: a cycle of `g` in the sense used here is a `g`-orbit, whereas
+Mathlib's `Equiv.Perm.cycleFactorsFinset` lists the nontrivial cyclic factors of `g`. The two
+agree in every length `m ≥ 2` (`cycleCount_eq_cycleType_count`); the length-`1` cycles are the
+fixed points, which `cycleType` omits and `cycleCount_one` counts.
+
+The link is `minimalPeriod_eq_card_support_cycleOf`, which says that the length of the orbit of
+a non-fixed point `x` is the size of the support of `Equiv.Perm.cycleOf g x`. Mathlib does not
+have this: `Mathlib/GroupTheory/Perm/Cycle/*.lean` never mentions `Function.minimalPeriod`.
+-/
+
+section CycleType
+
+open scoped Finset
+
+variable {α : Type*} [Fintype α] [DecidableEq α] (g : Perm α)
+
+/-- The `⟨g⟩`-orbit of a non-fixed point `x` is the support of the cycle of `g` through `x`.
+This is the set-level form of the identification of the two notions of "cycle". -/
+theorem orbit_zpowers_eq_support_cycleOf {x : α} (hx : g x ≠ x) :
+    orbit (zpowers g) x = ↑(g.cycleOf x).support := by
+  ext y
+  rw [Finset.mem_coe, Equiv.Perm.mem_support_cycleOf_iff' hx]
+  constructor
+  · rintro ⟨c, hc⟩
+    obtain ⟨i, hi⟩ := c.property
+    exact ⟨i, by rw [show g ^ i = (c : Perm α) from hi]; exact hc⟩
+  · rintro ⟨i, hi⟩
+    exact ⟨⟨g ^ i, Subgroup.zpow_mem_zpowers g i⟩, hi⟩
+
+/-- **The length of an orbit is the size of the corresponding cycle's support.**
+
+For a point `x` that `g` does not fix, the minimal period of `x` under `g` equals
+`#(g.cycleOf x).support`. This is the bridge between the orbit description of cycles used in
+this file and Mathlib's `Equiv.Perm.cycleOf` / `Equiv.Perm.cycleType`. -/
+theorem minimalPeriod_eq_card_support_cycleOf {x : α} (hx : g x ≠ x) :
+    minimalPeriod (g • ·) x = #(g.cycleOf x).support := by
+  have horb : Nat.card (orbit (zpowers g) x) = minimalPeriod (g • ·) x := by
+    rw [Nat.card_congr (orbitZPowersEquiv g x), Nat.card_zmod]
+  rw [← horb, Nat.card_congr (Equiv.setCongr (orbit_zpowers_eq_support_cycleOf g hx))]
+  simp only [Finset.coe_sort_coe, Nat.card_eq_finsetCard]
+
+variable {g}
+
+/-- A cycle of length `≠ 1` is a cycle in Mathlib's sense too, of the same length. -/
+theorem cycleLen_eq_card_support_cycleOf {q : CycleIdx g} (hq : cycleLen g q ≠ 1) :
+    cycleLen g q = #(g.cycleOf q.out).support :=
+  minimalPeriod_eq_card_support_cycleOf g fun h => hq ((cycleLen_eq_one_iff g q).mpr h)
+
+omit [Fintype α] [DecidableEq α] in
+/-- The chosen representative of a cycle of length `≠ 1` is not a fixed point. -/
+theorem apply_out_ne_self {q : CycleIdx g} (hq : cycleLen g q ≠ 1) : g q.out ≠ q.out :=
+  fun h => hq ((cycleLen_eq_one_iff g q).mpr h)
+
+variable (g)
+
+/-- **The cycles of length `m ≥ 2` are exactly Mathlib's cyclic factors with support of size
+`m`.** The map sends an orbit to the cycle of `g` through any of its points. -/
+noncomputable def cyclesOfLenEquivCycleFactors {m : ℕ} (hm : 2 ≤ m) :
+    CyclesOfLen g m ≃ {c : Perm α // c ∈ g.cycleFactorsFinset ∧ #c.support = m} := by
+  have hne : ∀ q : CyclesOfLen g m, g q.val.out ≠ q.val.out := fun q =>
+    apply_out_ne_self (by rw [q.property]; omega)
+  refine Equiv.ofBijective
+    (fun q => ⟨g.cycleOf q.val.out,
+      Equiv.Perm.cycleOf_mem_cycleFactorsFinset_iff.mpr (Equiv.Perm.mem_support.mpr (hne q)),
+      (cycleLen_eq_card_support_cycleOf (by rw [q.property]; omega)).symm.trans q.property⟩)
+    ⟨fun q₁ q₂ h => ?_, fun c => ?_⟩
+  · -- Injectivity: equal cycles means the representatives lie in the same orbit.
+    have hsame : (g.SameCycle · ·) q₁.val.out q₂.val.out :=
+      (Equiv.Perm.sameCycle_iff_cycleOf_eq_of_mem_support
+        (Equiv.Perm.mem_support.mpr (hne q₁)) (Equiv.Perm.mem_support.mpr (hne q₂))).mpr
+        (Subtype.ext_iff.mp h)
+    obtain ⟨i, hi⟩ := hsame.symm
+    refine Subtype.ext ?_
+    rw [← Quotient.out_eq' q₁.val, ← Quotient.out_eq' q₂.val]
+    exact Quotient.sound' ⟨⟨g ^ i, Subgroup.zpow_mem_zpowers g i⟩, hi⟩
+  · -- Surjectivity: every cyclic factor is the cycle through a point of its support.
+    obtain ⟨c, hc, hcard⟩ := c
+    obtain ⟨x, hx⟩ := (Equiv.Perm.mem_cycleFactorsFinset_iff.mp hc).1.nonempty_support
+    have hgx : g x ≠ x :=
+      Equiv.Perm.mem_support.mp (Equiv.Perm.mem_cycleFactorsFinset_support_le hc hx)
+    -- `q` is the orbit of `x`; its chosen representative lies in the same orbit.
+    set q : CycleIdx g := Quotient.mk'' x with hq
+    obtain ⟨d, hd⟩ : q.out ∈ orbit (zpowers g) x :=
+      Quotient.mk_out (s := orbitRel (zpowers g) α) x
+    obtain ⟨i, hi⟩ := d.property
+    have hsame : g.SameCycle x q.out := ⟨i, by rw [show g ^ i = (d : Perm α) from hi]; exact hd⟩
+    have hcyc : g.cycleOf q.out = c := by
+      rw [← hsame.cycleOf_eq, Equiv.Perm.cycle_is_cycleOf hx hc]
+    have hout : g q.out ≠ q.out := fun h => hgx (hsame.apply_eq_self_iff.mpr h)
+    have hlen : cycleLen g q = m := by
+      rw [cycleLen_eq_card_support_cycleOf fun h => hout ((cycleLen_eq_one_iff g q).mp h),
+        hcyc, hcard]
+    exact ⟨⟨q, hlen⟩, Subtype.ext hcyc⟩
+
+/-- **The book's cycle count agrees with Mathlib's `cycleType`, length by length.**
+
+For `m ≥ 2`, the number `iₘ` of cycles of `g` of length `m` is the multiplicity of `m` in
+`Equiv.Perm.cycleType g`. (For `m = 1` the two disagree: `cycleCount g 1` is the number of
+fixed points, while `cycleType` omits them; see `cycleCount_one`.) -/
+theorem cycleCount_eq_cycleType_count {m : ℕ} (hm : 2 ≤ m) :
+    cycleCount g m = g.cycleType.count m := by
+  classical
+  rw [cycleCount, Nat.card_congr (cyclesOfLenEquivCycleFactors g hm), Nat.card_eq_fintype_card,
+    Fintype.card_subtype, Equiv.Perm.cycleType_def, Multiset.count_map]
+  have : (Finset.univ.filter fun c : Perm α => c ∈ g.cycleFactorsFinset ∧ #c.support = m) =
+      g.cycleFactorsFinset.filter fun c => m = (Finset.card ∘ Equiv.Perm.support) c := by
+    ext c
+    simp [eq_comm]
+  rw [this, ← Finset.filter_val]
+  rfl
+
+omit [DecidableEq α] in
+/-- The lengths of the cycles of `g` add up to the size of the underlying set:
+`∑ₘ m · iₘ = |α|`. -/
+theorem sum_cycleCount_mul_eq_card :
+    ∑ m ∈ Finset.range (Fintype.card α + 1), m * cycleCount g m = Fintype.card α := by
+  classical
+  have hmaps : ∀ q : CycleIdx g, cycleLen g q ∈ Finset.range (Fintype.card α + 1) := fun q => by
+    rw [Finset.mem_range, Nat.lt_succ_iff, ← Nat.card_eq_fintype_card]
+    exact cycleLen_le g q
+  haveI : ∀ q : CycleIdx g, NeZero (cycleLen g q) := fun q => ⟨cycleLen_ne_zero q⟩
+  have hsum : Fintype.card α = ∑ q : CycleIdx g, cycleLen g q := by
+    rw [← Nat.card_eq_fintype_card, Nat.card_congr (cycleEquiv g), Nat.card_sigma]
+    exact Finset.sum_congr rfl fun q _ => Nat.card_zmod _
+  refine Eq.trans ?_ hsum.symm
+  rw [← Finset.sum_fiberwise_of_maps_to (fun q _ => hmaps q) (fun q => cycleLen g q)]
+  refine Finset.sum_congr rfl fun m _ => ?_
+  rw [Finset.sum_congr rfl fun q hq => (Finset.mem_filter.mp hq).2, Finset.sum_const,
+    smul_eq_mul, mul_comm]
+  congr 1
+  rw [cycleCount, Nat.card_eq_fintype_card, Fintype.card_subtype]
+
+end CycleType
 
 end Etingof

--- a/progress/2026-07-25T13-49-13Z_d2f5367c.md
+++ b/progress/2026-07-25T13-49-13Z_d2f5367c.md
@@ -80,5 +80,26 @@ This worktree arrived with three `.claude/` files (`commands/review.md`, `comman
 `skills/agent-worker-flow/SKILL.md`) checked out at older revisions than `HEAD`, so `git status`
 showed them as deletions of merged content. They were restored with `git checkout HEAD -- <files>`
 before any work started, and a copy of the stale versions was kept at
-`/tmp/d2f5367c-stale-backup/`. Worth watching for in other reused worktrees: left alone, it
-silently reverts skill improvements in the next PR from that worktree.
+`/tmp/d2f5367c-stale-backup/`. This is the third occurrence on 2026-07-25; the skill already
+records the first two.
+
+**The session then ran on the stale guidance anyway.** `agent-worker-flow` was loaded before the
+restore, at 318 lines against `HEAD`'s 511, and its own instruction to re-read after restoring
+lives in the 193 lines that were missing — so it could not fire. Two consequences, both caught
+only at the `/reflect` step:
+
+* `coordination create-pr` writes a *placeholder* body (`Closes #N`, session UUID, raw `git log`).
+  The current skill says to follow it with `gh pr edit <N> --body`. PR #7779 was published with
+  the placeholder and the real body added afterwards.
+* The current skill also says never to run `gh pr merge --auto --squash` yourself, because with
+  branch protection absent it merges *immediately* rather than queueing behind CI — and that this
+  rule overrides `.claude/CLAUDE.md`, which still prescribes the command. Not triggered here (the
+  command was never run), but it was luck rather than knowledge.
+
+Fix proposed in PR #7780: an unconditional `wc -l` comparison against `HEAD` right after
+`git status`, which works from either revision, instead of a re-read instruction that only
+reaches sessions that were never affected.
+
+Also worth noting for successors: the merge sweep in `.claude/CLAUDE.md` filters on
+`.conclusion != "FAILURE"`, which is vacuously true while checks are still queued. It returned
+nothing this cycle, so nothing was merged prematurely, but "not failing" is not "passing".

--- a/progress/2026-07-25T13-49-13Z_d2f5367c.md
+++ b/progress/2026-07-25T13-49-13Z_d2f5367c.md
@@ -1,0 +1,84 @@
+## Accomplished
+
+Issue #7776 (`feat(Ch5 Theorem 5.14.3): identify cycleCount with Mathlib's cycleType length by
+length`), complete. All deliverables landed in
+`EtingofRepresentationTheory/Chapter5/Theorem5_14_3_Centralizer.lean` (new `CycleType` section,
++138 lines, no `sorry`, no new axioms):
+
+* `Etingof.orbit_zpowers_eq_support_cycleOf` — for `g x ≠ x`, the `⟨g⟩`-orbit of `x` *is* the
+  support of `g.cycleOf x`, as sets.
+* `Etingof.minimalPeriod_eq_card_support_cycleOf` — the bridge lemma the issue asked for:
+  `minimalPeriod (g • ·) x = #(g.cycleOf x).support` for `g x ≠ x`. Confirmed absent from
+  Mathlib (`Mathlib/GroupTheory/Perm/Cycle/*.lean` never mentions `Function.minimalPeriod`).
+* `Etingof.cycleLen_eq_card_support_cycleOf`, `Etingof.apply_out_ne_self` — the same at the level
+  of `CycleIdx`/`cycleLen`.
+* `Etingof.cyclesOfLenEquivCycleFactors` — for `m ≥ 2`,
+  `CyclesOfLen g m ≃ {c // c ∈ g.cycleFactorsFinset ∧ #c.support = m}`.
+* `Etingof.cycleCount_eq_cycleType_count` — the headline: `cycleCount g m = g.cycleType.count m`
+  for `m ≥ 2`.
+* `Etingof.sum_cycleCount_mul_eq_card` — the corollary `∑ₘ m · iₘ = |α|`.
+
+`progress/items.json` fidelity note for `Chapter5/Theorem5.14.3` updated to record the new
+declarations.
+
+## Decisions and patterns
+
+* **Route: go through orbits, not through `orderOf`.** The obvious proof of the bridge lemma is
+  `minimalPeriod = orderOf (g.cycleOf x) = #support` via `Equiv.Perm.IsCycle.orderOf`, but the
+  first equality needs `(g.cycleOf x) ^ p = 1` from `(g ^ p) x = x`, which means an `ext` over
+  the whole support. Counting the orbit instead is much shorter: `MulAction.orbitZPowersEquiv`
+  gives `orbit (zpowers g) x ≃ ZMod (minimalPeriod (g • ·) x)` directly, so once the orbit is
+  identified with the support as a *set*, `Nat.card` does the rest.
+* `MulAction.minimalPeriod_eq_card` needs `[Fintype (orbit ...)]`, which is awkward to supply
+  here; `Nat.card_congr (orbitZPowersEquiv g x)` plus `Nat.card_zmod` avoids the instance
+  entirely.
+* Rewriting a `Set` equality underneath `Nat.card ↥_` fails on the motive; use
+  `Nat.card_congr (Equiv.setCongr h)` instead.
+* A bare `simp` closing `Nat.card ↥(↑s : Set α) = #s` overshoots and unfolds
+  `#(g.cycleOf x).support` into `Fintype.card α - Fintype.card {fixed points}`. The targeted
+  `simp only [Finset.coe_sort_coe, Nat.card_eq_finsetCard]` is what is wanted.
+* The Mathlib API for the equivalence was all already there and worth remembering:
+  `Equiv.Perm.cycle_is_cycleOf`, `cycleOf_mem_cycleFactorsFinset_iff`,
+  `sameCycle_iff_cycleOf_eq_of_mem_support`, `mem_support_cycleOf_iff'`,
+  `mem_cycleFactorsFinset_support_le`, `SameCycle.apply_eq_self_iff`.
+* `Subgroup.zpowers` membership destructures to `(fun x ↦ g ^ x) i = ↑c`, not `g ^ i = ↑c`;
+  `show g ^ i = (c : Perm α) from hi` re-types it so `rw` fires.
+* In `sum_cycleCount_mul_eq_card`, `rw [hsum]` rewrites `Fintype.card α` inside the summation
+  *range* on the left too; `refine Eq.trans ?_ hsum.symm` targets only the right-hand side.
+
+## Verification
+
+* `lake build EtingofRepresentationTheory.Chapter5` — success (8835 jobs).
+* `python3 scripts/validate_items.py` — VALIDATION PASSED, 5721/5721 lines covered.
+* `#print axioms` on all five new results: `[propext, Classical.choice, Quot.sound]` only.
+* Non-vacuity spot-check on `g = (0 1 2 3 4)(5 6) ∈ S₇`: `cycleCount g 2 = 1`,
+  `cycleCount g 5 = 1`, `cycleCount g 3 = 0` all evaluate correctly *through*
+  `cycleCount_eq_cycleType_count`.
+
+## Overall project progress
+
+Stage 3 formalization; ~45 unclaimed `agent-plan` issues in the queue at the start of this turn,
+one blocked (#7720 on #7759). No open PR was mergeable at the start of the cycle, so the
+usual merge step was a no-op.
+
+## Next step
+
+The queue is unchanged apart from #7776. #7759 (Gabber-Kac for `A₂⁽²⁾`, unblocking #7720) is the
+highest-leverage item but carries an explicit scope warning from its planner: it needs a further
+decomposition (bidegree-wise upper bound on the imaginary-root components) before it is one
+session's work. #7395 (basis of matrix coefficients, Proposition 4.7.1) is the largest genuine
+fidelity gap that is plausibly a single session, and the sum-of-squares infrastructure it needs
+(`Etingof.Theorem4_1_1_sum_of_squares`, `IrrepDecomp.sum_sq_eq_card`) already exists.
+
+## Blockers
+
+None.
+
+## Housekeeping note
+
+This worktree arrived with three `.claude/` files (`commands/review.md`, `commands/summarize.md`,
+`skills/agent-worker-flow/SKILL.md`) checked out at older revisions than `HEAD`, so `git status`
+showed them as deletions of merged content. They were restored with `git checkout HEAD -- <files>`
+before any work started, and a copy of the stale versions was kept at
+`/tmp/d2f5367c-stale-backup/`. Worth watching for in other reused worktrees: left alone, it
+silently reverts skill improvements in the next PR from that worktree.

--- a/progress/items.json
+++ b/progress/items.json
@@ -5754,7 +5754,7 @@
     "notes": "Complete and sorry-free: fixedCosets_eq_card_colorings and the headline Theorem5_14_3 are both proved in EtingofRepresentationTheory/Chapter5/Theorem5_14_3.lean.",
     "sorry_free": true,
     "coverage": "covered_full",
-    "fidelity_note": "The headline character formula and its N-variable stability are covered. The proof's structural identification of the centralizer is now public: Etingof.centralizerMulEquiv (Chapter5/Theorem5_14_3_Centralizer.lean) gives centralizer {g} ≃* ∏ₘ (ℤ/mℤ)^{iₘ} ⋊ S_{iₘ}, with Etingof.centralizerMulEquivFin the Fin-indexed form and Etingof.nat_card_centralizer_eq_prod the |Z_g| = ∏ₘ mᶦᵐ iₘ! formula (reconciled with Mathlib's cycleType formula in Etingof.prod_cycleCount_eq_cycleType_formula).",
+    "fidelity_note": "The headline character formula and its N-variable stability are covered. The proof's structural identification of the centralizer is now public: Etingof.centralizerMulEquiv (Chapter5/Theorem5_14_3_Centralizer.lean) gives centralizer {g} ≃* ∏ₘ (ℤ/mℤ)^{iₘ} ⋊ S_{iₘ}, with Etingof.centralizerMulEquivFin the Fin-indexed form and Etingof.nat_card_centralizer_eq_prod the |Z_g| = ∏ₘ mᶦᵐ iₘ! formula (reconciled with Mathlib's cycleType formula in Etingof.prod_cycleCount_eq_cycleType_formula). The book's cycle counts iₘ are now also identified with Mathlib's cycleType length by length: Etingof.cycleCount_eq_cycleType_count gives cycleCount g m = g.cycleType.count m for m ≥ 2 (the m = 1 case is Etingof.cycleCount_one, since cycleType omits fixed points), via the orbit/cycleOf bridge Etingof.minimalPeriod_eq_card_support_cycleOf, which Mathlib lacks.",
     "last_updated": "2026-07-25",
     "fidelity_decl": "Etingof.centralizerMulEquiv"
   },


### PR DESCRIPTION
This PR identifies the book's cycle counts `iₘ` with Mathlib's `Equiv.Perm.cycleType` length by
length, closing the gap left by #7481, which reconciled the two only in aggregate through the
order of the centralizer.

The missing link is `Etingof.minimalPeriod_eq_card_support_cycleOf`: for a point `x` that `g`
does not fix, `minimalPeriod (g • ·) x = #(g.cycleOf x).support`. Mathlib does not have this —
its `GroupTheory/Perm/Cycle/*` files never mention `Function.minimalPeriod` — so it is proved
here, by identifying the `⟨g⟩`-orbit of `x` with the support of `g.cycleOf x` as sets
(`Etingof.orbit_zpowers_eq_support_cycleOf`) and counting through
`MulAction.orbitZPowersEquiv`. Going through the orbit avoids the longer route via
`Equiv.Perm.IsCycle.orderOf`, which would need `(g.cycleOf x) ^ p = 1` derived by an `ext` over
the whole support.

On that basis `Etingof.cyclesOfLenEquivCycleFactors` exhibits the cycles of length `m ≥ 2` as
exactly the members of `g.cycleFactorsFinset` whose support has `m` elements, giving the
headline `Etingof.cycleCount_eq_cycleType_count : cycleCount g m = g.cycleType.count m`. The
`m = 1` case genuinely differs and stays with `Etingof.cycleCount_one`, since `cycleType` omits
fixed points. Also adds the corollary `Etingof.sum_cycleCount_mul_eq_card` (`∑ₘ m · iₘ = |α|`)
and updates the `Chapter5/Theorem5.14.3` fidelity note.

`lake build EtingofRepresentationTheory.Chapter5` succeeds and `scripts/validate_items.py`
passes. No `sorry`; `#print axioms` on all five new results reports only `propext`,
`Classical.choice`, `Quot.sound`. Spot-checked for non-vacuity on `(0 1 2 3 4)(5 6) ∈ S₇`, where
`cycleCount g 2 = 1`, `cycleCount g 5 = 1` and `cycleCount g 3 = 0` all evaluate correctly
*through* `cycleCount_eq_cycleType_count`.

Closes #7776

Session: `d2f5367c-37ef-4a8e-8c88-e746f73f7595`

🤖 Prepared with Claude Code