### PR TITLE
feat(Ch2 #7759): bidegree-wise upper bounds on 𝔤₄, reducing Gabber-Kac to one submodule inequality

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -6885,3 +6885,47 @@ Cheap way to get the negative: if the obstruction is known to be central (here
 finite matrix chase (`centralizer_NX_NY_eq_scalar`: commuting with the two generator images forces
 a scalar matrix; the trace condition then forces `0` when `3 ≠ 0`), and it settles the whole
 family at once rather than one element at a time.
+
+## Turning a global spanning theorem into graded upper bounds (#7759)
+
+When you have `Submodule.span k S = ⊤` for a presented algebra and a grading `deg : ι → Submodule k L`
+with projections `proj p`, you can convert the *global* spanning statement into a *per-degree*
+one for free, provided every member of `S` is homogeneous:
+
+```lean
+theorem range_proj (p) : LinearMap.range (proj p) = deg p           -- ≤ from `proj_mem`, ≥ from `proj_self_of_mem`
+theorem deg_eq_span_image (p) (hS : Submodule.span k S = ⊤) :
+    deg p = Submodule.span k (proj p '' S) := by
+  rw [← range_proj p, ← Submodule.map_top, ← hS, Submodule.map_span]
+```
+
+Then `proj p s` is either `s` (when `s` is homogeneous of degree `p`) or `0`, so the span collapses
+to the members of `S` that actually sit in degree `p`. Landed as `gDeg_eq_span_image` /
+`gDeg_le_span` in `Chapter2/Problem2_16_3_{Grading,Bidegree}.lean`.
+
+Two things make this pay off, and both are cheap:
+
+* **Prove the degree of every spanning-set member.** One lemma per constructor; the inductive
+  families (`evenTower`, `topOdd`) are inductions using the bracket-additivity lemma.
+* **Prove the degree assignment is injective on the index type.** `rintro` both indices,
+  `simp only [<the rfl degree lemmas>, Prod.mk.injEq] at h`, then `exfalso; omega` on the
+  cross cases and `Fin.ext (by omega)` on the diagonal ones. Injectivity is what turns "at most
+  the members of degree `p`" into the sharp count "at most **one** member".
+
+The payoff shape: the bound is `1` in every degree except where two spanning-set members collide,
+and *those* collisions are exactly the open problem, now stated as one submodule inequality
+instead of a family of element vanishings. This is the right way to leave a
+homomorphism-can't-witness-vanishing trap (previous section) in a state a successor can act on:
+`gDeg_imaginary_le` gives the unconditional bound `2`, and `topDefect_eq_zero_of_gDeg_le` /
+`gDeg_le_span_singleton_of_topDefect_eq_zero` prove that sharpening it to `1` is *equivalent* to the
+vanishing you could not derive. Recording the equivalence stops successors from hunting for a
+weaker sufficient condition that does not exist.
+
+Two hazards seen while doing this:
+
+* `Prod` equalities of the form `(2*m+2, 4*m+3+1) = (2*m+2, 4*m+4)` are **not** `rfl` for variable
+  `m`. Use `rw [Prod.mk.injEq]; omega`, or the `simp [Prod.ext_iff]; omega` idiom already used in
+  the file — but check the linter: `simp [Prod.ext_iff]` sometimes reports `Prod.ext_iff` unused
+  because plain `simp` already closed it.
+* `omega` will not close a non-arithmetic goal (`LoopIdx.base = LoopIdx.odd m i`) from
+  contradictory arithmetic hypotheses. Write `exfalso; omega`.

--- a/EtingofRepresentationTheory/Chapter2/Problem2_16_3_Bidegree.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_16_3_Bidegree.lean
@@ -17,6 +17,23 @@ of `𝔤₄` in `EtingofRepresentationTheory/Chapter2/Problem2_16_3_Layers.lean`
 The last one is the point: `evenTower k m` has bidegree `(m + 1) • (2, 4) + (0, -1)`, so the
 whole tower lives on the single ray of imaginary roots of `A₂⁽²⁾` that the layer induction
 walks up.
+
+The second half of the file cashes the grading in. `span_loopSet_eq_top` spans `𝔤₄`
+unconditionally by `loopFam₄` together with the layer defects; every member of that spanning set
+is bihomogeneous, and the bidegree assignment on `LoopIdx` is injective
+(`LoopIdx.bideg_injective`). Projecting the spanning statement onto a single bidegree therefore
+gives:
+
+* `gDeg_eq_bot` — `𝔤₄` vanishes in every bidegree the spanning set misses;
+* `gDeg_le_span_singleton` — `𝔤₄` is at most **one**-dimensional off the imaginary ray;
+* `gDeg_imaginary_le` — on the imaginary ray `(2m+2, 4m+4)` the unconditional bound is **two**,
+  `span {D (evenTower k m), topDefect k m}`, because the defect collides there with
+  `loopFam₄ (.even m 1)`.
+
+That single collision is the whole remaining gap in Problem 2.16.3(b):
+`topDefect_eq_zero_of_gDeg_le` and `gDeg_le_span_singleton_of_topDefect_eq_zero` show that
+sharpening the imaginary bound from two generators to one is *equivalent* to the vanishing of
+the layer defect, i.e. to the Gabber–Kac statement `mult((m+1)δ) = 1` for `A₂⁽²⁾`.
 -/
 
 namespace Etingof.Problem2_16_3

--- a/EtingofRepresentationTheory/Chapter2/Problem2_16_3_Bidegree.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_16_3_Bidegree.lean
@@ -21,6 +21,8 @@ walks up.
 
 namespace Etingof.Problem2_16_3
 
+section Degrees
+
 variable (k : Type*) [CommRing k]
 
 /-- `ad(ȳ)` raises the `y`-degree by one. -/
@@ -71,5 +73,199 @@ theorem evenTower_mem_gDeg (m : ℕ) : evenTower k m ∈ gDeg k 4 (2 * m + 2, 4 
       have h := evenTop_mem_gDeg k (oddTop_mem_gDeg k ih)
       rwa [show (2 * m + 2 + 1 + 1, 4 * m + 3 + 1 + 3) = (2 * (m + 1) + 2, 4 * (m + 1) + 3) by
         simp [Prod.ext_iff]; omega] at h
+
+/-- **The tower of odd tops.** `topOdd k m` — the top of the odd layer of `t`-degree `2m + 1` —
+has bidegree `(2m + 1, 4m)`. -/
+theorem topOdd_mem_gDeg (m : ℕ) : topOdd k m ∈ gDeg k 4 (2 * m + 1, 4 * m) := by
+  cases m with
+  | zero =>
+      rw [topOdd_zero]
+      simpa using xb_mem_gDeg k 4
+  | succ m =>
+      rw [topOdd_succ]
+      have h := oddTop_mem_gDeg k (evenTower_mem_gDeg k m)
+      rwa [show (2 * m + 2 + 1, 4 * m + 3 + 1) = (2 * (m + 1) + 1, 4 * (m + 1)) by
+        simp [Prod.ext_iff]; omega] at h
+
+/-! ## The bidegrees of the spanning set
+
+`span_loopSet_eq_top` spans `𝔤₄` by the `LoopIdx`-indexed family `loopFam₄` together with the
+layer defects `topDefect`. Every member of that set is bihomogeneous, and the assignment of
+bidegrees is *injective* on `LoopIdx` — the only collision in the whole spanning set is between
+`topDefect m` and `loopFam₄ (.even m 1) = D (evenTower m)`, both of bidegree `(2m+2, 4m+4)`.
+That single collision is exactly the remaining gap in Problem 2.16.3(b). -/
+
+/-- The bidegree of the spanning-family member at a given `LoopIdx`. -/
+def LoopIdx.bideg : LoopIdx → ℕ × ℕ
+  | .base => (0, 1)
+  | .odd m i => (2 * m + 1, 4 * m + i)
+  | .even m i => (2 * m + 2, 4 * m + 3 + i)
+
+@[simp] theorem bideg_base : LoopIdx.base.bideg = (0, 1) := rfl
+
+@[simp] theorem bideg_odd (m : ℕ) (i : Fin 5) :
+    (LoopIdx.odd m i).bideg = (2 * m + 1, 4 * m + i) := rfl
+
+@[simp] theorem bideg_even (m : ℕ) (i : Fin 3) :
+    (LoopIdx.even m i).bideg = (2 * m + 2, 4 * m + 3 + i) := rfl
+
+/-- The bidegree of the one index that collides with a defect. -/
+theorem bideg_even_one (m : ℕ) :
+    (LoopIdx.even m (1 : Fin 3)).bideg = (2 * m + 2, 4 * m + 4) := by
+  have h : ((1 : Fin 3) : ℕ) = 1 := rfl
+  rw [bideg_even, h, Prod.mk.injEq]
+  omega
+
+/-- **Distinct indices of the spanning family have distinct bidegrees.** The `t`-parity separates
+the odd strings from the even ones, the first coordinate recovers the string, and the second
+recovers the position along it. -/
+theorem LoopIdx.bideg_injective : Function.Injective LoopIdx.bideg := by
+  rintro (_ | ⟨m, i⟩ | ⟨m, i⟩) (_ | ⟨m', i'⟩ | ⟨m', i'⟩) h <;>
+    simp only [bideg_base, bideg_odd, bideg_even, Prod.mk.injEq] at h
+  · rfl
+  · exfalso; omega
+  · exfalso; omega
+  · exfalso; omega
+  · obtain rfl : m = m' := by omega
+    obtain rfl : i = i' := Fin.ext (by omega)
+    rfl
+  · exfalso; omega
+  · exfalso; omega
+  · exfalso; omega
+  · obtain rfl : m = m' := by omega
+    obtain rfl : i = i' := Fin.ext (by omega)
+    rfl
+
+/-- Every member of the `LoopIdx`-indexed family is bihomogeneous, of the recorded bidegree. -/
+theorem loopFam₄_mem_gDeg (I : LoopIdx) : loopFam₄ k I ∈ gDeg k 4 I.bideg := by
+  cases I with
+  | base => simpa using yb_mem_gDeg k 4
+  | odd m i =>
+      rw [loopFam₄_odd, bideg_odd]
+      exact dY_mem_gDeg k (i : ℕ) (topOdd_mem_gDeg k m)
+  | even m i =>
+      rw [loopFam₄_even, bideg_even]
+      exact dY_mem_gDeg k (i : ℕ) (evenTower_mem_gDeg k m)
+
+/-- **The defect is bihomogeneous of imaginary bidegree.** `topDefect k m` sits in bidegree
+`(2m+2, 4m+4) = (m+1) • (2, 4) + (0, 0)`, the same bidegree as `D (evenTower k m)`. -/
+theorem topDefect_mem_gDeg (m : ℕ) : topDefect k m ∈ gDeg k 4 (2 * m + 2, 4 * m + 4) := by
+  rw [topDefect]
+  refine sub_mem ?_ (Submodule.smul_mem _ _ ?_)
+  · have h := lie_mem_gDeg k (aElt_mem_gDeg k 4 4) (topOdd_mem_gDeg k m)
+    rwa [show ((1, 4) + (2 * m + 1, 4 * m) : ℕ × ℕ) = (2 * m + 2, 4 * m + 4) by
+      simp [Prod.ext_iff]; omega] at h
+  · have h := dY_mem_gDeg k 1 (evenTower_mem_gDeg k m)
+    rwa [show (2 * m + 2, 4 * m + 3 + 1) = (2 * m + 2, 4 * m + 4) by simp] at h
+
+end Degrees
+
+/-! ## Bidegree-wise upper bounds on `𝔤₄`
+
+Projecting the unconditional spanning theorem `span_loopSet_eq_top` onto a single bidegree turns
+it into an upper bound on that component: since every member of the spanning set is
+bihomogeneous, only the members of bidegree `p` survive the projection `gProj p`.
+
+The count is then read off `LoopIdx.bideg_injective`: every bidegree carries **at most one**
+member of `loopFam₄`, and the defects contribute one extra generator on the imaginary ray. So
+`𝔤₄` is one-dimensional in every bidegree it occupies, except possibly in the bidegrees
+`(2m+2, 4m+4)`, where the recorded upper bound is two.
+
+Closing Problem 2.16.3(b) is exactly the statement that the upper bound `2` on the imaginary ray
+is really `1` — this is `topDefect_eq_zero_of_gDeg_le` below, whose converse
+`gDeg_le_span_singleton_of_topDefect_eq_zero` shows nothing weaker will do. -/
+
+section Imaginary
+
+variable {k : Type*} [Field k]
+
+/-- **Bidegree-wise upper bound from the global spanning theorem.** To bound `gDeg k 4 p` by the
+span of a set `T` it suffices to place in `T` the members of the spanning set that actually have
+bidegree `p`. -/
+theorem gDeg_le_span (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0) (h5 : (5 : k) ≠ 0) (p : ℕ × ℕ)
+    (T : Set (g k 4)) (hfam : ∀ I : LoopIdx, I.bideg = p → loopFam₄ k I ∈ Submodule.span k T)
+    (hdef : ∀ m : ℕ, (2 * m + 2, 4 * m + 4) = p → topDefect k m ∈ Submodule.span k T) :
+    gDeg k 4 p ≤ Submodule.span k T := by
+  rw [gDeg_eq_span_image k p (span_loopSet_eq_top h2 h3 h5), Submodule.span_le]
+  rintro _ ⟨v, hv, rfl⟩
+  rcases mem_loopSet hv with ⟨I, rfl⟩ | ⟨m, rfl⟩
+  · by_cases hI : I.bideg = p
+    · rw [gProj_self_of_mem k (hI ▸ loopFam₄_mem_gDeg k I)]
+      exact hfam I hI
+    · rw [gProj_eq_zero_of_mem k (loopFam₄_mem_gDeg k I) hI]
+      exact Submodule.zero_mem _
+  · by_cases hm : (2 * m + 2, 4 * m + 4) = p
+    · rw [gProj_self_of_mem k (hm ▸ topDefect_mem_gDeg k m)]
+      exact hdef m hm
+    · rw [gProj_eq_zero_of_mem k (topDefect_mem_gDeg k m) hm]
+      exact Submodule.zero_mem _
+
+/-- **`𝔤₄` vanishes in every bidegree the spanning set misses.** -/
+theorem gDeg_eq_bot (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0) (h5 : (5 : k) ≠ 0) (p : ℕ × ℕ)
+    (hI : ∀ I : LoopIdx, I.bideg ≠ p) (hm : ∀ m : ℕ, (2 * m + 2, 4 * m + 4) ≠ p) :
+    gDeg k 4 p = ⊥ := by
+  refine le_antisymm ?_ bot_le
+  have h := gDeg_le_span h2 h3 h5 p (∅ : Set (g k 4)) (fun I hIp => absurd hIp (hI I))
+    (fun m hmp => absurd hmp (hm m))
+  simpa using h
+
+/-- **`𝔤₄` is at most one-dimensional off the imaginary ray.** -/
+theorem gDeg_le_span_singleton (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0) (h5 : (5 : k) ≠ 0)
+    (I : LoopIdx) (hI : ∀ m : ℕ, (2 * m + 2, 4 * m + 4) ≠ I.bideg) :
+    gDeg k 4 I.bideg ≤ Submodule.span k {loopFam₄ k I} := by
+  refine gDeg_le_span h2 h3 h5 _ _ (fun J hJ => ?_) (fun m hm => absurd hm (hI m))
+  rw [LoopIdx.bideg_injective hJ]
+  exact Submodule.mem_span_singleton_self _
+
+/-- **`𝔤₄` is at most two-dimensional on the imaginary ray**, spanned by `D (evenTower m)` and
+the defect. This is the unconditional half of Problem 2.16.3(b). -/
+theorem gDeg_imaginary_le (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0) (h5 : (5 : k) ≠ 0) (m : ℕ) :
+    gDeg k 4 (2 * m + 2, 4 * m + 4)
+      ≤ Submodule.span k {dY k 1 (evenTower k m), topDefect k m} := by
+  refine gDeg_le_span h2 h3 h5 _ _ (fun J hJ => ?_) (fun m' hm' => ?_)
+  · obtain rfl : J = LoopIdx.even m 1 :=
+      LoopIdx.bideg_injective (by rw [hJ, bideg_even_one])
+    rw [loopFam₄_even]
+    exact Submodule.subset_span (by simp)
+  · rw [Prod.mk.injEq] at hm'
+    obtain rfl : m' = m := by omega
+    exact Submodule.subset_span (by simp)
+
+/-- The defect vanishing is *equivalent* to the imaginary component being one-dimensional: this
+is the easy direction. -/
+theorem gDeg_le_span_singleton_of_topDefect_eq_zero (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0)
+    (h5 : (5 : k) ≠ 0) (m : ℕ) (h : topDefect k m = 0) :
+    gDeg k 4 (2 * m + 2, 4 * m + 4) ≤ Submodule.span k {dY k 1 (evenTower k m)} := by
+  refine gDeg_le_span h2 h3 h5 _ _ (fun J hJ => ?_) (fun m' hm' => ?_)
+  · obtain rfl : J = LoopIdx.even m 1 :=
+      LoopIdx.bideg_injective (by rw [hJ, bideg_even_one])
+    rw [loopFam₄_even]
+    exact Submodule.mem_span_singleton_self _
+  · rw [Prod.mk.injEq] at hm'
+    obtain rfl : m' = m := by omega
+    rw [h]
+    exact Submodule.zero_mem _
+
+/-- **The remaining gap in Problem 2.16.3(b), as a bidegree-wise dimension bound.**
+
+If the imaginary bidegree component `(2m+2, 4m+4)` of `𝔤₄` is spanned by `D (evenTower k m)`
+alone, then the layer defect at `m` vanishes: the defect lies in that component, so it is a
+multiple `λ • D (evenTower k m)`; bracketing with `x̄` sends the defect to `0` (it is central)
+and `D (evenTower k m)` to the next odd top, so `λ = 0`.
+
+Together with `gDeg_le_span_singleton_of_topDefect_eq_zero` this identifies the Gabber–Kac
+statement for `A₂⁽²⁾` with the sharpening of the unconditional bound `gDeg_imaginary_le` from
+two generators to one. -/
+theorem topDefect_eq_zero_of_gDeg_le (h2 : (2 : k) ≠ 0) (h3 : (3 : k) ≠ 0) (h5 : (5 : k) ≠ 0)
+    (m : ℕ) (hdim : gDeg k 4 (2 * m + 2, 4 * m + 4) ≤ Submodule.span k {dY k 1 (evenTower k m)})
+    (hne : topOdd k (m + 1) ≠ 0) : topDefect k m = 0 := by
+  obtain ⟨lam, hlam⟩ := Submodule.mem_span_singleton.1 (hdim (topDefect_mem_gDeg k m))
+  have h0 : ⁅aElt k 4 0, topDefect k m⁆ = 0 := central_topDefect h2 h3 h5 m _
+  rw [← hlam, lie_smul, lie_zero_dY_one_evenTower h2 h3 h5 m] at h0
+  rcases smul_eq_zero.1 h0 with hz | hz
+  · rw [← hlam, hz, zero_smul]
+  · exact absurd hz hne
+
+end Imaginary
 
 end Etingof.Problem2_16_3

--- a/EtingofRepresentationTheory/Chapter2/Problem2_16_3_Grading.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_16_3_Grading.lean
@@ -380,6 +380,23 @@ theorem gProj_of_mem {n : ℕ} {p q : ℕ × ℕ} {a : g k n} (ha : a ∈ gDeg k
 theorem gProj_self_of_mem {n : ℕ} {p : ℕ × ℕ} {a : g k n} (ha : a ∈ gDeg k n p) :
     gProj k n p a = a := by simp [gProj_of_mem k ha]
 
+theorem gProj_mem (n : ℕ) (p : ℕ × ℕ) (a : g k n) : gProj k n p a ∈ gDeg k n p := by
+  obtain ⟨u, rfl⟩ := proj_surjective k n a
+  rw [gProj_proj]
+  exact proj_mem_gDeg k (homogProj_mem k p u)
+
+/-- The bidegree-`p` projection has image exactly the bidegree-`p` component. -/
+theorem range_gProj (n : ℕ) (p : ℕ × ℕ) : LinearMap.range (gProj k n p) = gDeg k n p := by
+  refine le_antisymm ?_ fun a ha => ⟨a, gProj_self_of_mem k ha⟩
+  rintro _ ⟨a, rfl⟩
+  exact gProj_mem k n p a
+
+/-- **A spanning set of `𝔤ₙ` induces a spanning set of every bidegree component**, by projecting
+it. This is the tool that turns a global spanning family into bidegree-wise upper bounds. -/
+theorem gDeg_eq_span_image {n : ℕ} (p : ℕ × ℕ) {S : Set (g k n)} (hS : Submodule.span k S = ⊤) :
+    gDeg k n p = Submodule.span k (gProj k n p '' S) := by
+  rw [← range_gProj k n p, ← Submodule.map_top, ← hS, Submodule.map_span]
+
 theorem gProj_eq_zero_of_mem {n : ℕ} {p q : ℕ × ℕ} {a : g k n} (ha : a ∈ gDeg k n p)
     (hpq : p ≠ q) : gProj k n q a = 0 := by simp [gProj_of_mem k ha, hpq]
 

--- a/progress/2026-07-25T14-24-04Z_fc957182.md
+++ b/progress/2026-07-25T14-24-04Z_fc957182.md
@@ -1,0 +1,73 @@
+## Accomplished
+
+Session type: `/work` (meta), claimed #7759 — *prove `Injective (gbar k)` for `𝔤₄`
+(Gabber-Kac for `A₂⁽²⁾`)*. The issue carried an explicit scope warning that it is not one
+session's work and that the expected outcome is a decomposition. That is what happened, plus a
+landed unconditional half.
+
+**Landed (sorry-free, `lake build` clean):**
+
+`EtingofRepresentationTheory/Chapter2/Problem2_16_3_Grading.lean` — missing projection API:
+
+* `gProj_mem`, `range_gProj` — the bidegree projection lands in, and surjects onto, `gDeg k n p`;
+* `gDeg_eq_span_image` — a spanning set of `𝔤ₙ` induces a spanning set of each bidegree
+  component by projection. This is the tool that converts global spanning into bidegree-wise
+  upper bounds.
+
+`EtingofRepresentationTheory/Chapter2/Problem2_16_3_Bidegree.lean` — the bidegree-wise analysis:
+
+* `topOdd_mem_gDeg` — `topOdd k m` has bidegree `(2m+1, 4m)`;
+* `LoopIdx.bideg`, `bideg_base/odd/even`, `bideg_even_one`, `LoopIdx.bideg_injective` — the
+  spanning family's bidegrees, pairwise distinct;
+* `loopFam₄_mem_gDeg`, `topDefect_mem_gDeg` — every member of the unconditional spanning set
+  `loopSet = range loopFam₄ ∪ range topDefect` is bihomogeneous;
+* `gDeg_le_span` — the projection principle applied to `span_loopSet_eq_top`;
+* `gDeg_eq_bot` — `𝔤₄` vanishes in every bidegree the spanning set misses;
+* `gDeg_le_span_singleton` — **`𝔤₄` is at most one-dimensional off the imaginary ray**;
+* `gDeg_imaginary_le` — on the imaginary ray `(2m+2, 4m+4)` the unconditional bound is two:
+  `span {D (evenTower k m), topDefect k m}`;
+* `gDeg_le_span_singleton_of_topDefect_eq_zero` and `topDefect_eq_zero_of_gDeg_le` — the two
+  directions identifying "the imaginary component is one-dimensional" with "the layer defect
+  vanishes".
+
+## Current frontier
+
+The whole remaining gap in Problem 2.16.3(b) is now a single inequality of submodules,
+
+```lean
+gDeg k 4 (2 * m + 2, 4 * m + 4) ≤ Submodule.span k {dY k 1 (evenTower k m)}
+```
+
+i.e. `mult((m+1)δ) = 1` in `𝔫₊(A₂⁽²⁾)`, plus one nonvanishing side condition
+(`topOdd k (m+1) ≠ 0`) which `topDefect_eq_zero_of_gDeg_le` currently takes as a hypothesis.
+
+## Overall project progress
+
+Chapter 2, Problem 2.16.3(b): the layer induction and the `ℕ²`-grading are complete; `𝔤₄` is
+pinned to at most one dimension in every bidegree except the imaginary ray, where the bound is
+two. Everything downstream of the defect vanishing (`span_range_loopFam₄_eq_top`,
+`oddLayer_topOdd`, `Injective (gbar k)`, and #7720's explicit `Module.Basis`) is waiting on that
+one bound.
+
+## Next step
+
+Two independent successor issues were created; they can be worked in parallel.
+
+* **#7782** — compute `gbar` on the even/odd tower in closed form and derive
+  `evenTower k m ≠ 0`, `topOdd k m ≠ 0`. This discharges the `hne` hypothesis of
+  `topDefect_eq_zero_of_gDeg_le`, and (same induction) should yield
+  `LinearIndependent k (loopFam₄ k)`, which is what #7720 actually needs and which does **not**
+  require `gbar` to be injective. This is a matrix computation, modelled on `matHom₄_wSeq`.
+* **#7783** — the imaginary-bidegree dimension bound itself, i.e. the Gabber-Kac core. The issue
+  records the four routes already ruled out and two candidate routes for the genuinely new
+  input (Gröbner–Shirshov / composition-diamond, or the contravariant form on Verma modules).
+  A worker should expect to decompose rather than close it.
+
+Note for the next planner: #7720 is currently marked `blocked` on #7759, but its linear
+independence half only needs #7782, not Gabber-Kac. It may be worth narrowing #7720 or
+re-pointing its dependency once #7782 lands.
+
+## Blockers
+
+None for the landed work. #7783 is genuinely research-level and will need machinery the project
+does not have; that is stated explicitly in the issue rather than hidden.


### PR DESCRIPTION
Partial progress on #7759

Session: `fc957182-3f42-4c5b-94e5-0ba1dd7256f1`

3769d0fb doc(Ch2 #7759): record the bidegree-wise bounds in the module docstring; progress entry
e4f0d867 feat(Ch2 #7759): bidegree-wise upper bounds on 𝔤₄ and the sharp form of the Gabber-Kac gap

🤖 Prepared with Claude Code