### PR TITLE
docs: record replan triage of #7759, narrowed to the layer-defect assembly

### DIFF
--- a/progress/2026-07-25T14-30-13Z.md
+++ b/progress/2026-07-25T14-30-13Z.md
@@ -1,0 +1,55 @@
+## Accomplished
+
+Replan triage session. `coordination list-replan` had exactly one candidate, #7759
+(the layer defect for `𝔤₄` / Gabber-Kac for `A₂⁽²⁾`), back in the queue after a second
+worker decomposition.
+
+Disposition: **worker-decomposed, residual scope remains** — retargeted rather than closed.
+
+* Session `fc957182` split the issue into #7782 (evaluate `gbar` on the `evenTower` / `topOdd`
+  towers, giving `topOdd_ne_zero` and `linearIndependent_loopFam₄`) and #7783
+  (`gDeg_imaginary_le_singleton`, the imaginary-bidegree dimension bound — the Gabber-Kac core),
+  and published its bidegree work as partial PR
+  https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/pull/7784.
+* Those two do not cover the parent: #7782 says explicitly that nothing in it needs or can prove
+  `gbar` injective, and #7783's sole deliverable is the submodule inequality. The residual is the
+  final assembly — discharging the `hdim` and `hne` hypotheses of `topDefect_eq_zero_of_gDeg_le`
+  to get unconditional `topDefect_eq_zero` and `oddLayer_topOdd'`, then `Function.Injective (gbar k)`
+  from `span_range_loopFam₄_eq_top` together with the fidelity statement.
+* #7759 retitled and narrowed to that assembly; the four ruled-out attack families preserved, with
+  an explicit instruction not to attempt the Gabber-Kac core there. `replan` removed;
+  `depends-on: #7782` and `depends-on: #7783` recorded and `blocked` applied by
+  `coordination add-dep`, so `coordination check-blocked` reopens it automatically.
+* Noted in the issue that the downstream plumbing already exists: `oddLayer_topOdd` and
+  `span_range_loopFam₄_eq_top` in `Problem2_16_3_Layers.lean` already take
+  `(∀ m, topDefect k m = 0)` as a hypothesis, so the assembly is genuinely thin.
+* Enabled auto-merge (squash) on https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/pull/7784,
+  which was mergeable with CI still running and had no auto-merge set.
+
+## Current frontier
+
+`coordination list-replan` is empty. The `𝔤₄` layer induction is reduced to two independent
+issues plus a thin assembly:
+
+* #7782 — a matrix computation, claimable now, and also what unblocks #7720 (the explicit basis).
+* #7783 — Gabber-Kac for `A₂⁽²⁾`; needs new machinery (Gröbner-Shirshov, or contravariant
+  form / Verma modules) and its own decomposition. This is the real wall.
+* #7759 — blocked on both; a short session once they land.
+
+## Overall project progress
+
+Phase 3 formalization, chapter-by-chapter. No stage transition this turn: replan triage edits
+issues only. Chapter 2's `Problem2_16_3` cluster now spans five files
+(`Problem2_16_3{,_Layers,_Center,_Grading,_Bidegree}.lean`), all sorry-free, with the single
+remaining mathematical gap isolated in #7783.
+
+## Next step
+
+A worker should claim #7782 — it is a self-contained induction in matrices (`matHom₄_wSeq` is the
+model to imitate), it discharges the `hne` hypothesis, and it unblocks #7720 independently of the
+Gabber-Kac question. #7783 should go to a session that expects to spend its time choosing a route
+and decomposing, not closing.
+
+## Blockers
+
+None for this session. #7759 is deliberately `blocked` on #7782 and #7783.


### PR DESCRIPTION
This PR records the replan triage session for #7759, the single `replan` candidate this cycle.

Session `fc957182` had decomposed #7759 into https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/issues/7782 (evaluate `gbar` on the towers) and https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/issues/7783 (the imaginary-bidegree dimension bound, i.e. Gabber-Kac for `A₂⁽²⁾`), publishing its bidegree work as partial PR https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/pull/7784. Neither sub-issue covers the parent — #7782 states it cannot prove `gbar` injective and #7783 delivers only the submodule inequality — so #7759 was retargeted to the residual final assembly (unconditional `topDefect_eq_zero`, `oddLayer_topOdd'`, `Function.Injective (gbar k)`) and marked `blocked` on both, rather than closed. Auto-merge was enabled on #7784, which was mergeable with CI still running.

No code changes: the only file is the progress entry.

🤖 Prepared with Claude Code