### PR TITLE
docs: point feature and work sessions at the lean-formalization skill

### DIFF
--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -14,6 +14,14 @@ The priority order in the worker skill still applies — check for PR-fix issues
 
 ## Executing Implementation Work
 
+**Before writing any Lean, read the `lean-formalization` skill.** It is a long
+accumulated record of this project's traps, and most of them cost a build cycle
+each to rediscover. Search it for the vocabulary of your item (the ambient
+structure, the Mathlib API, the tactic that just failed) rather than reading it
+top to bottom. A rewrite or `simp` that fails to find a pattern the goal visibly
+contains is almost always one of the documented instance/elaboration traps, not
+a mistake in your proof — check the skill before rewriting the proof.
+
 Follow the plan's deliverables. For new implementations, follow the development
 cycle described in the project's CLAUDE.md.
 

--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -14,3 +14,8 @@ to pick the most important unclaimed issue and execute it.
 3. Based on your own judgment, select the most important one
 4. Identify its label (`feature`, `review`, `summarize`, or `meditate`)
 5. Execute the appropriate sub-command (`/feature`, `/review`, `/summarize`, `/meditate`)
+
+Step 5 means **actually invoking that sub-command**, not just doing the work you
+judge it implies. Each sub-command carries setup its issue type depends on — for
+`/feature`, reading the `lean-formalization` skill before writing Lean. Skipping
+the dispatch silently drops that setup.


### PR DESCRIPTION
This PR points `/feature` and `/work` sessions at the `lean-formalization` skill before they write any Lean.

Neither `/feature`, `/work`, nor `agent-worker-flow` currently mentions the skill, even though its own description names exactly the work a `feature` session does. The result is that its accumulated traps get rediscovered a build cycle at a time. In this session (#7782) that cost one cycle on the matrix Lie bracket local-instance trap: a new file bracketing matrices without `attribute [local instance] LieRing.ofAssociativeRing` gets `Ring.instBracket`, so none of the existing `lie_g*_g*` table lemmas match and the failure reads as `rewrite` not finding a pattern the goal visibly contains. The skill documents that verbatim, twice.

Also adds the diagnostic heuristic — a rewrite that fails to find a pattern the goal visibly contains is an instance/elaboration trap, not a broken proof — and notes on `/work` that dispatching means actually invoking the sub-command, since that is where the setup lives.

🤖 Prepared with Claude Code