### PR TITLE
docs(progress): record the #7790 conflict repair

### DIFF
--- a/progress/2026-07-25T15-43-42Z_a405089a-repair.md
+++ b/progress/2026-07-25T15-43-42Z_a405089a-repair.md
@@ -1,0 +1,70 @@
+## Accomplished
+
+Repair session for PR #7790 (`review(Stage3.7): re-audit Exercise 5.27.2 coverage and give
+the partial arms real follow-ups`), listed by `coordination list-pr-repair` as `conflict`.
+Salvaged and merged as `714818ed`.
+
+**Diagnosis.** The conflict was semantic, not textual noise. #7790 was an audit that
+recorded sub-part (ii) of `Chapter5/Exercise5.27.2` as `covered_partial` with follow-up
+#7788 ("transport the Heisenberg classification onto `Problem4_12_2.Heisenberg`"). While
+the PR sat unmerged, #7792 landed exactly that transport on `main` and moved (ii) to
+`covered_full`. Both sides had therefore rewritten the same three regions of
+`progress/items.json`: the parent `coverage_note`/`followup_issue`, the (ii) `reason`, and
+the (iii) `reason`.
+
+**Resolution** (`git merge origin/main`, three hunks, no Lean conflicts):
+
+* Parent — new `coverage_note` keeping the audit's specific evidence (the
+  `Theorem5_27_1` application sites at Dihedral:207 / Heisenberg:345 / Affine:209 and 454,
+  the `#print axioms` results, the settled `2 < Fintype.card K` scope worry) but restating
+  the Heisenberg paragraph as FULL. `followup_issue` moved from the now-closed #7788 to
+  #7789. Roll-up stays `covered_partial`, now solely because of the affine arm.
+* (ii) Heisenberg — took `main`'s FULL verdict, annotated with the line numbers verified
+  against the merged file (`heisenbergEquiv` at 731, `heisenberg_classification'` at 754,
+  `heisenberg_classification_named` at 782) and an explicit note that the audit's PARTIAL
+  verdict and #7788 are superseded.
+* (iii) affine — kept the audit's fuller PARTIAL text (`main`'s side was identical to the
+  merge base here, so nothing was lost); `followup_issue` #7789 unchanged.
+
+Also added a marked addendum to the PR's own progress file
+(`progress/2026-07-25T15-10-00Z_444393c8.md`) so its `covered_partial` row for (ii) is not
+read as current, and rewrote the PR body for the same reason.
+
+**Verification.** `python3 scripts/validate_items.py` → `VALIDATION PASSED` (593 items,
+5721/5721 lines covered; the `unexpected fields` warnings are pre-existing and
+project-wide). `git diff --stat origin/main HEAD` showed the branch differing from `main`
+only in `progress/items.json` and one progress file — the Lean tree was byte-identical to
+a green `main`, so no local `lake build` was needed.
+
+## Current frontier
+
+PR #7790 merged; `coordination mark-pr-salvaged 7790` done, `repair-claimed` cleared,
+issue #7320 closed. `coordination list-pr-repair` had no other candidates when this session
+started.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. `Chapter5/Exercise5.27.2` is now `covered_partial` with two
+of three sub-parts FULL: (i) dihedral over Mathlib's `DihedralGroup N`, (ii) Heisenberg
+over `Problem4_12_2.Heisenberg p` including the named `charRep`/`R_z` identification. Only
+(iii) affine remains, tracked by #7789.
+
+## Next step
+
+#7789 — transport the affine classifications from `Exercise5_27_2.AffineGroup K` onto
+`Problem4_12_6.Affine K` via `⟨a,b⟩ ↦ ⟨ofAdd b, a⟩`, and identify the `(q-1)`-dimensional
+member with the book's zero-sum `Problem4_12_6.Vsub`. The Heisenberg transport just merged
+in #7792 is the closest template; the issue flags a `Type` vs `Type*` binder mismatch to
+watch for.
+
+## Blockers
+
+None.
+
+### Note for the next session in this worktree
+
+This worktree (`worktrees/a405089a`) was stale on arrival: `.claude/commands/{feature,
+review,summarize,work}.md` and `.claude/skills/agent-worker-flow/SKILL.md` held older
+committed versions, blocking `gh pr checkout`. They were restored from `HEAD` after backing
+the diff up to `/tmp/a405089a-stale-worktree-backup/local-changes.patch`; the content was
+strictly older than `main`, so nothing was lost.


### PR DESCRIPTION
This PR records the handoff note for repair session `a405089a`, which salvaged https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/pull/7790 (review(Stage3.7): re-audit Exercise 5.27.2 coverage and give the partial arms real follow-ups). The conflict there was semantic: the audit recorded sub-part (ii) of `Chapter5/Exercise5.27.2` as `covered_partial` with follow-up #7788, while #7792 landed exactly that Heisenberg transport on `main` and moved (ii) to `covered_full`. The resolution kept the audit's evidence for the parent and the affine arm, took `main`'s FULL verdict for the Heisenberg arm, and repointed the parent follow-up at #7789.

Documentation only: one new file under `progress/`.

Session: `a405089a`

🤖 Prepared with Claude Code