### PR TITLE
docs(skill): hoist the stale-worktree check to the top of agent-worker-flow

### DIFF
--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -9,6 +9,30 @@ allowed-tools: Bash, Read, Glob, Grep
 This skill covers the shared workflow used by all pod worker agents.
 Session-specific commands reference this skill rather than duplicating it.
 
+## Step 0: Check you are reading the current skill (do this first)
+
+Reused worktrees keep arriving with `.claude/` guidance deleted, and skills load from
+the working tree — so the copy you are reading may be a stale revision with exactly the
+guidance you need cut out. Run this **before Step 1**, whether or not anything looks wrong:
+
+```bash
+git status --short
+wc -l .claude/skills/agent-worker-flow/SKILL.md
+git show HEAD:.claude/skills/agent-worker-flow/SKILL.md | wc -l
+```
+
+If the counts differ: save the diff (`git diff > /tmp/<uuid>-stale.patch`), restore with
+`git checkout HEAD -- .claude/`, then **re-invoke this skill** (the Skill tool, not `Read`)
+and start over from Step 1. Do the same for your `/command` file.
+
+This check lives at the top of the file on purpose. The fuller treatment is in Step 2 under
+"If the branch already exists", but every observed truncation left lines 1-70 intact while
+cutting blocks further down — so an instruction placed there is one a stale session never
+sees, and only this one is reliably reachable. (2026-07-25: four worktrees that day arrived
+with 169, 279, 193 and 209 lines of `.claude/` guidance deleted and nothing added. Three ran
+to completion on the old copy; the fourth caught it at Step 2 but only re-read the restored
+skill at the end of the session, after already publishing.)
+
 ## Coordination Reference
 
 The `coordination` script handles all GitHub-based multi-agent coordination.


### PR DESCRIPTION
This PR hoists the `agent-worker-flow` stale-worktree check from Step 2 to a new Step 0 at the top of the file, so that a session reading a truncated copy of the skill can still discover that its copy is truncated.

The unconditional check added in ac035c2e is self-referentially unreachable: a truncated `SKILL.md` deletes the Step 2 text along with everything else, so the instruction telling an agent to detect staleness only reaches agents who already have the full file. Every truncation observed so far leaves lines 1-70 intact and cuts scattered blocks further down (in all four cases to date, the earliest hunk against `HEAD` started at line 71), so a check placed in the file head survives this class of damage while one in Step 2 does not. Step 2 keeps the fuller treatment and is cross-referenced.

Session `aa205197` is the fourth instance: the worktree arrived with 209 lines deleted across five `.claude/` files. It caught the deletions at Step 2 by inspecting `git status`, but restored them without re-invoking the skill, so it ran its whole audit on the stale copy and only discovered at publish time that Step 7 requires replacing `create-pr`'s placeholder PR body.

Split from the #7302 audit work in https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/pull/7797, since a skill fix is a separate logical unit.

Session: `aa205197-ec81-4edf-89f1-7f0ab8e865d4`

🤖 Prepared with Claude Code