### PR TITLE
feat(Ch5 Remark5.23.3): SL_N restriction, the equivariant det-shift isomorphism, and the SLWeightParam parametrization map

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/Remark5_23_3.lean
+++ b/EtingofRepresentationTheory/Chapter5/Remark5_23_3.lean
@@ -1,7 +1,14 @@
 import Mathlib
-import Batteries.Util.ProofWanted
 import EtingofRepresentationTheory.Chapter5.Theorem5_23_2Core
 import EtingofRepresentationTheory.Chapter5.Proposition5_22_2
+import EtingofRepresentationTheory.Chapter5.AlgIrrepGLRep
+
+-- These mirror the lakefile's project-wide `[leanOptions]` so the module also type-checks under a
+-- bare `lake env lean`, which does not read the lakefile options. `maxSynthPendingDepth 3` clears
+-- the deep Schur-module instance chains; `backward.isDefEq.respectTransparency false` restores the
+-- full-transparency `isDefEq` the `charTwistRep`/Schur carrier identifications rely on.
+set_option maxSynthPendingDepth 3
+set_option backward.isDefEq.respectTransparency false
 
 /-!
 # Remark 5.23.3: Extension of the GL(V) theory to 𝔰𝔩(V) and SL(V)
@@ -18,8 +25,8 @@ representation theory of `𝔰𝔩(2)` from Problem 2.15.1.
 
 ## What is formalized here
 
-The provable content of the remark is the parametrization up to a
-simultaneous constant shift. We make this precise on `Etingof.DominantWeight`:
+**Weights.** The parametrization up to a simultaneous constant shift is made precise on
+`Etingof.DominantWeight`:
 
 * `Etingof.DominantWeight.constShift lam c`: the simultaneous shift `λ ↦ λ + c·1ᴺ` (adding the
   same integer `c` to every entry). This is the weight-side of tensoring `L_λ` with `det^c`.
@@ -28,21 +35,40 @@ simultaneous constant shift. We make this precise on `Etingof.DominantWeight`:
   parametrizes the irreducible `SL_N`-representations. This is exactly Etingof's "`λ₁ ≥ ⋯ ≥ λ_N` up
   to a simultaneous shift by a constant".
 
-The dimension-level shadow of the `SL(V)` isomorphism is proved as a `theorem`; the remaining
-assertion is recorded with `proof_wanted`, because the book omits its proof:
+**The `SL_N`-action and the isomorphism `L_λ ≅ L_{λ + c·1ᴺ}`.**
 
-* `Etingof.algIrrepGL_finrank_constShift`: the dimension-level shadow of `L_λ ≅ L_{λ + c·1ᴺ}`,
-  proved as a `theorem`. Twisting by a power of the (one-dimensional) determinant character does
-  not change the underlying dimension, so `dim L_λ = dim L_{λ + c·1ᴺ}` (proved via the `+1`
-  det-twist identity of Proposition 5.22.2, iterated). This is the consequence of the
-  `SL(V)` isomorphism available here: an `SL_N`-equivariant isomorphism
-  would require an `SL_N`-action on `AlgIrrepGL`, which is not constructed here.
-* `Etingof.sl_finiteDimensional_completely_reducible`: complete reducibility of an arbitrary
-  finite-dimensional `𝔰𝔩(V)`-module, stated in the same "every submodule has a complement" form as
-  the `𝔰𝔩(2)` case `Etingof.Sl2Irrep.complete_reducibility` (Problem 2.15.1). Etingof explicitly
-  omits the proof ("we will not do this here"); the companion assertion that every irreducible is an
-  `L_λ` is the highest-weight classification, whose parameter set is `SLWeightParam N` above.
+* `Etingof.slRestrict ρ`: the restriction of a `GL_N(k)`-representation to `SL_N(k)` along
+  `Matrix.SpecialLinearGroup.toGL`. Applied to `Etingof.algIrrepGLRepρ` this is the bundled
+  `SL_N`-action on `L_λ`.
+* `Etingof.slRestrict_charTwistRep_detChar_zpow`: any power of the determinant character becomes
+  trivial after restriction, so `det`-twists are invisible on `SL_N`. This is the one input that
+  makes the whole `GL_N` theory descend.
+* `Etingof.algIrrepGL_slEquiv_constShift`: the `SL_N`-equivariant isomorphism
+  `L_{λ + c·1ᴺ}|_{SL_N} ≅ L_λ|_{SL_N}` as a `Representation.Equiv`, obtained by restricting the
+  `GL_N`-level determinant-twist isomorphism of Proposition 5.22.2 and observing that the twist
+  disappears. `Etingof.algIrrepGL_finrank_constShift` is its dimension shadow.
+
+**The parametrization by `SLWeightParam N`.**
+
+* `Etingof.slIsoSetoid n k`: the relation "the `SL_N`-restrictions of `L_λ` and `L_μ` are
+  isomorphic" on dominant weights, an equivalence relation because `Representation.Equiv` has
+  `refl`/`symm`/`trans`.
+* `Etingof.slIrrepClass`: the induced map `SLWeightParam n → Quotient (slIsoSetoid n k)`. It is
+  well defined by `Etingof.shiftEquiv_slIso` (shift-equivalent weights give isomorphic `SL_N`
+  representations) and surjective by `Etingof.slIrrepClass_surjective`. Injectivity of this map,
+  and the statement that the `L_λ|_{SL_N}` exhaust the irreducibles, are the two remaining halves
+  of the classification; the latter rests on the `GL_N` highest-weight classification, which this
+  development does not yet prove.
+
+**What is intentionally omitted.** Etingof states, and explicitly declines to prove ("we will not
+do this here"), that every finite-dimensional `𝔰𝔩(V)`-representation is completely reducible and
+every irreducible one is an `L_λ`. Following the project's omission policy, this file carries no
+declaration for those assertions; the decision is recorded in `skipped-exercises.md` under
+"Remark 5.23.3". The `𝔰𝔩(2)` case that the remark points at is proved independently as
+`Etingof.Sl2Irrep.complete_reducibility` (Problem 2.15.1).
 -/
+
+open Etingof.KernelLemmaKPrime
 
 namespace Etingof
 
@@ -192,25 +218,217 @@ theorem algIrrepGL_finrank_constShift
     exact (finrank_schurModuleSubmodule_add_const (lam.constShift c).toNatWeight hb_anti
       (-Δ).toNat).symm
 
-open LieAlgebra in
-/-- **Complete reducibility of finite-dimensional `𝔰𝔩(V)`-representations (Remark 5.23.3).** Every
-finite-dimensional `𝔰𝔩_N(k)`-module `M` is completely reducible: every `𝔰𝔩_N`-submodule `N` has an
-`𝔰𝔩_N`-complement `N'` (`IsCompl N N'`, i.e. `M = N ⊕ N'`). This is the same "every submodule is a
-direct summand" formulation as the `𝔰𝔩(2)` case `Etingof.Sl2Irrep.complete_reducibility`
-(Problem 2.15.1), to which this specializes for `N = 2`.
+/-! ## Restriction of `GL_N`-representations to `SL_N`
 
-Etingof states this without proof ("we will not do this here"), so it is recorded via
-`proof_wanted`. The companion assertion, that every irreducible is of the
-form `L_λ`, is the highest-weight classification; its parameter set is `SLWeightParam N` (dominant
-weights up to a simultaneous constant shift). Stating that classification `𝔰𝔩_N`-equivariantly would
-require an `𝔰𝔩_N`-action on the `L_λ`, which this development does not build.
+Etingof's remark is about restricting the `GL(V)`-theory along `SL(V) ⊆ GL(V)`. We build that
+restriction and record the one fact that drives the whole descent: the determinant character, and
+hence every power of it, becomes trivial on `SL_N`. -/
+
+section SLRestriction
+
+variable {n : ℕ} {k : Type*} [CommRing k] {V : Type*} [AddCommMonoid V] [Module k V]
+
+/-- **Restriction of a `GL_N(k)`-representation to `SL_N(k)`**, along Mathlib's embedding
+`Matrix.SpecialLinearGroup.toGL` of the determinant-one matrices into the general linear group.
+This is the bundled `SL_N`-action that Remark 5.23.3 is about. -/
+def slRestrict (ρ : Representation k (Matrix.GeneralLinearGroup (Fin n) k) V) :
+    Representation k (Matrix.SpecialLinearGroup (Fin n) k) V :=
+  MonoidHom.comp ρ Matrix.SpecialLinearGroup.toGL
+
+@[simp] lemma slRestrict_apply (ρ : Representation k (Matrix.GeneralLinearGroup (Fin n) k) V)
+    (g : Matrix.SpecialLinearGroup (Fin n) k) (v : V) :
+    slRestrict ρ g v = ρ (Matrix.SpecialLinearGroup.toGL g) v := rfl
+
+/-- **The determinant character is trivial on `SL_N`.** This is the single input that makes the
+`GL(V)`-theory descend to `SL(V)`: the determinant twists that separate `L_λ` from `L_{λ + c·1ᴺ}`
+become invisible after restriction. -/
+@[simp] lemma detChar_toGL (g : Matrix.SpecialLinearGroup (Fin n) k) :
+    detChar k n (Matrix.SpecialLinearGroup.toGL g) = 1 :=
+  Units.ext (by simp [detChar, Matrix.GeneralLinearGroup.det])
+
+/-- Twisting by any integer power of the determinant character leaves the restriction to `SL_N`
+unchanged: `(det^c · ρ)|_{SL_N} = ρ|_{SL_N}`. -/
+lemma slRestrict_charTwistRep_detChar_zpow (c : ℤ)
+    (ρ : Representation k (Matrix.GeneralLinearGroup (Fin n) k) V) :
+    slRestrict (charTwistRep (detChar k n ^ c) ρ) = slRestrict ρ := by
+  ext g v
+  simp [MonoidHom.zpow_apply]
+
+end SLRestriction
+
+/-- Transport a categorical isomorphism `FDRep.of ρ ≅ FDRep.of σ` to an isomorphism of the
+underlying representations. The underlying linear equivalence is `FDRep.isoToLinearEquiv`, and its
+intertwining property is `FDRep.Iso.conj_ρ`, which says exactly that conjugating `ρ g` by it gives
+`σ g`. -/
+noncomputable def fdRepIsoToEquiv {K : Type} [Field K] {G : Type*} [Monoid G]
+    {V W : Type} [AddCommGroup V] [Module K V] [Module.Finite K V]
+    [AddCommGroup W] [Module K W] [Module.Finite K W]
+    (ρ : Representation K G V) (σ : Representation K G W)
+    (α : FDRep.of ρ ≅ FDRep.of σ) : Representation.Equiv ρ σ :=
+  Representation.Equiv.mk (FDRep.isoToLinearEquiv α) fun g => by
+    have h := FDRep.Iso.conj_ρ α g
+    rw [FDRep.of_ρ', FDRep.of_ρ'] at h
+    rw [h, LinearEquiv.conj_apply]
+    refine LinearMap.ext fun v => ?_
+    simp
+
+/-- Restrict an isomorphism of `GL_N`-representations to an isomorphism of their `SL_N`
+restrictions. -/
+def slRestrictEquiv {n : ℕ} {k : Type*} [CommRing k] {V W : Type*}
+    [AddCommMonoid V] [Module k V] [AddCommMonoid W] [Module k W]
+    {ρ : Representation k (Matrix.GeneralLinearGroup (Fin n) k) V}
+    {σ : Representation k (Matrix.GeneralLinearGroup (Fin n) k) W}
+    (E : Representation.Equiv ρ σ) :
+    Representation.Equiv (slRestrict ρ) (slRestrict σ) :=
+  Representation.Equiv.mk E.toLinearEquiv fun g =>
+    E.isIntertwining' (Matrix.SpecialLinearGroup.toGL g)
+
+/-! ## The `SL_N`-equivariant isomorphism `L_λ ≅ L_{λ + c·1ᴺ}`
+
+The `GL_N`-level input is Proposition 5.22.2 in the form
+`schurModule_shift_iso_detTwist : L_{μ+1ᴺ} ≅ L_μ ⊗ det`. Restriction to `SL_N` makes the `det`
+factor trivial, so `L_{μ+1ᴺ}|_{SL_N} ≅ L_μ|_{SL_N}`; iterating gives the constant shift. The
+`det^{-shift}` normalization built into `algIrrepGLRepρ` is invisible for the same reason, which
+extends the statement from non-negative to integer weights. -/
+
+section SLEquiv
+
+variable {k : Type} [Field k] [IsAlgClosed k] [CharZero k]
+
+omit [IsAlgClosed k] [CharZero k] in
+/-- The determinant twist of Proposition 5.22.2 is the character twist by `detChar`. -/
+lemma detTwistedSchurModuleRep_eq_charTwistRep (N : ℕ) (lam : Fin N → ℕ) :
+    detTwistedSchurModuleRep k N lam = charTwistRep (detChar k N) (schurModuleRep k N lam) := rfl
+
+omit [IsAlgClosed k] [CharZero k] in
+/-- The determinant-twisted Schur module and the Schur module have the same `SL_N`-restriction:
+the twisting scalar `det g` is `1` on `SL_N`. -/
+lemma slRestrict_detTwistedSchurModuleRep (N : ℕ) (lam : Fin N → ℕ) :
+    slRestrict (detTwistedSchurModuleRep k N lam) = slRestrict (schurModuleRep k N lam) := by
+  rw [detTwistedSchurModuleRep_eq_charTwistRep, ← zpow_one (detChar k N)]
+  exact slRestrict_charTwistRep_detChar_zpow 1 _
+
+/-- **One shift step, `SL_N`-equivariantly.** Restricting Proposition 5.22.2's determinant-twist
+isomorphism `L_{μ+1ᴺ} ≅ L_μ ⊗ det` to `SL_N`, where the `det` factor is trivial. -/
+theorem schurModule_slEquiv_succ (N : ℕ) (lam : Fin N → ℕ) (hlam : Antitone lam) :
+    Nonempty (Representation.Equiv (slRestrict (schurModuleRep k N (fun i => lam i + 1)))
+      (slRestrict (schurModuleRep k N lam))) := by
+  obtain ⟨e⟩ := schurModule_shift_iso_detTwist k N lam hlam
+  refine ⟨?_⟩
+  have E := slRestrictEquiv (fdRepIsoToEquiv _ _ e)
+  rwa [slRestrict_detTwistedSchurModuleRep N lam] at E
+
+omit [IsAlgClosed k] [CharZero k] in
+/-- Transporting along an equality of `ℕ`-weights. Stated separately because rewriting the weight
+inside `slRestrict (schurModuleRep k N ·)` also rewrites the carrier type. -/
+theorem schurModule_slEquiv_congr (N : ℕ) {lam mu : Fin N → ℕ} (h : lam = mu) :
+    Nonempty (Representation.Equiv (slRestrict (schurModuleRep k N lam))
+      (slRestrict (schurModuleRep k N mu))) := by
+  subst h; exact ⟨Representation.Equiv.refl _⟩
+
+/-- **Constant `+m` shift, `SL_N`-equivariantly.** Iterating `schurModule_slEquiv_succ`. -/
+theorem schurModule_slEquiv_add_const (N : ℕ) (lam : Fin N → ℕ) (hlam : Antitone lam) (m : ℕ) :
+    Nonempty (Representation.Equiv (slRestrict (schurModuleRep k N (fun i => lam i + m)))
+      (slRestrict (schurModuleRep k N lam))) := by
+  induction m with
+  | zero =>
+    exact schurModule_slEquiv_congr (k := k) N
+      (show (fun i => lam i + 0) = lam by funext i; omega)
+  | succ m ih =>
+    obtain ⟨E⟩ := ih
+    obtain ⟨F⟩ := schurModule_slEquiv_succ (k := k) N (fun i => lam i + m)
+      (fun a b h => Nat.add_le_add_right (hlam h) m)
+    obtain ⟨G⟩ := schurModule_slEquiv_congr (k := k) N
+      (show (fun i => lam i + (m + 1)) = (fun i => (lam i + m) + 1) by funext i; omega)
+    exact ⟨(G.trans F).trans E⟩
+
+omit [CharZero k] in
+/-- The `SL_N`-restriction of `L_λ` is the `SL_N`-restriction of the underlying Schur module: the
+`det^{-λ.shift}` normalization built into `algIrrepGLRepρ` is invisible on `SL_N`. -/
+lemma slRestrict_algIrrepGLRepρ {n : ℕ} (lam : DominantWeight n) :
+    slRestrict (algIrrepGLRepρ n lam k) = slRestrict (schurModuleRep k n lam.toNatWeight) :=
+  slRestrict_charTwistRep_detChar_zpow _ _
+
+/-- **The `SL_N`-equivariant isomorphism `L_{λ + c·1ᴺ} ≅ L_λ` (Remark 5.23.3).** On `SL(V)` the
+determinant character is trivial, so the `GL(V)`-representations `L_λ` and its determinant twists
+`L_{λ + c·1ᴺ}` become isomorphic. This is the representation-level statement whose dimension
+shadow is `algIrrepGL_finrank_constShift`.
 (Etingof Remark 5.23.3) -/
-proof_wanted sl_finiteDimensional_completely_reducible
-    {n : ℕ} {k : Type*} [Field k] [CharZero k]
-    {M : Type*} [AddCommGroup M] [Module k M] [FiniteDimensional k M]
-    [LieRingModule (SpecialLinear.sl (Fin n) k) M]
-    [LieModule k (SpecialLinear.sl (Fin n) k) M]
-    (N : LieSubmodule k (SpecialLinear.sl (Fin n) k) M) :
-    ∃ N' : LieSubmodule k (SpecialLinear.sl (Fin n) k) M, IsCompl N N'
+theorem algIrrepGL_slEquiv_constShift {n : ℕ} (lam : DominantWeight n) (c : ℤ) :
+    Nonempty (Representation.Equiv (slRestrict (algIrrepGLRepρ n (lam.constShift c) k))
+      (slRestrict (algIrrepGLRepρ n lam k))) := by
+  rw [slRestrict_algIrrepGLRepρ, slRestrict_algIrrepGLRepρ]
+  have ha_anti : Antitone lam.toNatWeight := toNatWeight_antitone lam
+  have hb_anti : Antitone (lam.constShift c).toNatWeight := toNatWeight_antitone (lam.constShift c)
+  set Δ : ℤ := c + ((lam.constShift c).shift : ℤ) - (lam.shift : ℤ) with hΔdef
+  have hrel : ∀ i, ((lam.constShift c).toNatWeight i : ℤ) = (lam.toNatWeight i : ℤ) + Δ := by
+    intro i
+    rw [toNatWeight_cast (lam.constShift c) i, toNatWeight_cast lam i,
+      DominantWeight.constShift_val, hΔdef]
+    ring
+  rcases le_total 0 Δ with hΔ | hΔ
+  · obtain ⟨G⟩ := schurModule_slEquiv_congr (k := k) n
+      (show (lam.constShift c).toNatWeight = (fun i => lam.toNatWeight i + Δ.toNat) by
+        funext i; have := hrel i; omega)
+    obtain ⟨E⟩ := schurModule_slEquiv_add_const (k := k) n lam.toNatWeight ha_anti Δ.toNat
+    exact ⟨G.trans E⟩
+  · obtain ⟨G⟩ := schurModule_slEquiv_congr (k := k) n
+      (show lam.toNatWeight = (fun i => (lam.constShift c).toNatWeight i + (-Δ).toNat) by
+        funext i; have := hrel i; omega)
+    obtain ⟨E⟩ := schurModule_slEquiv_add_const (k := k) n (lam.constShift c).toNatWeight hb_anti
+      (-Δ).toNat
+    exact ⟨(G.trans E).symm⟩
+
+end SLEquiv
+
+/-! ## The parametrization of the `L_λ|_{SL_N}` by `SLWeightParam N` -/
+
+section SLParam
+
+variable (n : ℕ) (k : Type) [Field k] [IsAlgClosed k] [CharZero k]
+
+/-- **Isomorphism of `SL_N`-restrictions**, as an equivalence relation on dominant weights: `λ` and
+`μ` are related when `L_λ` and `L_μ` become isomorphic after restricting to `SL_N`. It is an
+equivalence relation because `Representation.Equiv` carries `refl`, `symm` and `trans`. -/
+def slIsoSetoid : Setoid (DominantWeight n) where
+  r lam mu := Nonempty (Representation.Equiv (slRestrict (algIrrepGLRepρ n lam k))
+    (slRestrict (algIrrepGLRepρ n mu k)))
+  iseqv :=
+    { refl := fun _ => ⟨Representation.Equiv.refl _⟩
+      symm := fun ⟨E⟩ => ⟨E.symm⟩
+      trans := fun ⟨E⟩ ⟨F⟩ => ⟨E.trans F⟩ }
+
+variable {n k}
+
+/-- **Shift-equivalent weights give isomorphic `SL_N`-representations.** This is what makes the
+parametrization of the `L_λ|_{SL_N}` by `SLWeightParam N` well defined: the shift relation refines
+the isomorphism relation. -/
+theorem shiftEquiv_slIso {lam mu : DominantWeight n}
+    (h : DominantWeight.ShiftEquiv lam mu) : (slIsoSetoid n k).r lam mu := by
+  obtain ⟨c, rfl⟩ := h
+  exact ⟨(algIrrepGL_slEquiv_constShift (k := k) lam c).some.symm⟩
+
+variable (n k)
+
+/-- **The parametrization map.** Etingof's "the irreducible `SL(V)`-representations are
+parametrized by `λ₁ ≥ ⋯ ≥ λ_N` up to a simultaneous shift by a constant" says that
+`λ ↦ L_λ|_{SL_N}` descends to `SLWeightParam N` and is a bijection onto the irreducibles. The
+descent is `shiftEquiv_slIso`; the resulting map lands in the isomorphism classes of the
+`SL_N`-restrictions of the `L_λ`. -/
+def slIrrepClass : SLWeightParam n → Quotient (slIsoSetoid n k) :=
+  Quotient.map' id fun _ _ h => shiftEquiv_slIso h
+
+@[simp] lemma slIrrepClass_mk (lam : DominantWeight n) :
+    slIrrepClass n k (Quotient.mk _ lam) = Quotient.mk _ lam := rfl
+
+/-- The parametrization map is surjective: every `SL_N`-restriction `L_λ|_{SL_N}` is named by the
+shift class of `λ`. Injectivity, i.e. that weights in different shift classes give
+non-isomorphic `SL_N`-representations, is not proved here. -/
+theorem slIrrepClass_surjective : Function.Surjective (slIrrepClass n k) := by
+  intro q
+  induction q using Quotient.inductionOn with
+  | h lam => exact ⟨Quotient.mk _ lam, rfl⟩
+
+end SLParam
 
 end Etingof

--- a/progress/2026-07-25T17-23-35Z_ba25aaad.md
+++ b/progress/2026-07-25T17-23-35Z_ba25aaad.md
@@ -1,0 +1,65 @@
+## Accomplished
+
+Worked #7357, `feat(Ch5 #Remark5.23.3): prove the SL restriction results and document the omitted
+sl theorems`. Everything in the issue landed except the "existence and uniqueness" half of the
+parametrization, which was decomposed into #7807 and #7808.
+
+**`SL_N` restriction and the equivariant isomorphism** (`Chapter5/Remark5_23_3.lean`, all
+axiom-clean):
+
+* `Etingof.slRestrict` restricts a `GL_N(k)`-representation to `SL_N(k)` along Mathlib's
+  `Matrix.SpecialLinearGroup.toGL`. `Etingof.detChar_toGL` proves the determinant character is
+  trivial there, and `Etingof.slRestrict_charTwistRep_detChar_zpow` upgrades that to "any integer
+  power of `detChar` is invisible after restriction". This is the one input the whole descent runs
+  on.
+* `Etingof.fdRepIsoToEquiv` transports a categorical `FDRep.of ρ ≅ FDRep.of σ` to a
+  `Representation.Equiv` (underlying map `FDRep.isoToLinearEquiv`, intertwining from
+  `FDRep.Iso.conj_ρ`), and `Etingof.slRestrictEquiv` restricts such an equivalence to `SL_N`.
+* `Etingof.schurModule_slEquiv_succ` restricts Proposition 5.22.2's determinant-twist isomorphism
+  `L_{μ+1ᴺ} ≅ L_μ ⊗ det` to `SL_N`, where the `det` factor disappears;
+  `Etingof.schurModule_slEquiv_add_const` iterates it.
+* `Etingof.algIrrepGL_slEquiv_constShift` is the headline: an honest `SL_N`-equivariant
+  isomorphism `L_{λ + c·1ᴺ}|_{SL_N} ≅ L_λ|_{SL_N}` for an integer dominant weight `λ` and any
+  `c : ℤ`. The pre-existing `algIrrepGL_finrank_constShift` is now its dimension shadow rather than
+  the strongest available statement.
+
+**Parametrization by `SLWeightParam N`:** `Etingof.slIsoSetoid n k` is the relation "the `SL_N`
+restrictions of `L_λ` and `L_μ` are isomorphic" (an equivalence relation via
+`Representation.Equiv`'s `refl`/`symm`/`trans`); `Etingof.shiftEquiv_slIso` shows the shift
+relation refines it, so `Etingof.slIrrepClass : SLWeightParam n → Quotient (slIsoSetoid n k)` is
+well defined, and `Etingof.slIrrepClass_surjective` shows it is onto.
+
+**The book-disavowed `𝔰𝔩_N` assertions:** the `proof_wanted
+sl_finiteDimensional_completely_reducible` is gone, replaced by a "Remark 5.23.3" entry in
+`skipped-exercises.md` (with the cross-reference in the module docstring). Etingof writes "we will
+not do this here", so those are not proof obligations this formalization inherits; the `𝔰𝔩(2)` case
+the remark points at is already `Etingof.Sl2Irrep.complete_reducibility`.
+
+`progress/items.json` updated for `Chapter5/Remark5.23.3` (still `covered_partial`, follow-up now
+#7807).
+
+## Current frontier
+
+Two Lean-side notes worth carrying forward. `Matrix.SpecialLinearGroup.toGL` is the embedding to
+use; `Representation.Equiv` (Mathlib's `RepresentationTheory/Intertwining.lean`) is the right
+target type, and its `mk` wants `∀ g, ↑e ∘ₗ ρ g = σ g ∘ₗ ↑e`, which the structure field
+`isIntertwining'` supplies verbatim after composing with `toGL`. Rewriting an `ℕ`-weight inside
+`slRestrict (schurModuleRep k N ·)` changes the carrier type, so weight transports go through
+`schurModule_slEquiv_congr` (a `subst`), not `rw`.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. Chapter 5 Remark 5.23.3 moves from "dimension shadow only" to a
+genuine `SL_N`-equivariant isomorphism plus a well-defined, surjective parametrization map. The
+project's `proof_wanted` count drops from two to one (`Chapter2/Remark2_9_3` `ado` remains).
+
+## Next step
+
+#7807 (injectivity of `slIrrepClass`: weights in different shift classes give non-isomorphic
+`SL_N`-restrictions) is unblocked and is the natural continuation. It needs the torus argument of
+`Chapter5/AlgIrrepGLNonIso.lean` redone for the determinant-one subtorus of the diagonal torus.
+#7808 (exhaustiveness) is blocked on the `GL_N` highest-weight classification #7400.
+
+## Blockers
+
+None for #7807. #7808 is blocked on #7400, which is unclaimed.

--- a/progress/items.json
+++ b/progress/items.json
@@ -6600,11 +6600,11 @@
     "status": "partially_proved",
     "fidelity": "partial",
     "sorry_free": true,
-    "fidelity_note": "Added in #5729: the file defines the constant-shift relation and SLWeightParam and proves specialLinear_det_eq_one plus the dimension shadow algIrrepGL_finrank_constShift. It does not yet construct the claimed SL_N-equivariant shift isomorphism or prove the parametrization theorem. The general sl_N assertions are explicitly disavowed by the book and should be documented as intentional omissions rather than represented by proof_wanted; follow-up #7357.",
+    "fidelity_note": "#7357 completed the SL_N half. slRestrict restricts a GL_N representation along Matrix.SpecialLinearGroup.toGL; detChar_toGL and slRestrict_charTwistRep_detChar_zpow show every determinant twist is invisible on SL_N; algIrrepGL_slEquiv_constShift is the SL_N-equivariant isomorphism L_{lam + c*1^N} = L_lam as a Representation.Equiv (algIrrepGL_finrank_constShift is its dimension shadow); slIsoSetoid, shiftEquiv_slIso, slIrrepClass and slIrrepClass_surjective make the parametrization by SLWeightParam N well defined and surjective onto the isomorphism classes of the L_lam|_SL. The book-disavowed sl_N complete-reducibility and highest-weight assertions are now recorded in skipped-exercises.md under 'Remark 5.23.3' rather than as proof_wanted. Still open: injectivity of slIrrepClass (#7807) and exhaustiveness of the L_lam|_SL among the irreducibles (#7808, blocked on the GL_N classification #7400).",
     "coverage": "covered_partial",
     "coverage_issue": 7547,
-    "followup_issue": 7357,
-    "last_updated": "2026-07-22"
+    "followup_issue": 7807,
+    "last_updated": "2026-07-25"
   },
   {
     "id": "Chapter5/Introduction_5.24",

--- a/skipped-exercises.md
+++ b/skipped-exercises.md
@@ -54,6 +54,32 @@ This omission is documented in
 `EtingofRepresentationTheory/Chapter2/Problem2_16_5.lean`; no unproved
 classification declaration is introduced.
 
+### Remark 5.23.3 — the `𝔰𝔩(V)` complete-reducibility and highest-weight assertions
+
+Remark 5.23.3 records two assertions about the Lie algebra `𝔰𝔩(V)`: every
+finite-dimensional `𝔰𝔩(V)`-representation is completely reducible, and every
+irreducible one is an `L_λ`. The book states both and then writes "we will not do
+this here". Following the policy above, the project does not carry a declaration
+for either assertion, and in particular does not record them as `proof_wanted`:
+they are not results the book proves, so they are not proof obligations this
+formalization inherits.
+
+The rest of the remark is formalized. The group-level content — the restriction of
+a `GL_N`-representation to `SL_N`, the triviality of the determinant character
+there, the `SL_N`-equivariant isomorphism `L_λ ≅ L_{λ + c·1ᴺ}`, and the
+well-defined surjection from `SLWeightParam N` (dominant weights modulo a
+simultaneous constant shift) onto the isomorphism classes of the
+`L_λ|_{SL_N}` — lives in
+`EtingofRepresentationTheory/Chapter5/Remark5_23_3.lean`. The `dim V = 2` case
+that the remark points at, complete reducibility for `𝔰𝔩(2)`, is proved
+independently as `Etingof.Sl2Irrep.complete_reducibility` (Problem 2.15.1).
+
+Two parts of the `SL_N` picture are unfinished rather than omitted, and are
+tracked as ordinary work items: that weights in different shift classes give
+non-isomorphic `SL_N`-representations, and that the `L_λ|_{SL_N}` exhaust the
+irreducibles. The latter rests on the `GL_N` highest-weight classification, which
+is itself still open.
+
 ### Problem 6.1.6 — residual McKay-correspondence classification
 
 The project has formalized the tautological representation, symmetry and


### PR DESCRIPTION
This PR builds the `SL_N` half of Etingof's Remark 5.23.3: the restriction of a `GL_N(k)`-representation to `SL_N(k)` along `Matrix.SpecialLinearGroup.toGL`, the fact that every integer power of the determinant character becomes trivial there, and the resulting `SL_N`-equivariant isomorphism `L_{λ + c·1ᴺ}|_{SL_N} ≅ L_λ|_{SL_N}` as a `Representation.Equiv`, obtained by restricting Proposition 5.22.2's determinant-twist isomorphism and iterating it. The pre-existing `algIrrepGL_finrank_constShift` becomes the dimension shadow of that statement rather than the strongest one available.

It also packages the parametrization Etingof describes: `slIsoSetoid n k` is the relation "the `SL_N`-restrictions of `L_λ` and `L_μ` are isomorphic", `shiftEquiv_slIso` shows the simultaneous-constant-shift relation refines it, and `slIrrepClass : SLWeightParam n → Quotient (slIsoSetoid n k)` is therefore well defined, and surjective by `slIrrepClass_surjective`.

The `proof_wanted sl_finiteDimensional_completely_reducible` is retired. Etingof states the `𝔰𝔩(V)` complete-reducibility and highest-weight assertions and then writes "we will not do this here", so they are not proof obligations this formalization inherits; the decision is recorded in `skipped-exercises.md` under "Remark 5.23.3" and cross-referenced from the module docstring. The `𝔰𝔩(2)` case the remark points at is already proved as `Etingof.Sl2Irrep.complete_reducibility`.

Partial with respect to #7357: injectivity of `slIrrepClass` is #7807, and exhaustiveness of the `L_λ|_{SL_N}` among the irreducible algebraic `SL_N`-representations is #7808 (blocked on the `GL_N` highest-weight classification #7400).

Closes #7357

🤖 Prepared with Claude Code