### PR TITLE
complete Example 7.5.3: make the forgetful functor representable by a natural isomorphism

### DIFF
--- a/EtingofRepresentationTheory/Chapter7/Example7_5_3.lean
+++ b/EtingofRepresentationTheory/Chapter7/Example7_5_3.lean
@@ -16,8 +16,25 @@ representable. Etingof's witness is `A = c₀₀(ℤ)`, the algebra of complex f
 
 ### Claim (1): representability of the forgetful functor on all modules
 
-The core equivalence `Hom_R(R, M) ≃ M` is `LinearMap.ringLmapEquivSelf` in Mathlib,
-which says the forgetful functor from `R`-modules to types is representable by `R`.
+Section 7.5 of the book defines a functor `F : C ⥤ Sets` to be *representable* when it is
+isomorphic *as a functor* to `Hom(X, ?)`; an object-indexed family of bijections is not
+enough, the family has to be natural. So the endpoint here is a natural isomorphism
+
+`coyoneda.obj (op (ModuleCat.of R R)) ≅ forget (ModuleCat R)`,
+
+built from the two mutually inverse natural transformations the book names: evaluation at
+`1` (`Etingof.Example753.evalOne`) and multiplication of `1`'s image
+(`Etingof.Example753.smulOne`, `m ↦ (r ↦ r • m)`). Objectwise this is the core equivalence
+`Hom_R(R, M) ≃ M`, which is `LinearMap.ringLmapEquivSelf` in Mathlib
+(`Etingof.forgetful_representable`); `Etingof.Example753.forgetCorepresentableBy_homEquiv_apply`
+records that the natural isomorphism's components are exactly that equivalence.
+
+The book's `F ≅ Hom(X, ?)` is *covariant* in the argument, so the Mathlib API it lands in is
+`CategoryTheory.Functor.CorepresentableBy` (representability of a `C ⥤ Type` functor by an
+object of `C`), not `RepresentableBy` (which is for `Cᵒᵖ ⥤ Type`).
+
+The enriched (`k`-linear, vector-space-valued) refinement of representability is Remark 7.5.2
+rather than this example, and is tracked separately.
 
 ### Claim (2): non-representability on finite dimensional modules
 
@@ -43,6 +60,8 @@ A representing object `M` would force `dim_k Hom_A(M, ℂ_μ) = dim_k ℂ_μ = 1
 
 open Module
 
+universe u
+
 /-- The forgetful functor from `R`-mod to `Type` is representable by the free module `R`.
 (Etingof Example 7.5.3, first claim.)
 
@@ -54,6 +73,134 @@ noncomputable def Etingof.forgetful_representable
   LinearMap.ringLmapEquivSelf R ℕ M
 
 namespace Etingof.Example753
+
+open CategoryTheory Opposite
+
+section Corepresentable
+
+variable (R : Type u) [Ring R]
+
+/-- The objectwise bijection `Hom_R(R, M) ≃ M` of Example 7.5.3, in the category `ModuleCat R`:
+evaluation at `1` one way, `m ↦ (r ↦ r • m)` the other.
+
+This is `Etingof.forgetful_representable` transported across `ModuleCat.homEquiv`; see
+`forgetCorepresentableBy_homEquiv_eq`. -/
+def homEquivOne (M : ModuleCat.{u} R) : (ModuleCat.of R R ⟶ M) ≃ M :=
+  ModuleCat.homEquiv.trans (LinearMap.ringLmapEquivSelf R ℕ M).toEquiv
+
+@[simp]
+theorem homEquivOne_apply (M : ModuleCat.{u} R) (f : ModuleCat.of R R ⟶ M) :
+    homEquivOne R M f = ModuleCat.Hom.hom f 1 := rfl
+
+@[simp]
+theorem homEquivOne_symm_apply (M : ModuleCat.{u} R) (m : M) :
+    (homEquivOne R M).symm m =
+      ModuleCat.ofHom ((LinearMap.ringLmapEquivSelf R ℕ M).symm m) := rfl
+
+/-- **The forgetful functor on all left `R`-modules is representable, by the regular module
+`R`** (Etingof Example 7.5.3, first claim), in the categorical sense of Section 7.5: this is
+the `Functor.CorepresentableBy` witness, i.e. the natural bijection
+
+`Hom_R(R, M) ≃ M`,
+
+together with its compatibility with postcomposition, which is exactly the naturality the
+book's "isomorphism of functors" asks for. -/
+def forgetCorepresentableBy :
+    (forget (ModuleCat.{u} R)).CorepresentableBy (ModuleCat.of R R) where
+  homEquiv {M} := homEquivOne R M
+  homEquiv_comp _ _ := rfl
+
+@[simp]
+theorem forgetCorepresentableBy_homEquiv (M : ModuleCat.{u} R) :
+    (forgetCorepresentableBy R).homEquiv (Y := M) = homEquivOne R M := rfl
+
+instance : (forget (ModuleCat.{u} R)).IsCorepresentable :=
+  (forgetCorepresentableBy R).isCorepresentable
+
+/-- **The forgetful functor is isomorphic as a functor to `Hom_R(R, ?)`**
+(Etingof Example 7.5.3, first claim, in the form the book states it in Section 7.5: an
+isomorphism of functors, not merely an objectwise family of bijections).
+
+Its two halves are `evalOne` and `smulOne` below, and the naturality squares come with the
+`Iso` in the functor category. -/
+def forgetNatIso : coyoneda.obj (op (ModuleCat.of R R)) ≅ forget (ModuleCat.{u} R) :=
+  Functor.corepresentableByEquiv (forgetCorepresentableBy R)
+
+/-- **Evaluation at `1`**: the natural transformation `Hom_R(R, ?) ⟶ forget` sending an
+`R`-module map `f : R → M` to `f 1`.
+
+This is the forward half of the book's isomorphism of functors in Example 7.5.3; its
+naturality square is `(f ≫ g) 1 = g (f 1)` (`evalOne_naturality`). -/
+def evalOne : coyoneda.obj (op (ModuleCat.of R R)) ⟶ forget (ModuleCat.{u} R) :=
+  (forgetNatIso R).hom
+
+/-- **Multiplication into a chosen element**: the natural transformation
+`forget ⟶ Hom_R(R, ?)` sending `m : M` to the `R`-module map `r ↦ r • m`.
+
+This is the backward half of the book's isomorphism of functors in Example 7.5.3; its
+naturality square is `R`-linearity of the module maps (`smulOne_naturality`). -/
+def smulOne : forget (ModuleCat.{u} R) ⟶ coyoneda.obj (op (ModuleCat.of R R)) :=
+  (forgetNatIso R).inv
+
+@[simp]
+theorem forgetNatIso_hom : (forgetNatIso R).hom = evalOne R := rfl
+
+@[simp]
+theorem forgetNatIso_inv : (forgetNatIso R).inv = smulOne R := rfl
+
+@[simp]
+theorem evalOne_app_apply (M : ModuleCat.{u} R) (f : ModuleCat.of R R ⟶ M) :
+    (evalOne R).app M f = ModuleCat.Hom.hom f 1 := rfl
+
+@[simp]
+theorem smulOne_app_apply (M : ModuleCat.{u} R) (m : M) :
+    (smulOne R).app M m = ModuleCat.ofHom ((LinearMap.ringLmapEquivSelf R ℕ M).symm m) := rfl
+
+/-- The two natural transformations are mutually inverse, componentwise (one direction). -/
+theorem smulOne_app_evalOne_app (M : ModuleCat.{u} R) (f : ModuleCat.of R R ⟶ M) :
+    (smulOne R).app M ((evalOne R).app M f) = f :=
+  (homEquivOne R M).symm_apply_apply f
+
+/-- The two natural transformations are mutually inverse, componentwise (other direction). -/
+theorem evalOne_app_smulOne_app (M : ModuleCat.{u} R) (m : M) :
+    (evalOne R).app M ((smulOne R).app M m) = m :=
+  (homEquivOne R M).apply_symm_apply m
+
+theorem evalOne_comp_smulOne : evalOne R ≫ smulOne R = 𝟙 _ := (forgetNatIso R).hom_inv_id
+
+theorem smulOne_comp_evalOne : smulOne R ≫ evalOne R = 𝟙 _ := (forgetNatIso R).inv_hom_id
+
+/-- **The naturality square of `evalOne`**, in the form Example 7.5.3 uses it: for every
+`R`-module map `g : M ⟶ N`, evaluating at `1` commutes with pushing forward along `g`. -/
+theorem evalOne_naturality {M N : ModuleCat.{u} R} (g : M ⟶ N)
+    (f : ModuleCat.of R R ⟶ M) :
+    ModuleCat.Hom.hom (f ≫ g) 1 = g (ModuleCat.Hom.hom f 1) := rfl
+
+/-- **The naturality square of `smulOne`**: pushing `m` forward along `g` and then multiplying
+agrees with multiplying and then postcomposing with `g`. -/
+theorem smulOne_naturality {M N : ModuleCat.{u} R} (g : M ⟶ N) (m : M) :
+    ModuleCat.ofHom ((LinearMap.ringLmapEquivSelf R ℕ N).symm (g m)) =
+      ModuleCat.ofHom ((LinearMap.ringLmapEquivSelf R ℕ M).symm m) ≫ g := by
+  apply ModuleCat.hom_ext
+  refine LinearMap.ext fun r => ?_
+  simp
+
+/-- **The components of the natural isomorphism agree with the objectwise linear equivalence**
+`Etingof.forgetful_representable`, i.e. the categorical statement above really does refine the
+previously recorded `Hom_R(R, M) ≃ₗ[ℕ] M`. -/
+theorem forgetCorepresentableBy_homEquiv_eq (M : ModuleCat.{u} R) :
+    (forgetCorepresentableBy R).homEquiv (Y := M) =
+      ModuleCat.homEquiv.trans (Etingof.forgetful_representable R M).toEquiv :=
+  rfl
+
+/-- **Uniqueness of the representing object** (Lemma 7.5.1 applied to Example 7.5.3): any
+other module corepresenting the forgetful functor is canonically isomorphic to the regular
+module `R`. -/
+def uniqueUpToIso {X : ModuleCat.{u} R}
+    (e : (forget (ModuleCat.{u} R)).CorepresentableBy X) : ModuleCat.of R R ≅ X :=
+  (forgetCorepresentableBy R).uniqueUpToIso e
+
+end Corepresentable
 
 variable {k : Type*} [Field k] {V : Type*} [AddCommGroup V] [Module k V]
 

--- a/EtingofRepresentationTheory/Chapter7/Example7_5_3.lean
+++ b/EtingofRepresentationTheory/Chapter7/Example7_5_3.lean
@@ -22,12 +22,15 @@ enough, the family has to be natural. So the endpoint here is a natural isomorph
 
 `coyoneda.obj (op (ModuleCat.of R R)) ≅ forget (ModuleCat R)`,
 
-built from the two mutually inverse natural transformations the book names: evaluation at
-`1` (`Etingof.Example753.evalOne`) and multiplication of `1`'s image
+built from two mutually inverse natural transformations: evaluation at `1`
+(`Etingof.Example753.evalOne`) and multiplication into a chosen element
 (`Etingof.Example753.smulOne`, `m ↦ (r ↦ r • m)`). Objectwise this is the core equivalence
 `Hom_R(R, M) ≃ M`, which is `LinearMap.ringLmapEquivSelf` in Mathlib
-(`Etingof.forgetful_representable`); `Etingof.Example753.forgetCorepresentableBy_homEquiv_apply`
+(`Etingof.forgetful_representable`); `Etingof.Example753.forgetCorepresentableBy_homEquiv_eq`
 records that the natural isomorphism's components are exactly that equivalence.
+
+Lemma 7.5.1 then pins the representing object down: `Etingof.Example753.uniqueUpToIso` turns
+any other corepresenting module into an isomorphism with the regular module `R`.
 
 The book's `F ≅ Hom(X, ?)` is *covariant* in the argument, so the Mathlib API it lands in is
 `CategoryTheory.Functor.CorepresentableBy` (representability of a `C ⥤ Type` functor by an

--- a/progress/2026-07-25T18-49-20Z_a8a3438a.md
+++ b/progress/2026-07-25T18-49-20Z_a8a3438a.md
@@ -1,0 +1,66 @@
+## Accomplished
+
+Closed the fidelity gap in issue #7403 (Example 7.5.3, first claim): the forgetful
+functor's representability is now a *categorical* statement, not an objectwise family
+of bijections.
+
+`EtingofRepresentationTheory/Chapter7/Example7_5_3.lean` gains, all sorry-free and with
+axioms `[propext, Classical.choice, Quot.sound]` only:
+
+- `Etingof.Example753.homEquivOne` — the objectwise bijection `(ModuleCat.of R R ⟶ M) ≃ M`,
+  defined as `ModuleCat.homEquiv` composed with `LinearMap.ringLmapEquivSelf R ℕ M`, so it
+  is by construction the same map as the pre-existing `Etingof.forgetful_representable`.
+- `forgetCorepresentableBy : (forget (ModuleCat R)).CorepresentableBy (ModuleCat.of R R)` —
+  the Mathlib representability witness, whose `homEquiv_comp` field is the naturality
+  requirement. It holds by `rfl`.
+- the `(forget (ModuleCat R)).IsCorepresentable` instance.
+- `forgetNatIso : coyoneda.obj (op (ModuleCat.of R R)) ≅ forget (ModuleCat R)` — the
+  isomorphism of functors the book's Section 7.5 definition actually asks for.
+- `evalOne` / `smulOne` — the two halves as named natural transformations (evaluation at
+  `1`; `m ↦ (r ↦ r • m)`), with `evalOne_comp_smulOne`, `smulOne_comp_evalOne`, the two
+  componentwise inverse lemmas, and the naturality squares spelled out in elementary terms
+  (`evalOne_naturality`, `smulOne_naturality`).
+- `forgetCorepresentableBy_homEquiv_eq` — the components are *definitionally* the earlier
+  objectwise linear equivalence, so nothing was silently replaced.
+- `uniqueUpToIso` — Lemma 7.5.1 applied here: any other corepresenting module is
+  canonically isomorphic to the regular module `R`.
+
+Module docs rewritten so claim (1) describes the natural isomorphism rather than the bare
+equivalence. `progress/items.json` entry `Chapter7/Example7.5.3` moved from
+`covered_partial`/`partial` to `covered_full`/`faithful`, with `fidelity_issue` dropped.
+
+## Current frontier
+
+Issue #7403 is complete. The Chapter 7 representability material is otherwise untouched.
+
+## Decisions
+
+- The book's `F ≅ Hom(X, ?)` is covariant in the argument, so the correct Mathlib landing
+  point is `Functor.CorepresentableBy` (for `C ⥤ Type`), **not** `Functor.RepresentableBy`
+  (which is for `Cᵒᵖ ⥤ Type`). The issue text said "`NatIso` or `CorepresentableBy`"; both
+  are delivered, with `forgetNatIso` built from the witness via
+  `Functor.corepresentableByEquiv`.
+- The book's Example 7.5.3 says "forgetful functor to *vector spaces*", but Section 7.5
+  defines representability for `Sets`-valued functors; the enriched (`k`-linear) refinement
+  is Remark 7.5.2, which is open issue #7473. This session deliberately stayed in the
+  `Type`-valued setting so as not to overlap #7473, and the module docs say so.
+- Lean elaboration trap worth remembering: writing a `NatTrans` into `Type u` with field
+  syntax `app M f := ...` does **not** propagate the binder type through `X ⟶ Y` in `Type`,
+  and fails with `Type mismatch ... has type (M : C) → ModuleCat.Hom ?m ?m → _`. Building
+  the `Equiv` first and taking `Functor.corepresentableByEquiv` of the `CorepresentableBy`
+  witness avoids the problem entirely, and then `.hom` / `.inv` give the two natural
+  transformations with all components `rfl`.
+
+## Overall project progress
+
+Stage 3.7 fidelity repair continues. One more Chapter 7 item is now fully faithful.
+
+## Next step
+
+The remaining Chapter 7 representability gap is #7473 (enriched categories and enriched
+representability, Remark 7.5.2). It can now cite `forgetNatIso` as the unenriched model to
+refine.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -8411,13 +8411,12 @@
     "start_line": 7,
     "end_line": 8,
     "status": "sorry_free",
-    "coverage": "covered_partial",
-    "fidelity": "partial",
+    "coverage": "covered_full",
+    "fidelity": "faithful",
     "needs_statement": false,
     "sorry_free": true,
-    "fidelity_note": "The negative finite-dimensional claim is substantively covered by the public theorem forgetful_not_representable and its Hom-dimension obstruction. The positive all-modules claim remains only an objectwise evaluation equivalence, without the natural isomorphism/CorepresentableBy witness (#7403). Independent Opus review rejected reopening #5838 as categorical repackaging rather than missing mathematical content.",
-    "fidelity_issue": 7403,
-    "last_updated": "2026-07-22"
+    "fidelity_note": "Both source claims are public and sorry-free. The positive all-modules claim is now the natural isomorphism Etingof.Example753.forgetNatIso : coyoneda.obj (op (ModuleCat.of R R)) ≅ forget (ModuleCat R), with the Functor.CorepresentableBy witness forgetCorepresentableBy, the IsCorepresentable instance, and the two mutually inverse natural transformations evalOne (evaluation at 1) and smulOne (m ↦ (r ↦ r • m)); forgetCorepresentableBy_homEquiv_eq records that the components are the earlier objectwise equivalence Etingof.forgetful_representable (#7403). The negative finite-dimensional claim is forgetful_not_representable and its Hom-dimension obstruction. The enriched (vector-space-valued) refinement of representability is Remark 7.5.2, tracked in #7473.",
+    "last_updated": "2026-07-25"
   },
   {
     "id": "Chapter7/Introduction_7.6",


### PR DESCRIPTION
Closes #7403

Session: `a8a3438a-21d7-4d8c-be4d-74d561b539c4`

e9ef4fb2 docs(Ch7 Example7.5.3): record the natural-isomorphism endpoint in the module docs and coverage metadata
3dddb355 feat(Ch7 Example7.5.3): expose the forgetful functor's representability as a natural isomorphism

🤖 Prepared with Claude Code