### PR TITLE
docs(skill): scope the ExteriorAlgebra/PiTensorProduct dead-end to the subspace direction

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -3239,6 +3239,33 @@ Three API gotchas that cost build cycles here:
 - **Tensor-basis coefficients:** `Basis.piTensorProduct_repr_tprod_apply` gives
   `(piTensorProduct b).repr (⨂ₜ x) p = ∏ i, (b i).repr (x i) (p i)` — the clean way
   to read a coefficient of `PiTensorProduct.map f (tprod …)`.
+- **`⨂[k] (_ : ι), V` needs `open scoped TensorProduct`, NOT `open PiTensorProduct`** (the
+  notation is `scoped[TensorProduct]` even though it lives in `PiTensorProduct/Basic.lean`).
+  Getting this wrong is expensive out of all proportion: the only honest error is a bare
+  `expected token` at the first use, after which the enclosing `def`/`abbrev` auto-binds a
+  wrong implicit and *every later declaration in the file* fails with
+  `Application type mismatch: argument k … expected ℕ`. **Read the HEAD of the build log, not
+  the tail** — grepping `| tail -60` shows only the cascade and sends you rewriting correct
+  proofs. Same discipline for any file where the error count is suspiciously large: fix the
+  first error and rebuild before reading the rest.
+- **`exteriorPower.map` takes `n` explicitly:** `exteriorPower.map n A`, not
+  `exteriorPower.map A` (`variable (n) in` sits above the `def`). The failure is
+  `argument A … expected ℕ`, which reads like a unification bug rather than a missing argument.
+- **`simp` normalises `p.mkQ x` to `Submodule.Quotient.mk x`.** In quotient-heavy files this
+  silently desynchronises hypotheses from goals: a `have` you built with `mkQ` will not `rw`
+  into a goal `simp` has already touched, with `Did not find an occurrence of the pattern`
+  naming a term the goal visibly contains modulo that one coercion. Normalise both sides —
+  `simp only [Submodule.mkQ_apply, …] at h₁ h₂ ⊢` — before rewriting. Corollary: a `@[simp]`
+  lemma stated as `f (someTprodIntoQuotient …) = …` can never fire once the projection has
+  been normalised away; state such lemmas at the `Submodule.Quotient.mk` level.
+- **The default simp set rewrites `-(a + b)` to `-b + -a`** (`neg_add_rev`), reversing an
+  addition and leaving a goal that only `add_comm`/`abel` closes. In an
+  `induction … using PiTensorProduct.induction_on` `add` case, prefer
+  `simp only [map_add, ha, hb, neg_add]` over a bare `simp`.
+- **A type variable that appears only in a declaration's *result* type cannot be inferred from
+  its arguments.** Applying e.g. `exteriorPowerEquiv h2 n` to an element then fails with
+  `Function expected at …, but this term has type … ?m.10 …` — the coercion cannot be inserted
+  because the type is still a metavariable. Pass it: `exteriorPowerEquiv (V := V) h2 n x`.
 - **`Matrix.col` has no `col_apply`.** `M.col j = Mᵀ`, so `(M.col j) i` is
   *definitionally* `M i j` (via `transpose`/`of_apply`). After
   `rw [Matrix.mulVec_single_one]` just close the entry goal with `rfl`, not a
@@ -5189,6 +5216,15 @@ These are proof approaches that multiple agents have attempted and failed. Don't
 - `congr 1` strips one coercion layer but leaves incompatible goal forms
 
 **Status:** 3+ agents have attempted this (Example 5.19.3 exterior part). All failed. **Sorry and move on.** This requires new Mathlib bridging infrastructure between `ExteriorAlgebra` and `PiTensorProduct`.
+
+**Scope: this dead-end is the SUBSPACE direction only. The QUOTIENT direction works — do not sorry it.** The blocked statement realises `⋀[k]^n V` *inside* `V^{⊗ n}` as the alternating subspace. Identifying `⋀[k]^n V` with a *quotient* of `V^{⊗ n}` is a different problem and goes through in a few build cycles, because both maps come from universal properties instead of a coercion:
+- out of the tensor power: `PiTensorProduct.lift (exteriorPower.ιMulti k n).toMultilinearMap`, descended past the relation submodule with `Submodule.liftQ`;
+- out of the exterior power: `exteriorPower.alternatingMapLinearEquiv f` for an `AlternatingMap` `f` into the quotient (build `f` by giving `map_eq_zero_of_eq'` — a pure tensor with a repeated entry is in the relation submodule);
+- assemble with `LinearEquiv.ofLinear` and check both round-trips on generators.
+
+**To prove two linear maps out of `⋀[k]^n V` agree, use `LinearMap.ext_on (exteriorPower.ιMulti_span k n V)`, NOT `exteriorPower.linearMap_ext`.** `ιMulti_span` says the range of `ιMulti` spans, so `ext_on` reduces the goal to `ιMulti` generators as ordinary elements; `linearMap_ext` is exactly the lemma that produces the unresolvable `compAlternatingMap`/`↑` goals listed above. Worked sorry-free: `Chapter2/Problem2_11_3_SymExtPow.lean` `exteriorPowerEquiv` (#7365), identifying Etingof's quotient model of `∧^n V` with Mathlib's, plus `extPowOfExteriorPower_naturality` for `exteriorPower.map n A`.
+
+Note the char-2 caveat that argument carries: `span {T | ∃ transposition s, s • T = T} ≤ ker` is proved from `Φ T = Φ (s T) = -Φ T`, i.e. `(2 : k) • Φ T = 0`, so it needs `(2 : k) ≠ 0`. The statement is still true in characteristic 2 (the fixed space of `1 + s` equals the span of the pure tensors with a repeated entry) but there the averaging step has no analogue and you need a basis-and-orbits argument — see #7820.
 
 ### Dependent Type Issues with `if`-branching `obj` Fields
 

--- a/EtingofRepresentationTheory/Chapter2.lean
+++ b/EtingofRepresentationTheory/Chapter2.lean
@@ -98,6 +98,7 @@ import EtingofRepresentationTheory.Chapter2.Exercise2_9_11
 import EtingofRepresentationTheory.Chapter2.Definition2_11_1
 import EtingofRepresentationTheory.Chapter2.Remark2_11_4
 import EtingofRepresentationTheory.Chapter2.Problem2_11_3
+import EtingofRepresentationTheory.Chapter2.Problem2_11_3_SymExtPow
 import EtingofRepresentationTheory.Chapter2.Problem2_11_6
 import EtingofRepresentationTheory.Chapter2.Exercise2_11_2
 import EtingofRepresentationTheory.Chapter2.Exercise2_11_5

--- a/EtingofRepresentationTheory/Chapter2/Problem2_11_3.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_11_3.lean
@@ -15,8 +15,13 @@ The problem collects several standard facts about tensor products of vector spac
 
 ## Formalization
 
-This file records the cleanly-statable parts (a), (b), (c) and (g). Parts (d)–(f) concern
-symmetric/exterior powers and traces and are deferred to a dedicated follow-up item.
+This file records parts (a), (b), (c) and the determinant-multiplicativity endpoint of (g).
+
+The symmetric and exterior powers of parts (d)–(g) are built in
+`EtingofRepresentationTheory.Chapter2.Problem2_11_3_SymExtPow`, which constructs Etingof's
+quotient models `S^n V` and `⋀^n V` of `V^{⊗ n}`, the induced operators `S^n A` and `⋀^n A`, and
+the exterior half of part (d) (basis and dimension `m.choose n`, away from characteristic 2). See
+that file's module docstring for what remains open there.
 
 Bilinear maps `V × W → U` are modelled by `V →ₗ[k] W →ₗ[k] U`. All statements are fully proved.
 -/

--- a/EtingofRepresentationTheory/Chapter2/Problem2_11_3_SymExtPow.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_11_3_SymExtPow.lean
@@ -158,4 +158,105 @@ lemma symTprod_comp_perm {n : ℕ} (σ : Equiv.Perm (Fin n)) (f : Fin n → V) :
 
 end Basic
 
+section Functoriality
+
+variable {k : Type*} [CommRing k] {V W U : Type*}
+  [AddCommGroup V] [Module k V] [AddCommGroup W] [Module k W] [AddCommGroup U] [Module k U]
+
+/-- The operator `A^{⊗ n} : V^{⊗ n} → W^{⊗ n}` induced by `A : V → W`. -/
+def tensorPowMap (A : V →ₗ[k] W) (n : ℕ) : TensorPow k V n →ₗ[k] TensorPow k W n :=
+  PiTensorProduct.map fun _ : Fin n => A
+
+@[simp]
+lemma tensorPowMap_tprod (A : V →ₗ[k] W) {n : ℕ} (f : Fin n → V) :
+    tensorPowMap A n (PiTensorProduct.tprod k f) = PiTensorProduct.tprod k fun i => A (f i) :=
+  PiTensorProduct.map_tprod _ _
+
+lemma tensorPowMap_permAct (A : V →ₗ[k] W) {n : ℕ} (σ : Equiv.Perm (Fin n))
+    (T : TensorPow k V n) :
+    tensorPowMap A n (permAct σ T) = permAct σ (tensorPowMap A n T) := by
+  induction T using PiTensorProduct.induction_on with
+  | smul_tprod r f => simp
+  | add x y hx hy => simp [hx, hy]
+
+lemma symRelSubmodule_le_comap (A : V →ₗ[k] W) (n : ℕ) :
+    symRelSubmodule k V n ≤ (symRelSubmodule k W n).comap (tensorPowMap A n) := by
+  rw [symRelSubmodule, Submodule.span_le]
+  rintro _ ⟨T, i, j, hij, rfl⟩
+  refine Submodule.subset_span ⟨tensorPowMap A n T, i, j, hij, ?_⟩
+  rw [map_sub, tensorPowMap_permAct]
+
+lemma extRelSubmodule_le_comap (A : V →ₗ[k] W) (n : ℕ) :
+    extRelSubmodule k V n ≤ (extRelSubmodule k W n).comap (tensorPowMap A n) := by
+  rw [extRelSubmodule, Submodule.span_le]
+  rintro T ⟨i, j, hij, hT⟩
+  refine Submodule.subset_span ⟨i, j, hij, ?_⟩
+  rw [← tensorPowMap_permAct, hT]
+
+/-- **Problem 2.11.3(f).** The operator `S^n A : S^n V → S^n W` induced by `A : V → W`. -/
+def symPowMap (A : V →ₗ[k] W) (n : ℕ) : SymPow k V n →ₗ[k] SymPow k W n :=
+  Submodule.mapQ _ _ (tensorPowMap A n) (symRelSubmodule_le_comap A n)
+
+/-- **Problem 2.11.3(f).** The operator `⋀^n A : ⋀^n V → ⋀^n W` induced by `A : V → W`. -/
+def extPowMap (A : V →ₗ[k] W) (n : ℕ) : ExtPow k V n →ₗ[k] ExtPow k W n :=
+  Submodule.mapQ _ _ (tensorPowMap A n) (extRelSubmodule_le_comap A n)
+
+@[simp]
+lemma symPowMap_symTprod (A : V →ₗ[k] W) {n : ℕ} (f : Fin n → V) :
+    symPowMap A n (symTprod k V n f) = symTprod k W n fun i => A (f i) := by
+  simp [symPowMap, symTprod, Submodule.mapQ_apply]
+
+@[simp]
+lemma extPowMap_extTprod (A : V →ₗ[k] W) {n : ℕ} (f : Fin n → V) :
+    extPowMap A n (extTprod k V n f) = extTprod k W n fun i => A (f i) := by
+  simp [extPowMap, extTprod, Submodule.mapQ_apply]
+
+@[simp]
+lemma symPowMap_id (n : ℕ) : symPowMap (LinearMap.id : V →ₗ[k] V) n = LinearMap.id := by
+  refine LinearMap.ext fun x => ?_
+  obtain ⟨T, rfl⟩ := Submodule.mkQ_surjective _ x
+  induction T using PiTensorProduct.induction_on with
+  | smul_tprod r f => simpa using congrArg (r • ·) (symPowMap_symTprod LinearMap.id f)
+  | add a b ha hb => simp only [map_add, ha, hb]
+
+@[simp]
+lemma extPowMap_id (n : ℕ) : extPowMap (LinearMap.id : V →ₗ[k] V) n = LinearMap.id := by
+  refine LinearMap.ext fun x => ?_
+  obtain ⟨T, rfl⟩ := Submodule.mkQ_surjective _ x
+  induction T using PiTensorProduct.induction_on with
+  | smul_tprod r f => simpa using congrArg (r • ·) (extPowMap_extTprod LinearMap.id f)
+  | add a b ha hb => simp only [map_add, ha, hb]
+
+lemma symPowMap_comp (A : W →ₗ[k] U) (B : V →ₗ[k] W) (n : ℕ) :
+    symPowMap (A ∘ₗ B) n = symPowMap A n ∘ₗ symPowMap B n := by
+  refine LinearMap.ext fun x => ?_
+  obtain ⟨T, rfl⟩ := Submodule.mkQ_surjective _ x
+  induction T using PiTensorProduct.induction_on with
+  | smul_tprod r f =>
+      simp only [map_smul, LinearMap.comp_apply]
+      congr 1
+      have h1 := symPowMap_symTprod (A ∘ₗ B) f
+      have h2 := symPowMap_symTprod A fun i => B (f i)
+      have h3 := symPowMap_symTprod B f
+      simp only [symTprod_apply, Submodule.mkQ_apply, LinearMap.comp_apply] at h1 h2 h3 ⊢
+      rw [h1, h3, h2]
+  | add a b ha hb => simp only [map_add, ha, hb, LinearMap.comp_apply]
+
+lemma extPowMap_comp (A : W →ₗ[k] U) (B : V →ₗ[k] W) (n : ℕ) :
+    extPowMap (A ∘ₗ B) n = extPowMap A n ∘ₗ extPowMap B n := by
+  refine LinearMap.ext fun x => ?_
+  obtain ⟨T, rfl⟩ := Submodule.mkQ_surjective _ x
+  induction T using PiTensorProduct.induction_on with
+  | smul_tprod r f =>
+      simp only [map_smul, LinearMap.comp_apply]
+      congr 1
+      have h1 := extPowMap_extTprod (A ∘ₗ B) f
+      have h2 := extPowMap_extTprod A fun i => B (f i)
+      have h3 := extPowMap_extTprod B f
+      simp only [extTprod_apply, Submodule.mkQ_apply, LinearMap.comp_apply] at h1 h2 h3 ⊢
+      rw [h1, h3, h2]
+  | add a b ha hb => simp only [map_add, ha, hb, LinearMap.comp_apply]
+
+end Functoriality
+
 end Etingof.Problem2_11_3

--- a/EtingofRepresentationTheory/Chapter2/Problem2_11_3_SymExtPow.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_11_3_SymExtPow.lean
@@ -29,15 +29,26 @@ stated about the book's own objects.
 ## Main results
 
 * `symTprod_comp_perm` : the canonical map to `S^n V` is invariant under *all* permutations of its
-  arguments, not just transpositions.
+  arguments, not just the transpositions used to define the quotient.
+* `symPowMap_comp`, `extPowMap_comp`, `symPowMap_id`, `extPowMap_id` : functoriality of `S^n` and
+  `⋀^n` on operators.
 * `extPowOfExteriorPower_surjective` : the canonical map from Mathlib's `⋀[k]^n V` onto the book's
-  `ExtPow k V n` is surjective.
-* `extRelSubmodule_le_ker`, `exteriorPowerEquiv` : in characteristic `≠ 2` that map is an
-  isomorphism, so the book's quotient model agrees with Mathlib's exterior power.
+  `ExtPow k V n` is surjective, and `extPowOfExteriorPower_naturality` says it intertwines
+  `exteriorPower.map` with `extPowMap`.
+* `exteriorPowerEquiv` : away from characteristic 2 that map is an isomorphism, so the book's
+  quotient model agrees with Mathlib's exterior power. Transporting Mathlib's basis and dimension
+  along it gives `extPowBasis` and `finrank_extPow`, which are the exterior half of part (d).
 
-Parts (d) (bases and dimensions), (e) (the characteristic-zero identification with the symmetric
-and antisymmetric *subspaces* of `V^{⊗ n}`) and the trace formulas of part (f) are stated in
-`Problem2_11_3_SymExtPow_Statements` and tracked separately.
+Still open, tracked as separate items:
+
+* the symmetric half of part (d) — a basis of `S^n V` indexed by multisets and the dimension
+  `(m + n - 1).choose n`. Mathlib's `SymmetricPower` has no universal property or basis yet, so
+  this has to be built here;
+* part (e), the characteristic-zero identification of `S^n V` and `⋀^n V` with the symmetric and
+  antisymmetric *subspaces* of `V^{⊗ n}`;
+* the trace formulas of part (f), `Tr(S^n A)` and `Tr(⋀^n A)` in terms of the eigenvalues of `A`;
+* part (g), `⋀^N A = det(A) • id` proved from the exterior-power construction. (The determinant
+  multiplicativity it is meant to yield is already available as `Problem2_11_3.det_comp`.)
 -/
 
 namespace Etingof.Problem2_11_3
@@ -261,7 +272,8 @@ end Functoriality
 
 section ExteriorComparison
 
-variable {k : Type*} [CommRing k] {V : Type*} [AddCommGroup V] [Module k V]
+variable {k : Type*} [CommRing k] {V W : Type*}
+  [AddCommGroup V] [Module k V] [AddCommGroup W] [Module k W]
 
 variable (k V) in
 /-- The canonical map from Mathlib's exterior power onto the book's model `ExtPow k V n`,
@@ -310,6 +322,17 @@ lemma tensorPowToExteriorPower_swap {n : ℕ} {i j : Fin n} (hij : i ≠ j) (T :
         smul_neg]
   | add a b ha hb => simp only [map_add, ha, hb, neg_add]
 
+/-- The comparison map is natural: it intertwines Mathlib's `exteriorPower.map A` with the book's
+`⋀^n A`. -/
+lemma extPowOfExteriorPower_naturality (A : V →ₗ[k] W) (n : ℕ) :
+    extPowMap A n ∘ₗ extPowOfExteriorPower k V n
+      = extPowOfExteriorPower k W n ∘ₗ exteriorPower.map n A := by
+  refine LinearMap.ext_on (exteriorPower.ιMulti_span k n V) ?_
+  rintro _ ⟨f, rfl⟩
+  simp only [LinearMap.comp_apply, extPowOfExteriorPower_ιMulti,
+    exteriorPower.map_apply_ιMulti]
+  simpa [Function.comp_def] using extPowMap_extTprod A f
+
 end ExteriorComparison
 
 section CharNeTwo
@@ -352,6 +375,19 @@ noncomputable def exteriorPowerEquiv (h2 : (2 : k) ≠ 0) (n : ℕ) :
 lemma exteriorPowerEquiv_ιMulti (h2 : (2 : k) ≠ 0) {n : ℕ} (f : Fin n → V) :
     exteriorPowerEquiv (V := V) h2 n (exteriorPower.ιMulti k n f) = extTprod k V n f :=
   extPowOfExteriorPower_ιMulti f
+
+/-- **Problem 2.11.3(d), exterior case.** A basis `{vᵢ}` of `V` indexed by a linearly ordered `I`
+induces a basis of `⋀^n V` indexed by the `n`-element subsets of `I`, whose members are the
+classes of the tensors `v_{i₁} ⊗ ⋯ ⊗ v_{iₙ}` for `i₁ < ⋯ < iₙ`. -/
+noncomputable def extPowBasis (h2 : (2 : k) ≠ 0) {I : Type*} [LinearOrder I]
+    (b : Module.Basis I k V) (n : ℕ) :
+    Module.Basis (Set.powersetCard I n) k (ExtPow k V n) :=
+  (b.exteriorPower n).map (exteriorPowerEquiv h2 n)
+
+/-- **Problem 2.11.3(d), exterior case.** If `dim V = m` then `dim ⋀^n V = m.choose n`. -/
+theorem finrank_extPow (h2 : (2 : k) ≠ 0) [Module.Finite k V] (n : ℕ) :
+    Module.finrank k (ExtPow k V n) = (Module.finrank k V).choose n := by
+  rw [← (exteriorPowerEquiv (V := V) h2 n).finrank_eq, exteriorPower.finrank_eq]
 
 end CharNeTwo
 

--- a/EtingofRepresentationTheory/Chapter2/Problem2_11_3_SymExtPow.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_11_3_SymExtPow.lean
@@ -1,0 +1,161 @@
+import Mathlib
+
+/-!
+# Problem 2.11.3(d)–(g): symmetric and exterior powers
+
+Etingof defines, for a vector space `V` over a field `k` and `n : ℕ`,
+
+* `S^n V` as the quotient of `V^{⊗ n}` by the subspace spanned by the tensors `T - s(T)`, where
+  `T ∈ V^{⊗ n}` and `s` is a transposition of the tensor factors;
+* `⋀^n V` as the quotient of `V^{⊗ n}` by the subspace spanned by the tensors `T` such that
+  `s(T) = T` for some transposition `s`.
+
+This file constructs those two quotients **exactly as the book defines them** — as
+`Submodule.Quotient`s of `PiTensorProduct` — rather than substituting Mathlib's
+`SymmetricAlgebra`/`ExteriorAlgebra` models, so that the parts (d)–(g) of the problem can be
+stated about the book's own objects.
+
+## Main definitions
+
+* `Etingof.Problem2_11_3.TensorPow k V n` : the `n`-fold tensor power `V^{⊗ n}`.
+* `Etingof.Problem2_11_3.permAct σ` : the action of `σ : Equiv.Perm (Fin n)` permuting the
+  tensor factors of `V^{⊗ n}`.
+* `Etingof.Problem2_11_3.SymPow k V n` and `ExtPow k V n` : the book's `S^n V` and `⋀^n V`.
+* `Etingof.Problem2_11_3.symTprod` : the canonical *symmetric* multilinear map `V^n → S^n V`.
+* `Etingof.Problem2_11_3.extTprod` : the canonical *alternating* map `V^n → ⋀^n V`.
+* `Etingof.Problem2_11_3.symPowMap A` and `extPowMap A` : the operators `S^n A` and `⋀^n A`
+  induced by a linear map `A : V → W` (part (f)).
+
+## Main results
+
+* `symTprod_comp_perm` : the canonical map to `S^n V` is invariant under *all* permutations of its
+  arguments, not just transpositions.
+* `extPowOfExteriorPower_surjective` : the canonical map from Mathlib's `⋀[k]^n V` onto the book's
+  `ExtPow k V n` is surjective.
+* `extRelSubmodule_le_ker`, `exteriorPowerEquiv` : in characteristic `≠ 2` that map is an
+  isomorphism, so the book's quotient model agrees with Mathlib's exterior power.
+
+Parts (d) (bases and dimensions), (e) (the characteristic-zero identification with the symmetric
+and antisymmetric *subspaces* of `V^{⊗ n}`) and the trace formulas of part (f) are stated in
+`Problem2_11_3_SymExtPow_Statements` and tracked separately.
+-/
+
+namespace Etingof.Problem2_11_3
+
+open PiTensorProduct
+open scoped TensorProduct
+
+section Defs
+
+variable (k : Type*) [CommRing k] (V : Type*) [AddCommGroup V] [Module k V]
+
+/-- The `n`-fold tensor power `V^{⊗ n}` of `V`, as a `PiTensorProduct` over `Fin n`. -/
+abbrev TensorPow (n : ℕ) : Type _ := ⨂[k] (_ : Fin n), V
+
+variable {k V}
+
+/-- The action of a permutation `σ` of `Fin n` on `V^{⊗ n}`, permuting the tensor factors. -/
+def permAct {n : ℕ} (σ : Equiv.Perm (Fin n)) : TensorPow k V n ≃ₗ[k] TensorPow k V n :=
+  PiTensorProduct.reindex k (fun _ : Fin n => V) σ
+
+@[simp]
+lemma permAct_tprod {n : ℕ} (σ : Equiv.Perm (Fin n)) (f : Fin n → V) :
+    permAct σ (PiTensorProduct.tprod k f) = PiTensorProduct.tprod k fun i => f (σ.symm i) :=
+  PiTensorProduct.reindex_tprod (s := fun _ : Fin n => V) σ f
+
+variable (k V)
+
+/-- The subspace of `V^{⊗ n}` spanned by the tensors `T - s(T)` for `s` a transposition of the
+tensor factors. Quotienting by it gives the book's `S^n V`. -/
+def symRelSubmodule (n : ℕ) : Submodule k (TensorPow k V n) :=
+  Submodule.span k {D : TensorPow k V n | ∃ (T : TensorPow k V n) (i j : Fin n), i ≠ j ∧
+    D = T - permAct (Equiv.swap i j) T}
+
+/-- The subspace of `V^{⊗ n}` spanned by the tensors `T` with `s(T) = T` for some transposition
+`s` of the tensor factors. Quotienting by it gives the book's `⋀^n V`. -/
+def extRelSubmodule (n : ℕ) : Submodule k (TensorPow k V n) :=
+  Submodule.span k {T : TensorPow k V n | ∃ i j : Fin n, i ≠ j ∧
+    permAct (Equiv.swap i j) T = T}
+
+/-- **Problem 2.11.3(d).** The `n`th symmetric power `S^n V`: the quotient of `V^{⊗ n}` by the
+span of the tensors `T - s(T)`, `s` a transposition. -/
+abbrev SymPow (n : ℕ) : Type _ := TensorPow k V n ⧸ symRelSubmodule k V n
+
+/-- **Problem 2.11.3(d).** The `n`th exterior power `⋀^n V`: the quotient of `V^{⊗ n}` by the
+span of the tensors `T` fixed by some transposition. -/
+abbrev ExtPow (n : ℕ) : Type _ := TensorPow k V n ⧸ extRelSubmodule k V n
+
+/-- The canonical multilinear map `V^n → S^n V`, `f ↦ [f 0 ⊗ ⋯ ⊗ f (n-1)]`. -/
+def symTprod (n : ℕ) : MultilinearMap k (fun _ : Fin n => V) (SymPow k V n) :=
+  (symRelSubmodule k V n).mkQ.compMultilinearMap (PiTensorProduct.tprod k)
+
+@[simp]
+lemma symTprod_apply {n : ℕ} (f : Fin n → V) :
+    symTprod k V n f = (symRelSubmodule k V n).mkQ (PiTensorProduct.tprod k f) := rfl
+
+end Defs
+
+section Basic
+
+variable {k : Type*} [CommRing k] {V W : Type*}
+  [AddCommGroup V] [Module k V] [AddCommGroup W] [Module k W]
+
+@[simp]
+lemma permAct_one {n : ℕ} (T : TensorPow k V n) : permAct (1 : Equiv.Perm (Fin n)) T = T := by
+  rw [permAct, show (1 : Equiv.Perm (Fin n)) = Equiv.refl (Fin n) from rfl,
+    PiTensorProduct.reindex_refl]
+  rfl
+
+lemma permAct_mul {n : ℕ} (σ τ : Equiv.Perm (Fin n)) (T : TensorPow k V n) :
+    permAct (σ * τ) T = permAct σ (permAct τ T) := by
+  rw [permAct, permAct, permAct, Equiv.Perm.mul_def, ← PiTensorProduct.reindex_reindex]
+
+/-- A pure tensor with two equal entries is fixed by the corresponding transposition, hence lies in
+the relation subspace defining `⋀^n V`. -/
+lemma tprod_mem_extRelSubmodule {n : ℕ} (f : Fin n → V) {i j : Fin n} (hij : i ≠ j)
+    (hf : f i = f j) : PiTensorProduct.tprod k f ∈ extRelSubmodule k V n := by
+  refine Submodule.subset_span ⟨i, j, hij, ?_⟩
+  rw [permAct_tprod, Equiv.symm_swap]
+  congr 1
+  funext l
+  rcases eq_or_ne l i with rfl | hli
+  · rw [Equiv.swap_apply_left]; exact hf.symm
+  · rcases eq_or_ne l j with rfl | hlj
+    · rw [Equiv.swap_apply_right]; exact hf
+    · rw [Equiv.swap_apply_of_ne_of_ne hli hlj]
+
+/-- The canonical alternating map `V^n → ⋀^n V`. -/
+def extTprod (k : Type*) [CommRing k] (V : Type*) [AddCommGroup V] [Module k V] (n : ℕ) :
+    V [⋀^Fin n]→ₗ[k] ExtPow k V n where
+  toMultilinearMap := (extRelSubmodule k V n).mkQ.compMultilinearMap (PiTensorProduct.tprod k)
+  map_eq_zero_of_eq' f i j hf hij := by
+    simpa using (Submodule.Quotient.mk_eq_zero _).2 (tprod_mem_extRelSubmodule f hij hf)
+
+@[simp]
+lemma extTprod_apply {n : ℕ} (f : Fin n → V) :
+    extTprod k V n f = (extRelSubmodule k V n).mkQ (PiTensorProduct.tprod k f) := rfl
+
+/-- The transposition relation of `S^n V` holds after passing to the quotient. -/
+lemma symTprod_swap {n : ℕ} (f : Fin n → V) {i j : Fin n} (hij : i ≠ j) :
+    symTprod k V n (fun l => f (Equiv.swap i j l)) = symTprod k V n f := by
+  have h : PiTensorProduct.tprod k f -
+      PiTensorProduct.tprod k (fun l => f (Equiv.swap i j l)) ∈ symRelSubmodule k V n := by
+    refine Submodule.subset_span ⟨PiTensorProduct.tprod k f, i, j, hij, ?_⟩
+    rw [permAct_tprod, Equiv.symm_swap]
+  simpa [symTprod_apply, Submodule.mkQ_apply] using ((Submodule.Quotient.eq _).2 h).symm
+
+/-- **The canonical map to `S^n V` is symmetric in all its arguments**, not merely under the
+transpositions used to define the quotient. -/
+lemma symTprod_comp_perm {n : ℕ} (σ : Equiv.Perm (Fin n)) (f : Fin n → V) :
+    symTprod k V n (fun l => f (σ l)) = symTprod k V n f := by
+  induction σ using Equiv.Perm.swap_induction_on generalizing f with
+  | one => simp
+  | swap_mul τ i j hij ihτ =>
+      have e1 : symTprod k V n (fun l => f ((Equiv.swap i j * τ) l))
+          = symTprod k V n fun m => f (Equiv.swap i j m) :=
+        ihτ fun m => f (Equiv.swap i j m)
+      exact e1.trans (symTprod_swap f hij)
+
+end Basic
+
+end Etingof.Problem2_11_3

--- a/EtingofRepresentationTheory/Chapter2/Problem2_11_3_SymExtPow.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_11_3_SymExtPow.lean
@@ -259,4 +259,100 @@ lemma extPowMap_comp (A : W →ₗ[k] U) (B : V →ₗ[k] W) (n : ℕ) :
 
 end Functoriality
 
+section ExteriorComparison
+
+variable {k : Type*} [CommRing k] {V : Type*} [AddCommGroup V] [Module k V]
+
+variable (k V) in
+/-- The canonical map from Mathlib's exterior power onto the book's model `ExtPow k V n`,
+sending `v₁ ∧ ⋯ ∧ vₙ` to the class of `v₁ ⊗ ⋯ ⊗ vₙ`. -/
+noncomputable def extPowOfExteriorPower (n : ℕ) : (⋀[k]^n V) →ₗ[k] ExtPow k V n :=
+  exteriorPower.alternatingMapLinearEquiv (extTprod k V n)
+
+@[simp]
+lemma extPowOfExteriorPower_ιMulti {n : ℕ} (f : Fin n → V) :
+    extPowOfExteriorPower k V n (exteriorPower.ιMulti k n f) = extTprod k V n f :=
+  exteriorPower.alternatingMapLinearEquiv_apply_ιMulti _ _
+
+/-- The book's `⋀^n V` is a quotient of Mathlib's exterior power. -/
+theorem extPowOfExteriorPower_surjective (n : ℕ) :
+    Function.Surjective (extPowOfExteriorPower k V n) := by
+  intro x
+  obtain ⟨T, rfl⟩ := Submodule.mkQ_surjective _ x
+  induction T using PiTensorProduct.induction_on with
+  | smul_tprod r f =>
+      exact ⟨r • exteriorPower.ιMulti k n f, by simp⟩
+  | add a b ha hb =>
+      obtain ⟨u, hu⟩ := ha
+      obtain ⟨v, hv⟩ := hb
+      exact ⟨u + v, by rw [map_add, hu, hv, map_add]⟩
+
+variable (k V) in
+/-- The map `V^{⊗ n} → ⋀[k]^n V`, `v₁ ⊗ ⋯ ⊗ vₙ ↦ v₁ ∧ ⋯ ∧ vₙ`. -/
+noncomputable def tensorPowToExteriorPower (n : ℕ) : TensorPow k V n →ₗ[k] ⋀[k]^n V :=
+  PiTensorProduct.lift (exteriorPower.ιMulti k n).toMultilinearMap
+
+@[simp]
+lemma tensorPowToExteriorPower_tprod {n : ℕ} (f : Fin n → V) :
+    tensorPowToExteriorPower k V n (PiTensorProduct.tprod k f) = exteriorPower.ιMulti k n f :=
+  PiTensorProduct.lift.tprod _
+
+/-- Transposing two tensor factors negates the image in the exterior power. -/
+lemma tensorPowToExteriorPower_swap {n : ℕ} {i j : Fin n} (hij : i ≠ j) (T : TensorPow k V n) :
+    tensorPowToExteriorPower k V n (permAct (Equiv.swap i j) T)
+      = - tensorPowToExteriorPower k V n T := by
+  induction T using PiTensorProduct.induction_on with
+  | smul_tprod r f =>
+      have h : exteriorPower.ιMulti k n (fun l => f (Equiv.swap i j l))
+          = - exteriorPower.ιMulti k n f :=
+        (exteriorPower.ιMulti k n).map_swap (v := f) hij
+      simp only [map_smul, permAct_tprod, Equiv.symm_swap, tensorPowToExteriorPower_tprod, h,
+        smul_neg]
+  | add a b ha hb => simp only [map_add, ha, hb, neg_add]
+
+end ExteriorComparison
+
+section CharNeTwo
+
+variable {k : Type*} [Field k] {V : Type*} [AddCommGroup V] [Module k V]
+
+/-- **Away from characteristic 2**, every tensor fixed by a transposition maps to zero in the
+exterior power. This is the content that identifies Etingof's quotient model with the usual
+exterior power. -/
+lemma extRelSubmodule_le_ker (h2 : (2 : k) ≠ 0) (n : ℕ) :
+    extRelSubmodule k V n ≤ LinearMap.ker (tensorPowToExteriorPower k V n) := by
+  rw [extRelSubmodule, Submodule.span_le]
+  rintro T ⟨i, j, hij, hT⟩
+  have hswap := tensorPowToExteriorPower_swap hij T
+  rw [hT] at hswap
+  have h : (2 : k) • tensorPowToExteriorPower k V n T = 0 := by
+    rw [two_smul]
+    nth_rewrite 1 [hswap]
+    exact neg_add_cancel _
+  rcases smul_eq_zero.mp h with h' | h'
+  · exact absurd h' h2
+  · simpa using h'
+
+/-- **Problem 2.11.3(d), exterior case.** Away from characteristic 2, the book's quotient model
+`ExtPow k V n` is canonically isomorphic to Mathlib's exterior power `⋀[k]^n V`. -/
+noncomputable def exteriorPowerEquiv (h2 : (2 : k) ≠ 0) (n : ℕ) :
+    (⋀[k]^n V) ≃ₗ[k] ExtPow k V n := by
+  refine LinearEquiv.ofLinear (extPowOfExteriorPower k V n)
+    (Submodule.liftQ _ (tensorPowToExteriorPower k V n) (extRelSubmodule_le_ker h2 n)) ?_ ?_
+  · refine LinearMap.ext fun x => ?_
+    obtain ⟨T, rfl⟩ := Submodule.mkQ_surjective _ x
+    induction T using PiTensorProduct.induction_on with
+    | smul_tprod r f => simp
+    | add a b ha hb => simp only [map_add, ha, hb]
+  · refine LinearMap.ext_on (exteriorPower.ιMulti_span k n V) ?_
+    rintro _ ⟨f, rfl⟩
+    simp
+
+@[simp]
+lemma exteriorPowerEquiv_ιMulti (h2 : (2 : k) ≠ 0) {n : ℕ} (f : Fin n → V) :
+    exteriorPowerEquiv (V := V) h2 n (exteriorPower.ιMulti k n f) = extTprod k V n f :=
+  extPowOfExteriorPower_ιMulti f
+
+end CharNeTwo
+
 end Etingof.Problem2_11_3

--- a/progress/2026-07-25T19-22-22Z_0d319ea8.md
+++ b/progress/2026-07-25T19-22-22Z_0d319ea8.md
@@ -1,0 +1,100 @@
+# 2026-07-25T19:22:22Z — work session (0d319ea8), issue #7365
+
+## Accomplished
+
+Claimed #7365 (Problem 2.11.3 parts (d)–(g): symmetric and exterior powers and trace formulas)
+and landed the shared foundation plus the exterior half of part (d), then decomposed the rest.
+
+New file `EtingofRepresentationTheory/Chapter2/Problem2_11_3_SymExtPow.lean`, sorry-free
+(`#print axioms` on every endpoint: `propext, Classical.choice, Quot.sound` only):
+
+* `TensorPow k V n` (`V^{⊗ n}` as a `PiTensorProduct` over `Fin n`) and `permAct σ`, the
+  permutation action on the tensor factors, with `permAct_one` / `permAct_mul`.
+* `symRelSubmodule` and `extRelSubmodule` — **Etingof's own relation subspaces**, the span of the
+  `T - s(T)` and the span of the `T` with `s(T) = T`, and the quotients `SymPow k V n`,
+  `ExtPow k V n`. These are the book's definitions, not Mathlib's `SymmetricAlgebra` /
+  `ExteriorAlgebra` models.
+* `symTprod` (canonical symmetric multilinear map) with `symTprod_comp_perm`: invariance under
+  *all* of `Equiv.Perm (Fin n)`, obtained from the defining transposition relation by
+  `Equiv.Perm.swap_induction_on`. `extTprod`, the canonical `AlternatingMap` into `ExtPow`.
+* Part (f)'s operators: `symPowMap A n` (`S^n A`) and `extPowMap A n` (`⋀^n A`) by descending
+  `PiTensorProduct.map`, with `symPowMap_id`/`extPowMap_id` and `symPowMap_comp`/`extPowMap_comp`.
+* `extPowOfExteriorPower : ⋀[k]^n V →ₗ[k] ExtPow k V n`, proved surjective, and natural for
+  `exteriorPower.map n A` vs `extPowMap A n`.
+* `exteriorPowerEquiv (h2 : (2 : k) ≠ 0) : ⋀[k]^n V ≃ₗ[k] ExtPow k V n`, and transported along it
+  the exterior half of part (d): `extPowBasis` (indexed by `Set.powersetCard I n`) and
+  `finrank_extPow : finrank k (ExtPow k V n) = (finrank k V).choose n`.
+
+`Problem2_11_3.lean`'s module docstring no longer says (d)–(f) are deferred; it points at the new
+file. `progress/items.json` entry for `Chapter2/Problem2.11.3` updated (still `covered_partial`).
+
+## Decisions and patterns
+
+**The `ExteriorAlgebra ↔ PiTensorProduct` dead-end does not block the *quotient* direction.** The
+skill's Known Dead-Ends entry is about `∧^n V ≅ (V^{⊗ n})^{Alt}` — realising the exterior power as
+a *subspace* of the tensor power. Identifying the book's *quotient* with `⋀[k]^n V` is a different
+problem and went through without difficulty: forward map by
+`exteriorPower.alternatingMapLinearEquiv (extTprod …)`, backward by `Submodule.liftQ` of
+`PiTensorProduct.lift (ιMulti …)`, and the two round-trips checked on generators. The one move
+worth copying: to prove two maps out of `⋀[k]^n V` agree, use
+`LinearMap.ext_on (exteriorPower.ιMulti_span k n V)` rather than
+`exteriorPower.linearMap_ext` — the latter is what produced the unresolvable `compAlternatingMap`
+coercion goals recorded in the dead-ends section.
+
+**Why the char-2 hypothesis is there.** `extRelSubmodule ≤ ker` is proved from
+`Φ T = Φ (s T) = -Φ T`, so `2 • Φ T = 0`. In characteristic 2 the fixed subspace of `1 + s` is
+strictly larger than its image and the averaging argument has no analogue; the statement is still
+true but needs a basis-and-orbits argument. Tracked as #7820 rather than silently restricting the
+file to characteristic zero.
+
+**Elaboration traps hit (each cost a build cycle):**
+
+* `⨂[k] (_ : Fin n), V` needs `open scoped TensorProduct`, not `open PiTensorProduct`. Without it
+  the `abbrev` fails with a bare `expected token` and every later declaration auto-binds a wrong
+  implicit, producing a cascade of `expected ℕ, got Type` errors that hide the real cause.
+* `exteriorPower.map` takes `n` explicitly: `exteriorPower.map n A`, not `exteriorPower.map A`.
+* `(Equiv.swap i j).symm` is `Equiv.symm_swap`, not `Equiv.swap_symm`; `Equiv.Perm.one_symm` is
+  deprecated — `permAct 1 = id` is cleanest via `PiTensorProduct.reindex_refl`, and
+  `permAct (σ * τ)` via `Equiv.Perm.mul_def` + `PiTensorProduct.reindex_reindex`.
+* `simp` normalises `p.mkQ x` to `Submodule.Quotient.mk x`, so a hypothesis stated with `mkQ` will
+  not `rw` into a goal simp has already touched — normalise both with
+  `simp only [Submodule.mkQ_apply] at h ⊢`.
+* The default simp set rewrites `-(a + b)` to `-b + -a` (`neg_add_rev`), which silently reverses
+  an addition and leaves a goal only `add_comm` can close; use `simp only [..., neg_add]`.
+* Where a lemma's type variable appears only in the *result* type (`exteriorPowerEquiv`'s `V`),
+  application to an argument fails with "Function expected" — pass `(V := V)`.
+
+## Current frontier
+
+`Problem2_11_3_SymExtPow.lean` builds clean and sorry-free. The symmetric side has its
+construction and `symTprod_comp_perm` but no universal property, basis or dimension yet, because
+Mathlib's `SymmetricPower` is a bare quotient (its docstring lists universal property, basis and
+grading as TODO) — that has to be built here.
+
+## Overall project progress
+
+Stage 3.7 (fidelity/completeness follow-ups) continues. `Chapter2/Problem2.11.3` moves from
+"parts (d)–(f) entirely absent" to "book's objects constructed, exterior half of (d) proved",
+still `covered_partial`.
+
+## Next step
+
+Claim one of the successor issues, in rough dependency order:
+
+* #7816 — symmetric basis and dimension (unblocks #7819's symmetric half)
+* #7818 — `⋀^N A = det(A) • id` (self-contained; `extPowBasis` is already in place)
+* #7817 — part (e), the characteristic-zero (anti)symmetrizer identifications
+* #7820 — remove the characteristic-2 hypothesis
+* #7819 — trace formulas (blocked on #7816 for the symmetric half)
+
+## Blockers
+
+None. #7819 is `blocked` on #7816 by design.
+
+## Housekeeping
+
+This worktree arrived with 320 lines of `.claude/` guidance deleted and nothing added — the whole
+"Verify Assumptions" and "Publish" halves of `agent-worker-flow`, plus the `lean-formalization`
+pointer in `/feature`. Restored from `HEAD` before starting (backup of the discarded diff at
+`/tmp/0d319ea8-stale-worktree-deletions.patch`) and re-read the skill. This is the fourth such
+worktree recorded on 2026-07-25; the unconditional `wc -l` check now in Step 2 caught it.

--- a/progress/items.json
+++ b/progress/items.json
@@ -1539,13 +1539,14 @@
     "start_line": 2,
     "end_line": 15,
     "status": "sorry_free",
-    "coverage_note": "Partially formalized in EtingofRepresentationTheory/Chapter2/Problem2_11_3.lean. Parts (a)-(c) and determinant multiplicativity from part (g) are proved; the symmetric/exterior-power quotient models, characteristic-zero tensor identifications, induced maps and trace formulas in parts (d)-(f), and the top-exterior-power proof of (g) remain. Follow-up: #7365.",
-    "followup_issue": 7365,
+    "coverage_note": "Partially formalized. Parts (a)-(c) and determinant multiplicativity from part (g) are in EtingofRepresentationTheory/Chapter2/Problem2_11_3.lean. Problem2_11_3_SymExtPow.lean constructs the book's quotient models S^n V and ∧^n V of V^{⊗n}, the induced operators S^n A and ∧^n A with their functoriality, and the exterior half of part (d) (basis and dimension m.choose n) via an isomorphism with Mathlib's exterior power, proved away from characteristic 2. Remaining: the symmetric basis and dimension of part (d) (#7816), the characteristic-zero identification with the (anti)symmetric subspaces of part (e) (#7817), the trace formulas of part (f) (#7819), the top-exterior-power proof of part (g) (#7818), and removing the characteristic-2 hypothesis (#7820).",
+    "followup_issue": 7816,
     "coverage": "covered_partial",
     "lean_file": [
-      "EtingofRepresentationTheory/Chapter2/Problem2_11_3.lean"
+      "EtingofRepresentationTheory/Chapter2/Problem2_11_3.lean",
+      "EtingofRepresentationTheory/Chapter2/Problem2_11_3_SymExtPow.lean"
     ],
-    "last_updated": "2026-07-22"
+    "last_updated": "2026-07-25"
   },
   {
     "id": "Chapter2/Remark2.11.4",


### PR DESCRIPTION
This PR corrects the `lean-formalization` skill's Known Dead-Ends entry for `ExteriorAlgebra ↔ PiTensorProduct`, which is currently written as a blanket "sorry it immediately and move on" and would have caused this session to abandon a result that in fact went through in three build cycles. The blocked statement is the *subspace* direction — realising `⋀[k]^n V` inside `V^{⊗ n}` as the alternating subspace. The *quotient* direction is a different problem: both maps come from universal properties (`PiTensorProduct.lift` + `Submodule.liftQ` one way, `exteriorPower.alternatingMapLinearEquiv` the other) rather than from a coercion, and `exteriorPowerEquiv` in `Chapter2/Problem2_11_3_SymExtPow.lean` (#7821) proves it sorry-free. The entry now records that scope, the working route, the reason to reach for `LinearMap.ext_on (exteriorPower.ιMulti_span …)` instead of `exteriorPower.linearMap_ext` — the latter being the source of the coercion goals the entry lists — and the characteristic-2 caveat the argument carries.

It also adds six tensor-power elaboration traps from the same session, each of which cost a build cycle: the `⨂[k]` notation being `scoped[TensorProduct]` and the misleading error cascade it produces (with the general lesson to read the head of a long build log rather than its tail), `exteriorPower.map` taking `n` explicitly, `simp` normalising `mkQ` to `Submodule.Quotient.mk` and thereby desynchronising hypotheses from goals in quotient-heavy files, `neg_add_rev` silently reversing an addition, and result-only type variables needing to be passed by name.

🤖 Prepared with Claude Code