### PR TITLE
docs: record replan triage of #7365, closed as fully decomposed

### DIFF
--- a/progress/2026-07-25T19-27-51Z_ee1a98a7-replan.md
+++ b/progress/2026-07-25T19-27-51Z_ee1a98a7-replan.md
@@ -1,0 +1,74 @@
+## Accomplished
+
+Replan triage session. `coordination list-replan` had exactly one candidate, #7365
+(Problem 2.11.3(d)-(f): symmetric and exterior powers and trace formulas).
+
+Disposition: **worker-decomposed, sub-issues fully cover the parent** — closed with a forward
+link, not narrowed.
+
+* Session `0d319ea8` decomposed #7365 into five issues and published the shared foundation as
+  partial PR https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/pull/7821,
+  a new file `EtingofRepresentationTheory/Chapter2/Problem2_11_3_SymExtPow.lean` carrying the
+  book's quotient models `SymPow`/`ExtPow` of `V^{⊗ n}`, the factor-permutation action `permAct`,
+  the canonical maps `symTprod`/`extTprod`, the operators `symPowMap`/`extPowMap` with
+  functoriality, `exteriorPowerEquiv` (away from characteristic 2), and the exterior half of
+  part (d) as `extPowBasis` / `finrank_extPow`.
+* Coverage check against the parent's acceptance criteria, all five satisfied:
+  * part (d) quotient models — landed in #7821; symmetric basis and dimension
+    (`symPowBasis`, `finrank_symPow = Nat.multichoose m n`) → #7816; the leftover
+    `(2 : k) ≠ 0` hypothesis on `exteriorPowerEquiv` → #7820;
+  * part (e) characteristic-zero identification with the symmetric / alternating subspaces
+    of `V^{⊗ n}` → #7817;
+  * part (f) `trace (extPowMap A n) = e_n(λ)` and `trace (symPowMap A n) = h_n(λ)` → #7819
+    (`blocked`, `depends-on: #7816` for the symmetric half; the exterior half can go first
+    against the existing `extPowBasis`);
+  * part (g) `extPowMap A N = det A • id` plus the book's derivation of `det_comp` from it
+    → #7818;
+  * the documentation criterion (`Problem2_11_3.lean` must stop calling (d)-(f) deferred) is
+    already discharged inside #7821, which re-points the module docstring at
+    `Problem2_11_3_SymExtPow.lean` and its list of open pieces.
+  No residual scope remained, so the parent was closed rather than retargeted.
+* #7365 had already been closed by the decomposing worker but still carried `replan`, which is
+  why it surfaced in the queue. Triage rationale posted as a comment and the `replan` label
+  removed, so it stays out of future queues.
+* Verified #7819's dependency marker is in the exact `depends-on: #7816` form that
+  `coordination check-blocked` matches, so it unblocks automatically when #7816 closes.
+* Enabled auto-merge (squash) on
+  https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/pull/7821, which was
+  `MERGEABLE` with both `build` checks still in progress and no auto-merge set. The four
+  follow-ups all build on that file, so it is on the critical path for every one of them.
+
+## Current frontier
+
+`coordination list-replan` is empty; no open issue carries the `replan` label.
+
+Problem 2.11.3 is now four independent claimable pieces plus one blocked assembly, all stated
+against concrete declarations in `Problem2_11_3_SymExtPow.lean`:
+
+* #7816 — the symmetric basis. The real work of the group: Mathlib's `SymmetricPower` has no
+  universal property, basis, or grading (its own docstring lists all three as TODO), so this
+  needs the "quotient of a free module by orbit-differences is free on the orbits" lemma built
+  from scratch. Also what unblocks #7819.
+* #7817 — part (e). Routed deliberately through the book's `ExtPow` rather than Mathlib's
+  `ExteriorAlgebra`, so it sidesteps the coercion gap that has defeated three or more agents.
+* #7818 — part (g). Self-contained; one-dimensionality of the top exterior power plus
+  `Module.Basis.det_comp`.
+* #7820 — removing the characteristic-2 hypothesis. Needs the tensor-basis coefficient argument
+  spelled out in the issue.
+* #7819 — the trace formulas, blocked on #7816.
+
+## Overall project progress
+
+Stages 1 through 3.6 complete; Stage 3.7 (completeness audit and residual formalization) is the
+active frontier. This session changed no Lean code and produced no new plan items beyond
+confirming the five already created by the decomposing worker.
+
+## Next step
+
+Workers should claim #7816 first — it is the deepest of the five and gates #7819. #7818 and
+#7820 are good short sessions. All four assume PR #7821 has landed on `main`; auto-merge is set,
+so confirm it merged before branching.
+
+## Blockers
+
+None for this session. #7819 is correctly blocked on #7816.


### PR DESCRIPTION
This PR records the replan triage session for #7365, the single `replan` candidate this cycle.

Session `0d319ea8` had decomposed #7365 into https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/issues/7816 (symmetric basis and dimension), https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/issues/7817 (the characteristic-zero identification of part (e)), https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/issues/7818 (`⋀^N A = det(A)·id` of part (g)), https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/issues/7819 (the trace formulas of part (f), blocked on #7816) and https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/issues/7820 (dropping the characteristic-2 hypothesis), publishing the shared `SymPow`/`ExtPow` foundation as partial PR https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/pull/7821. Those five cover every acceptance criterion of the parent, including the documentation criterion already discharged inside #7821, so #7365 was closed with a forward link rather than narrowed, and its stale `replan` label removed. Auto-merge was enabled on #7821, which was mergeable with CI still running and gates all four follow-ups.

No code changes: the only file is the progress entry.

🤖 Prepared with Claude Code
