### PR TITLE
fix(agent-config): restore the command and skill docs clobbered by PR #7834

### DIFF
--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -14,6 +14,14 @@ The priority order in the worker skill still applies — check for PR-fix issues
 
 ## Executing Implementation Work
 
+**Before writing any Lean, read the `lean-formalization` skill.** It is a long
+accumulated record of this project's traps, and most of them cost a build cycle
+each to rediscover. Search it for the vocabulary of your item (the ambient
+structure, the Mathlib API, the tactic that just failed) rather than reading it
+top to bottom. A rewrite or `simp` that fails to find a pattern the goal visibly
+contains is almost always one of the documented instance/elaboration traps, not
+a mistake in your proof — check the skill before rewriting the proof.
+
 Follow the plan's deliverables. For new implementations, follow the development
 cycle described in the project's CLAUDE.md.
 

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -39,6 +39,80 @@ Rotate through these areas across sessions:
 **Security**:
 - Check for new issues in recent code, verify past fixes
 
+## Verifying sorry-freeness (fidelity audits)
+
+`grep -c sorry` is unreliable for "is this file sorry-free?": it counts the
+substring `sorry-free` inside comments, so a fully-complete file can report a
+large nonzero count (e.g. 10 comment mentions → looks like 10 sorries). Always
+confirm real sorries with `grep -n sorry <file> | grep -v sorry-free`, and treat
+`#print axioms <decl>` (no `sorryAx` in the list) as the ground truth for whether
+a declaration is genuinely sorry-free. Do not trust a stale sorry-count from the
+issue body — re-check it.
+
+To run `#print axioms`, **append the `#print axioms <decl>` lines to the end of
+the target source file** and run `lake env lean <that-file>` (restore the file
+after). Do NOT create a separate scratch file that `import`s the target module and
+run `lake env lean` on it — loading a project olean that way can demand a transitive
+olean the local build never produced and fail with a spurious
+`object file '…/SomeOtherModule.olean' … does not exist`, even for a module the
+target does not import. Running against the actual source file only needs the
+target's own already-built dependency oleans, so it works after a successful
+`lake build EtingofRepresentationTheory.<Module>`.
+
+**Beware a false `sorryAx` from the append-to-source method.** `lake env lean`
+re-elaborates the whole source from scratch, and for some files that re-elaboration
+is nondeterministically flaky (e.g. `synthInstanceFailed` or `rewrite failed` on a
+line that compiles fine under `lake build`). Lean fills a failed elaboration with
+`sorryAx`, so a genuinely sorry-free decl can be reported as depending on `sorryAx`
+— a false positive. Tell it apart from a real sorry: if the same `lake env lean`
+run prints **any `error:`** on lines of the target decl (or its helpers), the
+`sorryAx` is an elaboration artifact, not a real sorry. To confirm, cross-check
+against the built oleans: after `lake build EtingofRepresentationTheory.<Module>`
+succeeds, create a scratch file that only `import`s the module and runs
+`#print axioms` there, then `lake env lean` it. Because every olean already exists,
+the "object file does not exist" hazard above does not fire, and the axiom list is
+computed from the compiled olean rather than a fresh re-elaboration — this is the
+authoritative result. (Observed on `Chapter3/Problem3_9_2.lean`, audit #7375.)
+
+## Editing `progress/items.json` (coverage-arm audits)
+
+Coverage-arm audits record verdicts by editing one entry in
+`progress/items.json` — a single ~8000-line JSON array shared by every session.
+When you rewrite it programmatically (e.g. Python `json.dump`), **match the
+existing serialization exactly or you will reformat the whole file** into a
+spurious multi-thousand-line diff that is merge-conflict bait and hides your real
+change. The file uses `indent=2`, `ensure_ascii=False` (unicode kept literal, not
+`\uXXXX`), and a trailing newline. Concretely:
+
+```python
+json.dump(items, open(p, "w"), indent=2, ensure_ascii=False)
+open(p, "a").write("\n")   # restore trailing newline json.dump omits
+```
+
+Then **verify the diff is localized** before committing:
+`git diff --stat progress/items.json` should report a handful of changed lines,
+not thousands. If it is large, `git checkout progress/items.json` and redo with
+the right format. Prefer editing the single target entry over touching others.
+
+## Completing the Review
+
+Post your report as a comment on the review issue. Then close the issue yourself —
+a review's deliverable is the report, not a code change, so there is usually **no PR**
+to swap `claimed` → `has-pr`, and an unclosed issue would stay stuck in `claimed`:
+
+- **No defect found:** `gh issue close <N> --comment "Review complete — PASS. See report above."`
+- **Defect found:** open a fix PR (`coordination create-pr <N>` — this closes the issue on
+  merge) **or** a follow-up `feature` issue for the fix, then close the review issue with a
+  link to it. Do not leave the review issue open waiting on a human.
+
+`coordination create-pr` builds the PR body itself from the commit (`Closes #N` +
+session + commit subjects); it does **not** read a piped/`--body` body. When the issue
+requires the per-check verdict *in the PR body*, either put that reasoning in the commit
+message or add it afterward with `gh pr edit <N> --body-file <file>`.
+
+Any progress-file commit lives on your branch; there is no need to push or PR it for a
+report-only review.
+
 ## Updating Skills
 
 When you discover a recurring pattern or encounter a situation not covered by

--- a/.claude/commands/summarize.md
+++ b/.claude/commands/summarize.md
@@ -43,10 +43,32 @@ Write an updated progress document that:
   remaining work, gaps between goals and achievements)
 - **Is honest in its framing** — don't overstate what has been achieved
 
+### Step 5b: Reconciling `items.json` statuses (when asked)
+
+Summarize issues often ask you to correct stale `items.json` statuses using a
+comment-stripped `sorry` scan as ground truth. Two things bite here:
+
+- **A zero-sorry scan does NOT license reclassifying to `sorry_free`.** Many
+  `statement_formalized` items are *deliberate holds* with sorry-free source:
+  a crux passed in as a hypothesis, an unstated/deferred book part, or a
+  `Prop`-only stub definition. Before flipping any `statement_formalized` /
+  `partially_proved` item, **blob-check it**: read `blobs/<Chapter>/<Item>.md`
+  for the full set of book parts, then confirm each part is both *stated and
+  proved* in the item's Lean file(s) and its imported sub-files. Reclassify only
+  when every part is genuinely met. Treat any reclassification list in the issue
+  body as a *heuristic suggestion*, not a directive — the issue's own examples
+  have included genuine holds (verify each; do not overstate completion).
+- **`items.json` is not a uniform schema.** Most items are problem items keyed
+  by `id` (e.g. `Chapter6/Problem6.9.2`), but some are `derived`-type items with
+  **no `id`**, keyed instead by `lean_file`. Match on whichever key the item
+  actually has, and assert exactly one hit before editing. A `derived` item may
+  also carry a stale `note` listing now-closed sorries — fix it in the same edit.
+
 ## Constraints
 
 - Do NOT modify any code or implementation files
-- Commit ONLY the progress document changes
+- Commit ONLY the progress document changes (plus `items.json` / `PROGRESS.md`
+  when the issue asks for a status reconciliation)
 - The progress entry should note what changed and why
 
 ## Reflect

--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -14,3 +14,8 @@ to pick the most important unclaimed issue and execute it.
 3. Based on your own judgment, select the most important one
 4. Identify its label (`feature`, `review`, `summarize`, or `meditate`)
 5. Execute the appropriate sub-command (`/feature`, `/review`, `/summarize`, `/meditate`)
+
+Step 5 means **actually invoking that sub-command**, not just doing the work you
+judge it implies. Each sub-command carries setup its issue type depends on — for
+`/feature`, reading the `lean-formalization` skill before writing Lean. Skipping
+the dispatch silently drops that setup.

--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -71,6 +71,28 @@ open. `check-blocked` (run by `pod` each loop) removes `blocked` when
 all dependencies close. Blocked issues are excluded from
 `list-unclaimed` and `queue-depth`.
 
+**Dependency code that lives only in an unmerged PR**: a dependency issue
+can be *closed* while the def/lemma it produced is still in an open PR
+(residual assembly, split work), so it is absent from `main`. If the code
+you need to build on is in such a PR, do NOT wait or skip — `git fetch`
+that PR's head branch and base your branch on it
+(`git reset --hard origin/<pr-head>`). Then in your PR body add an
+ordering note naming the predecessor PR and the exact rebase command, so a
+repair/planner agent can sequence the merges. Confirm the dependency file
+actually builds on that base before writing new code.
+
+The rebase is **not** a plain `git rebase origin/main`. A squash merge
+collapses the predecessor's commits into one new commit that is not
+patch-equivalent to any of them, so a plain rebase re-applies them on top of
+`main`, which already has the same content — an add/add conflict on every
+file the predecessor created. Replay only *your* commits instead:
+
+```bash
+git rebase --onto origin/main <pr-head-sha-you-branched-from> <your-branch>
+```
+
+See Step 2 for the publish-time version of this.
+
 **Branch naming**: `agent/<first-8-chars-of-UUID>`
 **Plan files**: `plans/<UUID-prefix>.md`
 **Progress files**: `progress/<UTC-timestamp>_<UUID-prefix>.md`
@@ -132,7 +154,60 @@ git rev-parse HEAD      # record starting commit
 **If the branch already exists** (common in reused worktrees): check for an
 open PR on it first (`gh pr list --head agent/<id>`). If a PR exists, create
 a new branch with a suffix (`agent/<id>-v2`). If no PR exists, reset it to
-master: `git checkout agent/<id> && git reset --hard origin/master`.
+the default branch: `git checkout agent/<id> && git reset --hard origin/main`
+(this repo's default branch is `main`, not `master`).
+
+**Do not try to `git checkout main` in a pod worktree.** `main` is checked out
+in the primary worktree, so the checkout fails — and if you chain it as
+`git checkout main || git checkout master` the first failure is silent and you
+only see a confusing "pathspec 'master' did not match" error. Fetch and compare
+against `origin/main` instead: `git fetch origin && git log --oneline -1 origin/main`.
+
+**Before that `git reset --hard`, run `git status --short` and inspect any
+uncommitted changes** (`git diff`). A reused worktree can carry in-progress
+edits from a crashed prior session; `reset --hard` discards them irrecoverably.
+If the changes look like real work (not stray build artifacts), stash them
+(`git stash`, never `git stash -u`) or commit them on a scratch branch before
+resetting.
+
+Judge that inspection in *both* directions: stray changes you leave in place ride
+along into your PR as unrelated regressions. Check `git diff --numstat` for changes
+that are pure *deletions* against `main` in files you were not asked to touch,
+especially under `.claude/`. A crashed session can leave an accidental revert of
+accumulated workflow guidance, which is easy to commit without noticing and hard to
+spot in review. Restore those (`git checkout HEAD -- <paths>`) rather than carrying
+them. (2026-07-25: twice, worktrees arrived with 169 and 279 lines of `.claude/`
+guidance deleted and nothing added.)
+
+**If the restored files include this skill or your `/command` file, re-read them.**
+Skills load from the working tree, so a truncated `SKILL.md` means the guidance you
+started the session on was the deleted version and you never saw these instructions.
+
+That instruction only reaches an agent who already *has* the full file, so do not rely
+on it — run the check unconditionally, right after `git status`, whether or not
+anything looked wrong:
+
+```bash
+wc -l .claude/skills/agent-worker-flow/SKILL.md
+git show HEAD:.claude/skills/agent-worker-flow/SKILL.md | wc -l
+```
+
+If the counts differ, restore and **re-invoke the skill** (not just `Read` the file), then
+restart the workflow from Step 1. Guidance added since the stale revision is exactly the
+guidance you are most likely to need — e.g. the Step 7 rules on replacing `create-pr`'s
+placeholder PR body and on never running `gh pr merge --auto` yourself.
+(2026-07-25: a third worktree that day arrived 193 lines stale; the session ran to
+completion on the old copy and shipped a placeholder PR body.)
+
+**If you branched off an unmerged PR's head** (see "Dependency code that lives
+only in an unmerged PR" above), decide at publish time:
+
+- Predecessor already merged → replay only *your* commits onto `main` with
+  `git rebase --onto origin/main <pr-head-sha> <your-branch>`, then push.
+- Predecessor still open → publish anyway rather than stalling the session, and
+  leave a PR comment naming it and giving that exact command. Do not wait more
+  than ~15 minutes on someone else's CI; a `repair` agent can fix the conflict
+  if one appears, but only if the PR says what it is stacked on.
 
 Record any project-specific quality metrics (e.g. sorry count, test coverage)
 as described in the project's CLAUDE.md.
@@ -149,12 +224,110 @@ Check that the plan's assumptions still hold:
 - Quality metrics match what the issue says
 - Files mentioned in the issue still exist and haven't been restructured
 - No recently merged PR invalidates the plan
+- **A foundation the issue says "landed in #N" is actually in `main`.** Planners
+  often reference a sibling PR/commit by number as if merged. If the issue's
+  "Current state" describes machinery you'll build on (e.g. "added in #7222"),
+  confirm it: `grep` for the named decls in the target file, and if absent check
+  whether #N is still an *open* PR (`gh pr view <N>`, `git merge-base --is-ancestor
+  <sha> origin/main`). If the foundation is only in an unmerged branch, the issue
+  is blocked — `coordination skip` it with a "blocked on unmerged #N" reason
+  rather than stacking your work on that branch (a stacked PR against `main`
+  carries the other PR's commits and conflicts on merge).
+- **The "missing"/"partial" result may already exist — grep before implementing.**
+  Any issue that describes a gap — an audit reconciliation flagging a
+  `covered_partial` residual, *or* a feature issue asserting a result is "not in
+  Mathlib and not yet in this repo" — describes it as of when the issue was
+  written, which can be stale: a parallel agent may since have proved it, often in
+  a *more general* form and in a *different, downstream* file than the issue names
+  (e.g. #7315 asked to build reducible "characters determine the representation"
+  from scratch; `Etingof.charEq_iso` in `Chapter5/CharEqIso.lean` already had it).
+  Before writing any new lemma — *especially* general infrastructure an issue calls
+  missing — `grep -rn "<decl_name>\|<key phrase>"` across `EtingofRepresentationTheory/`
+  for an existing version; a name collision at build time is the expensive way to
+  discover this. If it already exists, reuse it: the task shrinks to a thin
+  bridge/assembly (or, for audits, a tracking reconciliation — flip `items.json`,
+  repoint `lean_ref`, drop the residual issue), not new infrastructure.
+- **The issue's work may be *entirely* done and merged already — if so `close` it,
+  don't `skip` it.** A PR whose body omits `Closes #N` merges without closing its
+  issue, so the issue keeps appearing in `coordination list-unclaimed` forever and
+  the next worker redoes landed work. Cheapest check, before claiming: scan
+  `git log origin/main --oneline -20` for a commit whose title matches the issue
+  title or cites `#N`, then confirm the decls are on `main`
+  (`git show origin/main:<file> | grep <decl>`). If they are, `gh issue close <N>
+  --comment "Completed by PR #M (merged as <sha>); the PR body omitted a Closes
+  line."` — `coordination skip` is wrong here, it only re-queues the issue for a
+  planner. (2026-07: #7704, landed in #7722, sat unclaimed for a full cycle.)
+- **A "restore/regression" issue whose reproduction is `lake env lean <file>` may
+  be a false positive — reconfirm the failure with `lake build <Module>` before any
+  work.** `lake env lean` drops the lakefile's `[leanOptions]` (`maxSynthPendingDepth
+  = 3`, `backward.isDefEq.respectTransparency = false`), so files with deep instance
+  chains or `isDefEq` diamonds throw spurious `synthInstanceFailed` / instance-path
+  errors under it that never occur under `lake build`. See `lean-formalization`
+  ("Typecheck with `lake build`, NOT `lake env lean`") for the full account. If
+  `lake build <Module>` is green and `#print axioms` on the endpoints is clean, the
+  issue is already resolved (often by a since-merged dependency fix) — close it with
+  the build evidence rather than editing a working file. (2026-07: #7490, #7547.)
 
 If stale:
 ```
 coordination skip <issue-number> "reason: <what changed>"
 ```
 Go back to Step 1 and try the next issue.
+
+**If the premise is wrong but the problem is real, fix the real defect, not the
+prescribed one.** A third case sits between "proceed" and `skip`: the issue reports a
+genuine failure but misdiagnoses its cause, so following it literally would leave the
+failure in place or actively damage correct data. Neither exit fits: proceeding as
+written does harm, and `skip` abandons a real defect. Instead:
+
+- Deliver the issue's stated **verification criterion**, not its prescribed **method**.
+  The criterion is what the planner wanted; the method was a guess at how to get there.
+- Comment on the issue, before or alongside opening the PR: what the actual defect was,
+  why the prescribed fix was rejected, and what you did instead.
+- Repeat that reasoning in the PR body, so a reviewer meeting a diff that touches
+  different files than the issue named is not surprised by it.
+- This still counts as full completion (no `--partial`) as long as the criterion is met.
+
+Worked example: #7712 correctly reported `scripts/validate_items.py` exiting 1 with ten
+errors, but blamed `progress/items.json`. Both remedies it proposed would have corrupted
+correct data: the ten entries already matched `PLAN.md` Stage 1.6, and the defect was in
+the validator, which never implemented that part of the spec. PR #7713 fixed the validator,
+met the stated criterion (`validate_items.py` exits 0), and left `items.json` content
+untouched.
+
+**Where the authority sits.** `PLAN.md` is the spec and is off-limits to agents, so when an
+issue body and `PLAN.md` disagree, `PLAN.md` wins and the issue is the thing that is wrong.
+This is the *reverse* of the `directive` rule in Step 1, and the two are easy to confuse: a
+`directive` carries the owner's own stated approach, which is not yours to second-guess even
+when you would have done it differently; an `agent-plan` issue carries a planner's guess,
+which you are expected to check against the spec and the code.
+
+| Situation | Exit |
+|---|---|
+| Plan is stale (work already done, moot, or blocked on an unmerged foundation) | `coordination skip` |
+| Symptom real, diagnosis or prescribed fix wrong | fix the real defect, document the deviation on the issue and in the PR |
+| `directive` whose approach you would have chosen differently | do it as asked (Step 1) |
+
+**items.json status reconciliation — sorry-free ≠ item-complete.** For issues
+that ask you to flip a `partially_*`/`statement_formalized`/`formalized` entry
+to `sorry_free` because "the `.lean` file is sorry-free," read the entry's
+existing `coverage_note`/`fidelity_note` **before** changing anything. Those
+notes often record a deliberate "sorry-free file but kept `partially_*` because
+book part (X) is not formalized as a theorem / is only a `Prop`-def / is an
+informal identification" decision that a raw sorry-count sweep cannot see.
+Cross-check each part against the item's `blobs/…` file. A file with zero
+sorries can still leave a book part unformalized; flipping it to `sorry_free`
+hides genuine remaining exercise work. Only set `sorry_free` when a **complete**
+sorry-free file backs the item. (Recurred: #7001, #7092.)
+
+**items.json is Unicode + 2-space-indented — preserve both when scripting an
+edit.** The file contains math glyphs (`ℂ`, `λ`, `≅`, em-dashes). A naive
+`json.dump(d, f, indent=2)` escapes every glyph to `\uXXXX` and reflows the whole
+file, turning a 3-line change into a multi-thousand-line diff. Always dump with
+`indent=2, ensure_ascii=False` and re-add the trailing newline
+(`f.write("\n")`), then confirm with `git diff --stat` that only your entry
+changed. For a single-field flip, a targeted `Edit` on the entry is simpler and
+safer than a full re-dump.
 
 **PR fix plans**: If the plan asks you to fix a broken PR, use judgement. If the
 PR is low quality or not worth salvaging:
@@ -291,7 +464,43 @@ Write a progress entry to `progress/<UTC-timestamp>_<UUID-prefix>.md`:
 ```bash
 git push -u origin <branch>
 coordination create-pr <issue-number>
+gh pr edit <new-pr-number> --body "$(cat <<'EOF'
+This PR ...
+EOF
+)"
 ```
+
+**`create-pr` writes a placeholder body, so replace it.** The body it generates is just
+the `Closes #N` line, your session UUID, and a raw `git log`; it takes no body argument
+and reads nothing from stdin. Follow it with `gh pr edit <N> --body`, opening with a
+paragraph that starts "This PR ..." in imperative present, since that paragraph becomes
+the release note. Keep the `Closes #N`, `Session:` and `🤖 Prepared with Claude Code`
+lines.
+
+**Do not run `gh pr merge --auto --squash` yourself.** `create-pr` already attempts to
+enable auto-merge, and on this repo it reports `auto-merge not available (branch
+protection may not be set up)`. That warning is the whole story: with auto-merge
+unavailable, a follow-up `gh pr merge <N> --auto --squash` does not queue behind CI, it
+**merges immediately**, landing your branch on `main` with `build` still `IN_PROGRESS`.
+For a Lean change that means unbuilt code on `main` and a broken base for every other
+agent. Leave the PR alone after `create-pr`; the next planning cycle's merge sweep
+checks `statusCheckRollup` before merging. (2026-07-25: PR #7725 merged 24s after
+creation, both `build` checks still running.)
+
+**This rule overrides the project `.claude/CLAUDE.md`, which still says to run
+`gh pr merge "$PR_NUM" --auto --squash` right after `create-pr`.** That file is
+off-limits to agents, so the contradiction cannot be fixed at the source — when the
+two disagree, follow this skill. (2026-07-25: an agent that had read CLAUDE.md's PR
+workflow section ran the command on its own PR #7744 *and* on another session's #7743,
+merging both with `build` still `IN_PROGRESS`.)
+
+**The merge sweep in CLAUDE.md has the same hazard: its jq filter is
+`all(.conclusion != "FAILURE" and .conclusion != "CANCELLED")`, which is vacuously
+true for a PR whose checks are still queued or running (`conclusion` is empty), and
+also true for a PR with no checks at all.** Before merging anything in the sweep,
+require every check to have *completed successfully* — e.g. select on
+`(.statusCheckRollup | length > 0 and all(.conclusion == "SUCCESS"))`, or just read
+`gh pr checks <N>` and skip anything `pending`. "Not failing" is not "passing".
 
 **Once the PR is created, exit.** Do not poll CI, wait for the merge, or
 otherwise spin on the PR. Another session will pick up any follow-up work


### PR DESCRIPTION
This PR restores `.claude/commands/feature.md`, `review.md`, `summarize.md`, `work.md` and `.claude/skills/agent-worker-flow/SKILL.md` to the content they had before #7834.

The worktree that produced #7834 held stale copies of those five files, predating #7787 (point feature/work sessions at the lean-formalization skill) and #7780 (make the stale-worktree check unconditional). They showed up as uncommitted modifications at session start, and a `git add -A` swept them into the Künneth PR, reverting 320 lines of command and skill guidance on main. No Lean code is touched.

🤖 Prepared with Claude Code