### PR TITLE
docs: addendum progress entry for the PR #7834 .claude regression

### DIFF
--- a/progress/2026-07-25T22-31-41Z_3fa02f4e.md
+++ b/progress/2026-07-25T22-31-41Z_3fa02f4e.md
@@ -1,0 +1,41 @@
+## Accomplished
+
+Addendum to `progress/2026-07-25T22-26-49Z_3fa02f4e.md` (issue #7830, merged as PR #7834).
+
+After #7834 merged I found it had also reverted 320 lines of `.claude/` guidance. The
+worktree for this session arrived holding stale copies of `.claude/commands/{feature,
+review,summarize,work}.md` and `.claude/skills/agent-worker-flow/SKILL.md`, predating
+#7787 and #7780; they showed up as uncommitted modifications at session start and a
+`git add -A` swept them into the Künneth PR.
+
+* PR #7835 restored all five files to their pre-#7834 content. `git diff fe4f43f1
+  origin/main -- .claude/` is now additions only. No Lean code was affected.
+* Commit `ee2d9cc4` (docs-only, pushed straight to `main` — the merge of #7835 with
+  `--delete-branch` left this worktree checked out on `main` and I did not re-branch
+  before committing; noting it rather than churning a revert of correct content) adds two
+  guards. The existing Step 2 stale-worktree check lives inside the file that goes stale,
+  so an agent whose copy is truncated never learns to run it; the same check now also sits
+  in `.claude/commands/work.md` and `feature.md`, and Step 7 of `agent-worker-flow` gained
+  a publish-time backstop (diff scope against `origin/main`, never blanket `git add -A`)
+  that fires even when both start-of-session copies were stale.
+
+This is the third `.claude/`-clobbering worktree recorded on 2026-07-25 (169, 279 and 320
+lines); the running tally in the skill's Step 2 is updated.
+
+## Current frontier
+
+`main` at `ee2d9cc4`. Chapter 7 Künneth modules build clean; `.claude/` guidance intact.
+
+## Overall project progress
+
+Unchanged from the previous entry: the natural Künneth isomorphism and its bifunctor
+`NatIso` are in `Chapter7/KunnethIso.lean`, and #7831 is unblocked.
+
+## Next step
+
+Unchanged: pick up #7831, migrating the reindexed chain/cochain and Tor Künneth consumers
+off `Problem7_8_7_iv_nonempty`/`Nonempty.some` and onto `kunnethIso`/`kunnethNatIso`.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR adds a follow-up progress entry recording that PR #7834 also reverted 320 lines of `.claude/` guidance from a stale worktree, that PR #7835 restored it, and that commit `ee2d9cc4` added a bootstrap-independent stale-worktree check to the command files plus a publish-time diff-scope backstop in `agent-worker-flow` Step 7.

🤖 Prepared with Claude Code