### PR TITLE
feat(Ch7 #7397): migrate the chain/cochain and Tor Künneth consumers to the natural API

### DIFF
--- a/EtingofRepresentationTheory/Chapter7/KunnethChainComplexNat.lean
+++ b/EtingofRepresentationTheory/Chapter7/KunnethChainComplexNat.lean
@@ -1,10 +1,11 @@
 import Mathlib
 import EtingofRepresentationTheory.Chapter7.Problem7_8_7
+import EtingofRepresentationTheory.Chapter7.KunnethIso
 
 /-!
 # Künneth for `ℕ`-indexed chain complexes via `ℕ`/`ℤ` reindexing
 
-Chapter 7's Künneth formula (`Etingof.Problem7_8_7_iv_nonempty`) is stated for cohomologically
+Chapter 7's Künneth formula (`Etingof.Problem7_8_7_iv`) is stated for cohomologically
 indexed `CochainComplex (ModuleCat k) ℤ`. The `Tor`/`Ext` construction of Problem 8.2.8,
 however, works with its own complexes `P• ⊗_A N`, which are homologically indexed
 `ChainComplex (ModuleCat.{u} k) ℕ`
@@ -51,12 +52,15 @@ this iso can equivalently be read as "the `ℤ`-tensor of the extends is the ext
 `≅ ⨁_{p+q=i} H_p(C) ⊗ H_q(D)` (reindex `a = -p`, `b = -q`; the `a > 0` / `b > 0` summands are
 zero by `homology_extend_isZero`).
 
-The final identification uses the universe-general `Problem7_8_7_iv_nonempty`. The reindex of the
-coproduct is not a bare index bijection: the `ℤ`-side sum `⨁_{a+b=-i}` ranges over all of
-`ℤ × ℤ`, and the extra summands vanish only via `homology_extend_isZero`.
+The final identification uses the universe-general `Problem7_8_7_iv`, the honest isomorphism
+inverse to the natural cross product `Etingof.kunnethMap`. The reindex of the coproduct is not a
+bare index bijection: the `ℤ`-side sum `⨁_{a+b=-i}` ranges over all of `ℤ × ℤ`, and the extra
+summands vanish only via `homology_extend_isZero`.
 
-The main deliverable `kunnethChainComplexNat` is stated below (Prop-valued `Nonempty`), pinning the
-API that the Problem 8.2.8 construction consumes.
+The main deliverable is `kunnethChainComplexNatIso`, an actual `Iso`; `kunnethChainComplexNat` is
+the `Nonempty` corollary kept for compatibility. Nothing in this file extracts an isomorphism from
+a `Nonempty` via `Classical.choice`. See `kunnethChainComplexNatIso`'s docstring for a step-by-step
+account of which naturality squares are formalized.
 -/
 
 open CategoryTheory Limits MonoidalCategory HomologicalComplex
@@ -72,6 +76,24 @@ Mathlib's `extendHomologyIso` for `embeddingDownNat` (`e.f n = -n`). -/
 noncomputable def homology_extend_iso (C : ChainComplex (ModuleCat.{u} k) ℕ) (n : ℕ) :
     (C.extend ComplexShape.embeddingDownNat).homology (-(n : ℤ)) ≅ C.homology n :=
   C.extendHomologyIso ComplexShape.embeddingDownNat (by simp)
+
+/-- **`homology_extend_iso` is natural in the complex.** For `φ : C ⟶ D` the square
+
+`H_{-n}(extend C) → H_{-n}(extend D)`
+`      ↓                  ↓        `
+`   H_n(C)      →      H_n(D)      `
+
+commutes, the horizontal maps being `homologyMap (extendMap φ e) (-n)` and `homologyMap φ n`.
+This is Mathlib's `extendHomologyIso_hom_naturality` at `e = embeddingDownNat`; it supplies the
+naturality of steps 1 and 4 of `kunnethChainComplexNatIso` (see that definition's docstring). -/
+@[reassoc]
+lemma homology_extend_iso_hom_naturality {C D : ChainComplex (ModuleCat.{u} k) ℕ} (φ : C ⟶ D)
+    (n : ℕ) :
+    homologyMap (extendMap φ ComplexShape.embeddingDownNat) (-(n : ℤ)) ≫
+        (homology_extend_iso D n).hom =
+      (homology_extend_iso C n).hom ≫ homologyMap φ n :=
+  HomologicalComplex.extendHomologyIso_hom_naturality (φ := φ)
+    (e := ComplexShape.embeddingDownNat) (hj' := by simp)
 
 /-- Homology of `extend e C` vanishes at positive degrees `j' > 0`, which lie outside the image
 `{-n : n : ℕ} = ℤ≤0` of `embeddingDownNat`. -/
@@ -552,17 +574,36 @@ theorem nonempty_tensorObj_extend_iso (C D : ChainComplex (ModuleCat.{u} k) ℕ)
       (HomologicalComplex.tensorObj C D).extend ComplexShape.embeddingDownNat) :=
   ⟨TensorExtend.tensorObjExtendIso C D⟩
 
-/-- **Künneth for `ℕ`-indexed chain complexes.** For chain complexes `C, D` of `k`-vector spaces
-indexed over `ℕ`, the homology of the tensor product decomposes as a direct sum:
+/-- **Künneth for `ℕ`-indexed chain complexes**, as an honest isomorphism. For chain complexes
+`C, D` of `k`-vector spaces indexed over `ℕ`,
 `Hᵢ(C ⊗ D) ≅ ⨁_{p+q=i} H_p(C) ⊗ H_q(D)`.
 
-Reindexes Chapter 7's `Problem7_8_7_iv_nonempty` along `embeddingDownNat`; see the module
-docstring for the derivation. Consumed by the Problem 8.2.8 `Tor`/`Ext` construction. -/
-theorem kunnethChainComplexNat (C D : ChainComplex (ModuleCat.{u} k) ℕ) (i : ℕ) :
-    Nonempty ((HomologicalComplex.tensorObj C D).homology i ≅
+Reindexes Chapter 7's `Etingof.Problem7_8_7_iv` along `embeddingDownNat`; see the module
+docstring for the derivation. Consumed by the Problem 8.2.8 `Tor`/`Ext` construction.
+
+## Naturality of the four steps
+
+The composite is `α₁ ≪≫ α₂ ≪≫ α₃ ≪≫ α₄`, and **every one of the four steps is natural in
+`(C, D)`**; nothing here is a non-natural choice, and no step uses `Classical.choice` to
+extract an isomorphism from a `Nonempty`. What differs is how much of that naturality is
+currently *formalized*:
+
+* `α₁`, `α₄` (the `extend` homology comparison): naturality is proved, as
+  `homology_extend_iso_hom_naturality` (a restatement of Mathlib's
+  `extendHomologyIso_hom_naturality`).
+* `α₃` (Chapter 7 Künneth): naturality is proved, as `Etingof.kunnethNatIso` — the underlying
+  map is the choice-free cross product `Etingof.kunnethMap`.
+* `α₂` (the tensor/extend compatibility `TensorExtend.tensorObjExtendIso`): natural in `(C, D)`,
+  since it is assembled degreewise from `mapBifunctorDesc` over the `ιTensorObj` injections,
+  but **the naturality square is not formalized here**. Stating it needs the bifunctor form of
+  `extend` on `ℕ`-indexed complexes, which this file does not set up. This is the one gap
+  between "natural" and "proved natural"; it is not a claim that the step is non-natural.
+
+Consequently this file exposes the isomorphism, not a natural isomorphism of bifunctors. -/
+noncomputable def kunnethChainComplexNatIso (C D : ChainComplex (ModuleCat.{u} k) ℕ) (i : ℕ) :
+    (HomologicalComplex.tensorObj C D).homology i ≅
       ∐ fun (p : {p : ℕ × ℕ // p.1 + p.2 = i}) =>
-        C.homology p.1.1 ⊗ D.homology p.1.2) := by
-  classical
+        C.homology p.1.1 ⊗ D.homology p.1.2 := by
   let e := ComplexShape.embeddingDownNat
   -- Step 1: `Hᵢ(C ⊗ D) ≅ H_{-i}(extend (C ⊗ D))`.
   let α₁ : (HomologicalComplex.tensorObj C D).homology i ≅
@@ -571,11 +612,12 @@ theorem kunnethChainComplexNat (C D : ChainComplex (ModuleCat.{u} k) ℕ) (i : �
   -- Step 2: apply `H_{-i}` to the compatibility iso `extend (C ⊗ D) ≅ extend C ⊗ extend D`.
   let φ : (HomologicalComplex.tensorObj C D).extend e ≅
       HomologicalComplex.tensorObj (C.extend e) (D.extend e) :=
-    (nonempty_tensorObj_extend_iso C D).some.symm
+    (TensorExtend.tensorObjExtendIso C D).symm
   let α₂ := (HomologicalComplex.homologyFunctor (ModuleCat.{u} k) (ComplexShape.up ℤ)
     (-(i : ℤ))).mapIso φ
-  -- Step 3: Chapter 7's universe-general Künneth at degree `-i`.
-  let α₃ := (Problem7_8_7_iv_nonempty (C.extend e) (D.extend e) (-(i : ℤ))).some
+  -- Step 3: Chapter 7's universe-general Künneth at degree `-i`, as the honest isomorphism
+  -- inverse to the natural cross product `kunnethMap`.
+  let α₃ := Problem7_8_7_iv (C.extend e) (D.extend e) (-(i : ℤ))
   -- Step 4: reindex the `ℤ`-coproduct `⨁_{a+b=-i}` onto the `ℕ`-antidiagonal `⨁_{p+q=i}`;
   -- the summands with `a > 0` or `b > 0` vanish by `homology_extend_isZero`.
   let ι : {p : ℕ × ℕ // p.1 + p.2 = i} → {p : ℤ × ℤ // p.1 + p.2 = -(i : ℤ)} :=
@@ -611,6 +653,15 @@ theorem kunnethChainComplexNat (C D : ChainComplex (ModuleCat.{u} k) ℕ) (i : �
         change (-(((-a).toNat : ℕ) : ℤ), -(((-b).toNat : ℕ) : ℤ)) = (a, b)
         rw [Prod.mk.injEq]
         exact ⟨by rw [hp]; ring, by rw [hq]; ring⟩)
-  exact ⟨α₁ ≪≫ α₂ ≪≫ α₃ ≪≫ α₄⟩
+  exact α₁ ≪≫ α₂ ≪≫ α₃ ≪≫ α₄
+
+/-- **Künneth for `ℕ`-indexed chain complexes**, `Nonempty` form. A one-line corollary of
+`kunnethChainComplexNatIso`, kept so that existing consumers phrased in terms of `Nonempty`
+keep working; new consumers should use the `Iso` directly. -/
+theorem kunnethChainComplexNat (C D : ChainComplex (ModuleCat.{u} k) ℕ) (i : ℕ) :
+    Nonempty ((HomologicalComplex.tensorObj C D).homology i ≅
+      ∐ fun (p : {p : ℕ × ℕ // p.1 + p.2 = i}) =>
+        C.homology p.1.1 ⊗ D.homology p.1.2) :=
+  ⟨kunnethChainComplexNatIso C D i⟩
 
 end Etingof

--- a/EtingofRepresentationTheory/Chapter7/KunnethChainComplexNat.lean
+++ b/EtingofRepresentationTheory/Chapter7/KunnethChainComplexNat.lean
@@ -598,6 +598,7 @@ currently *formalized*:
   but **the naturality square is not formalized here**. Stating it needs the bifunctor form of
   `extend` on `ℕ`-indexed complexes, which this file does not set up. This is the one gap
   between "natural" and "proved natural"; it is not a claim that the step is non-natural.
+  Tracked as issue #7837.
 
 Consequently this file exposes the isomorphism, not a natural isomorphism of bifunctors. -/
 noncomputable def kunnethChainComplexNatIso (C D : ChainComplex (ModuleCat.{u} k) ℕ) (i : ℕ) :

--- a/EtingofRepresentationTheory/Chapter7/KunnethCochainComplexNat.lean
+++ b/EtingofRepresentationTheory/Chapter7/KunnethCochainComplexNat.lean
@@ -5,7 +5,7 @@ import EtingofRepresentationTheory.Chapter7.KunnethChainComplexNat
 /-!
 # Künneth for `ℕ`-indexed cochain complexes via `ℕ`/`ℤ` reindexing (cochain case)
 
-Chapter 7's Künneth formula (`Etingof.Problem7_8_7_iv_nonempty`) is stated for cohomologically
+Chapter 7's Künneth formula (`Etingof.Problem7_8_7_iv`) is stated for cohomologically
 indexed `CochainComplex (ModuleCat k) ℤ`. The `Ext` construction of Problem 8.2.8, however,
 works with the Hom cochain complexes `Hom_A(P•, N)`, which are `ℕ`-indexed cochain complexes
 `CochainComplex (ModuleCat.{u} k) ℕ` (`= HomologicalComplex _ (ComplexShape.up ℕ)`). This file
@@ -54,8 +54,10 @@ constructed via `TensorExtend.tensorObjExtendIso`.
 `≅ ⨁_{p+q=i} H_p(C) ⊗ H_q(D)` (reindex `a = p`, `b = q`; the `a < 0` / `b < 0` summands are zero by
 `homology_extend_isZero_up`).
 
-The main deliverable `kunnethCochainComplexNat` is stated below (Prop-valued `Nonempty`), pinning
-the API that the Problem 8.2.8 `Ext` construction consumes.
+The main deliverable is `kunnethCochainComplexNatIso`, an actual `Iso`;
+`kunnethCochainComplexNat` is the `Nonempty` corollary kept for compatibility. Nothing in this
+file extracts an isomorphism from a `Nonempty` via `Classical.choice`. See
+`kunnethCochainComplexNatIso`'s docstring for which naturality squares are formalized.
 -/
 
 open CategoryTheory Limits MonoidalCategory HomologicalComplex
@@ -86,6 +88,19 @@ Mathlib's `extendHomologyIso` for `embeddingUpNat` (`e.f n = n`). -/
 noncomputable def homology_extend_iso_up (C : CochainComplex (ModuleCat.{u} k) ℕ) (n : ℕ) :
     (C.extend ComplexShape.embeddingUpNat).homology (n : ℤ) ≅ C.homology n :=
   C.extendHomologyIso ComplexShape.embeddingUpNat (by simp)
+
+/-- **`homology_extend_iso_up` is natural in the complex.** For `φ : C ⟶ D` the comparison
+squares of `Hⁿ(extend -) ≅ Hⁿ(-)` commute; Mathlib's `extendHomologyIso_hom_naturality` at
+`e = embeddingUpNat`. This supplies the naturality of steps 1 and 4 of
+`kunnethCochainComplexNatIso` (see that definition's docstring). -/
+@[reassoc]
+lemma homology_extend_iso_up_hom_naturality {C D : CochainComplex (ModuleCat.{u} k) ℕ} (φ : C ⟶ D)
+    (n : ℕ) :
+    homologyMap (extendMap φ ComplexShape.embeddingUpNat) (n : ℤ) ≫
+        (homology_extend_iso_up D n).hom =
+      (homology_extend_iso_up C n).hom ≫ homologyMap φ n :=
+  HomologicalComplex.extendHomologyIso_hom_naturality (φ := φ)
+    (e := ComplexShape.embeddingUpNat) (hj' := by simp)
 
 /-- Homology of `extend e C` vanishes at negative degrees `j' < 0`, which lie outside the image
 `{n : n : ℕ} = ℤ≥0` of `embeddingUpNat`. -/
@@ -479,14 +494,22 @@ theorem nonempty_tensorObj_extend_iso_up (C D : CochainComplex (ModuleCat.{u} k)
 spaces indexed over `ℕ`, the homology of the tensor product decomposes as a direct sum:
 `Hⁱ(C ⊗ D) ≅ ⨁_{p+q=i} Hᵖ(C) ⊗ Hᵍ(D)`.
 
-Reindexes Chapter 7's `Problem7_8_7_iv_nonempty` along `embeddingUpNat`; the exact mirror of
-`kunnethChainComplexNat`. Consumed by the Problem 8.2.8 `Ext` construction on the Hom cochain
-complexes `Hom_A(P•, N)`. -/
-theorem kunnethCochainComplexNat (C D : CochainComplex (ModuleCat.{u} k) ℕ) (i : ℕ) :
-    Nonempty ((HomologicalComplex.tensorObj C D).homology i ≅
+Reindexes Chapter 7's `Etingof.Problem7_8_7_iv` along `embeddingUpNat`; the exact mirror of
+`kunnethChainComplexNatIso`. Consumed by the Problem 8.2.8 `Ext` construction on the Hom cochain
+complexes `Hom_A(P•, N)`.
+
+## Naturality of the four steps
+
+As in the chain case, **all four steps are natural in `(C, D)`** and none is a non-natural
+choice: `α₁`, `α₄` by `homology_extend_iso_up_hom_naturality`, `α₃` by `Etingof.kunnethNatIso`.
+Step `α₂` (`TensorExtendUp.tensorObjExtendIso`) is natural too, but its naturality square is
+**not formalized here** — stating it needs the bifunctor form of `extend` on `ℕ`-indexed
+complexes, which this file does not set up. So this file exposes an isomorphism, not a natural
+isomorphism of bifunctors. -/
+noncomputable def kunnethCochainComplexNatIso (C D : CochainComplex (ModuleCat.{u} k) ℕ) (i : ℕ) :
+    (HomologicalComplex.tensorObj C D).homology i ≅
       ∐ fun (p : {p : ℕ × ℕ // p.1 + p.2 = i}) =>
-        C.homology p.1.1 ⊗ D.homology p.1.2) := by
-  classical
+        C.homology p.1.1 ⊗ D.homology p.1.2 := by
   let e := ComplexShape.embeddingUpNat
   -- Step 1: `Hⁱ(C ⊗ D) ≅ Hⁱ(extend (C ⊗ D))`.
   let α₁ : (HomologicalComplex.tensorObj C D).homology i ≅
@@ -495,11 +518,12 @@ theorem kunnethCochainComplexNat (C D : CochainComplex (ModuleCat.{u} k) ℕ) (i
   -- Step 2: apply `Hⁱ` to the compatibility iso `extend (C ⊗ D) ≅ extend C ⊗ extend D`.
   let φ : (HomologicalComplex.tensorObj C D).extend e ≅
       HomologicalComplex.tensorObj (C.extend e) (D.extend e) :=
-    (nonempty_tensorObj_extend_iso_up C D).some.symm
+    (TensorExtendUp.tensorObjExtendIso C D).symm
   let α₂ := (HomologicalComplex.homologyFunctor (ModuleCat.{u} k) (ComplexShape.up ℤ)
     (i : ℤ)).mapIso φ
-  -- Step 3: Chapter 7's universe-general Künneth at degree `i`.
-  let α₃ := (Problem7_8_7_iv_nonempty (C.extend e) (D.extend e) (i : ℤ)).some
+  -- Step 3: Chapter 7's universe-general Künneth at degree `i`, as the honest isomorphism
+  -- inverse to the natural cross product `kunnethMap`.
+  let α₃ := Problem7_8_7_iv (C.extend e) (D.extend e) (i : ℤ)
   -- Step 4: reindex the `ℤ`-coproduct `⨁_{a+b=i}` onto the `ℕ`-antidiagonal `⨁_{p+q=i}`;
   -- the summands with `a < 0` or `b < 0` vanish by `homology_extend_isZero_up`.
   let ι : {p : ℕ × ℕ // p.1 + p.2 = i} → {p : ℤ × ℤ // p.1 + p.2 = (i : ℤ)} :=
@@ -535,6 +559,15 @@ theorem kunnethCochainComplexNat (C D : CochainComplex (ModuleCat.{u} k) ℕ) (i
         change (((a.toNat : ℕ) : ℤ), ((b.toNat : ℕ) : ℤ)) = (a, b)
         rw [Prod.mk.injEq]
         exact ⟨hp, hq⟩)
-  exact ⟨α₁ ≪≫ α₂ ≪≫ α₃ ≪≫ α₄⟩
+  exact α₁ ≪≫ α₂ ≪≫ α₃ ≪≫ α₄
+
+/-- **Künneth for `ℕ`-indexed cochain complexes**, `Nonempty` form. A one-line corollary of
+`kunnethCochainComplexNatIso`, kept so that existing consumers phrased in terms of `Nonempty`
+keep working; new consumers should use the `Iso` directly. -/
+theorem kunnethCochainComplexNat (C D : CochainComplex (ModuleCat.{u} k) ℕ) (i : ℕ) :
+    Nonempty ((HomologicalComplex.tensorObj C D).homology i ≅
+      ∐ fun (p : {p : ℕ × ℕ // p.1 + p.2 = i}) =>
+        C.homology p.1.1 ⊗ D.homology p.1.2) :=
+  ⟨kunnethCochainComplexNatIso C D i⟩
 
 end Etingof

--- a/EtingofRepresentationTheory/Chapter7/KunnethCochainComplexNat.lean
+++ b/EtingofRepresentationTheory/Chapter7/KunnethCochainComplexNat.lean
@@ -504,8 +504,8 @@ As in the chain case, **all four steps are natural in `(C, D)`** and none is a n
 choice: `α₁`, `α₄` by `homology_extend_iso_up_hom_naturality`, `α₃` by `Etingof.kunnethNatIso`.
 Step `α₂` (`TensorExtendUp.tensorObjExtendIso`) is natural too, but its naturality square is
 **not formalized here** — stating it needs the bifunctor form of `extend` on `ℕ`-indexed
-complexes, which this file does not set up. So this file exposes an isomorphism, not a natural
-isomorphism of bifunctors. -/
+complexes, which this file does not set up (tracked as issue #7837). So this file exposes an
+isomorphism, not a natural isomorphism of bifunctors. -/
 noncomputable def kunnethCochainComplexNatIso (C D : CochainComplex (ModuleCat.{u} k) ℕ) (i : ℕ) :
     (HomologicalComplex.tensorObj C D).homology i ≅
       ∐ fun (p : {p : ℕ × ℕ // p.1 + p.2 = i}) =>

--- a/EtingofRepresentationTheory/Chapter8/ExternalTensorResolution.lean
+++ b/EtingofRepresentationTheory/Chapter8/ExternalTensorResolution.lean
@@ -40,8 +40,8 @@ identifies with the augmentation `Φ` of the `k`-tensor total complex
 
 * **positive degrees** by `homology_tensorObj_res_isZero_succ`: the `k`-tensor of the two restricted
   resolutions is exact in every degree `n + 1`, via the Chapter 7 Künneth formula
-  `kunnethChainComplexNat` (`H_{n+1}(C₁ ⊗ C₂) ≅ ⨁_{p+q=n+1} H_p(C₁) ⊗ H_q(C₂)`, every summand zero
-  since one index is positive and the restricted resolutions are acyclic in positive degrees);
+  `kunnethChainComplexNatIso` (`H_{n+1}(C₁ ⊗ C₂) ≅ ⨁_{p+q=n+1} H_p(C₁) ⊗ H_q(C₂)`, every summand
+  zero since one index is positive and the restricted resolutions are acyclic in positive degrees);
 * **degree `0`** by `quasiIsoAt_zero_of_isColimitCokernelCofork` together with
   `isColimitCokernelCofork_tensorObj_augmentation`: `Φ.f 0` is a cokernel of the total-complex
   differential `d 1 0`. Its degree-`0` component is `res₁ (P₁.π)₀ ⊗ res₂ (P₂.π)₀` (the map-level
@@ -132,7 +132,7 @@ theorem homology_mapHomologicalComplex_projective_isZero_succ
     (by simp)
 
 /-- **Positive-degree acyclicity** of the `k`-tensor of the two restricted resolutions. By the
-Chapter 7 Künneth formula `kunnethChainComplexNat`,
+Chapter 7 Künneth formula `kunnethChainComplexNatIso`,
 `H_{n+1}(C₁ ⊗ C₂) ≅ ⨁_{p+q=n+1} H_p(C₁) ⊗ H_q(C₂)`; every summand vanishes because one of `p, q`
 is positive and `homology_mapHomologicalComplex_projective_isZero_succ` makes the corresponding
 restricted-resolution homology zero, so the tensor summand is zero. This is the positive-degree
@@ -143,8 +143,8 @@ theorem homology_tensorObj_res_isZero_succ
       (res₂Complex (k := k) P₂)).homology (n + 1)) := by
   haveI : (res₁ k A₁).PreservesHomology := restrictScalars_preservesHomology _
   haveI : (res₂ k A₂).PreservesHomology := restrictScalars_preservesHomology _
-  obtain ⟨iso⟩ := kunnethChainComplexNat (res₁Complex (k := k) P₁) (res₂Complex (k := k) P₂) (n + 1)
-  refine IsZero.of_iso ?_ iso
+  refine IsZero.of_iso ?_
+    (kunnethChainComplexNatIso (res₁Complex (k := k) P₁) (res₂Complex (k := k) P₂) (n + 1))
   rw [IsZero.iff_id_eq_zero]
   apply Limits.Sigma.hom_ext
   intro a

--- a/EtingofRepresentationTheory/Chapter8/ExternalTensorResolutionLeft.lean
+++ b/EtingofRepresentationTheory/Chapter8/ExternalTensorResolutionLeft.lean
@@ -95,9 +95,8 @@ theorem homology_tensorObj_resL_isZero_succ
       (res₂ComplexL (k := k) P₂)).homology (n + 1)) := by
   haveI : (res₁L k A₁).PreservesHomology := restrictScalars_preservesHomology _
   haveI : (res₂L k A₂).PreservesHomology := restrictScalars_preservesHomology _
-  obtain ⟨iso⟩ :=
-    kunnethChainComplexNat (res₁ComplexL (k := k) P₁) (res₂ComplexL (k := k) P₂) (n + 1)
-  refine IsZero.of_iso ?_ iso
+  refine IsZero.of_iso ?_
+    (kunnethChainComplexNatIso (res₁ComplexL (k := k) P₁) (res₂ComplexL (k := k) P₂) (n + 1))
   rw [IsZero.iff_id_eq_zero]
   apply Limits.Sigma.hom_ext
   intro a

--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_8.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_8.lean
@@ -104,8 +104,39 @@ tensors.
 
 The proof is the four-step book route: a tensor of projective resolutions
 (`extTensorProjectiveResolution`), the complex-level rearrangement `rearrangeComplex`, and the
-algebraic Künneth theorem over the field `kunnethChainComplexNat`, with the factor homologies
+algebraic Künneth theorem over the field `kunnethChainComplexNatIso`, with the factor homologies
 identified as `Torₖ` through `torIsoHomologyTensorRightₖ`. -/
+noncomputable def Problem_8_2_8_torIso (i : ℕ)
+    (hN : ∀ (a₁ : A₁) (a₂ : A₂) (n₁ : N₁) (n₂ : N₂),
+      (a₁ ⊗ₜ[k] a₂ : A₁ ⊗[k] A₂) • (n₁ ⊗ₜ[k] n₂ : N₁ ⊗[k] N₂)
+        = (a₁ • n₁) ⊗ₜ[k] (a₂ • n₂)) :
+    Torₖ k (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂) (extTensorFunctorObj k A₁ A₂ M₁ M₂) i
+      ≅ ∐ fun p : {p : ℕ × ℕ // p.1 + p.2 = i} =>
+          Torₖ k A₁ N₁ M₁ p.1.1 ⊗ Torₖ k A₂ N₂ M₂ p.1.2 :=
+  -- Chosen projective resolutions of the two right modules, and of their external tensor.
+  let P₁ : ProjectiveResolution M₁ := ProjectiveResolution.of M₁
+  let P₂ : ProjectiveResolution M₂ := ProjectiveResolution.of M₂
+  let Q : ProjectiveResolution (extTensorFunctorObj k A₁ A₂ M₁ M₂) :=
+    extTensorProjectiveResolution P₁ P₂
+  -- The two `k`-linear factor complexes `Cᵢ = P•ᵢ ⊗_{Aᵢ} Nᵢ`.
+  -- Step 1: `Torᵢ` of the external tensor = `Hᵢ` of `(P•₁ ⊗_k P•₂) ⊗_{A₁⊗A₂} (N₁⊗ₖN₂)`.
+  torIsoHomologyTensorRightₖ k (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)
+      (extTensorFunctorObj k A₁ A₂ M₁ M₂) Q i ≪≫
+  -- Step 2 & 3: rearrange the complex to `(P•₁ ⊗_{A₁} N₁) ⊗_k (P•₂ ⊗_{A₂} N₂)`, then take `Hᵢ`.
+  (HomologicalComplex.homologyFunctor (ModuleCat.{u} k) (ComplexShape.down ℕ) i).mapIso
+      (rearrangeComplex k A₁ A₂ N₁ N₂ hN P₁ P₂) ≪≫
+  -- Step 4a: algebraic Künneth over the field for the tensor of the two factor complexes.
+  kunnethChainComplexNatIso
+      (((tensorRightFunctorₖ k A₁ N₁).mapHomologicalComplex (ComplexShape.down ℕ)).obj P₁.complex)
+      (((tensorRightFunctorₖ k A₂ N₂).mapHomologicalComplex (ComplexShape.down ℕ)).obj P₂.complex)
+      i ≪≫
+  -- Step 4b: identify the factor homologies as `Torⱼ^{A₁}` / `Torₘ^{A₂}`.
+  Sigma.mapIso (fun p => tensorIso
+    (torIsoHomologyTensorRightₖ k A₁ N₁ M₁ P₁ p.1.1).symm
+    (torIsoHomologyTensorRightₖ k A₂ N₂ M₂ P₂ p.1.2).symm)
+
+/-- **Problem 8.2.8, `Tor`**, `Nonempty` form: a one-line corollary of the isomorphism
+`Problem_8_2_8_torIso`, kept for consumers phrased in terms of `Nonempty`. -/
 theorem Problem_8_2_8_tor (i : ℕ)
     (hN : ∀ (a₁ : A₁) (a₂ : A₂) (n₁ : N₁) (n₂ : N₂),
       (a₁ ⊗ₜ[k] a₂ : A₁ ⊗[k] A₂) • (n₁ ⊗ₜ[k] n₂ : N₁ ⊗[k] N₂)
@@ -113,29 +144,8 @@ theorem Problem_8_2_8_tor (i : ℕ)
     Nonempty
       (Torₖ k (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂) (extTensorFunctorObj k A₁ A₂ M₁ M₂) i
         ≅ ∐ fun p : {p : ℕ × ℕ // p.1 + p.2 = i} =>
-            Torₖ k A₁ N₁ M₁ p.1.1 ⊗ Torₖ k A₂ N₂ M₂ p.1.2) := by
-  -- Chosen projective resolutions of the two right modules, and of their external tensor.
-  let P₁ : ProjectiveResolution M₁ := ProjectiveResolution.of M₁
-  let P₂ : ProjectiveResolution M₂ := ProjectiveResolution.of M₂
-  let Q : ProjectiveResolution (extTensorFunctorObj k A₁ A₂ M₁ M₂) :=
-    extTensorProjectiveResolution P₁ P₂
-  -- The two `k`-linear factor complexes `Cᵢ = P•ᵢ ⊗_{Aᵢ} Nᵢ`.
-  refine ⟨
-    -- Step 1: `Torᵢ` of the external tensor = `Hᵢ` of `(P•₁ ⊗_k P•₂) ⊗_{A₁⊗A₂} (N₁⊗ₖN₂)`.
-    torIsoHomologyTensorRightₖ k (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)
-        (extTensorFunctorObj k A₁ A₂ M₁ M₂) Q i ≪≫
-    -- Step 2 & 3: rearrange the complex to `(P•₁ ⊗_{A₁} N₁) ⊗_k (P•₂ ⊗_{A₂} N₂)`, then take `Hᵢ`.
-    (HomologicalComplex.homologyFunctor (ModuleCat.{u} k) (ComplexShape.down ℕ) i).mapIso
-        (rearrangeComplex k A₁ A₂ N₁ N₂ hN P₁ P₂) ≪≫
-    -- Step 4a: algebraic Künneth over the field for the tensor of the two factor complexes.
-    (kunnethChainComplexNat
-        (((tensorRightFunctorₖ k A₁ N₁).mapHomologicalComplex (ComplexShape.down ℕ)).obj P₁.complex)
-        (((tensorRightFunctorₖ k A₂ N₂).mapHomologicalComplex (ComplexShape.down ℕ)).obj P₂.complex)
-        i).some ≪≫
-    -- Step 4b: identify the factor homologies as `Torⱼ^{A₁}` / `Torₘ^{A₂}`.
-    Sigma.mapIso (fun p => tensorIso
-      (torIsoHomologyTensorRightₖ k A₁ N₁ M₁ P₁ p.1.1).symm
-      (torIsoHomologyTensorRightₖ k A₂ N₂ M₂ P₂ p.1.2).symm)⟩
+            Torₖ k A₁ N₁ M₁ p.1.1 ⊗ Torₖ k A₂ N₂ M₂ p.1.2) :=
+  ⟨Problem_8_2_8_torIso k A₁ A₂ M₁ M₂ N₁ N₂ i hN⟩
 
 end Tor
 
@@ -233,7 +243,7 @@ The proof is the four-step book route dualised through `Hom`:
    with `P•₁ ⊗ₖ P•₂ = extTensorProjectiveResolutionLeft P₁ P₂`;
 2. rearrange the Hom cochain complex to `Hom_{A₁}(P•₁, N₁) ⊗ₖ Hom_{A₂}(P•₂, N₂)`
    (`rearrangeHomComplex`, needs the `Pᵢ` finitely generated projective), then take `Hⁱ`;
-3. cochain Künneth over `k` (`kunnethCochainComplexNat`);
+3. cochain Künneth over `k` (`kunnethCochainComplexNatIso`);
 4. identify the factor cohomologies as `Extⱼ^{A₁}` / `Extₘ^{A₂}` (`extIsoCohomologyHomₖ` again).
 
 The finite-generation of the `Pᵢ` (an `∀ j, Module.Finite Aᵢ (Pᵢ.complex.X j)` hypothesis) is what
@@ -241,6 +251,40 @@ makes the degreewise Hom-tensor map an isomorphism; it holds for finite dimensio
 finite dimensional `Aᵢ`. This `Extₖ` isomorphism is used in the derived-category `Etingof.Ext`
 statement `Problem_8_2_8_ext` through the module-structure reconciliation and the
 `Etingof.Ext ≃ Extₖ` comparison isomorphism. -/
+noncomputable def Problem_8_2_8_extₖIso (i : ℕ)
+    (P₁ : ProjectiveResolution (ModuleCat.of A₁ M₁))
+    (P₂ : ProjectiveResolution (ModuleCat.of A₂ M₂))
+    [∀ j, Module.Finite A₁ (P₁.complex.X j)] [∀ j, Module.Projective A₁ (P₁.complex.X j)]
+    [∀ m, Module.Finite A₂ (P₂.complex.X m)] [∀ m, Module.Projective A₂ (P₂.complex.X m)]
+    [IsScalarTower k A₁ N₁] [IsScalarTower k A₂ N₂]
+    [instN : Module (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)]
+    [IsScalarTower k (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)]
+    (hN : ∀ (a₁ : A₁) (a₂ : A₂) (n₁ : N₁) (n₂ : N₂),
+      (a₁ ⊗ₜ[k] a₂ : A₁ ⊗[k] A₂) • (n₁ ⊗ₜ[k] n₂ : N₁ ⊗[k] N₂)
+        = (a₁ • n₁) ⊗ₜ[k] (a₂ • n₂)) :
+    Extₖ k (A₁ ⊗[k] A₂)
+        (extTensorFunctorLeftObj k A₁ A₂ (ModuleCat.of A₁ M₁) (ModuleCat.of A₂ M₂))
+        (ModuleCat.of (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)) i
+      ≅ ∐ fun p : {p : ℕ × ℕ // p.1 + p.2 = i} =>
+          Extₖ k A₁ (ModuleCat.of A₁ M₁) (ModuleCat.of A₁ N₁) p.1.1
+            ⊗ Extₖ k A₂ (ModuleCat.of A₂ M₂) (ModuleCat.of A₂ N₂) p.1.2 :=
+    -- Step 1: `Extⁱ` of the external tensor = `Hⁱ` of `Hom_{A₁⊗A₂}(P•₁ ⊗ₖ P•₂, N₁⊗ₖN₂)`.
+    extIsoCohomologyHomₖ k (A₁ ⊗[k] A₂) _
+        (ModuleCat.of (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)) (extTensorProjectiveResolutionLeft P₁ P₂) i ≪≫
+    -- Step 2 & 3: rearrange to `Hom_{A₁}(P•₁,N₁) ⊗ₖ Hom_{A₂}(P•₂,N₂)`, then take `Hⁱ`.
+    (HomologicalComplex.homologyFunctor (ModuleCat.{u} k) (ComplexShape.up ℕ) i).mapIso
+        (rearrangeHomComplex k N₁ N₂ hN P₁ P₂) ≪≫
+    -- Step 4a: cochain Künneth over the field for the tensor of the two Hom complexes.
+    kunnethCochainComplexNatIso
+        (P₁.complex.linearYonedaObj k (ModuleCat.of A₁ N₁))
+        (P₂.complex.linearYonedaObj k (ModuleCat.of A₂ N₂)) i ≪≫
+    -- Step 4b: identify the factor cohomologies as `Extⱼ^{A₁}` / `Extₘ^{A₂}`.
+    Sigma.mapIso (fun p => tensorIso
+      (extIsoCohomologyHomₖ k A₁ (ModuleCat.of A₁ M₁) (ModuleCat.of A₁ N₁) P₁ p.1.1).symm
+      (extIsoCohomologyHomₖ k A₂ (ModuleCat.of A₂ M₂) (ModuleCat.of A₂ N₂) P₂ p.1.2).symm)
+
+/-- **Problem 8.2.8, `Extₖ`**, `Nonempty` form: a one-line corollary of the isomorphism
+`Problem_8_2_8_extₖIso`, kept for consumers phrased in terms of `Nonempty`. -/
 theorem Problem_8_2_8_extₖ (i : ℕ)
     (P₁ : ProjectiveResolution (ModuleCat.of A₁ M₁))
     (P₂ : ProjectiveResolution (ModuleCat.of A₂ M₂))
@@ -258,22 +302,8 @@ theorem Problem_8_2_8_extₖ (i : ℕ)
           (ModuleCat.of (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)) i
         ≅ ∐ fun p : {p : ℕ × ℕ // p.1 + p.2 = i} =>
             Extₖ k A₁ (ModuleCat.of A₁ M₁) (ModuleCat.of A₁ N₁) p.1.1
-              ⊗ Extₖ k A₂ (ModuleCat.of A₂ M₂) (ModuleCat.of A₂ N₂) p.1.2) := by
-  refine ⟨
-    -- Step 1: `Extⁱ` of the external tensor = `Hⁱ` of `Hom_{A₁⊗A₂}(P•₁ ⊗ₖ P•₂, N₁⊗ₖN₂)`.
-    extIsoCohomologyHomₖ k (A₁ ⊗[k] A₂) _
-        (ModuleCat.of (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂)) (extTensorProjectiveResolutionLeft P₁ P₂) i ≪≫
-    -- Step 2 & 3: rearrange to `Hom_{A₁}(P•₁,N₁) ⊗ₖ Hom_{A₂}(P•₂,N₂)`, then take `Hⁱ`.
-    (HomologicalComplex.homologyFunctor (ModuleCat.{u} k) (ComplexShape.up ℕ) i).mapIso
-        (rearrangeHomComplex k N₁ N₂ hN P₁ P₂) ≪≫
-    -- Step 4a: cochain Künneth over the field for the tensor of the two Hom complexes.
-    (kunnethCochainComplexNat
-        (P₁.complex.linearYonedaObj k (ModuleCat.of A₁ N₁))
-        (P₂.complex.linearYonedaObj k (ModuleCat.of A₂ N₂)) i).some ≪≫
-    -- Step 4b: identify the factor cohomologies as `Extⱼ^{A₁}` / `Extₘ^{A₂}`.
-    Sigma.mapIso (fun p => tensorIso
-      (extIsoCohomologyHomₖ k A₁ (ModuleCat.of A₁ M₁) (ModuleCat.of A₁ N₁) P₁ p.1.1).symm
-      (extIsoCohomologyHomₖ k A₂ (ModuleCat.of A₂ M₂) (ModuleCat.of A₂ N₂) P₂ p.1.2).symm)⟩
+              ⊗ Extₖ k A₂ (ModuleCat.of A₂ M₂) (ModuleCat.of A₂ N₂) p.1.2) :=
+  ⟨Problem_8_2_8_extₖIso k A₁ A₂ M₁ M₂ N₁ N₂ i P₁ P₂ hN⟩
 
 -- The factor `k`-scalar towers on `Mᵢ` / `Nᵢ`: needed to form the finitely generated projective
 -- `Etingof.barResolution` and consumed by `Problem_8_2_8_extₖ`. They only attach to
@@ -368,8 +398,8 @@ theorem Problem_8_2_8_ext (i : ℕ)
   refine (extAbelianIsoExtₖ k (ModuleCat.of (A₁ ⊗[k] A₂) (N₁ ⊗[k] N₂))
       (barResolution k (A₁ ⊗[k] A₂) (M₁ ⊗[k] M₂)) i) ≪≫ₗ ?_
   rw [hXM]
-  refine (Problem_8_2_8_extₖ k A₁ A₂ M₁ M₂ N₁ N₂ i
-      (barResolution k A₁ M₁) (barResolution k A₂ M₂) hN).some.toLinearEquiv ≪≫ₗ ?_
+  refine (Problem_8_2_8_extₖIso k A₁ A₂ M₁ M₂ N₁ N₂ i
+      (barResolution k A₁ M₁) (barResolution k A₂ M₂) hN).toLinearEquiv ≪≫ₗ ?_
   refine (ModuleCat.coprodIsoDirectSum _).toLinearEquiv ≪≫ₗ ?_
   exact DirectSum.congrLinearEquiv (fun p => TensorProduct.congr
     (extAbelianIsoExtₖ k (ModuleCat.of A₁ N₁) (barResolution k A₁ M₁) p.1.1).symm

--- a/progress/2026-07-25T23-05-00Z_a1aed91c.md
+++ b/progress/2026-07-25T23-05-00Z_a1aed91c.md
@@ -1,0 +1,84 @@
+## Accomplished
+
+Issue #7831 (parent #7397): migrated the ℕ-reindexed Künneth statements and their Chapter 8
+consumers off `Nonempty`-plus-`Classical.choice` and onto honest isomorphisms.
+
+**Session start: a fourth `.claude/`-clobbering worktree.** `git status` listed the same five
+files as the three cases recorded on 2026-07-25 — `.claude/commands/{feature,review,summarize,
+work}.md` and `.claude/skills/agent-worker-flow/SKILL.md` — as pure deletions, 364 lines against
+`HEAD` with 2 "insertions" that were just older wordings of surviving lines. `SKILL.md` alone was
+`1 222` in `--numstat`, i.e. 318 lines against `HEAD`'s 539, so the guidance this session loaded
+was itself the truncated copy.
+Restored with `git checkout HEAD -- .claude/`, **re-invoked** the skill (not just `Read`), and
+restarted from Step 1. The Step 2 check added in `ee2d9cc4` is what caught this, and the
+re-invocation mattered: the stale copy predated the Step 7 rules on replacing `create-pr`'s
+placeholder body and on never running `gh pr merge --auto` by hand.
+
+**Chapter 7.** Both `.some` extractions are gone from each of `KunnethChainComplexNat.lean` and
+`KunnethCochainComplexNat.lean`. They were choosing from `Nonempty`s whose witnesses were already
+constructed: `TensorExtend.tensorObjExtendIso` and, since #7834, the honest `Problem7_8_7_iv` of
+`KunnethIso.lean`. Using those directly turns each proof into a `noncomputable def` —
+`kunnethChainComplexNatIso`, `kunnethCochainComplexNatIso` — with the old `Nonempty` theorems kept
+as one-line corollaries. The `classical` tactic each proof opened with was unnecessary
+(`sigmaSupportHom` already carries its own `open Classical in`) and was dropped.
+
+**Naturality audit (deliverable 2).** All four steps of each composite are natural; none is a
+non-natural choice. Three now have formalized naturality squares: steps 1 and 4 via new
+`homology_extend_iso_hom_naturality` / `homology_extend_iso_up_hom_naturality` (thin wrappers on
+Mathlib's `HomologicalComplex.extendHomologyIso_hom_naturality`), and step 3 via `kunnethNatIso`.
+Step 2, the tensor/extend comparison `TensorExtend.tensorObjExtendIso`, is natural but its square
+is not formalized: stating it needs the bifunctor form of `extend` on ℕ-indexed complexes, which
+neither file sets up. Both docstrings say exactly that, and say it is *not* a claim of
+non-naturality. Filed as #7837.
+
+**Chapter 8.** `ExternalTensorResolution` and `ExternalTensorResolutionLeft` take the `Iso`
+directly instead of `obtain ⟨iso⟩`. In `Problem8_2_8.lean` the two remaining Künneth `.some`s
+needed slightly more: `Problem_8_2_8_extₖ` and `Problem_8_2_8_tor` were already choice-free
+composites of isomorphisms hidden behind `refine ⟨…⟩`, so they became
+`Problem_8_2_8_extₖIso` / `Problem_8_2_8_torIso` with `Nonempty` corollaries, and
+`Problem_8_2_8_ext` consumes the `Iso`. `RearrangeHomComplexX.lean` and `TensorRightFunctorK.lean`
+are named in the issue but contain no `Nonempty` destructuring; they needed no change.
+
+**items.json.** `Chapter7/Problem7.8.7` moves `covered_partial` → `covered_full`: the book asks
+for a *natural* isomorphism in part (iv) and `kunnethNatIso` supplies it, which is what the old
+note said was missing. `fidelity_issue: 7397` dropped (that issue is closed). The note records
+that the ℕ-reindexed variants are deliberately claimed objectwise only, so they are not reported
+as stronger than what is proved. `validate_items.py` passes; the diff is 4 lines.
+
+Verification: full `lake build` clean (9303 jobs); no new `sorry` (all five touched files have
+zero); `#print axioms` on `kunnethChainComplexNatIso`, `kunnethCochainComplexNatIso`, both
+naturality lemmas, `Problem_8_2_8_torIso`, `Problem_8_2_8_extₖIso`, `Problem_8_2_8_tor` and
+`Problem_8_2_8_ext` shows `[propext, Classical.choice, Quot.sound]` and no `sorryAx`.
+`Classical.choice` remains only as Mathlib's ambient noncomputability (`Sigma.desc`,
+`ProjectiveResolution.of`), not as a `.some` on a `Nonempty` isomorphism — the issue's stated
+criterion.
+
+## Current frontier
+
+Branch `agent/a1aed91c` at two commits on top of `770558b9`. All four deliverables of #7831 are
+complete. The one thing #7831 gestured at but did not get is a bifunctor-level `NatIso` for the
+ℕ-reindexed Künneth; that was never in its deliverables and is now #7837.
+
+## Overall project progress
+
+Chapter 7's Künneth story is now honest end to end: `kunnethMap` (choice-free cross product) →
+`kunnethIso`/`kunnethNatIso` (#7834) → `kunnethChainComplexNatIso`/`kunnethCochainComplexNatIso`
+(this PR) → the Chapter 8 `Tor`/`Ext` external-tensor statements. Problem 7.8.7 is fully covered.
+
+## Next step
+
+#7837 (naturality of `tensorObjExtendIso`, then the ℕ-reindexed `NatIso`) is the direct
+continuation and is self-contained; the chain and cochain cases are independent and identically
+shaped, so it decomposes cleanly if it proves large. Otherwise the unclaimed queue is unchanged
+and FIFO from #7399.
+
+## Blockers
+
+None.
+
+## Note for whoever hits the stale-worktree trap next
+
+Four occurrences in one day (169, 279, 320, 364 lines). The Step 2 check works, but only for an
+agent whose copy of Step 2 survived — this session's had not, and it was the duplicated check in
+`.claude/commands/work.md` (added in `ee2d9cc4`) that fired. That duplication is load-bearing;
+please do not consolidate it back into the skill.

--- a/progress/items.json
+++ b/progress/items.json
@@ -8728,10 +8728,10 @@
     "start_line": 23,
     "end_line": 18,
     "status": "sorry_free",
-    "coverage": "covered_partial",
-    "coverage_note": "Parts (i)–(iii) are proved. Part (iv) now gives Nonempty of an objectwise Künneth isomorphism, but the source explicitly requires a natural isomorphism; no NatIso or naturality in C and D is exposed (follow-up #7397).",
-    "fidelity_issue": 7397,
-    "last_updated": "2026-07-22"
+    "sorry_free": true,
+    "coverage": "covered_full",
+    "coverage_note": "Parts (i)–(iv) are proved. Part (iv) now meets the source's demand for a *natural* isomorphism: Etingof.kunnethNatIso (Chapter7/KunnethIso.lean) is a natural isomorphism of bifunctors (C,D) ↦ ∐_{j+m=i} Hʲ(C) ⊗ Hᵐ(D) ≅ (C,D) ↦ Hⁱ(C ⊗ D), with Etingof.kunnethIso its objectwise form; the underlying map is the choice-free cross product Etingof.kunnethMap. Problem7_8_7_iv_nonempty is retained only as a compatibility corollary. The ℕ-reindexed variants kunnethChainComplexNatIso / kunnethCochainComplexNatIso are objectwise isomorphisms only: three of their four steps have formalized naturality squares, but the tensor/extend comparison TensorExtend.tensorObjExtendIso is natural without its naturality being formalized, so they are deliberately not claimed as natural isomorphisms.",
+    "last_updated": "2026-07-25"
   },
   {
     "id": "Chapter7/Introduction_7.9",


### PR DESCRIPTION
This PR migrates the ℕ-reindexed Künneth statements and their Chapter 8 consumers off
`Nonempty` and onto honest isomorphisms. Both `.some` extractions in
`KunnethChainComplexNat.lean` and `KunnethCochainComplexNat.lean` were choosing from
`Nonempty`s whose witnesses were already constructed — `TensorExtend.tensorObjExtendIso`, and
(since #7834) the honest `Problem7_8_7_iv` of `KunnethIso.lean` — so using those directly turns
each proof into a `noncomputable def`: `kunnethChainComplexNatIso` and
`kunnethCochainComplexNatIso`, with the old `Nonempty` theorems kept as one-line corollaries.
The `classical` each proof opened with was unnecessary and is dropped.

All four steps of each composite are natural in `(C, D)`; none is a non-natural choice. Three
now have formalized naturality squares: steps 1 and 4 via the new
`homology_extend_iso_hom_naturality` / `homology_extend_iso_up_hom_naturality` (thin wrappers on
Mathlib's `HomologicalComplex.extendHomologyIso_hom_naturality`), and step 3 via `kunnethNatIso`.
Step 2, the tensor/extend comparison, is natural but its square is not formalized — stating it
needs the bifunctor form of `extend` on ℕ-indexed complexes, which neither file sets up. Both
docstrings say exactly that, and say explicitly that it is not a claim of non-naturality; it is
filed as #7837.

On the Chapter 8 side, `ExternalTensorResolution` and `ExternalTensorResolutionLeft` take the
`Iso` directly instead of `obtain ⟨iso⟩`. The two remaining Künneth `.some`s in `Problem8_2_8`
needed slightly more than the issue anticipated: `Problem_8_2_8_extₖ` and `Problem_8_2_8_tor`
were already choice-free composites of isomorphisms hidden behind `refine ⟨…⟩`, so they become
`Problem_8_2_8_extₖIso` / `Problem_8_2_8_torIso` with `Nonempty` corollaries, and
`Problem_8_2_8_ext` consumes the `Iso`. `RearrangeHomComplexX.lean` and `TensorRightFunctorK.lean`
are named in the issue but contain no `Nonempty` destructuring and needed no change.

`progress/items.json` moves `Chapter7/Problem7.8.7` from `covered_partial` to `covered_full`:
the book asks for a *natural* isomorphism in part (iv), and `kunnethNatIso` is exactly what the
old `coverage_note` recorded as missing. The note now also states that the ℕ-reindexed variants
are deliberately claimed objectwise only, so they are not reported as stronger than what is
proved; `fidelity_issue: 7397` is dropped, that issue being closed.

Full `lake build` is clean (9303 jobs) and no touched file contains a `sorry`. `#print axioms`
on `kunnethChainComplexNatIso`, `kunnethCochainComplexNatIso`, both naturality lemmas,
`Problem_8_2_8_torIso`, `Problem_8_2_8_extₖIso`, `Problem_8_2_8_tor` and `Problem_8_2_8_ext`
gives `[propext, Classical.choice, Quot.sound]` with no `sorryAx`; the residual `Classical.choice`
is Mathlib's ambient noncomputability (`Sigma.desc`, `ProjectiveResolution.of`), not a `.some` on
a `Nonempty` isomorphism, which is the issue's stated criterion.

Closes #7831

Session: \`a1aed91c-29cf-4980-9978-4e79a8a59f18\`

🤖 Prepared with Claude Code