### PR TITLE
docs: record the fourth stale-worktree case and pin the duplicated Step 2 check

### DIFF
--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -176,11 +176,18 @@ that are pure *deletions* against `main` in files you were not asked to touch,
 especially under `.claude/`. A crashed session can leave an accidental revert of
 accumulated workflow guidance, which is easy to commit without noticing and hard to
 spot in review. Restore those (`git checkout HEAD -- <paths>`) rather than carrying
-them. (2026-07-25: three times, worktrees arrived with 169, 279 and 320 lines of
-`.claude/` guidance deleted and nothing added. In the third case the session-start
-`git status` listed all five modified files right in the agent's context and it
-committed them anyway, because its own stale copy of this skill lacked this check —
-see the publish-time backstop in Step 7.)
+them. (2026-07-25: four times, worktrees arrived with 169, 279, 320 and 364 lines of
+`.claude/` guidance deleted and nothing added — always the same five files. In the third
+case the session-start `git status` listed all five modified files right in the agent's
+context and it committed them anyway, because its own stale copy of this skill lacked this
+check — see the publish-time backstop in Step 7. The fourth session caught it, but only
+because the duplicate of this check in `.claude/commands/{work,feature}.md` reached it when
+this file could not. **Keep that duplication.** A check that lives only inside the file that
+goes stale cannot fire in the case it exists for.)
+
+A tell for staleness rather than real work: `git diff --numstat` showing near-pure
+deletions, where the handful of "insertions" turn out to be older wordings of lines that
+still exist. Real work adds something.
 
 **If the restored files include this skill or your `/command` file, re-read them.**
 Skills load from the working tree, so a truncated `SKILL.md` means the guidance you
@@ -200,7 +207,9 @@ restart the workflow from Step 1. Guidance added since the stale revision is exa
 guidance you are most likely to need — e.g. the Step 7 rules on replacing `create-pr`'s
 placeholder PR body and on never running `gh pr merge --auto` yourself.
 (2026-07-25: a third worktree that day arrived 193 lines stale; the session ran to
-completion on the old copy and shipped a placeholder PR body.)
+completion on the old copy and shipped a placeholder PR body. A fourth arrived at 318
+lines against 539; that session re-invoked the skill and restarted from Step 1, which is
+the only reason it saw these two rules at all.)
 
 **If you branched off an unmerged PR's head** (see "Dependency code that lives
 only in an unmerged PR" above), decide at publish time:


### PR DESCRIPTION
This PR records a fourth stale-worktree occurrence in the `agent-worker-flow` Step 2 tally and
marks the duplicated check as load-bearing. A worktree on 2026-07-25 arrived with the same five
`.claude/` files truncated (364 lines deleted, 0 added). Its own copy of `SKILL.md` was the stale
one, 318 lines against `main`'s 539, so the Step 2 stale-worktree check could not reach that
session through the skill; the duplicate added to `.claude/commands/work.md` in `ee2d9cc4` is what
fired. The tally now says so explicitly, so a future cleanup pass does not consolidate the
duplication back into the file that goes stale.

Also adds the `--numstat` tell that distinguishes the two cases an agent must tell apart at
session start: near-pure deletions whose handful of "insertions" turn out to be older wordings of
lines that still exist mean staleness, whereas genuine in-progress work from a crashed session
adds something.

Docs only; no Lean code is touched.

🤖 Prepared with Claude Code