### PR TITLE
feat(Ch7 #7837): formalize naturality of the tensor/extend comparison

### DIFF
--- a/EtingofRepresentationTheory/Chapter7/KunnethChainComplexNat.lean
+++ b/EtingofRepresentationTheory/Chapter7/KunnethChainComplexNat.lean
@@ -40,6 +40,11 @@ matching the `ιTensorObj` injections and the Koszul-signed total differential (
 summands). This is `nonempty_tensorObj_extend_iso` below, constructed via
 `TensorExtend.tensorObjExtendIso` (milestones (a)–(c)).
 
+The comparison is moreover natural in `(C, D)` (milestone (d)):
+`TensorExtend.tensorObjExtendIso_hom_naturality` states the joint naturality square, and
+`TensorExtend.tensorObjExtendNatIso` packages the whole comparison as an isomorphism of the
+bifunctors `(C, D) ↦ extend C ⊗ extend D` and `(C, D) ↦ extend (C ⊗ D)`.
+
 Note `extend C ⊗ extend D` is itself supported on `ℤ≤0`, i.e. on the image of the embedding, so
 this iso can equivalently be read as "the `ℤ`-tensor of the extends is the extension of the
 `ℕ`-tensor".
@@ -474,6 +479,179 @@ noncomputable def tensorObjExtendIso :
       congr 1
       rw [← tensorExtendXIso_hom_extendXIso C D n, Category.assoc, Iso.hom_inv_id,
         Category.comp_id])
+
+/-!
+## Milestone (d): naturality of the comparison
+
+`tensorObjExtendIso` is natural in `(C, D)`. Degreewise it is a `mapBifunctorDesc` over the
+`ιTensorObj` injections, and both those injections (`ι_mapBifunctorMap`) and the `extendXIso`
+transports (`extendMap_f`) are natural, so the comparison intertwines
+`tensorHom (extendMap f) (extendMap g)` with `extendMap (tensorHom f g)`.
+
+`fwdNeg_naturality` is the degreewise square, `tensorObjExtendIso_hom_naturality` the
+complex-level one (with `_left`/`_right` giving the one-variable specialisations), and
+`tensorObjExtendNatIso` packages the comparison as an isomorphism of the two bifunctors
+`(C, D) ↦ extend C ⊗ extend D` and `(C, D) ↦ extend (C ⊗ D)`.
+-/
+
+section Naturality
+
+variable {C₁ C₂ D₁ D₂ : ChainComplex (ModuleCat.{u} k) ℕ}
+
+/-- **Naturality of the degree `-n` forward map.** The coproduct forward maps `fwdNeg` intertwine
+`tensorHom (extendMap f) (extendMap g)` with `tensorHom f g`. Proved summand-by-summand: the
+summands outside the image of the embedding have zero source, and on an `(a, b) = (-p, -q)`
+summand both sides reduce to
+`((extendXIso C₁).hom ≫ f.f p) ⊗ₘ ((extendXIso D₁).hom ≫ g.f q)` followed by the `ℕ`-side
+injection `ιN C₂ D₂ p q n`. -/
+lemma fwdNeg_naturality (f : C₁ ⟶ C₂) (g : D₁ ⟶ D₂) (n : ℕ) :
+    (HomologicalComplex.tensorHom (HomologicalComplex.extendMap f e)
+          (HomologicalComplex.extendMap g e)).f (-(n : ℤ)) ≫ fwdNeg C₂ D₂ n =
+      fwdNeg C₁ D₁ n ≫ (HomologicalComplex.tensorHom f g).f n := by
+  apply HomologicalComplex.mapBifunctor.hom_ext
+  intro a b hab
+  rcases ha : e.r a with _ | p
+  · exact (isZero_tensorObj_left (C₁.isZero_extend_X' e a ha)).eq_of_src _ _
+  rcases hb : e.r b with _ | q
+  · exact (isZero_tensorObj_right (D₁.isZero_extend_X' e b hb)).eq_of_src _ _
+  obtain rfl : a = -(p : ℤ) := by have := e.f_eq_of_r_eq_some ha; simpa using this.symm
+  obtain rfl : b = -(q : ℤ) := by have := e.f_eq_of_r_eq_some hb; simpa using this.symm
+  have hab' : (-(p : ℤ)) + (-(q : ℤ)) = -(n : ℤ) := hab
+  have hpq : (ComplexShape.down ℕ).π (ComplexShape.down ℕ) (ComplexShape.down ℕ) (p, q) = n := by
+    have : p + q = n := by omega
+    simpa using this
+  rw [show HomologicalComplex.ιMapBifunctor (C₁.extend e) (D₁.extend e)
+        (curriedTensor (ModuleCat.{u} k)) (ComplexShape.up ℤ)
+        (-(p : ℤ)) (-(q : ℤ)) (-(n : ℤ)) hab = ιZ C₁ D₁ _ _ _ hab from rfl]
+  rw [HomologicalComplex.ι_mapBifunctorMap_assoc, ιZ_fwdNeg,
+    phiFwd_some C₂ D₂ n _ (r_negNat p) (r_negNat q) hpq,
+    ← Category.assoc (ιZ C₁ D₁ _ _ _ hab), ιZ_fwdNeg,
+    phiFwd_some C₁ D₁ n _ (r_negNat p) (r_negNat q) hpq,
+    Category.assoc, HomologicalComplex.ι_mapBifunctorMap,
+    HomologicalComplex.extendMap_f f e (ef_eq_neg p),
+    HomologicalComplex.extendMap_f g e (ef_eq_neg q)]
+  simp only [curriedTensor_map_app, curriedTensor_obj_map, Functor.map_comp, NatTrans.comp_app,
+    Category.assoc, ← MonoidalCategory.tensorHom_id, ← MonoidalCategory.id_tensorHom,
+    MonoidalCategory.tensorHom_comp_tensorHom_assoc, Category.comp_id, Category.id_comp,
+    Iso.inv_hom_id]
+
+-- The reassociated form of `tensorExtendXIso_hom_extendXIso`, used to strip the extend
+-- transport off the middle of a composite in `tensorObjExtendIso_hom_naturality`.
+attribute [reassoc] tensorExtendXIso_hom_extendXIso
+
+/-- **Milestone (d): naturality of the complex isomorphism.** The tensor/extend comparison
+`extend C ⊗ extend D ≅ extend (C ⊗ D)` commutes with the maps induced by arbitrary chain maps
+`f : C₁ ⟶ C₂` and `g : D₁ ⟶ D₂`. Degreewise this is `fwdNeg_naturality`; the degrees outside the
+image of the embedding are handled by vanishing of the target. -/
+theorem tensorObjExtendIso_hom_naturality (f : C₁ ⟶ C₂) (g : D₁ ⟶ D₂) :
+    HomologicalComplex.tensorHom (HomologicalComplex.extendMap f e)
+          (HomologicalComplex.extendMap g e) ≫ (tensorObjExtendIso C₂ D₂).hom =
+      (tensorObjExtendIso C₁ D₁).hom ≫
+        HomologicalComplex.extendMap (HomologicalComplex.tensorHom f g) e := by
+  ext j' : 1
+  by_cases hj : 0 < j'
+  · exact (HomologicalComplex.isZero_extend_X (HomologicalComplex.tensorObj C₂ D₂) e j'
+      (fun m => by simp only [ComplexShape.embeddingDownNat_f]; omega)).eq_of_tgt _ _
+  · rw [not_lt] at hj
+    obtain ⟨n, rfl⟩ : ∃ n : ℕ, j' = -(n : ℤ) := ⟨(-j').toNat, by omega⟩
+    rw [← cancel_mono (HomologicalComplex.extendXIso
+      (HomologicalComplex.tensorObj C₂ D₂) e (ef_eq_neg n)).hom,
+      HomologicalComplex.comp_f, HomologicalComplex.comp_f, Category.assoc, Category.assoc,
+      show (tensorObjExtendIso C₂ D₂).hom.f (-(n : ℤ)) = (tensorExtendXIso C₂ D₂ (-(n : ℤ))).hom
+        from rfl,
+      show (tensorObjExtendIso C₁ D₁).hom.f (-(n : ℤ)) = (tensorExtendXIso C₁ D₁ (-(n : ℤ))).hom
+        from rfl,
+      tensorExtendXIso_hom_extendXIso,
+      HomologicalComplex.extendMap_f (HomologicalComplex.tensorHom f g) e (ef_eq_neg n),
+      Category.assoc, Category.assoc, Iso.inv_hom_id, Category.comp_id,
+      tensorExtendXIso_hom_extendXIso_assoc]
+    exact fwdNeg_naturality f g n
+
+/-- Naturality in the first argument. -/
+theorem tensorObjExtendIso_hom_naturality_left (f : C₁ ⟶ C₂)
+    (D : ChainComplex (ModuleCat.{u} k) ℕ) :
+    HomologicalComplex.tensorHom (HomologicalComplex.extendMap f e) (𝟙 (D.extend e)) ≫
+        (tensorObjExtendIso C₂ D).hom =
+      (tensorObjExtendIso C₁ D).hom ≫
+        HomologicalComplex.extendMap (HomologicalComplex.tensorHom f (𝟙 D)) e := by
+  simpa using tensorObjExtendIso_hom_naturality f (𝟙 D)
+
+/-- Naturality in the second argument. -/
+theorem tensorObjExtendIso_hom_naturality_right (C : ChainComplex (ModuleCat.{u} k) ℕ)
+    (g : D₁ ⟶ D₂) :
+    HomologicalComplex.tensorHom (𝟙 (C.extend e)) (HomologicalComplex.extendMap g e) ≫
+        (tensorObjExtendIso C D₂).hom =
+      (tensorObjExtendIso C D₁).hom ≫
+        HomologicalComplex.extendMap (HomologicalComplex.tensorHom (𝟙 C) g) e := by
+  simpa using tensorObjExtendIso_hom_naturality (𝟙 C) g
+
+end Naturality
+
+section Bifunctor
+
+/-- The tensor bifunctor on `ℤ`-cochain complexes, as `map₂HomologicalComplex`. Its object map is
+`HomologicalComplex.tensorObj` and its morphism maps are `HomologicalComplex.tensorHom`. -/
+noncomputable abbrev tensorBifunctorZ :
+    CochainComplex (ModuleCat.{u} k) ℤ ⥤ CochainComplex (ModuleCat.{u} k) ℤ ⥤
+      CochainComplex (ModuleCat.{u} k) ℤ :=
+  (curriedTensor (ModuleCat.{u} k)).map₂HomologicalComplex
+    (ComplexShape.up ℤ) (ComplexShape.up ℤ) (ComplexShape.up ℤ)
+
+/-- The tensor bifunctor on `ℕ`-chain complexes. -/
+noncomputable abbrev tensorBifunctorN :
+    ChainComplex (ModuleCat.{u} k) ℕ ⥤ ChainComplex (ModuleCat.{u} k) ℕ ⥤
+      ChainComplex (ModuleCat.{u} k) ℕ :=
+  (curriedTensor (ModuleCat.{u} k)).map₂HomologicalComplex
+    (ComplexShape.down ℕ) (ComplexShape.down ℕ) (ComplexShape.down ℕ)
+
+/-- `extend` along `embeddingDownNat` as a functor `ChainComplex ℕ ⥤ CochainComplex ℤ`. -/
+noncomputable abbrev extFunctor :
+    ChainComplex (ModuleCat.{u} k) ℕ ⥤ CochainComplex (ModuleCat.{u} k) ℤ :=
+  e.extendFunctor (ModuleCat.{u} k)
+
+/-- The bifunctor `(C, D) ↦ extend C ⊗ extend D`. -/
+noncomputable abbrev tensorExtendSrc :
+    ChainComplex (ModuleCat.{u} k) ℕ ⥤ ChainComplex (ModuleCat.{u} k) ℕ ⥤
+      CochainComplex (ModuleCat.{u} k) ℤ :=
+  (extFunctor ⋙ tensorBifunctorZ) ⋙
+    (CategoryTheory.Functor.whiskeringLeft (ChainComplex (ModuleCat.{u} k) ℕ)
+      (CochainComplex (ModuleCat.{u} k) ℤ)
+      (CochainComplex (ModuleCat.{u} k) ℤ)).obj extFunctor
+
+/-- The bifunctor `(C, D) ↦ extend (C ⊗ D)`. -/
+noncomputable abbrev tensorExtendTgt :
+    ChainComplex (ModuleCat.{u} k) ℕ ⥤ ChainComplex (ModuleCat.{u} k) ℕ ⥤
+      CochainComplex (ModuleCat.{u} k) ℤ :=
+  tensorBifunctorN ⋙
+    (CategoryTheory.Functor.whiskeringRight (ChainComplex (ModuleCat.{u} k) ℕ)
+      (ChainComplex (ModuleCat.{u} k) ℕ)
+      (CochainComplex (ModuleCat.{u} k) ℤ)).obj extFunctor
+
+/-- **The tensor/extend comparison as an isomorphism of bifunctors.** Assembles
+`tensorObjExtendIso` over all `(C, D)` into a `NatIso` between `tensorExtendSrc` and
+`tensorExtendTgt`; the objectwise isos are recovered as `(tensorObjExtendNatIso.app C).app D`.
+Both naturality squares are `tensorObjExtendIso_hom_naturality` with one argument an identity. -/
+noncomputable def tensorObjExtendNatIso :
+    tensorExtendSrc (k := k) ≅ tensorExtendTgt (k := k) :=
+  NatIso.ofComponents
+    (fun C => NatIso.ofComponents (fun D => tensorObjExtendIso C D) (fun {D₁ D₂} g => by
+      have h := tensorObjExtendIso_hom_naturality (𝟙 C) g
+      rw [HomologicalComplex.extendMap_id] at h
+      exact h))
+    (fun {C₁ C₂} f => by
+      ext D : 2
+      simp only [NatTrans.comp_app]
+      have h := tensorObjExtendIso_hom_naturality f (𝟙 D)
+      rw [HomologicalComplex.extendMap_id] at h
+      exact h)
+
+/-- The objectwise components of `tensorObjExtendNatIso` are the original `tensorObjExtendIso`. -/
+@[simp]
+lemma tensorObjExtendNatIso_app_app (C D : ChainComplex (ModuleCat.{u} k) ℕ) :
+    (tensorObjExtendNatIso.app C).app D = tensorObjExtendIso C D :=
+  rfl
+
+end Bifunctor
 
 end TensorExtend
 

--- a/EtingofRepresentationTheory/Chapter7/KunnethCochainComplexNat.lean
+++ b/EtingofRepresentationTheory/Chapter7/KunnethCochainComplexNat.lean
@@ -47,6 +47,11 @@ non-mechanical step is the sign match, here `negOnePow_natCast` (`Int.negOnePow 
 simpler than the chain case (no `negOnePow_neg`). This is `nonempty_tensorObj_extend_iso` below,
 constructed via `TensorExtend.tensorObjExtendIso`.
 
+The comparison is moreover natural in `(C, D)`:
+`TensorExtendUp.tensorObjExtendIso_hom_naturality` states the joint naturality square, and
+`TensorExtendUp.tensorObjExtendNatIso` packages the whole comparison as an isomorphism of the
+bifunctors `(C, D) ↦ extend C ⊗ extend D` and `(C, D) ↦ extend (C ⊗ D)`.
+
 ## The resulting isomorphism
 
 `Hᵢ(C ⊗ D)` (`ℕ`) `≅ Hᵢ(extend (C ⊗ D))` `≅ Hᵢ(extend C ⊗ extend D)` (compatibility)
@@ -459,6 +464,168 @@ noncomputable def tensorObjExtendIso :
       congr 1
       rw [← tensorExtendXIso_hom_extendXIso C D (n + 1), Category.assoc, Iso.hom_inv_id,
         Category.comp_id])
+
+/-!
+## Naturality of the comparison
+
+The cochain mirror of `TensorExtend`'s milestone (d). `tensorObjExtendIso` is natural in
+`(C, D)`: degreewise it is a `mapBifunctorDesc` over the `ιTensorObj` injections, and both those
+injections (`ι_mapBifunctorMap`) and the `extendXIso` transports (`extendMap_f`) are natural.
+
+`fwdNat_naturality` is the degreewise square, `tensorObjExtendIso_hom_naturality` the
+complex-level one (with `_left`/`_right` giving the one-variable specialisations), and
+`tensorObjExtendNatIso` packages the comparison as an isomorphism of the two bifunctors
+`(C, D) ↦ extend C ⊗ extend D` and `(C, D) ↦ extend (C ⊗ D)`.
+-/
+
+section Naturality
+
+variable {C₁ C₂ D₁ D₂ : CochainComplex (ModuleCat.{u} k) ℕ}
+
+/-- **Naturality of the degree `n` forward map.** The coproduct forward maps `fwdNat` intertwine
+`tensorHom (extendMap f) (extendMap g)` with `tensorHom f g`. Proved summand-by-summand: the
+summands outside the image of the embedding have zero source, and on an `(a, b) = (p, q)` summand
+both sides reduce to `((extendXIso C₁).hom ≫ f.f p) ⊗ₘ ((extendXIso D₁).hom ≫ g.f q)` followed by
+the `ℕ`-side injection `ιN C₂ D₂ p q n`. -/
+lemma fwdNat_naturality (f : C₁ ⟶ C₂) (g : D₁ ⟶ D₂) (n : ℕ) :
+    (HomologicalComplex.tensorHom (HomologicalComplex.extendMap f e)
+          (HomologicalComplex.extendMap g e)).f (n : ℤ) ≫ fwdNat C₂ D₂ n =
+      fwdNat C₁ D₁ n ≫ (HomologicalComplex.tensorHom f g).f n := by
+  apply HomologicalComplex.mapBifunctor.hom_ext
+  intro a b hab
+  rcases ha : e.r a with _ | p
+  · exact (isZero_tensorObj_left (C₁.isZero_extend_X' e a ha)).eq_of_src _ _
+  rcases hb : e.r b with _ | q
+  · exact (isZero_tensorObj_right (D₁.isZero_extend_X' e b hb)).eq_of_src _ _
+  obtain rfl : a = (p : ℤ) := by have := e.f_eq_of_r_eq_some ha; simpa using this.symm
+  obtain rfl : b = (q : ℤ) := by have := e.f_eq_of_r_eq_some hb; simpa using this.symm
+  have hab' : (p : ℤ) + (q : ℤ) = (n : ℤ) := hab
+  have hpq : (ComplexShape.up ℕ).π (ComplexShape.up ℕ) (ComplexShape.up ℕ) (p, q) = n := by
+    have : p + q = n := by omega
+    simpa using this
+  rw [show HomologicalComplex.ιMapBifunctor (C₁.extend e) (D₁.extend e)
+        (curriedTensor (ModuleCat.{u} k)) (ComplexShape.up ℤ)
+        (p : ℤ) (q : ℤ) (n : ℤ) hab = ιZ C₁ D₁ _ _ _ hab from rfl]
+  rw [HomologicalComplex.ι_mapBifunctorMap_assoc, ιZ_fwdNat,
+    phiFwd_some C₂ D₂ n _ (r_nat p) (r_nat q) hpq,
+    ← Category.assoc (ιZ C₁ D₁ _ _ _ hab), ιZ_fwdNat,
+    phiFwd_some C₁ D₁ n _ (r_nat p) (r_nat q) hpq,
+    Category.assoc, HomologicalComplex.ι_mapBifunctorMap,
+    HomologicalComplex.extendMap_f f e (ef_eq p),
+    HomologicalComplex.extendMap_f g e (ef_eq q)]
+  simp only [curriedTensor_map_app, curriedTensor_obj_map, Functor.map_comp, NatTrans.comp_app,
+    Category.assoc, ← MonoidalCategory.tensorHom_id, ← MonoidalCategory.id_tensorHom,
+    MonoidalCategory.tensorHom_comp_tensorHom_assoc, Category.comp_id, Category.id_comp,
+    Iso.inv_hom_id]
+
+-- The reassociated form of `tensorExtendXIso_hom_extendXIso`, used to strip the extend
+-- transport off the middle of a composite in `tensorObjExtendIso_hom_naturality`.
+attribute [reassoc] tensorExtendXIso_hom_extendXIso
+
+/-- **Naturality of the complex isomorphism.** The tensor/extend comparison
+`extend C ⊗ extend D ≅ extend (C ⊗ D)` commutes with the maps induced by arbitrary cochain maps
+`f : C₁ ⟶ C₂` and `g : D₁ ⟶ D₂`. Degreewise this is `fwdNat_naturality`; the degrees outside the
+image of the embedding are handled by vanishing of the target. -/
+theorem tensorObjExtendIso_hom_naturality (f : C₁ ⟶ C₂) (g : D₁ ⟶ D₂) :
+    HomologicalComplex.tensorHom (HomologicalComplex.extendMap f e)
+          (HomologicalComplex.extendMap g e) ≫ (tensorObjExtendIso C₂ D₂).hom =
+      (tensorObjExtendIso C₁ D₁).hom ≫
+        HomologicalComplex.extendMap (HomologicalComplex.tensorHom f g) e := by
+  ext j' : 1
+  by_cases hj : j' < 0
+  · exact (HomologicalComplex.isZero_extend_X (HomologicalComplex.tensorObj C₂ D₂) e j'
+      (fun m => by simp only [ComplexShape.embeddingUpNat_f]; omega)).eq_of_tgt _ _
+  · rw [not_lt] at hj
+    obtain ⟨n, rfl⟩ : ∃ n : ℕ, j' = (n : ℤ) := ⟨j'.toNat, by omega⟩
+    rw [← cancel_mono (HomologicalComplex.extendXIso
+      (HomologicalComplex.tensorObj C₂ D₂) e (ef_eq n)).hom,
+      HomologicalComplex.comp_f, HomologicalComplex.comp_f, Category.assoc, Category.assoc,
+      show (tensorObjExtendIso C₂ D₂).hom.f (n : ℤ) = (tensorExtendXIso C₂ D₂ (n : ℤ)).hom
+        from rfl,
+      show (tensorObjExtendIso C₁ D₁).hom.f (n : ℤ) = (tensorExtendXIso C₁ D₁ (n : ℤ)).hom
+        from rfl,
+      tensorExtendXIso_hom_extendXIso,
+      HomologicalComplex.extendMap_f (HomologicalComplex.tensorHom f g) e (ef_eq n),
+      Category.assoc, Category.assoc, Iso.inv_hom_id, Category.comp_id,
+      tensorExtendXIso_hom_extendXIso_assoc]
+    exact fwdNat_naturality f g n
+
+/-- Naturality in the first argument. -/
+theorem tensorObjExtendIso_hom_naturality_left (f : C₁ ⟶ C₂)
+    (D : CochainComplex (ModuleCat.{u} k) ℕ) :
+    HomologicalComplex.tensorHom (HomologicalComplex.extendMap f e) (𝟙 (D.extend e)) ≫
+        (tensorObjExtendIso C₂ D).hom =
+      (tensorObjExtendIso C₁ D).hom ≫
+        HomologicalComplex.extendMap (HomologicalComplex.tensorHom f (𝟙 D)) e := by
+  simpa using tensorObjExtendIso_hom_naturality f (𝟙 D)
+
+/-- Naturality in the second argument. -/
+theorem tensorObjExtendIso_hom_naturality_right (C : CochainComplex (ModuleCat.{u} k) ℕ)
+    (g : D₁ ⟶ D₂) :
+    HomologicalComplex.tensorHom (𝟙 (C.extend e)) (HomologicalComplex.extendMap g e) ≫
+        (tensorObjExtendIso C D₂).hom =
+      (tensorObjExtendIso C D₁).hom ≫
+        HomologicalComplex.extendMap (HomologicalComplex.tensorHom (𝟙 C) g) e := by
+  simpa using tensorObjExtendIso_hom_naturality (𝟙 C) g
+
+end Naturality
+
+section Bifunctor
+
+/-- The tensor bifunctor on `ℕ`-cochain complexes. -/
+noncomputable abbrev tensorBifunctorN :
+    CochainComplex (ModuleCat.{u} k) ℕ ⥤ CochainComplex (ModuleCat.{u} k) ℕ ⥤
+      CochainComplex (ModuleCat.{u} k) ℕ :=
+  (curriedTensor (ModuleCat.{u} k)).map₂HomologicalComplex
+    (ComplexShape.up ℕ) (ComplexShape.up ℕ) (ComplexShape.up ℕ)
+
+/-- `extend` along `embeddingUpNat` as a functor `CochainComplex ℕ ⥤ CochainComplex ℤ`. -/
+noncomputable abbrev extFunctor :
+    CochainComplex (ModuleCat.{u} k) ℕ ⥤ CochainComplex (ModuleCat.{u} k) ℤ :=
+  e.extendFunctor (ModuleCat.{u} k)
+
+/-- The bifunctor `(C, D) ↦ extend C ⊗ extend D`. -/
+noncomputable abbrev tensorExtendSrc :
+    CochainComplex (ModuleCat.{u} k) ℕ ⥤ CochainComplex (ModuleCat.{u} k) ℕ ⥤
+      CochainComplex (ModuleCat.{u} k) ℤ :=
+  (extFunctor ⋙ TensorExtend.tensorBifunctorZ) ⋙
+    (CategoryTheory.Functor.whiskeringLeft (CochainComplex (ModuleCat.{u} k) ℕ)
+      (CochainComplex (ModuleCat.{u} k) ℤ)
+      (CochainComplex (ModuleCat.{u} k) ℤ)).obj extFunctor
+
+/-- The bifunctor `(C, D) ↦ extend (C ⊗ D)`. -/
+noncomputable abbrev tensorExtendTgt :
+    CochainComplex (ModuleCat.{u} k) ℕ ⥤ CochainComplex (ModuleCat.{u} k) ℕ ⥤
+      CochainComplex (ModuleCat.{u} k) ℤ :=
+  tensorBifunctorN ⋙
+    (CategoryTheory.Functor.whiskeringRight (CochainComplex (ModuleCat.{u} k) ℕ)
+      (CochainComplex (ModuleCat.{u} k) ℕ)
+      (CochainComplex (ModuleCat.{u} k) ℤ)).obj extFunctor
+
+/-- **The tensor/extend comparison as an isomorphism of bifunctors (cochain case).** Assembles
+`tensorObjExtendIso` over all `(C, D)` into a `NatIso` between `tensorExtendSrc` and
+`tensorExtendTgt`; the objectwise isos are recovered as `(tensorObjExtendNatIso.app C).app D`. -/
+noncomputable def tensorObjExtendNatIso :
+    tensorExtendSrc (k := k) ≅ tensorExtendTgt (k := k) :=
+  NatIso.ofComponents
+    (fun C => NatIso.ofComponents (fun D => tensorObjExtendIso C D) (fun {D₁ D₂} g => by
+      have h := tensorObjExtendIso_hom_naturality (𝟙 C) g
+      rw [HomologicalComplex.extendMap_id] at h
+      exact h))
+    (fun {C₁ C₂} f => by
+      ext D : 2
+      simp only [NatTrans.comp_app]
+      have h := tensorObjExtendIso_hom_naturality f (𝟙 D)
+      rw [HomologicalComplex.extendMap_id] at h
+      exact h)
+
+/-- The objectwise components of `tensorObjExtendNatIso` are the original `tensorObjExtendIso`. -/
+@[simp]
+lemma tensorObjExtendNatIso_app_app (C D : CochainComplex (ModuleCat.{u} k) ℕ) :
+    (tensorObjExtendNatIso.app C).app D = tensorObjExtendIso C D :=
+  rfl
+
+end Bifunctor
 
 end TensorExtendUp
 

--- a/progress/2026-07-26T00-07-52Z_ca2374e8.md
+++ b/progress/2026-07-26T00-07-52Z_ca2374e8.md
@@ -1,0 +1,63 @@
+## Accomplished
+
+Claimed #7837 (`feature`). Delivered its **deliverable 1** in full, for both the chain and the
+cochain case: the naturality of the tensor/extend comparison
+`extend C ⊗ extend D ≅ extend (C ⊗ D)` is now formalized, closing the last unproved naturality
+step of the ℕ-reindexed Künneth composites.
+
+`EtingofRepresentationTheory/Chapter7/KunnethChainComplexNat.lean` (milestone (d)) and its mirror
+in `KunnethCochainComplexNat.lean`, +345 lines, purely additive:
+
+* `TensorExtend.fwdNeg_naturality` / `TensorExtendUp.fwdNat_naturality` — the degreewise square.
+  Proved summand-by-summand with `mapBifunctor.hom_ext`: summands outside the image of the
+  embedding have zero source, and on an `(a, b) = (-p, -q)` summand both sides collapse to
+  `((extendXIso C₁).hom ≫ f.f p) ⊗ₘ ((extendXIso D₁).hom ≫ g.f q)` followed by the ℕ-side
+  injection. The monoidal step is `tensorHom_comp_tensorHom` after converting whiskerings to
+  `⊗ₘ` via `← tensorHom_id` / `← id_tensorHom`.
+* `tensorObjExtendIso_hom_naturality` (both namespaces) — the complex-level square, plus `_left`
+  and `_right` one-variable specialisations so "natural in each argument" is literally available.
+* `tensorObjExtendNatIso` (both namespaces) — the comparison as an isomorphism of bifunctors
+  `tensorExtendSrc : (C, D) ↦ extend C ⊗ extend D` and `tensorExtendTgt : (C, D) ↦ extend (C ⊗ D)`,
+  built from `Functor.map₂HomologicalComplex` and `ComplexShape.Embedding.extendFunctor` as the
+  issue suggested, with `tensorObjExtendNatIso_app_app` recovering the objectwise iso by `rfl`.
+
+Key mechanical find: `(tensorExtendSrc.obj C).map g` reduces definitionally to
+`tensorHom (𝟙 _) (extendMap g e)`, so both `NatIso.ofComponents` obligations are the joint
+naturality lemma with one argument an identity, modulo `rw [extendMap_id]`. `ext … : 1` / `: 2`
+matters — an unbounded `ext` descends into `ModuleCat` elements and the goal stops being
+rewritable.
+
+Also restored 364 lines of `.claude/` guidance that this worktree arrived holding stale copies of
+(commands `feature`/`review`/`summarize`/`work` and `agent-worker-flow/SKILL.md`), before doing
+any work. That is the **fourth** such worktree on 2026-07-25/26 after the 169/279/320-line cases;
+the Step 2 check in `agent-worker-flow` caught it this time, and the restored skill was re-read
+before the workflow continued. Not committed here — it is not in this issue's scope and `main`
+already has the correct content.
+
+## Current frontier
+
+`main` at `770558b9` plus this branch's two additive Chapter 7 commits. Both Künneth ℕ modules
+and the full project build clean; no new `sorry`.
+
+## Overall project progress
+
+All four steps of each ℕ-reindexed Künneth composite now have formalized naturality: steps 1 and 4
+(`homology_extend_iso{,_up}_hom_naturality`), step 2 (this turn), step 3 (`kunnethNatIso`, #7834).
+
+## Next step
+
+#7843, created this turn for #7837's **deliverables 2 and 3**, which could not be done here:
+both build on `kunnethChainComplexNatIso` / `kunnethCochainComplexNatIso`, which are **not on
+`main`** — they live in open PR #7838 (issue #7831). Per `agent-worker-flow` Step 4, work was not
+stacked on an unmerged PR. #7843 carries `depends-on: #7831` and is labelled `blocked`; it will
+unblock automatically when #7838 merges.
+
+Deliverable 3 was deliberately left alone for the same reason: #7838 *rewrites* the
+`Chapter7/Problem7.8.7` `coverage_note` that deliverable 3 asks to edit, so touching it on `main`
+would have produced a guaranteed merge conflict against a file that PR already changes. The
+sentence to replace ("… `tensorObjExtendIso` is natural without its naturality being formalized …")
+only exists inside #7838, and is false once both land — #7843 spells out the fix.
+
+## Blockers
+
+None for this PR. #7843 is blocked on #7838 / #7831 merging.


### PR DESCRIPTION
This PR formalizes the naturality of the tensor/extend comparison `extend C ⊗ extend D ≅ extend (C ⊗ D)` for both the chain and the cochain reindexing, closing the last unproved naturality step of the ℕ-reindexed Künneth composites, and packages the comparison as an isomorphism of bifunctors.

In each of `TensorExtend` (`Chapter7/KunnethChainComplexNat.lean`) and `TensorExtendUp` (`Chapter7/KunnethCochainComplexNat.lean`):

* `fwdNeg_naturality` / `fwdNat_naturality` — the degreewise square. Proved summand-by-summand with `mapBifunctor.hom_ext`: summands outside the image of the embedding have zero source, and on an `(a, b) = (-p, -q)` summand both sides collapse to `((extendXIso C₁).hom ≫ f.f p) ⊗ₘ ((extendXIso D₁).hom ≫ g.f q)` followed by the ℕ-side injection. The monoidal step is `tensorHom_comp_tensorHom` after converting whiskerings to `⊗ₘ`.
* `tensorObjExtendIso_hom_naturality` — the complex-level square for the actual `tensorObjExtendIso`, with `_left` and `_right` one-variable specialisations.
* `tensorObjExtendNatIso` — the comparison as a `NatIso` between the bifunctors `tensorExtendSrc : (C, D) ↦ extend C ⊗ extend D` and `tensorExtendTgt : (C, D) ↦ extend (C ⊗ D)`, built from `Functor.map₂HomologicalComplex` and `ComplexShape.Embedding.extendFunctor` as #7837 suggested. `tensorObjExtendNatIso_app_app` recovers the objectwise `tensorObjExtendIso` by `rfl`.

Purely additive: +345 lines of Lean, no existing declaration changed except an `attribute [reassoc]` on the already-`@[simp]` `tensorExtendXIso_hom_extendXIso`. `lake build` clean (9303 jobs); no new `sorry`; all four new endpoints depend only on `propext`, `Classical.choice`, `Quot.sound`.

This is deliverable 1 of #7837. Deliverables 2 and 3 are **not** in this PR and are tracked in #7843: both build on `kunnethChainComplexNatIso` / `kunnethCochainComplexNatIso`, which are not on `main` — they live in open PR #7838 (issue #7831). Per `agent-worker-flow` Step 4 the work was not stacked on an unmerged PR. Deliverable 3 was left alone for the same reason: #7838 rewrites the `Chapter7/Problem7.8.7` `coverage_note` that deliverable 3 asks to edit, so changing it here would produce a guaranteed conflict against a file that PR already changes. #7843 carries `depends-on: #7831` and unblocks when #7838 merges.

Closes #7837

Session: ca2374e8-0826-48ee-bccc-5798bca42564

🤖 Prepared with Claude Code