### PR TITLE
formalize Remark 5.15.2: Laurent-polynomial coefficient form of Frobenius character formula

### DIFF
--- a/EtingofRepresentationTheory/Chapter5.lean
+++ b/EtingofRepresentationTheory/Chapter5.lean
@@ -88,6 +88,8 @@ import EtingofRepresentationTheory.Chapter5.Theorem5_14_3_Centralizer
 -- Section 5.15: Frobenius Character Formula
 import EtingofRepresentationTheory.Chapter5.Theorem5_15_1
 import EtingofRepresentationTheory.Chapter5.Theorem5_15_1_Test
+import EtingofRepresentationTheory.Chapter5.Remark5_15_2
+import EtingofRepresentationTheory.Chapter5.Remark5_15_2_Test
 import EtingofRepresentationTheory.Chapter5.CharacterMultiplicityBridge
 import EtingofRepresentationTheory.Chapter5.Discussion_footnote_5_15
 import EtingofRepresentationTheory.Chapter5.Lemma5_15_3

--- a/EtingofRepresentationTheory/Chapter5/Remark5_15_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Remark5_15_2.lean
@@ -1,0 +1,260 @@
+import Mathlib
+import EtingofRepresentationTheory.Chapter5.Theorem5_15_1
+
+/-!
+# Remark 5.15.2: the Laurent-polynomial form of the Frobenius character formula
+
+Etingof's Remark 5.15.2 records an equivalent formulation of Theorem 5.15.1:
+`χ_{V_λ}(C_i)` is the coefficient of `x^λ` in the **Laurent** polynomial
+
+  `∏_{i < j} (1 - x_j / x_i) · ∏_{m ≥ 1} H_m(x)^{i_m}`.
+
+Theorem 5.15.1 extracts the coefficient of `x^{λ+ρ}` from the honest polynomial
+`Δ(x) · ∏_m H_m(x)^{i_m}`. The two agree because
+
+  `Δ(x) = ∏_{i<j} (x_i - x_j) = x^ρ · ∏_{i<j} (1 - x_j / x_i)`,
+
+so dividing by the monomial `x^ρ` shifts the extracted exponent from `λ+ρ` down
+to `λ`. The quotient is no longer a polynomial, which is why the remark has to be
+stated in a Laurent ring.
+
+## Contents
+
+* `MvLaurent n`: Laurent polynomials in `n` variables over `ℂ`, modelled as the
+  group algebra `ℂ[ℤ^n]` of the exponent group `Fin n →₀ ℤ`.
+* `toLaurent`: the ring embedding of `MvPolynomial (Fin n) ℂ` into `MvLaurent n`.
+* `frobeniusLaurentFactor n`: the factor `∏_{i<j} (1 - x_j / x_i)`.
+* `rho_monomial_mul_frobeniusLaurentFactor`: the identity
+  `x^ρ · ∏_{i<j}(1 - x_j/x_i) = ∏_{i<j}(x_i - x_j)`, which is the whole content
+  of the remark.
+* `Remark5_15_2_equiv_Theorem5_15_1`: the two coefficient extractions agree, for
+  an arbitrary polynomial factor. This is the "equivalent formulation" claim,
+  proved without reference to characters.
+* `Remark5_15_2`: the character statement itself, `χ_{V_λ}(σ) = [x^λ] (…)`.
+
+## Sign conventions
+
+`Etingof.vandermondePoly n` is Mathlib-oriented, `∏_{i<j} (x_j - x_i)`, whereas the
+book's `Δ` is `∏_{i<j} (x_i - x_j)`; the two differ by `sign(rev)`, which is why
+`Theorem5_15_1` carries a `sign(rev) •` factor. That factor cancels here: the book's
+`∏_{i<j}(1 - x_j/x_i)` is built from the book's `Δ`, so `Remark5_15_2` is sign-free,
+exactly as printed in the book.
+
+As in `Theorem5_15_1`, the book's `H_m` is the power sum `p_m` (Etingof p. 116),
+represented by `Etingof.cycleTypePsumProduct`.
+-/
+
+namespace Etingof
+
+noncomputable section
+
+open Finset
+
+/-! ## Laurent polynomials in several variables -/
+
+/-- Laurent polynomials in `n` variables over `ℂ`: the group algebra of the exponent
+group `Fin n →₀ ℤ`. This is the same construction as `MvPolynomial (Fin n) ℂ`, which is
+`AddMonoidAlgebra ℂ (Fin n →₀ ℕ)`, with the exponents allowed to go negative. -/
+abbrev MvLaurent (n : ℕ) : Type := AddMonoidAlgebra ℂ (Fin n →₀ ℤ)
+
+namespace MvLaurent
+
+/-- The Laurent monomial `c · x^e` for an integer exponent vector `e`. -/
+def monomial {n : ℕ} (e : Fin n →₀ ℤ) (c : ℂ) : MvLaurent n := AddMonoidAlgebra.single e c
+
+/-- The coefficient of `x^e` in a Laurent polynomial. -/
+def coeff {n : ℕ} (e : Fin n →₀ ℤ) (f : MvLaurent n) : ℂ := f e
+
+/-- The variable `x i`. -/
+def X {n : ℕ} (i : Fin n) : MvLaurent n := monomial (Finsupp.single i 1) 1
+
+/-- The inverse variable `x i⁻¹`. This is what takes us outside `MvPolynomial`. -/
+def Xinv {n : ℕ} (i : Fin n) : MvLaurent n := monomial (Finsupp.single i (-1)) 1
+
+@[simp] theorem monomial_mul {n : ℕ} (e f : Fin n →₀ ℤ) (c d : ℂ) :
+    monomial e c * monomial f d = monomial (e + f) (c * d) := by
+  simp only [monomial]
+  exact AddMonoidAlgebra.single_mul_single (R := ℂ) (M := Fin n →₀ ℤ) e f c d
+
+@[simp] theorem monomial_zero_one {n : ℕ} : monomial (0 : Fin n →₀ ℤ) 1 = 1 := by
+  simp [monomial, AddMonoidAlgebra.one_def]
+
+/-- `x i · x i⁻¹ = 1`: the variables really are invertible. -/
+@[simp] theorem X_mul_Xinv {n : ℕ} (i : Fin n) : X i * Xinv i = 1 := by
+  rw [X, Xinv, monomial_mul]
+  simp
+
+theorem monomial_prod {n : ℕ} (s : Finset (Fin n)) (g : Fin n → (Fin n →₀ ℤ)) :
+    ∏ i ∈ s, monomial (g i) (1 : ℂ) = monomial (∑ i ∈ s, g i) 1 := by
+  classical
+  induction s using Finset.induction with
+  | empty => simp
+  | insert a s ha ih => rw [Finset.prod_insert ha, Finset.sum_insert ha, ih, monomial_mul, one_mul]
+
+theorem monomial_pow {n : ℕ} (e : Fin n →₀ ℤ) (k : ℕ) :
+    monomial e (1 : ℂ) ^ k = monomial (k • e) 1 := by
+  induction k with
+  | zero => simp
+  | succ k ih => rw [pow_succ, ih, monomial_mul, succ_nsmul, one_mul]
+
+/-- Multiplying by the monomial `x^e` shifts coefficient extraction by `e`. -/
+theorem coeff_monomial_mul {n : ℕ} (e a : Fin n →₀ ℤ) (c : ℂ) (f : MvLaurent n) :
+    coeff (e + a) (monomial e c * f) = c * coeff a f := by
+  rw [coeff, coeff, monomial, AddMonoidAlgebra.single_mul_apply]
+  simp
+
+end MvLaurent
+
+/-! ## Embedding polynomials into Laurent polynomials -/
+
+/-- The inclusion of `ℕ`-valued exponent vectors into `ℤ`-valued ones. -/
+def expEmbed (n : ℕ) : (Fin n →₀ ℕ) →+ (Fin n →₀ ℤ) :=
+  Finsupp.mapRange.addMonoidHom (Nat.castAddMonoidHom ℤ)
+
+@[simp] theorem expEmbed_apply (n : ℕ) (e : Fin n →₀ ℕ) (i : Fin n) :
+    expEmbed n e i = (e i : ℤ) := by
+  simp [expEmbed]
+
+theorem expEmbed_injective (n : ℕ) : Function.Injective (expEmbed n) := by
+  intro a b h
+  ext i
+  have := congrArg (fun f => f i) h
+  simpa using this
+
+/-- A polynomial is a Laurent polynomial: the exponents are just reinterpreted in `ℤ`. -/
+def toLaurent (n : ℕ) : MvPolynomial (Fin n) ℂ →+* MvLaurent n :=
+  AddMonoidAlgebra.mapDomainRingHom ℂ (expEmbed n)
+
+/-- Coefficients are unchanged by `toLaurent`. -/
+theorem coeff_toLaurent (n : ℕ) (P : MvPolynomial (Fin n) ℂ) (e : Fin n →₀ ℕ) :
+    MvLaurent.coeff (expEmbed n e) (toLaurent n P) = MvPolynomial.coeff e P := by
+  change Finsupp.mapDomain (expEmbed n) P (expEmbed n e) = _
+  rw [Finsupp.mapDomain_apply (expEmbed_injective n)]
+  rfl
+
+@[simp] theorem toLaurent_X (n : ℕ) (i : Fin n) :
+    toLaurent n (MvPolynomial.X i) = MvLaurent.X i := by
+  change Finsupp.mapDomain (expEmbed n) (MvPolynomial.X i) = _
+  rw [MvPolynomial.X, MvPolynomial.monomial]
+  simp [Finsupp.mapDomain_single, expEmbed, MvLaurent.X, MvLaurent.monomial,
+    AddMonoidAlgebra.single]
+
+/-! ## The book's Vandermonde product and its Laurent factorisation -/
+
+/-- The book's Vandermonde polynomial `Δ(x) = ∏_{i<j} (x_i - x_j)`.
+
+`Etingof.vandermondePoly` uses the opposite factor order, `∏_{i<j} (x_j - x_i)`. -/
+def bookVandermondePoly (n : ℕ) : MvPolynomial (Fin n) ℂ :=
+  ∏ i : Fin n, ∏ j ∈ Finset.Ioi i, (MvPolynomial.X i - MvPolynomial.X j)
+
+/-- The book's Laurent factor `∏_{i<j} (1 - x_j / x_i)` from Remark 5.15.2. -/
+def frobeniusLaurentFactor (n : ℕ) : MvLaurent n :=
+  ∏ i : Fin n, ∏ j ∈ Finset.Ioi i, (1 - MvLaurent.X j * MvLaurent.Xinv i)
+
+/-- `sign(rev)` is `-1` once for each pair `i < j`: reversal inverts every pair. -/
+theorem sign_revPerm_eq_prod (n : ℕ) :
+    Equiv.Perm.sign (Fin.revPerm (n := n)) =
+      ∏ i : Fin n, ∏ _j ∈ Finset.Ioi i, (-1 : ℤˣ) := by
+  rw [Equiv.Perm.sign_eq_prod_prod_Ioi]
+  refine Finset.prod_congr rfl fun i _ => Finset.prod_congr rfl fun j hj => ?_
+  have hij : i < j := Finset.mem_Ioi.mp hj
+  simp only [Fin.revPerm_apply]
+  rw [if_neg (asymm (Fin.rev_lt_rev.mpr hij))]
+
+/-- The cast of `sign(rev)` into any commutative ring, as a product of `-1`s over pairs. -/
+theorem cast_sign_revPerm (n : ℕ) (R : Type*) [CommRing R] :
+    ((Equiv.Perm.sign (Fin.revPerm (n := n)) : ℤ) : R) =
+      ∏ i : Fin n, ∏ _j ∈ Finset.Ioi i, (-1 : R) := by
+  rw [sign_revPerm_eq_prod]
+  push_cast
+  simp
+
+/-- The book's `Δ` and `Etingof.vandermondePoly` differ by `sign(rev)`. -/
+theorem bookVandermondePoly_eq_smul (n : ℕ) :
+    bookVandermondePoly n =
+      (Equiv.Perm.sign (Fin.revPerm (n := n)) : ℤ) • vandermondePoly n := by
+  have hprod : bookVandermondePoly n =
+      (∏ i : Fin n, ∏ _j ∈ Finset.Ioi i, (-1 : MvPolynomial (Fin n) ℂ)) * vandermondePoly n := by
+    rw [bookVandermondePoly, vandermondePoly, ← Finset.prod_mul_distrib]
+    refine Finset.prod_congr rfl fun i _ => ?_
+    rw [← Finset.prod_mul_distrib]
+    exact Finset.prod_congr rfl fun j _ => by ring
+  rw [hprod, ← cast_sign_revPerm n (MvPolynomial (Fin n) ℂ), ← zsmul_eq_mul]
+
+/-- `x^ρ` as a Laurent monomial, where `ρ = (n-1, …, 1, 0)`. -/
+theorem rhoShift_eq_sum_single (n : ℕ) :
+    expEmbed n (rhoShift n) = ∑ i : Fin n, Finsupp.single i (#(Finset.Ioi i) : ℤ) := by
+  ext j
+  simp [Finsupp.finsetSum_apply, Finsupp.single_apply, Finset.sum_ite_eq', Fin.card_Ioi,
+    rhoShift]
+
+/-- `x^ρ = ∏_{i<j} x_i`: the variable `x_i` occurs once for each `j > i`. -/
+theorem monomial_rho_eq_prod (n : ℕ) :
+    MvLaurent.monomial (expEmbed n (rhoShift n)) 1 =
+      ∏ i : Fin n, ∏ _j ∈ Finset.Ioi i, MvLaurent.X i := by
+  rw [rhoShift_eq_sum_single, ← MvLaurent.monomial_prod]
+  refine Finset.prod_congr rfl fun i _ => ?_
+  rw [Finset.prod_const, MvLaurent.X, MvLaurent.monomial_pow]
+  congr 1
+  ext j
+  simp [Finsupp.single_apply]
+
+/-- **The content of Remark 5.15.2**: multiplying the book's Laurent factor by the
+monomial `x^ρ` recovers the book's Vandermonde polynomial `Δ(x) = ∏_{i<j}(x_i - x_j)`.
+
+Dividing `Δ` by `x^ρ` is exactly what turns the `x^{λ+ρ}`-coefficient of Theorem 5.15.1
+into the `x^λ`-coefficient of the remark. -/
+theorem rho_monomial_mul_frobeniusLaurentFactor (n : ℕ) :
+    MvLaurent.monomial (expEmbed n (rhoShift n)) 1 * frobeniusLaurentFactor n =
+      toLaurent n (bookVandermondePoly n) := by
+  rw [monomial_rho_eq_prod, frobeniusLaurentFactor, ← Finset.prod_mul_distrib]
+  rw [bookVandermondePoly, map_prod]
+  refine Finset.prod_congr rfl fun i _ => ?_
+  rw [map_prod, ← Finset.prod_mul_distrib]
+  refine Finset.prod_congr rfl fun j _ => ?_
+  rw [map_sub, toLaurent_X, toLaurent_X, mul_sub, mul_one]
+  congr 1
+  rw [← mul_assoc, mul_comm (MvLaurent.X i) (MvLaurent.X j), mul_assoc,
+    MvLaurent.X_mul_Xinv, mul_one]
+
+/-! ## The two coefficient extractions agree -/
+
+/-- **Remark 5.15.2, equivalence with Theorem 5.15.1.** For any polynomial factor `P`,
+the coefficient of `x^e` in `∏_{i<j}(1 - x_j/x_i) · P` equals `sign(rev)` times the
+coefficient of `x^{e+ρ}` in `Δ(x) · P`, where `Δ = Etingof.vandermondePoly`.
+
+Both sides are computed here, with no reference to representation theory; this is the
+machine-checked form of the book's "here is an equivalent formulation". -/
+theorem Remark5_15_2_equiv_Theorem5_15_1 (n : ℕ) (e : Fin n →₀ ℕ)
+    (P : MvPolynomial (Fin n) ℂ) :
+    MvLaurent.coeff (expEmbed n e) (frobeniusLaurentFactor n * toLaurent n P) =
+      (Equiv.Perm.sign (Fin.revPerm (n := n)) : ℤ) •
+        MvPolynomial.coeff (e + rhoShift n) (vandermondePoly n * P) := by
+  have hsmul : (Equiv.Perm.sign (Fin.revPerm (n := n)) : ℤ) •
+      MvPolynomial.coeff (e + rhoShift n) (vandermondePoly n * P) =
+      MvPolynomial.coeff (e + rhoShift n)
+        (((Equiv.Perm.sign (Fin.revPerm (n := n)) : ℤ) • vandermondePoly n) * P) := by
+    rw [smul_mul_assoc, MvPolynomial.coeff_smul]
+  rw [hsmul, ← bookVandermondePoly_eq_smul, ← coeff_toLaurent, map_mul,
+    ← rho_monomial_mul_frobeniusLaurentFactor, map_add, mul_assoc,
+    add_comm (expEmbed n e) (expEmbed n (rhoShift n)),
+    MvLaurent.coeff_monomial_mul, one_mul]
+
+/-- **Remark 5.15.2** (Etingof): the character of the Specht module `V_λ` at a permutation
+`σ` of cycle type `i` is the coefficient of `x^λ` in the Laurent polynomial
+
+  `∏_{i<j} (1 - x_j/x_i) · ∏_{m≥1} H_m(x)^{i_m}`.
+
+Unlike `Theorem5_15_1` this carries no sign correction: the book's Laurent factor uses the
+book's factor order `∏_{i<j}(x_i - x_j)`, and the resulting `sign(rev)` cancels the one in
+`Theorem5_15_1`. -/
+theorem Remark5_15_2 (n : ℕ) (la : Nat.Partition n) (σ : Equiv.Perm (Fin n)) :
+    spechtModuleCharacter n la σ =
+      MvLaurent.coeff (expEmbed n (Nat.Partition.toFinsupp la))
+        (frobeniusLaurentFactor n * toLaurent n (cycleTypePsumProduct n σ)) := by
+  rw [Remark5_15_2_equiv_Theorem5_15_1, ← Theorem5_15_1, smul_smul]
+  simp
+
+end
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter5/Remark5_15_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Remark5_15_2.lean
@@ -132,6 +132,13 @@ theorem coeff_toLaurent (n : ℕ) (P : MvPolynomial (Fin n) ℂ) (e : Fin n →�
   rw [Finsupp.mapDomain_apply (expEmbed_injective n)]
   rfl
 
+/-- `toLaurent` is injective, so passing to the Laurent ring loses nothing and the target
+is not a degenerate ring. -/
+theorem toLaurent_injective (n : ℕ) : Function.Injective (toLaurent n) := by
+  intro P Q h
+  ext e
+  rw [← coeff_toLaurent n P e, ← coeff_toLaurent n Q e, h]
+
 @[simp] theorem toLaurent_X (n : ℕ) (i : Fin n) :
     toLaurent n (MvPolynomial.X i) = MvLaurent.X i := by
   change Finsupp.mapDomain (expEmbed n) (MvPolynomial.X i) = _

--- a/EtingofRepresentationTheory/Chapter5/Remark5_15_2_Test.lean
+++ b/EtingofRepresentationTheory/Chapter5/Remark5_15_2_Test.lean
@@ -40,10 +40,16 @@ what makes `frobeniusLaurentFactor` live outside `MvPolynomial`. -/
 example (n : ℕ) (i : Fin n) : MvLaurent.X i * MvLaurent.Xinv i = 1 :=
   MvLaurent.X_mul_Xinv i
 
-/-- `toLaurent` is injective on coefficients, so the embedding loses no information. -/
+/-- `toLaurent` preserves coefficients, so the embedding loses no information. -/
 example (n : ℕ) (P : MvPolynomial (Fin n) ℂ) (e : Fin n →₀ ℕ) :
     MvLaurent.coeff (expEmbed n e) (toLaurent n P) = MvPolynomial.coeff e P :=
   coeff_toLaurent n P e
+
+/-- Non-vacuity: `MvLaurent n` is not the zero ring, and `toLaurent` is injective, so the
+coefficient statements above are not trivially satisfied. -/
+example (n : ℕ) : Nontrivial (MvLaurent n) := inferInstance
+
+example (n : ℕ) : Function.Injective (toLaurent n) := toLaurent_injective n
 
 #print axioms Etingof.Remark5_15_2
 #print axioms Etingof.Remark5_15_2_equiv_Theorem5_15_1

--- a/EtingofRepresentationTheory/Chapter5/Remark5_15_2_Test.lean
+++ b/EtingofRepresentationTheory/Chapter5/Remark5_15_2_Test.lean
@@ -1,0 +1,53 @@
+import EtingofRepresentationTheory.Chapter5.Remark5_15_2
+
+/-!
+# Downstream import/`#check` test for Remark 5.15.2
+
+Pins the public signatures of the Laurent-polynomial form of the Frobenius character
+formula, and records that the endpoints are axiom-clean.
+
+See issue #7405.
+-/
+
+namespace Etingof
+
+#check @Etingof.MvLaurent
+#check @Etingof.frobeniusLaurentFactor
+#check @Etingof.toLaurent
+#check @Etingof.Remark5_15_2
+#check @Etingof.Remark5_15_2_equiv_Theorem5_15_1
+#check @Etingof.rho_monomial_mul_frobeniusLaurentFactor
+
+/-- Signature lock for the remark: the Specht-module character at `σ` is *literally* the
+`x^λ` coefficient of `∏_{i<j}(1 - x_j/x_i) · ∏_m pₘ^{iₘ}`, with no sign correction. -/
+example (n : ℕ) (la : Nat.Partition n) (σ : Equiv.Perm (Fin n)) :
+    spechtModuleCharacter n la σ =
+      MvLaurent.coeff (expEmbed n (Nat.Partition.toFinsupp la))
+        (frobeniusLaurentFactor n * toLaurent n (cycleTypePsumProduct n σ)) :=
+  Remark5_15_2 n la σ
+
+/-- Signature lock for the equivalence with Theorem 5.15.1, stated for an arbitrary
+polynomial factor so that it is a statement about the two coefficient extractions and
+not about characters. -/
+example (n : ℕ) (e : Fin n →₀ ℕ) (P : MvPolynomial (Fin n) ℂ) :
+    MvLaurent.coeff (expEmbed n e) (frobeniusLaurentFactor n * toLaurent n P) =
+      (Equiv.Perm.sign (Fin.revPerm (n := n)) : ℤ) •
+        MvPolynomial.coeff (e + rhoShift n) (vandermondePoly n * P) :=
+  Remark5_15_2_equiv_Theorem5_15_1 n e P
+
+/-- The Laurent ring is not degenerate: the variables are genuinely invertible, which is
+what makes `frobeniusLaurentFactor` live outside `MvPolynomial`. -/
+example (n : ℕ) (i : Fin n) : MvLaurent.X i * MvLaurent.Xinv i = 1 :=
+  MvLaurent.X_mul_Xinv i
+
+/-- `toLaurent` is injective on coefficients, so the embedding loses no information. -/
+example (n : ℕ) (P : MvPolynomial (Fin n) ℂ) (e : Fin n →₀ ℕ) :
+    MvLaurent.coeff (expEmbed n e) (toLaurent n P) = MvPolynomial.coeff e P :=
+  coeff_toLaurent n P e
+
+#print axioms Etingof.Remark5_15_2
+#print axioms Etingof.Remark5_15_2_equiv_Theorem5_15_1
+#print axioms Etingof.rho_monomial_mul_frobeniusLaurentFactor
+#print axioms Etingof.bookVandermondePoly_eq_smul
+
+end Etingof

--- a/progress/2026-07-26T00-41-29Z_d8f4aef5.md
+++ b/progress/2026-07-26T00-41-29Z_d8f4aef5.md
@@ -1,0 +1,88 @@
+## Accomplished
+
+Session type: `/work` (meta). Claimed and completed **#7405**, Remark 5.15.2 — the
+Laurent-polynomial coefficient form of the Frobenius character formula.
+
+New: `EtingofRepresentationTheory/Chapter5/Remark5_15_2.lean` (+ `_Test.lean`), registered
+in `Chapter5.lean`. Zero sorries; `#print axioms` on all four endpoints reports exactly
+`propext, Classical.choice, Quot.sound`.
+
+* `MvLaurent n := AddMonoidAlgebra ℂ (Fin n →₀ ℤ)` models multivariate Laurent
+  polynomials — the same construction as `MvPolynomial (Fin n) ℂ` with exponents in `ℤ`.
+  `MvLaurent.Xinv` is a genuine inverse (`X_mul_Xinv`), so the ring really is larger.
+* `toLaurent : MvPolynomial (Fin n) ℂ →+* MvLaurent n` via
+  `AddMonoidAlgebra.mapDomainRingHom`; `coeff_toLaurent` transfers coefficients and
+  `toLaurent_injective` guards non-vacuity.
+* `Etingof.Remark5_15_2` states the book's claim verbatim and **sign-free**:
+  `spechtModuleCharacter n la σ = [x^λ] (∏_{i<j}(1 - x_j/x_i) · ∏_m p_m^{i_m})`.
+* `Remark5_15_2_equiv_Theorem5_15_1` is the "equivalent formulation" claim proper: for an
+  *arbitrary* polynomial factor `P` (no characters involved), the `x^e` coefficient of
+  `∏_{i<j}(1-x_j/x_i) · P` equals `sign(rev) •` the `x^{e+ρ}` coefficient of
+  `vandermondePoly · P`.
+* Mathematical content: `rho_monomial_mul_frobeniusLaurentFactor`, i.e.
+  `x^ρ · ∏_{i<j}(1 - x_j/x_i) = ∏_{i<j}(x_i - x_j)`. Dividing by the monomial `x^ρ` is
+  exactly what shifts the extracted exponent from `λ+ρ` down to `λ`.
+
+## Decisions and key patterns
+
+**The sign cancels, and that is why the remark is sign-free.** `Etingof.vandermondePoly`
+is `∏_{i<j}(x_j - x_i)` (Mathlib order) while the book's `Δ` is `∏_{i<j}(x_i - x_j)`, which
+is why `Theorem5_15_1` carries a `sign(rev) •` factor. The book's Laurent factor
+`∏_{i<j}(1 - x_j/x_i)` is built from the book's `Δ`, so it carries the same `sign(rev)`,
+and the two cancel. Getting `Remark5_15_2` to come out with no sign correction is a useful
+consistency check on the whole chain.
+
+**Avoiding a hard sign computation.** Bridging the two factor orders needs
+`sign(Fin.revPerm) = (-1)^{#pairs}`, which looks like it requires counting inversions.
+`Equiv.Perm.sign_eq_prod_prod_Ioi` (Mathlib `GroupTheory/Perm/Fin.lean`) expresses
+`sign σ` as `∏ i, ∏ j ∈ Ioi i, (if σ i < σ j then 1 else -1)` — the *same nested
+`Finset.Ioi` shape* as `vandermondePoly`. Reversal inverts every pair, so each factor is
+`-1` and the identity falls out by `Finset.prod_congr` with no `n(n-1)/2` arithmetic and no
+`signAux` unfolding. Worth remembering for anything else that reconciles a `∏_{i<j}` factor
+order in this project (Chapter 5 does this in several places).
+
+**Building the Laurent model is cheap.** `MonoidAlgebra R M := M →₀ R` is a plain `def`, so
+`AddMonoidAlgebra.mapDomainRingHom ℂ (expEmbed n)` elaborates directly at type
+`MvPolynomial (Fin n) ℂ →+* MvLaurent n` with no coercion boilerplate, and
+`Finsupp.mapDomain_apply` gives coefficient transfer in one line.
+`AddMonoidAlgebra.single_mul_apply` (the `AddGroup` version) gives the monomial-shift rule
+`coeff (e + a) (monomial e c * f) = c * coeff a f`, which is the whole proof of the
+coefficient shift. If another item needs Laurent polynomials, reuse `MvLaurent` from this
+file rather than rebuilding.
+
+The statement was checked by hand on `S₂` before proving it (both irreducibles, both
+classes; the sign character at a transposition gives `-1`, matching).
+
+## Current frontier
+
+`agent/d8f4aef5` at two commits ahead of `origin/main` (`770558b9`). Chapter 5 aggregate
+builds clean.
+
+## Overall project progress
+
+Stage 3 formalization continues. `Chapter5/Remark5.15.2` moves `covered_partial →
+covered_full` in `progress/items.json` (`scripts/validate_items.py` passes). The Section
+5.15 cluster now has Theorem 5.15.1, its Laurent reformulation (this item), Lemma 5.15.3
+and Corollary 5.15.4; Remark 5.15.5 (#7406) is the remaining unclaimed item in the section.
+
+## Next step
+
+#7406 (Remark 5.15.5: positive-root order, inverse-Kostka expansion, Kostka vanishing) is
+the natural neighbour but is genuinely four separate claims — it is a decomposition
+candidate rather than a single session. `#7456` (generalize Theorem 5.15.1 to the book's
+independent variable count `N`) would also lift this file, since `MvLaurent` and
+`frobeniusLaurentFactor` are already stated for arbitrary `n`.
+
+## Blockers
+
+None.
+
+## Note on session start
+
+This worktree again arrived with the `.claude/` regression recorded in
+`progress/2026-07-25T22-31-41Z_3fa02f4e.md`: `git status` showed five modified files under
+`.claude/` amounting to 364 pure deletions against `origin/main` (including a 223-line
+truncation of `agent-worker-flow/SKILL.md`, so the skill this session initially loaded was
+the stale copy). Restored with `git checkout origin/main -- .claude/` before any other
+work, then re-read the full skill and restarted from Step 1. That is the fourth occurrence;
+the Step 2 check and the Step 7 diff-scope backstop both worked as written.

--- a/progress/items.json
+++ b/progress/items.json
@@ -5799,10 +5799,18 @@
     "start_line": 19,
     "end_line": 22,
     "status": "sorry_free",
-    "coverage": "covered_partial",
-    "coverage_note": "No Lean declaration states the Laurent-polynomial coefficient formula in this remark. Nearby Frobenius-character results do not expose this equivalent formulation; follow-up #7405.",
-    "fidelity_issue": 7405,
-    "last_updated": "2026-07-22"
+    "coverage": "covered_full",
+    "coverage_note": "Formalized (#7405) in Chapter5/Remark5_15_2.lean. Multivariate Laurent polynomials are modelled as MvLaurent n = AddMonoidAlgebra ℂ (Fin n →₀ ℤ), with the coefficient extraction MvLaurent.coeff and the ring embedding toLaurent from MvPolynomial (coefficient-preserving, coeff_toLaurent). frobeniusLaurentFactor n is the book's displayed factor ∏_{i<j} (1 - x_j/x_i), built from the genuinely invertible MvLaurent.Xinv (X_mul_Xinv). Etingof.Remark5_15_2 states the book's claim with no sign correction: spechtModuleCharacter n la σ = MvLaurent.coeff (expEmbed n la.toFinsupp) (frobeniusLaurentFactor n * toLaurent n (cycleTypePsumProduct n σ)). The equivalence with Theorem 5.15.1 is machine-checked and character-free in Remark5_15_2_equiv_Theorem5_15_1, which equates the x^e coefficient of ∏_{i<j}(1-x_j/x_i)·P with sign(rev) times the x^{e+ρ} coefficient of vandermondePoly·P for an arbitrary P. The mathematical content is rho_monomial_mul_frobeniusLaurentFactor: x^ρ · ∏_{i<j}(1-x_j/x_i) = ∏_{i<j}(x_i-x_j) = bookVandermondePoly. bookVandermondePoly_eq_smul reconciles the book's factor order with the project's vandermondePoly via sign(rev), computed from Equiv.Perm.sign_eq_prod_prod_Ioi (reversal inverts every pair); that sign cancels the one in Theorem5_15_1, which is why the remark is sign-free. Signature locks and #print axioms in Chapter5/Remark5_15_2_Test.lean: propext, Classical.choice, Quot.sound only, no sorryAx.",
+    "lean_file": [
+      "EtingofRepresentationTheory/Chapter5/Remark5_15_2.lean"
+    ],
+    "fidelity_decl": [
+      "Etingof.Remark5_15_2",
+      "Etingof.Remark5_15_2_equiv_Theorem5_15_1",
+      "Etingof.rho_monomial_mul_frobeniusLaurentFactor",
+      "Etingof.frobeniusLaurentFactor"
+    ],
+    "last_updated": "2026-07-26"
   },
   {
     "id": "Chapter5/Discussion_proof_of_Theorem5.15.1",


### PR DESCRIPTION
This PR formalizes Etingof's Remark 5.15.2, the Laurent-polynomial coefficient form of the Frobenius character formula, and machine-checks its equivalence with Theorem 5.15.1.

Multivariate Laurent polynomials are modelled as `MvLaurent n = AddMonoidAlgebra ℂ (Fin n →₀ ℤ)` — the same construction as `MvPolynomial (Fin n) ℂ` with exponents allowed in `ℤ` — together with the coefficient extraction `MvLaurent.coeff`, genuinely invertible variables (`MvLaurent.X_mul_Xinv`), and a coefficient-preserving ring embedding `toLaurent` from `MvPolynomial` (`coeff_toLaurent`, `toLaurent_injective`). `frobeniusLaurentFactor n` is the book's displayed factor `∏_{i<j} (1 - x_j/x_i)`, which lives outside `MvPolynomial` precisely because of those inverses.

`Etingof.Remark5_15_2` states the book's claim verbatim and with no sign correction: the Specht-module character `χ_{V_λ}(σ)` is the coefficient of `x^λ` in `∏_{i<j}(1 - x_j/x_i) · ∏_{m≥1} p_m(x)^{i_m}`. `Remark5_15_2_equiv_Theorem5_15_1` is the "equivalent formulation" claim proper, stated for an arbitrary polynomial factor `P` and so free of any reference to representation theory: the `x^e` coefficient of `∏_{i<j}(1-x_j/x_i) · P` equals `sign(rev) •` the `x^{e+ρ}` coefficient of `vandermondePoly · P`. The mathematical content is `rho_monomial_mul_frobeniusLaurentFactor`, `x^ρ · ∏_{i<j}(1 - x_j/x_i) = ∏_{i<j}(x_i - x_j)`; dividing by the monomial `x^ρ` is what shifts the extracted exponent from `λ+ρ` down to `λ`.

`Etingof.vandermondePoly` uses the Mathlib factor order `∏_{i<j}(x_j - x_i)` while the book's `Δ` is `∏_{i<j}(x_i - x_j)`, which is why `Theorem5_15_1` carries a `sign(rev) •` factor; `bookVandermondePoly_eq_smul` reconciles the two. That sign cancels against the one implicit in the book's Laurent factor, so the remark comes out sign-free exactly as printed. The reconciliation avoids counting inversions: `Equiv.Perm.sign_eq_prod_prod_Ioi` expresses `sign σ` over the same nested `Finset.Ioi` shape as `vandermondePoly`, and reversal inverts every pair, so each factor is `-1` by `Finset.prod_congr`.

No new sorries; `#print axioms` on all endpoints reports `propext, Classical.choice, Quot.sound` only. Signature locks, non-vacuity guards and the axiom checks live in `Chapter5/Remark5_15_2_Test.lean`. `progress/items.json` moves `Chapter5/Remark5.15.2` from `covered_partial` to `covered_full` (`scripts/validate_items.py` passes).

Closes #7405.

Session: d8f4aef5-5a22-4c10-8b4d-94b31ccfd72c

🤖 Prepared with Claude Code