### PR TITLE
docs: progress file for the #7815 repair session

### DIFF
--- a/progress/2026-07-26T04-31-19Z.md
+++ b/progress/2026-07-26T04-31-19Z.md
@@ -1,0 +1,51 @@
+## Accomplished
+
+Repair session. Salvaged PR #7815 ("docs(skill): record the NatTrans-into-Type
+elaboration trap and the CorepresentableBy route"), the only candidate reported by
+`coordination list-pr-repair`.
+
+Diagnosis: CI was already green on both `build` jobs; the sole problem was
+`mergeable == "CONFLICTING"`. The conflict was in
+`.claude/skills/lean-formalization/SKILL.md`, at the end of the file: the PR appended
+its "Building a `NatTrans` into `Type`" section at exactly the point where
+`origin/main` had meanwhile appended the "Classifying the simple modules of an algebra
+with 'diagonal characters' (#7419)" section from #7860. Two independent additions to the
+same tail, no semantic overlap.
+
+Resolution: merged `origin/main` into the PR branch and kept both sections, ordering
+main's section first so the branch diff against `main` is purely additive. Verified the
+staged result: `git diff --cached origin/main` is 64 insertions, 0 deletions, in one
+file, matching the PR's original intent exactly. No Lean sources differ from `main`, so
+the build is unaffected by construction and no `lake build` was needed. Pushed with
+`--force-with-lease`; `coordination mark-pr-salvaged 7815` cleared `repair-claimed`, and
+the PR merged.
+
+Note for future sessions: this repair was done in a fresh clone at
+`/tmp/pr7815-repair` rather than the assigned worktree
+(`worktrees/4f3b01a3`), because that worktree carried pre-existing uncommitted
+deletions in `.claude/commands/*.md` and `.claude/skills/agent-worker-flow/SKILL.md`
+(-364 lines) that blocked `gh pr checkout`. Those changes were not mine and were left
+untouched — they look like leftovers of the same class as the #7834 `.claude` regression
+recorded in commit 770558b9, and are worth a look by whoever owns that worktree.
+
+## Current frontier
+
+No PRs currently need repair: `coordination list-pr-repair` had exactly one candidate
+and it is now merged.
+
+## Overall project progress
+
+Unchanged by this session in mathematical terms — the salvaged PR was skill
+documentation only, no Lean sources touched. The `lean-formalization` skill now carries
+both the #7419 character-module recipe and the #7403 `CorepresentableBy` route.
+
+## Next step
+
+Re-run `coordination list-pr-repair`; if it is still empty, dispatch planners/workers
+rather than a repair session. Separately, someone should inspect the uncommitted
+`.claude/` deletions sitting in `worktrees/4f3b01a3` and either restore or discard them
+deliberately.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR records the progress handoff for the repair session that salvaged https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/pull/7815, whose only problem was a merge conflict from two independent sections appended to the tail of `lean-formalization/SKILL.md`. Both sections were kept; the branch diff against `main` stayed purely additive.

🤖 Prepared with Claude Code