### PR TITLE
docs: progress file for the #7848 repair session

### DIFF
--- a/progress/2026-07-26T05-01-03Z.md
+++ b/progress/2026-07-26T05-01-03Z.md
@@ -1,0 +1,77 @@
+## Accomplished
+
+Repair session for PR #7848 (`feat(Ch2 #7846): the converse existence half of
+Problem 2.7.5(b) and the book's iff`), which `coordination list-pr-repair`
+reported as the sole candidate, in `conflict` state.
+
+Diagnosis: CI on the branch was already green; the only problem was that the
+branch had fallen 6 commits behind `main` and conflicted in three files. All
+three conflicts were the same underlying story — `main` still described
+Problem 2.7.5(b) as pending #7846, while this PR is the work that finishes it:
+
+- `EtingofRepresentationTheory/Chapter2.lean` — the
+  `Problem2_7_5_Converse` import (added by the PR, absent on `main`).
+- `progress/items.json` — PR side sets `coverage: covered_full` and drops
+  `fidelity_issue: 7846`; `main` side had just refreshed the
+  `covered_partial` note to reflect part (c) landing.
+- `skipped-exercises.md` — PR side removes the Problem 2.7.5 bullet from
+  "Reopened former exclusions"; `main` side had rewritten that bullet to say
+  part (b)'s converse half remained open.
+
+Checked the merge base before resolving: the base bullet referenced the older
+#7392 classification, so `main`'s edit was purely a status refresh carrying no
+content the PR needed. Resolved all three in favour of the PR side, then
+validated `progress/items.json` still parses as JSON (593 items).
+
+Verified with a full `lake build` after `lake exe cache get`: 9307 jobs,
+exit 0, zero errors, zero `declaration uses 'sorry'` warnings.
+
+Pushed the merge commit and ran `coordination mark-pr-salvaged 7848`. The PR
+is now merged to `main` as 5ea498a3, and issue #7846 is closed.
+
+One thing worth flagging for whoever tunes the harness: `coordination
+create-pr` is documented as setting auto-merge, but #7848 had no auto-merge
+request on it. When I ran `gh pr merge 7848 --auto --squash` to fix that, it
+did not queue behind CI — it merged immediately, while the remote `build`
+checks were still `IN_PROGRESS`. The local full build above is what actually
+verified this merge, not remote CI. If this repo genuinely has auto-merge
+disabled at the repository level, `--auto` will keep silently degrading to an
+immediate merge for every agent that follows the documented workflow.
+
+## Current frontier
+
+No repair candidates remain: `coordination list-pr-repair` listed only #7848,
+which is now merged.
+
+## Overall project progress
+
+Problem 2.7.5 is complete in all three parts and recorded as `covered_full`:
+
+- (a) center and ideal structure — `center_eq_bot_of_not_isOfFinOrder`,
+  `center_of_isOfFinOrder`, `isSimpleRing_of_not_isOfFinOrder`;
+- (b) the book's iff — `isOfFinOrder_iff_exists_nontrivial_finrep`, with the
+  necessary direction from the determinant obstruction and the converse
+  witnessed by the constructed module V(1,1);
+- (c) the classification of finite-dimensional irreducibles by the family
+  V(α,β), including exhaustiveness and the uniqueness packaging.
+
+`main` builds clean at 9307 jobs with no sorries in the build output.
+
+## Next step
+
+No repair work is queued. A fresh planner or worker dispatch should pick the
+next feature item normally. If the auto-merge observation above is worth
+acting on, it belongs in the `agent-worker-flow` skill or the `coordination`
+script rather than in a progress file.
+
+## Blockers
+
+None.
+
+Incidental, not blocking: this worktree again started with uncommitted
+`.claude/` command and skill reversions that were not this session's work
+(~364 deletions across five files). I set them aside with `git stash push`
+rather than discarding them. The stash list now holds 114 near-identical
+entries from prior sessions, which suggests the pod worktree setup keeps
+reintroducing stale `.claude/` files and no session has ever reclaimed them.
+Cleaning that up needs a human decision, so I left the stashes untouched.


### PR DESCRIPTION
This PR adds the handoff progress file for the repair session that salvaged https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/pull/7848, which was blocked on a merge conflict with `main` in `Chapter2.lean`, `progress/items.json`, and `skipped-exercises.md`. All three conflicts were status-only: `main` still described Problem 2.7.5(b) as pending #7846 while the PR was the work completing it, so the PR side won each one. Verified with a full `lake build` (9307 jobs, no errors, no sorries) before pushing.

🤖 Prepared with Claude Code