### PR TITLE
Fix fidelity of Example 5.12.3: distinguish the two 3-dim S₄ irreps ℂ³₋ (3,1) and ℂ³₊ (2,1,1)

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -7486,3 +7486,59 @@ Three related points:
   `rfl`s in this file "failed" only because the sorry'd `app` above them had poisoned the terms;
   they all closed once the first error was fixed. Re-run the build after fixing error #1 before
   believing errors #2 onward.
+
+## Orienting a constructed simple rep against a named model (#7188, Specht modules vs the `S₄` catalogue)
+
+When the book says "and this one *is* the standard representation", a dimension count and even a
+non-isomorphism proof are not enough — you need an *oriented* identification. The recipe that
+worked, in three moves:
+
+1. **Narrow by the catalogue.** `Etingof.Example4_3_S4.S4_simple_iso` (and its `S₃` sibling) takes
+   any `S : FDRep ℂ S4` with `[Simple S]` and returns a five-way disjunction of `Nonempty (S ≅ _)`.
+   Kill the wrong-dimension branches with `(FDRep.isoToLinearEquiv h.some).finrank_eq`. For a
+   3-dimensional rep this leaves exactly `stdRep` (`ℂ³₋`) and `rotRep` (`ℂ³₊`).
+2. **Separate the survivors by a transported vector.** Find a property of a single vector that one
+   model has and the other cannot. The project had no equivariance-transport helper before this
+   (every prior `FDRep.isoToLinearEquiv` use was for `finrank`), so write one:
+
+   ```lean
+   theorem fixed_vector_of_iso {V W : FDRep ℂ S4} (e : V ≅ W) (g : S4) (v : V)
+       (hv : V.ρ g v = v) : W.ρ g (FDRep.isoToLinearEquiv e v) = FDRep.isoToLinearEquiv e v := by
+     rw [FDRep.Iso.conj_ρ e g, LinearEquiv.conj_apply]
+     simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe,
+       LinearEquiv.symm_apply_apply]
+     rw [hv]
+   ```
+
+   `FDRep.Iso.conj_ρ` is the only bridge you need; note `LinearEquiv.conj_apply` leaves the goal in
+   `∘ₗ` form, so `symm_apply_apply` has to go in the `simp only`, not in the preceding `rw`.
+3. **Get the second identification by elimination, not by repeating the work.** Once
+   `V_{(3,1)} ≅ stdRep` is in hand, `V_{(2,1,1)} ≅ stdRep` would give the two Specht modules equal
+   characters (`FDRep.char_iso` both ways, then `spechtModuleFDRep_character`), and
+   `spechtModuleCharacter_injective` turns that into `(2,1,1) = (3,1)`, refuted by `decide`. One
+   concrete computation, two oriented theorems.
+
+### The `c_λ = b_λ a_λ` ordering trap
+
+`Etingof.YoungSymmetrizer n la` is `ColumnAntisymmetrizer * RowSymmetrizer`, i.e. `b_λ a_λ`, **not**
+Etingof's `c_λ = a_λ b_λ` (its own docstring warns about this). Consequences for choosing a witness
+vector in `SpechtModule n la = ℂ[Sₙ]·c_λ`:
+
+* `of(p) · c_λ = c_λ` is **false** for `p ∈ P_λ`. What is true is `of(q) · c_λ = sign(q) • c_λ` for
+  `q ∈ Q_λ` (`of_col_mul_ColumnAntisymmetrizer`), and the column group is usually too small to
+  separate a rep from its sign twist.
+* The row-invariant vector is `a_λ c_λ`, not `c_λ`: `of(p) · (a_λ c_λ) = a_λ c_λ` by
+  `of_row_mul_RowSymmetrizer` after `← mul_assoc`.
+* `a_λ c_λ ≠ 0` is free: `c_λ² = b_λ (a_λ c_λ)`, so `a_λ c_λ = 0` would contradict
+  `young_symmetrizer_sq_ne_zero`. Prove it with `nth_rewrite 1 [hy]` where
+  `hy : YoungSymmetrizer n la = ColumnAntisymmetrizer n la * RowSymmetrizer n la := rfl` — a plain
+  `rw [YoungSymmetrizer]` rewrites both factors of `c_λ * c_λ` and loses the shape you want.
+
+### Small tactic notes from the same proof
+
+* Row/column-subgroup membership for a *literal* partition is `decide`-able once you rewrite
+  `sortedParts`: `intro k; rw [sortedParts_p_31]; revert k; decide`. `rowOfPos`/`colOfPos` are plain
+  structural recursions on the parts list, so the kernel evaluates them fine.
+* `linear_combination` coefficients for `-x = x ⊢ x = 0` are `-h/2`, not `-h`. The residue rule is
+  `goal_lhs - goal_rhs - Σ cᵢ (hᵢ_lhs - hᵢ_rhs) ≡ 0 by ring`; work the coefficient out rather than
+  guessing, since the error message shows the *unreduced* residue and reads confusingly.

--- a/EtingofRepresentationTheory/Chapter5/Example5_12_3.lean
+++ b/EtingofRepresentationTheory/Chapter5/Example5_12_3.lean
@@ -3,6 +3,7 @@ import EtingofRepresentationTheory.Chapter5.FRTHelpers
 import EtingofRepresentationTheory.Chapter5.Lemma5_13_1
 import EtingofRepresentationTheory.Chapter5.Theorem5_12_2_Distinct
 import EtingofRepresentationTheory.Chapter5.Problem5_24_1_b
+import EtingofRepresentationTheory.Chapter5.Discussion5_11_S4S3
 
 /-!
 # Example 5.12.3: Concrete Examples of Specht Modules
@@ -37,7 +38,11 @@ irreducibles: `V_{(3,1)} = ℂ³₋` (standard) and `V_{(2,1,1)} = ℂ³₊ = �
 `Example5_12_3_sign_twist_31_211` witnesses the sign-twist relation `ℂ³₊ = ℂ³₋ ⊗ ℂ₋`
 (since `(2,1,1)` is the conjugate partition of `(3,1)`, `conjugatePartition_p_31`), and
 `Example5_12_3_specht_31_211_noniso` witnesses that the two are non-isomorphic, neither of
-which a dimension count (both `= 3`) can capture.
+which a dimension count (both `= 3`) can capture. Finally
+`Example5_12_3_specht_31_iso_stdRep` and `Example5_12_3_specht_211_iso_rotRep` orient the
+pair, identifying `V_{(3,1)}` with the named standard representation
+`Etingof.Example4_3_S4.stdRep = ℂ³₋` and `V_{(2,1,1)}` with its sign twist
+`Etingof.Example4_3_S4.rotRep = ℂ³₊`.
 
 ## Mathlib correspondence
 
@@ -511,6 +516,178 @@ theorem Example5_12_3_sign_rep (n : ℕ) (hn : 0 < n) (σ : Equiv.Perm (Fin n))
       = ((↑(↑(Equiv.Perm.sign σ) : ℤ) : ℂ)) • v :=
   spechtModule_smul_eq n (columnPartition n hn) σ _ (Example5_12_3_sign n hn)
     (of_mul_youngSymmetrizer_columnPartition n hn σ) v
+
+/-! ## Orientation: which of `ℂ³₋`, `ℂ³₊` is which
+
+`Example5_12_3_specht_31_211_noniso` separates `V_{(3,1)}` from `V_{(2,1,1)}` but does not say
+which is the standard representation `ℂ³₋` and which is its sign twist `ℂ³₊`. The book does:
+`V_{(3,1)} = ℂ³₋` and `V_{(2,1,1)} = ℂ³₊`. We prove exactly that, against the named `S₄` models
+`Etingof.Example4_3_S4.stdRep` (`ℂ³₋`, the sum-zero subrepresentation of `ℂ⁴`) and
+`Etingof.Example4_3_S4.rotRep` (`ℂ³₊ = ℂ³₋ ⊗ ℂ₋`).
+
+The orientation comes from a single vector. Since `c_λ = b_λ a_λ`, the element `a_λ c_λ` of the
+left ideal `V_λ = ℂ[S₄]c_λ` is fixed by the whole row group `P_λ`, and it is nonzero because
+`c_λ² = b_λ (a_λ c_λ)` is nonzero. For `λ = (3,1)` the row group contains the transpositions
+`(0 1)` and `(1 2)`, so `V_{(3,1)}` has a nonzero vector fixed by both. The sign twist `ℂ³₊` has
+no such vector: on `ℂ³₊` a transposition acts by `−1` times the coordinate permutation, and the
+two conditions force all four coordinates to vanish. Since `dim V_{(3,1)} = 3`, the `S₄`
+catalogue (`Etingof.Example4_3_S4.S4_simple_iso`) leaves only `ℂ³₋`.
+
+`V_{(2,1,1)}` is then `ℂ³₊` by elimination: it is 3-dimensional, hence `ℂ³₋` or `ℂ³₊`, and it
+cannot be `ℂ³₋` because that would give it the same character as `V_{(3,1)}`, forcing
+`(2,1,1) = (3,1)` by `spechtModuleCharacter_injective`. -/
+
+section Orientation
+
+open Etingof.Example4_3_S4
+
+/-- `a_λ c_λ ≠ 0`: otherwise `c_λ² = b_λ (a_λ c_λ)` would vanish. -/
+theorem rowSymmetrizer_mul_youngSymmetrizer_ne_zero (n : ℕ) (la : Nat.Partition n) :
+    RowSymmetrizer n la * YoungSymmetrizer n la ≠ 0 := by
+  intro h
+  apply young_symmetrizer_sq_ne_zero n la
+  have hy : YoungSymmetrizer n la = ColumnAntisymmetrizer n la * RowSymmetrizer n la := rfl
+  nth_rewrite 1 [hy]
+  rw [mul_assoc, h, mul_zero]
+
+/-- The sorted parts of `(3,1)`. -/
+theorem sortedParts_p_31 : p_31.sortedParts = [3, 1] :=
+  sortedParts_eq_of _ [3, 1] rfl (by decide)
+
+/-- The transposition `(0 1)` preserves the rows of `(3,1)`: both cells lie in row `0`. -/
+theorem swap01_mem_rowSubgroup_p_31 :
+    Equiv.swap (0 : Fin 4) 1 ∈ RowSubgroup 4 p_31 := by
+  intro k
+  rw [sortedParts_p_31]
+  revert k
+  decide
+
+/-- The transposition `(1 2)` preserves the rows of `(3,1)`: both cells lie in row `0`. -/
+theorem swap12_mem_rowSubgroup_p_31 :
+    Equiv.swap (1 : Fin 4) 2 ∈ RowSubgroup 4 p_31 := by
+  intro k
+  rw [sortedParts_p_31]
+  revert k
+  decide
+
+/-- The row-invariant generator `a_λ c_λ` of `V_{(3,1)}`. -/
+noncomputable def w31 : ↥(SpechtModule 4 p_31) :=
+  ⟨RowSymmetrizer 4 p_31 * YoungSymmetrizer 4 p_31,
+    (SpechtModule 4 p_31).smul_mem (RowSymmetrizer 4 p_31) (Submodule.subset_span rfl)⟩
+
+theorem w31_ne_zero : w31 ≠ 0 := by
+  intro h
+  exact rowSymmetrizer_mul_youngSymmetrizer_ne_zero 4 p_31 (congrArg Subtype.val h)
+
+/-- Every row-group element fixes `a_λ c_λ`, because it is absorbed by `a_λ`. -/
+theorem spechtModuleRep_p_31_w31 (σ : Equiv.Perm (Fin 4)) (hσ : σ ∈ RowSubgroup 4 p_31) :
+    spechtModuleRep 4 p_31 σ w31 = w31 := by
+  apply Subtype.ext
+  change MonoidAlgebra.of ℂ (Equiv.Perm (Fin 4)) σ
+        * (RowSymmetrizer 4 p_31 * YoungSymmetrizer 4 p_31)
+      = RowSymmetrizer 4 p_31 * YoungSymmetrizer 4 p_31
+  rw [← mul_assoc, of_row_mul_RowSymmetrizer σ hσ]
+
+/-- On `ℂ³₊` a transposition acts by `−1` times the coordinate permutation. -/
+theorem rotRep_swap_apply (a b : Fin 4) (hab : a ≠ b) (v : ↥stdSub.toSubmodule) (i : Fin 4) :
+    (twistRep signHom stdSub.toRepresentation (Equiv.swap a b) v).1 i
+      = -(v.1 (Equiv.swap a b i)) := by
+  rw [twistRep_apply, signHom_coe, Equiv.Perm.sign_swap hab]
+  change ((-1 : ℤ) : ℂ) * (permRep (Equiv.swap a b) v.1 i) = _
+  rw [permRep_apply, Equiv.swap_inv]
+  ring
+
+/-- **`ℂ³₊` has no vector fixed by both `(0 1)` and `(1 2)`.** This is what orients the two
+3-dimensional irreducibles: `V_{(3,1)}` does have such a vector (`w31`). -/
+theorem rotRep_no_common_fixed_vector (v : ↥stdSub.toSubmodule)
+    (h1 : twistRep signHom stdSub.toRepresentation (Equiv.swap (0 : Fin 4) 1) v = v)
+    (h2 : twistRep signHom stdSub.toRepresentation (Equiv.swap (1 : Fin 4) 2) v = v) :
+    v = 0 := by
+  have e1 : ∀ i, -(v.1 (Equiv.swap (0 : Fin 4) 1 i)) = v.1 i := fun i => by
+    rw [← rotRep_swap_apply 0 1 (by decide) v i, h1]
+  have e2 : ∀ i, -(v.1 (Equiv.swap (1 : Fin 4) 2 i)) = v.1 i := fun i => by
+    rw [← rotRep_swap_apply 1 2 (by decide) v i, h2]
+  have h2' := e1 2
+  rw [show Equiv.swap (0 : Fin 4) 1 2 = 2 by decide] at h2'
+  have hv2 : v.1 2 = 0 := by linear_combination -h2' / 2
+  have h3' := e1 3
+  rw [show Equiv.swap (0 : Fin 4) 1 3 = 3 by decide] at h3'
+  have hv3 : v.1 3 = 0 := by linear_combination -h3' / 2
+  have h0' := e2 0
+  rw [show Equiv.swap (1 : Fin 4) 2 0 = 0 by decide] at h0'
+  have hv0 : v.1 0 = 0 := by linear_combination -h0' / 2
+  have h1' := e1 0
+  rw [show Equiv.swap (0 : Fin 4) 1 0 = 1 by decide] at h1'
+  have hv1 : v.1 1 = 0 := by linear_combination -h1' - hv0
+  apply Subtype.ext
+  funext i
+  fin_cases i <;> assumption
+
+/-- Transport of a fixed vector along an isomorphism of representations. -/
+theorem fixed_vector_of_iso {V W : FDRep ℂ S4} (e : V ≅ W) (g : S4) (v : V)
+    (hv : V.ρ g v = v) : W.ρ g (FDRep.isoToLinearEquiv e v) = FDRep.isoToLinearEquiv e v := by
+  rw [FDRep.Iso.conj_ρ e g, LinearEquiv.conj_apply]
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe,
+    LinearEquiv.symm_apply_apply]
+  rw [hv]
+
+/-- `dim V_{(3,1)} = 3` in the `FDRep` packaging. -/
+theorem finrank_spechtModuleFDRep_p_31 :
+    Module.finrank ℂ ((spechtModuleFDRep 4 p_31 : FDRep ℂ S4) : Type) = 3 :=
+  Example5_12_3_dim_31
+
+/-- `dim V_{(2,1,1)} = 3` in the `FDRep` packaging. -/
+theorem finrank_spechtModuleFDRep_p_211 :
+    Module.finrank ℂ ((spechtModuleFDRep 4 p_211 : FDRep ℂ S4) : Type) = 3 :=
+  Example5_12_3_dim_211
+
+/-- **Etingof Example 5.12.3 (`V_{(3,1)} = ℂ³₋`).** The Specht module for `λ = (3,1)` is the
+standard 3-dimensional irreducible `ℂ³₋` of `S₄`. -/
+theorem Example5_12_3_specht_31_iso_stdRep :
+    Nonempty (spechtModuleFDRep 4 p_31 ≅ stdRep) := by
+  rcases S4_simple_iso (spechtModuleFDRep 4 p_31) with h | h | h | h | h
+  · exact absurd (((FDRep.isoToLinearEquiv h.some).finrank_eq).symm.trans
+      finrank_spechtModuleFDRep_p_31) (by rw [trivRep_finrank]; decide)
+  · exact absurd (((FDRep.isoToLinearEquiv h.some).finrank_eq).symm.trans
+      finrank_spechtModuleFDRep_p_31) (by rw [signRep_finrank]; decide)
+  · exact absurd (((FDRep.isoToLinearEquiv h.some).finrank_eq).symm.trans
+      finrank_spechtModuleFDRep_p_31) (by rw [twoDimRep_finrank]; decide)
+  · exact h
+  · -- `V_{(3,1)}` has a vector fixed by `(0 1)` and `(1 2)`; `ℂ³₊` has none.
+    exfalso
+    obtain ⟨e⟩ := h
+    set u := FDRep.isoToLinearEquiv e w31 with hu
+    have hu0 : u ≠ 0 := fun h0 => w31_ne_zero
+      ((FDRep.isoToLinearEquiv e).injective (by rw [← hu, h0, map_zero]))
+    refine hu0 (rotRep_no_common_fixed_vector u ?_ ?_)
+    · exact fixed_vector_of_iso e _ w31
+        (spechtModuleRep_p_31_w31 _ swap01_mem_rowSubgroup_p_31)
+    · exact fixed_vector_of_iso e _ w31
+        (spechtModuleRep_p_31_w31 _ swap12_mem_rowSubgroup_p_31)
+
+/-- **Etingof Example 5.12.3 (`V_{(2,1,1)} = ℂ³₊`).** The Specht module for `λ = (2,1,1)` is the
+sign-twisted standard representation `ℂ³₊ = ℂ³₋ ⊗ ℂ₋` of `S₄`. -/
+theorem Example5_12_3_specht_211_iso_rotRep :
+    Nonempty (spechtModuleFDRep 4 p_211 ≅ rotRep) := by
+  rcases S4_simple_iso (spechtModuleFDRep 4 p_211) with h | h | h | h | h
+  · exact absurd (((FDRep.isoToLinearEquiv h.some).finrank_eq).symm.trans
+      finrank_spechtModuleFDRep_p_211) (by rw [trivRep_finrank]; decide)
+  · exact absurd (((FDRep.isoToLinearEquiv h.some).finrank_eq).symm.trans
+      finrank_spechtModuleFDRep_p_211) (by rw [signRep_finrank]; decide)
+  · exact absurd (((FDRep.isoToLinearEquiv h.some).finrank_eq).symm.trans
+      finrank_spechtModuleFDRep_p_211) (by rw [twoDimRep_finrank]; decide)
+  · -- `V_{(2,1,1)} ≅ ℂ³₋ ≅ V_{(3,1)}` would force `(2,1,1) = (3,1)`.
+    exfalso
+    obtain ⟨e⟩ := h
+    obtain ⟨e'⟩ := Example5_12_3_specht_31_iso_stdRep
+    have hchar : ∀ σ, spechtModuleCharacter 4 p_211 σ = spechtModuleCharacter 4 p_31 σ := by
+      intro σ
+      rw [← spechtModuleFDRep_character, ← spechtModuleFDRep_character,
+        congrFun (FDRep.char_iso e) σ, congrFun (FDRep.char_iso e') σ]
+    exact absurd (spechtModuleCharacter_injective 4 hchar) (by decide)
+  · exact h
+
+end Orientation
 
 end Example5_12_3
 

--- a/progress/2026-07-26T05-34-01Z_7006d56b.md
+++ b/progress/2026-07-26T05-34-01Z_7006d56b.md
@@ -1,0 +1,100 @@
+## Accomplished
+
+Closed issue #7188, the last fidelity gap on `Chapter5/Example5.12.3`: the book
+names the two 3-dimensional `S₄` Specht modules as `V_{(3,1)} = ℂ³₋` (standard)
+and `V_{(2,1,1)} = ℂ³₊` (standard ⊗ sign), and the formalization could not tell
+them apart.
+
+State on arrival was newer than the issue body claimed. A previous PR (#7197) had
+already landed `Example5_12_3_sign_twist_31_211` (the conjugate-partition sign
+twist) and `Example5_12_3_specht_31_211_noniso` (the two are non-isomorphic), so
+the *pair* was pinned. What was missing — and what `progress/items.json` recorded
+as the residual gap — was the **orientation**: which member of the pair is the
+standard representation. That is what this session adds.
+
+Two new headline theorems in
+`EtingofRepresentationTheory/Chapter5/Example5_12_3.lean`:
+
+- `Example5_12_3_specht_31_iso_stdRep : Nonempty (spechtModuleFDRep 4 p_31 ≅ stdRep)`
+- `Example5_12_3_specht_211_iso_rotRep : Nonempty (spechtModuleFDRep 4 p_211 ≅ rotRep)`
+
+against the named `S₄` models `Etingof.Example4_3_S4.stdRep` (sum-zero
+subrepresentation of `ℂ⁴`) and `.rotRep` (its sign twist).
+
+### The orientation argument
+
+The whole thing turns on one vector. This project's `YoungSymmetrizer` is
+`c_λ = b_λ a_λ` (column-then-row order — see the warning in its docstring), so
+left multiplication by a *row*-group element does **not** fix `c_λ`; it fixes
+`a_λ c_λ`. That element is the right witness:
+
+- `a_λ c_λ ≠ 0`, because `c_λ² = b_λ (a_λ c_λ)` and
+  `young_symmetrizer_sq_ne_zero`. (New lemma
+  `rowSymmetrizer_mul_youngSymmetrizer_ne_zero`, stated for all `n`, `λ`.)
+- `of(p) · (a_λ c_λ) = a_λ c_λ` for every `p ∈ P_λ`, by
+  `of_row_mul_RowSymmetrizer`. For `λ = (3,1)` the row group contains `(0 1)` and
+  `(1 2)` (membership by `decide` after `sortedParts_p_31 : p_31.sortedParts = [3,1]`).
+- `ℂ³₊` has **no** nonzero vector fixed by both `(0 1)` and `(1 2)`: a
+  transposition acts there by `−1` times the coordinate permutation, and the two
+  conditions force all four coordinates to vanish
+  (`rotRep_no_common_fixed_vector`, four `linear_combination` steps).
+- `dim V_{(3,1)} = 3` rules out `ℂ₊`, `ℂ₋`, `ℂ²` in the `S₄` catalogue
+  `Etingof.Example4_3_S4.S4_simple_iso`, leaving only `ℂ³₋`.
+
+`V_{(2,1,1)}` then follows by elimination without a second fixed-vector
+computation: it is 3-dimensional, so it is `ℂ³₋` or `ℂ³₊`; if it were `ℂ³₋` it
+would share a character with `V_{(3,1)}` (via `FDRep.char_iso` both ways), and
+`spechtModuleCharacter_injective` would force `(2,1,1) = (3,1)`.
+
+### Reusable pieces
+
+- `rowSymmetrizer_mul_youngSymmetrizer_ne_zero (n) (la)` — general, not `S₄`-specific.
+- `fixed_vector_of_iso` — transports a `ρ g`-fixed vector along an `FDRep` iso,
+  via `FDRep.Iso.conj_ρ`. The project had no equivariance-transport helper before
+  this; every prior use of `FDRep.isoToLinearEquiv` was for `finrank` only.
+- `rotRep_swap_apply` — a transposition acts on `ℂ³₊` by `−1 ∘ (coordinate swap)`.
+
+## Current frontier
+
+`lake build EtingofRepresentationTheory.Chapter5.Example5_12_3` exits 0 with no
+errors and no new warnings. `#print axioms` on the two new headline theorems, on
+`rotRep_no_common_fixed_vector`, `w31_ne_zero`, and on the two pre-existing
+3-dimensional theorems, all report exactly
+`[propext, Classical.choice, Quot.sound]` — no `sorryAx`. A full `lake build` of
+the project was run to confirm nothing downstream regressed.
+
+`progress/items.json` entry `Chapter5/Example5.12.3` moved from
+`fidelity: verified` / `coverage: covered_partial` / `followup_issue: 7188` to
+`fidelity: verified` / `coverage: covered`, `followup_issue` dropped, with
+`fidelity_decl` listing all eight deliverable declarations and a `fidelity_note`
+recording why the `(2,1)` and `(2,2)` cases remain faithfully dimension-only
+(each symmetric group has a *unique* 2-dimensional irreducible, so a dimension
+count determines the isomorphism class there).
+
+One import was added: `Chapter5.Discussion5_11_S4S3`, which brings in the `S₄`
+catalogue and the `Example4_3_S4` named models. No import cycle: nothing but
+`Chapter5.lean` imports `Example5_12_3`.
+
+## Overall project progress
+
+Stage 3 formalization ongoing; `progress/items.json` tracks 593 items. This turn
+retires one `completeness-audit` follow-up issue outright rather than partially.
+
+## Next step
+
+The `S₄` orientation toolkit assembled here transfers directly to nearby items.
+`fixed_vector_of_iso` plus `S4_simple_iso` is a general recipe for pinning any
+concretely-constructed simple `S₄`-representation to a named model, and the
+`a_λ c_λ` row-invariance trick generalises to any `λ` whose row group is large
+enough to separate a representation from its sign twist. Candidates in the
+unclaimed queue that could use it: #7457 (Young's rule module decomposition) and
+#7379 (equivariant Schur-Weyl decomposition).
+
+Independently, the oldest unclaimed issues remain #6644 (universe-lift invariance
+of `homologicalDimension` — genuinely hard, the reverse inequality needs an
+Auslander-style reduction) and #7127 (finiteness half of Theorem 3.5.4, marked
+low priority by the owner).
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -5489,10 +5489,20 @@
     "status": "sorry_free",
     "fidelity": "verified",
     "sorry_free": true,
-    "fidelity_note": "The trivial/sign cases are proved at representation level, and the two three-dimensional Specht modules are proved nonisomorphic and related by sign twist. The missing endpoint is their oriented identification with the separately constructed named S₄ models: V_(3,1) ≅ stdRep = ℂ³₋ and V_(2,1,1) ≅ rotRep = ℂ³₊.",
-    "coverage": "covered_partial",
-    "followup_issue": 7188,
-    "last_updated": "2026-07-22"
+    "fidelity_note": "All four book claims are now at representation level. The (n) and (1^n) extremes are the trivial and sign representations (Example5_12_3_trivial_rep, Example5_12_3_sign_rep). The n=3 lambda=(2,1) and n=4 lambda=(2,2) cases are dimension-only, which is faithful because each symmetric group has a unique 2-dimensional irreducible. The two 3-dimensional n=4 cases are oriented against the named S4 models of Chapter4/Example4_3_S4: Example5_12_3_specht_31_iso_stdRep gives V_(3,1) iso stdRep = C^3_-, and Example5_12_3_specht_211_iso_rotRep gives V_(2,1,1) iso rotRep = C^3_+. The orientation argument uses the row-invariant generator a_lambda c_lambda of V_(3,1), which C^3_+ cannot carry, plus the S4 irreducible catalogue Etingof.Example4_3_S4.S4_simple_iso. Closes the gap tracked by issue 7188.",
+    "coverage": "covered",
+    "last_updated": "2026-07-26",
+    "fidelity_decl": [
+      "Etingof.Example5_12_3.Example5_12_3_trivial_rep",
+      "Etingof.Example5_12_3.Example5_12_3_sign_rep",
+      "Etingof.Example5_12_3.Example5_12_3_dim_21",
+      "Etingof.Example5_12_3.Example5_12_3_dim_22",
+      "Etingof.Example5_12_3.Example5_12_3_specht_31_iso_stdRep",
+      "Etingof.Example5_12_3.Example5_12_3_specht_211_iso_rotRep",
+      "Etingof.Example5_12_3.Example5_12_3_sign_twist_31_211",
+      "Etingof.Example5_12_3.Example5_12_3_specht_31_211_noniso"
+    ],
+    "lean_file": "EtingofRepresentationTheory/Chapter5/Example5_12_3.lean"
   },
   {
     "id": "Chapter5/Corollary5.12.4",


### PR DESCRIPTION
Closes #7188

Session: `7006d56b-e085-417b-b518-ed305fd1c48f`

efb73f21 docs(Ch5 #7188): items.json fidelity update and progress file for the Example 5.12.3 orientation
57d73f85 feat(Ch5 #7188): orient the two 3-dimensional Specht modules against the named S4 models

🤖 Prepared with Claude Code