### PR TITLE
feat(Ch2 #Example2.3.14): classify every finite-dimensional indecomposable k[X]-module

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Example2_3_14.lean
+++ b/EtingofRepresentationTheory/Chapter2/Example2_3_14.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.Polynomial.Module.AEval
 import Mathlib.RingTheory.Nilpotent.Lemmas
 import Mathlib.LinearAlgebra.Eigenspace.Minpoly
 import Mathlib.LinearAlgebra.Pi
+import Mathlib.Algebra.Module.PID
 
 /-!
 # Example 2.3.14: Irreducible and Indecomposable Representations of k and k[x]
@@ -20,10 +21,9 @@ import Mathlib.LinearAlgebra.Pi
 
 This example shows that an indecomposable representation need not be irreducible.
 
-## Mathlib correspondence
-
-Exact match for the algebraic infrastructure. Polynomial rings, irreducibility, and Jordan
-normal form theory are available in Mathlib.
+The classification is exhaustive in both directions: `jordanRep_indecomposable` shows each
+`V_{λ,n}` is indecomposable, `exists_equiv_jordanRep` shows there are no others, and
+`jordanRep_equiv_iff` shows they are pairwise nonisomorphic.
 -/
 
 /-- For A = k, the unique irreducible representation is k itself (1-dimensional).
@@ -65,9 +65,12 @@ these as `k[X]`-modules (`Module.AEval'` of the Jordan-block operator), prove th
 indecomposable, and prove that for `n ≥ 2` they are not simple, giving the book's
 conclusion that an indecomposable representation need not be irreducible.
 
-The remaining half of the book's claim, that every finite-dimensional indecomposable
-`k[x]`-representation is isomorphic to some `V_{λ,n}`, is the existence-and-uniqueness of
-Jordan normal form, and is not formalized here.
+The other half of the book's claim — that every finite-dimensional indecomposable
+`k[x]`-representation is isomorphic to some `V_{λ,n}`, and that the parameters `(λ, n)` are
+determined — is the existence-and-uniqueness of Jordan normal form. It is proved below
+(`exists_equiv_jordanRep`, `jordanRep_equiv_iff`) from the structure theorem for finitely
+generated modules over the principal ideal domain `k[X]`, via the cyclic model
+`V_{λ,n} ≅ k[X]/((X-λ)ⁿ)` (`jordanQuotEquiv`).
 -/
 
 open Polynomial
@@ -394,15 +397,16 @@ lemma cyclicMap_X_sub_C_pow (lam : k) (n : ℕ) [NeZero n] (j : ℕ) :
       = Module.AEval'.of (jordanBlock lam n) (((shift n) ^ j) (eTop n)) := by
   rw [cyclicMap_apply, map_pow, aeval_jordanBlock_X_sub_C]
 
+/-- The shift on `kⁿ` is nilpotent of index exactly `n`. -/
+lemma shift_pow_self (n : ℕ) : ((shift n : (Fin n → k) →ₗ[k] (Fin n → k)) ^ n) = 0 := by
+  apply LinearMap.ext; intro v; funext i
+  rw [shift_pow_apply, dif_neg (by omega : ¬ (i : ℕ) + n < n)]
+  simp
+
 /-- `(X - λ)ⁿ` annihilates the cyclic vector, since the shift is nilpotent of index `n`. -/
 lemma cyclicMap_X_sub_C_pow_self (lam : k) (n : ℕ) [NeZero n] :
     cyclicMap lam n ((X - C lam) ^ n) = 0 := by
-  rw [cyclicMap_X_sub_C_pow]
-  have : ((shift n : (Fin n → k) →ₗ[k] (Fin n → k)) ^ n) = 0 := by
-    apply LinearMap.ext; intro v; funext i
-    rw [shift_pow_apply, dif_neg (by omega : ¬ (i : ℕ) + n < n)]
-    simp
-  rw [this]
+  rw [cyclicMap_X_sub_C_pow, shift_pow_self]
   simp
 
 /-- The cyclic vector generates: `q ↦ q • e_{n-1}` is onto `V_{λ,n}`. -/
@@ -461,5 +465,193 @@ noncomputable def jordanQuotEquiv (lam : k) (n : ℕ) [NeZero n] :
   · intro y
     obtain ⟨q, hq⟩ := cyclicMap_surjective lam n y
     exact ⟨Submodule.Quotient.mk q, hq⟩
+
+/-!
+## The converse: every finite-dimensional indecomposable `k[X]`-module is a Jordan block
+
+This is the second half of Etingof Example 2.3.14(2), the content the book attributes to the
+existence and uniqueness of Jordan normal form. We get it from the structure theorem for
+finitely generated modules over the principal ideal domain `k[X]`: such a module is a finite
+direct sum of cyclic primary pieces `k[X]/(pᵉ)`, indecomposability leaves exactly one piece,
+over an algebraically closed field `p` is linear, and `k[X]/((X-λ)ⁿ)` is the Jordan block
+`V_{λ,n}` by `jordanQuotEquiv`.
+-/
+
+/-- Indecomposability transfers along a linear equivalence. -/
+lemma IsIndecomposable.congr {R : Type*} [Ring R] {M N : Type*} [AddCommGroup M] [Module R M]
+    [AddCommGroup N] [Module R N] (e : M ≃ₗ[R] N) (h : IsIndecomposable R M) :
+    IsIndecomposable R N := by
+  haveI := h.1
+  refine ⟨e.symm.toEquiv.nontrivial, fun A B hAB => ?_⟩
+  set f := Submodule.orderIsoMapComap e with hf
+  rcases h.2 (f.symm A) (f.symm B) (f.symm.isCompl hAB) with hbot | hbot
+  · exact Or.inl (by rw [← f.apply_symm_apply A, hbot, f.map_bot])
+  · exact Or.inr (by rw [← f.apply_symm_apply B, hbot, f.map_bot])
+
+/-- An indecomposable module presented as a finite product of modules is isomorphic to one of
+the factors: the factor inclusions cut the product into complementary pieces, so all but one
+factor must vanish. -/
+lemma exists_equiv_of_equiv_pi {R : Type*} [Ring R] {M : Type*} [AddCommGroup M] [Module R M]
+    {ι : Type*} [Finite ι] (φ : ι → Type*) [∀ i, AddCommGroup (φ i)] [∀ i, Module R (φ i)]
+    (e : M ≃ₗ[R] ∀ i, φ i) (h : IsIndecomposable R M) :
+    ∃ i, Nonempty (M ≃ₗ[R] φ i) := by
+  classical
+  haveI := h.1
+  have hind : IsIndecomposable R (∀ i, φ i) := IsIndecomposable.congr e h
+  haveI := hind.1
+  set P : ι → Submodule R (∀ i, φ i) := fun i => LinearMap.range (LinearMap.single R φ i) with hP
+  have hsup : ⨆ i, P i = ⊤ := LinearMap.iSup_range_single R φ
+  -- some factor is nonzero, else the whole product would be
+  obtain ⟨i₀, hi₀⟩ : ∃ i, P i ≠ ⊥ := by
+    by_contra hcon
+    have hcon' : ∀ i, P i = ⊥ := fun i => not_not.mp fun hne => hcon ⟨i, hne⟩
+    exact top_ne_bot (α := Submodule R (∀ i, φ i)) (by rw [← hsup]; simp [hcon'])
+  -- the `i₀` factor and the rest are complementary
+  have hcompl : IsCompl (P i₀) (⨆ i ∈ ({i₀}ᶜ : Set ι), P i) := by
+    constructor
+    · have hd := LinearMap.disjoint_single_single R φ {i₀} {i₀}ᶜ disjoint_compl_right
+      rwa [iSup_singleton] at hd
+    · rw [codisjoint_iff, eq_top_iff, ← hsup]
+      refine iSup_le fun i => ?_
+      by_cases hi : i = i₀
+      · exact hi ▸ le_sup_left
+      · exact le_sup_of_le_right (le_biSup P hi)
+  rcases hind.2 _ _ hcompl with hbot | hbot
+  · exact absurd hbot hi₀
+  -- so the `i₀` factor is everything
+  have htop : P i₀ = ⊤ := by
+    have := hcompl.sup_eq_top
+    rwa [hbot, sup_bot_eq] at this
+  refine ⟨i₀, ⟨e.trans (LinearEquiv.ofBijective (LinearMap.single R φ i₀) ⟨?_, ?_⟩).symm⟩⟩
+  · rw [← LinearMap.ker_eq_bot]; exact LinearMap.ker_single R φ i₀
+  · rw [← LinearMap.range_eq_top]; exact htop
+
+section Converse
+
+variable (M : Type*) [AddCommGroup M] [Module k M] [Module (Polynomial k) M]
+  [IsScalarTower k (Polynomial k) M]
+
+/-- A `k[X]`-module that is finite dimensional over `k` is a torsion `k[X]`-module: no element
+can generate a free `k[X]`-submodule, because `k[X]` is infinite dimensional over `k`. -/
+lemma isTorsion_of_finiteDimensional [FiniteDimensional k M] :
+    Module.IsTorsion (Polynomial k) M := by
+  intro m
+  have hnotinj : ¬ Function.Injective
+      ((LinearMap.toSpanSingleton (Polynomial k) M m).restrictScalars k) := fun hinj =>
+    Polynomial.not_finite (Module.Finite.of_injective _ hinj)
+  rw [← LinearMap.ker_eq_bot] at hnotinj
+  obtain ⟨q, hq, hqne⟩ := (Submodule.ne_bot_iff _).mp hnotinj
+  exact ⟨⟨q, mem_nonZeroDivisors_of_ne_zero hqne⟩, LinearMap.mem_ker.mp hq⟩
+
+/-- **Etingof Example 2.3.14(2), the classification.** Over an algebraically closed field,
+every finite-dimensional indecomposable `k[X]`-representation is isomorphic to a Jordan block
+`V_{λ,n} = (kⁿ, ρ(x) = J_{λ,n})` with `n ≥ 1`.
+
+Together with `jordanRep_indecomposable` (each `V_{λ,n}` is indecomposable) and
+`jordanRep_equiv_iff` (they are pairwise nonisomorphic), this is the book's statement that the
+`V_{λ,n}` are exactly the finite-dimensional indecomposable representations of `k[x]`. -/
+theorem exists_equiv_jordanRep [IsAlgClosed k] [FiniteDimensional k M]
+    (h : IsIndecomposable (Polynomial k) M) :
+    ∃ (lam : k) (n : ℕ), 0 < n ∧ Nonempty (M ≃ₗ[Polynomial k] jordanRep lam n) := by
+  classical
+  haveI := h.1
+  haveI : Module.Finite (Polynomial k) M := Module.Finite.of_restrictScalars_finite k _ _
+  -- structure theorem over the PID `k[X]`
+  obtain ⟨ι, _, p, hp, expo, ⟨estr⟩⟩ :=
+    Module.equiv_directSum_of_isTorsion (isTorsion_of_finiteDimensional (k := k) M)
+  -- indecomposability keeps exactly one summand
+  obtain ⟨i, ⟨eqi⟩⟩ := exists_equiv_of_equiv_pi _
+    (estr.trans (DirectSum.linearEquivFunOnFintype _ _ _)) h
+  -- over an algebraically closed field the irreducible `p i` is linear
+  have hdeg : (p i).degree ≠ 0 := fun hd =>
+    (hp i).not_isUnit (Polynomial.isUnit_iff_degree_eq_zero.mpr hd)
+  obtain ⟨lam, hlam⟩ := IsAlgClosed.exists_root (p i) hdeg
+  have hassoc : Associated (X - C lam) (p i) :=
+    (Polynomial.irreducible_X_sub_C lam).associated_of_dvd (hp i)
+      (Polynomial.dvd_iff_isRoot.mpr hlam)
+  -- the exponent is positive, else the summand would be the zero module
+  have hpos : 0 < expo i := by
+    rcases Nat.eq_zero_or_pos (expo i) with h0 | h0
+    · exfalso
+      have : Subsingleton (Polynomial k ⧸ (Polynomial k) ∙ p i ^ expo i) := by
+        rw [h0, pow_zero, Ideal.submodule_span_eq, Ideal.span_singleton_one]
+        infer_instance
+      exact not_subsingleton M (eqi.toEquiv.subsingleton)
+    · exact h0
+  haveI : NeZero (expo i) := ⟨by omega⟩
+  refine ⟨lam, expo i, hpos, ⟨eqi.trans ((Submodule.quotEquivOfEq _ _ ?_).trans
+    (jordanQuotEquiv lam (expo i)))⟩⟩
+  rw [Ideal.submodule_span_eq]
+  exact Ideal.span_singleton_eq_span_singleton.mpr (hassoc.pow_pow (n := expo i)).symm
+
+end Converse
+
+/-!
+## The Jordan blocks are pairwise nonisomorphic
+
+The dimension pins down `n`; the eigenvalue is pinned down because `(X-λ)ⁿ` annihilates
+`V_{λ,n}`, while on `V_{μ,m}` the operator `X - λ` is `(μ-λ)·id + S` with `S` nilpotent, which
+is nilpotent only when `λ = μ`.
+-/
+
+/-- On `V_{μ,n}`, the element `X - λ` acts as `(μ - λ)·id` plus the nilpotent shift. -/
+lemma aeval_jordanBlock_X_sub_C' (lam mu : k) (n : ℕ) :
+    Polynomial.aeval (jordanBlock mu n) (X - C lam)
+      = (mu - lam) • (1 : Module.End k (Fin n → k)) + shift n := by
+  rw [map_sub, Polynomial.aeval_X, Polynomial.aeval_C]
+  ext v i
+  simp [jordanBlock, Module.algebraMap_end_apply, sub_smul]
+  ring
+
+/-- `(X - λ)ⁿ` annihilates every element of `V_{λ,n}`. -/
+lemma X_sub_C_pow_smul_jordanRep (lam : k) (n : ℕ) (v : jordanRep lam n) :
+    ((X - C lam) ^ n : Polynomial k) • v = 0 := by
+  obtain ⟨w, rfl⟩ := (Module.AEval'.of (jordanBlock lam n)).surjective v
+  have hsmul : ((X - C lam) ^ n : Polynomial k) • (Module.AEval'.of (jordanBlock lam n) w)
+      = Module.AEval'.of (jordanBlock lam n)
+        (Polynomial.aeval (jordanBlock lam n) ((X - C lam) ^ n) w) := rfl
+  rw [hsmul, map_pow, aeval_jordanBlock_X_sub_C, shift_pow_self]
+  simp
+
+/-- **The Jordan blocks are pairwise nonisomorphic.** `V_{λ,n} ≅ V_{μ,m}` as `k[X]`-modules
+forces `λ = μ` and `n = m`. (Etingof Example 2.3.14(2): "clearly, these representations are
+pairwise nonisomorphic".) -/
+theorem jordanRep_equiv_iff (lam mu : k) (n m : ℕ) [NeZero n] [NeZero m] :
+    Nonempty (jordanRep lam n ≃ₗ[Polynomial k] jordanRep mu m) ↔ lam = mu ∧ n = m := by
+  refine ⟨fun ⟨e⟩ => ?_, fun ⟨h1, h2⟩ => h1 ▸ h2 ▸ ⟨LinearEquiv.refl _ _⟩⟩
+  have hnm : n = m := by
+    have h := (e.restrictScalars k).finrank_eq
+    rwa [finrank_jordanRep, finrank_jordanRep] at h
+  refine ⟨?_, hnm⟩
+  by_contra hne
+  -- `(X-λ)ⁿ` kills `V_{λ,n}`, hence — transporting along `e` — also `V_{μ,m}`
+  have hop : Polynomial.aeval (jordanBlock mu m) ((X - C lam) ^ n) = 0 := by
+    apply LinearMap.ext
+    intro w
+    have h := X_sub_C_pow_smul_jordanRep lam n (e.symm (Module.AEval'.of (jordanBlock mu m) w))
+    have h2 := congrArg e h
+    rw [map_smul, e.apply_symm_apply, map_zero] at h2
+    exact (map_eq_zero_iff _ (Module.AEval'.of (jordanBlock mu m)).injective).mp h2
+  -- so `(μ-λ)·id + S` is nilpotent; subtracting the nilpotent `S` makes `(μ-λ)·id` nilpotent
+  set A := Polynomial.aeval (jordanBlock mu m) (X - C lam) with hA
+  have hAnil : IsNilpotent A := ⟨n, by rw [hA, ← map_pow]; exact hop⟩
+  have hAeq : A = (mu - lam) • (1 : Module.End k (Fin m → k)) + shift m :=
+    aeval_jordanBlock_X_sub_C' lam mu m
+  have hcomm : Commute A (shift m) := by
+    rw [hAeq]
+    exact Commute.add_left ((Commute.one_left _).smul_left _) (Commute.refl _)
+  have hscal : IsNilpotent ((mu - lam) • (1 : Module.End k (Fin m → k))) := by
+    have := hcomm.isNilpotent_sub hAnil (shift_nilpotent m)
+    rwa [hAeq, add_sub_cancel_right] at this
+  -- a nilpotent scalar on a nonzero space is zero
+  obtain ⟨j, hj⟩ := hscal
+  rw [smul_pow, one_pow] at hj
+  have hvec : ((mu - lam) ^ j) • (e0 m : Fin m → k) = 0 := by
+    have := congrArg (fun f : Module.End k (Fin m → k) => f (e0 m)) hj
+    simpa using this
+  have hpow : (mu - lam) ^ j = 0 := (smul_eq_zero.mp hvec).resolve_right (e0_ne_zero m)
+  rcases Nat.eq_zero_or_pos j with hj0 | hj0
+  · rw [hj0, pow_zero] at hpow; exact one_ne_zero hpow
+  · exact hne (by have := pow_eq_zero_iff (n := j) (by omega) |>.mp hpow; linear_combination -this)
 
 end Etingof.Example_2_3_14

--- a/EtingofRepresentationTheory/Chapter2/Example2_3_14.lean
+++ b/EtingofRepresentationTheory/Chapter2/Example2_3_14.lean
@@ -335,4 +335,131 @@ theorem exists_indecomposable_not_simple :
       ¬ IsSimpleModule (Polynomial k) (jordanRep (0 : k) 2) :=
   ⟨jordanRep_indecomposable 0 2, jordanRep_not_isSimpleModule 0 2 le_rfl⟩
 
+/-!
+## The cyclic model of a Jordan block
+
+`V_{λ,n}` is the cyclic `k[X]`-module `k[X]/((X-λ)ⁿ)`: the top basis vector `e_{n-1}` is a
+cyclic vector, `X - λ` acts on it as the nilpotent down-shift, and `(X-λ)ⁿ` kills it.
+
+This is the form in which the structure theorem for modules over the principal ideal domain
+`k[X]` delivers its summands, so it is what connects that theorem to the Jordan blocks.
+-/
+
+/-- The top standard basis vector `e_{n-1} = (0, …, 0, 1)`. It is a cyclic vector for the
+Jordan block `J_{λ,n}`: applying the shift repeatedly sweeps out the whole standard basis. -/
+def eTop (n : ℕ) [NeZero n] : Fin n → k :=
+  Pi.single ⟨n - 1, Nat.sub_lt (Nat.pos_of_ne_zero (NeZero.ne n)) one_pos⟩ 1
+
+/-- Applying the shift `j < n` times to `e_{n-1}` gives the basis vector `e_{n-1-j}`. -/
+lemma shift_pow_eTop (n : ℕ) [NeZero n] {j : ℕ} (hj : j < n) :
+    ((shift n) ^ j) (eTop n : Fin n → k) = Pi.single ⟨n - 1 - j, by omega⟩ 1 := by
+  funext i
+  rw [shift_pow_apply]
+  by_cases h : (i : ℕ) + j < n
+  · rw [dif_pos h]
+    simp only [eTop, Pi.single_apply, Fin.ext_iff]
+    have : ((i : ℕ) + j = n - 1) ↔ ((i : ℕ) = n - 1 - j) := by omega
+    simp [this]
+  · rw [dif_neg h]
+    symm
+    simp only [Pi.single_apply, Fin.ext_iff]
+    rw [if_neg (by omega)]
+
+/-- `X - λ` acts on `V_{λ,n}` as the nilpotent down-shift: `J_{λ,n} - λ = S`. -/
+lemma aeval_jordanBlock_X_sub_C (lam : k) (n : ℕ) :
+    Polynomial.aeval (jordanBlock lam n) (X - C lam) = shift n := by
+  rw [map_sub, Polynomial.aeval_X, Polynomial.aeval_C]
+  ext v i
+  simp [jordanBlock, Module.algebraMap_end_apply]
+
+/-- `V_{λ,n}` has `k`-dimension `n`. -/
+@[simp] lemma finrank_jordanRep (lam : k) (n : ℕ) :
+    Module.finrank k (jordanRep lam n) = n := by
+  rw [← (Module.AEval'.of (jordanBlock lam n)).finrank_eq]
+  simp
+
+/-- Evaluation at the cyclic vector: the `k[X]`-linear map `k[X] → V_{λ,n}`, `q ↦ q • e_{n-1}`. -/
+noncomputable def cyclicMap (lam : k) (n : ℕ) [NeZero n] :
+    Polynomial k →ₗ[Polynomial k] jordanRep lam n :=
+  LinearMap.toSpanSingleton (Polynomial k) (jordanRep lam n)
+    (Module.AEval'.of (jordanBlock lam n) (eTop n))
+
+lemma cyclicMap_apply (lam : k) (n : ℕ) [NeZero n] (q : Polynomial k) :
+    cyclicMap lam n q
+      = Module.AEval'.of (jordanBlock lam n) (Polynomial.aeval (jordanBlock lam n) q (eTop n)) :=
+  rfl
+
+lemma cyclicMap_X_sub_C_pow (lam : k) (n : ℕ) [NeZero n] (j : ℕ) :
+    cyclicMap lam n ((X - C lam) ^ j)
+      = Module.AEval'.of (jordanBlock lam n) (((shift n) ^ j) (eTop n)) := by
+  rw [cyclicMap_apply, map_pow, aeval_jordanBlock_X_sub_C]
+
+/-- `(X - λ)ⁿ` annihilates the cyclic vector, since the shift is nilpotent of index `n`. -/
+lemma cyclicMap_X_sub_C_pow_self (lam : k) (n : ℕ) [NeZero n] :
+    cyclicMap lam n ((X - C lam) ^ n) = 0 := by
+  rw [cyclicMap_X_sub_C_pow]
+  have : ((shift n : (Fin n → k) →ₗ[k] (Fin n → k)) ^ n) = 0 := by
+    apply LinearMap.ext; intro v; funext i
+    rw [shift_pow_apply, dif_neg (by omega : ¬ (i : ℕ) + n < n)]
+    simp
+  rw [this]
+  simp
+
+/-- The cyclic vector generates: `q ↦ q • e_{n-1}` is onto `V_{λ,n}`. -/
+lemma cyclicMap_surjective (lam : k) (n : ℕ) [NeZero n] :
+    Function.Surjective (cyclicMap lam n) := by
+  set of := Module.AEval'.of (jordanBlock lam n) with hof
+  -- every standard basis vector is `(X-λ)^{n-1-i} • e_{n-1}`
+  have hbasis : ∀ i : Fin n,
+      of (Pi.single i 1) ∈ LinearMap.range (cyclicMap lam n) := by
+    intro i
+    have hi := i.isLt
+    refine ⟨(X - C lam) ^ (n - 1 - (i : ℕ)), ?_⟩
+    rw [cyclicMap_X_sub_C_pow, shift_pow_eTop n (by omega)]
+    have hidx : (⟨n - 1 - (n - 1 - (i : ℕ)), by omega⟩ : Fin n) = i :=
+      Fin.ext (show n - 1 - (n - 1 - (i : ℕ)) = (i : ℕ) by omega)
+    rw [hidx]
+  -- the standard basis spans, so the (a fortiori `k`-) submodule they generate is everything
+  have hspan : Submodule.span k (Set.range fun i : Fin n => (Pi.single i 1 : Fin n → k)) = ⊤ := by
+    rw [show (fun i : Fin n => (Pi.single i 1 : Fin n → k)) = ⇑(Pi.basisFun k (Fin n)) from
+      funext fun i => (Pi.basisFun_apply k (Fin n) i).symm]
+    exact (Pi.basisFun k (Fin n)).span_eq
+  have htop : (⊤ : Submodule k (Fin n → k)) ≤
+      Submodule.comap (of : (Fin n → k) →ₗ[k] jordanRep lam n)
+        ((LinearMap.range (cyclicMap lam n)).restrictScalars k) := by
+    rw [← hspan, Submodule.span_le]
+    rintro _ ⟨i, rfl⟩
+    exact hbasis i
+  intro y
+  have := htop (Submodule.mem_top (x := of.symm y))
+  rw [Submodule.mem_comap] at this
+  simpa using this
+
+/-- **The cyclic model of a Jordan block.** `V_{λ,n} ≅ k[X]/((X-λ)ⁿ)` as `k[X]`-modules.
+
+Both sides have `k`-dimension `n`, and `q ↦ q • e_{n-1}` is a surjection killing `(X-λ)ⁿ`,
+so the induced map out of the quotient is an isomorphism. -/
+noncomputable def jordanQuotEquiv (lam : k) (n : ℕ) [NeZero n] :
+    (Polynomial k ⧸ Ideal.span {(X - C lam) ^ n}) ≃ₗ[Polynomial k] jordanRep lam n := by
+  haveI : Module.Finite k (Polynomial k ⧸ Ideal.span {(X - C lam) ^ n}) :=
+    ((monic_X_sub_C lam).pow n).finite_quotient
+  have hle : Ideal.span {(X - C lam) ^ n} ≤ LinearMap.ker (cyclicMap lam n) := by
+    rw [Ideal.span_le]
+    rintro _ rfl
+    exact cyclicMap_X_sub_C_pow_self lam n
+  refine LinearEquiv.ofBijective (Submodule.liftQ _ (cyclicMap lam n) hle) ⟨?_, ?_⟩
+  · -- injective, by equality of `k`-dimensions
+    have hdim : Module.finrank k (Polynomial k ⧸ Ideal.span {(X - C lam) ^ n})
+        = Module.finrank k (jordanRep lam n) := by
+      rw [finrank_quotient_span_eq_natDegree, finrank_jordanRep]
+      simp [Polynomial.natDegree_pow]
+    have := (LinearMap.injective_iff_surjective_of_finrank_eq_finrank (K := k) hdim
+      (f := (Submodule.liftQ _ (cyclicMap lam n) hle).restrictScalars k)).2
+    exact this (fun y => by
+      obtain ⟨q, hq⟩ := cyclicMap_surjective lam n y
+      exact ⟨Submodule.Quotient.mk q, hq⟩)
+  · intro y
+    obtain ⟨q, hq⟩ := cyclicMap_surjective lam n y
+    exact ⟨Submodule.Quotient.mk q, hq⟩
+
 end Etingof.Example_2_3_14

--- a/progress/2026-07-26T07-12-09Z_52629581.md
+++ b/progress/2026-07-26T07-12-09Z_52629581.md
@@ -101,4 +101,35 @@ counterexample of Remark 3.10.3) are all real, self-contained, and unclaimed.
 
 ## Blockers
 
-None.
+None for the work itself. One anomaly worth a human look, deliberately left untouched:
+
+this worktree started the session with six `.claude/` files already modified and
+uncommitted, all large deletions —
+
+```
+ .claude/commands/feature.md               |  24 ---
+ .claude/commands/meditate.md              |  16 --
+ .claude/commands/review.md                |  90 ----------
+ .claude/commands/summarize.md             |  40 +----
+ .claude/commands/work.md                  |  21 ---
+ .claude/skills/agent-worker-flow/SKILL.md | 288 +-----------------------------
+ 6 files changed, 2 insertions(+), 477 deletions(-)
+```
+
+They predate this session (they are in the git status snapshot taken at session
+start), so they are not this session's work and are not in PR #7879. I left them
+uncommitted rather than reverting them, since they may be in-progress work.
+
+The practical consequence: the skill improvement this session would otherwise have
+made — adding a pre-claim staleness check to `agent-worker-flow` — could not be
+landed cleanly, because any commit touching `SKILL.md` would have dragged the 288
+deleted lines along with it. The proposed addition, for whoever picks this up on a
+clean tree, is a step between "claim" and "set up":
+
+> **Check the issue is not already done.** If the issue names a specific declaration,
+> `grep` for it before writing any code. If it exists and its file has no `sorry`,
+> confirm with `#print axioms` and close the issue with that evidence rather than
+> working it. Caveat: a zero `sorry` count is only evidence of staleness for issues
+> that ask you to *fill* a named `sorry`. Issues that ask you to *add* a new
+> declaration ("expose", "generalize", "bridge") sit in already-sorry-free files and
+> are genuine work.

--- a/progress/2026-07-26T07-12-09Z_52629581.md
+++ b/progress/2026-07-26T07-12-09Z_52629581.md
@@ -1,0 +1,104 @@
+## Accomplished
+
+A `/work` session that did two things: cleared a large block of stale issues off the
+head of the work queue, then formalized #7364.
+
+### Queue triage
+
+The seven oldest unclaimed issues were all already done on `main` and had simply never
+been closed. Each was verified before closing (module builds green, no `sorry` in the
+file, `#print axioms` on the named declaration reporting only
+`propext, Classical.choice, Quot.sound`):
+
+- #6045 Ch8 Problem 8.2.5 — `Problem_8_2_5_morphism_of_resolutions`,
+  `Problem_8_2_5_independence` (landed in `629474b6` / PR #6052)
+- #5972 Ch2 Exercise 2.11.2 — `nonempty_addEquiv_tensorProduct`
+- #6217 Ch2 Problem 2.14.3 — `exists_tensorHom_adjunction`
+- #6282 Ch5 Problem 5.16.1 — `res_spechtModule_character`,
+  `ind_spechtModule_multiplicity`
+- #6567 Ch9 Problem 9.6.5 — `exists_quasiInverse_tensor_functor`
+- #6644 Ch9 — closed in the equivalent `HasHomologicalDimensionLE` form
+  (`hasHomologicalDimensionLE_of_ulift` + `_congr`); deliverable 2,
+  `homologicalDimension_freeAlgebra_eq_one`, is proved
+- #6607 Ch3 Problem 3.9.5(i) even case — `even_isMatrixAlgebra` (landed via
+  Wedderburn–Artin rather than the book's explicit spinor construction; the odd case
+  has since landed too)
+
+Note `coordination list-unclaimed` is capped at ~32 entries, so closing these surfaced
+older issues that had been hidden behind the cap (#5972 only became visible after
+#6045 closed). There may be more stale items still hidden.
+
+### #7364 — the finite-dimensional indecomposable `k[X]`-modules
+
+`EtingofRepresentationTheory/Chapter2/Example2_3_14.lean` had the "these are
+indecomposable" half of Etingof Example 2.3.14(2) but explicitly disclaimed the
+converse. Both halves are now formalized, sorry-free and axiom-clean.
+
+New results:
+
+- `jordanQuotEquiv : k[X] ⧸ ((X-λ)ⁿ) ≃ₗ[k[X]] jordanRep λ n` — the cyclic model.
+  Built from `cyclicMap` (evaluation at the cyclic vector `eTop = e_{n-1}`), which is
+  surjective and kills `(X-λ)ⁿ`; injectivity is a dimension count, using
+  `finrank_quotient_span_eq_natDegree` on one side and `finrank_jordanRep` on the
+  other, with `Polynomial.Monic.finite_quotient` supplying the finite-dimensionality
+  of the quotient.
+- `exists_equiv_jordanRep` — over an algebraically closed field, every
+  finite-dimensional indecomposable `k[X]`-module is `≃ₗ[k[X]] jordanRep λ n` for some
+  `λ` and some `n ≥ 1`.
+- `jordanRep_equiv_iff` — `jordanRep λ n ≃ₗ[k[X]] jordanRep μ m ↔ λ = μ ∧ n = m`.
+
+Supporting lemmas worth knowing about for reuse:
+
+- `isTorsion_of_finiteDimensional` — a `k[X]`-module finite dimensional over `k` is
+  torsion. The argument is that `q ↦ q • m` cannot be injective, since `k[X]` is not
+  finite dimensional over `k` (`Polynomial.not_finite`).
+- `exists_equiv_of_equiv_pi` — general: an indecomposable module presented as a finite
+  *product* is isomorphic to one factor. Uses `LinearMap.iSup_range_single` and
+  `LinearMap.disjoint_single_single` to make the `i₀` factor and the rest
+  complementary. This is the piece that turns the structure theorem's `⨁` into a
+  single summand; `DirectSum.linearEquivFunOnFintype` converts the sum to a product.
+- `IsIndecomposable.congr` — transport along a `LinearEquiv`, via
+  `Submodule.orderIsoMapComap` and `OrderIso.isCompl`.
+
+Proof shape overall: `Module.equiv_directSum_of_isTorsion` (Mathlib's structure
+theorem for f.g. modules over a PID) → one summand by indecomposability →
+`IsAlgClosed.exists_root` + `Irreducible.associated_of_dvd` to replace the irreducible
+generator by `X - λ` → `jordanQuotEquiv`. Uniqueness of `n` is `finrank`; uniqueness of
+`λ` is nilpotency: `X - λ` acts on `V_{μ,m}` as `(μ-λ)·id + S` with `S` nilpotent, and
+`Commute.isNilpotent_sub` would then make the scalar `(μ-λ)·id` nilpotent, forcing
+`λ = μ`.
+
+Module docs and the `progress/items.json` entry for `Chapter2/Example2.3.14` (which
+said the converse was unformalized, coverage `covered_partial`) are updated; coverage
+is now `covered_full`.
+
+## Current frontier
+
+#7364 is complete. `EtingofRepresentationTheory.Chapter2.Example2_3_14` builds green
+with zero `sorry`; `jordanQuotEquiv`, `exists_equiv_jordanRep`, `jordanRep_equiv_iff`,
+`exists_equiv_of_equiv_pi` and `isTorsion_of_finiteDimensional` all report only
+`propext, Classical.choice, Quot.sound`. Whole-project `lake build` was run to
+completion before publishing.
+
+## Overall project progress
+
+Unchanged in shape — this closed one formalization item and removed seven phantom ones
+from the queue. `Chapter2/Example2.3.14` moves from `covered_partial` to
+`covered_full`.
+
+## Next step
+
+Worth a dedicated pass: the staleness rate at the head of the queue was 7 out of the 8
+oldest issues. A cheap check before claiming — does the issue name a specific
+declaration, and is that declaration already sorry-free? — would save whole sessions.
+Note that a zero `sorry` count in the named file is *not* sufficient evidence on its
+own: many issues ask for a *new* declaration in an already-sorry-free file (#7457,
+#7473, #7476, #7489 are of that kind and are genuine open work).
+
+Otherwise: #7395 (Proposition 4.7.1, matrix coefficients form a basis of `F(G,ℂ)`),
+#7453 (the tensor-product Jacobson-radical formula) and #7430 (the Weyl-algebra
+counterexample of Remark 3.10.3) are all real, self-contained, and unclaimed.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -603,12 +603,11 @@
     "fidelity": "verified",
     "needs_statement": false,
     "sorry_free": true,
-    "fidelity_note": "Part (1): k is the only simple/indecomposable k-module (IsSimpleModule k k). Part (2): the 1-dim irreducibles are classified (Example_2_3_14_polynomial_reps: simple k[x]-modules are 1-dimensional). The Jordan-block reps V_{λ,n} are now built as genuine k[X]-modules (jordanRep = Module.AEval' of jordanBlock), proved indecomposable (jordanRep_indecomposable, via: every nonzero J-invariant subspace contains the eigenvector e₀) and proved not simple for n≥2 (jordanRep_not_isSimpleModule), giving the book's conclusion 'indecomposable need not be irreducible' (exists_indecomposable_not_simple, witness V_{0,2}). Remaining (noted in file): the completeness half — that every f.d. indecomposable k[x]-rep is some V_{λ,n} — is Jordan normal form existence/uniqueness, which the book cites rather than proves and which is not formalized here.",
-    "fidelity_decl": "Etingof.Example_2_3_14.jordanRep_indecomposable; Etingof.Example_2_3_14.jordanRep_not_isSimpleModule; Etingof.Example_2_3_14.exists_indecomposable_not_simple",
-    "coverage": "covered_partial",
-    "coverage_note": "The Jordan-block modules are constructed and proved indecomposable, but the exhaustive and unique classification of every finite-dimensional indecomposable k[X]-module is not yet formalized. Follow-up: #7364.",
-    "followup_issue": 7364,
-    "last_updated": "2026-07-22"
+    "fidelity_note": "Part (1): k is the only simple/indecomposable k-module (IsSimpleModule k k). Part (2): the 1-dim irreducibles are classified (Example_2_3_14_polynomial_reps: simple k[x]-modules are 1-dimensional). The Jordan-block reps V_{λ,n} are built as genuine k[X]-modules (jordanRep = Module.AEval' of jordanBlock), proved indecomposable (jordanRep_indecomposable, via: every nonzero J-invariant subspace contains the eigenvector e₀) and proved not simple for n>=2 (jordanRep_not_isSimpleModule), giving the book's conclusion 'indecomposable need not be irreducible' (exists_indecomposable_not_simple, witness V_{0,2}). The completeness half is now formalized too: exists_equiv_jordanRep shows every finite-dimensional indecomposable k[X]-module over an algebraically closed field is isomorphic to some V_{λ,n} with n ≥ 1, and jordanRep_equiv_iff shows the blocks are pairwise nonisomorphic (V_{λ,n} ≅ V_{μ,m} forces λ = μ and n = m). The route is the Mathlib structure theorem for finitely generated modules over the PID k[X] (Module.equiv_directSum_of_isTorsion) plus the cyclic model jordanQuotEquiv : k[X]/((X-λ)ⁿ) ≅ V_{λ,n}.",
+    "fidelity_decl": "Etingof.Example_2_3_14.jordanRep_indecomposable; Etingof.Example_2_3_14.jordanRep_not_isSimpleModule; Etingof.Example_2_3_14.exists_indecomposable_not_simple; Etingof.Example_2_3_14.exists_equiv_jordanRep; Etingof.Example_2_3_14.jordanRep_equiv_iff",
+    "coverage": "covered_full",
+    "coverage_note": "The Jordan-block modules are constructed, proved indecomposable, proved to exhaust the finite-dimensional indecomposable k[X]-modules over an algebraically closed field (exists_equiv_jordanRep), and proved pairwise nonisomorphic (jordanRep_equiv_iff). Both halves of the book's classification are formalized.",
+    "last_updated": "2026-07-26"
   },
   {
     "id": "Chapter2/Example2.3.14_continued",


### PR DESCRIPTION
Closes #7364

Session: `52629581-88d1-4ab6-bcba-e8dae29e6fe7`

fcfea9d3 docs(progress): 2026-07-26T07-12-09Z session handoff
8450cafc feat(Ch2 #7364): classify the finite-dimensional indecomposable k[X]-modules
956fff60 feat(Ch2 #7364): the cyclic model V_{lambda,n} = k[X]/((X-lambda)^n)

🤖 Prepared with Claude Code