### PR TITLE
feat(Ch8 Problem8.2.10): the Koszul contraction and the Koszul complex

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -632,6 +632,36 @@ type-variable level where `f x : W` matches `asModule σ` syntactically) instead
 re-deriving. Worked example: #7554 (`Chapter5/RepresentationAsModuleHom.lean`, all
 four `map_smul'` proofs).
 
+**`ext` over-applies on `A ⊗[R] N →ₗ[A] P` when `N` carries its own `@[ext]` lemma.** On a goal
+`f = g` between `A`-linear maps out of a tensor product, `ext s w` does not stop after splitting
+off the elementary tensor: it keeps going into the second factor, so if `N` is something like
+`⋀[R]^n M` (which has an exterior-power ext lemma) you land on a goal phrased in
+`TensorProduct.curry … |>.compAlternatingMap (exteriorPower.ιMulti …)` applied to a
+`Fin n → M`, and every `rw` naming your `_tmul` simp lemma fails to find its pattern —
+`ext` also warns `` `ext` did not consume the patterns `w` ``, which is the tell. Don't chase it
+with more `simp only [… curry_apply, coe_restrictScalars]`. **Use `LinearMap.ext` plus an
+explicit `TensorProduct.induction_on` instead**, which stops exactly where you want:
+
+```lean
+refine LinearMap.ext fun x => ?_
+simp only [LinearMap.add_apply, LinearMap.zero_apply]   -- reduce to `F x + G x = 0` first
+induction x using TensorProduct.induction_on with
+| zero => simp
+| tmul s w => rw [my_tmul_lemma, my_tmul_lemma]; …
+| add x y hx hy => rw [map_add, map_add, add_add_add_comm, hx, hy, add_zero]
+```
+
+Doing the `simp only` *before* the induction is what makes the `add` case a one-liner: the
+induction hypotheses are then already in the summed-to-zero form. Worked example: #5723
+(`Chapter8/KoszulDifferential.lean`, `koszulDD_swap_add` / `koszulDD_diag`).
+
+Two related name checks from the same session: there is **no `LinearMap.sum_comp`** — prove
+`(∑ a, F a).comp (∑ c, G c) = …` pointwise with `LinearMap.ext` + `LinearMap.sum_apply` +
+`map_sum`, then reindex with `Finset.univ_product_univ` / `Finset.sum_product` /
+`Finset.sum_comm`. And `ChainComplex.of_d` is stated about the auxiliary `ChainComplex.of.d`,
+so it will not `exact`-match a goal about `(ChainComplex.of X d sq).d (i+1) i` even though the
+two are defeq; close that with `by simp [<your complex def>]`.
+
 **A `Module.compHom` scalar action defeats bare `zero_smul`/`simp` in the `| zero =>` case
 of a `TensorProduct.induction_on` on the scalar.** When the module is built with
 `Module.compHom` (e.g. `Problem3_8_4_Functoriality.bcMod`, the `↥R ⊗[K] A`-action on

--- a/EtingofRepresentationTheory/Chapter8/KoszulContraction.lean
+++ b/EtingofRepresentationTheory/Chapter8/KoszulContraction.lean
@@ -1,0 +1,174 @@
+import Mathlib.LinearAlgebra.CliffordAlgebra.Contraction
+import Mathlib.LinearAlgebra.ExteriorPower.Basic
+
+/-!
+# The contraction `ιᵤ : ⋀ⁱ V → ⋀ⁱ⁻¹ V` of Problem 8.2.10
+
+Problem 8.2.10 builds the Koszul resolution out of the *contraction* operator: for a linear
+functional `u : V →ₗ[k] k` the book defines `ιᵤ : ⋀ⁱ V → ⋀ⁱ⁻¹ V` by
+
+> `ιᵤ (v₁ ∧ ⋯ ∧ vᵢ) = ∑_{j=1}^{i} (-1)ʲ u(vⱼ) v₁ ∧ … v̂ⱼ ⋯ ∧ vᵢ`.
+
+This file constructs that operator and establishes the two properties the Koszul differential
+needs: it squares to zero, and contractions by different functionals anticommute.
+
+## Main definitions
+
+* `Etingof.exteriorContraction u n : ⋀[R]^(n + 1) M →ₗ[R] ⋀[R]^n M` — the book's `ιᵤ`.
+
+## Main results
+
+* `Etingof.exteriorContraction_ιMulti` — the book's defining formula, verbatim (with `Fin (n + 1)`
+  0-indexed, so the book's `(-1)ʲ` for `j = 1, …, i` becomes `(-1)^(j + 1)`).
+* `Etingof.exteriorContraction_exteriorContraction` — `ιᵤ ∘ ιᵤ = 0`.
+* `Etingof.exteriorContraction_comm` — `ιᵤ ∘ ιᵤ' = - ιᵤ' ∘ ιᵤ`.
+
+## Implementation notes
+
+Mathlib's `⋀[R]^n M` is a submodule of `ExteriorAlgebra R M`, which in turn is an abbreviation for
+`CliffordAlgebra (0 : QuadraticForm R M)`. So the ungraded contraction is already available as
+`CliffordAlgebra.contractLeft`, together with `CliffordAlgebra.contractLeft_contractLeft` and
+`CliffordAlgebra.contractLeft_comm`. The work here is to check that it carries `⋀ⁿ⁺¹` into `⋀ⁿ`
+and that the resulting graded map is the book's alternating sum.
+
+`CliffordAlgebra.contractLeft` corresponds to the *unsigned* alternating sum, i.e. to the book's
+`ιᵤ` up to an overall sign; `exteriorContraction` carries that sign so that the statement of
+`exteriorContraction_ιMulti` matches the book character for character.
+-/
+
+universe u v
+
+open scoped BigOperators
+
+namespace Etingof
+
+variable {R : Type u} [CommRing R] {M : Type v} [AddCommGroup M] [Module R M]
+
+section Formula
+
+variable (R)
+
+/-- The ungraded contraction applied to a wedge of `n + 1` vectors: the alternating sum
+`∑ⱼ (-1)ʲ u(vⱼ) v₀ ∧ … v̂ⱼ ⋯ ∧ vₙ`, with `j` running over `Fin (n + 1)` (so 0-indexed).
+
+This is `CliffordAlgebra.contractLeft`'s value; the book's `ιᵤ` is its negative, see
+`Etingof.exteriorContraction_ιMulti`. -/
+theorem contractLeft_ιMulti (u : Module.Dual R M) :
+    ∀ (n : ℕ) (v : Fin (n + 1) → M),
+      CliffordAlgebra.contractLeft u (ExteriorAlgebra.ιMulti R (n + 1) v) =
+        ∑ j : Fin (n + 1),
+          ((-1 : R) ^ (j : ℕ) * u (v j)) • ExteriorAlgebra.ιMulti R n (v ∘ j.succAbove) := by
+  intro n
+  induction n with
+  | zero =>
+    intro v
+    rw [ExteriorAlgebra.ιMulti_succ_apply, CliffordAlgebra.contractLeft_ι_mul]
+    simp [ExteriorAlgebra.ιMulti_zero_apply]
+  | succ n ih =>
+    intro v
+    rw [ExteriorAlgebra.ιMulti_succ_apply, CliffordAlgebra.contractLeft_ι_mul]
+    have htail : Matrix.vecTail v = v ∘ Fin.succ := rfl
+    rw [htail, ih (v ∘ Fin.succ)]
+    -- Push `ι (v 0) * -` through the sum coming from the inductive hypothesis.
+    rw [Finset.mul_sum]
+    rw [Fin.sum_univ_succ (f := fun j : Fin (n + 2) =>
+      ((-1 : R) ^ (j : ℕ) * u (v j)) • ExteriorAlgebra.ιMulti R (n + 1) (v ∘ j.succAbove))]
+    have h0 : (v ∘ (0 : Fin (n + 2)).succAbove) = v ∘ Fin.succ := by
+      funext i; simp [Fin.succAbove_zero]
+    rw [h0]
+    simp only [Fin.val_zero, pow_zero, one_mul, Fin.val_succ, pow_succ]
+    rw [sub_eq_add_neg]
+    congr 1
+    rw [← Finset.sum_neg_distrib]
+    refine Finset.sum_congr rfl fun j _ => ?_
+    have hsucc : (v ∘ (Fin.succ j).succAbove) =
+        Fin.cons (v 0) ((v ∘ Fin.succ) ∘ j.succAbove) := by
+      funext i
+      induction i using Fin.cases with
+      | zero => simp
+      | succ i => simp [Fin.succ_succAbove_succ]
+    have htl : Matrix.vecTail (Fin.cons (v 0) ((v ∘ Fin.succ) ∘ j.succAbove)) =
+        (v ∘ Fin.succ) ∘ j.succAbove := by
+      funext i; simp [Matrix.vecTail]
+    rw [hsucc, ExteriorAlgebra.ιMulti_succ_apply, htl]
+    simp only [Fin.cons_zero, Function.comp_apply]
+    rw [mul_smul_comm]
+    module
+
+end Formula
+
+section Graded
+
+variable (R)
+
+/-- `CliffordAlgebra.contractLeft u` carries `⋀ⁿ⁺¹ M` into `⋀ⁿ M`. -/
+theorem contractLeft_mem_exteriorPower (u : Module.Dual R M) (n : ℕ)
+    {x : ExteriorAlgebra R M} (hx : x ∈ ⋀[R]^(n + 1) M) :
+    CliffordAlgebra.contractLeft u x ∈ ⋀[R]^n M := by
+  rw [← exteriorPower.ιMulti_span_fixedDegree R (n + 1) M] at hx
+  induction hx using Submodule.span_induction with
+  | mem y hy =>
+      obtain ⟨v, rfl⟩ := hy
+      rw [contractLeft_ιMulti R u n v]
+      refine Submodule.sum_mem _ fun j _ => Submodule.smul_mem _ _ ?_
+      exact ExteriorAlgebra.ιMulti_range R n (Set.mem_range_self _)
+  | zero => simp
+  | add y z _ _ hy hz => simpa using Submodule.add_mem _ hy hz
+  | smul r y _ hy => simpa using Submodule.smul_mem _ r hy
+
+/-- **The contraction of Problem 8.2.10.** For `u : V →ₗ[k] k` this is the book's
+`ιᵤ : ⋀ⁱ V → ⋀ⁱ⁻¹ V`, characterised by
+`ιᵤ (v₁ ∧ ⋯ ∧ vᵢ) = ∑ⱼ (-1)ʲ u(vⱼ) v₁ ∧ … v̂ⱼ ⋯ ∧ vᵢ`
+(see `Etingof.exteriorContraction_ιMulti`). -/
+noncomputable def exteriorContraction (u : Module.Dual R M) (n : ℕ) :
+    ⋀[R]^(n + 1) M →ₗ[R] ⋀[R]^n M :=
+  -(LinearMap.restrict (CliffordAlgebra.contractLeft u)
+    (fun _ hx => contractLeft_mem_exteriorPower R u n hx))
+
+variable {R}
+
+@[simp]
+theorem exteriorContraction_coe (u : Module.Dual R M) (n : ℕ) (x : ⋀[R]^(n + 1) M) :
+    (exteriorContraction R u n x : ExteriorAlgebra R M) =
+      -CliffordAlgebra.contractLeft u (x : ExteriorAlgebra R M) :=
+  rfl
+
+/-- **The book's defining formula for `ιᵤ`.** With `Fin (n + 1)` indexed from `0`, the book's
+`∑_{j=1}^{i} (-1)ʲ u(vⱼ) v₁ ∧ … v̂ⱼ ⋯ ∧ vᵢ` reads as follows. -/
+theorem exteriorContraction_ιMulti (u : Module.Dual R M) (n : ℕ) (v : Fin (n + 1) → M) :
+    exteriorContraction R u n (exteriorPower.ιMulti R (n + 1) v) =
+      ∑ j : Fin (n + 1),
+        ((-1 : R) ^ ((j : ℕ) + 1) * u (v j)) • exteriorPower.ιMulti R n (v ∘ j.succAbove) := by
+  apply Subtype.ext
+  push_cast
+  rw [exteriorContraction_coe]
+  simp only [exteriorPower.ιMulti_apply_coe]
+  rw [contractLeft_ιMulti R u n v, ← Finset.sum_neg_distrib]
+  refine Finset.sum_congr rfl fun j _ => ?_
+  simp only [pow_succ]
+  module
+
+/-- The Koszul differential's defining property: `ιᵤ ∘ ιᵤ = 0`. -/
+@[simp]
+theorem exteriorContraction_exteriorContraction (u : Module.Dual R M) (n : ℕ)
+    (x : ⋀[R]^(n + 2) M) :
+    exteriorContraction R u n (exteriorContraction R u (n + 1) x) = 0 := by
+  apply Subtype.ext
+  simp [CliffordAlgebra.contractLeft_contractLeft]
+
+theorem exteriorContraction_comp_exteriorContraction (u : Module.Dual R M) (n : ℕ) :
+    (exteriorContraction R u n).comp (exteriorContraction R u (n + 1)) = 0 :=
+  LinearMap.ext fun x => exteriorContraction_exteriorContraction u n x
+
+/-- Contractions by two functionals anticommute. This is what makes the Koszul differential
+`∑ₐ xₐ ⊗ ι_{xₐ*}` square to zero: the symmetric-algebra factors commute while the contractions
+anticommute. -/
+theorem exteriorContraction_comm (u u' : Module.Dual R M) (n : ℕ) (x : ⋀[R]^(n + 2) M) :
+    exteriorContraction R u n (exteriorContraction R u' (n + 1) x) =
+      -exteriorContraction R u' n (exteriorContraction R u (n + 1) x) := by
+  apply Subtype.ext
+  simp [CliffordAlgebra.contractLeft_comm (d := u) (d' := u')]
+
+end Graded
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter8/KoszulDifferential.lean
+++ b/EtingofRepresentationTheory/Chapter8/KoszulDifferential.lean
@@ -1,6 +1,8 @@
 import EtingofRepresentationTheory.Chapter8.KoszulContraction
 import Mathlib.LinearAlgebra.SymmetricAlgebra.Basis
 import Mathlib.LinearAlgebra.TensorProduct.Tower
+import Mathlib.Algebra.Homology.HomologicalComplex
+import Mathlib.Algebra.Category.ModuleCat.Basic
 
 /-!
 # The Koszul differential `d : SV ⊗ ⋀ⁱ⁺¹ V → SV ⊗ ⋀ⁱ V` of Problem 8.2.10
@@ -28,6 +30,7 @@ cancellation is done with `Finset.sum_ninvolution`, so the argument is character
 
 * `Etingof.koszulD_tmul` — the value of `d` on an elementary tensor.
 * `Etingof.koszulD_comp_koszulD` — `d ∘ d = 0`.
+* `Etingof.koszulComplex b : ChainComplex (ModuleCat SV) ℕ` — the assembled complex.
 
 Exactness of the resulting complex (the "free resolution of `k`" half of Problem 8.2.10(i)) is
 not proved here.
@@ -127,5 +130,25 @@ theorem koszulD_comp_koszulD (b : Module.Basis κ k V) (i : ℕ) :
   have : p.1 = p.2 := congrArg Prod.snd hswap
   rw [show p = (p.1, p.1) from Prod.ext rfl this.symm]
   exact koszulDD_diag b i p.1
+
+/-- **The Koszul complex** `C_• : ⋯ → SV ⊗ ⋀² V → SV ⊗ ⋀¹ V → SV ⊗ ⋀⁰ V` of
+Problem 8.2.10(i), as a chain complex of `SV`-modules. Exactness (equivalently, that the
+augmentation `C₀ = SV → k` makes this a free resolution of `k`) is not proved here. -/
+noncomputable def koszulComplex (b : Module.Basis κ k V) :
+    ChainComplex (ModuleCat.{max u v} (SymmetricAlgebra k V)) ℕ :=
+  ChainComplex.of (fun i => ModuleCat.of _ (koszulX k V i))
+    (fun i => ModuleCat.ofHom (koszulD b i))
+    (fun i => by
+      apply ModuleCat.hom_ext
+      exact koszulD_comp_koszulD b i)
+
+@[simp]
+theorem koszulComplex_X (b : Module.Basis κ k V) (i : ℕ) :
+    (koszulComplex b).X i = ModuleCat.of _ (koszulX k V i) :=
+  rfl
+
+theorem koszulComplex_d (b : Module.Basis κ k V) (i : ℕ) :
+    (koszulComplex b).d (i + 1) i = ModuleCat.ofHom (koszulD b i) :=
+  by simp [koszulComplex]
 
 end Etingof

--- a/EtingofRepresentationTheory/Chapter8/KoszulDifferential.lean
+++ b/EtingofRepresentationTheory/Chapter8/KoszulDifferential.lean
@@ -1,0 +1,131 @@
+import EtingofRepresentationTheory.Chapter8.KoszulContraction
+import Mathlib.LinearAlgebra.SymmetricAlgebra.Basis
+import Mathlib.LinearAlgebra.TensorProduct.Tower
+
+/-!
+# The Koszul differential `d : SV ⊗ ⋀ⁱ⁺¹ V → SV ⊗ ⋀ⁱ V` of Problem 8.2.10
+
+Problem 8.2.10(i) sets `Cᵢ = SV ⊗ ⋀ⁱ V`, views it as the space of polynomial functions on `V*`
+with values in `⋀ⁱ V`, and defines `dᵢ(f)(u) = ιᵤ (f u)`. Written algebraically, and in terms of a
+basis `x₁, …, x_n` of `V` with dual basis `x₁*, …, x_n*`, that differential is
+
+`d = ∑ₐ (multiplication by xₐ) ⊗ ι_{xₐ*}`.
+
+This file constructs `d` in that form and proves `d ∘ d = 0`. The proof is exactly the interplay
+the contraction file (`Chapter8/KoszulContraction.lean`) was built for: in the double sum
+`∑_{a,c} (xₐ x_c) ⊗ (ι_a ι_c)` the symmetric-algebra factors commute while the contractions
+anticommute, so off-diagonal terms cancel in pairs and diagonal terms vanish outright. The
+cancellation is done with `Finset.sum_ninvolution`, so the argument is characteristic-free (a
+`2 • S = 0` argument would fail in characteristic 2).
+
+## Main definitions
+
+* `Etingof.koszulX k V i` — the degree-`i` term `SV ⊗[k] ⋀ⁱ V`, an `SV`-module.
+* `Etingof.koszulD b i : koszulX k V (i + 1) →ₗ[SV] koszulX k V i` — the differential, for a
+  chosen finite basis `b` of `V`.
+
+## Main results
+
+* `Etingof.koszulD_tmul` — the value of `d` on an elementary tensor.
+* `Etingof.koszulD_comp_koszulD` — `d ∘ d = 0`.
+
+Exactness of the resulting complex (the "free resolution of `k`" half of Problem 8.2.10(i)) is
+not proved here.
+-/
+
+universe u v w
+
+open scoped TensorProduct
+
+namespace Etingof
+
+variable {k : Type u} [CommRing k] {V : Type v} [AddCommGroup V] [Module k V]
+variable {κ : Type w} [Fintype κ]
+
+variable (k V) in
+/-- The degree-`i` term `Cᵢ = SV ⊗ ⋀ⁱ V` of the Koszul complex, as an `SV`-module (the symmetric
+algebra acts on the left factor). -/
+abbrev koszulX (i : ℕ) : Type max u v :=
+  SymmetricAlgebra k V ⊗[k] (⋀[k]^i V)
+
+/-- **The Koszul differential.** For a finite basis `b` of `V`,
+`d = ∑ₐ (multiplication by b a) ⊗ ι_{b a *}`, the algebraic form of the book's
+`dᵢ(f)(u) = ιᵤ (f u)`. -/
+noncomputable def koszulD (b : Module.Basis κ k V) (i : ℕ) :
+    koszulX k V (i + 1) →ₗ[SymmetricAlgebra k V] koszulX k V i :=
+  ∑ a : κ, TensorProduct.AlgebraTensorModule.map
+    (LinearMap.mulLeft (SymmetricAlgebra k V) (SymmetricAlgebra.ι k V (b a)))
+    (exteriorContraction k (b.coord a) i)
+
+@[simp]
+theorem koszulD_tmul (b : Module.Basis κ k V) (i : ℕ) (s : SymmetricAlgebra k V)
+    (w : ⋀[k]^(i + 1) V) :
+    koszulD b i (s ⊗ₜ[k] w) =
+      ∑ a : κ, (SymmetricAlgebra.ι k V (b a) * s) ⊗ₜ[k] exteriorContraction k (b.coord a) i w := by
+  simp [koszulD]
+
+omit [Fintype κ] in
+/-- A single summand of `d ∘ d`: contracting twice and multiplying by two basis vectors. -/
+private noncomputable def koszulDD (b : Module.Basis κ k V) (i : ℕ) (p : κ × κ) :
+    koszulX k V (i + 2) →ₗ[SymmetricAlgebra k V] koszulX k V i :=
+  (TensorProduct.AlgebraTensorModule.map
+      (LinearMap.mulLeft (SymmetricAlgebra k V) (SymmetricAlgebra.ι k V (b p.1)))
+      (exteriorContraction k (b.coord p.1) i)).comp
+    (TensorProduct.AlgebraTensorModule.map
+      (LinearMap.mulLeft (SymmetricAlgebra k V) (SymmetricAlgebra.ι k V (b p.2)))
+      (exteriorContraction k (b.coord p.2) (i + 1)))
+
+omit [Fintype κ] in
+private theorem koszulDD_tmul (b : Module.Basis κ k V) (i : ℕ) (p : κ × κ)
+    (s : SymmetricAlgebra k V) (w : ⋀[k]^(i + 2) V) :
+    koszulDD b i p (s ⊗ₜ[k] w) =
+      (SymmetricAlgebra.ι k V (b p.1) * (SymmetricAlgebra.ι k V (b p.2) * s)) ⊗ₜ[k]
+        exteriorContraction k (b.coord p.1) i
+          (exteriorContraction k (b.coord p.2) (i + 1) w) := by
+  simp [koszulDD]
+
+omit [Fintype κ] in
+private theorem koszulDD_swap_add (b : Module.Basis κ k V) (i : ℕ) (p : κ × κ) :
+    koszulDD b i p + koszulDD b i p.swap = 0 := by
+  refine LinearMap.ext fun x => ?_
+  simp only [LinearMap.add_apply, LinearMap.zero_apply]
+  induction x using TensorProduct.induction_on with
+  | zero => simp
+  | tmul s w =>
+      rw [koszulDD_tmul, koszulDD_tmul]
+      simp only [Prod.fst_swap, Prod.snd_swap]
+      rw [exteriorContraction_comm (u := b.coord p.1) (u' := b.coord p.2),
+        TensorProduct.tmul_neg,
+        show SymmetricAlgebra.ι k V (b p.2) * (SymmetricAlgebra.ι k V (b p.1) * s) =
+          SymmetricAlgebra.ι k V (b p.1) * (SymmetricAlgebra.ι k V (b p.2) * s) by ring]
+      exact neg_add_cancel _
+  | add x y hx hy => rw [map_add, map_add, add_add_add_comm, hx, hy, add_zero]
+
+omit [Fintype κ] in
+private theorem koszulDD_diag (b : Module.Basis κ k V) (i : ℕ) (a : κ) :
+    koszulDD b i (a, a) = 0 := by
+  refine LinearMap.ext fun x => ?_
+  simp only [LinearMap.zero_apply]
+  induction x using TensorProduct.induction_on with
+  | zero => simp
+  | tmul s w => rw [koszulDD_tmul]; simp
+  | add x y hx hy => rw [map_add, hx, hy, add_zero]
+
+/-- **The Koszul differential squares to zero.** -/
+theorem koszulD_comp_koszulD (b : Module.Basis κ k V) (i : ℕ) :
+    (koszulD b i).comp (koszulD b (i + 1)) = 0 := by
+  have hsum : (koszulD b i).comp (koszulD b (i + 1)) = ∑ p : κ × κ, koszulDD b i p := by
+    refine LinearMap.ext fun x => ?_
+    simp only [LinearMap.comp_apply, koszulD, koszulDD, LinearMap.sum_apply, map_sum]
+    rw [← Finset.univ_product_univ, Finset.sum_product]
+    exact Finset.sum_comm
+  rw [hsum]
+  refine Finset.sum_ninvolution Prod.swap (fun p => koszulDD_swap_add b i p) ?_
+    (fun _ => Finset.mem_univ _) (fun p => Prod.swap_swap p)
+  intro p hp hswap
+  refine hp ?_
+  have : p.1 = p.2 := congrArg Prod.snd hswap
+  rw [show p = (p.1, p.1) from Prod.ext rfl this.symm]
+  exact koszulDD_diag b i p.1
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_10.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_10.lean
@@ -1,4 +1,5 @@
 import EtingofRepresentationTheory.Chapter8.KoszulContraction
+import EtingofRepresentationTheory.Chapter8.KoszulDifferential
 
 /-!
 # Problem 8.2.10: Koszul resolution and the Hilbert syzygies theorem
@@ -56,8 +57,15 @@ The exercise itself is being formalized bottom-up. Landed so far:
   `ιᵤ ∘ ιᵤ' = - ιᵤ' ∘ ιᵤ` (`Etingof.exteriorContraction_comm`). The last two are exactly what
   makes the Koszul differential `d = ∑ₐ xₐ ⊗ ι_{xₐ*}` square to zero.
 
-Still to come: the complex `Cᵢ = SV ⊗ ⋀ⁱ V` with `d² = 0` and its exactness (i), the `SW`
-resolution (ii), the bimodule resolution (iii), Hilbert syzygies (iv), and the `Ext`/`Tor`
-computation (v). See the child issues linked from
+* `Chapter8/KoszulDifferential.lean` — the terms `Etingof.koszulX k V i = SV ⊗[k] ⋀ⁱ V` as
+  `SV`-modules and the Koszul differential
+  `Etingof.koszulD b i : koszulX k V (i + 1) →ₗ[SV] koszulX k V i`, the algebraic form
+  `d = ∑ₐ (multiplication by xₐ) ⊗ ι_{xₐ*}` of the book's `dᵢ(f)(u) = ιᵤ (f u)`, together with
+  `Etingof.koszulD_comp_koszulD : d ∘ d = 0`. The cancellation is characteristic-free
+  (`Finset.sum_ninvolution` on the off-diagonal pairs, `ιᵤ ∘ ιᵤ = 0` on the diagonal).
+
+Still to come: packaging `C_•` as a `ChainComplex` with its augmentation and proving exactness
+(i), the `SW` resolution (ii), the bimodule resolution (iii), Hilbert syzygies (iv), and the
+`Ext`/`Tor` computation (v). See the child issues linked from
 <https://github.com/kim-em/Etingof-RepresentationTheory-draft1/issues/5723>.
 -/

--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_10.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_10.lean
@@ -62,10 +62,11 @@ The exercise itself is being formalized bottom-up. Landed so far:
   `Etingof.koszulD b i : koszulX k V (i + 1) →ₗ[SV] koszulX k V i`, the algebraic form
   `d = ∑ₐ (multiplication by xₐ) ⊗ ι_{xₐ*}` of the book's `dᵢ(f)(u) = ιᵤ (f u)`, together with
   `Etingof.koszulD_comp_koszulD : d ∘ d = 0`. The cancellation is characteristic-free
-  (`Finset.sum_ninvolution` on the off-diagonal pairs, `ιᵤ ∘ ιᵤ = 0` on the diagonal).
+  (`Finset.sum_ninvolution` on the off-diagonal pairs, `ιᵤ ∘ ιᵤ = 0` on the diagonal). The
+  complex itself is `Etingof.koszulComplex b : ChainComplex (ModuleCat SV) ℕ`.
 
-Still to come: packaging `C_•` as a `ChainComplex` with its augmentation and proving exactness
-(i), the `SW` resolution (ii), the bimodule resolution (iii), Hilbert syzygies (iv), and the
-`Ext`/`Tor` computation (v). See the child issues linked from
-<https://github.com/kim-em/Etingof-RepresentationTheory-draft1/issues/5723>.
+Still to come: the augmentation `C₀ = SV → k`, freeness of each `Cᵢ`, basis-independence of `d`,
+and exactness (i), the `SW` resolution (ii), the bimodule resolution (iii), Hilbert syzygies
+(iv), and the `Ext`/`Tor` computation (v). See the child issues linked from
+<https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/issues/5723>.
 -/

--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_10.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_10.lean
@@ -1,3 +1,5 @@
+import EtingofRepresentationTheory.Chapter8.KoszulContraction
+
 /-!
 # Problem 8.2.10: Koszul resolution and the Hilbert syzygies theorem
 
@@ -40,4 +42,22 @@ conclusion.
 The explicit Koszul resolution (i), the `SW` resolution (ii), the Koszul bimodule
 resolution (iii), and the computation of `Ext_{SV}(k, k)` and `Tor_{SV}(k, k)` (v)
 are self-contained and are not used elsewhere in the book.
+
+## State of the source-level formalization
+
+The exercise itself is being formalized bottom-up. Landed so far:
+
+* `Chapter8/KoszulContraction.lean` — the contraction operator `ιᵤ : ⋀ⁱ V → ⋀ⁱ⁻¹ V` that the
+  problem statement defines, in the form
+  `Etingof.exteriorContraction (u : Module.Dual R M) (n : ℕ) : ⋀[R]^(n+1) M →ₗ[R] ⋀[R]^n M`,
+  together with the book's defining alternating-sum formula
+  (`Etingof.exteriorContraction_ιMulti`), `ιᵤ ∘ ιᵤ = 0`
+  (`Etingof.exteriorContraction_exteriorContraction`) and the anticommutation
+  `ιᵤ ∘ ιᵤ' = - ιᵤ' ∘ ιᵤ` (`Etingof.exteriorContraction_comm`). The last two are exactly what
+  makes the Koszul differential `d = ∑ₐ xₐ ⊗ ι_{xₐ*}` square to zero.
+
+Still to come: the complex `Cᵢ = SV ⊗ ⋀ⁱ V` with `d² = 0` and its exactness (i), the `SW`
+resolution (ii), the bimodule resolution (iii), Hilbert syzygies (iv), and the `Ext`/`Tor`
+computation (v). See the child issues linked from
+<https://github.com/kim-em/Etingof-RepresentationTheory-draft1/issues/5723>.
 -/

--- a/progress/2026-07-26T07-31-56Z_65a63411.md
+++ b/progress/2026-07-26T07-31-56Z_65a63411.md
@@ -1,0 +1,80 @@
+## Accomplished
+
+Session type: `/work` (meta worker), claimed #5723 — "Missing formalization: Problem 8.2.10".
+
+Problem 8.2.10 (the Koszul resolution and the Hilbert syzygies theorem) was reopened on
+2026-07-22 with the ruling that the *source-level exercise itself* must be formalized: the
+existing `Chapter8/Problem8_2_10.lean` was pure documentation, and Example 9.4.4 only proves one
+downstream consequence by an independent route. The exercise has five parts and Mathlib has no
+Koszul complex at all, so it cannot land in one session. This session decomposed it and built
+the first two bricks.
+
+**Landed (all sorry-free, `#print axioms` shows only `propext, Classical.choice, Quot.sound`):**
+
+* `EtingofRepresentationTheory/Chapter8/KoszulContraction.lean` — the contraction operator the
+  problem statement defines.
+  * `Etingof.exteriorContraction (u : Module.Dual R M) (n : ℕ) : ⋀[R]^(n+1) M →ₗ[R] ⋀[R]^n M`
+  * `Etingof.exteriorContraction_ιMulti` — the book's formula
+    `ιᵤ (v₁ ∧ ⋯ ∧ vᵢ) = ∑ⱼ (-1)ʲ u(vⱼ) v₁ ∧ … v̂ⱼ ⋯ ∧ vᵢ`, verbatim (0-indexed `Fin`, so the
+    book's `(-1)ʲ` for `j = 1..i` appears as `(-1)^(j+1)`)
+  * `Etingof.exteriorContraction_exteriorContraction` — `ιᵤ ∘ ιᵤ = 0`
+  * `Etingof.exteriorContraction_comm` — `ιᵤ ∘ ιᵤ' = - ιᵤ' ∘ ιᵤ`
+* `EtingofRepresentationTheory/Chapter8/KoszulDifferential.lean` — the complex.
+  * `Etingof.koszulX k V i = SymmetricAlgebra k V ⊗[k] ⋀[k]^i V`, an `SV`-module
+  * `Etingof.koszulD b i : koszulX k V (i+1) →ₗ[SV] koszulX k V i`, the algebraic form
+    `d = ∑ₐ (mult by xₐ) ⊗ ι_{xₐ*}` of the book's `dᵢ(f)(u) = ιᵤ (f u)`
+  * `Etingof.koszulD_comp_koszulD` — `d ∘ d = 0`
+  * `Etingof.koszulComplex b : ChainComplex (ModuleCat SV) ℕ`
+* `Chapter8/Problem8_2_10.lean` now imports both and records what is and is not done.
+
+**Decomposition:** #5723 split into #7881 (i, data), #7882 (i, exactness), #7883 (ii),
+#7884 (iii), #7885 (iv), #7886 (v), with `depends-on` edges. #7881's body was rewritten to
+subtract the work that landed here. A `Decomposed into …` breadcrumb is on #5723.
+
+## Key patterns discovered
+
+* **Mathlib has no Koszul complex** (checked against `v4.32.0-rc1`), but it does have
+  `CliffordAlgebra.contractLeft` plus `contractLeft_contractLeft` and `contractLeft_comm`, and
+  `ExteriorAlgebra R M` is an *abbrev* for `CliffordAlgebra (0 : QuadraticForm R M)` while
+  `⋀[R]^n M` is an *abbrev* for a submodule of it. So the contraction on graded pieces is
+  `CliffordAlgebra.contractLeft` restricted via `LinearMap.restrict`; the only real work is the
+  `mapsTo` proof (`Submodule.span_induction` against `exteriorPower.ιMulti_span_fixedDegree`)
+  and the alternating-sum formula (induction with `ExteriorAlgebra.ιMulti_succ_apply` +
+  `CliffordAlgebra.contractLeft_ι_mul`). This avoids constructing an `AlternatingMap` by hand
+  entirely.
+* `CliffordAlgebra.contractLeft` is the *unsigned* alternating sum; the book's `ιᵤ` is its
+  negative (the book indexes `j` from 1). `exteriorContraction` carries that sign so the
+  fidelity statement matches character for character.
+* **`d² = 0` must not be proved by `2 • S = 0`** — that fails in characteristic 2. Use
+  `Finset.sum_ninvolution` with `Prod.swap` over `κ × κ`: off-diagonal pairs cancel via
+  `exteriorContraction_comm` + `mul_comm`, the diagonal vanishes via `ιᵤ ∘ ιᵤ = 0`.
+* `Basis` is `Module.Basis` in this Mathlib; `LinearMap.sum_comp` does not exist (prove the
+  composite-of-sums identity pointwise with `LinearMap.sum_apply` + `map_sum` + `Finset.sum_comm`
+  instead); `ext s w` on `S ⊗[k] N →ₗ[S] P` over-applies and reaches the exterior-power ext
+  lemma, so use `LinearMap.ext` + `TensorProduct.induction_on`.
+
+## Current frontier
+
+`Etingof.koszulComplex` exists as a chain complex of `SV`-modules with `d² = 0`. It has no
+augmentation, its terms are not yet shown free, `koszulD` still takes an explicit basis, and
+exactness is unproved. Those four items are #7881 (first three) and #7882 (exactness).
+
+## Overall project progress
+
+Problem 8.2.10 moves from "documentary only" to "the contraction and the Koszul complex are
+constructed, five successor issues scoped". Nothing else in the repo changed; no existing
+declaration was touched, so no downstream item is affected.
+
+## Next step
+
+Claim #7881 and finish the data half: the augmentation `C₀ = SV → k` via
+`SymmetricAlgebra.algebraMapInv`, freeness of `Cᵢ = SV ⊗[k] ⋀ⁱ V` from
+`exteriorPower.basis`, and basis-independence of `koszulD` (or a basis-free redefinition through
+the co-contraction `⋀ⁱ⁺¹ V →ₗ[k] V ⊗[k] ⋀ⁱ V`). Then #7882, whose recommended route is
+regular-sequence induction on `dim V` — the repo already has the degree-one case as
+`koszulSES_shortExact` in `Chapter9/Example9_4_4.lean` — and *not* the contracting-homotopy
+argument, which needs division by the total degree and so is not characteristic-free.
+
+## Blockers
+
+None.


### PR DESCRIPTION
This PR begins the source-level formalization of Problem 8.2.10 by constructing the contraction operator the exercise defines and the Koszul complex built from it. `Etingof.exteriorContraction u n : ⋀[R]^(n+1) M →ₗ[R] ⋀[R]^n M` is the book's `ιᵤ`, proved to satisfy the book's defining formula `ιᵤ (v₁ ∧ ⋯ ∧ vᵢ) = ∑ⱼ (-1)ʲ u(vⱼ) v₁ ∧ … v̂ⱼ ⋯ ∧ vᵢ` verbatim, to square to zero, and to anticommute with contraction by a second functional. `Etingof.koszulD b i : SV ⊗[k] ⋀ⁱ⁺¹ V →ₗ[SV] SV ⊗[k] ⋀ⁱ V` is the algebraic form `∑ₐ (multiplication by xₐ) ⊗ ι_{xₐ*}` of the book's `dᵢ(f)(u) = ιᵤ (f u)`, with `d ∘ d = 0` and the assembled `Etingof.koszulComplex b : ChainComplex (ModuleCat SV) ℕ`.

Mathlib has no Koszul complex, but it does have `CliffordAlgebra.contractLeft` together with `contractLeft_contractLeft` and `contractLeft_comm`, and `⋀[R]^n M` is a submodule of `ExteriorAlgebra R M = CliffordAlgebra (0 : QuadraticForm R M)`. So `ιᵤ` is that ungraded contraction restricted to graded pieces; the work is the `mapsTo` proof and the alternating-sum formula. The `d ∘ d = 0` cancellation uses `Finset.sum_ninvolution` over `κ × κ` with `Prod.swap`, so it is characteristic-free — a `2 • S = 0` argument would fail in characteristic 2.

Partial against #5723. That issue was reopened requiring the whole five-part exercise, which is far more than one session; it is decomposed here into #7881 (part (i), remaining data: augmentation, freeness, basis-independence), #7882 (part (i), exactness), #7883 (ii), #7884 (iii), #7885 (iv) and #7886 (v), with dependency edges. #7881's body was rewritten to subtract what landed here. Everything in this PR is sorry-free and `#print axioms` on every new endpoint shows only `propext, Classical.choice, Quot.sound`; the full project build is green.

Closes #5723

Session: 65a63411-0751-405d-95f9-af9f3d4017b0

🤖 Prepared with Claude Code