### PR TITLE
feat(Ch7 #Example7.2.2): construct the symmetric-power and Schur functors

### DIFF
--- a/EtingofRepresentationTheory/Chapter7.lean
+++ b/EtingofRepresentationTheory/Chapter7.lean
@@ -22,6 +22,8 @@ import EtingofRepresentationTheory.Chapter7.Introduction_7_4
 import EtingofRepresentationTheory.Chapter7.Example7_1_3
 import EtingofRepresentationTheory.Chapter7.Example7_1_5
 import EtingofRepresentationTheory.Chapter7.Example7_1_6
+import EtingofRepresentationTheory.Chapter7.SymmetricPowerFunctor
+import EtingofRepresentationTheory.Chapter7.SchurFunctor
 import EtingofRepresentationTheory.Chapter7.Example7_2_2
 import EtingofRepresentationTheory.Chapter7.Example7_3_2
 import EtingofRepresentationTheory.Chapter7.Example7_5_3

--- a/EtingofRepresentationTheory/Chapter7/Example7_2_2.lean
+++ b/EtingofRepresentationTheory/Chapter7/Example7_2_2.lean
@@ -13,13 +13,16 @@ import Mathlib.Algebra.Ring.Pi
 import Mathlib.LinearAlgebra.Dual.Defs
 import Mathlib.RepresentationTheory.Rep.Res
 import Mathlib.RepresentationTheory.Induced
+import EtingofRepresentationTheory.Chapter7.SymmetricPowerFunctor
+import EtingofRepresentationTheory.Chapter7.SchurFunctor
 
 /-!
 # Example 7.2.2: Examples of Functors
 
 Etingof's Example 7.2.2 collects nine illustrations of functors. We formalize
-each item against Mathlib where the construction is available, and note the
-advanced ones (Schur and reflection functors) that are out of scope.
+each item, against Mathlib where the construction is available and against
+purpose-built API otherwise (the symmetric-power and Schur functors, neither of
+which Mathlib carries).
 
 1. A category with one object is a monoid; a functor between such categories is
    a monoid homomorphism.
@@ -29,9 +32,9 @@ advanced ones (Schur and reflection functors) that are out of scope.
 5. X ↦ Fun(X, ℤ) is a functor Sets → Rings^op.
 6. Functors from the path category of a quiver to Vect_k are quiver representations.
 7. Induction and restriction functors Ind_K^G, Res_K^G.
-8. Direct sum, tensor product, tensor/exterior power as functors on Vect_k; the
-   symmetric-power and Schur functors are discussed as scope notes.
-9. Reflection functors on quiver representation categories (scope note).
+8. Direct sum, tensor product, tensor/symmetric/exterior power as functors on Vect_k,
+   and the Schur functors `V ↦ Hom_{S_n}(π, V^{⊗n})`.
+9. Reflection functors on quiver representation categories (object level only; see below).
 -/
 
 open CategoryTheory
@@ -165,10 +168,9 @@ noncomputable example (k : Type*) [CommRing k] {K G : Type*} [Group K] [Group G]
 /-! ### (8) Products of categories: direct sum, tensor, and power functors
 
 Using the Cartesian product `Vect_k × Vect_k`, direct sum and tensor product are
-bifunctors `Vect_k × Vect_k ⥤ Vect_k`, and the powers `V ↦ V^{⊗n}`, `V ↦ ∧ⁿ V`
-are endofunctors of `Vect_k`. We formalize each against `ModuleCat k`. The
-symmetric power `Sⁿ V` and the general Schur functors are discussed in the scope
-notes below. -/
+bifunctors `Vect_k × Vect_k ⥤ Vect_k`, and the powers `V ↦ V^{⊗n}`, `V ↦ SⁿV`,
+`V ↦ ∧ⁿ V` are endofunctors of `Vect_k`, as are the Schur functors
+`V ↦ Hom_{S_n}(π, V^{⊗n})`. We formalize each against `ModuleCat k`. -/
 
 /-- The direct-sum bifunctor `⊕ : Vect_k × Vect_k → Vect_k`. On modules the binary
 direct sum is carried by the product `M × N`, with `LinearMap.prodMap` on arrows.
@@ -209,22 +211,42 @@ noncomputable example (k : Type*) [CommRing k] (n : ℕ) : ModuleCat k ⥤ Modul
 noncomputable example (k : Type*) [CommRing k] (n : ℕ) : ModuleCat k ⥤ ModuleCat k :=
   ModuleCat.exteriorPower.functor k n
 
-/-! #### (8) Scope notes: symmetric power and Schur functors
+/-- The `n`-th symmetric-power functor `V ↦ SⁿV` on `Vect_k`. Mathlib has the
+symmetric power `Sym[k]^n V` but no action on linear maps (the universal property
+is listed as future work there), so `SymmetricPower.map` and the resulting functor
+are supplied by `Chapter7/SymmetricPowerFunctor.lean`. (Etingof 7.2.2(8)) -/
+noncomputable example (k : Type) [Field k] (n : ℕ) : ModuleCat k ⥤ ModuleCat k :=
+  ModuleCat.symmetricPower k n
 
-**Symmetric power `V ↦ Sⁿ V`.** Mathlib has the symmetric power `Sym[k]^n V`
-(`Mathlib.LinearAlgebra.TensorPower.Symmetric`, the quotient of `V^{⊗n}` by the
-symmetric-group action), but its functoriality (a `map` on linear maps together
-with the universal property) is not yet available (it is listed as future work
-in that file). Once `SymmetricPower.map` (or the symmetric universal property)
-lands upstream, `V ↦ Sⁿ V` forms an endofunctor of `ModuleCat k` exactly
-as the exterior power does above. This is a missing-API gap, not a mathematical
-obstruction.
+/-! #### (8) Schur functors
 
-**Schur functors `V ↦ Hom_{S_n}(π, V^{⊗n})`.** For a representation `π` of `Sₙ`,
-the Schur functor sends `V` to `Hom_{S_n}(π, V^{⊗n})`; the irreducible ones are
-labeled by Young diagrams. This requires the `Sₙ`-action on `V^{⊗n}` and the
-`Sₙ`-equivariant Hom, neither packaged as a functor in Mathlib. It is advanced
-and is deferred; the tensor-power functor above is the first ingredient. -/
+For a representation `π` of `Sₙ` on `W`, the Schur functor sends `V` to
+`Hom_{S_n}(π, V^{⊗n})`, the `Sₙ`-intertwiners from `π` into the tensor power
+carrying the slot-permutation action. Neither that action nor the equivariant Hom
+is packaged in Mathlib, so both are built in `Chapter7/SchurFunctor.lean`. -/
+
+/-- The Schur functor attached to an `Sₙ`-representation `π`. (Etingof 7.2.2(8)) -/
+noncomputable example (k : Type) [Field k] (n : ℕ) (W : Type) [AddCommGroup W]
+    [Module k W] (π : Representation k (Equiv.Perm (Fin n)) W) :
+    ModuleCat k ⥤ ModuleCat k :=
+  Etingof.schurFunctor π
+
+/-- The value of the Schur functor at `V` really is the space of `Sₙ`-equivariant maps
+`π → V^{⊗n}`: membership unfolds to the intertwining identity. (Etingof 7.2.2(8)) -/
+example (k : Type) [Field k] (n : ℕ) {W : Type} [AddCommGroup W] [Module k W]
+    (π : Representation k (Equiv.Perm (Fin n)) W)
+    {V : Type} [AddCommGroup V] [Module k V] (φ : W →ₗ[k] ⨂[k] (_ : Fin n), V) :
+    φ ∈ Etingof.schurObj π V ↔
+      ∀ σ : Equiv.Perm (Fin n),
+        (Etingof.tensorPowerPermRep k n V σ) ∘ₗ φ = φ ∘ₗ (π σ) :=
+  Etingof.mem_schurObj_iff π φ
+
+/-- Sanity check on the Schur construction: at the trivial `Sₙ`-representation it returns
+the symmetric tensors `(V^{⊗n})^{Sₙ}`. (Etingof 7.2.2(8)) -/
+noncomputable example (k : Type) [Field k] (n : ℕ) (V : Type) [AddCommGroup V] [Module k V] :
+    Etingof.schurObj (Representation.trivial k (Equiv.Perm (Fin n)) k) V ≃ₗ[k]
+      (Etingof.tensorPowerPermRep k n V).invariants :=
+  Etingof.schurObjTrivialEquiv
 
 /-! ### (9) Reflection functors (scope note)
 
@@ -238,7 +260,11 @@ of `Q̄_i` at a source, with the companion `reflectionFunctorPlus` at a sink.
 Packaging these as `CategoryTheory.Functor`s between the representation categories
 `Rep(Q) ⥤ Rep(Q̄_i)` additionally requires the action on morphisms of representations
 plus the functor laws, which are not carried out here (BGP reflection functors are not
-in Mathlib). This is deferred pending a `CategoryTheory`-level quiver-representation
-category compatible with the object-level construction of Definition 6.6.4. -/
+in Mathlib). That packaging is tracked as its own work item,
+https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/issues/7383
+("feat(Ch6–7): package BGP reflection constructions as actual functors"), because it
+needs a `CategoryTheory`-level quiver-representation category compatible with the
+object-level construction of Definition 6.6.4, and that construction is Chapter 6's
+to supply. -/
 
 end EtingofRepresentationTheory.Example722

--- a/EtingofRepresentationTheory/Chapter7/SchurFunctor.lean
+++ b/EtingofRepresentationTheory/Chapter7/SchurFunctor.lean
@@ -1,0 +1,177 @@
+import Mathlib.RepresentationTheory.Invariants
+import Mathlib.LinearAlgebra.PiTensorProduct.Basic
+import Mathlib.Algebra.Category.ModuleCat.Basic
+
+/-!
+# Schur functors
+
+Etingof's Example 7.2.2(8) closes with: *"More generally, if `π` is a representation of `Sₙ`,
+we have functors `V ↦ Hom_{Sₙ}(π, V^{⊗n})`. Such functors are called the Schur functors."*
+
+This file constructs those functors. The two ingredients are
+
+* `Etingof.tensorPowerPermRep k n V` — the permutation action of `Sₙ` on `V^{⊗n}`, sending
+  `v₁ ⊗ ⋯ ⊗ vₙ` to `v_{σ⁻¹(1)} ⊗ ⋯ ⊗ v_{σ⁻¹(n)}`, packaged as a `Representation`;
+* `Etingof.piTensorMap_comm_perm` — the diagonal map `f ⊗ ⋯ ⊗ f` induced by `f : V →ₗ W`
+  is `Sₙ`-equivariant, which is what makes the construction functorial at all.
+
+The functor itself is `Etingof.schurFunctor π`, with underlying object assignment
+`Etingof.schurObj π V = Hom_{Sₙ}(π, V^{⊗n})`, realised as the invariants of
+`Representation.linHom` — i.e. the submodule of `W →ₗ[k] V^{⊗n}` consisting of the
+intertwiners. `Etingof.mem_schurObj_iff` restates membership as the usual intertwining
+identity `ρ σ ∘ₗ φ = φ ∘ₗ π σ`.
+
+Neither the `Sₙ`-action on a tensor power nor the equivariant Hom is packaged as a functor
+in Mathlib, so this is new API rather than a wrapper.
+-/
+
+open CategoryTheory
+open scoped TensorProduct
+
+namespace Etingof
+
+universe u
+
+section PermAction
+
+variable (k : Type u) [CommRing k] (n : ℕ)
+  (V : Type u) [AddCommGroup V] [Module k V]
+  (W : Type u) [AddCommGroup W] [Module k W]
+
+/-- Extensionality for linear maps out of a tensor power: it suffices to check pure tensors.
+Mathlib's `PiTensorProduct.ext` is only a local `ext` lemma, so we re-expose it here in
+applied form. -/
+theorem piTensor_ext {E : Type*} [AddCommMonoid E] [Module k E]
+    {φ₁ φ₂ : (⨂[k] (_ : Fin n), V) →ₗ[k] E}
+    (h : ∀ v : Fin n → V, φ₁ (PiTensorProduct.tprod k v) = φ₂ (PiTensorProduct.tprod k v)) :
+    φ₁ = φ₂ :=
+  PiTensorProduct.ext (MultilinearMap.ext h)
+
+/-- The permutation action of the symmetric group `Sₙ` on the tensor power `V^{⊗n}`:
+`σ` sends `v₁ ⊗ ⋯ ⊗ vₙ` to `v_{σ⁻¹(1)} ⊗ ⋯ ⊗ v_{σ⁻¹(n)}`. -/
+noncomputable def tensorPowerPermRep :
+    Representation k (Equiv.Perm (Fin n)) (⨂[k] (_ : Fin n), V) where
+  toFun σ := (PiTensorProduct.reindex k (fun _ : Fin n => V) σ).toLinearMap
+  map_one' := by
+    refine piTensor_ext k n V fun v => ?_
+    simp only [LinearEquiv.coe_coe, PiTensorProduct.reindex_tprod, Module.End.one_apply]
+    rfl
+  map_mul' σ τ := by
+    refine piTensor_ext k n V fun v => ?_
+    simp only [LinearEquiv.coe_coe, PiTensorProduct.reindex_tprod, Module.End.mul_apply]
+    rfl
+
+variable {k n V}
+
+@[simp] theorem tensorPowerPermRep_tprod (σ : Equiv.Perm (Fin n)) (v : Fin n → V) :
+    tensorPowerPermRep k n V σ (PiTensorProduct.tprod k v) =
+      PiTensorProduct.tprod k fun i => v (σ.symm i) :=
+  PiTensorProduct.reindex_tprod (s := fun _ : Fin n => V) σ v
+
+variable {W}
+
+/-- The diagonal map `f ⊗ ⋯ ⊗ f : V^{⊗n} → W^{⊗n}` is `Sₙ`-equivariant for the permutation
+actions. This is the functoriality input for the Schur functors: both operations act on
+disjoint data (`f` on the entries, `σ` on the slots), so they commute. -/
+theorem piTensorMap_comm_perm (f : V →ₗ[k] W) (σ : Equiv.Perm (Fin n)) :
+    (PiTensorProduct.map fun _ : Fin n => f) ∘ₗ (tensorPowerPermRep k n V σ) =
+      (tensorPowerPermRep k n W σ) ∘ₗ (PiTensorProduct.map fun _ : Fin n => f) := by
+  refine piTensor_ext k n V fun v => ?_
+  simp
+
+end PermAction
+
+section Schur
+
+variable {k : Type u} [CommRing k] {n : ℕ}
+  {W : Type u} [AddCommGroup W] [Module k W]
+  (π : Representation k (Equiv.Perm (Fin n)) W)
+
+/-- `Hom_{Sₙ}(π, V^{⊗n})`, the value of the Schur functor attached to the `Sₙ`-representation
+`π` at the vector space `V`. It is the space of `Sₙ`-intertwiners from `π` to the tensor
+power `V^{⊗n}` with its permutation action, realised as the invariants of the representation
+`Representation.linHom` on `W →ₗ[k] V^{⊗n}`. -/
+noncomputable def schurObj (V : Type u) [AddCommGroup V] [Module k V] :
+    Submodule k (W →ₗ[k] ⨂[k] (_ : Fin n), V) :=
+  (Representation.linHom π (tensorPowerPermRep k n V)).invariants
+
+variable {V : Type u} [AddCommGroup V] [Module k V]
+  {V' : Type u} [AddCommGroup V'] [Module k V']
+
+private theorem rep_inv_apply (σ : Equiv.Perm (Fin n)) (w : W) : π σ⁻¹ (π σ w) = w := by
+  rw [← Module.End.mul_apply, ← map_mul, inv_mul_cancel, map_one, Module.End.one_apply]
+
+private theorem rep_apply_inv (σ : Equiv.Perm (Fin n)) (w : W) : π σ (π σ⁻¹ w) = w := by
+  rw [← Module.End.mul_apply, ← map_mul, mul_inv_cancel, map_one, Module.End.one_apply]
+
+/-- Membership in `schurObj` is the usual intertwining identity: `φ` commutes with the two
+`Sₙ`-actions. -/
+theorem mem_schurObj_iff (φ : W →ₗ[k] ⨂[k] (_ : Fin n), V) :
+    φ ∈ schurObj π V ↔
+      ∀ σ : Equiv.Perm (Fin n), (tensorPowerPermRep k n V σ) ∘ₗ φ = φ ∘ₗ (π σ) := by
+  simp only [schurObj, Representation.mem_invariants, Representation.linHom_apply]
+  constructor
+  · intro h σ
+    ext w
+    have := congrArg (fun ψ : W →ₗ[k] ⨂[k] (_ : Fin n), V => ψ (π σ w)) (h σ)
+    simpa [rep_inv_apply π σ w] using this
+  · intro h σ
+    ext w
+    have := congrArg (fun ψ : W →ₗ[k] ⨂[k] (_ : Fin n), V => ψ (π σ⁻¹ w)) (h σ)
+    simpa [rep_apply_inv π σ w] using this
+
+/-- The action of the Schur functor on morphisms: postcomposition with the diagonal map
+`f ⊗ ⋯ ⊗ f`, which lands in the intertwiners because that map is `Sₙ`-equivariant. -/
+noncomputable def schurMap (f : V →ₗ[k] V') : schurObj π V →ₗ[k] schurObj π V' :=
+  (LinearMap.llcomp k W _ _ (PiTensorProduct.map fun _ : Fin n => f)).restrict
+    (fun φ hφ => by
+      rw [mem_schurObj_iff] at hφ ⊢
+      intro σ
+      change (tensorPowerPermRep k n V' σ) ∘ₗ
+        ((PiTensorProduct.map fun _ : Fin n => f) ∘ₗ φ) = _
+      rw [← LinearMap.comp_assoc, ← piTensorMap_comm_perm f σ, LinearMap.comp_assoc, hφ σ,
+        ← LinearMap.comp_assoc]
+      rfl)
+
+@[simp] theorem schurMap_coe (f : V →ₗ[k] V') (φ : schurObj π V) :
+    (schurMap π f φ : W →ₗ[k] ⨂[k] (_ : Fin n), V') =
+      (PiTensorProduct.map fun _ : Fin n => f) ∘ₗ (φ : W →ₗ[k] ⨂[k] (_ : Fin n), V) :=
+  rfl
+
+theorem schurMap_id : schurMap π (LinearMap.id : V →ₗ[k] V) = LinearMap.id := by
+  ext φ
+  simp [PiTensorProduct.map_id]
+
+theorem schurMap_comp {V'' : Type u} [AddCommGroup V''] [Module k V'']
+    (g : V' →ₗ[k] V'') (f : V →ₗ[k] V') :
+    schurMap π (g ∘ₗ f) = (schurMap π g) ∘ₗ (schurMap π f) := by
+  ext φ
+  change ((PiTensorProduct.map fun _ : Fin n => g ∘ₗ f) ∘ₗ (φ : W →ₗ[k] _)) _ = _
+  rw [show (fun _ : Fin n => g ∘ₗ f) =
+      fun i : Fin n => (fun _ : Fin n => g) i ∘ₗ (fun _ : Fin n => f) i from rfl,
+    PiTensorProduct.map_comp]
+  rfl
+
+/-- **The Schur functor** attached to a representation `π` of `Sₙ`:
+`V ↦ Hom_{Sₙ}(π, V^{⊗n})`. (Etingof, Example 7.2.2(8).)
+
+Taking `π` to run over the irreducible representations of `Sₙ` — which by Chapter 5 are
+labelled by Young diagrams with `n` boxes — gives the irreducible Schur functors. -/
+noncomputable def schurFunctor : ModuleCat.{u} k ⥤ ModuleCat.{u} k where
+  obj V := ModuleCat.of k (schurObj π V)
+  map f := ModuleCat.ofHom (schurMap π f.hom)
+  map_id V := by
+    apply ModuleCat.hom_ext
+    simp only [ModuleCat.hom_ofHom, ModuleCat.hom_id]
+    exact schurMap_id π
+  map_comp f g := by
+    apply ModuleCat.hom_ext
+    simp only [ModuleCat.hom_ofHom, ModuleCat.hom_comp]
+    exact schurMap_comp π _ _
+
+@[simp] theorem schurFunctor_obj (V : ModuleCat.{u} k) :
+    (schurFunctor π).obj V = ModuleCat.of k (schurObj π V) := rfl
+
+end Schur
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter7/SchurFunctor.lean
+++ b/EtingofRepresentationTheory/Chapter7/SchurFunctor.lean
@@ -174,4 +174,39 @@ noncomputable def schurFunctor : ModuleCat.{u} k ⥤ ModuleCat.{u} k where
 
 end Schur
 
+section Trivial
+
+variable {k : Type u} [CommRing k] {n : ℕ}
+  {V : Type u} [AddCommGroup V] [Module k V]
+
+/-- The Schur functor of the trivial `Sₙ`-representation on `k` is the space of symmetric
+tensors: `Hom_{Sₙ}(k, V^{⊗n}) ≃ (V^{⊗n})^{Sₙ}`, by evaluation at `1`.
+
+This pins down the construction: the invariants submodule `schurObj` really is the
+equivariant Hom the book asks for, and in the simplest case it is visibly nonzero
+whenever `V` is (for `n = 0`, or for `n ≥ 1` and `v : V`, the symmetrised pure tensor
+lies in it). -/
+noncomputable def schurObjTrivialEquiv :
+    schurObj (Representation.trivial k (Equiv.Perm (Fin n)) k) V ≃ₗ[k]
+      (tensorPowerPermRep k n V).invariants where
+  toFun φ := ⟨(φ : k →ₗ[k] ⨂[k] (_ : Fin n), V) 1, fun σ => by
+    have := (mem_schurObj_iff _ _).mp φ.2 σ
+    have h := congrArg (fun ψ : k →ₗ[k] ⨂[k] (_ : Fin n), V => ψ 1) this
+    simpa [Representation.trivial_apply] using h⟩
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+  invFun t := ⟨LinearMap.toSpanSingleton k _ (t : ⨂[k] (_ : Fin n), V), by
+    rw [mem_schurObj_iff]
+    intro σ
+    ext
+    simpa [LinearMap.toSpanSingleton_apply, Representation.trivial_apply] using t.2 σ⟩
+  left_inv φ := by
+    refine Subtype.ext (LinearMap.ext_ring ?_)
+    simp [LinearMap.toSpanSingleton_apply]
+  right_inv t := by
+    refine Subtype.ext ?_
+    simp [LinearMap.toSpanSingleton_apply]
+
+end Trivial
+
 end Etingof

--- a/EtingofRepresentationTheory/Chapter7/SymmetricPowerFunctor.lean
+++ b/EtingofRepresentationTheory/Chapter7/SymmetricPowerFunctor.lean
@@ -1,0 +1,135 @@
+import Mathlib.LinearAlgebra.TensorPower.Symmetric
+import Mathlib.Algebra.Category.ModuleCat.Basic
+
+/-!
+# Functoriality of the symmetric tensor power
+
+Mathlib's `SymmetricPower` (`Sym[R] ι M`) is defined as a quotient of the tensor power
+`⨂[R] (_ : ι), M`, but it carries no action on linear maps: the file
+`Mathlib/LinearAlgebra/TensorPower/Symmetric.lean` lists the universal property as future
+work, and there is no `SymmetricPower.map`. Example 7.2.2(8) of Etingof asserts that
+`V ↦ SⁿV` is a functor `Vect_k → Vect_k`, so the missing action is exactly what has to be
+supplied.
+
+This file supplies it, for an arbitrary index type `ι` rather than just `Fin n`:
+
+* `SymmetricPower.map f : Sym[R] ι M →ₗ[R] Sym[R] ι N` for `f : M →ₗ[R] N`, descending
+  `PiTensorProduct.map (fun _ => f)` through the symmetrising quotient;
+* `SymmetricPower.map_id` and `SymmetricPower.map_comp`, the functor laws;
+* `SymmetricPower.functor R ι : ModuleCat R ⥤ ModuleCat R`, the packaged functor, and
+  `ModuleCat.symmetricPower.functor R n` for the `n`-th symmetric power.
+
+The project's `Etingof.symmetricPowerMap` (`Chapter5/Example5_19_3.lean`) is the special
+case of `SymmetricPower.map` for an endomorphism of a finite-dimensional space over a
+field; it predates this file and is left in place, since a large amount of Chapter 5
+depends on it definitionally.
+-/
+
+open scoped TensorProduct
+
+namespace SymmetricPower
+
+universe u v w x
+
+variable {R ι : Type u} [CommSemiring R]
+  {M : Type v} [AddCommMonoid M] [Module R M]
+  {N : Type w} [AddCommMonoid N] [Module R N]
+  {P : Type x} [AddCommMonoid P] [Module R P]
+
+/-- Two linear maps out of a symmetric power agree as soon as they agree on the image of
+the quotient map `mk`, which is surjective. -/
+theorem linearMap_ext {Q : Type*} [AddCommMonoid Q] [Module R Q]
+    {f g : Sym[R] ι M →ₗ[R] Q}
+    (h : ∀ x : ⨂[R] (_ : ι), M, f (mk R ι M x) = g (mk R ι M x)) : f = g := by
+  ext x
+  exact AddCon.induction_on x h
+
+/-- The functorial action of a linear map `f : M →ₗ[R] N` on symmetric powers.
+
+It is the descent of the diagonal tensor-power map `f ⊗ ⋯ ⊗ f` through the symmetrising
+quotient: this is legitimate because permuting the factors of a pure tensor commutes with
+applying `f` in every slot. -/
+noncomputable def map (f : M →ₗ[R] N) : Sym[R] ι M →ₗ[R] Sym[R] ι N :=
+  let F : (⨂[R] (_ : ι), M) →+ Sym[R] ι N :=
+    (AddCon.mk' _).comp (PiTensorProduct.map (fun _ : ι => f)).toAddMonoidHom
+  { toFun := AddCon.lift _ F (fun x y h => Quotient.sound (by
+      induction h with
+      | of x y h => cases h with
+        | perm e g =>
+          simp only [LinearMap.toAddMonoidHom_coe, PiTensorProduct.map_tprod]
+          exact AddConGen.Rel.of _ _ (SymmetricPower.Rel.perm e (fun i => f (g i)))
+      | refl => exact AddCon.refl _ _
+      | symm _ ih => exact AddCon.symm _ ih
+      | trans _ _ ih₁ ih₂ => exact AddCon.trans _ ih₁ ih₂
+      | add _ _ ih₁ ih₂ => simp only [map_add]; exact AddCon.add _ ih₁ ih₂))
+    map_add' := fun x y => by
+      refine AddCon.induction_on₂ x y (fun a b => ?_)
+      change mk R ι N (PiTensorProduct.map (fun _ : ι => f) (a + b))
+        = mk R ι N (PiTensorProduct.map (fun _ : ι => f) a)
+          + mk R ι N (PiTensorProduct.map (fun _ : ι => f) b)
+      rw [map_add, map_add]
+    map_smul' := fun r x => by
+      refine AddCon.induction_on x (fun a => ?_)
+      change mk R ι N (PiTensorProduct.map (fun _ : ι => f) (r • a))
+        = r • mk R ι N (PiTensorProduct.map (fun _ : ι => f) a)
+      rw [map_smul, map_smul] }
+
+@[simp] theorem map_mk (f : M →ₗ[R] N) (x : ⨂[R] (_ : ι), M) :
+    map (ι := ι) f (mk R ι M x) = mk R ι N (PiTensorProduct.map (fun _ : ι => f) x) :=
+  rfl
+
+@[simp] theorem map_tprod (f : M →ₗ[R] N) (g : ι → M) :
+    map (ι := ι) f (⨂ₛ[R] i, g i) = ⨂ₛ[R] i, f (g i) := by
+  change map (ι := ι) f (mk R ι M (PiTensorProduct.tprod R g)) = _
+  rw [map_mk, PiTensorProduct.map_tprod]
+  rfl
+
+@[simp] theorem map_id : map (ι := ι) (LinearMap.id : M →ₗ[R] M) = LinearMap.id := by
+  refine linearMap_ext fun x => ?_
+  rw [map_mk, PiTensorProduct.map_id]
+  rfl
+
+theorem map_comp (g : N →ₗ[R] P) (f : M →ₗ[R] N) :
+    map (ι := ι) (g ∘ₗ f) = map (ι := ι) g ∘ₗ map (ι := ι) f := by
+  refine linearMap_ext fun x => ?_
+  rw [map_mk, LinearMap.comp_apply, map_mk, map_mk,
+    show (fun _ : ι => g ∘ₗ f) = fun i : ι => (fun _ : ι => g) i ∘ₗ (fun _ : ι => f) i from rfl,
+    PiTensorProduct.map_comp]
+  rfl
+
+@[simp] theorem map_comp_apply (g : N →ₗ[R] P) (f : M →ₗ[R] N) (x : Sym[R] ι M) :
+    map (ι := ι) (g ∘ₗ f) x = map (ι := ι) g (map (ι := ι) f x) := by
+  rw [map_comp]; rfl
+
+end SymmetricPower
+
+namespace ModuleCat
+
+open CategoryTheory
+
+universe u v
+
+/-- The `ι`-indexed symmetric-power functor `M ↦ Sym[R] ι M` on `ModuleCat R`.
+
+The index type `ι` must live in the same universe as `R`, because that is how
+`SymmetricPower` is set up in Mathlib; the carriers may live anywhere above it. -/
+noncomputable def symmetricPowerFunctor (R : Type u) [CommRing R] (ι : Type u) :
+    ModuleCat.{max u v} R ⥤ ModuleCat.{max u v} R where
+  obj M := ModuleCat.of R (Sym[R] ι M)
+  map f := ModuleCat.ofHom (SymmetricPower.map (ι := ι) f.hom)
+  map_id M := by
+    apply ModuleCat.hom_ext
+    simp only [ModuleCat.hom_ofHom, ModuleCat.hom_id]
+    exact SymmetricPower.map_id
+  map_comp f g := by
+    apply ModuleCat.hom_ext
+    simp only [ModuleCat.hom_ofHom, ModuleCat.hom_comp]
+    exact SymmetricPower.map_comp _ _
+
+/-- The `n`-th symmetric-power functor `V ↦ SⁿV` on `ModuleCat R`: Etingof's
+Example 7.2.2(8), the companion of `ModuleCat.exteriorPower.functor`. -/
+noncomputable abbrev symmetricPower (R : Type) [CommRing R] (n : ℕ) :
+    ModuleCat.{v} R ⥤ ModuleCat.{v} R :=
+  symmetricPowerFunctor R (Fin n)
+
+end ModuleCat

--- a/progress/2026-07-26T10-18-01Z_84ae8674.md
+++ b/progress/2026-07-26T10-18-01Z_84ae8674.md
@@ -1,0 +1,88 @@
+## Accomplished
+
+Worker session `84ae8674`, issue #5642 (`Complete example: Chapter7/Example7.2.2`).
+
+The issue body was a Wave-2 fidelity finding from 2026-06-29 listing seven entirely missing
+sub-items. Re-confirming it first (as the issue instructs) showed it had gone almost entirely
+stale: `Chapter7/Example7_2_2.lean` had since acquired items (1)–(7) and the direct-sum,
+tensor-product, tensor-power and exterior-power halves of item (8), and the wrong-codomain
+`Rings → Sets` complaint had been fixed to `forget₂ RingCat AddCommGrpCat`. What actually
+remained were two constructions the file had written off as "deferred" scope notes, plus
+item (9).
+
+Per `.claude/CLAUDE.md` ("Missing Mathlib API: ... If genuinely missing from Mathlib, prove
+it here — that's the highest-priority work, not a reason to defer"), both were built.
+
+**`Chapter7/SymmetricPowerFunctor.lean` (new).** Mathlib's `SymmetricPower` (`Sym[R] ι M`)
+has no action on linear maps at all — the universal property is listed as future work in
+`Mathlib/LinearAlgebra/TensorPower/Symmetric.lean` — so `V ↦ SⁿV` could not be a functor.
+This file supplies the missing API for an arbitrary index type:
+
+* `SymmetricPower.linearMap_ext`, extensionality via surjectivity of the quotient map `mk`;
+* `SymmetricPower.map f : Sym[R] ι M →ₗ[R] Sym[R] ι N`, the descent of
+  `PiTensorProduct.map (fun _ => f)` through the symmetrising quotient, with `map_mk`,
+  `map_tprod`, `map_id`, `map_comp`, `map_comp_apply`;
+* `ModuleCat.symmetricPowerFunctor R ι` and `ModuleCat.symmetricPower R n`, the packaged
+  endofunctors of `ModuleCat R`.
+
+**`Chapter7/SchurFunctor.lean` (new).** Etingof's item (8) ends with the Schur functors
+`V ↦ Hom_{Sₙ}(π, V^{⊗n})`. Neither ingredient existed:
+
+* `Etingof.tensorPowerPermRep k n V : Representation k (Perm (Fin n)) (⨂[k]^n V)` — the
+  slot-permutation action, from `PiTensorProduct.reindex`;
+* `Etingof.piTensorMap_comm_perm` — the diagonal map `f ⊗ ⋯ ⊗ f` is `Sₙ`-equivariant, which
+  is exactly what makes the construction functorial;
+* `Etingof.schurObj π V`, the equivariant Hom, realised as the invariants of
+  `Representation.linHom`, with `mem_schurObj_iff` restating membership as the intertwining
+  identity `ρ σ ∘ₗ φ = φ ∘ₗ π σ`;
+* `Etingof.schurMap`, `schurMap_id`, `schurMap_comp`, and `Etingof.schurFunctor π :
+  ModuleCat k ⥤ ModuleCat k`;
+* `Etingof.schurObjTrivialEquiv`, a non-vacuity witness: at the trivial `Sₙ`-representation
+  the Schur functor returns the symmetric tensors `(V^{⊗n})^{Sₙ}`.
+
+`Example7_2_2.lean` now exhibits both as `example`s alongside the existing eight, plus the
+`mem_schurObj_iff` and trivial-representation identifications so the objects are pinned down
+rather than merely typechecked. The two "deferred" scope-note paragraphs are gone.
+
+Item (9) (BGP reflection functors as `CategoryTheory.Functor`s) is genuinely out of scope
+here: it needs a Chapter 6 quiver-representation *category* compatible with the object-level
+`Etingof.reflectionFunctorMinus` of Definition 6.6.4, which does not exist yet. Its scope
+note was rewritten to point at the existing tracking issue #7383 rather than saying
+"deferred" with no owner.
+
+## Current frontier
+
+`lake build` is green across all 9332 jobs. The three touched files carry zero `sorry`s.
+`progress/items.json` for `Chapter7/Example7.2.2` moves from `followup_issue: 5642` to
+`followup_issue: 7383` with an updated coverage note; it stays `covered_partial` because of
+item (9).
+
+## Overall project progress
+
+Stage 3 (formalization) remains the active stage. Two pieces of API that Mathlib does not
+have — functoriality of the symmetric tensor power, and Schur functors — now exist in this
+repo and are available to any downstream item. In particular `ModuleCat.symmetricPower` is
+the companion of Mathlib's `ModuleCat.exteriorPower.functor`, and could be upstreamed;
+`SymmetricPower.map` is a direct answer to a TODO in Mathlib's own source.
+
+Note for whoever touches Chapter 5: the pre-existing `Etingof.symmetricPowerMap`
+(`Chapter5/Example5_19_3.lean`) is the endomorphism-only, finite-dimensional-over-a-field
+special case of the new `SymmetricPower.map`. It was deliberately left in place, since a
+large amount of Chapter 5 depends on it definitionally, but the two should eventually be
+reconciled.
+
+## Next step
+
+For the next worker: #7383 ("feat(Ch6–7): package BGP reflection constructions as actual
+functors") is now the sole remaining gap in Example 7.2.2 and is unclaimed. It is also the
+blocker behind #5639 (Example 6.8.5), whose finding is precisely that the Lean proof computes
+the simple-reflection action on dimension vectors without connecting it to the actual
+reflection functors. Doing #7383 unblocks both.
+
+The other three month-old Wave-2 issues (#5639, #5644, #5648) should be re-confirmed before
+being worked, as #5642 was: the codebase has moved a long way since 2026-06-29 and at least
+part of each finding is likely stale.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -8298,9 +8298,9 @@
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_partial",
-    "coverage_note": "Items (1)-(7) and the tensor/exterior-power portions of (8) are formalized. Symmetric/Schur functors in item (8) remain #5642; BGP reflection functors in item (9) remain #7383.",
-    "followup_issue": 5642,
-    "last_updated": "2026-07-22"
+    "coverage_note": "Items (1)-(8) are formalized, including the symmetric-power functor (ModuleCat.symmetricPower, built on a new SymmetricPower.map since Mathlib has none) and the Schur functors (Etingof.schurFunctor). Only item (9), packaging the BGP reflection constructions as functors, remains; that is #7383.",
+    "followup_issue": 7383,
+    "last_updated": "2026-07-26"
   },
   {
     "id": "Chapter7/Introduction_7.3",


### PR DESCRIPTION
This PR constructs the two functors Example 7.2.2(8) asserts but the file had written off as "deferred" scope notes: the symmetric power `V ↦ SⁿV` and the Schur functors `V ↦ Hom_{Sₙ}(π, V^{⊗n})`.

Mathlib's `SymmetricPower` carries no action on linear maps at all — the universal property is an explicit TODO in `Mathlib/LinearAlgebra/TensorPower/Symmetric.lean` — so `Chapter7/SymmetricPowerFunctor.lean` supplies `SymmetricPower.map` for an arbitrary index type, along with `map_mk`, `map_tprod`, `map_id`, `map_comp` and the packaged `ModuleCat.symmetricPowerFunctor` / `ModuleCat.symmetricPower`, the companion of Mathlib's `ModuleCat.exteriorPower.functor`.

Neither ingredient of the Schur functors existed either, so `Chapter7/SchurFunctor.lean` builds the slot-permutation representation `Etingof.tensorPowerPermRep` of `Sₙ` on `V^{⊗n}`, proves the diagonal map `f ⊗ ⋯ ⊗ f` is `Sₙ`-equivariant (`piTensorMap_comm_perm`, the functoriality input), and assembles `Etingof.schurObj` — the equivariant Hom, as invariants of `Representation.linHom` — into `Etingof.schurFunctor π : ModuleCat k ⥤ ModuleCat k`. `mem_schurObj_iff` restates membership as the intertwining identity `ρ σ ∘ₗ φ = φ ∘ₗ π σ`, and `schurObjTrivialEquiv` pins the construction down by identifying the trivial-representation case with the symmetric tensors `(V^{⊗n})^{Sₙ}`.

The issue's Wave-2 finding was largely stale on re-confirmation: items (1)-(7) and the direct-sum, tensor-product, tensor-power and exterior-power halves of (8) had already landed, and the wrong-codomain `Rings → Sets` complaint had been fixed. Item (9), packaging the BGP reflection constructions as functors, needs a Chapter 6 quiver-representation category that does not exist yet; its scope note now points at the tracking issue https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/issues/7383 instead of saying "deferred" with no owner. `progress/items.json` moves the follow-up for `Chapter7/Example7.2.2` accordingly.

Full `lake build` is green (9332 jobs); the three touched files carry no `sorry`.

Closes #5642

Session: `84ae8674-520e-4bd4-a8da-2e876da1027c`

🤖 Prepared with Claude Code