### PR TITLE
complete Proposition 4.7.1: prove irreducible matrix coefficients form a basis of F(G, ℂ)

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Proposition4_7_1.lean
+++ b/EtingofRepresentationTheory/Chapter4/Proposition4_7_1.lean
@@ -1,4 +1,5 @@
 import Mathlib
+import EtingofRepresentationTheory.Infrastructure.IrreducibleEnumeration
 
 /-!
 # Proposition 4.7.1: Orthogonality of Matrix Elements
@@ -11,8 +12,23 @@ Define matrix elements t^V_{ij}(g) = ⟨v_i, ρ_V(g) v_j⟩.
 
 (ii) (t^V_{ij}, t^V_{i'j'}) = δ_{ii'} δ_{jj'} / dim(V).
 
-In particular, the matrix elements of all irreducible representations form an orthogonal
-basis of the space of functions F(G, ℂ) (Peter–Weyl for finite groups).
+Thus the matrix elements of all irreducible representations form an orthogonal basis of the
+space of functions F(G, ℂ) (Peter–Weyl for finite groups). That last sentence is the
+content of the `Etingof.MatrixCoefficients` section below: `MatrixCoefficients.basis`
+is the `Module.Basis` itself, and `Etingof.Proposition4_7_1_orthogonal_basis` is the
+statement-level packaging.
+
+## The pairing
+
+Etingof states the orthogonality with respect to the Hermitian form
+`(f, h) = |G|⁻¹ Σ_x f(x) conj(h(x))` on `F(G, ℂ)`. Parts (i) and (ii) below are proved for
+a general algebraically closed `k`, so they are phrased with the bilinear convolution
+pairing `⟪f, h⟫ = |G|⁻¹ Σ_g f(g) h(g⁻¹)` (`MatrixCoefficients.pairing`) instead. Over `ℂ`,
+with the `v_i` an orthonormal basis for a positive-definite invariant Hermitian form, the
+matrix of `ρ(g)` is unitary, so `t_{qp}(g⁻¹) = conj (t_{pq}(g))` and the two agree on
+matrix coefficients up to transposing the index pair. The bilinear form is the one that
+makes sense over an arbitrary `k`, and it is nondegenerate, which is all the basis
+statement needs.
 
 ## Mathlib correspondence
 
@@ -197,3 +213,259 @@ theorem Etingof.Proposition4_7_1_ii
   simp only [LinearMap.smul_apply, LinearMap.id_apply, map_smul,
     Finsupp.smul_apply, Module.Basis.repr_self, Finsupp.single_apply, hc_val]
   split_ifs <;> simp_all
+
+/-!
+## The matrix coefficients as a basis of `F(G, k)`
+
+Etingof's concluding sentence — "matrix elements of irreducible representations of `G` form
+an orthogonal basis of `F(G, ℂ)`" — is assembled here. Orthogonality (parts (i) and (ii)
+above) gives linear independence; the sum-of-squares formula of Theorem 4.1.1 gives that
+the number of matrix coefficients is exactly `|G| = dim_k F(G, k)`, which upgrades linear
+independence to a basis.
+-/
+
+namespace Etingof.MatrixCoefficients
+
+variable {k G : Type u} [Field k] [IsAlgClosed k] [Group G] [Fintype G]
+
+section Pairing
+
+variable [Invertible (Fintype.card G : k)]
+
+/-- The convolution pairing `⟪f, h⟫ = |G|⁻¹ Σ_g f(g) h(g⁻¹)` on `F(G, k) = G → k`.
+
+This is the bilinear stand-in for Etingof's Hermitian form `|G|⁻¹ Σ_x f(x) conj(h(x))`; see
+the module docstring for why the two agree on matrix coefficients over `ℂ`. -/
+noncomputable def pairing (f h : G → k) : k :=
+  ⅟(Fintype.card G : k) • ∑ g : G, f g * h g⁻¹
+
+omit [IsAlgClosed k] in
+/-- `pairing` is symmetric: reindexing the sum by `g ↦ g⁻¹` swaps the two arguments. -/
+theorem pairing_comm (f h : G → k) : pairing f h = pairing h f := by
+  unfold pairing
+  congr 1
+  exact Fintype.sum_equiv (Equiv.inv G) _ _ fun g => by simp [mul_comm]
+
+/-- `pairing` as a linear functional in its first argument. -/
+noncomputable def pairingRight (h : G → k) : (G → k) →ₗ[k] k where
+  toFun f := pairing f h
+  map_add' f₁ f₂ := by
+    simp only [pairing, Pi.add_apply, add_mul, Finset.sum_add_distrib, smul_add]
+  map_smul' c f := by
+    simp only [pairing, Pi.smul_apply, smul_eq_mul, RingHom.id_apply, mul_assoc,
+      ← Finset.mul_sum]
+    ring
+
+omit [IsAlgClosed k] in
+@[simp]
+theorem pairingRight_apply (f h : G → k) : pairingRight h f = pairing f h := rfl
+
+end Pairing
+
+variable {n : ℕ} {d : Fin n → ℕ}
+
+/-- The index set for the matrix coefficients of a family `V` of representations equipped
+with bases of sizes `d i`: a block index `i` together with a row and a column. -/
+abbrev Index (n : ℕ) (d : Fin n → ℕ) : Type := Σ i : Fin n, Fin (d i) × Fin (d i)
+
+/-- The matrix coefficient `t^{V i}_{p q}(g) = (ρ_{V i}(g))_{p q}`, read off in the basis
+`b i`. -/
+noncomputable def coeff (V : Fin n → FDRep k G) (b : ∀ i, Module.Basis (Fin (d i)) k (V i))
+    (e : Index n d) : G → k :=
+  fun g => LinearMap.toMatrix (b e.1) (b e.1) ((V e.1).ρ g) e.2.1 e.2.2
+
+variable {V : Fin n → FDRep k G} {b : ∀ i, Module.Basis (Fin (d i)) k (V i)}
+
+omit [IsAlgClosed k] [Fintype G] in
+/-- `d i` is the dimension of `V i`, since `b i` is a basis indexed by `Fin (d i)`. -/
+theorem finrank_eq (b : ∀ i, Module.Basis (Fin (d i)) k (V i)) (i : Fin n) :
+    Module.finrank k (V i) = d i := by
+  rw [Module.finrank_eq_card_basis (b i), Fintype.card_fin]
+
+section Orthogonality
+
+variable [Invertible (Fintype.card G : k)]
+
+/-- **Cross-block orthogonality** (Proposition 4.7.1(i)): matrix coefficients belonging to
+non-isomorphic irreducibles pair to zero. -/
+theorem pairing_coeff_of_ne (hV : ∀ i, Simple (V i))
+    (hinj : ∀ i j, Nonempty ((V i) ≅ (V j)) → i = j)
+    {i i' : Fin n} (hii : i ≠ i') (p' q' : Fin (d i')) (p q : Fin (d i)) :
+    pairing (coeff V b ⟨i', p', q'⟩) (coeff V b ⟨i, q, p⟩) = 0 := by
+  haveI := hV i; haveI := hV i'
+  have hVW : IsEmpty ((V i') ≅ (V i)) :=
+    not_nonempty_iff.mp fun h => hii (hinj i i' ⟨h.some.symm⟩)
+  exact Etingof.Proposition4_7_1_i (V i') (V i) hVW (b i') (b i) p' q' q p
+
+/-- **Within-block orthogonality** (Proposition 4.7.1(ii)): `⟪t_{p'q'}, t_{qp}⟫` is
+`δ_{p'p} δ_{q'q} / dim V`. -/
+theorem pairing_coeff_self (hV : ∀ i, Simple (V i)) {i : Fin n} (hd : ((d i : k)) ≠ 0)
+    (p' q' p q : Fin (d i)) :
+    pairing (coeff V b ⟨i, p', q'⟩) (coeff V b ⟨i, q, p⟩) =
+      if p' = p ∧ q' = q then ((d i : k))⁻¹ else 0 := by
+  haveI := hV i
+  have hfr : ((Module.finrank k (V i) : k)) = (d i : k) := by rw [finrank_eq b i]
+  haveI : Invertible ((Module.finrank k (V i) : k)) :=
+    invertibleOfNonzero (by rw [hfr]; exact hd)
+  have hinv : (⅟(Module.finrank k (V i) : k) : k) = ((d i : k))⁻¹ :=
+    invOf_eq_right_inv (by rw [hfr]; exact mul_inv_cancel₀ hd)
+  have hunfold : pairing (coeff V b ⟨i, p', q'⟩) (coeff V b ⟨i, q, p⟩) =
+      ⅟(Fintype.card G : k) • ∑ g : G,
+        (LinearMap.toMatrix (b i) (b i) ((V i).ρ g)) p' q' *
+        (LinearMap.toMatrix (b i) (b i) ((V i).ρ g⁻¹)) q p := rfl
+  rw [hunfold, Etingof.Proposition4_7_1_ii (V i) (b i) p' q' q p, hinv]
+
+end Orthogonality
+
+section Basis
+
+variable [Invertible (Fintype.card G : k)]
+
+/-- The matrix coefficients of a family of pairwise non-isomorphic irreducibles are
+linearly independent in `F(G, k)`.
+
+This is exactly Proposition 4.7.1(i)+(ii): pairing a vanishing linear combination against
+the transposed coefficient `t_{q₀p₀}` kills every term except the one indexed by
+`⟨i₀, p₀, q₀⟩`, whose coefficient survives multiplied by the nonzero scalar
+`(dim V i₀)⁻¹`. -/
+theorem linearIndependent_coeff (hV : ∀ i, Simple (V i))
+    (hinj : ∀ i j, Nonempty ((V i) ≅ (V j)) → i = j)
+    (hd : ∀ i, ((d i : k)) ≠ 0) :
+    LinearIndependent k (coeff V b) := by
+  classical
+  rw [Fintype.linearIndependent_iff]
+  rintro c hc ⟨i₀, p₀, q₀⟩
+  -- Pair the vanishing combination against the transposed coefficient `t_{q₀ p₀}`.
+  have h0 := congrArg (pairingRight (k := k) (coeff V b ⟨i₀, q₀, p₀⟩)) hc
+  rw [map_sum, map_zero] at h0
+  simp only [map_smul, smul_eq_mul, pairingRight_apply] at h0
+  -- Split the sum over the sigma type into a sum over blocks.
+  rw [← Finset.univ_sigma_univ, Finset.sum_sigma] at h0
+  -- Blocks other than `i₀` contribute nothing.
+  rw [Finset.sum_eq_single i₀ (fun i _ hi => ?_) (fun h => absurd (Finset.mem_univ i₀) h)] at h0
+  · -- Inside block `i₀`, only the `(p₀, q₀)` term survives.
+    rw [← Finset.univ_product_univ, Finset.sum_product] at h0
+    rw [Finset.sum_eq_single p₀ (fun p _ hp => ?_) (fun h => absurd (Finset.mem_univ p₀) h)] at h0
+    · rw [Finset.sum_eq_single q₀ (fun q _ hq => ?_) (fun h => absurd (Finset.mem_univ q₀) h)] at h0
+      · rw [pairing_coeff_self hV (hd i₀) p₀ q₀ p₀ q₀, if_pos ⟨rfl, rfl⟩] at h0
+        exact (mul_eq_zero.mp h0).resolve_right (inv_ne_zero (hd i₀))
+      · rw [pairing_coeff_self hV (hd i₀) p₀ q p₀ q₀, if_neg (by simp [hq]), mul_zero]
+    · refine Finset.sum_eq_zero fun q _ => ?_
+      rw [pairing_coeff_self hV (hd i₀) p q p₀ q₀, if_neg (by simp [hp]), mul_zero]
+  · refine Finset.sum_eq_zero fun pq _ => ?_
+    obtain ⟨p, q⟩ := pq
+    rw [pairing_coeff_of_ne hV hinj (Ne.symm hi) p q p₀ q₀, mul_zero]
+
+/-- The number of matrix coefficients of a *complete* family of pairwise non-isomorphic
+irreducibles is `|G|`, by the sum-of-squares formula of Theorem 4.1.1. -/
+theorem card_index (hV : ∀ i, Simple (V i))
+    (hinj : ∀ i j, Nonempty ((V i) ≅ (V j)) → i = j)
+    (hsurj : ∀ (W : FDRep k G), Simple W → ∃ i, Nonempty (W ≅ V i))
+    (b : ∀ i, Module.Basis (Fin (d i)) k (V i)) :
+    Fintype.card (Index n d) = Module.finrank k (G → k) := by
+  haveI : NeZero (Nat.card G : k) :=
+    ⟨by rw [Nat.card_eq_fintype_card]; exact (isUnit_of_invertible _).ne_zero⟩
+  rw [Module.finrank_fintype_fun_eq_card, ← sum_finrank_sq_eq_card_of_complete V hV hinj hsurj]
+  simp only [Index, Fintype.card_sigma, Fintype.card_prod, Fintype.card_fin]
+  exact Finset.sum_congr rfl fun i _ => by rw [finrank_eq b i, sq]
+
+/-- **Proposition 4.7.1, concluding statement.** The matrix coefficients of a complete set
+of pairwise non-isomorphic irreducible representations of `G` form a basis of `F(G, k)`.
+
+Orthogonality is `basis_pairing` below; the two together are Etingof's "matrix elements of
+irreducible representations of `G` form an orthogonal basis of `F(G, ℂ)`". -/
+noncomputable def basis (hV : ∀ i, Simple (V i))
+    (hinj : ∀ i j, Nonempty ((V i) ≅ (V j)) → i = j)
+    (hsurj : ∀ (W : FDRep k G), Simple W → ∃ i, Nonempty (W ≅ V i))
+    (hd : ∀ i, ((d i : k)) ≠ 0) :
+    Module.Basis (Index n d) k (G → k) :=
+  basisOfLinearIndependentOfCardEqFinrank' (coeff V b)
+    (linearIndependent_coeff hV hinj hd) (card_index hV hinj hsurj b)
+
+@[simp]
+theorem coe_basis (hV : ∀ i, Simple (V i))
+    (hinj : ∀ i j, Nonempty ((V i) ≅ (V j)) → i = j)
+    (hsurj : ∀ (W : FDRep k G), Simple W → ∃ i, Nonempty (W ≅ V i))
+    (hd : ∀ i, ((d i : k)) ≠ 0) :
+    ⇑(basis (b := b) hV hinj hsurj hd) = coeff V b :=
+  coe_basisOfLinearIndependentOfCardEqFinrank' _ _ _
+
+end Basis
+
+end Etingof.MatrixCoefficients
+
+/-- **Proposition 4.7.1, final statement.** For a finite group `G` over an algebraically
+closed field `k` in which `|G|` is invertible and every irreducible dimension is nonzero,
+the matrix elements of a complete set of pairwise non-isomorphic irreducible
+representations form an *orthogonal* basis of `F(G, k) = G → k`, orthogonal with respect
+to the convolution pairing `⟪f, h⟫ = |G|⁻¹ Σ_g f(g) h(g⁻¹)`.
+
+The basis is indexed by triples `⟨i, p, q⟩` (an irreducible `V i` together with a matrix
+position), the basis vector at `⟨i, p, q⟩` is `g ↦ (ρ_{V i}(g))_{p q}`, and
+
+`⟪t^{V i'}_{p' q'}, t^{V i}_{q p}⟫ = δ_{i i'} δ_{p p'} δ_{q q'} / dim (V i)`,
+
+which is precisely `Proposition4_7_1_i` (the `i ≠ i'` case) and `Proposition4_7_1_ii` (the
+`i = i'` case). -/
+theorem Etingof.Proposition4_7_1_orthogonal_basis
+    {k G : Type u} [Field k] [IsAlgClosed k] [Group G] [Fintype G]
+    [Invertible (Fintype.card G : k)]
+    {n : ℕ} {d : Fin n → ℕ} (V : Fin n → FDRep k G)
+    (b : ∀ i, Module.Basis (Fin (d i)) k (V i))
+    (hV : ∀ i, Simple (V i))
+    (hinj : ∀ i j, Nonempty ((V i) ≅ (V j)) → i = j)
+    (hsurj : ∀ (W : FDRep k G), Simple W → ∃ i, Nonempty (W ≅ V i))
+    (hd : ∀ i, ((d i : k)) ≠ 0) :
+    ∃ B : Module.Basis (Σ i : Fin n, Fin (d i) × Fin (d i)) k (G → k),
+      (∀ (e : Σ i : Fin n, Fin (d i) × Fin (d i)) (g : G),
+        B e g = LinearMap.toMatrix (b e.1) (b e.1) ((V e.1).ρ g) e.2.1 e.2.2) ∧
+      (∀ (i i' : Fin n) (p' q' : Fin (d i')) (p q : Fin (d i)),
+        Etingof.MatrixCoefficients.pairing (B ⟨i', p', q'⟩) (B ⟨i, q, p⟩) =
+          if h : i = i' then
+            (if p' = h ▸ p ∧ q' = h ▸ q then ((d i' : k))⁻¹ else 0)
+          else 0) := by
+  classical
+  refine ⟨Etingof.MatrixCoefficients.basis (b := b) hV hinj hsurj hd, fun e g => ?_, ?_⟩
+  · rw [Etingof.MatrixCoefficients.coe_basis]; rfl
+  · intro i i' p' q' p q
+    rw [Etingof.MatrixCoefficients.coe_basis]
+    by_cases hii : i = i'
+    · subst hii
+      rw [dif_pos rfl, Etingof.MatrixCoefficients.pairing_coeff_self hV (hd i) p' q' p q]
+    · rw [dif_neg hii,
+        Etingof.MatrixCoefficients.pairing_coeff_of_ne hV hinj hii p' q' p q]
+
+/-- **Existence form.** Every finite group `G` over an algebraically closed field `k` of
+characteristic zero admits a complete set of pairwise non-isomorphic irreducibles whose
+matrix elements form an orthogonal basis of `F(G, k)`. -/
+theorem Etingof.Proposition4_7_1_exists_orthogonal_basis
+    (k G : Type u) [Field k] [IsAlgClosed k] [CharZero k] [Group G] [Fintype G] :
+    ∃ (n : ℕ) (V : Fin n → FDRep k G) (d : Fin n → ℕ)
+      (b : ∀ i, Module.Basis (Fin (d i)) k (V i))
+      (B : Module.Basis (Σ i : Fin n, Fin (d i) × Fin (d i)) k (G → k)),
+      (∀ i, Simple (V i)) ∧
+      (∀ i j, Nonempty ((V i) ≅ (V j)) → i = j) ∧
+      (∀ (W : FDRep k G), Simple W → ∃ i, Nonempty (W ≅ V i)) ∧
+      (∀ (e : Σ i : Fin n, Fin (d i) × Fin (d i)) (g : G),
+        B e g = LinearMap.toMatrix (b e.1) (b e.1) ((V e.1).ρ g) e.2.1 e.2.2) ∧
+      (∀ (i i' : Fin n) (p' q' : Fin (d i')) (p q : Fin (d i)),
+        Etingof.MatrixCoefficients.pairing (B ⟨i', p', q'⟩) (B ⟨i, q, p⟩) =
+          if h : i = i' then
+            (if p' = h ▸ p ∧ q' = h ▸ q then ((d i' : k))⁻¹ else 0)
+          else 0) := by
+  classical
+  haveI : NeZero (Nat.card G : k) := ⟨by
+    rw [Nat.card_eq_fintype_card]
+    exact (Nat.cast_ne_zero (R := k)).mpr Fintype.card_ne_zero⟩
+  -- Take the Wedderburn column representations: their dimensions are the block sizes
+  -- `D.d i`, which are positive by `IrrepDecomp.d_pos`.
+  let D : IrrepDecomp k G := IrrepDecomp.mk'
+  let b : ∀ i, Module.Basis (Fin (D.d i)) k (D.columnFDRep i) := fun i =>
+    Module.finBasisOfFinrankEq k _ (D.finrank_columnFDRep i)
+  have hd : ∀ i, ((D.d i : k)) ≠ 0 := fun i =>
+    (Nat.cast_ne_zero (R := k)).mpr (D.d_pos i).ne
+  obtain ⟨B, hB, horth⟩ :=
+    Etingof.Proposition4_7_1_orthogonal_basis D.columnFDRep b
+      D.columnFDRep_simple D.columnFDRep_injective D.columnFDRep_surjective hd
+  exact ⟨D.n, D.columnFDRep, D.d, b, B, D.columnFDRep_simple, D.columnFDRep_injective,
+    D.columnFDRep_surjective, hB, horth⟩

--- a/EtingofRepresentationTheory/Chapter4/Proposition4_7_1.lean
+++ b/EtingofRepresentationTheory/Chapter4/Proposition4_7_1.lean
@@ -372,8 +372,10 @@ theorem card_index (hV : ∀ i, Simple (V i))
 /-- **Proposition 4.7.1, concluding statement.** The matrix coefficients of a complete set
 of pairwise non-isomorphic irreducible representations of `G` form a basis of `F(G, k)`.
 
-Orthogonality is `basis_pairing` below; the two together are Etingof's "matrix elements of
-irreducible representations of `G` form an orthogonal basis of `F(G, ℂ)`". -/
+Orthogonality of this basis is `pairing_coeff_of_ne` and `pairing_coeff_self` (transported
+along `coe_basis`); the two together are Etingof's "matrix elements of irreducible
+representations of `G` form an orthogonal basis of `F(G, ℂ)`", packaged as
+`Etingof.Proposition4_7_1_orthogonal_basis`. -/
 noncomputable def basis (hV : ∀ i, Simple (V i))
     (hinj : ∀ i j, Nonempty ((V i) ≅ (V j)) → i = j)
     (hsurj : ∀ (W : FDRep k G), Simple W → ∃ i, Nonempty (W ≅ V i))

--- a/EtingofRepresentationTheory/Infrastructure/IrreducibleEnumeration.lean
+++ b/EtingofRepresentationTheory/Infrastructure/IrreducibleEnumeration.lean
@@ -802,3 +802,30 @@ theorem exists_simples_sum_finrank_sq_eq_card (k : Type u) (G : Type v) [Field k
   refine ⟨D.n, D.columnFDRep, D.columnFDRep_simple, D.columnFDRep_injective,
     D.columnFDRep_surjective, ?_⟩
   exact D.sum_finrank_sq_eq_card D.columnFDRep D.columnFDRep_simple D.columnFDRep_injective
+
+/-- **Artin-Wedderburn dimension count for an arbitrary complete family.** Unlike
+`IrrepDecomp.sum_finrank_sq_eq_card`, the index type here is an arbitrary `Fin n` rather
+than the Wedderburn index `Fin D.n`: completeness of the family forces `n = D.n`, because
+the assignment sending `i` to the Wedderburn block containing `V i` is a bijection. -/
+theorem sum_finrank_sq_eq_card_of_complete [NeZero (Nat.card G : k)]
+    {n : ℕ} (V : Fin n → FDRep k G)
+    (hV : ∀ i, Simple (V i))
+    (hinj : ∀ i j, Nonempty ((V i) ≅ (V j)) → i = j)
+    (hsurj : ∀ (W : FDRep k G), Simple W → ∃ i, Nonempty (W ≅ V i)) :
+    ∑ i, (Module.finrank k (V i)) ^ 2 = Fintype.card G := by
+  let D : IrrepDecomp k G := IrrepDecomp.mk'
+  -- `τ i` is the Wedderburn block matching `V i`
+  choose τ hτ using fun i => D.columnFDRep_surjective (V i) (hV i)
+  have hτ_inj : Function.Injective τ := fun i j h =>
+    hinj i j ⟨(hτ i).some ≪≫ (h ▸ (hτ j).some.symm)⟩
+  have hτ_surj : Function.Surjective τ := fun j => by
+    obtain ⟨i, hi⟩ := hsurj (D.columnFDRep j) (D.columnFDRep_simple j)
+    exact ⟨i, (D.columnFDRep_injective j (τ i) ⟨hi.some ≪≫ (hτ i).some⟩).symm⟩
+  let e : Fin n ≃ Fin D.n := Equiv.ofBijective τ ⟨hτ_inj, hτ_surj⟩
+  calc ∑ i, (Module.finrank k (V i)) ^ 2
+      = ∑ i, (D.d (e i)) ^ 2 := by
+        refine Finset.sum_congr rfl fun i _ => ?_
+        rw [show (e : Fin n → Fin D.n) i = τ i from rfl, ← D.finrank_columnFDRep (τ i)]
+        exact congrArg (· ^ 2) (LinearEquiv.finrank_eq (FDRep.isoToLinearEquiv (hτ i).some))
+    _ = ∑ j, (D.d j) ^ 2 := Equiv.sum_comp e (fun j => D.d j ^ 2)
+    _ = Fintype.card G := D.sum_sq_eq_card

--- a/progress/2026-07-26T12-06-17Z_d0aea7aa.md
+++ b/progress/2026-07-26T12-06-17Z_d0aea7aa.md
@@ -1,0 +1,87 @@
+## Accomplished
+
+Closed the omitted endpoint of **Proposition 4.7.1** (issue #7395): the concluding sentence
+"matrix elements of irreducible representations of `G` form an orthogonal basis of
+`F(G, ℂ)`". The file previously proved only the two orthogonality identities, with no
+spanning or cardinality statement, so the basis conclusion was absent.
+
+New in `EtingofRepresentationTheory/Chapter4/Proposition4_7_1.lean`
+(namespace `Etingof.MatrixCoefficients`):
+
+* `pairing` — the convolution pairing `⟪f, h⟫ = |G|⁻¹ Σ_g f(g) h(g⁻¹)` on `F(G, k)`, plus
+  `pairing_comm` and `pairingRight` (the pairing as a linear functional).
+* `Index n d` — the index type `Σ i : Fin n, Fin (d i) × Fin (d i)` (irreducible, row,
+  column), and `coeff` — the family `g ↦ (ρ_{V i}(g))_{p q}` in a chosen basis `b i`.
+* `pairing_coeff_of_ne` / `pairing_coeff_self` — parts (i) and (ii) restated for that
+  family.
+* `linearIndependent_coeff` — linear independence, by pairing a vanishing combination
+  against the *transposed* coefficient `t_{q₀ p₀}`; the sigma sum splits by block, part (i)
+  kills the other blocks, part (ii) kills the other positions.
+* `card_index` — `#Index = Σ (dim V i)² = |G| = dim_k F(G, k)`.
+* `basis` — the `Module.Basis (Index n d) k (G → k)`, with `coe_basis`.
+
+Statement-level packaging at top level: `Etingof.Proposition4_7_1_orthogonal_basis`
+(basis + the full orthogonality relation, for any given complete family) and
+`Etingof.Proposition4_7_1_exists_orthogonal_basis` (unconditional for algebraically closed
+`k` of characteristic zero, built from the Wedderburn column representations, so the result
+is demonstrably non-vacuous).
+
+Infrastructure, in `Infrastructure/IrreducibleEnumeration.lean`:
+`sum_finrank_sq_eq_card_of_complete` generalises `IrrepDecomp.sum_finrank_sq_eq_card` from
+the Wedderburn index `Fin D.n` to an *arbitrary* complete family `Fin n → FDRep k G` —
+completeness forces `n = D.n` via the block-matching bijection.
+
+`progress/items.json`: `Chapter4/Proposition4.7.1` flipped from `covered_partial` to
+`covered_full`, `fidelity_issue: 7395` dropped, `lean_decl` added, `fidelity_note` rewritten.
+
+## Decisions made
+
+**Bilinear pairing, not the Hermitian form.** Etingof states orthogonality with respect to
+`(f, h) = |G|⁻¹ Σ_x f(x) conj(h(x))` on `F(G, ℂ)`. The pre-existing parts (i) and (ii) in
+this file are proved over an arbitrary algebraically closed `k`, so they are naturally
+phrased with the bilinear convolution pairing `|G|⁻¹ Σ_g f(g) h(g⁻¹)`. Over `ℂ` with an
+orthonormal basis for an invariant positive-definite Hermitian form, `ρ(g)` is unitary, so
+`t_{qp}(g⁻¹) = conj (t_{pq}(g))` and the two agree on matrix coefficients up to transposing
+the index pair. Building the Hermitian version would first require constructing the
+invariant form and a unitary basis for each irreducible; the bilinear form is nondegenerate
+on the matrix coefficients, which is all the basis statement needs. This is recorded in the
+module docstring and in the `fidelity_note`.
+
+**Bases supplied by the caller.** `basis` takes `d : Fin n → ℕ` and
+`b : ∀ i, Module.Basis (Fin (d i)) k (V i)` rather than fixing
+`d i = Module.finrank k (V i)`, so callers with a natural basis (e.g. the Wedderburn column
+representations, where `d i` is the block size) do not have to transport along a `finrank`
+equation. `finrank_eq` recovers `Module.finrank k (V i) = d i`.
+
+## Current frontier
+
+Verification: `lake build` clean on the target file and its imports; `#print axioms` on
+`basis`, `linearIndependent_coeff`, and both top-level statements returns only
+`propext, Classical.choice, Quot.sound`; no new `sorry`; `scripts/validate_items.py` passes.
+A full-project `lake build` was running at the end of the turn (no errors up to 9001/9335
+jobs); CI on the PR is the authoritative check.
+
+## Overall project progress
+
+Stage 3 formalization continues. This turn removed one `covered_partial` fidelity gap in
+Chapter 4 and added one reusable Artin-Wedderburn infrastructure lemma.
+
+## Next step
+
+Note for whoever picks up **#7896** (`assemble the q²−1 constructed GL₂(𝔽_q) irreducibles`):
+it appears in `list-unclaimed` because both its `depends-on` issues are closed, but #7894
+was closed by *decomposition* into #7904/#7905/#7906, and #7906 (the actual
+complementary-series family) is still open and blocked. Deliverable 1 of #7896 has no
+complementary-series family to concatenate yet. It should stay parked until #7906 lands.
+
+Natural follow-ups to this turn, neither of which is currently an issue:
+
+1. The Hermitian-form version of the orthogonal basis over `ℂ`: construct the invariant
+   positive-definite form and a unitary basis on each irreducible, then transport
+   `Proposition4_7_1_orthogonal_basis` to Etingof's `(f, h) = |G|⁻¹ Σ_x f(x) conj(h(x))`.
+2. Deduce the class-function corollary (characters as an orthonormal basis of the space of
+   class functions) from the matrix-coefficient basis, if some other chapter item wants it.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3632,12 +3632,12 @@
     "start_line": 15,
     "end_line": 24,
     "status": "sorry_free",
-    "coverage": "covered_partial",
+    "coverage": "covered_full",
     "fidelity": "verified",
     "sorry_free": true,
-    "fidelity_note": "The two matrix-coefficient orthogonality formulas are proved faithfully. The source's final conclusion that all irreducible matrix coefficients form a basis of F(G, ℂ) is not stated: spanning via the sum-of-squares formula remains follow-up #7395.",
-    "fidelity_issue": 7395,
-    "last_updated": "2026-07-22"
+    "lean_decl": "Etingof.Proposition4_7_1_i, Etingof.Proposition4_7_1_ii, Etingof.Proposition4_7_1_orthogonal_basis, Etingof.Proposition4_7_1_exists_orthogonal_basis",
+    "fidelity_note": "All three sentences are formalized. Parts (i) and (ii) are the two matrix-coefficient orthogonality formulas. The concluding sentence -- that the irreducible matrix coefficients form an orthogonal basis of F(G, ℂ) -- is `Etingof.MatrixCoefficients.basis` (the `Module.Basis` itself), packaged as `Etingof.Proposition4_7_1_orthogonal_basis` and, unconditionally for algebraically closed characteristic-zero k, as `Etingof.Proposition4_7_1_exists_orthogonal_basis`; spanning comes from the Artin-Wedderburn sum-of-squares count as the source indicates. Orthogonality is stated for the bilinear convolution pairing |G|^-1 sum_g f(g) h(g^-1) rather than the source's Hermitian form, since parts (i) and (ii) hold over any algebraically closed k; the two agree on matrix coefficients over the complex numbers in a unitary basis.",
+    "last_updated": "2026-07-26"
   },
   {
     "id": "Chapter4/Introduction_4.8",


### PR DESCRIPTION
Closes #7395

Session: `d0aea7aa-cdce-4049-b5ac-d38141852b72`

058cef15 doc(Ch4 #7395): fix stale cross-reference in basis docstring; add progress entry for 2026-07-26T12-06-17Z
0795b267 chore(Ch4 #7395): mark Proposition 4.7.1 covered_full in items.json
afee9cff feat(Ch4 #7395): matrix coefficients of the irreducibles form an orthogonal basis of F(G,k)

🤖 Prepared with Claude Code