### PR TITLE
feat(Ch8 #7882): exactness of the augmented Koszul complex and the free-resolution endpoint

### DIFF
--- a/EtingofRepresentationTheory/Chapter8.lean
+++ b/EtingofRepresentationTheory/Chapter8.lean
@@ -14,6 +14,7 @@ import EtingofRepresentationTheory.Chapter8.Definition8_2_4
 import EtingofRepresentationTheory.Chapter8.Problem8_2_10
 import EtingofRepresentationTheory.Chapter8.KoszulBasis
 import EtingofRepresentationTheory.Chapter8.KoszulHomotopy
+import EtingofRepresentationTheory.Chapter8.KoszulResolution
 import EtingofRepresentationTheory.Chapter8.Problem8_1_3
 import EtingofRepresentationTheory.Chapter8.Exercise8_1_4
 import EtingofRepresentationTheory.Chapter8.Horseshoe

--- a/EtingofRepresentationTheory/Chapter8/KoszulResolution.lean
+++ b/EtingofRepresentationTheory/Chapter8/KoszulResolution.lean
@@ -37,6 +37,8 @@ though the witness `h x` is produced by a merely `k`-linear map.
   `CategoryTheory.ProjectiveResolution (ModuleCat.of SV (Etingof.KoszulAugModule k V))`. Its terms
   are free, not merely projective (`Etingof.koszulXBasis`), which is the "(in fact, free)" of the
   problem statement.
+* `Etingof.koszulResolutionOfFiniteDimensional` — the same under the book's hypothesis, `V` a
+  finite dimensional vector space over a field.
 -/
 
 universe u v w
@@ -204,5 +206,17 @@ theorem koszulResolution_free (i : ℕ) :
   koszulX_free_of_basis b i
 
 end Resolution
+
+/-! ### The book's hypothesis: `V` a finite dimensional vector space -/
+
+/-- **The Koszul resolution of a finite dimensional vector space**, the exact hypothesis of
+Problem 8.2.10: `V` finite dimensional over a field `k`. This is `Etingof.koszulResolution` for the
+basis `Module.finBasis k V`; by `Etingof.koszulComplex_eq_of_basis` the underlying complex does not
+depend on that choice. -/
+noncomputable def koszulResolutionOfFiniteDimensional (k : Type u) [Field k] (V : Type v)
+    [AddCommGroup V] [Module k V] [FiniteDimensional k V] :
+    CategoryTheory.ProjectiveResolution
+      (ModuleCat.of (SymmetricAlgebra k V) (KoszulAugModule k V)) :=
+  koszulResolution (Module.finBasis k V)
 
 end Etingof

--- a/EtingofRepresentationTheory/Chapter8/KoszulResolution.lean
+++ b/EtingofRepresentationTheory/Chapter8/KoszulResolution.lean
@@ -97,8 +97,9 @@ open CategoryTheory Limits
 variable (b : Module.Basis κ k V)
 
 /-- Each term of `Etingof.koszulComplex` is a projective object of `ModuleCat SV` — indeed a free
-module, by `Etingof.koszulXBasis`. -/
-instance koszulComplex_projective_X (i : ℕ) : Projective ((koszulComplex b).X i) :=
+module, by `Etingof.koszulXBasis`. Not an `instance`: it needs the basis `b`, which typeclass
+inference cannot supply. -/
+theorem koszulComplex_projective_X (i : ℕ) : Projective ((koszulComplex b).X i) :=
   haveI := koszulX_free_of_basis b i
   inferInstanceAs
     (Projective (ModuleCat.of (SymmetricAlgebra k V) (koszulX k V i)))

--- a/EtingofRepresentationTheory/Chapter8/KoszulResolution.lean
+++ b/EtingofRepresentationTheory/Chapter8/KoszulResolution.lean
@@ -1,0 +1,208 @@
+import EtingofRepresentationTheory.Chapter8.KoszulHomotopy
+import Mathlib.Algebra.Category.ModuleCat.Abelian
+import Mathlib.Algebra.Category.ModuleCat.Projective
+import Mathlib.Algebra.Homology.ShortComplex.ModuleCat
+import Mathlib.CategoryTheory.Abelian.Projective.Resolution
+
+/-!
+# Exactness of the augmented Koszul complex, and the Koszul resolution
+
+`Chapter8/KoszulHomotopy.lean` produced a `k`-linear contracting homotopy of the augmented
+Koszul complex
+
+`⋯ → C₂ → C₁ → C₀ --ε--> k → 0`,   `Cᵢ = SV ⊗[k] ⋀ⁱ V`,
+
+namely `Etingof.koszulH` together with the splitting `Etingof.koszulEta` of the augmentation,
+satisfying `d h + h d = id` in positive degrees and `d h + η ε = id` in degree zero. This file
+turns that into the statement Problem 8.2.10(i) actually asks for: the augmented complex is
+**exact**, so `C_•` is a free resolution of `k`.
+
+The homotopy is only `k`-linear — no `SV`-linear contracting homotopy can exist, since `C_•` is a
+resolution of `k` and is not `SV`-split. That is harmless: exactness is a statement about the
+underlying additive groups. If `d x = 0` then
+
+`x = d (h x) + h (d x) = d (h x) ∈ range d`,
+
+and the ranges and kernels involved are `SV`-submodules because `d` and `ε` are `SV`-linear, even
+though the witness `h x` is produced by a merely `k`-linear map.
+
+## Main results
+
+* `Etingof.koszulD_range_eq_ker` — `range dᵢ₊₁ = ker dᵢ`, exactness in positive degrees.
+* `Etingof.koszulD_zero_range_eq_ker_koszulAug` — `range d₀ = ker ε`, exactness at `C₀`.
+* `Etingof.koszulComplex_exactAt_succ` — the same, as `HomologicalComplex.ExactAt`.
+* `Etingof.koszulPi` — the augmentation as a chain map `C_• ⟶ k[0]`, and
+  `Etingof.koszulPi_quasiIso`, which says it is a quasi-isomorphism.
+* `Etingof.koszulResolution` — **the Koszul resolution**: the whole package, as a
+  `CategoryTheory.ProjectiveResolution (ModuleCat.of SV (Etingof.KoszulAugModule k V))`. Its terms
+  are free, not merely projective (`Etingof.koszulXBasis`), which is the "(in fact, free)" of the
+  problem statement.
+-/
+
+universe u v w
+
+open scoped TensorProduct
+
+namespace Etingof
+
+variable {k : Type u} [CommRing k] {V : Type v} [AddCommGroup V] [Module k V]
+variable {κ : Type w} [LinearOrder κ] [Fintype κ]
+
+/-! ### Exactness as an identity of `SV`-submodules -/
+
+/-- **Exactness of the Koszul complex in positive degrees**: `range dᵢ₊₁ = ker dᵢ`.
+
+`⊆` is `d ∘ d = 0`. For `⊇`, the contracting homotopy exhibits an explicit preimage: a cycle `x`
+satisfies `x = d (h x) + h (d x) = d (h x)`. The homotopy is only `k`-linear, but both sides of
+the equation are `SV`-submodules of `Cᵢ₊₁` regardless, since `d` is `SV`-linear. -/
+theorem koszulD_range_eq_ker (b : Module.Basis κ k V) (i : ℕ) :
+    LinearMap.range (koszulD b (i + 1)) = LinearMap.ker (koszulD b i) := by
+  refine le_antisymm ?_ fun x hx => ?_
+  · rintro _ ⟨y, rfl⟩
+    rw [LinearMap.mem_ker, ← LinearMap.comp_apply, koszulD_comp_koszulD b i,
+      LinearMap.zero_apply]
+  · refine ⟨koszulH b (i + 1) x, ?_⟩
+    have h := koszulD_koszulH_add_koszulH_koszulD b i x
+    rwa [LinearMap.mem_ker.mp hx, map_zero, add_zero] at h
+
+/-- **Exactness of the augmented Koszul complex at `C₀`**: `range d₀ = ker ε`.
+
+Together with `Etingof.koszulAug_surjective` and `Etingof.koszulD_range_eq_ker` this is the whole
+of "the augmented complex `⋯ → C₁ → C₀ → k → 0` is exact". -/
+theorem koszulD_zero_range_eq_ker_koszulAug (b : Module.Basis κ k V) :
+    LinearMap.range (koszulD b 0) = LinearMap.ker (koszulAug k V) := by
+  refine le_antisymm ?_ fun x hx => ?_
+  · rintro _ ⟨y, rfl⟩
+    rw [LinearMap.mem_ker, ← LinearMap.comp_apply, koszulAug_comp_koszulD b,
+      LinearMap.zero_apply]
+  · refine ⟨koszulH b 0 x, ?_⟩
+    have h := koszulD_koszulH_add_eta_aug b x
+    rwa [LinearMap.mem_ker.mp hx, map_zero, add_zero] at h
+
+omit [Fintype κ] in
+/-- Freeness of the Koszul terms, in the form needed below: a basis of `V` is all one needs, no
+separate `Module.Free k V` hypothesis. -/
+theorem koszulX_free_of_basis (b : Module.Basis κ k V) (i : ℕ) :
+    Module.Free (SymmetricAlgebra k V) (koszulX k V i) :=
+  Module.Free.of_basis (koszulXBasis k V b i)
+
+/-! ### The categorical package -/
+
+section Resolution
+
+open CategoryTheory Limits
+
+variable (b : Module.Basis κ k V)
+
+/-- Each term of `Etingof.koszulComplex` is a projective object of `ModuleCat SV` — indeed a free
+module, by `Etingof.koszulXBasis`. -/
+instance koszulComplex_projective_X (i : ℕ) : Projective ((koszulComplex b).X i) :=
+  haveI := koszulX_free_of_basis b i
+  inferInstanceAs
+    (Projective (ModuleCat.of (SymmetricAlgebra k V) (koszulX k V i)))
+
+/-- **The augmentation as a chain map** `C_• ⟶ k[0]`, where `k` carries the trivial `SV`-action.
+This is the `π` datum of the Koszul resolution; it is a chain map precisely because
+`ε ∘ d₀ = 0` (`Etingof.koszulAug_comp_koszulD`). -/
+noncomputable def koszulPi :
+    koszulComplex b ⟶
+      (ChainComplex.single₀ (ModuleCat.{max u v} (SymmetricAlgebra k V))).obj
+        (ModuleCat.of _ (KoszulAugModule k V)) :=
+  (ChainComplex.toSingle₀Equiv (koszulComplex b)
+      (ModuleCat.of (SymmetricAlgebra k V) (KoszulAugModule k V))).symm
+    ⟨ModuleCat.ofHom (koszulAug k V), by
+      rw [koszulComplex_d b 0]
+      ext x
+      exact LinearMap.congr_fun (koszulAug_comp_koszulD b) x⟩
+
+omit [LinearOrder κ] in
+@[simp]
+theorem koszulPi_f_zero :
+    (koszulPi b).f 0 = ModuleCat.ofHom (koszulAug k V) :=
+  ChainComplex.toSingle₀Equiv_symm_apply_f_zero _ _
+
+/-- **The Koszul complex is exact in every positive degree.** This is
+`Etingof.koszulD_range_eq_ker` transported into `HomologicalComplex.ExactAt`. -/
+theorem koszulComplex_exactAt_succ (i : ℕ) : (koszulComplex b).ExactAt (i + 1) := by
+  rw [HomologicalComplex.exactAt_iff' _ (i + 2) (i + 1) i (by simp) (by simp),
+    ShortComplex.moduleCat_exact_iff]
+  have hf : ((koszulComplex b).sc' (i + 2) (i + 1) i).f
+      = ModuleCat.ofHom (koszulD b (i + 1)) := koszulComplex_d b (i + 1)
+  have hg : ((koszulComplex b).sc' (i + 2) (i + 1) i).g
+      = ModuleCat.ofHom (koszulD b i) := koszulComplex_d b i
+  intro x hx
+  rw [hg] at hx
+  refine ⟨koszulH b (i + 1) x, ?_⟩
+  rw [hf]
+  change koszulD b i x = 0 at hx
+  change koszulD b (i + 1) (koszulH b (i + 1) x) = x
+  have h := koszulD_koszulH_add_koszulH_koszulD b i x
+  rwa [hx, map_zero, add_zero] at h
+
+/-- The augmented degree-zero short complex `C₁ → C₀ → k` is exact: this is
+`Etingof.koszulD_zero_range_eq_ker_koszulAug` in `ShortComplex` form. -/
+theorem koszulAug_shortComplex_exact :
+    (ShortComplex.moduleCatMk (koszulD b 0) (koszulAug k V)
+      (koszulAug_comp_koszulD b)).Exact := by
+  rw [ShortComplex.moduleCat_exact_iff]
+  intro x hx
+  refine ⟨koszulH b 0 x, ?_⟩
+  change koszulAug k V x = 0 at hx
+  change koszulD b 0 (koszulH b 0 x) = x
+  have h := koszulD_koszulH_add_eta_aug b x
+  rwa [hx, map_zero, add_zero] at h
+
+/-- **The augmentation is a quasi-isomorphism.** In positive degrees both complexes are exact
+(`Etingof.koszulComplex_exactAt_succ` for the source, and `k[0]` trivially); in degree zero the
+augmentation presents `k` as the cokernel of `d₀`, being surjective
+(`Etingof.koszulAug_surjective`) with kernel exactly the boundaries
+(`Etingof.koszulD_zero_range_eq_ker_koszulAug`). -/
+theorem koszulPi_quasiIso : QuasiIso (koszulPi b) := by
+  rw [quasiIso_iff]
+  rintro (_ | i)
+  · have hepi : Epi (ShortComplex.moduleCatMk (koszulD b 0) (koszulAug k V)
+        (koszulAug_comp_koszulD b)).g := by
+      rw [show (ShortComplex.moduleCatMk (koszulD b 0) (koszulAug k V)
+        (koszulAug_comp_koszulD b)).g = ModuleCat.ofHom (koszulAug k V) from rfl,
+        ModuleCat.epi_iff_surjective]
+      exact koszulAug_surjective
+    rw [ChainComplex.quasiIsoAt₀_iff, ShortComplex.quasiIso_iff_of_zeros']
+    · refine (ShortComplex.exact_and_epi_g_iff_of_iso
+        (ShortComplex.isoMk (Iso.refl _) (Iso.refl _) (Iso.refl _) ?_ ?_)).2
+        ⟨koszulAug_shortComplex_exact b, hepi⟩
+      · simp only [Iso.refl_hom, Category.id_comp, Category.comp_id]
+      · simp only [Iso.refl_hom, Category.id_comp, Category.comp_id]
+    all_goals rfl
+  · rw [quasiIsoAt_iff_exactAt' _ _ (ChainComplex.exactAt_succ_single_obj _ _)]
+    exact koszulComplex_exactAt_succ b i
+
+/-- **The Koszul resolution** of Problem 8.2.10(i): `C_• = SV ⊗ ⋀^• V` is a free — in particular
+projective — resolution of `k` as an `SV`-module, `k` carrying the trivial action of `V`.
+
+The three ingredients are `Etingof.koszulComplex` (the complex, with `d ∘ d = 0`), freeness of
+the terms via the base-changed basis `Etingof.koszulXBasis`, and the augmentation
+`Etingof.koszulPi`, a quasi-isomorphism because the augmented complex admits the `k`-linear
+contracting homotopy `Etingof.koszulH`. -/
+noncomputable def koszulResolution :
+    ProjectiveResolution
+      (ModuleCat.of (SymmetricAlgebra k V) (KoszulAugModule k V)) where
+  complex := koszulComplex b
+  π := koszulPi b
+  projective i := koszulComplex_projective_X b i
+  quasiIso := koszulPi_quasiIso b
+
+@[simp]
+theorem koszulResolution_complex : (koszulResolution b).complex = koszulComplex b := rfl
+
+@[simp]
+theorem koszulResolution_π : (koszulResolution b).π = koszulPi b := rfl
+
+/-- Every term of the Koszul resolution is a *free* `SV`-module, not merely projective — the
+parenthetical "(in fact, free)" of Problem 8.2.10(i). -/
+theorem koszulResolution_free (i : ℕ) :
+    Module.Free (SymmetricAlgebra k V) ((koszulResolution b).complex.X i) :=
+  koszulX_free_of_basis b i
+
+end Resolution
+
+end Etingof

--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_10.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_10.lean
@@ -2,6 +2,7 @@ import EtingofRepresentationTheory.Chapter8.KoszulContraction
 import EtingofRepresentationTheory.Chapter8.KoszulDifferential
 import EtingofRepresentationTheory.Chapter8.KoszulAugmentation
 import EtingofRepresentationTheory.Chapter8.KoszulBasis
+import EtingofRepresentationTheory.Chapter8.KoszulResolution
 
 /-!
 # Problem 8.2.10: Koszul resolution and the Hilbert syzygies theorem
@@ -101,8 +102,70 @@ The exercise itself is being formalized bottom-up. Landed so far:
   sends it to `(-1)^(pos(a,s)+1) e_(s \ {a})` for `a ∈ s`. The augmentation is
   `Etingof.koszulAug_koszulKBasis`: `ε (x^α ⊗ 1) = 1` if `α = 0` and `0` otherwise.
 
-Still to come: exactness of the augmented complex (i), the `SW` resolution (ii), the bimodule
-resolution (iii), Hilbert syzygies (iv), and the `Ext`/`Tor` computation (v). See the child issues
-linked from
+* `Chapter8/KoszulHomotopy.lean` — the `k`-linear contracting homotopy `Etingof.koszulH` of the
+  augmented complex, together with the splitting `Etingof.koszulEta` of the augmentation. On the
+  basis vector `x^α ⊗ e_s` it is `-(x^(α - eₚ) ⊗ e_(insert p s))` when `p = min (supp α)` lies
+  strictly below every element of `s` (the pivot condition `Etingof.IsKoszulPivot`), and `0`
+  otherwise. The two identities it satisfies are
+  `Etingof.koszulD_koszulH_add_koszulH_koszulD` (`d h + h d = id` on `Cᵢ₊₁`) and
+  `Etingof.koszulD_koszulH_add_eta_aug` (`d h + η ε = id` on `C₀`). No `SV`-linear homotopy can
+  exist — the complex resolves `k` and is not `SV`-split — and the construction is
+  characteristic-free, unlike the Euler-operator homotopy `dκ + κd = (p + q) • id`.
+
+* `Chapter8/KoszulResolution.lean` — **part (i), complete**. The homotopy gives exactness, since
+  exactness is a statement about the underlying additive groups: a cycle `x` satisfies
+  `x = d (h x) + h (d x) = d (h x)`, so `Etingof.koszulD_range_eq_ker` (`range dᵢ₊₁ = ker dᵢ`) and
+  `Etingof.koszulD_zero_range_eq_ker_koszulAug` (`range d₀ = ker ε`), the two ranges and kernels
+  being honest `SV`-submodules because `d` and `ε` are `SV`-linear. Packaged categorically, the
+  augmentation `Etingof.koszulPi : C_• ⟶ k[0]` is a quasi-isomorphism
+  (`Etingof.koszulPi_quasiIso`), giving `Etingof.koszulResolution` — see `Etingof.Problem_8_2_10_i`
+  below.
+
+Still to come: the `SW` resolution (ii), the bimodule resolution (iii), Hilbert syzygies (iv), and
+the `Ext`/`Tor` computation (v). See the child issues linked from
 <https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/issues/5723>.
 -/
+
+universe u v w
+
+namespace Etingof
+
+/-- **Problem 8.2.10(i).** For a vector space `V` with a finite basis `b` over a commutative ring
+`k`, the Koszul complex `Cᵢ = SV ⊗ ⋀ⁱ V` with the contraction differential `dᵢ(f)(u) = ιᵤ (f u)` is
+a **free resolution of `k`** as an `SV`-module, `k` carrying the trivial action of `V` — the
+*Koszul resolution*.
+
+This is `Etingof.koszulResolution`. The three components of the assertion are recorded separately
+below: the underlying complex is the Koszul complex itself (`Etingof.Problem_8_2_10_i_complex`),
+its terms are free and not merely projective (`Etingof.Problem_8_2_10_i_free`), and the
+augmentation is the counit `ε : SV ⊗ ⋀⁰ V → k` (`Etingof.Problem_8_2_10_i_π`). The book states
+this for a finite dimensional `V` over a field, which is
+`Etingof.koszulResolutionOfFiniteDimensional`. -/
+noncomputable def Problem_8_2_10_i {k : Type u} [CommRing k] {V : Type v} [AddCommGroup V]
+    [Module k V] {κ : Type w} [LinearOrder κ] [Fintype κ] (b : Module.Basis κ k V) :
+    CategoryTheory.ProjectiveResolution
+      (ModuleCat.of (SymmetricAlgebra k V) (KoszulAugModule k V)) :=
+  koszulResolution b
+
+section
+
+variable {k : Type u} [CommRing k] {V : Type v} [AddCommGroup V] [Module k V]
+variable {κ : Type w} [LinearOrder κ] [Fintype κ] (b : Module.Basis κ k V)
+
+/-- The resolving complex of Problem 8.2.10(i) is the Koszul complex `Cᵢ = SV ⊗ ⋀ⁱ V` of the
+problem statement, not some abstract resolution produced by `EnoughProjectives`. -/
+theorem Problem_8_2_10_i_complex : (Problem_8_2_10_i b).complex = koszulComplex b := rfl
+
+/-- The resolution of Problem 8.2.10(i) is by **free** `SV`-modules — the parenthetical
+"(in fact, free)" of the problem statement. -/
+theorem Problem_8_2_10_i_free (i : ℕ) :
+    Module.Free (SymmetricAlgebra k V) ((Problem_8_2_10_i b).complex.X i) :=
+  koszulResolution_free b i
+
+/-- The map resolving `k` is the augmentation `ε : C₀ = SV ⊗ ⋀⁰ V → k`, the counit of `SV`. -/
+theorem Problem_8_2_10_i_π : (Problem_8_2_10_i b).π.f 0 = ModuleCat.ofHom (koszulAug k V) :=
+  koszulPi_f_zero b
+
+end
+
+end Etingof

--- a/progress/2026-07-26T18-04-04Z_562af196.md
+++ b/progress/2026-07-26T18-04-04Z_562af196.md
@@ -1,0 +1,97 @@
+# 2026-07-26T18:04:04Z — worker session `562af196` (`/work`, feature)
+
+Issue #7912: *feat(Ch8 #7882): exactness of the augmented Koszul complex and the free-resolution
+endpoint*. Child of #7882 (Problem 8.2.10(i)), itself a child of #5723.
+
+## Accomplished
+
+All three deliverables of #7912 landed, no `sorry` and no `native_decide`.
+
+**New file `EtingofRepresentationTheory/Chapter8/KoszulResolution.lean`** (216 lines).
+
+1. *Exactness as `SV`-submodule identities.*
+   * `Etingof.koszulD_range_eq_ker b i : range (koszulD b (i+1)) = ker (koszulD b i)`
+   * `Etingof.koszulD_zero_range_eq_ker_koszulAug b : range (koszulD b 0) = ker (koszulAug k V)`
+
+   `⊆` is `koszulD_comp_koszulD` / `koszulAug_comp_koszulD`; `⊇` uses the #7911 homotopy —
+   a cycle `x` satisfies `x = d (h x) + h (d x) = d (h x)`. The homotopy `koszulH` is only
+   `k`-linear, which is harmless: both sides of each equation are `SV`-submodules because `d`
+   and `ε` are `SV`-linear, and only the *witness* comes from a `k`-linear map.
+
+2. *The categorical endpoint.*
+   * `Etingof.koszulPi b : koszulComplex b ⟶ (ChainComplex.single₀ _).obj (ModuleCat.of SV (KoszulAugModule k V))`
+     — the augmentation as a chain map, via `ChainComplex.toSingle₀Equiv`.
+   * `Etingof.koszulComplex_exactAt_succ`, `Etingof.koszulAug_shortComplex_exact` — the same
+     exactness in `HomologicalComplex.ExactAt` / `ShortComplex.Exact` form.
+   * `Etingof.koszulPi_quasiIso` — `koszulPi` is a quasi-isomorphism.
+   * **`Etingof.koszulResolution b : CategoryTheory.ProjectiveResolution (ModuleCat.of SV (KoszulAugModule k V))`**
+     — the requested name.
+   * `Etingof.koszulResolution_free` — every term is *free*, not merely projective (the
+     "(in fact, free)" of the problem statement), via the base-changed `koszulXBasis`.
+   * `Etingof.koszulResolutionOfFiniteDimensional k V` — the same under the book's own hypothesis,
+     `V` finite dimensional over a field, using `Module.finBasis k V`.
+
+3. *Statement recorded* in `Chapter8/Problem8_2_10.lean`: `Etingof.Problem_8_2_10_i`, plus the
+   three components that make it non-vacuous — `Problem_8_2_10_i_complex` (the resolving complex
+   really is `koszulComplex b`, not an abstract `EnoughProjectives` resolution),
+   `Problem_8_2_10_i_free`, and `Problem_8_2_10_i_π` (the resolving map really is the augmentation
+   `ε`). The file's "State of the source-level formalization" section, which listed exactness as
+   still to come, now records `KoszulHomotopy.lean` and `KoszulResolution.lean` and lists only
+   (ii)–(v) as outstanding.
+
+`EtingofRepresentationTheory/Chapter8.lean` imports the new file.
+
+## Decisions / patterns
+
+* `Chapter8/BarResolution.lean` was the template. It faces exactly the same situation — a
+  `k`-linear contracting homotopy of an `A`-linear complex — and its
+  `barComplex_exactAt_succ` / `barπChainMap_quasiIso` / `barResolution` trio transfers almost
+  verbatim. Anyone doing this again for parts (ii)/(iii) should start from `KoszulResolution.lean`
+  or `BarResolution.lean` rather than from Mathlib.
+* Precise imports rather than `import Mathlib`: `Mathlib.Algebra.Homology.ShortComplex.ModuleCat`
+  (for `ShortComplex.moduleCatMk` / `moduleCat_exact_iff`),
+  `Mathlib.Algebra.Category.ModuleCat.Abelian` (for the `HasHomology` instances),
+  `Mathlib.Algebra.Category.ModuleCat.Projective`,
+  `Mathlib.CategoryTheory.Abelian.Projective.Resolution`.
+* The project builds warning-free, and the `unusedDecidableInType` / `unusedSectionVars` /
+  `unusedFintypeInType` linters are live. `[DecidableEq κ]` is *not* needed in this file's section
+  variables (the statements mention only `koszulD`/`koszulAug`/`koszulComplex`); `omit` clauses
+  handle the two decls that also do not need `[Fintype κ]` or `[LinearOrder κ]`.
+* `koszulComplex_projective_X` is a `theorem`, not an `instance`: it takes the basis `b`
+  explicitly, so typeclass inference could never fire it.
+
+## Verification
+
+* `lake build` green across the project (9343 targets), zero errors, zero new warnings.
+* `#print axioms` on `koszulResolution`, `koszulD_range_eq_ker`,
+  `koszulD_zero_range_eq_ker_koszulAug`, `koszulComplex_exactAt_succ`, `koszulPi_quasiIso`,
+  `koszulResolution_free`, `koszulResolutionOfFiniteDimensional`, `Problem_8_2_10_i` and its three
+  components: all `[propext, Classical.choice, Quot.sound]`. No `sorryAx`.
+
+## Current frontier
+
+Problem 8.2.10(i) is complete. Parts (ii)–(v) remain.
+
+## Overall project progress
+
+Chapter 8, Problem 8.2.10: part (i) done end to end
+(`KoszulContraction` → `KoszulDifferential` → `KoszulAugmentation` → `KoszulBasis` →
+`KoszulHomotopy` → `KoszulResolution`).
+
+## Next step
+
+#7912 was the blocker on three issues, which `coordination check-blocked` should now release:
+
+* #7883 — the free `SV`-resolution of `SW` for `V = U ⊕ W` (Problem 8.2.10(ii))
+* #7884 — the Koszul bimodule resolution of `SV` over `SV ⊗ SV` (Problem 8.2.10(iii))
+* #7886 — `Ext^i_{SV}(k,k) ≅ ⋀ⁱ V*` and `Tor_i^{SV}(k,k) ≅ ⋀ⁱ V` (Problem 8.2.10(v))
+
+\#7886 is the most direct follow-on: `Etingof.koszulResolution` is exactly the input to
+`ProjectiveResolution.isoExt` / `isoLeftDerivedObj`, and the differentials of
+`Hom_{SV}(C_•, k)` and `C_• ⊗_{SV} k` vanish because every term of `koszulD` is multiplied by
+some `ι xₐ`, which the trivial action kills — the same computation as
+`Etingof.koszulAug_comp_koszulD`. #7885 (Hilbert syzygies, (iv)) is blocked on #7884.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -9304,7 +9304,7 @@
     "end_line": 1,
     "status": "partially_formalized",
     "coverage": "covered_partial",
-    "note": "Part (i) is now most of the way in: KoszulContraction/KoszulDifferential build the complex Cᵢ = SV ⊗ ⋀ⁱ V with d ∘ d = 0, KoszulAugmentation adds the augmentation, freeness of the terms and basis-independence of d, KoszulBasis writes d out on the monomial/subset k-basis, and KoszulHomotopy (#7911) constructs the characteristic-free contracting homotopy of the augmented complex with both identities dh + hd = id and dh + ηε = id proved sorry-free. Exactness itself (deducing it from the homotopy) is #7912; the SW and bimodule resolutions, the bounded-resolution result and the Ext/Tor(k,k) computations of parts (ii)-(v) remain unformalized under reopened #5723.",
+    "note": "Part (i) is complete (#7912): KoszulContraction/KoszulDifferential build the complex Cᵢ = SV ⊗ ⋀ⁱ V with d ∘ d = 0, KoszulAugmentation adds the augmentation, freeness of the terms and basis-independence of d, KoszulBasis writes d out on the monomial/subset k-basis, KoszulHomotopy (#7911) constructs the k-linear contracting homotopy, and KoszulResolution turns it into exactness (koszulD_range_eq_ker, koszulD_zero_range_eq_ker_koszulAug) and the packaged CategoryTheory.ProjectiveResolution Etingof.koszulResolution, recorded as Etingof.Problem_8_2_10_i. Parts (ii)-(v) are still open: see issues #7883, #7884, #7885, #7886.",
     "fidelity_issue": 5723,
     "last_updated": "2026-07-26"
   },


### PR DESCRIPTION
Closes #7912

Session: `562af196-94cc-4239-9dac-89eb602b13c4`

a790e29d chore(#7912): make koszulComplex_projective_X a theorem, progress entry, items.json
d5013a14 doc(Ch8 #7912): record Problem 8.2.10(i) and the finite-dimensional Koszul resolution
e9d79070 feat(Ch8 #7912): exactness of the augmented Koszul complex and the Koszul resolution

🤖 Prepared with Claude Code