### PR TITLE
This PR records the replan triage session that disposed of the single `coordination list-replan` candidate, #5145.

#5145 carried the `replan` label from a partial-completion publish. Its two literal deliverables (dimension minimisation and the model-level commutativity criterion) are already on `main` from https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/pull/5194, the genuine-quotient form asked for by the 2026-07-22 reopen is in the open partial PR https://github.com/FormalFrontier/Etingof-RepresentationTheory-draft1/pull/7922, and the residual scope (identifying the Wedderburn matrix sizes with the multiplicities `n_i`) is fully covered by #7921. The issue was therefore closed with forward links rather than re-scoped, and no duplicate issue was created.

No code changes; the progress file is the only addition.

🤖 Prepared with Claude Code

### DIFF
--- a/progress/2026-07-26T18-22-00Z_89971662-replan.md
+++ b/progress/2026-07-26T18-22-00Z_89971662-replan.md
@@ -1,0 +1,54 @@
+## Accomplished
+
+Replan triage session (session `89971662`). `coordination list-replan` reported exactly one
+candidate, which was disposed of:
+
+* **#5145** "Formalize Discussion_after_Definition9.7.1: minimal basic algebra (min dim at
+  n_i=1, B/Rad commutative criterion)" — **partial progress, residual already split out →
+  closed with forward link to #7921**.
+
+  The `replan` label came from a partial-completion publish
+  (`coordination create-pr --partial`) at 18:13 UTC, not from a skip or an unsalvageable
+  close. Verification:
+
+  - Both literal deliverables are on `main` from PR #5194, in
+    `EtingofRepresentationTheory/Chapter9/Discussion_after_Definition9_7_1.lean` — confirmed
+    by grep against `origin/main`: `Etingof.sum_cartan_le_finrank_cartanAlgebra`,
+    `Etingof.finrank_cartanAlgebra_eq_sum_cartan_iff` (equality iff every `n_i = 1`), and
+    `Etingof.semisimpleQuotient_comm_iff`.
+  - The 2026-07-22 reopen asked for the commutativity criterion on the *genuine* quotient
+    `B_𝐧 / Rad(B_𝐧)` rather than the bare product model. That is delivered by the partial PR
+    #7922 (open, MERGEABLE, auto-merge enabled, CI in progress):
+    `Etingof.exists_matrix_structure_mod_radical`,
+    `Etingof.isBasicAlgebra_iff_of_matrixForm`,
+    `Etingof.exists_matrix_structure_cartanAlgebra`.
+  - The one remaining gap — identifying the abstract Wedderburn matrix sizes with the
+    multiplicities `n_i`, so that "commutative iff every `n_i = 1`" is stated in terms of
+    `𝐧` — is already tracked with full deliverables in #7921, created by the worker before
+    releasing the claim. Since #7921 fully covers the residual scope, #5145 was closed rather
+    than re-scoped (no duplicate issue created).
+
+`coordination list-replan` is now empty.
+
+## Current frontier
+
+No replan candidates outstanding. The Chapter 9 §9.7 frontier is #7921 (Wedderburn matrix
+sizes of `B_𝐧` = the multiplicities `n_i`), which needs projective covers and the
+Kronecker-delta Hom property in a general finite abelian category — the project currently has
+those only for module categories (`Chapter9/Theorem9_2_1.lean`,
+`Chapter9/Proposition9_2_3.lean`).
+
+## Overall project progress
+
+Stage 3 formalization. This session made no code changes; it is issue triage only.
+
+## Next step
+
+A worker should claim #7921, likely decomposing it first into (a) projective covers /
+delta-Hom in a finite abelian category and (b) the assembly `d_j = n_j` on top of
+`Etingof.exists_matrix_structure_cartanAlgebra`. Separately, #5147 (Morita classes =
+`{B_𝐧(𝒞)}`, the other open child of #5139) is unblocked.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #--title

Session: `89971662-9db2-4c59-bd43-390800590f0d`

c207524b docs: record replan triage of #5145, closed as partial with residual in #7921

🤖 Prepared with Claude Code