### PR TITLE
meditate: feature workers never read the lean-formalization skill, and re-learn what it already documents

### DIFF
--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -35,8 +35,14 @@ The priority order in the worker skill still applies — check for PR-fix issues
 
 ## Executing Implementation Work
 
-**Before writing any Lean, read the `lean-formalization` skill** — and don't just
-read the top: it is thousands of lines of accumulated traps, so `grep` it for the
+**Before writing any Lean, read `.claude/skills/lean-conventions/SKILL.md` in full.**
+It is deliberately short (~160 lines) and holds the house rules every Lean session
+needs: the build commands, the lint-clean policy and the exact `omit`/`set_option`
+ordering, import practice, and the non-negotiables. Sessions that skip it spend build
+cycles re-deriving the same handful of rules. Read it with `Read`, not the Skill tool.
+
+**Then use the `lean-formalization` skill as a reference** — do not read it top to
+bottom: it is thousands of lines of accumulated traps, so `grep` it for the
 file, chapter item, and Mathlib types you are about to touch (e.g.
 `grep -n 'Problem2_16_3\|LieSubalgebra' .claude/skills/lean-formalization/SKILL.md`).
 Most items already have a section naming the exact instance/tactic trap that will

--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -36,7 +36,7 @@ The priority order in the worker skill still applies — check for PR-fix issues
 ## Executing Implementation Work
 
 **Before writing any Lean, read `.claude/skills/lean-conventions/SKILL.md` in full.**
-It is deliberately short (~160 lines) and holds the house rules every Lean session
+It is deliberately short and holds the house rules every Lean session
 needs: the build commands, the lint-clean policy and the exact `omit`/`set_option`
 ordering, import practice, and the non-negotiables. Sessions that skip it spend build
 cycles re-deriving the same handful of rules. Read it with `Read`, not the Skill tool.

--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -32,6 +32,13 @@ telling you nothing about the file on disk. `Read` the restored paths directly i
 (2026-07-26, #7873: a session hit exactly this, saw "unchanged" after restoring 477 deleted
 lines, and only got the current guidance by falling back to `Read`.)
 
+**When you `Read` a `.claude/` path, make sure it is *your worktree's* copy.** The project
+root is itself a checkout, so `<project-root>/.claude/skills/<skill>/SKILL.md` and
+`<project-root>/worktrees/<id>/.claude/skills/<skill>/SKILL.md` both exist, at different
+revisions, and the shorter path is the one you will type by reflex. Nothing warns you: you
+get a real file with plausible content and line numbers that quietly disagree with your own
+`grep`. Prefer relative paths from the worktree root, or paste the path from `pwd`.
+
 This check lives at the top of the file on purpose. The fuller treatment is in Step 2 under
 "If the branch already exists", but every observed truncation left lines 1-70 intact while
 cutting blocks further down — so an instruction placed there is one a stale session never

--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -323,6 +323,18 @@ Read the specific files mentioned in the plan/issue. Understand the current stat
 of code you'll be modifying. Don't read progress history — the issue body provides
 that context.
 
+**If the issue touches `EtingofRepresentationTheory/`, read
+`.claude/skills/lean-conventions/SKILL.md` in full before your first edit.** It is
+short by design (~160 lines) and carries the rules that otherwise cost a build cycle
+each to rediscover: `lake exe cache get`, `lake build <Module>` rather than `lake env
+lean`, the lint-clean policy, and the one working order for `set_option`/`omit`/
+docstring above a declaration. The large `lean-formalization` skill is the *searchable*
+companion to it — `grep` that one for your chapter item and Mathlib types, never read
+it top to bottom.
+
+Read both with `Read` rather than the Skill tool: the Skill tool caches per session and
+will answer `instructions unchanged` without re-reading the file.
+
 ## Step 4: Verify Assumptions
 
 Check that the plan's assumptions still hold:

--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -325,7 +325,7 @@ that context.
 
 **If the issue touches `EtingofRepresentationTheory/`, read
 `.claude/skills/lean-conventions/SKILL.md` in full before your first edit.** It is
-short by design (~160 lines) and carries the rules that otherwise cost a build cycle
+short by design and carries the rules that otherwise cost a build cycle
 each to rediscover: `lake exe cache get`, `lake build <Module>` rather than `lake env
 lean`, the lint-clean policy, and the one working order for `set_option`/`omit`/
 docstring above a declaration. The large `lean-formalization` skill is the *searchable*

--- a/.claude/skills/lean-conventions/SKILL.md
+++ b/.claude/skills/lean-conventions/SKILL.md
@@ -46,7 +46,7 @@ and a bare `lake build` **silently builds Mathlib and reports success**. If a bu
 "unknown target" or an unexpected job count, run `pwd` first. Read Mathlib sources by
 absolute path from the worktree root instead.
 
-**Use `set -o pipefail` when piping a build through `tee`/`tail`** — otherwise the
+**Use `set -o pipefail` when piping a build through `tee`/`tail`**, otherwise the
 pipeline's exit status is `tee`'s `0` and a real failure reads as success:
 
 ```bash
@@ -98,7 +98,7 @@ against the current toolchain:
   in theorem …`, which is exactly the wrong thing to paste above a documented declaration.
 - **`set_option maxHeartbeats` needs a `--` comment between the `in` and whatever follows**,
   or `linter.style.setOption` asks you to "add a comment explaining the need for modifying
-  the maxHeartbeat limit". **A docstring does not satisfy this** — it must be a `--`
+  the maxHeartbeat limit". **A docstring does not satisfy this**: it must be a `--`
   comment.
 - **`set_option … in` must come *above* `omit … in`, not below it.** With the `omit` on
   top, `linter.style.setOption` loses track of the scope and reports the confusing
@@ -114,7 +114,7 @@ Three follow-on details:
   instance (Lean auto-includes an instance-implicit section variable whenever its type
   mentions an already-used variable, even if the body never touches it), a per-lemma
   `omit [Inst] in` on a *downstream* lemma that calls that def fails with `failed to
-  synthesize instance … Inst` — the def now demands it. Fix by putting a bare `omit
+  synthesize instance … Inst`, because the def now demands it. Fix by putting a bare `omit
   [Inst]` command (no `in`, no docstring) right after the section's `variable` line, so
   nothing in the section captures it.
 - **`set_option … in` does not work before `private`.** Wrap those declarations in a
@@ -138,7 +138,7 @@ Go granular only when there is a specific reason:
 
 **A missing *tactic* import reads as a broken proof, not a missing import.** In a file with
 granular imports, `unknown tactic` is reported at a misleading line (often the next
-declaration) plus cascading `unsolved goals` on every `have` that used it — which reads as
+declaration) plus cascading `unsolved goals` on every `have` that used it, which reads as
 "my algebra was wrong". `linear_combination` needs `Mathlib.Tactic.LinearCombination`,
 `module` → `Mathlib.Tactic.Module`, `noncomm_ring` → `Mathlib.Tactic.NoncommRing`, `group`
 → `Mathlib.Tactic.Group`.

--- a/.claude/skills/lean-conventions/SKILL.md
+++ b/.claude/skills/lean-conventions/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: lean-conventions
+description: Read before writing or editing any .lean file in this repository. The build commands, linter/`omit` placement rules, and import conventions that every Lean session needs. Use when starting a feature issue that touches EtingofRepresentationTheory/.
+allowed-tools: Read, Edit, Write, Bash, Glob, Grep
+---
+
+# Lean Conventions for This Repository
+
+The house rules every Lean session needs, in the order you will hit them. Read this
+in full before your first edit; it is short by design.
+
+This is **not** the reference. `lean-formalization/SKILL.md` is a ~7900-line searchable
+catalogue of specific mathematical traps (tensor products, `ModuleCat`, quiver
+representations, Specht modules, …). Do not read it front to back. `grep` it for the
+Mathlib name, error message, or chapter you are stuck on:
+
+```bash
+grep -n 'TensorProduct.liftAddHom' .claude/skills/lean-formalization/SKILL.md | cut -c1-200
+```
+
+Its lines are very long, so pipe through `cut` and read the hits with `awk`/`Read` at
+a narrow offset rather than reading whole sections.
+
+## Build and typecheck
+
+Before the first build of any session:
+
+```bash
+lake exe cache get
+```
+
+Skipping it triggers a full Mathlib rebuild (1800+ jobs).
+
+**Typecheck with `lake build EtingofRepresentationTheory.<Module>`, not `lake env lean
+<file>`.** `lake env lean` ignores the lakefile's `[leanOptions]`, in particular
+`maxSynthPendingDepth = 3` (the Lean default is 2). Deep instance chains in this project
+throw *spurious* `synthInstanceFailed` errors under `lake env lean` that do not occur
+under `lake build`. If a file fails `lake env lean` with instance-synthesis errors,
+re-check with `lake build` before debugging: files already on `main` fail `lake env lean`
+too.
+
+**Never `cd` into `.lake/packages/mathlib`** (or any subdirectory). The shell's working
+directory persists across calls, and that directory is itself a lake project: once you are
+inside it, `lake build EtingofRepresentationTheory.<Module>` fails with "unknown target",
+and a bare `lake build` **silently builds Mathlib and reports success**. If a build reports
+"unknown target" or an unexpected job count, run `pwd` first. Read Mathlib sources by
+absolute path from the worktree root instead.
+
+**Use `set -o pipefail` when piping a build through `tee`/`tail`** — otherwise the
+pipeline's exit status is `tee`'s `0` and a real failure reads as success:
+
+```bash
+set -o pipefail
+lake build EtingofRepresentationTheory.Chapter5.Foo 2>&1 | tee /tmp/build-Foo.log | tail -30
+```
+
+## The build stays lint-clean
+
+`lakefile.toml` sets `weak.linter.mathlibStandardSet = true`. These warnings do **not**
+fail CI (CI runs plain `lake build`, which exits 0 on warnings), but the project keeps the
+build clean, and a PR that adds warnings will be asked to remove them.
+
+The linters you will actually trip:
+
+| Linter | Fires when |
+|---|---|
+| `unusedSectionVars` | a `variable` block instance/hypothesis is not used by the declaration |
+| `unusedDecidableInType` | a `[DecidableEq _]` section variable is unused |
+| `unusedFintypeInType` | a `[Fintype _]` section variable is used only to *form* the type, not in the proof |
+| `linter.style.show` | `show` is used to change the goal to a defeq form (use `change` instead) |
+| `linter.style.setOption` | a `set_option maxHeartbeats … in` has no explanatory comment, or sits below an `omit … in` (see below) |
+
+A statement-only theorem trips these easily: what counts is whether the declaration's
+**type** mentions the variable, not whether the file needs it elsewhere.
+
+### `omit` and `set_option` placement (the single most repeated slip)
+
+There is exactly one order that is both a parse success and lint-clean. Everything above
+the declaration goes in this sequence:
+
+```lean
+set_option maxHeartbeats 400000 in
+-- Why the raised budget is needed.
+omit [FiniteDimensional ℂ V] in
+/-- Doc comment. -/
+@[simp]
+theorem foo : … := …
+```
+
+`set_option … in`, then its explanatory comment, then `omit … in`, then the docstring,
+then attributes, then the declaration. Three separate rules force this, each verified
+against the current toolchain:
+
+- **`omit`/`set_option` must precede the docstring.** Putting either between the
+  docstring and the declaration is a parse error, `unexpected token 'omit'; expected
+  'lemma'` (likewise `unexpected token 'set_option'`), reported at a column that points
+  nowhere useful. Note the `unusedSectionVars` linter's own suggested fix is `omit [Inst]
+  in theorem …`, which is exactly the wrong thing to paste above a documented declaration.
+- **`set_option maxHeartbeats` needs a `--` comment between the `in` and whatever follows**,
+  or `linter.style.setOption` asks you to "add a comment explaining the need for modifying
+  the maxHeartbeat limit". **A docstring does not satisfy this** — it must be a `--`
+  comment.
+- **`set_option … in` must come *above* `omit … in`, not below it.** With the `omit` on
+  top, `linter.style.setOption` loses track of the scope and reports the confusing
+  "Unscoped option maxHeartbeats is not allowed" even though you did write `in`. Reversing
+  the two lines silences it.
+
+Three follow-on details:
+
+- **The linter reports unused instances one at a time.** After omitting the flagged ones
+  it may flag a further instance (e.g. `Module.Finite` once `Fintype`/`DecidableEq` are
+  omitted). Expect to extend the `omit` list across a build cycle or two.
+- **Section-wide vs per-lemma.** If an earlier `def` in the section *captured* the
+  instance (Lean auto-includes an instance-implicit section variable whenever its type
+  mentions an already-used variable, even if the body never touches it), a per-lemma
+  `omit [Inst] in` on a *downstream* lemma that calls that def fails with `failed to
+  synthesize instance … Inst` — the def now demands it. Fix by putting a bare `omit
+  [Inst]` command (no `in`, no docstring) right after the section's `variable` line, so
+  nothing in the section captures it.
+- **`set_option … in` does not work before `private`.** Wrap those declarations in a
+  `section` with a bare `set_option linter.unusedFintypeInType false` instead.
+
+## Imports
+
+**`import Mathlib` is fine, and is the normal choice for a new file** (336 of the 765
+files in `EtingofRepresentationTheory/` use it). Do not spend a build cycle hand-narrowing
+imports for a file that has no reason to be narrow.
+
+Go granular only when there is a specific reason:
+
+- **Import-cycle work**, where a file must avoid a named transitive edge. Verify with a
+  real transitive trace, never a direct-import grep (see the "import-cleanliness" section
+  of the reference).
+- **A `Finsupp`-based algebra.** Under `import Mathlib` the pointwise `Finsupp.instMul`
+  becomes a valid `Mul` and can outrank an intended convolution/concatenation
+  multiplication. The defence is to declare such a carrier as a semireducible `def`, never
+  an `abbrev`; a `def` blocks the pointwise instance regardless of imports.
+
+**A missing *tactic* import reads as a broken proof, not a missing import.** In a file with
+granular imports, `unknown tactic` is reported at a misleading line (often the next
+declaration) plus cascading `unsolved goals` on every `have` that used it — which reads as
+"my algebra was wrong". `linear_combination` needs `Mathlib.Tactic.LinearCombination`,
+`module` → `Mathlib.Tactic.Module`, `noncomm_ring` → `Mathlib.Tactic.NoncommRing`, `group`
+→ `Mathlib.Tactic.Group`.
+
+**`Basis` lives in the `Module` namespace** in this Mathlib version: the type is
+`Module.Basis ι R M`, and explicit references need the prefix (`Module.Basis.ext`,
+`Module.finBasis`). Dot notation on a basis term (`b.repr`, `b.constr`) resolves fine
+unprefixed.
+
+## Non-negotiables
+
+- **Never `sorry` the body of a `def`, `noncomputable def`, `instance`, or `abbrev`.** A
+  sorry'd definition means the object does not exist and every theorem about it is
+  vacuous. Proof obligations *inside* a definition (`where` clauses) may be sorried.
+- **`native_decide` is forbidden.** CI fails fast on it before the build, and the guard
+  also rejects `set_option linter.style.nativeDecide false`. A finite check too slow for
+  honest `decide` is a signal to find a real proof, not a bigger hammer.
+- **Never use `True` as a placeholder** for a proposition you have not worked out. Sorry
+  the real statement instead.
+
+## Writing style
+
+Comments and docstrings read as mathematics, never as a record of the formalization.
+
+- **No war stories.** No PR/issue numbers, no `relocated`, `is now in`, `## Status`,
+  `sorry-free`, `route B`. That history belongs in git and GitHub.
+- **Banned words** (standing bans, all technical writing): `bridge`, `gate`, `smoke`, and
+  em-dashes. Also avoid the AI register: `genuine`, `crux`, `payoff`, `seam`, `glue`,
+  `assembly` (for a proof), `would-be`, `routes through`, `feeding`.
+
+`EtingofRepresentationTheory/Chapter6/Problem6_1_5_OrbitInjective.lean` is written to this
+standard; use it for calibration.

--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -1419,20 +1419,10 @@ Greek *lowercase* (`σ`, `τ`, `π`) work fine as identifiers, but the capitals 
 
 ### `omit [inst] in` goes *before* the docstring, not between it and the declaration
 
-The `unusedSectionVars` linter's suggested fix is `omit [IsAlgClosed k] in theorem …`, which is
-easy to paste directly above the `theorem`/`lemma` line — but if the declaration has a `/-- … -/`
-docstring, that puts `omit` *between* the docstring and the declaration and is a parse error:
-`unexpected token 'omit'; expected 'lemma'`, reported at a column that points nowhere useful. The
-`omit … in` must come **before** the docstring:
-
-```lean
-omit [IsAlgClosed k] [CharZero k] in
-/-- Doc comment. -/
-lemma foo : … := …
-```
-
-(Cost one build cycle in #7807; the existing `omit` sites in `Chapter5/Remark5_23_3.lean` show the
-right placement.)
+The full ordering rule for `set_option`/`omit`/docstring/attributes above a declaration,
+and the three linters that police it, live in `.claude/skills/lean-conventions/SKILL.md`
+("`omit` and `set_option` placement"). The existing `omit` sites in
+`Chapter5/Remark5_23_3.lean` show the right placement.
 
 ### `open MvPolynomial` inside `namespace Etingof` opens the wrong namespace
 
@@ -2763,7 +2753,7 @@ noncomputable def pathMap (R …) {a b : Q} (p : Quiver.Path a b) : … :=
 `induction p with | nil | cons …` still works on top of the recursor def (it just uses these simp
 lemmas). Separately: when a lemma over a section with `variable [DecidableEq Q]` does not actually
 use it (the `pathMap_*` lemmas don't), the `unusedDecidableInType` linter warns — prefix the lemma
-with `omit [DecidableEq Q] in` (placed *before* any docstring).
+with `omit [DecidableEq Q] in` (placement rule: `lean-conventions/SKILL.md`).
 
 ### Representation Theory Patterns
 
@@ -2860,11 +2850,9 @@ Mathlib's prebuilt `Module.Dual.instLieRingModule`. Worked example:
   (`MulOpposite`).** Using `ᵒᵖ` for an algebra gives a bare `expected token` parse
   error. Import `Mathlib.Algebra.Module.Opposite` for the notation and `Module Aᵐᵒᵖ`
   prerequisites, and `Mathlib.Algebra.Algebra.Defs` if you reference `Algebra k A`.
-- **`omit [Inst] in` must precede the docstring AND the attributes**, i.e.
-  `omit [Algebra k A] in` / `/-- … -/` / `@[simp]` / `theorem …`, in that order.
-  Placing it after the docstring (or after `@[simp]`) is a parse error. Use it to
-  silence the "automatically included section variable unused" warning for a lemma
-  (e.g. the `rfl` defining-equation lemma) that doesn't touch every section variable.
+- **`omit [Inst] in`** silences the "automatically included section variable unused"
+  warning for a lemma (e.g. the `rfl` defining-equation lemma) that doesn't touch
+  every section variable. Placement rule: `lean-conventions/SKILL.md`.
 
 #### Adjunction / universal-property examples — Mathlib usually has both directions (#5644, Example7.6.3)
 
@@ -3389,7 +3377,7 @@ Before submitting a PR for a formalized item:
    - **400000–800000**: Acceptable for trace/character computations over finite groups. Add a comment explaining why.
    - **800000–1600000**: Borderline. Acceptable only for GL₂(𝔽_q) trace computations or similar unavoidable large finite sums. Must have a comment. Consider whether `simp` can be replaced with targeted `rw` to reduce heartbeats.
    - **> 1600000**: Refactor the proof. Extract helper lemmas, precompute intermediate results, or split the finite check into smaller pieces. **NEVER reach for `native_decide`** — it is FORBIDDEN in this project (an unverified trust hole outside the kernel; see "FORBIDDEN: `native_decide`" below). If a finite check is too slow for honest `decide`, that is a signal to find a real proof, not a bigger hammer.
-   - **Placement:** `set_option ... in` lines must come *before* the `/-- ... -/` docstring (the docstring must sit immediately above `theorem`/`def`). Putting the docstring first gives `unexpected token 'set_option'; expected 'lemma'`. **The same constraint applies to `omit [Inst] in`** (used to silence the `unusedSectionVars` linter when a section instance like `[Fintype ι]`/`[∀ i, Module.Finite ...]` is genuinely unused by a lemma): it must precede the docstring, else `unexpected token 'omit'; expected 'lemma'`. Note the linter reports unused instances *one at a time* — after omitting the flagged ones it may flag a further instance (e.g. `Module.Finite` once `Fintype`/`DecidableEq` are omitted), so expect to extend the `omit` list across a build cycle or two. **Section-wide vs per-lemma:** if an earlier `def` in the section *captured* the instance (Lean auto-includes an instance-implicit section var whenever its type mentions an already-used var, even if the def's body never touches it), then a per-lemma `omit [Inst] in` on a *downstream* lemma that calls that def fails with `failed to synthesize instance … Inst` — the def now demands it. Fix by putting a bare `omit [Inst]` command (no `in`, no docstring) *right after the section's `variable` line, before the defs*, so nothing in the section captures `Inst` in the first place; keep per-lemma `omit … in` only for instances (like `Module.Finite`) that some later lemma genuinely needs but others don't.
+   - **Placement:** `set_option … in` / its explanatory comment / `omit … in` / docstring / attributes / declaration, in that order. The full rule, the parse errors each wrong order gives, the one-at-a-time linter behaviour, and the section-wide bare `omit` for an instance an earlier `def` captured are all in `.claude/skills/lean-conventions/SKILL.md`.
    - **`whnf` timeout despite a high budget** usually means Lean is eagerly reducing through a *non-reducible* coercion (e.g. an `FDRep`/`FGModuleCat` carrier identified with a hom-space, re-typed mid-proof via `let e' := e`). Fix it by paying that coercion *once* in a helper theorem whose output is already stated in the target type, then consume the result opaquely — do not re-coerce inside the heavy proof.
    - **`whnf` timeout through a `Quotient.liftOn'` definition** (e.g. `MulAction.orbitRel.Quotient.orbit`, relevant to the Ch6 orbit-counting chain #4777). Proving a membership like `a ∈ (Quotient.mk'' a).orbit` via `orbitRel.Quotient.mem_orbit.mpr rfl` forces Lean to whnf-unfold the `liftOn'` and blows the heartbeat budget for a one-line goal. Fix: don't lean on defeq — rewrite with the `_mk` simp lemma first (`rw [orbitRel.Quotient.orbit_mk]`, turning the quotient orbit into `MulAction.orbit G a`), then close with the plain-orbit API (`mem_orbit_self`). Also pin the quotient index explicitly (`Set.mem_biUnion (Set.mem_univ (Quotient.mk'' a)) …`) rather than letting unification infer it through the `liftOn'`. With both, the proof drops back under the default 200000 budget.
    - **Pushing an `AlgEquiv`/`RingEquiv` through `Polynomial.eval₂`/`aeval`** (e.g. the scaling-action transcendence argument in `Problem6_1_5_StrictDimBound`, #4828). To rewrite `(e : K ≃ₐ[k] K) (eval₂ f x p)` with `Polynomial.hom_eval₂` (which is stated for a bare `RingHom`), first bridge the coercion: `rw [show (e) (eval₂ f x p) = e.toRingHom (eval₂ f x p) from rfl]`, then `rw [Polynomial.hom_eval₂]`. The `⇑e` vs `⇑e.toRingHom` coercions are defeq, so `show … from rfl` matches — but an ascribed `(rfl : … = …)` does **not** match under `rw` (it fails to find the pattern). Express `aeval` as `eval₂` first via `Polynomial.aeval_def`. CI runs only `lake build` (no separate linter), so the `show`-tactic style warning on the `from rfl` term is harmless.
@@ -5080,7 +5068,7 @@ These naming mismatches have bitten multiple agents across waves 44-47. Check th
 **When unsure about a lemma name:** Use `#check` or `exact?` on a small test goal. Don't guess and iterate — the 30 seconds spent checking saves 10 minutes of mysterious failures.
 
 **A missing *tactic* import reads as a broken proof, not a missing import.** Chapter files import
-selective `Mathlib.*` modules, never `import Mathlib`, so tactics beyond the core set are often
+selective `Mathlib.*` modules rather than bare `import Mathlib`, so tactics beyond the core set are often
 absent. Lean reports this as `unknown tactic` at a **misleading line** (often the next
 declaration, or a `<;>` several lines below the real call) plus cascading `unsolved goals` on
 every `have` that used it — which reads as "my algebra was wrong". Before rewriting the
@@ -6288,14 +6276,10 @@ instance/hypothesis from the `variable` block that a lemma does not use emits
 a stated `(hdeg : …)` emit `Variable name … is not explicitly referenced`).
 These are **warnings only** — plain `lake build` still returns 0, so CI passes —
 but the project keeps lint clean. Silence an unused instance with
-`omit [Inst] in` immediately before the declaration. Gotcha: `omit … in` must go
-**before** the docstring, not between the `/-- … -/` and the `theorem`
-(`omit` after a docstring gives `unexpected token 'omit'; expected 'lemma'`):
-```lean
-omit [FiniteDimensional ℂ V] in
-/-- doc … -/
-theorem foo … := …
-```
+`omit [Inst] in` before the declaration; for the exact ordering against the
+docstring, attributes and any `set_option … in`, see
+`.claude/skills/lean-conventions/SKILL.md`.
+
 Related `mathlibStandardSet` linter: `linter.style.show` flags every `show` used
 to *change* the goal to a defeq form. Use `change` instead of `show` for those
 (reserve `show` for readability of an intermediate state).
@@ -6922,10 +6906,9 @@ full graph rather than waiting on the aggregator locally.
   output, an idempotent in a local ring being `0`/`1` (End ring `1 = 𝟙` via `End.one_def`)
   bridges back to morphism `g = 0 ∨ g = 𝟙 Z` cleanly; wrap this once and consume the morphism-level
   result so callers never touch `End`-vs-`Hom` zero/one mismatches.
-- **`set_option … in` must precede the doc comment, not sit between `/-- … -/` and the theorem**
-  (otherwise: `unexpected token 'set_option'; expected 'lemma'`). To silence
-  `linter.unusedFintypeInType` on a theorem whose `[Fintype κ]` is only used to form `⨁` in the
-  type, put `set_option linter.unusedFintypeInType false in` on the line *above* the docstring.
+- **To silence `linter.unusedFintypeInType`** on a theorem whose `[Fintype κ]` is only used to
+  form `⨁` in the type, use `set_option linter.unusedFintypeInType false in` (placement rule:
+  `.claude/skills/lean-conventions/SKILL.md`).
 - **Round-tripping a functor/decomposition through a *derived* module (e.g. `forwardRep`/
   `vertexSpace` applied to `reverseModule R`) — three frictions that cost many iterations
   (see `Chapter2/Discussion_quiver_rep_bijection.lean`):**

--- a/progress/2026-07-26T18-29-08Z_92cf19a5.md
+++ b/progress/2026-07-26T18-29-08Z_92cf19a5.md
@@ -1,0 +1,74 @@
+## Accomplished
+
+Meditate session on #7924: feature workers never read the `lean-formalization` skill and
+re-derive what it already documents.
+
+Took deliverable 2 (extract a short always-read preamble). Deliverable 1 (point workers at
+the existing "Pre-Flight Checklist", line 1069) was rejected on inspection: that section is a
+"Known Dead-Ends" catalogue plus process advice, and contains none of the three slips the
+issue reports. Pointing workers there would not have prevented any of them.
+
+* New skill `.claude/skills/lean-conventions/SKILL.md` (173 lines), meant to be read in full:
+  build and typecheck commands, the lint-clean policy and the five linters that fire, the
+  `omit`/`set_option` ordering rule, import practice, the non-negotiables (`def` bodies,
+  `native_decide`, `True` placeholders), and the writing-style bans. It opens by saying it is
+  not the reference and showing how to `grep` the large skill instead.
+* Wired it into `agent-worker-flow` Step 3 and `.claude/commands/feature.md`, naming the path
+  explicitly and saying which of the two skills is read in full and which is grepped. Both say
+  to load it with `Read` rather than the Skill tool, which caches.
+* Consolidated the five scattered `omit`/`set_option` placement entries in
+  `lean-formalization/SKILL.md` into pointers to the single statement, keeping the
+  site-specific content (which linter fires where) in place. Net 34 lines removed.
+
+## Verified against the toolchain, not copied
+
+The placement rules were checked with a scratch module rather than transcribed, which
+corrected the guidance in two ways no existing entry covered:
+
+* `set_option maxHeartbeats … in` requires a `--` comment between the `in` and the next line.
+  A docstring does **not** satisfy `linter.style.setOption`.
+* `set_option … in` must sit *above* a chained `omit … in`. With the `omit` on top the linter
+  reports "Unscoped option maxHeartbeats is not allowed" despite the `in` being present.
+
+So the one order that both parses and lints clean is: `set_option … in` / explanatory comment
+/ `omit … in` / docstring / attributes / declaration. Confirmed by a zero-warning build.
+
+Also corrected a factual error in `lean-formalization`: it claimed chapter files use granular
+imports and "never `import Mathlib`". 336 of the 765 files under `EtingofRepresentationTheory/`
+use bare `import Mathlib`, and it is the reasonable default for a new file. A worker who
+believed the absolute would waste a cycle hand-narrowing imports.
+
+## Current frontier
+
+Workflow change only, no Lean content touched. The `lean-conventions` skill is unexercised by
+a real feature session so far; its value shows up the first time a worker reads it instead of
+rediscovering the `omit` rule.
+
+## Overall project progress
+
+Stage 3 formalization ongoing. This session changed no formalization state: sorry count,
+item counts, and `progress/items.json` are untouched.
+
+## Next step
+
+For a feature worker: read `.claude/skills/lean-conventions/SKILL.md` before your first Lean
+edit and report friction. Per `acquiring-skills`, a skill that gets used and corrected beats
+one written once. If something in it is wrong or missing, fix it in the same PR as the
+formalization work rather than filing a follow-up.
+
+The issue's deliverable 3 (a CI check rejecting new warnings in touched files) was explicitly
+out of scope, the issue says to pick one. It remains the durable fix, since it moves the
+feedback from a document to the build. Worth a future meditate issue if the preamble alone
+does not stop the repeats.
+
+## Blockers
+
+None.
+
+## Worktree note
+
+This worktree arrived stale: 567 lines of `.claude/` guidance deleted in the working tree
+relative to `HEAD`, including the `feature.md` section that explains how to detect exactly
+that. Step 0 of `agent-worker-flow` caught it. Restored with `git checkout HEAD -- .claude/`
+after backing up to `/tmp/stale-backup-92cf19a5`, then reloaded the guidance with `Read`.
+This is the recurring problem tracked in #7917 / #7891.


### PR DESCRIPTION
Closes #7924

Session: `92cf19a5-6ab4-4a97-884d-3f6a24ab7663`

0d499b8b docs(progress): 2026-07-26T18-29-08Z meditate session on #7924
323e7d21 docs: drop the line-count figure from the lean-conventions pointers
27513a2a style(lean-conventions): drop em-dashes, which the skill itself bans
cf5e6f12 docs(lean-formalization): consolidate the duplicated omit/set_option placement rule
33082332 docs(worker-flow): point Lean sessions at lean-conventions before their first edit
63d292da feat(skills): add lean-conventions, a short always-read Lean preamble

🤖 Prepared with Claude Code