### PR TITLE
Stage 3.2: Formalize Theorem 5.10.1 statement (Frobenius reciprocity)

### DIFF
--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -101,6 +101,15 @@ notification, or start a *single* foreground `lake build` and let lake's lock qu
 not interleave. When a build fails on a missing olean for an unrelated module, suspect this
 before debugging, and confirm with one clean re-run.
 
+**Read build logs with an anchored `grep -nE '^error:'`, never a bare `grep -i error`.** A
+full-library `lake build` currently emits ~970 `PANIC at Lean.Expr.appFn!/appArg!` lines with
+long C++ backtraces, all from `Chapter4/Example4_9_1.lean:328`. They are pre-existing, the
+build still exits 0, and they are *not* a regression from whatever you just changed — but an
+unanchored grep surfaces the backtrace frames (which contain the substring `mapErrorImp`) and
+reads as if your change broke the world. Confirm by counting `PANIC` in a before-and-after
+log; identical counts mean it is the known noise. Trust the final
+`Build completed successfully` line and the exit code.
+
 **Typecheck with `lake build EtingofRepresentationTheory.<Module>`, NOT `lake env lean
 <file>`.** `lake env lean` does **not** apply the lakefile's `[leanOptions]` — in
 particular `maxSynthPendingDepth = 3` (lakefile.toml; the Lean default is 2). Deep
@@ -2891,6 +2900,41 @@ not by hand-building counits:
   (`Res ⊣ Ind`/`Res ⊣ Coind`, finite index, since `Ind ≅ Coind`). Before treating an
   adjoint-direction discrepancy as a real gap, grep for the other-direction adjunction;
   record both with docstrings explaining the biadjointness rather than "fixing" one.
+- **"The book says *naturally* isomorphic but Lean has only a pointwise `Hom`-equivalence"
+  IS a real gap, and the fix is mechanical.** (#647, Theorem 5.10.1 Frobenius reciprocity,
+  `Chapter5/Theorem5_10_1.lean`.) Build the two `Hom` bifunctors from
+  `CategoryTheory.linearCoyoneda k C : Cᵒᵖ ⥤ C ⥤ ModuleCat k` — the curried `k`-linear Hom
+  bifunctor, which is what `NatIso.ofComponents` wants; there is no `Cᵒᵖ × C ⥤ ModuleCat k`
+  version and you do not need one. `Rep k G` has the required `Linear k` instance. Precompose
+  the *inner* functor with `(Functor.whiskeringLeft _ _ _).obj F` and the *outer* one with
+  `G.op ⋙ …` (note `whiskeringLeft` lives in `CategoryTheory.Functor`, so it is
+  `Functor.whiskeringLeft` under a bare `open CategoryTheory`). Both naturality squares are
+  then one-liners off the adjunction — inner (covariant variable)
+  `adj.homEquiv_naturality_right_symm α g`, outer (contravariant variable)
+  `adj.homEquiv_naturality_left_symm f.unop α`, each after `ext` — so no `simp` ever runs
+  over the nested `NatIso.ofComponents` and the whnf-timeout trap noted above never fires.
+  Finish with a `rfl` lemma identifying the components with the pre-existing pointwise
+  equivalence, and another pinning them to the book's own formula for the map; without that
+  second one you have proved *some* isomorphism natural, not the book's.
+- **Universe trap in that construction: `Rep.resCoindHomEquiv` cannot synthesize its first
+  universe.** Its own Mathlib docstring says so ("even with all inputs explicitly given"):
+  its arguments are `Rep.{max w t}` and only the max ever appears, leaving `t` ambiguous.
+  Symptom is a wall of `Rep.coind.{0,0,0,u_1}` vs `?u.12` mismatches on *every* new
+  declaration at once. Fix: declare a file-level `universe w`, spell every representation
+  `Rep.{w} k G`, and write `Rep.resCoindHomEquiv.{w}` / `Rep.resCoindAdjunction.{w}`
+  (`max w w = w`). Relatedly, state object-level `rfl` lemmas through the *functors*
+  (`(coindFunctor …).obj W`), never through a bare `Rep.coind H.subtype W` — the standalone
+  spelling auto-binds a fresh universe and the `rfl` is then rejected. Do not be reassured
+  by the file's *existing* declarations compiling without annotations; a single unconstrained
+  statement can auto-bind its own universe while a file that ties several declarations
+  together cannot.
+- **Give the item's own name to the strongest statement in the file.** When a fidelity fix
+  adds a stronger form alongside the old one, rename so `Etingof.<ItemID>` resolves to the
+  strong one and the superseded form gets a qualified name (`…_nonempty`, `…_pointwise`).
+  A later audit greps the item name and stops at the first hit; leaving the weak statement
+  there invites a re-reopening of the issue you just closed. Check first that nothing but
+  docstrings references the old name (`grep -rn "Etingof.<ItemID>" --include=*.lean`), and
+  that no script keys on it — as of 2026-07 none do.
 - **A fidelity finding of "the bridge linking the computed shadow to the real
   object is assumed implicitly" — check whether that bridge is already a proved
   Proposition in the project before treating it as a doc-only caveat or a big new

--- a/EtingofRepresentationTheory/Chapter2/Problem2_11_6.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_11_6.lean
@@ -34,15 +34,16 @@ So the role of Problem 2.11.6 in the book is to supply the tensor-hom adjunction
 
 Theorem 5.10.1 itself is formalized directly in `Chapter5/Theorem5_10_1.lean` as
 
-  `Etingof.Theorem5_10_1 (k G : Type) [Field k] [Group G] (H : Subgroup G)`
-  `    (V : Rep k G) (W : Rep k ↥H) :`
-  `    Nonempty ((Rep.ind H.subtype W ⟶ V) ≃ₗ[k]`
-  `      (W ⟶ (Rep.resFunctor H.subtype).obj V))`
+  `Etingof.Theorem5_10_1 (k G : Type) [Field k] [Group G] (H : Subgroup G) :`
+  `    Etingof.homIndBifunctor k G H ≅ Etingof.homResBifunctor k G H`
 
-That proof obtains Frobenius reciprocity from Mathlib's `Rep.indResHomEquiv`, the
-`k`-linear equivalence packaging the `Ind ⊣ Res` adjunction, rather than from the
-`k[G]`-bimodule tensor-hom adjunction of Problem 2.11.6(b). So Theorem 5.10.1 does
-not depend on Problem 2.11.6.
+a natural isomorphism of the `ModuleCat k`-valued `Hom` bifunctors
+`Hom_G(-, Ind_H^G -)` and `Hom_H(Res_H^G -, -)` on `(Rep k G)ᵒᵖ × Rep k H`
+(`Etingof.Theorem5_10_1_nonempty` is the pointwise shadow of it). That proof
+obtains Frobenius reciprocity from Mathlib's `Rep.resCoindHomEquiv` and
+`Rep.resCoindAdjunction`, packaging the `Res ⊣ Coind` adjunction, rather than from
+the `k[G]`-bimodule tensor-hom adjunction of Problem 2.11.6(b). So Theorem 5.10.1
+does not depend on Problem 2.11.6.
 
 The Discussion of Problem 5.10.2 that carries the citation is an alternative,
 module-theoretic re-derivation of the induction/restriction adjunctions. The

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_10_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_10_1.lean
@@ -27,14 +27,15 @@ The word *naturally* in the book's statement is load-bearing, so a pointwise
 `Hom`-space equivalence does not on its own express Theorem 5.10.1. This file
 records the statement at three increasing strengths, all sorry-free:
 
-* `Etingof.Theorem5_10_1_adjunction` — the adjunction `Res_H^G ⊣ Ind_H^G`.
-* `Etingof.Theorem5_10_1_natIso` — the natural isomorphism of `k`-linear `Hom`
+* `Etingof.Theorem5_10_1` — the natural isomorphism of `k`-linear `Hom`
   bifunctors `Hom_G(-, Ind_H^G -) ≅ Hom_H(Res_H^G -, -)` on
   `(Rep k G)ᵒᵖ × Rep k H`, i.e. naturality in `V` *and* in `W`, with the
   isomorphism being one of `k`-modules (the book's "space ... isomorphic").
-* `Etingof.Theorem5_10_1_homEquiv` / `Etingof.Theorem5_10_1` — the underlying
-  pointwise `k`-linear equivalence, recovered as the components of the natural
-  isomorphism (`Theorem5_10_1_natIso_hom_app_app_apply`).
+  This is the book's statement, and carries the item's name for that reason.
+* `Etingof.Theorem5_10_1_adjunction` — the adjunction `Res_H^G ⊣ Ind_H^G`.
+* `Etingof.Theorem5_10_1_homEquiv` / `Etingof.Theorem5_10_1_nonempty` — the
+  underlying pointwise `k`-linear equivalence, recovered as the components of
+  the natural isomorphism (`Theorem5_10_1_hom_app_app_apply`).
 
 `Etingof.Theorem5_10_1_apply` pins the components down to the book's own formula
 `F(α)v = (αv)(e)`, so the natural isomorphism above is the map the book's proof
@@ -151,7 +152,7 @@ naturally isomorphic — natural in the `G`-representation `V` *and* in the
 This is the book's statement verbatim: "the space `Hom_G(V, Ind_H^G W)` is
 naturally isomorphic to `Hom_H(Res_H^G V, W)`". The components are the book's own
 map `F(α)v = (αv)(e)` — see `Theorem5_10_1_apply`. -/
-noncomputable def Theorem5_10_1_natIso :
+noncomputable def Theorem5_10_1 :
     homIndBifunctor.{w} k G H ≅ homResBifunctor.{w} k G H :=
   NatIso.ofComponents (fun V => frobeniusNatIsoApp V.unop)
     (fun {_ _} f => by
@@ -159,17 +160,17 @@ noncomputable def Theorem5_10_1_natIso :
       exact (Rep.resCoindAdjunction.{w} k H.subtype).homEquiv_naturality_left_symm f.unop α)
 
 @[simp]
-lemma Theorem5_10_1_natIso_hom_app (V : Rep.{w} k G) :
-    (Theorem5_10_1_natIso.{w} k G H).hom.app (op V) = (frobeniusNatIsoApp V).hom :=
+lemma Theorem5_10_1_hom_app (V : Rep.{w} k G) :
+    (Theorem5_10_1.{w} k G H).hom.app (op V) = (frobeniusNatIsoApp V).hom :=
   rfl
 
 /-- The components of the natural isomorphism are exactly Mathlib's Frobenius
 reciprocity equivalence `Rep.resCoindHomEquiv`, read in the book's orientation.
 This is what ties the naturality statement above to the pointwise equivalence. -/
 @[simp]
-lemma Theorem5_10_1_natIso_hom_app_app_apply (V : Rep.{w} k G) (W : Rep.{w} k ↥H)
+lemma Theorem5_10_1_hom_app_app_apply (V : Rep.{w} k G) (W : Rep.{w} k ↥H)
     (α : V ⟶ (indSubgroupFunctor.{w} k G H).obj W) :
-    (((Theorem5_10_1_natIso.{w} k G H).hom.app (op V)).app W).hom α =
+    (((Theorem5_10_1.{w} k G H).hom.app (op V)).app W).hom α =
       (Rep.resCoindHomEquiv.{w} H.subtype V W).symm α :=
   rfl
 
@@ -179,7 +180,7 @@ variable {k G H}
 
 /-- Frobenius reciprocity as a `k`-linear equivalence of `Hom` spaces,
 `Hom_G(V, Ind_H^G W) ≃ₗ[k] Hom_H(Res_H^G V, W)`, in the book's orientation.
-It is the component at `(V, W)` of `Theorem5_10_1_natIso`. -/
+It is the component at `(V, W)` of `Theorem5_10_1`. -/
 noncomputable def Theorem5_10_1_homEquiv (V : Rep.{w} k G) (W : Rep.{w} k ↥H) :
     (V ⟶ (indSubgroupFunctor.{w} k G H).obj W) ≃ₗ[k]
       ((resSubgroupFunctor.{w} k G H).obj V ⟶ W) :=
@@ -191,7 +192,7 @@ identity of `G`. -/
 @[simp]
 lemma Theorem5_10_1_apply (V : Rep.{w} k G) (W : Rep.{w} k ↥H)
     (α : V ⟶ (indSubgroupFunctor.{w} k G H).obj W) (v : V.V) :
-    (Theorem5_10_1_homEquiv V W α).hom v = (α.hom v).1 1 :=
+    (Theorem5_10_1_homEquiv V W α).hom v = (α.hom v).1 (1 : G) :=
   rfl
 
 /-- Frobenius reciprocity: there is a k-linear equivalence
@@ -201,9 +202,11 @@ representation, the right adjoint of restriction. The arrows match the book:
 maps `V ⟶ Ind W` of `G`-representations correspond to maps `Res V ⟶ W` of
 `H`-representations. (Etingof Theorem 5.10.1)
 
-This is the pointwise shadow of `Theorem5_10_1_natIso`, which additionally records
-the naturality asserted by the book. -/
-theorem Theorem5_10_1
+This is only the pointwise shadow of the book's statement; `Theorem5_10_1` itself
+is the natural isomorphism, which additionally records the naturality the book
+asserts. Retained under this name because it is the form cited from
+`Chapter2/Problem2_11_6.lean` and `Chapter5/Discussion5_11_examples.lean`. -/
+theorem Theorem5_10_1_nonempty
     (k G : Type) [Field k] [Group G]
     (H : Subgroup G)
     (V : Rep k G) (W : Rep k ↥H) :

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_10_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_10_1.lean
@@ -19,9 +19,26 @@ in the book's direction `Res ⊣ Coind`.
 
 with `V : Rep G`, `W : Rep H`, and `Ind_H^G W` the function-space representation.
 The book's proof constructs `F(α)v = (αv)(e)` for `α : V → Ind W`, i.e. the
-right-adjoint form `Res ⊣ Coind`. Mathlib's `Rep.coind` is precisely this
-function-space (coinduced) representation, and `Rep.resCoindHomEquiv` provides the
-`k`-linear equivalence realising the adjunction.
+right-adjoint form `Res ⊣ Coind`.
+
+## What is formalized here
+
+The word *naturally* in the book's statement is load-bearing, so a pointwise
+`Hom`-space equivalence does not on its own express Theorem 5.10.1. This file
+records the statement at three increasing strengths, all sorry-free:
+
+* `Etingof.Theorem5_10_1_adjunction` — the adjunction `Res_H^G ⊣ Ind_H^G`.
+* `Etingof.Theorem5_10_1_natIso` — the natural isomorphism of `k`-linear `Hom`
+  bifunctors `Hom_G(-, Ind_H^G -) ≅ Hom_H(Res_H^G -, -)` on
+  `(Rep k G)ᵒᵖ × Rep k H`, i.e. naturality in `V` *and* in `W`, with the
+  isomorphism being one of `k`-modules (the book's "space ... isomorphic").
+* `Etingof.Theorem5_10_1_homEquiv` / `Etingof.Theorem5_10_1` — the underlying
+  pointwise `k`-linear equivalence, recovered as the components of the natural
+  isomorphism (`Theorem5_10_1_natIso_hom_app_app_apply`).
+
+`Etingof.Theorem5_10_1_apply` pins the components down to the book's own formula
+`F(α)v = (αv)(e)`, so the natural isomorphism above is the map the book's proof
+constructs and not merely *some* isomorphism.
 
 ## Mathlib correspondence
 
@@ -29,6 +46,8 @@ function-space (coinduced) representation, and `Rep.resCoindHomEquiv` provides t
 - `Rep.resCoindAdjunction`: the categorical adjunction `Res ⊣ Coind`
 - `Rep.coind`: the coinduced (function-space) representation, right adjoint of `res`
 - `Rep.resFunctor` / `Rep.res`: the restriction functor along `φ`
+- `CategoryTheory.linearCoyoneda`: the `ModuleCat k`-valued `Hom` bifunctor of a
+  `k`-linear category, used to state naturality on the nose
 
 Instantiating `φ := H.subtype : ↥H →* G`, `B := V : Rep k G`, `A := W : Rep k ↥H`
 gives `(Res_H^G V ⟶ W) ≃ₗ[k] (V ⟶ Ind_H^G W)`; taking `.symm` states it in the
@@ -44,18 +63,152 @@ Problem 2.11.6. See `Chapter2/Problem2_11_6.lean` for the conclusion that
 Problem 2.11.6 is not load-bearing for any formalized content.
 -/
 
-open CategoryTheory
+open CategoryTheory Opposite
+
+universe w
+
+namespace Etingof
+
+variable (k G : Type) [Field k] [Group G] (H : Subgroup G)
+
+/-! ### The two functors of the adjunction -/
+
+/-- `Res_H^G : Rep k G ⥤ Rep k H`, restriction along the inclusion `H ↪ G`. -/
+abbrev resSubgroupFunctor : Rep.{w} k G ⥤ Rep.{w} k ↥H := Rep.resFunctor H.subtype
+
+/-- `Ind_H^G : Rep k H ⥤ Rep k G`, the book's function-space induction
+`Ind_H^G W = {f : G → W | f (h * x) = h · f x}`. This is Mathlib's coinduction
+functor along `H.subtype`, the right adjoint of restriction. -/
+noncomputable abbrev indSubgroupFunctor : Rep.{w} k ↥H ⥤ Rep.{w} k G :=
+  Rep.coindFunctor k H.subtype
+
+/-- Frobenius reciprocity as an adjunction: `Res_H^G ⊣ Ind_H^G`.
+This is the categorical content of Etingof Theorem 5.10.1. -/
+noncomputable def Theorem5_10_1_adjunction :
+    resSubgroupFunctor.{w} k G H ⊣ indSubgroupFunctor.{w} k G H :=
+  Rep.resCoindAdjunction.{w} k H.subtype
+
+/-! ### The two `Hom` bifunctors, in the book's orientation -/
+
+/-- The bifunctor `(V, W) ↦ Hom_G(V, Ind_H^G W)`, contravariant in `V : Rep k G`
+and covariant in `W : Rep k H`, valued in `k`-modules. This is the left-hand side
+of the book's statement of Theorem 5.10.1. -/
+noncomputable def homIndBifunctor : (Rep.{w} k G)ᵒᵖ ⥤ Rep.{w} k ↥H ⥤ ModuleCat k :=
+  linearCoyoneda k (Rep.{w} k G) ⋙
+    (Functor.whiskeringLeft (Rep.{w} k ↥H) (Rep.{w} k G) (ModuleCat k)).obj
+      (indSubgroupFunctor.{w} k G H)
+
+/-- The bifunctor `(V, W) ↦ Hom_H(Res_H^G V, W)`, contravariant in `V : Rep k G`
+and covariant in `W : Rep k H`, valued in `k`-modules. This is the right-hand side
+of the book's statement of Theorem 5.10.1. -/
+noncomputable def homResBifunctor : (Rep.{w} k G)ᵒᵖ ⥤ Rep.{w} k ↥H ⥤ ModuleCat k :=
+  (resSubgroupFunctor.{w} k G H).op ⋙ linearCoyoneda k (Rep.{w} k ↥H)
+
+@[simp]
+lemma homIndBifunctor_obj_obj (V : Rep.{w} k G) (W : Rep.{w} k ↥H) :
+    ((homIndBifunctor.{w} k G H).obj (op V)).obj W =
+      ModuleCat.of k (V ⟶ (indSubgroupFunctor.{w} k G H).obj W) :=
+  rfl
+
+@[simp]
+lemma homResBifunctor_obj_obj (V : Rep.{w} k G) (W : Rep.{w} k ↥H) :
+    ((homResBifunctor.{w} k G H).obj (op V)).obj W =
+      ModuleCat.of k ((resSubgroupFunctor.{w} k G H).obj V ⟶ W) :=
+  rfl
+
+/-! ### The natural isomorphism -/
+
+variable {k G H}
+
+/-- For a fixed `G`-representation `V`, the `k`-linear isomorphism
+`Hom_G(V, Ind_H^G W) ≅ Hom_H(Res_H^G V, W)` is natural in `W`.
+
+Kept as a separate named definition (rather than inlined into
+`Theorem5_10_1_natIso`) so that the outer naturality proof never has to unfold the
+baked-in proof term of this inner `NatIso`. -/
+noncomputable def frobeniusNatIsoApp (V : Rep.{w} k G) :
+    (homIndBifunctor.{w} k G H).obj (op V) ≅ (homResBifunctor.{w} k G H).obj (op V) :=
+  NatIso.ofComponents
+    (fun W => (Rep.resCoindHomEquiv.{w} H.subtype V W).symm.toModuleIso)
+    (fun {_ _} g => by
+      ext α
+      exact (Rep.resCoindAdjunction.{w} k H.subtype).homEquiv_naturality_right_symm α g)
+
+@[simp]
+lemma frobeniusNatIsoApp_hom_app_apply (V : Rep.{w} k G) (W : Rep.{w} k ↥H)
+    (α : V ⟶ (indSubgroupFunctor.{w} k G H).obj W) :
+    ((frobeniusNatIsoApp V).hom.app W).hom α =
+      (Rep.resCoindHomEquiv.{w} H.subtype V W).symm α :=
+  rfl
+
+variable (k G H)
+
+/-- **Theorem 5.10.1 (Frobenius reciprocity).** The `k`-linear `Hom` bifunctors
+`Hom_G(-, Ind_H^G -)` and `Hom_H(Res_H^G -, -)` on `(Rep k G)ᵒᵖ × Rep k H` are
+naturally isomorphic — natural in the `G`-representation `V` *and* in the
+`H`-representation `W`, and an isomorphism of `k`-modules pointwise.
+
+This is the book's statement verbatim: "the space `Hom_G(V, Ind_H^G W)` is
+naturally isomorphic to `Hom_H(Res_H^G V, W)`". The components are the book's own
+map `F(α)v = (αv)(e)` — see `Theorem5_10_1_apply`. -/
+noncomputable def Theorem5_10_1_natIso :
+    homIndBifunctor.{w} k G H ≅ homResBifunctor.{w} k G H :=
+  NatIso.ofComponents (fun V => frobeniusNatIsoApp V.unop)
+    (fun {_ _} f => by
+      ext W α
+      exact (Rep.resCoindAdjunction.{w} k H.subtype).homEquiv_naturality_left_symm f.unop α)
+
+@[simp]
+lemma Theorem5_10_1_natIso_hom_app (V : Rep.{w} k G) :
+    (Theorem5_10_1_natIso.{w} k G H).hom.app (op V) = (frobeniusNatIsoApp V).hom :=
+  rfl
+
+/-- The components of the natural isomorphism are exactly Mathlib's Frobenius
+reciprocity equivalence `Rep.resCoindHomEquiv`, read in the book's orientation.
+This is what ties the naturality statement above to the pointwise equivalence. -/
+@[simp]
+lemma Theorem5_10_1_natIso_hom_app_app_apply (V : Rep.{w} k G) (W : Rep.{w} k ↥H)
+    (α : V ⟶ (indSubgroupFunctor.{w} k G H).obj W) :
+    (((Theorem5_10_1_natIso.{w} k G H).hom.app (op V)).app W).hom α =
+      (Rep.resCoindHomEquiv.{w} H.subtype V W).symm α :=
+  rfl
+
+/-! ### The pointwise equivalence, and the book's formula for it -/
+
+variable {k G H}
+
+/-- Frobenius reciprocity as a `k`-linear equivalence of `Hom` spaces,
+`Hom_G(V, Ind_H^G W) ≃ₗ[k] Hom_H(Res_H^G V, W)`, in the book's orientation.
+It is the component at `(V, W)` of `Theorem5_10_1_natIso`. -/
+noncomputable def Theorem5_10_1_homEquiv (V : Rep.{w} k G) (W : Rep.{w} k ↥H) :
+    (V ⟶ (indSubgroupFunctor.{w} k G H).obj W) ≃ₗ[k]
+      ((resSubgroupFunctor.{w} k G H).obj V ⟶ W) :=
+  (Rep.resCoindHomEquiv.{w} H.subtype V W).symm
+
+/-- The equivalence of Theorem 5.10.1 is the book's map `F(α)v = (αv)(e)`:
+it sends `α : V ⟶ Ind_H^G W` to the `H`-map evaluating `α v : G → W` at the
+identity of `G`. -/
+@[simp]
+lemma Theorem5_10_1_apply (V : Rep.{w} k G) (W : Rep.{w} k ↥H)
+    (α : V ⟶ (indSubgroupFunctor.{w} k G H).obj W) (v : V.V) :
+    (Theorem5_10_1_homEquiv V W α).hom v = (α.hom v).1 1 :=
+  rfl
 
 /-- Frobenius reciprocity: there is a k-linear equivalence
   Hom_G(V, Ind_H^G W) ≃ₗ[k] Hom_H(Res_H^G V, W),
 where `Ind_H^G W = Rep.coind H.subtype W` is the book's function-space (coinduced)
 representation, the right adjoint of restriction. The arrows match the book:
 maps `V ⟶ Ind W` of `G`-representations correspond to maps `Res V ⟶ W` of
-`H`-representations. (Etingof Theorem 5.10.1) -/
-theorem Etingof.Theorem5_10_1
+`H`-representations. (Etingof Theorem 5.10.1)
+
+This is the pointwise shadow of `Theorem5_10_1_natIso`, which additionally records
+the naturality asserted by the book. -/
+theorem Theorem5_10_1
     (k G : Type) [Field k] [Group G]
     (H : Subgroup G)
     (V : Rep k G) (W : Rep k ↥H) :
     Nonempty ((V ⟶ Rep.coind H.subtype W) ≃ₗ[k]
       ((Rep.resFunctor H.subtype).obj V ⟶ W)) :=
-  ⟨(Rep.resCoindHomEquiv H.subtype V W).symm⟩
+  ⟨Theorem5_10_1_homEquiv V W⟩
+
+end Etingof

--- a/progress/2026-07-26T19-05-27Z_f3b9b92b.md
+++ b/progress/2026-07-26T19-05-27Z_f3b9b92b.md
@@ -1,0 +1,82 @@
+# 2026-07-26T19:05:27Z — feature session (via `/work`), issue #647
+
+## Accomplished
+
+Closed the fidelity gap on `Chapter5/Theorem5.10.1` (Frobenius reciprocity), reopened
+2026-07-22 with the objection that the book says "naturally isomorphic" while the Lean
+file exposed only `Nonempty` of a *pointwise* linear equivalence.
+
+`EtingofRepresentationTheory/Chapter5/Theorem5_10_1.lean` now states the theorem at three
+increasing strengths, all axiom-clean (`propext`, `Classical.choice`, `Quot.sound` only):
+
+- `Etingof.Theorem5_10_1_adjunction : resSubgroupFunctor ⊣ indSubgroupFunctor` — the
+  adjunction `Res_H^G ⊣ Ind_H^G`, from `Rep.resCoindAdjunction`.
+- `Etingof.homIndBifunctor` / `Etingof.homResBifunctor` — the two `ModuleCat k`-valued
+  `Hom` bifunctors on `(Rep k G)ᵒᵖ × Rep k H` in the book's orientation, built from
+  `CategoryTheory.linearCoyoneda` (so the isomorphism is one of `k`-modules, matching the
+  book's "the *space* ... is naturally isomorphic").
+- `Etingof.Theorem5_10_1_natIso : homIndBifunctor ≅ homResBifunctor` — the natural
+  isomorphism, natural in `V` *and* in `W`. This is the deliverable the reopening asked for.
+- `Etingof.Theorem5_10_1_natIso_hom_app_app_apply` — identifies the components with the
+  existing pointwise equivalence `Rep.resCoindHomEquiv.symm`.
+- `Etingof.Theorem5_10_1_apply` — pins the components to the book's own formula
+  `F(α)v = (αv)(e)`, so the natural isomorphism is *the* map the book's proof constructs,
+  not merely some isomorphism.
+
+The pre-existing `Etingof.Theorem5_10_1` statement is **unchanged** (still `Nonempty` of the
+pointwise equivalence, still universe-polymorphic in the carrier) and is now derived from
+`Theorem5_10_1_homEquiv`. All references to it elsewhere in the repo are docstring-only
+(`Chapter2/Problem2_11_6.lean`, `Chapter5/Discussion5_11_examples.lean`), so nothing
+downstream needed touching.
+
+`progress/items.json`: `Chapter5/Theorem5.10.1` `coverage` `covered_partial` → `covered_full`,
+`fidelity_note` rewritten to record what now backs the naturality claim, stale
+`fidelity_issue: 647` dropped.
+
+## Decisions made / patterns discovered
+
+- **Universe pinning is mandatory for `Rep.resCoindHomEquiv`.** Its own Mathlib docstring
+  warns that "even with all inputs explicitly given, the first universe cannot be
+  synthesized" — its arguments are `Rep.{max w t}` where only the max appears, so `t` is
+  ambiguous. Declaring a file-level `universe w`, spelling every representation
+  `Rep.{w} k G`, and writing `Rep.resCoindHomEquiv.{w}` / `Rep.resCoindAdjunction.{w}`
+  resolves it (`max w w = w`). Without this the first build failed with
+  `Rep.coind.{0,0,0,u_1}` vs `?u.12` mismatches on every declaration.
+- **State object-level `rfl` lemmas through the functors, not through `Rep.coind`/`Rep.res`
+  directly.** `((homIndBifunctor …).obj (op V)).obj W = ModuleCat.of k (V ⟶ Rep.coind H.subtype W)`
+  is *not* accepted as `rfl` (the standalone `Rep.coind` auto-binds a fresh universe), while
+  the same statement written with `(indSubgroupFunctor k G H).obj W` is.
+- **Both naturality squares come straight from the adjunction.** Inner (in `W`) is
+  `Adjunction.homEquiv_naturality_right_symm α g`; outer (in `V`) is
+  `homEquiv_naturality_left_symm f.unop α`. `ext α` / `ext W α` then `exact` — no `simp`
+  needed, so the timeout trap the `lean-formalization` skill records for nested
+  `NatIso.ofComponents` never fires. The inner NatIso is still a separate named `def`
+  (`frobeniusNatIsoApp`) per that skill's advice.
+- `whiskeringLeft` now lives in `CategoryTheory.Functor`, so it is `Functor.whiskeringLeft`
+  under a bare `open CategoryTheory`.
+- `CategoryTheory.linearCoyoneda R C : Cᵒᵖ ⥤ C ⥤ ModuleCat R` is the curried `k`-linear Hom
+  bifunctor; Mathlib has no `Cᵒᵖ × C ⥤ ModuleCat R` version, but the curried form is what
+  `NatIso.ofComponents` wants anyway. `Rep k G` has the required `Linear k` instance.
+
+## Overall project progress
+
+Phase 3 formalization. `lake build` green across the whole library (9342 jobs, no errors);
+`scripts/validate_items.py` exits 0. Quality metrics unchanged: no sorries added, no
+definition-level sorries, axioms clean on every new declaration.
+
+## Current frontier
+
+Issue #647 is fully delivered. Nothing left open on Theorem 5.10.1.
+
+## Next step
+
+The true FIFO head of the unclaimed queue is badly starved — `coordination list-unclaimed`
+caps at 20 and shows the *newest* issues, so #765, #770, #1066 and #2489 have sat unclaimed
+since March 2026 and are invisible to it. Use the direct `gh issue list ... | sort_by(.createdAt)`
+query in `agent-worker-flow` Step 1 and take one of those next. Several look like they may
+already be done and merged without a `Closes #N` line, which the Step 4 check would close
+cheaply.
+
+## Blockers
+
+None.

--- a/progress/2026-07-26T19-05-27Z_f3b9b92b.md
+++ b/progress/2026-07-26T19-05-27Z_f3b9b92b.md
@@ -9,25 +9,28 @@ file exposed only `Nonempty` of a *pointwise* linear equivalence.
 `EtingofRepresentationTheory/Chapter5/Theorem5_10_1.lean` now states the theorem at three
 increasing strengths, all axiom-clean (`propext`, `Classical.choice`, `Quot.sound` only):
 
-- `Etingof.Theorem5_10_1_adjunction : resSubgroupFunctor ⊣ indSubgroupFunctor` — the
-  adjunction `Res_H^G ⊣ Ind_H^G`, from `Rep.resCoindAdjunction`.
 - `Etingof.homIndBifunctor` / `Etingof.homResBifunctor` — the two `ModuleCat k`-valued
   `Hom` bifunctors on `(Rep k G)ᵒᵖ × Rep k H` in the book's orientation, built from
   `CategoryTheory.linearCoyoneda` (so the isomorphism is one of `k`-modules, matching the
   book's "the *space* ... is naturally isomorphic").
-- `Etingof.Theorem5_10_1_natIso : homIndBifunctor ≅ homResBifunctor` — the natural
-  isomorphism, natural in `V` *and* in `W`. This is the deliverable the reopening asked for.
-- `Etingof.Theorem5_10_1_natIso_hom_app_app_apply` — identifies the components with the
+- `Etingof.Theorem5_10_1 : homIndBifunctor ≅ homResBifunctor` — the natural isomorphism,
+  natural in `V` *and* in `W`. This is the deliverable the reopening asked for, and it now
+  carries the item's own name (see below).
+- `Etingof.Theorem5_10_1_adjunction : resSubgroupFunctor ⊣ indSubgroupFunctor` — the
+  adjunction `Res_H^G ⊣ Ind_H^G`, from `Rep.resCoindAdjunction`.
+- `Etingof.Theorem5_10_1_hom_app_app_apply` — identifies the components with the
   existing pointwise equivalence `Rep.resCoindHomEquiv.symm`.
 - `Etingof.Theorem5_10_1_apply` — pins the components to the book's own formula
   `F(α)v = (αv)(e)`, so the natural isomorphism is *the* map the book's proof constructs,
   not merely some isomorphism.
+- `Etingof.Theorem5_10_1_nonempty` — the previous statement (`Nonempty` of the pointwise
+  equivalence), unchanged in content and still universe-polymorphic in the carrier, now
+  derived from `Theorem5_10_1_homEquiv`.
 
-The pre-existing `Etingof.Theorem5_10_1` statement is **unchanged** (still `Nonempty` of the
-pointwise equivalence, still universe-polymorphic in the carrier) and is now derived from
-`Theorem5_10_1_homEquiv`. All references to it elsewhere in the repo are docstring-only
-(`Chapter2/Problem2_11_6.lean`, `Chapter5/Discussion5_11_examples.lean`), so nothing
-downstream needed touching.
+All references to `Etingof.Theorem5_10_1` elsewhere in the repo are docstring-only, so
+nothing downstream needed rewiring. One of them (`Chapter2/Problem2_11_6.lean`) was already
+stale before this session — it quoted a superseded `Rep.ind`/`Rep.indResHomEquiv` form of
+the statement — and is corrected here.
 
 `progress/items.json`: `Chapter5/Theorem5.10.1` `coverage` `covered_partial` → `covered_full`,
 `fidelity_note` rewritten to record what now backs the naturality claim, stale
@@ -57,6 +60,17 @@ downstream needed touching.
 - `CategoryTheory.linearCoyoneda R C : Cᵒᵖ ⥤ C ⥤ ModuleCat R` is the curried `k`-linear Hom
   bifunctor; Mathlib has no `Cᵒᵖ × C ⥤ ModuleCat R` version, but the curried form is what
   `NatIso.ofComponents` wants anyway. `Rep k G` has the required `Linear k` instance.
+- **Give the item's own name to the *strongest* statement in the file.** Codex review
+  (`/second-opinion`) accepted the fidelity of the new declarations but flagged that
+  `Etingof.Theorem5_10_1` still resolved to the `Nonempty` form, so a future audit grepping
+  the item name would meet the weakest statement first — exactly the reading that got #647
+  reopened. Renamed accordingly: `Theorem5_10_1` is the natural isomorphism,
+  `Theorem5_10_1_nonempty` is the pointwise shadow. Worth applying generally when a file
+  accumulates several strengths of one item.
+- Pre-existing and unrelated: `lake build` emits 972 `PANIC at Lean.Expr.appFn!/appArg!`
+  lines from `Chapter4/Example4_9_1.lean:328`. Identical count before and after this
+  session's changes, and the build still exits 0, so it is not a regression — but it is
+  noise that makes `grep -i error` on a build log useless.
 
 ## Overall project progress
 

--- a/progress/items.json
+++ b/progress/items.json
@@ -5247,7 +5247,7 @@
     "fidelity": "faithful",
     "needs_statement": false,
     "sorry_free": true,
-    "fidelity_note": "The Hom-space equivalence is in the book's orientation and axiom-clean, resolving #7187. The source's 'naturally isomorphic' is now formalized as such (#647): Theorem5_10_1_adjunction gives Res_H^G ⊣ Ind_H^G, and Theorem5_10_1_natIso is a natural isomorphism of the ModuleCat k-valued Hom bifunctors Hom_G(-, Ind_H^G -) ≅ Hom_H(Res_H^G -, -) on (Rep k G)ᵒᵖ × Rep k H, natural in V and in W. Theorem5_10_1_natIso_hom_app_app_apply identifies its components with the pointwise equivalence Rep.resCoindHomEquiv.symm, and Theorem5_10_1_apply pins them to the book's own formula F(α)v = (αv)(e). All axiom-clean.",
+    "fidelity_note": "The Hom-space equivalence is in the book's orientation and axiom-clean, resolving #7187. The source's 'naturally isomorphic' is now formalized as such (#647): Etingof.Theorem5_10_1 is a natural isomorphism of the ModuleCat k-valued Hom bifunctors Hom_G(-, Ind_H^G -) ≅ Hom_H(Res_H^G -, -) on (Rep k G)ᵒᵖ × Rep k H, natural in V and in W, and Theorem5_10_1_adjunction gives Res_H^G ⊣ Ind_H^G. Theorem5_10_1_hom_app_app_apply identifies its components with the pointwise equivalence Rep.resCoindHomEquiv.symm, and Theorem5_10_1_apply pins them to the book's own formula F(α)v = (αv)(e). The earlier Nonempty-of-a-pointwise-equivalence statement is retained as Theorem5_10_1_nonempty. All axiom-clean.",
     "last_updated": "2026-07-26"
   },
   {

--- a/progress/items.json
+++ b/progress/items.json
@@ -5243,13 +5243,12 @@
     "start_line": 7,
     "end_line": 34,
     "status": "sorry_free",
-    "coverage": "covered_partial",
+    "coverage": "covered_full",
     "fidelity": "faithful",
     "needs_statement": false,
     "sorry_free": true,
-    "fidelity_note": "The Hom-space equivalence is in the book's orientation and axiom-clean, resolving #7187. The source calls it natural, but the public result remains Nonempty of a pointwise linear equivalence rather than an Adjunction or natural Hom-bifunctor isomorphism; reopened #647.",
-    "fidelity_issue": 647,
-    "last_updated": "2026-07-22"
+    "fidelity_note": "The Hom-space equivalence is in the book's orientation and axiom-clean, resolving #7187. The source's 'naturally isomorphic' is now formalized as such (#647): Theorem5_10_1_adjunction gives Res_H^G ⊣ Ind_H^G, and Theorem5_10_1_natIso is a natural isomorphism of the ModuleCat k-valued Hom bifunctors Hom_G(-, Ind_H^G -) ≅ Hom_H(Res_H^G -, -) on (Rep k G)ᵒᵖ × Rep k H, natural in V and in W. Theorem5_10_1_natIso_hom_app_app_apply identifies its components with the pointwise equivalence Rep.resCoindHomEquiv.symm, and Theorem5_10_1_apply pins them to the book's own formula F(α)v = (αv)(e). All axiom-clean.",
+    "last_updated": "2026-07-26"
   },
   {
     "id": "Chapter5/Problem5.10.2",


### PR DESCRIPTION
This PR states Etingof Theorem 5.10.1 (Frobenius reciprocity) with the naturality the book asserts, replacing a public result that exposed only `Nonempty` of a pointwise `k`-linear equivalence. `Etingof.Theorem5_10_1` is now a natural isomorphism of the two `ModuleCat k`-valued `Hom` bifunctors `homIndBifunctor` and `homResBifunctor` on `(Rep k G)ᵒᵖ × Rep k H` — natural in the `G`-representation and in the `H`-representation, and an isomorphism of `k`-modules pointwise. `Theorem5_10_1_adjunction` records the underlying `Res_H^G ⊣ Ind_H^G`, `Theorem5_10_1_hom_app_app_apply` identifies the components with the existing pointwise equivalence `Rep.resCoindHomEquiv.symm`, and `Theorem5_10_1_apply` pins them to the book's own formula `F(α)v = (αv)(e)`, so what is proved natural is the map the book's proof constructs rather than some isomorphism.

The previous statement survives unchanged in content as `Theorem5_10_1_nonempty`. Giving the item's own name to the strongest statement is deliberate: a fidelity audit that greps `Etingof.Theorem5_10_1` should not meet the weakest one first, which is the reading that got #647 reopened. Every reference to the name elsewhere in the repo is docstring-only, so nothing downstream needed rewiring; the one in `Chapter2/Problem2_11_6.lean` was already stale before this change (it quoted a superseded `Rep.ind`/`Rep.indResHomEquiv` form) and is corrected. `progress/items.json` flips `Chapter5/Theorem5.10.1` to `covered_full` with a `fidelity_note` recording what backs the naturality claim.

Both naturality squares come directly from the adjunction (`Adjunction.homEquiv_naturality_right_symm` and `homEquiv_naturality_left_symm`), so no `simp` runs over a nested `NatIso.ofComponents`. Note for future work in this area: `Rep.resCoindHomEquiv` cannot synthesize its first universe (its own Mathlib docstring says so), so the file fixes a `universe w` and spells representations `Rep.{w} k G` throughout; object-level `rfl` lemmas have to be stated through `indSubgroupFunctor`/`resSubgroupFunctor` rather than through a bare `Rep.coind`, which auto-binds a fresh universe and breaks the `rfl`.

`lake build` is green across the library (9342 jobs), `scripts/validate_items.py` exits 0, and `#print axioms` on every new declaration reports only `propext`, `Classical.choice`, `Quot.sound`.

Closes #647

Session: \`f3b9b92b-247d-4d7f-bea7-75d515b05e71\`

🤖 Prepared with Claude Code