### PR TITLE
meditate: review sessions can inherit construction scope from a reopen, but review.md assumes report-only

### DIFF
--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -32,6 +32,38 @@ nothing about what is on disk.
 
 Use `coordination list-unclaimed --label review` to find work for this session type.
 
+## Read the Comments Before Deciding the Deliverable
+
+A review issue's body describes the world as it was when the issue was *filed*. If the
+issue was later closed and reopened, the reopening comment — not the body — defines the
+live scope, and **a `review` issue can carry construction scope**. When it does, the
+deliverable is a PR with real `.lean` work, not a report, and "Completing the Review"
+below does not apply.
+
+Check before you start:
+
+```bash
+gh issue view <N> --json stateReason,comments \
+  --jq '.stateReason, (.comments[] | "--- \(.createdAt) \(.author.login)\n\(.body)")'
+```
+
+`stateReason == "REOPENED"` is the reliable tell. Two softer ones: a linked *merged* PR
+that already performed the audit named in the body, and a body whose factual claims about
+the repo no longer hold. Any of the three means re-derive the scope from the comments.
+
+Do not pattern-match on a `Reopening:` prefix — reopening comments are written in prose.
+#7276 was filed as a report-only Stage 3.7 fidelity audit of `Chapter4/Problem4_12_5.lean`,
+its audit ran and merged as #7300, and it was then reopened with a comment beginning
+"Reopening because the audit treated unformalized existence/model identification as
+sufficient." The new scope was to *construct* the icosahedral vertex/face/edge actions and
+prove transitivity/stabilizer facts — hours of Lean work, still wearing a `review` label,
+with the body still describing the finished report-only audit. A session that read the body
+and skipped the comments would have written a second report on an already-audited file and
+closed the issue, leaving the real gap open.
+
+This is not rare: as of 2026-07-26, 17 open `agent-plan` issues have
+`stateReason == "REOPENED"`, seven of them unclaimed.
+
 ## Review Focus Areas
 
 Each session should pick **one or two** focus areas and go deep, rather than
@@ -116,6 +148,10 @@ not thousands. If it is large, `git checkout progress/items.json` and redo with
 the right format. Prefer editing the single target entry over touching others.
 
 ## Completing the Review
+
+**This section assumes the report-only case.** If the comments re-scoped the issue to
+construction work (see "Read the Comments Before Deciding the Deliverable"), ignore it:
+finish the Lean work and publish with `coordination create-pr <N>` like a feature session.
 
 Post your report as a comment on the review issue. Then close the issue yourself —
 a review's deliverable is the report, not a code change, so there is usually **no PR**

--- a/.claude/skills/agent-worker-flow/SKILL.md
+++ b/.claude/skills/agent-worker-flow/SKILL.md
@@ -210,15 +210,36 @@ filed — the *live* scope is in the reopening comment. Bodies also go stale whe
 later PR lands part of the work:
 
 ```bash
-gh issue view <N> --json comments --jq '.comments[] | "\(.createdAt) \(.body)"'
+gh issue view <N> --json stateReason,comments \
+  --jq '.stateReason, (.comments[] | "--- \(.createdAt) \(.author.login)\n\(.body)")'
 ```
 
-Treat any comment starting "Reopening:" as authoritative over the body, and check the
-body's factual claims about the repo before acting on them. (2026-07-25, #7320: the
-body said an item in `progress/items.json` had no `coverage` field and "was never
-coverage-audited"; it had been audited three days earlier and reopened over a
-*different*, narrower objection recorded only in a comment. A session that trusts the
-body redoes finished work and misses the actual ask.)
+`stateReason == "REOPENED"` is the mechanical tell that the body is stale — ask for it
+explicitly, because nothing in `list-unclaimed` or `orient` surfaces it. As of
+2026-07-26, 17 open `agent-plan` issues are reopened, so this is the common case, not
+an edge case. To see them all at once:
+
+```bash
+gh issue list --state open --label agent-plan --limit 200 \
+  --json number,title,stateReason,labels \
+  --jq 'map(select(.stateReason=="REOPENED")) | .[] | "\(.number) \(.title)"'
+```
+
+**Any comment that reopens or re-scopes the issue is authoritative over the body,
+however it is worded.** Do not look for a literal `Reopening:` prefix — reopening
+comments are written in prose and usually do not have one. #7276's began "Reopening
+because the audit treated unformalized existence/model identification as sufficient.",
+and it silently converted a report-only `review` audit into a multi-hour Lean
+construction task; a session grepping for `Reopening:` would have matched nothing and
+trusted the stale body. Also check the body's factual claims about the repo before
+acting on them. (2026-07-25, #7320: the body said an item in `progress/items.json` had
+no `coverage` field and "was never coverage-audited"; it had been audited three days
+earlier and reopened over a *different*, narrower objection recorded only in a comment.
+A session that trusts the body redoes finished work and misses the actual ask.)
+
+A re-scope can change the *kind* of deliverable, not just its size: a `review` issue
+whose reopening comment asks for constructions is a PR task, not a report task. Let the
+comments, not the label, decide what you hand back.
 
 ## Step 2: Set Up
 

--- a/progress/2026-07-26T19-17-07Z_e74ba0fd.md
+++ b/progress/2026-07-26T19-17-07Z_e74ba0fd.md
@@ -1,0 +1,76 @@
+## Accomplished
+
+Meditate session, issue #7930: review sessions could inherit construction scope from a
+reopen while `review.md` assumed the deliverable was always a report.
+
+**Worktree was stale on arrival.** `git diff HEAD` showed 567 pure-deletion lines across
+five `.claude/commands/*.md` files and `agent-worker-flow/SKILL.md` — the exact regression
+#7930's body describes session `2caa5111` having repaired. The `Skill` tool had already
+loaded the *old* copies, so the workflow I started on was the superseded one. Backed the
+diff up to `/tmp/e74ba0fd-stale-backup/worktree-vs-head.patch`, restored with
+`git checkout HEAD -- <paths>`, and re-read the files from disk rather than re-invoking
+`Skill` (which caches per session and would have answered "unchanged"). The pre-Step-1
+staleness check that both `review.md` and `meditate.md` already carry is doing real work —
+it caught this on the second worktree in a row.
+
+**Deliverable 1 — `.claude/commands/review.md`.** New section "Read the Comments Before
+Deciding the Deliverable", placed between "Claiming Your Issue" and "Review Focus Areas",
+so a top-to-bottom reader meets it before any focus-area or report guidance. It gives the
+`gh issue view <N> --json stateReason,comments` check, names `stateReason == "REOPENED"` as
+the reliable tell plus two softer ones (a linked *merged* PR that already did the audit named
+in the body; body claims that no longer hold), and states that a re-scoped `review` issue's
+deliverable is a PR. "Completing the Review" now opens by scoping itself to the report-only
+case and forwarding the construction case to `coordination create-pr`.
+
+**Deliverable 2 — `agent-worker-flow` Step 1.** Replaced the literal `Treat any comment
+starting "Reopening:"` trigger with "any comment that reopens or re-scopes the issue,
+however it is worded", citing #7276 — whose reopening comment began "Reopening because the
+audit treated..." and so would not have matched the documented prefix. Added the point that
+a re-scope can change the *kind* of deliverable, not just its size, and that the comments
+rather than the label decide what you hand back.
+
+**Deliverable 3 — reported, not implemented.** Posted as a comment on #7930.
+
+## Decisions and findings
+
+- **`stateReason` is the cheap reopen signal.** `gh issue list --json` already accepts
+  `stateReason`, and it reads `"REOPENED"` for a reopened-still-open issue.
+  `_unclaimed_issues()` in `coordination.py` requests `number,title,labels,createdAt` in that
+  same call, so surfacing `[REOPENED]` costs zero extra API round-trips — no timeline/events
+  call (one request per issue) needed. The change is ~2 lines.
+- **But it cannot land from this repo.** `coordination` on PATH is a four-line
+  `exec pod _coordination "$@"` shim into the installed `dev-pod` package
+  (`~/.local/share/uv/tools/dev-pod/.../pod/coordination.py`). Not agent-editable here, and
+  hot-patching a running fleet's harness unasked is not appropriate. Left for the pod owner.
+- **Mitigation without a harness change.** Because the signal is one `--json` field away,
+  both guidance files now query it directly: per-issue in the claim step, plus a fleet-wide
+  sweep in Step 1.
+- **The trap is systemic, not anecdotal.** 17 open `agent-plan` issues currently carry
+  `stateReason == "REOPENED"`; seven were unclaimed at the time of writing (#5377, #5429,
+  #5449, #5639, #5644, #5648, #6298). Any worker claiming one of those from the queue view
+  alone is acting on a body that predates the reopen.
+
+## Current frontier
+
+All three deliverables of #7930 are done. Verification condition from the issue holds: the
+comment-reading step precedes "Review Focus Areas" (line 35 vs 67) and "Completing the
+Review" (line 150) in `review.md`.
+
+## Overall project progress
+
+No `.lean` changes; this is workflow guidance only, per `meditate.md`'s constraints. Two
+files touched, both agent-editable. `.claude/CLAUDE.md` and `PLAN.md` untouched.
+
+## Next step
+
+Two follow-ups, neither blocking:
+
+1. A pod-owner-side change to add `stateReason` to `_unclaimed_issues()`'s `--json` list and
+   print a `[REOPENED]` marker in `cmd_list_unclaimed` / `cmd_orient`. Details in the #7930
+   comment. This removes the dependency on workers remembering to fetch comments.
+2. The seven unclaimed reopened issues above are worth a planner pass: their bodies describe
+   pre-reopen scope, so their queue titles understate (or misstate) the actual work.
+
+## Blockers
+
+None.


### PR DESCRIPTION
Closes #7930

Session: `e74ba0fd-023e-4e11-8ed2-f07c24e9496d`

145bcc30 doc: progress entry for #7930 (reopened-issue scope inheritance)
2bd45c15 doc: treat any reopening comment as authoritative, and warn review sessions that a reopen can carry construction scope

🤖 Prepared with Claude Code