### PR TITLE
Fidelity gap: Chapter4/Example4.9.1

### DIFF
--- a/EtingofRepresentationTheory/Chapter4/Example4_9_1.lean
+++ b/EtingofRepresentationTheory/Chapter4/Example4_9_1.lean
@@ -20,6 +20,15 @@ character formula `n_{ij}^k = (χ_i · χ_j, χ_k)`; equivalently, the product o
 irreducible characters decomposes as the integer combination `χ_i · χ_j = Σ_k n_{ij}^k χ_k`
 of irreducible characters, which is exactly the statement `V_i ⊗ V_j ≅ ⊕_k n_{ij}^k V_k`.
 
+The book asserts decompositions of *representations*, so for each of the three groups the
+table is formalized twice: first as the character identity it is computed from, and then as
+the isomorphism of representations it asserts.  The right-hand side `⊕_k n_{ij}^k V_k` is the
+object `multSum` built below, and the upgrade is `Etingof.charEq_iso` (Chapter 5: over `ℂ`,
+equal characters imply isomorphism).  The isomorphisms are `S3_tensor_iso`, `S4_tensor_iso`,
+`A5_tensor_iso` — one statement quantified over `i, j`, hence covering *every* entry of all
+three tables, including the multiplicity-2 constituents of `ℂ⁴ ⊗ ℂ⁵` and `ℂ⁵ ⊗ ℂ⁵` for `A₅` —
+with `*_biproduct` variants stated using the categorical `⨁`.
+
 ## The representations of `S₃`
 
 The three irreducible representations of `S₃` are built as objects of `FDRep ℂ S₃`, and the
@@ -37,6 +46,9 @@ representations):
 * `S3_tensor_product_character`: the same identity phrased on the tensor product
   `V_i ⊗ V_j` of `FDRep`s, via `FDRep.char_tensor`.  This is the character form of
   `V_i ⊗ V_j ≅ ⊕_k n_{ij}^k V_k`.
+* `S3_tensor_iso` / `S3_tensor_iso_biproduct`: the decomposition itself,
+  `V_i ⊗ V_j ≅ ⊕_k n_{ij}^k V_k` in `FDRep ℂ S₃`, for every entry of the table;
+  `stdRep_tensor_stdRep_iso` spells out the one nontrivial entry `ℂ² ⊗ ℂ² ≅ ℂ₊ ⊕ ℂ₋ ⊕ ℂ²`.
 
 ## The representations of `A₅`
 
@@ -53,6 +65,8 @@ functions, the multiplicity identity for every `g` reduces to the five conjugacy
   characters (traces) of the five representations.
 * `A5_tensor_product_character`: the same identity on the tensor product
   `V_i ⊗ V_j` of `FDRep`s, via `FDRep.char_tensor`.
+* `A5_tensor_iso` / `A5_tensor_iso_biproduct`: the decomposition itself,
+  `V_i ⊗ V_j ≅ ⊕_k n_{ij}^k V_k` in `FDRep ℂ A₅`, for every entry of the table.
 
 ## The representations of `S₄`
 
@@ -68,12 +82,17 @@ multiplicity identity for every `g` reduces, via `Etingof.Example4_8_1.S4.classR
   characters (traces) of the five representations.
 * `S4_tensor_product_character`: the same identity on the tensor product
   `V_i ⊗ V_j` of `FDRep`s, via `FDRep.char_tensor`.
+* `S4_tensor_iso` / `S4_tensor_iso_biproduct`: the decomposition itself,
+  `V_i ⊗ V_j ≅ ⊕_k n_{ij}^k V_k` in `FDRep ℂ S₄`, for every entry of the table.
 
 ## Mathlib correspondence
 
 Tensor-product decomposition multiplicities for these groups are not in Mathlib; the
 standard representation and its character are built here from scratch.  `FDRep.char_tensor`
-supplies `(V ⊗ W).character = V.character · W.character`.
+supplies `(V ⊗ W).character = V.character · W.character`.  Mathlib has no `⨁`-indexed
+biproduct for `FDRep`, so the right-hand sides are built with `Etingof.FDRep.pi`
+(`Infrastructure/FDRepDirectSum`), and the converse of `FDRep.char_iso` needed to go from
+characters to isomorphisms is `Etingof.charEq_iso` (`Chapter5/CharEqIso`).
 -/
 
 open CategoryTheory MonoidalCategory

--- a/EtingofRepresentationTheory/Chapter4/Example4_9_1.lean
+++ b/EtingofRepresentationTheory/Chapter4/Example4_9_1.lean
@@ -1,5 +1,7 @@
 import Mathlib
 import EtingofRepresentationTheory.Chapter4.Example4_8_1
+import EtingofRepresentationTheory.Chapter5.CharEqIso
+import EtingofRepresentationTheory.Infrastructure.FDRepDirectSum
 
 /-!
 # Example 4.9.1: Tensor Product Multiplicities
@@ -79,6 +81,62 @@ open CategoryTheory MonoidalCategory
 noncomputable section
 
 namespace Etingof.Example4_9_1
+
+/-! ## The right-hand sides of the tables, and the character-to-isomorphism bridge
+
+Every entry of Etingof's three tables is a direct sum `⊕_k n_{ij}^k V_k` of irreducibles with
+multiplicities, so the right-hand side needs to exist as an object of `FDRep ℂ G` before the
+table entry can be stated as an isomorphism.  `multSum V n` is that object: the direct sum
+`Etingof.FDRep.pi` (`Infrastructure/FDRepDirectSum`) of the family indexed by the sigma type
+`(k : ι) × Fin (n k)`, i.e. `n k` copies of `V k` for each `k`.  Its character is
+`Σ_k n k · χ_{V k}` (`character_multSum`), which is exactly the shape of the multiplicity
+identities proved below, so `Etingof.charEq_iso` (Chapter 5, equal characters imply isomorphism
+over `ℂ`) turns each of them into an isomorphism of representations (`iso_multSum_of_character`).
+
+The isomorphisms are non-canonical — `charEq_iso` produces one from a character computation
+without singling one out — so they are stated as `Nonempty (· ≅ ·)`, as elsewhere in the project
+(`Etingof.Problem4_12_9.tensor_iso_Rz_mul`). -/
+
+section MultSum
+
+variable {G : Type} [Group G] [Finite G] {ι : Type} [Fintype ι]
+
+/-- **The right-hand side of a multiplicity table entry**: the direct sum `⊕_k n k · V k`,
+containing `n k` copies of `V k` for each `k`, realised as `Etingof.FDRep.pi` over the sigma
+type `(k : ι) × Fin (n k)`. -/
+def multSum (V : ι → FDRep ℂ G) (n : ι → ℕ) : FDRep ℂ G :=
+  Etingof.FDRep.pi fun p : (k : ι) × Fin (n k) => V p.1
+
+/-- **Character of `multSum`**: `χ_{⊕_k n k · V k} = Σ_k n k · χ_{V k}`.  Character additivity
+over the direct sum (`Etingof.FDRep.character_pi`), with the sum over the sigma type unfolded
+to a double sum. -/
+theorem character_multSum (V : ι → FDRep ℂ G) (n : ι → ℕ) (g : G) :
+    (multSum V n).character g = ∑ k, (n k : ℂ) * (V k).character g := by
+  classical
+  rw [multSum, Etingof.FDRep.character_pi, ← Finset.univ_sigma_univ, Finset.sum_sigma]
+  refine Finset.sum_congr rfl fun k _ => ?_
+  -- the summand `(V ⟨k, s⟩.1).character g` is `(V k).character g` by iota reduction, but not
+  -- syntactically constant in `s`, so `Finset.sum_const` needs the reduced form first
+  show ∑ _s : Fin (n k), (V k).character g = (n k : ℂ) * (V k).character g
+  rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+
+/-- **The bridge from a multiplicity identity to a decomposition of representations.**  If the
+character of `W` is the tabulated combination `Σ_k n k · χ_{V k}`, then `W ≅ ⊕_k n k · V k`.
+This is `Etingof.charEq_iso` ("equal characters imply isomorphism", Chapter 5) applied to
+`character_multSum`. -/
+theorem iso_multSum_of_character (V : ι → FDRep ℂ G) (n : ι → ℕ) (W : FDRep ℂ G)
+    (h : ∀ g, W.character g = ∑ k, (n k : ℂ) * (V k).character g) :
+    Nonempty (W ≅ multSum V n) :=
+  Etingof.charEq_iso _ _ (funext fun g => by rw [character_multSum]; exact h g)
+
+/-- `multSum V n` is the categorical biproduct of the family `(k, _) ↦ V k`
+(`Etingof.FDRep.piIsoBiproduct`). -/
+def multSumIsoBiproduct (V : ι → FDRep ℂ G) (n : ι → ℕ) :
+    multSum V n ≅ ⨁ fun p : (k : ι) × Fin (n k) => V p.1 := by
+  classical
+  exact Etingof.FDRep.piIsoBiproduct _
+
+end MultSum
 
 /-- `S₃`, realised as the symmetric group on `Fin 3`. -/
 abbrev S3 : Type := Equiv.Perm (Fin 3)
@@ -349,6 +407,31 @@ theorem S3_tensor_product_character (i j : Fin 3) (g : S3) :
   rw [FDRep.char_tensor, Pi.mul_apply]
   exact S3_tensor_character i j g
 
+/-- **Tensor-product decomposition for `S₃`, as an isomorphism of representations**
+(Etingof Example 4.9.1).  Every entry of the book's `S₃` table holds at the level of
+representations, not merely characters: `V_i ⊗ V_j ≅ ⊕_k n_{ij}^k V_k` in `FDRep ℂ S₃`.
+The character identity `S3_tensor_product_character` is the computation this rests on. -/
+theorem S3_tensor_iso (i j : Fin 3) :
+    Nonempty ((irrep i ⊗ irrep j : FDRep ℂ S3) ≅ multSum irrep (nS3 i j)) :=
+  iso_multSum_of_character irrep (nS3 i j) _ (S3_tensor_product_character i j)
+
+/-- `V_i ⊗ V_j ≅ ⊕_k n_{ij}^k V_k` for `S₃`, stated with the categorical biproduct. -/
+theorem S3_tensor_iso_biproduct (i j : Fin 3) :
+    Nonempty ((irrep i ⊗ irrep j : FDRep ℂ S3) ≅
+      ⨁ fun p : (k : Fin 3) × Fin (nS3 i j k) => irrep p.1) :=
+  (S3_tensor_iso i j).map fun e => e ≪≫ multSumIsoBiproduct irrep (nS3 i j)
+
+/-- **`ℂ² ⊗ ℂ² ≅ ℂ₊ ⊕ ℂ₋ ⊕ ℂ²`**, the one nontrivial entry of Etingof's `S₃` table, in the
+book's own form: each of the three irreducibles occurs exactly once, so the right-hand side is
+the plain direct sum of the catalogue `irrep`. -/
+theorem stdRep_tensor_stdRep_iso :
+    Nonempty ((stdRep ⊗ stdRep : FDRep ℂ S3) ≅ Etingof.FDRep.pi irrep) := by
+  have hone : ∀ k, nS3 2 2 k = 1 := by decide
+  refine Etingof.charEq_iso _ _ (funext fun g => ?_)
+  rw [Etingof.FDRep.character_pi]
+  refine (S3_tensor_product_character 2 2 g).trans (Finset.sum_congr rfl fun k _ => ?_)
+  rw [hone k, Nat.cast_one, one_mul]
+
 /-! ## Underlying combinatorial data -/
 
 /-- `S₃` has exactly 3 conjugacy classes, hence 3 irreducible representations
@@ -467,6 +550,21 @@ theorem A5_tensor_product_character (i j : Fin 5) (g : A5.G) :
   rw [FDRep.char_tensor, Pi.mul_apply]
   exact A5_tensor_character i j g
 
+/-- **Tensor-product decomposition for `A₅`, as an isomorphism of representations**
+(Etingof Example 4.9.1).  Every entry of the book's `A₅` table holds at the level of
+representations, not merely characters: `V_i ⊗ V_j ≅ ⊕_k n_{ij}^k V_k` in `FDRep ℂ A₅`,
+including the multiplicity-2 constituents of `ℂ⁴ ⊗ ℂ⁵` and `ℂ⁵ ⊗ ℂ⁵`. -/
+theorem A5_tensor_iso (i j : Fin 5) :
+    Nonempty ((A5.irrepA5 i ⊗ A5.irrepA5 j : FDRep ℂ A5.G) ≅
+      multSum A5.irrepA5 (nA5 i j)) :=
+  iso_multSum_of_character A5.irrepA5 (nA5 i j) _ (A5_tensor_product_character i j)
+
+/-- `V_i ⊗ V_j ≅ ⊕_k n_{ij}^k V_k` for `A₅`, stated with the categorical biproduct. -/
+theorem A5_tensor_iso_biproduct (i j : Fin 5) :
+    Nonempty ((A5.irrepA5 i ⊗ A5.irrepA5 j : FDRep ℂ A5.G) ≅
+      ⨁ fun p : (k : Fin 5) × Fin (nA5 i j k) => A5.irrepA5 p.1) :=
+  (A5_tensor_iso i j).map fun e => e ≪≫ multSumIsoBiproduct A5.irrepA5 (nA5 i j)
+
 /-- `A₅` has exactly 5 conjugacy classes, hence 5 irreducible representations
 (the trivial `ℂ`, the two icosahedral `ℂ³₊, ℂ³₋`, and the permutation reps `ℂ⁴, ℂ⁵`).
 (Etingof Example 4.9.1) -/
@@ -561,6 +659,19 @@ theorem S4_tensor_product_character (i j : Fin 5) (g : S4) :
       = ∑ k, (nS4 i j k : ℂ) * (irrepS4 k).character g := by
   rw [FDRep.char_tensor, Pi.mul_apply]
   exact S4_tensor_character i j g
+
+/-- **Tensor-product decomposition for `S₄`, as an isomorphism of representations**
+(Etingof Example 4.9.1).  Every entry of the book's `S₄` table holds at the level of
+representations, not merely characters: `V_i ⊗ V_j ≅ ⊕_k n_{ij}^k V_k` in `FDRep ℂ S₄`. -/
+theorem S4_tensor_iso (i j : Fin 5) :
+    Nonempty ((irrepS4 i ⊗ irrepS4 j : FDRep ℂ S4) ≅ multSum irrepS4 (nS4 i j)) :=
+  iso_multSum_of_character irrepS4 (nS4 i j) _ (S4_tensor_product_character i j)
+
+/-- `V_i ⊗ V_j ≅ ⊕_k n_{ij}^k V_k` for `S₄`, stated with the categorical biproduct. -/
+theorem S4_tensor_iso_biproduct (i j : Fin 5) :
+    Nonempty ((irrepS4 i ⊗ irrepS4 j : FDRep ℂ S4) ≅
+      ⨁ fun p : (k : Fin 5) × Fin (nS4 i j k) => irrepS4 p.1) :=
+  (S4_tensor_iso i j).map fun e => e ≪≫ multSumIsoBiproduct irrepS4 (nS4 i j)
 
 /-- `S₄` has exactly 5 conjugacy classes, hence 5 irreducible representations
 (the trivial `ℂ₊`, sign `ℂ₋`, standard `ℂ²`, and the two 3-dimensionals `ℂ³₊, ℂ³₋`).

--- a/progress/2026-07-26T19-37-35Z_5cc85515.md
+++ b/progress/2026-07-26T19-37-35Z_5cc85515.md
@@ -1,0 +1,109 @@
+# 2026-07-26T19:37:35Z — work session (`5cc85515`)
+
+Issue #5377 — *Fidelity gap: Chapter4/Example4.9.1*, residual scope from the owner's
+2026-07-22 reopening comment: "Closure now requires representation-level decomposition
+isomorphisms for every table entry, with the current character identities retained as
+corollaries."
+
+## Accomplished
+
+`EtingofRepresentationTheory/Chapter4/Example4_9_1.lean` now states each of Etingof's three
+Clebsch-Gordan tables as an isomorphism of representations, not only as a character identity.
+
+New general machinery (section `MultSum`, `G` finite, `ι` a `Fintype`):
+
+* `multSum V n : FDRep ℂ G` — the right-hand side `⊕_k n k · V k`, realised as
+  `Etingof.FDRep.pi` over the sigma type `(k : ι) × Fin (n k)`. This is the object the book's
+  table entries name, and it did not previously exist anywhere in the project.
+* `character_multSum` — `χ_{multSum V n} = Σ_k n k · χ_{V k}`, from
+  `Etingof.FDRep.character_pi` with the sigma sum unfolded to a double sum.
+* `iso_multSum_of_character` — the bridge: a character identity of the tabulated shape yields
+  `W ≅ multSum V n`, via `Etingof.charEq_iso`.
+* `multSumIsoBiproduct` — `multSum V n ≅ ⨁ …`, from `Etingof.FDRep.piIsoBiproduct`.
+
+New endpoints, one per group, each quantified over `i j` and so covering **every** entry of
+the corresponding table:
+
+* `S3_tensor_iso`, `S4_tensor_iso`, `A5_tensor_iso` —
+  `V_i ⊗ V_j ≅ ⊕_k n_{ij}^k V_k` in `FDRep ℂ G`. The `A₅` one includes the multiplicity-2
+  constituents of `ℂ⁴ ⊗ ℂ⁵` and `ℂ⁵ ⊗ ℂ⁵`.
+* `S3_tensor_iso_biproduct`, `S4_tensor_iso_biproduct`, `A5_tensor_iso_biproduct` — the same,
+  stated with the categorical `⨁`.
+* `stdRep_tensor_stdRep_iso` — the one nontrivial `S₃` entry in the book's own readable form,
+  `ℂ² ⊗ ℂ² ≅ ℂ₊ ⊕ ℂ₋ ⊕ ℂ²` (the plain direct sum of the catalogue, each irreducible once).
+
+The pre-existing `*_tensor_character` / `*_tensor_product_character` identities are retained
+unchanged and are now the computations the isomorphisms rest on, exactly as the reopening
+comment asked.
+
+`progress/items.json`: `Chapter4/Example4.9.1` moved `covered_partial` → `covered`,
+`fidelity_decl` extended with the seven new endpoints, `fidelity_note` rewritten, and the
+now-resolved `fidelity_issue: 5377` removed. `scripts/validate_items.py` passes.
+
+## Decisions made
+
+* **Reused, did not rebuild.** `Etingof.charEq_iso` (`Chapter5/CharEqIso.lean`) and
+  `Etingof.FDRep.pi` / `character_pi` / `piIsoBiproduct`
+  (`Infrastructure/FDRepDirectSum.lean`) already existed; `Chapter4/Problem4_12_9.lean` had
+  already established the exact "character identity → `Nonempty (· ≅ ·)`" pattern for the
+  Heisenberg group. This session's work is the `multSum` right-hand side plus assembly, not
+  new infrastructure. Two imports were added to `Example4_9_1.lean`; neither creates a cycle
+  (`CharEqIso` and `FDRepDirectSum` import only `Mathlib`).
+* **One quantified statement per group rather than 15/25/25 named entries.** `S3_tensor_iso
+  (i j)` *is* every entry of the `S₃` table; enumerating them separately would be weaker to
+  read and no stronger to prove.
+* **`Nonempty (· ≅ ·)`, not a chosen `Iso`.** `charEq_iso` produces an isomorphism without
+  singling one out, and no canonical intertwiner exists for these decompositions. This matches
+  `Problem4_12_9.tensor_iso_Rz_mul` and `charRep_iso_iff` elsewhere in the project.
+* **`multSum` kept local to `Example4_9_1`.** It is genuinely general and would sit naturally
+  in `Infrastructure/FDRepDirectSum.lean`, but that file is imported broadly and this PR should
+  not force a project-wide rebuild. Worth promoting if a second caller appears.
+
+## Key patterns discovered
+
+`Finset.sum_const` does not fire on `∑ s, (V ⟨k, s⟩.1).character g`: the summand is constant in
+`s` only up to iota reduction, not syntactically. A `show` with the reduced form first is the
+fix (see the comment in `character_multSum`).
+
+## Verification
+
+* `lake build` clean, no new `sorry`.
+* `#print axioms` on all seven new endpoints and on `character_multSum`:
+  `[propext, Classical.choice, Quot.sound]` — no `sorryAx`.
+* `python3 scripts/validate_items.py` → `VALIDATION PASSED`.
+
+The `PANIC at Lean.Expr.appArg!` lines and the `maxHeartbeats`/`show`/unused-simp-argument
+warnings in the build log are pre-existing: the PANIC count is identical (972) before and after
+this change, and the warnings come from `Example4_8_1/{Q8,S4,A5Classes}.lean`, untouched here.
+
+## Current frontier
+
+Issue #5377 is fully addressed; no residual scope.
+
+## Overall project progress
+
+Chapter 4 Example 4.9.1 is now `covered` / `fidelity: verified` with the source's actual
+representation-level claim formalized. The `multSum` + `iso_multSum_of_character` pair is
+directly reusable for any other book item that states a decomposition with multiplicities.
+
+## Next step
+
+Nothing follows from this issue. If another item needs a multiplicity direct sum, promote
+`multSum`, `character_multSum` and `iso_multSum_of_character` from
+`Chapter4/Example4_9_1.lean` into `Infrastructure/FDRepDirectSum.lean` rather than duplicating
+them.
+
+## Blockers
+
+None.
+
+## Session housekeeping
+
+The worktree arrived stale: `.claude/commands/{feature,meditate,review,summarize,work}.md` and
+`.claude/skills/agent-worker-flow/SKILL.md` were present as pure deletions against `HEAD`
+(567 lines removed, 2 added), so the `/work` command and worker-flow skill loaded at session
+start were truncated revisions missing the stale-worktree check itself. Restored with
+`git checkout HEAD -- .claude/` and re-read via `Read` (not the Skill tool, which reports
+"instructions unchanged" without re-reading disk). No backup patch was kept: the diff was pure
+deletion of tracked guidance with no original content. This is the same recurrence recorded on
+2026-07-25 and in #7917.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3703,13 +3703,12 @@
     "start_line": 9,
     "end_line": 31,
     "status": "sorry_free",
-    "coverage": "covered_partial",
+    "coverage": "covered",
     "fidelity": "verified",
     "sorry_free": true,
-    "fidelity_decl": "Etingof.Example4_9_1.S3_tensor_character, Etingof.Example4_9_1.S3_tensor_product_character, Etingof.Example4_9_1.A5_tensor_character, Etingof.Example4_9_1.A5_tensor_product_character, Etingof.Example4_9_1.S4_tensor_character, Etingof.Example4_9_1.S4_tensor_product_character",
-    "fidelity_note": "All three book tables (S3, S4, A5) are proved as genuine character identities for FDRep tensor products. The source states direct-sum decompositions of representations, but the corresponding RHS FDRep objects and equivariant isomorphisms are not exposed; reopened #5377 tracks that residual endpoint.",
-    "fidelity_issue": 5377,
-    "last_updated": "2026-07-22"
+    "fidelity_decl": "Etingof.Example4_9_1.S3_tensor_iso, Etingof.Example4_9_1.S4_tensor_iso, Etingof.Example4_9_1.A5_tensor_iso, Etingof.Example4_9_1.S3_tensor_iso_biproduct, Etingof.Example4_9_1.S4_tensor_iso_biproduct, Etingof.Example4_9_1.A5_tensor_iso_biproduct, Etingof.Example4_9_1.stdRep_tensor_stdRep_iso, Etingof.Example4_9_1.S3_tensor_character, Etingof.Example4_9_1.S3_tensor_product_character, Etingof.Example4_9_1.A5_tensor_character, Etingof.Example4_9_1.A5_tensor_product_character, Etingof.Example4_9_1.S4_tensor_character, Etingof.Example4_9_1.S4_tensor_product_character",
+    "fidelity_note": "All three book tables (S3, S4, A5) are formalized at the level the source asserts: `*_tensor_iso` gives `V_i ⊗ V_j ≅ ⊕_k n_ij^k V_k` in FDRep ℂ G for every table entry (quantified over i, j, so every entry of all three tables, including the multiplicity-2 constituents of ℂ⁴⊗ℂ⁵ and ℂ⁵⊗ℂ⁵ for A5), with `*_biproduct` variants using the categorical ⨁ and `stdRep_tensor_stdRep_iso` spelling out ℂ²⊗ℂ² ≅ ℂ₊⊕ℂ₋⊕ℂ² for S3. The right-hand sides are the genuine FDRep objects `multSum` (Etingof.FDRep.pi with multiplicities); the isomorphisms come from the character identities `*_tensor_character` / `*_tensor_product_character` via Etingof.charEq_iso, and are non-canonical, hence stated as `Nonempty (· ≅ ·)`.",
+    "last_updated": "2026-07-26"
   },
   {
     "id": "Chapter4/Introduction_4.10",


### PR DESCRIPTION
This PR upgrades all three of Etingof's Example 4.9.1 Clebsch-Gordan tables from character identities to isomorphisms of representations, closing the residual scope the owner recorded when reopening the issue: "Closure now requires representation-level decomposition isomorphisms for every table entry, with the current character identities retained as corollaries."

The right-hand side `⊕_k n_{ij}^k V_k` did not exist as an object anywhere in the project, so `multSum V n` builds it as `Etingof.FDRep.pi` over the sigma type `(k : ι) × Fin (n k)`, with `character_multSum` computing its character as `Σ_k n k · χ_{V k}` and `iso_multSum_of_character` feeding a tabulated character identity to `Etingof.charEq_iso`. On top of that sit `S3_tensor_iso`, `S4_tensor_iso` and `A5_tensor_iso`, each quantified over `i, j` and so covering every entry of its table, including the multiplicity-2 constituents of `ℂ⁴ ⊗ ℂ⁵` and `ℂ⁵ ⊗ ℂ⁵` for `A₅`; `*_tensor_iso_biproduct` restates them with the categorical `⨁`, and `stdRep_tensor_stdRep_iso` spells out `ℂ² ⊗ ℂ² ≅ ℂ₊ ⊕ ℂ₋ ⊕ ℂ²` in the book's own form. The existing `*_tensor_character` and `*_tensor_product_character` identities are untouched and are now the computations the isomorphisms rest on.

The isomorphisms are stated as `Nonempty (· ≅ ·)`: `charEq_iso` produces one without singling it out and none of these decompositions has a canonical intertwiner, matching `Problem4_12_9.tensor_iso_Rz_mul` elsewhere in the project. No new infrastructure was needed beyond `multSum` itself: `Etingof.charEq_iso` (`Chapter5/CharEqIso.lean`) and `Etingof.FDRep.pi` / `character_pi` / `piIsoBiproduct` (`Infrastructure/FDRepDirectSum.lean`) already existed, and both are imported without creating a cycle.

`progress/items.json` moves `Chapter4/Example4.9.1` from `covered_partial` to `covered`, extends `fidelity_decl` with the seven new endpoints, and drops the now-resolved `fidelity_issue`.

Verification: `lake build` clean (9341/9342, zero errors); `#print axioms` on all seven new endpoints and on `character_multSum` reports only `[propext, Classical.choice, Quot.sound]`, no `sorryAx`; `scripts/validate_items.py` passes.

Closes #5377

Session: 5cc85515-da57-4493-9252-7579faec85d5

🤖 Prepared with Claude Code