### PR TITLE
Expose enriched categories and enriched representability

### DIFF
--- a/EtingofRepresentationTheory/Chapter5/GL2CharacterIdentification.lean
+++ b/EtingofRepresentationTheory/Chapter5/GL2CharacterIdentification.lean
@@ -38,11 +38,14 @@ line, and the two fixed-point sets correspond under `t ↦ −t⁻¹`. Subtracti
 `ℂ_1` of `V(1, 1)` gives `charW₁`.
 -/
 
-open CategoryTheory CategoryTheory.Limits Classical
+open CategoryTheory CategoryTheory.Limits
 
 noncomputable section
 
 variable (p : ℕ) [hp : Fact (Nat.Prime p)] (n : ℕ)
+
+local instance (priority := low) : DecidableEq (GaloisField p n) := Classical.decEq _
+local instance (priority := low) (q : Prop) : Decidable q := Classical.propDecidable q
 
 private abbrev GL2 (p n : ℕ) [Fact (Nat.Prime p)] :=
   Matrix.GeneralLinearGroup (Fin 2) (GaloisField p n)
@@ -105,7 +108,7 @@ theorem principalSeries_character_apply [Fintype (GaloisField p n)]
           Etingof.GL2.borelCharValue p n chi1 chi2
             (Etingof.GL2.cosetBorel p n (Etingof.GL2.cosetRep p n i * g))
         else 0 := by
-  show LinearMap.trace ℂ ↥(Etingof.GL2.principalSeriesSubmodule p n chi1 chi2)
+  change LinearMap.trace ℂ ↥(Etingof.GL2.principalSeriesSubmodule p n chi1 chi2)
       (Etingof.GL2.principalSeriesRep p n chi1 chi2 g) = _
   rw [← LinearMap.trace_conj' (Etingof.GL2.principalSeriesRep p n chi1 chi2 g)
       (Etingof.GL2.psEquiv p n chi1 chi2),
@@ -125,8 +128,7 @@ theorem principalSeries_character_apply [Fintype (GaloisField p n)]
     change ((Etingof.GL2.psEquiv p n chi1 chi2).symm (Pi.single i 1) : GL2 p n → ℂ)
       (Etingof.GL2.cosetRep p n i * g) = _
     rw [Etingof.GL2.psEquiv_symm_apply]
-  simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe,
-    LinearEquiv.coe_toLinearMap] at hval ⊢
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe] at hval ⊢
   rw [hval, Etingof.GL2.mkCovariantFun, Pi.single_apply]
   by_cases h : Etingof.GL2.cosetIndex p n (Etingof.GL2.cosetRep p n i * g) = i <;> simp [h]
 
@@ -163,7 +165,7 @@ def borelEntriesEquiv :
         !![(adc.1 : GaloisField p n), adc.2.2; 0, (adc.2.1 : GaloisField p n)]
         (by simp [Matrix.det_fin_two]),
       by
-        show ((Matrix.GeneralLinearGroup.mkOfDetNeZero
+        change ((Matrix.GeneralLinearGroup.mkOfDetNeZero
           !![(adc.1 : GaloisField p n), adc.2.2; 0, (adc.2.1 : GaloisField p n)]
           (by simp [Matrix.det_fin_two])).val :
             Matrix (Fin 2) (Fin 2) (GaloisField p n)) 1 0 = 0
@@ -286,7 +288,7 @@ lemma borelCharExt_cosetRep (chi1 chi2 : (GaloisField p n)ˣ →* ℂˣ)
 /-- **Frobenius character formula for the principal series** in its raw form: summing the
 Borel character (extended by zero) over all of `G` gives `|B|` times the character. -/
 theorem sum_borelCharExt_conj
-    [Fintype (GaloisField p n)] [Fintype (GL2 p n)]
+    [Fintype (GL2 p n)]
     [Fintype ↥(Etingof.GL2.BorelSubgroup p n)]
     (chi1 chi2 : (GaloisField p n)ˣ →* ℂˣ) (g : GL2 p n) :
     ∑ x : GL2 p n, Etingof.GL2.borelCharExt p n chi1 chi2 (x * g * x⁻¹) =
@@ -369,7 +371,7 @@ lemma borelCharValue_one_one (b : ↥(Etingof.GL2.BorelSubgroup p n)) :
 lemma character_detChar (mu : (GaloisField p n)ˣ →* ℂˣ) (g : GL2 p n) :
     (Etingof.GL2.detChar p n mu).character g =
       ((mu (Matrix.GeneralLinearGroup.det g) : ℂˣ) : ℂ) := by
-  show LinearMap.trace ℂ ℂ
+  change LinearMap.trace ℂ ℂ
     (((mu (Matrix.GeneralLinearGroup.det g) : ℂˣ) : ℂ) • LinearMap.id) = _
   rw [map_smul, LinearMap.trace_id]
   simp
@@ -477,7 +479,7 @@ lemma rootIndicator_projInvol [DecidableEq (GaloisField p n)]
     simp [neg_eq_zero]
   · by_cases ht : t = 0
     · subst ht
-      simp only [Etingof.GL2.projInvol, if_pos rfl, Etingof.GL2.rootIndicator]
+      simp only [Etingof.GL2.projInvol, Etingof.GL2.rootIndicator]
       simp [neg_eq_zero]
     · simp only [Etingof.GL2.projInvol, if_neg ht, Etingof.GL2.rootIndicator]
       have hexp : c * (-t⁻¹) ^ 2 + b * (-t⁻¹) - a = -(a * t ^ 2 + b * t - c) / t ^ 2 := by
@@ -545,7 +547,7 @@ theorem finrank_complementW_one [Fintype (GaloisField p n)] :
   have hscalar : _root_.GL2.IsScalar (p := p) (n := n) 1 := by
     rw [_root_.GL2.isScalar_iff]
     refine ⟨?_, ?_, ?_⟩ <;>
-      simp [Matrix.one_apply, (by decide : (0 : Fin 2) ≠ 1), (by decide : (1 : Fin 2) ≠ 0)]
+      simp [(by decide : (0 : Fin 2) ≠ 1), (by decide : (1 : Fin 2) ≠ 0)]
   have h := (Etingof.GL2.character_complementW p n (1 : GL2 p n)).symm
   rw [Etingof.charW₁_scalar p n 1 hscalar, FDRep.char_one] at h
   exact_mod_cast h.symm

--- a/EtingofRepresentationTheory/Chapter7.lean
+++ b/EtingofRepresentationTheory/Chapter7.lean
@@ -22,6 +22,7 @@ import EtingofRepresentationTheory.Chapter7.Introduction_7_4
 import EtingofRepresentationTheory.Chapter7.Example7_1_3
 import EtingofRepresentationTheory.Chapter7.Example7_1_5
 import EtingofRepresentationTheory.Chapter7.Example7_1_6
+import EtingofRepresentationTheory.Chapter7.EnrichedRepresentability
 import EtingofRepresentationTheory.Chapter7.SymmetricPowerFunctor
 import EtingofRepresentationTheory.Chapter7.SchurFunctor
 import EtingofRepresentationTheory.Chapter7.Example7_2_2

--- a/EtingofRepresentationTheory/Chapter7/EnrichedRepresentability.lean
+++ b/EtingofRepresentationTheory/Chapter7/EnrichedRepresentability.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 FormalFrontier contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: FormalFrontier contributors
+-/
+import Mathlib.CategoryTheory.Enriched.Ordinary.Basic
+
+/-!
+# Enriched categories and representable enriched-valued functors
+
+The discussion after Example 7.1.5 replaces hom-sets by hom-objects in a monoidal category
+and requires composition to be a morphism in that category.  Mathlib packages exactly this
+data as `CategoryTheory.EnrichedCategory`, with composition `CategoryTheory.eComp`.
+
+Remark 7.5.2 extends representability to this setting.  When an ordinary category `C` is
+compatibly enriched over `V`, a functor `F : C ⟶ V` is enriched-representable when it is
+naturally isomorphic to the enriched coyoneda functor `X ⟶ (X ⟶[V] -)` for some `X`.
+-/
+
+open CategoryTheory
+
+namespace Etingof
+
+universe w v u
+
+variable (V : Type v) [Category.{w} V] [MonoidalCategory V]
+
+/-- Discussion after Example 7.1.5: a category enriched over the monoidal category `V`.
+
+This source-facing abbreviation re-exports Mathlib's `CategoryTheory.EnrichedCategory`.
+Its fields are the enriched hom-object, identity morphism, composition morphism, and the
+unit and associativity laws. -/
+abbrev EnrichedCategory (C : Type u) := CategoryTheory.EnrichedCategory V C
+
+/-- Discussion after Example 7.1.5: composition of enriched hom-objects is a morphism in
+the enriching category.  This is the source-facing name for `CategoryTheory.eComp`. -/
+abbrev enrichedComposition {C : Type u} [CategoryTheory.EnrichedCategory V C]
+    (X Y Z : C) :=
+  CategoryTheory.eComp V X Y Z
+
+variable {C : Type u} [Category C] [EnrichedOrdinaryCategory V C]
+
+/-- Remark 7.5.2: a `V`-valued functor on a `V`-enriched ordinary category is
+representable when it is naturally isomorphic to enriched hom from some object. -/
+def EnrichedRepresentable (F : Functor C V) : Prop :=
+  ∃ X : C, Nonempty (F ≅ eCoyoneda V X)
+
+/-- The definition of enriched representability, exposed as a convenient iff. -/
+theorem enrichedRepresentable_iff (F : Functor C V) :
+    EnrichedRepresentable V F ↔ ∃ X : C, Nonempty (F ≅ eCoyoneda V X) :=
+  Iff.rfl
+
+/-- The enriched coyoneda functor represented by `X` is enriched-representable, with
+representing object `X`. -/
+theorem eCoyoneda_enrichedRepresentable (X : C) :
+    EnrichedRepresentable V (eCoyoneda V X) :=
+  ⟨X, ⟨Iso.refl _⟩⟩
+
+/-- A direct witness form of `eCoyoneda_enrichedRepresentable`. -/
+theorem eCoyoneda_representedBy (X : C) :
+    Nonempty (eCoyoneda V X ≅ eCoyoneda V X) :=
+  ⟨Iso.refl _⟩
+
+end Etingof

--- a/EtingofRepresentationTheory/Infrastructure/FDRepCharacterBiprod.lean
+++ b/EtingofRepresentationTheory/Infrastructure/FDRepCharacterBiprod.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 FormalFrontier contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: FormalFrontier contributors
+-/
 import Mathlib
 
 /-!

--- a/EtingofRepresentationTheory/Infrastructure/IrrepClasses.lean
+++ b/EtingofRepresentationTheory/Infrastructure/IrrepClasses.lean
@@ -1,3 +1,8 @@
+/-
+Copyright (c) 2026 FormalFrontier contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: FormalFrontier contributors
+-/
 import Mathlib
 
 /-!

--- a/progress/items.json
+++ b/progress/items.json
@@ -8208,12 +8208,12 @@
     "start_line": 7,
     "end_line": 8,
     "status": "sorry_free",
-    "fidelity": "partial",
+    "fidelity": "verified",
     "sorry_free": true,
-    "coverage": "covered_partial",
-    "coverage_note": "Mathlib has the enriched-category and enriched-composition infrastructure, but Chapter 7 exposes no source-shaped public endpoint; combined follow-up #7473.",
+    "coverage": "covered_full",
+    "coverage_note": "EnrichedRepresentability.lean exposes Mathlib's EnrichedCategory and eComp through source-facing declarations EnrichedCategory and enrichedComposition.",
     "fidelity_issue": 7473,
-    "last_updated": "2026-07-22",
+    "last_updated": "2026-07-26",
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -8414,12 +8414,12 @@
     "start_line": 5,
     "end_line": 6,
     "status": "sorry_free",
-    "fidelity": "partial",
+    "fidelity": "verified",
     "sorry_free": true,
-    "coverage": "covered_partial",
-    "coverage_note": "The project exposes no definition of representability for a functor from an enriched category into its enriching category, despite Mathlib's eCoyoneda infrastructure; combined follow-up #7473.",
+    "coverage": "covered_full",
+    "coverage_note": "EnrichedRepresentability.lean defines EnrichedRepresentable by a natural isomorphism to eCoyoneda and proves every eCoyoneda functor has its canonical representing witness.",
     "fidelity_issue": 7473,
-    "last_updated": "2026-07-22"
+    "last_updated": "2026-07-26"
   },
   {
     "id": "Chapter7/Example7.5.3",

--- a/scripts/lint-warning-baseline.txt
+++ b/scripts/lint-warning-baseline.txt
@@ -6,7 +6,6 @@
 #
 # Regenerate after a deliberate change with:
 #   scripts/check_lint_clean.py --log <build.log> --update
-EtingofRepresentationTheory/Chapter2/Definition2_8_4.lean
 EtingofRepresentationTheory/Chapter2/FaithfulWeylModule.lean
 EtingofRepresentationTheory/Chapter2/Problem2_14_3.lean
 EtingofRepresentationTheory/Chapter2/Problem2_15_1_complete_reducibility.lean


### PR DESCRIPTION
Closes #7473

Adds source-facing Chapter 7 endpoints for Mathlib’s enriched-category structure and composition morphism, defines representability of a `V`-valued functor via `eCoyoneda`, and supplies the canonical representing witness. Updates the Chapter 7 roll-up and both coverage entries.

Validation:
- `lake env lean EtingofRepresentationTheory/Chapter7/EnrichedRepresentability.lean`
- `lake build EtingofRepresentationTheory.Chapter7.EnrichedRepresentability EtingofRepresentationTheory.Chapter7`
- `python3 -m json.tool progress/items.json`
- `git diff --check`