### PR TITLE
Expose the canonical Ext one comparison API

### DIFF
--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_6.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_6.lean
@@ -59,7 +59,7 @@ higher `Tor` on projectives, and the naturality of the degree-`0` balancing isom
 
 namespace Etingof
 
-open CategoryTheory TensorProduct
+open CategoryTheory TensorProduct CochainComplex.HomComplex
 
 universe u
 
@@ -83,6 +83,66 @@ theorem Problem_8_2_6_i_ext
 
 /-! ### Part (ii) -/
 
+/-- The canonical additive equivalence from categorical `Ext¹_A(W, V)` to the explicit
+cocycle-modulo-coboundary model of Problem 3.9.1. -/
+noncomputable def extOneAddEquivProblem3Ext1
+    (k : Type u) (A : Type u) [Field k] [Ring A] [Algebra k A]
+    (V W : Type u) [AddCommGroup V] [Module k V] [Module A V] [IsScalarTower k A V]
+    [AddCommGroup W] [Module k W] [Module A W] [IsScalarTower k A W] :
+    Etingof.Ext (ModuleCat.of A W) (ModuleCat.of A V) 1
+      ≃+ Etingof.Problem3_9_1.Ext1 k A V W :=
+  ((Etingof.barResolution k A W).extAddEquivCohomologyClass
+      (Y := ModuleCat.of A V) (n := 1)).trans
+    (Etingof.cohomologyClassEquivExt1 k A W V)
+
+/-- The canonical comparison factors through degree-one cohomology of the bar resolution. -/
+@[simp]
+theorem extOneAddEquivProblem3Ext1_apply
+    (k : Type u) (A : Type u) [Field k] [Ring A] [Algebra k A]
+    (V W : Type u) [AddCommGroup V] [Module k V] [Module A V] [IsScalarTower k A V]
+    [AddCommGroup W] [Module k W] [Module A W] [IsScalarTower k A W]
+    (x : Etingof.Ext (ModuleCat.of A W) (ModuleCat.of A V) 1) :
+    extOneAddEquivProblem3Ext1 k A V W x =
+      cohomologyClassEquivExt1 k A W V
+        ((barResolution k A W).extAddEquivCohomologyClass x) :=
+  rfl
+
+/-- The bar cocycle represented by a degree-one chain map used in `ProjectiveResolution.extMk`. -/
+noncomputable def barExtCocycle
+    (k : Type u) (A : Type u) [Field k] [Ring A] [Algebra k A]
+    (V W : Type u) [AddCommGroup V] [Module k V] [Module A V] [IsScalarTower k A V]
+    [AddCommGroup W] [Module k W] [Module A W] [IsScalarTower k A W]
+    (f : (barResolution k A W).complex.X 1 ⟶ ModuleCat.of A V)
+    (hf : (barResolution k A W).complex.d 2 1 ≫ f = 0) :
+    Cocycle (barCochainComplex k A W) (singleV A V) 1 :=
+  Cocycle.toSingleMk
+    (((barResolution k A W).cochainComplexXIso (-(1 : ℕ)) 1 rfl).hom ≫ f) (by simp)
+    (-(2 : ℕ)) (by lia)
+    (by
+      rw [ProjectiveResolution.cochainComplex_d (barResolution k A W)
+        (-(2 : ℕ)) (-(1 : ℕ)) 2 1 (by norm_num) (by norm_num)]
+      simp [Category.assoc, hf])
+
+/-- On the standard `extMk` generators, the canonical comparison is the quotient class of the
+corresponding bar cocycle.  Together with `barCocycleEquivProblem3Cocycle_apply`, this computes
+the representative by the tensor–hom formula `z (1 ⊗ (a ⊗ w))`. -/
+@[simp]
+theorem extOneAddEquivProblem3Ext1_extMk
+    (k : Type u) (A : Type u) [Field k] [Ring A] [Algebra k A]
+    (V W : Type u) [AddCommGroup V] [Module k V] [Module A V] [IsScalarTower k A V]
+    [AddCommGroup W] [Module k W] [Module A W] [IsScalarTower k A W]
+    (f : (barResolution k A W).complex.X 1 ⟶ ModuleCat.of A V)
+    (hf : (barResolution k A W).complex.d 2 1 ≫ f = 0) :
+    extOneAddEquivProblem3Ext1 k A V W
+        ((barResolution k A W).extMk f 2 rfl hf) =
+      cohomologyClassEquivExt1 k A W V
+        (CohomologyClass.mk (barExtCocycle k A V W f hf)) := by
+  unfold extOneAddEquivProblem3Ext1
+  rw [AddEquiv.trans_apply,
+    ProjectiveResolution.extAddEquivCohomologyClass_apply,
+    ProjectiveResolution.extEquivCohomologyClass_extMk]
+  rfl
+
 /-- **Problem 8.2.6(ii).** For representations `V`, `W` of a `k`-algebra `A`, the group
 `Ext¹_A(W, V)` of Definition 8.2.4 is canonically isomorphic to the group `Ext¹(W, V)` of
 Problem 3.9.1, defined as 1-cocycles modulo coboundaries. (Both classify extensions
@@ -93,14 +153,7 @@ theorem Problem_8_2_6_ii
     [AddCommGroup W] [Module k W] [Module A W] [IsScalarTower k A W] :
     Nonempty (Etingof.Ext (ModuleCat.of A W) (ModuleCat.of A V) 1
       ≃+ Etingof.Problem3_9_1.Ext1 k A V W) :=
-  -- Step 1: the relative bar resolution `Etingof.barResolution` computes `Ext¹` as the degree-1
-  -- cohomology of the Hom-into-`V` cochain complex, via
-  -- `ProjectiveResolution.extAddEquivCohomologyClass`.
-  -- Step 2: identify that cohomology group with `Problem3_9_1.Ext1` via
-  -- `Etingof.cohomologyClassEquivExt1`.
-  ⟨((Etingof.barResolution k A W).extAddEquivCohomologyClass
-      (Y := ModuleCat.of A V) (n := 1)).trans
-    (Etingof.cohomologyClassEquivExt1 k A W V)⟩
+  ⟨extOneAddEquivProblem3Ext1 k A V W⟩
 
 /-! ### Part (iii): long exact sequence in the second argument (`Ext` half) -/
 
@@ -116,6 +169,7 @@ theorem Problem_8_2_6_iii_ext
     (Abelian.Ext.covariantSequence (X := M) hS n₀ n₁ h).Exact :=
   Abelian.Ext.covariantSequence_exact M hS n₀ n₁ h
 
+set_option backward.isDefEq.respectTransparency false in
 /-- **Problem 8.2.6(iii), `Tor`.** A short exact sequence `S : 0 → N₁ → N₂ → N₃ → 0` of left
 `A`-modules induces, for each right `A`-module `M` and each `n₀ + 1 = n₁`, a connecting
 homomorphism `δ : Torₙ₁(M, N₃) → Torₙ₀(M, N₁)` making the six-term homology window
@@ -178,6 +232,7 @@ noncomputable def balancingIsoZero
   ((tensorRightFunctor A N).leftDerivedZeroIsoSelf.app M) ≪≫
     ((tensorLeftFunctor A M).leftDerivedZeroIsoSelf.app (ModuleCat.of A N)).symm
 
+set_option backward.isDefEq.respectTransparency false in
 /-- **Balancing-side six-term window.** The mirror of `Problem_8_2_6_iii_tor` for the
 balancing-side derived functor: a short exact sequence `S : 0 → M₁ → M₂ → M₃ → 0` of *right*
 `A`-modules induces, for a fixed left module `N` and each `n₀ + 1 = n₁`, a connecting homomorphism
@@ -233,6 +288,8 @@ open CategoryTheory.Limits
 
 universe v₁ u₁
 
+set_option backward.defeqAttrib.useBackward true in
+set_option backward.isDefEq.respectTransparency false in
 /-- **Naturality of `fromLeftDerivedZero` in the functor variable.** For a natural transformation
 `α : F ⟶ G` of additive functors between abelian categories (`C` with enough projectives), the
 degree-`0` comparison maps `L₀F ⟶ F` and `L₀G ⟶ G` intertwine `NatTrans.leftDerived α 0` with `α`.
@@ -259,6 +316,7 @@ lemma fromLeftDerivedZero_natTrans_app
   simp only [NatTrans.mapHomologicalComplex_app_f]
   exact (α.naturality (P.π.f 0)).symm
 
+set_option backward.isDefEq.respectTransparency false in
 /-- In a six-term exact window with the two neighbours `obj 1` and `obj 4` of the central map
 `obj 2 ⟶ obj 3` both zero, that central map is an isomorphism, giving `obj 2 ≅ obj 3`. Used to
 collapse each six-term window `Tₙ(K) → Tₙ(P) → Tₙ(M) → Tₙ₋₁(K) → Tₙ₋₁(P) → Tₙ₋₁(M)` to
@@ -267,12 +325,14 @@ noncomputable def iso_of_sixTerm_exact
     {D : Type*} [Category D] [Abelian D] {W : ComposableArrows D 5}
     (hW : W.Exact) (h1 : IsZero (W.obj 1)) (h4 : IsZero (W.obj 4)) :
     W.obj 2 ≅ W.obj 3 := by
-  haveI : Mono (W.map' 2 3) := (hW.exact' 1 2 3).mono_g (h1.eq_of_src _ _)
-  haveI : Epi (W.map' 2 3) := (hW.exact' 2 3 4).epi_f (h4.eq_of_tgt _ _)
   let g : W.obj 2 ⟶ W.obj 3 := W.map' 2 3
+  haveI : Mono g := (hW.exact' 1 2 3).mono_g (h1.eq_of_src _ _)
+  haveI : Epi g := (hW.exact' 2 3 4).epi_f (h4.eq_of_tgt _ _)
   haveI : IsIso g := isIso_of_mono_of_epi _
   exact asIso g
 
+set_option backward.defeqAttrib.useBackward true in
+set_option backward.isDefEq.respectTransparency false in
 /-- **Naturality of the degree-0 balancing isomorphism** in the right module. For a map
 `f : M ⟶ M'` of right `A`-modules, the square relating `balancingIsoZero A N M` and
 `balancingIsoZero A N M'` commutes: the `Tor`-side functoriality `(TorFunctor A N 0).map f` and

--- a/EtingofRepresentationTheory/Chapter8/Problem8_2_6_ii_Crux.lean
+++ b/EtingofRepresentationTheory/Chapter8/Problem8_2_6_ii_Crux.lean
@@ -172,8 +172,8 @@ lemma homEquivDeg_δ_one (z : Cochain (barCochainComplex k A W) (singleV A V) 1)
     Cochain.toSingleEquiv_toSingleMk, Cochain.toSingleEquiv_toSingleMk,
     ProjectiveResolution.cochainComplex_d (Etingof.barResolution k A W)
       (-((2 : ℕ) : ℤ)) (-((1 : ℕ) : ℤ)) 2 1 (by norm_num) (by norm_num), hd21]
-  simp only [Category.assoc, Iso.inv_hom_id_assoc, ModuleCat.hom_comp, ModuleCat.hom_ofHom,
-    LinearMap.comp_assoc]
+  simp only [Category.assoc, Iso.inv_hom_id_assoc, ModuleCat.hom_comp]
+  rfl
 
 /-- Under `homEquivDeg`, the coboundary `δ 0 1 β` becomes `-(barDiff 0)` precomposed:
 `homEquivDeg 1 (δ 0 1 β) = -((homEquivDeg 0 β) ∘ₗ barDiff 0)`. -/
@@ -189,7 +189,8 @@ lemma homEquivDeg_δ_zero (β : Cochain (barCochainComplex k A W) (singleV A V) 
     ProjectiveResolution.cochainComplex_d (Etingof.barResolution k A W)
       (-((1 : ℕ) : ℤ)) (-((0 : ℕ) : ℤ)) 1 0 (by norm_num) (by norm_num), hd10]
   simp only [Preadditive.comp_neg, Category.assoc, Iso.inv_hom_id_assoc, ModuleCat.hom_neg,
-    ModuleCat.hom_comp, ModuleCat.hom_ofHom, LinearMap.comp_assoc]
+    ModuleCat.hom_comp]
+  rfl
 
 /-! ### Cocycle correspondence -/
 
@@ -276,7 +277,7 @@ lemma Ψ1_δ_zero_eq (β : Cochain (barCochainComplex k A W) (singleV A V) 0) :
       show a ⊗ₜ[k] (barCoeffZeroEquiv k A W).symm w
           = a • ((1 : A) ⊗ₜ[k] (barCoeffZeroEquiv k A W).symm w) by
         rw [TensorProduct.smul_tmul', smul_eq_mul, mul_one],
-      map_smul, ← hΨ0 w, ← hΨ0 (a • w)]
+      g0.map_smul, ← hΨ0 w, ← hΨ0 (a • w)]
     abel
   have hΨ1 : Ψ1 k A W V (δ 0 1 β)
       = coeffEquiv1 k A W V (-(g0.comp (barDiff k A W 0))) := by
@@ -297,59 +298,117 @@ lemma Ψ1_δ_zero_mem_coboundaries
 
 /-! ### The isomorphism -/
 
-/-- **Problem 8.2.6(ii).** The degree-`1` cohomology of `Hom(barResolution, V)` is
-canonically isomorphic to `Ext¹` in the cocycle/coboundary presentation of Problem 3.9.1. -/
-noncomputable def cohomologyClassEquivExt1 :
-    CohomologyClass (barCochainComplex k A W) (singleV A V) 1
-      ≃+ Problem3_9_1.Ext1 k A V W := by
-  -- `Ψ1` carries cocycle cochains bijectively onto `Problem3_9_1`-cocycles.
+/-- The degree-`1` bar cocycles are additively equivalent to the cocycles of
+Problem 3.9.1.  On underlying cochains this is exactly the tensor–hom chart `Ψ1`. -/
+noncomputable def barCocycleEquivProblem3Cocycle :
+    Cocycle (barCochainComplex k A W) (singleV A V) 1 ≃+
+      ↥(Problem3_9_1.cocycles k A V W) := by
   have hcocy : (cocycle (barCochainComplex k A W) (singleV A V) 1).map
         ((Ψ1 k A W V).toAddMonoidHom)
       = (Problem3_9_1.cocycles k A V W).toAddSubgroup := by
     ext F
-    simp only [AddSubgroup.mem_map, AddEquiv.coe_toAddMonoidHom, Submodule.mem_toAddSubgroup]
+    simp only [AddSubgroup.mem_map, AddEquiv.coe_toAddMonoidHom,
+      Submodule.mem_toAddSubgroup]
     constructor
     · rintro ⟨z, hz, rfl⟩
-      exact (isCocycle_Ψ1_iff k A W V z).mpr ((Cocycle.mem_iff 1 2 (by norm_num) z).mp hz)
+      exact (isCocycle_Ψ1_iff k A W V z).mpr
+        ((Cocycle.mem_iff 1 2 (by norm_num) z).mp hz)
     · intro hF
-      refine ⟨(Ψ1 k A W V).symm F, (Cocycle.mem_iff 1 2 (by norm_num) _).mpr ?_, by simp⟩
-      rw [← isCocycle_Ψ1_iff, AddEquiv.apply_symm_apply]; exact hF
-  set e : Cocycle (barCochainComplex k A W) (singleV A V) 1 ≃+
+      refine ⟨(Ψ1 k A W V).symm F,
+        (Cocycle.mem_iff 1 2 (by norm_num) _).mpr ?_, by simp⟩
+      rw [← isCocycle_Ψ1_iff, AddEquiv.apply_symm_apply]
+      exact hF
+  exact
+    ((Ψ1 k A W V).addSubgroupMap
+      (cocycle (barCochainComplex k A W) (singleV A V) 1)).trans
+      (AddEquiv.addSubgroupCongr hcocy)
+
+@[simp]
+theorem barCocycleEquivProblem3Cocycle_coe
+    (z : Cocycle (barCochainComplex k A W) (singleV A V) 1) :
+    ((barCocycleEquivProblem3Cocycle k A W V z :
+        ↥(Problem3_9_1.cocycles k A V W)) : A →ₗ[k] W →ₗ[k] V) =
+      Ψ1 k A W V (z : Cochain (barCochainComplex k A W) (singleV A V) 1) :=
+  rfl
+
+/-- On elements, the cocycle comparison is the tensor–hom chart: evaluate the bar cochain on
+`1 ⊗ (a ⊗ w)`. -/
+@[simp]
+theorem barCocycleEquivProblem3Cocycle_apply
+    (z : Cocycle (barCochainComplex k A W) (singleV A V) 1) (a : A) (w : W) :
+    (barCocycleEquivProblem3Cocycle k A W V z :
+        ↥(Problem3_9_1.cocycles k A V W)).1 a w =
+      homEquivDeg k A W V 1
+        (z : Cochain (barCochainComplex k A W) (singleV A V) 1)
+        ((1 : A) ⊗ₜ[k] ((tprod k ![a]) ⊗ₜ[k] w)) := by
+  rw [barCocycleEquivProblem3Cocycle_coe]
+  exact coeffEquiv1_apply k A W V _ a w
+
+/-- The Problem-3.9.1 coboundaries, regarded as an additive subgroup of its cocycles. -/
+abbrev problem3CoboundariesInCocycles (k A V W : Type u)
+    [Field k] [Ring A] [Algebra k A]
+    [AddCommGroup V] [Module k V] [Module A V] [IsScalarTower k A V]
+    [AddCommGroup W] [Module k W] [Module A W] [IsScalarTower k A W] :
+    AddSubgroup ↥(Problem3_9_1.cocycles k A V W) :=
+  ((Problem3_9_1.coboundaries k A V W).submoduleOf
+    (Problem3_9_1.cocycles k A V W)).toAddSubgroup
+
+/-- The bar-coboundary subgroup is carried exactly onto the Problem-3.9.1
+coboundary subgroup by `barCocycleEquivProblem3Cocycle`. -/
+theorem barCocycleEquivProblem3Cocycle_map_coboundaries :
+    (coboundaries (barCochainComplex k A W) (singleV A V) 1).map
+        (barCocycleEquivProblem3Cocycle k A W V).toAddMonoidHom =
+      problem3CoboundariesInCocycles k A V W := by
+  let e : Cocycle (barCochainComplex k A W) (singleV A V) 1 ≃+
       ↥(Problem3_9_1.cocycles k A V W) :=
-    ((Ψ1 k A W V).addSubgroupMap (cocycle (barCochainComplex k A W) (singleV A V) 1)).trans
-      (AddEquiv.addSubgroupCongr hcocy) with he_def
-  -- The coercion of `e` is `Ψ1` on the underlying cochain.
-  have he_coe : ∀ x : Cocycle (barCochainComplex k A W) (singleV A V) 1,
-      ((e x : ↥(Problem3_9_1.cocycles k A V W)) : A →ₗ[k] W →ₗ[k] V)
-        = Ψ1 k A W V (x : Cochain (barCochainComplex k A W) (singleV A V) 1) :=
-    fun _ => rfl
+    barCocycleEquivProblem3Cocycle k A W V
   have hmem : ∀ c : ↥(Problem3_9_1.cocycles k A V W),
       c ∈ (Problem3_9_1.coboundaries k A V W).submoduleOf (Problem3_9_1.cocycles k A V W)
         ↔ (↑c : A →ₗ[k] W →ₗ[k] V) ∈ Problem3_9_1.coboundaries k A V W :=
     fun _ => Submodule.mem_comap
-  have he : (coboundaries (barCochainComplex k A W) (singleV A V) 1).map (e.toAddMonoidHom)
-      = ((Problem3_9_1.coboundaries k A V W).submoduleOf
-          (Problem3_9_1.cocycles k A V W)).toAddSubgroup := by
-    ext c
-    simp only [AddSubgroup.mem_map, AddEquiv.coe_toAddMonoidHom, Submodule.mem_toAddSubgroup, hmem]
-    constructor
-    · rintro ⟨x, hx, rfl⟩
-      obtain ⟨β, hβ⟩ := (mem_coboundaries_iff x 0 (by norm_num)).mp hx
-      rw [he_coe, ← hβ, Ψ1_δ_zero_eq]
-      exact Submodule.subset_span (Set.mem_range_self _)
-    · intro hc
-      obtain ⟨X, hX⟩ := (Problem3_9_1.mem_coboundaries_iff k A V W _).mp hc
-      refine ⟨e.symm c, ?_, by simp⟩
-      rw [mem_coboundaries_iff _ 0 (by norm_num)]
-      refine ⟨(Ψ0 k A W V).symm (-X), ?_⟩
-      apply (Ψ1 k A W V).injective
-      have h1 : Ψ1 k A W V (↑(e.symm c)) = (↑c : A →ₗ[k] W →ₗ[k] V) := by
-        rw [← he_coe (e.symm c), AddEquiv.apply_symm_apply]
-      have hcoe : (↑(e.symm c) : Cochain (barCochainComplex k A W) (singleV A V) 1)
-          = (Ψ1 k A W V).symm (↑c : A →ₗ[k] W →ₗ[k] V) :=
-        (AddEquiv.eq_symm_apply (Ψ1 k A W V)).mpr h1
-      rw [Ψ1_δ_zero_eq, AddEquiv.apply_symm_apply, neg_neg, hcoe, AddEquiv.apply_symm_apply, hX]
-  exact QuotientAddGroup.congr _ _ e he
+  ext c
+  simp only [AddSubgroup.mem_map, AddEquiv.coe_toAddMonoidHom,
+    Submodule.mem_toAddSubgroup, hmem]
+  constructor
+  · rintro ⟨x, hx, rfl⟩
+    obtain ⟨β, hβ⟩ := (mem_coboundaries_iff x 0 (by norm_num)).mp hx
+    rw [barCocycleEquivProblem3Cocycle_coe, ← hβ, Ψ1_δ_zero_eq]
+    exact Submodule.subset_span (Set.mem_range_self _)
+  · intro hc
+    obtain ⟨X, hX⟩ := (Problem3_9_1.mem_coboundaries_iff k A V W _).mp hc
+    refine ⟨e.symm c, ?_, by simp [e]⟩
+    rw [mem_coboundaries_iff _ 0 (by norm_num)]
+    refine ⟨(Ψ0 k A W V).symm (-X), ?_⟩
+    apply (Ψ1 k A W V).injective
+    have h1 : Ψ1 k A W V (↑(e.symm c)) = (↑c : A →ₗ[k] W →ₗ[k] V) := by
+      rw [← barCocycleEquivProblem3Cocycle_coe k A W V (e.symm c)]
+      simp [e]
+    have hcoe : (↑(e.symm c) : Cochain (barCochainComplex k A W) (singleV A V) 1)
+        = (Ψ1 k A W V).symm (↑c : A →ₗ[k] W →ₗ[k] V) :=
+      (AddEquiv.eq_symm_apply (Ψ1 k A W V)).mpr h1
+    rw [Ψ1_δ_zero_eq, AddEquiv.apply_symm_apply, neg_neg, hcoe,
+      AddEquiv.apply_symm_apply, hX]
+
+/-- **Problem 8.2.6(ii).** The degree-`1` cohomology of `Hom(barResolution, V)` is
+canonically isomorphic to `Ext¹` in the cocycle/coboundary presentation of Problem 3.9.1. -/
+noncomputable def cohomologyClassEquivExt1 :
+    CohomologyClass (barCochainComplex k A W) (singleV A V) 1
+      ≃+ Problem3_9_1.Ext1 k A V W :=
+  QuotientAddGroup.congr _ _ (barCocycleEquivProblem3Cocycle k A W V)
+    (barCocycleEquivProblem3Cocycle_map_coboundaries k A W V)
+
+set_option maxHeartbeats 1000000 in
+-- Unfolding the quotient congruence is expensive because its source is a nested
+-- cocycle/coboundary subtype quotient, so give this representative formula local headroom.
+/-- The canonical cohomology comparison sends a represented bar-cohomology class to the
+class of the corresponding Problem-3.9.1 cocycle. -/
+@[simp]
+theorem cohomologyClassEquivExt1_mk
+    (z : Cocycle (barCochainComplex k A W) (singleV A V) 1) :
+    cohomologyClassEquivExt1 k A W V (CohomologyClass.mk z) =
+      QuotientAddGroup.mk'
+        (problem3CoboundariesInCocycles k A V W)
+        (barCocycleEquivProblem3Cocycle k A W V z) :=
+  rfl
 
 end Etingof
-

--- a/progress/items.json
+++ b/progress/items.json
@@ -9207,11 +9207,10 @@
     "start_line": 9,
     "end_line": 22,
     "status": "sorry_free",
-    "coverage_note": "Substantial local Tor/Ext results are proved. Two API/fidelity gaps remain: part (ii) hides its canonical Ext¹ comparison inside Nonempty (#6298), while parts (iii) and (v) expose only independent six-term windows rather than coherent natural long exact sequences and omit their zero-ended degree-zero assertions (#7421).",
+    "coverage_note": "Substantial local Tor/Ext results are proved. Part (ii) now exposes a named canonical Ext¹ AddEquiv, its factorization through bar-resolution cohomology, and representative-level tensor–hom computation theorems. The remaining gap is that parts (iii) and (v) expose only independent six-term windows rather than coherent natural long exact sequences and omit their zero-ended degree-zero assertions (#7421).",
     "coverage": "covered_partial",
-    "fidelity_issue": 6298,
     "followup_issue": 7421,
-    "last_updated": "2026-07-22"
+    "last_updated": "2026-07-27"
   },
   {
     "id": "Chapter8/Problem8.2.7",


### PR DESCRIPTION
Closes #6298.

Exposes the canonical additive equivalence from categorical `Ext¹_A(W,V)` to the Problem 3.9.1 cocycle quotient. It also exposes the bar-cocycle equivalence, its exact coboundary correspondence, the tensor–hom evaluation formula, and an `extMk` generator computation theorem. The existing `Problem_8_2_6_ii` `Nonempty` statement is now an immediate corollary. Metadata retains only the separate #7421 long-exact-sequence gap.

Validation:
- `lake build EtingofRepresentationTheory.Chapter8.Problem8_2_6`
- full CI-equivalent build: 9,346 jobs
- warning ratchet: no new warnings
- `python3 scripts/validate_items.py`
- trust-hole guard and axiom audit: standard `propext`, `Classical.choice`, `Quot.sound` only