### PR TITLE
Prove that B_n exhaust the Morita class

### DIFF
--- a/EtingofRepresentationTheory/Chapter9/Introduction_9_7_Morita.lean
+++ b/EtingofRepresentationTheory/Chapter9/Introduction_9_7_Morita.lean
@@ -1,10 +1,16 @@
 import EtingofRepresentationTheory.Chapter9.Introduction_9_7
 import EtingofRepresentationTheory.Chapter9.Theorem9_6_4
 import EtingofRepresentationTheory.Chapter9.Definition9_7_1
+import EtingofRepresentationTheory.Chapter2.Problem2_3_17
+import EtingofRepresentationTheory.Infrastructure.FGModuleCatEnoughProjectives
+import EtingofRepresentationTheory.Infrastructure.MoritaFGRestriction
+import Mathlib.Algebra.Category.FGModuleCat.Colimits
+import Mathlib.Algebra.Category.ModuleCat.ChangeOfRings
 import Mathlib.CategoryTheory.Conj
+import Mathlib.CategoryTheory.Limits.Preserves.Shapes.Biproducts
 import Mathlib.Algebra.Ring.Equiv
 
-universe u v
+universe w u u' v
 
 /-!
 # §9.7 capstone: the `B_𝐧` enumerate the Morita class of `𝒞`
@@ -42,14 +48,15 @@ isomorphisms `≃+*` rather than `k`-algebra isomorphisms.
 * `Etingof.Bn`: the algebra `B_𝐧(𝒞) = (End P_𝐧)ᵐᵒᵖ`.
 * `Etingof.nonempty_equivalence_fgModuleCat_Bn`, each `B_𝐧` realizes `𝒞`:
   `𝒞 ≌ FGModuleCat (B_𝐧)` (the `⊇` of the book's claim).
-* `Etingof.ringEquiv_endOp_iff_isBn`, the capstone biconditional: a ring `A` is
-  (isomorphic to) the endomorphism algebra `(End Q)ᵐᵒᵖ` of some progenerator `Q` of
-  `𝒞` iff `A ≃+* B_𝐧` for some `𝐧` with all `nᵢ ≥ 1`. Via Theorem 9.6.4 the
-  left-hand side is exactly "`A`'s module category is `𝒞`", so this is precisely
-  Etingof's "the `B_𝐧` are all the algebras whose module category is `𝒞`".
-* `Etingof.nonempty_fgModuleCat_equivalence_of_isBn`, the Discussion restatement:
-  all the `B_𝐧` lie in a single Morita class (their module categories are mutually
-  equivalent, both being `𝒞`).
+* `Etingof.ringEquiv_endOp_iff_isBn` classifies endomorphism rings already presented by a
+  progenerator.
+* `Etingof.nonempty_fgModuleCat_equivalence_iff_isBn` supplies the missing Morita
+  reconstruction from an arbitrary equivalence `FGModuleCat A ≌ 𝒞`, proving that these and
+  only these rings are the `B_𝐧`.
+* `Etingof.moritaEquivalentFmod_iff_isBn` is the Discussion's global restatement: the
+  entire Morita class of any one positive `B_𝐧` is exactly the positive `B_𝐧` family.
+* `Etingof.nonempty_fgModuleCat_equivalence_of_isBn` records the forward containment
+  separately: any two positive `B_𝐧` have equivalent finitely generated module categories.
 -/
 
 open CategoryTheory CategoryTheory.Limits
@@ -58,6 +65,7 @@ namespace CategoryTheory.Iso
 
 variable {C : Type u} [Category.{v} C] [Preadditive C] {X Y : C}
 
+set_option backward.isDefEq.respectTransparency false in
 /-- Conjugation by an isomorphism `e : X ≅ Y` as a ring isomorphism of endomorphism
 rings, `End X ≃+* End Y`, `f ↦ e.inv ≫ f ≫ e.hom`. This upgrades Mathlib's multiplicative
 `Iso.conj` with additivity, which holds because composition is bilinear in a preadditive
@@ -77,6 +85,98 @@ end CategoryTheory.Iso
 namespace Etingof
 
 variable {C : Type u} [Category.{v} C]
+
+/-! ## Recovering a progenerator from a module-category equivalence -/
+
+/-- The regular module, regarded as an object of the finitely generated module category. -/
+noncomputable def fgModuleCatRegular (A : Type u) [Ring A] : FGModuleCat.{u} A :=
+  FGModuleCat.of A A
+
+/-- The regular module is a progenerator of `FGModuleCat A`: it is projective, and every
+finitely generated module is a quotient of a finite-rank free module. -/
+theorem fgModuleCatRegular_isProgenerator (A : Type u) [Ring A] :
+    IsProgenerator (fgModuleCatRegular A) := by
+  letI : HasFiniteBiproducts (FGModuleCat.{u} A) :=
+    HasFiniteBiproducts.of_hasFiniteCoproducts
+  let R := fgModuleCatRegular A
+  have hproj : Projective R :=
+    FGModuleCat.projective_of_forget₂_projective
+      (inferInstanceAs (Projective (ModuleCat.of A A)))
+  refine { toProjective := hproj, epiFromBiproduct := fun X => ?_ }
+  obtain ⟨n, l, hl⟩ := Module.Finite.exists_fin' (R := A) (M := X)
+  let F : Fin n → FGModuleCat.{u} A := fun _ => R
+  letI : PreservesBiproduct F (FGModuleCat.incl A) :=
+    preservesBiproduct_of_preservesCoproduct (FGModuleCat.incl A)
+  let free : FGModuleCat.{u} A := FGModuleCat.of A (Fin n → A)
+  let eUnder : (FGModuleCat.incl A).obj free ≅
+      (FGModuleCat.incl A).obj (⨁ F) :=
+    (ModuleCat.biproductIsoPi (fun _ : Fin n => ModuleCat.of A A)).symm.trans
+      ((FGModuleCat.incl A).mapBiproduct F).symm
+  let e : free ≅ ⨁ F := (ModuleCat.isFG A).isoMk eUnder
+  let f : (⨁ F) ⟶ X := e.inv ≫ FGModuleCat.ofHom l
+  refine ⟨n, inferInstance, f, ?_⟩
+  apply FGModuleCat.epi_of_forget₂_epi f
+  rw [Functor.map_comp]
+  haveI : Epi ((FGModuleCat.incl A).map (FGModuleCat.ofHom l)) :=
+    (ModuleCat.epi_iff_surjective _).mpr hl
+  exact epi_comp _ _
+
+/-- An equivalence between preadditive categories with finite biproducts carries finite
+progenerators to finite progenerators. -/
+theorem IsProgenerator.map_equivalence
+    {C : Type u} [Category.{v} C] [Preadditive C] [HasFiniteBiproducts C]
+    {D : Type u'} [Category.{v} D] [Preadditive D] [HasFiniteBiproducts D]
+    (E : C ≌ D) (P : C) (hP : IsProgenerator P) :
+    IsProgenerator (E.functor.obj P) := by
+  letI : E.functor.Additive :=
+    letI : E.functor.IsEquivalence := E.isEquivalence_functor
+    Functor.additive_of_preserves_binary_products E.functor
+  letI : Functor.PreservesEpimorphisms E.functor :=
+    Functor.preservesEpimorphisms_of_adjunction E.toAdjunction
+  have hproj : Projective (E.functor.obj P) :=
+    (E.map_projective_iff P).mpr hP.toProjective
+  refine { toProjective := hproj, epiFromBiproduct := fun X => ?_ }
+  obtain ⟨n, hbp, f, hf⟩ := hP.epiFromBiproduct (E.inverse.obj X)
+  let F : Fin n → C := fun _ => P
+  haveI : HasBiproduct F := hbp
+  let g : (⨁ fun _ : Fin n => E.functor.obj P) ⟶ X :=
+    (E.functor.mapBiproduct F).inv ≫ E.functor.map f ≫ (E.counitIso.app X).hom
+  refine ⟨n, inferInstance, g, ?_⟩
+  haveI : Epi f := hf
+  haveI : Epi (E.functor.map f) := inferInstance
+  have htail : Epi (E.functor.map f ≫ (E.counitIso.app X).hom) := epi_comp _ _
+  haveI := htail
+  exact epi_comp _ _
+
+/-- Endomorphisms of the regular object in `FGModuleCat A` are the usual `A`-linear
+endomorphisms of the left regular module. -/
+noncomputable def fgModuleCatRegularEndRingEquiv (A : Type u) [Ring A] :
+    End (fgModuleCatRegular A) ≃+* Module.End A A where
+  toFun f := f.hom.hom
+  invFun f := FGModuleCat.ofHom f
+  left_inv f := by apply FGModuleCat.hom_ext; rfl
+  right_inv _ := rfl
+  map_mul' _ _ := rfl
+  map_add' _ _ := rfl
+
+/-- The opposite endomorphism ring of the regular object of `FGModuleCat A` recovers `A`.
+This is the categorical form of `End_A(A) = Aᵒᵖ`. -/
+noncomputable def ringEquiv_fgModuleCatRegularEndOp (A : Type u) [Ring A] :
+    A ≃+* (End (fgModuleCatRegular A))ᵐᵒᵖ :=
+  (((RingEquiv.op ((fgModuleCatRegularEndRingEquiv A).trans (EndSelfEquivOp A))).trans
+    (RingEquiv.opOp A).symm)).symm
+
+/-- A categorical equivalence between preadditive categories induces a ring isomorphism between
+the endomorphism rings of an object and its image. -/
+noncomputable def equivalenceEndRingEquiv
+    {C : Type u} [Category.{v} C] [Preadditive C] [HasFiniteBiproducts C]
+    {D : Type u'} [Category.{v} D] [Preadditive D] [HasFiniteBiproducts D]
+    (E : C ≌ D) (X : C) : End X ≃+* End (E.functor.obj X) := by
+  letI : E.functor.Additive :=
+    letI : E.functor.IsEquivalence := E.isEquivalence_functor
+    Functor.additive_of_preserves_binary_products E.functor
+  exact { E.fullyFaithfulFunctor.mulEquivEnd X with
+    map_add' := fun _ _ => E.functor.map_add }
 
 /-- **`B_𝐧(𝒞) = End(P_𝐧)ᵒᵖ`** (Etingof §9.7): the (opposite of the) endomorphism ring of
 the multiplicity biproduct `P_𝐧 = ⊕ᵢ nᵢ Pᵢ`. The opposite matches the convention of
@@ -126,12 +226,85 @@ theorem ringEquiv_endOp_iff_isBn
     haveI : IsProgenerator (multBiproduct P n) := isProgenerator_multBiproduct P n hn
     exact ⟨multBiproduct P n, inferInstance, ⟨φ⟩⟩
 
-/-- **Discussion after Definition 9.7.1: the `B_𝐧` form a single Morita class.**
+/-- **§9.7 capstone, stated for an arbitrary module-category equivalence.**
+
+Let `C` be a finite abelian category over `k`, and let `P` enumerate its indecomposable
+projectives. For any ring `A`, the category `FGModuleCat A` is equivalent to `C` if and only if
+`A` is isomorphic to one of the rings `B_𝐧(C)`, with every multiplicity positive.
+
+The forward implication is the Morita reconstruction missing from
+`ringEquiv_endOp_iff_isBn`: transport the regular `A`-module across the supplied equivalence.
+Its image is a progenerator `Q` of `C`, and full faithfulness identifies
+`A ≃+* (End Q)ᵐᵒᵖ`; the projective-generator classification then identifies `Q` with
+some `P_𝐧`. The reverse implication combines change of rings with Theorem 9.6.4.
+
+The conclusion is deliberately a ring isomorphism. A bare categorical equivalence need not be
+`k`-linear (it may twist scalars by a field automorphism), so a `k`-algebra isomorphism would
+require a `k`-linear equivalence hypothesis. -/
+theorem nonempty_fgModuleCat_equivalence_iff_isBn
+    {k : Type w} [Field k] [Linear k C] [IsFiniteAbelianCategoryOverField k C]
+    (hproj : ∀ i, Projective (P i)) (hindec : ∀ i, Indecomposable (P i))
+    (hdistinct : ∀ i j, Nonempty (P i ≅ P j) → i = j)
+    (hcomplete : ∀ R : C, Projective R → Indecomposable R → ∃ i, Nonempty (R ≅ P i))
+    [IsProgenerator (⨁ P)] (A : Type v) [Ring A] :
+    Nonempty (FGModuleCat.{v} A ≌ C) ↔
+      ∃ n : ι → ℕ, (∀ i, 1 ≤ n i) ∧ Nonempty (A ≃+* Bn P n) := by
+  letI : HasFiniteBiproducts (FGModuleCat.{v} A) :=
+    HasFiniteBiproducts.of_hasFiniteCoproducts
+  constructor
+  · rintro ⟨E⟩
+    let R := fgModuleCatRegular A
+    let Q := E.functor.obj R
+    have hR : IsProgenerator R := fgModuleCatRegular_isProgenerator A
+    have hQ : IsProgenerator Q := hR.map_equivalence E
+    let endEquiv : End R ≃+* End Q := equivalenceEndRingEquiv E R
+    let ringEquiv : A ≃+* (End Q)ᵐᵒᵖ :=
+      (ringEquiv_fgModuleCatRegularEndOp A).trans (RingEquiv.op endEquiv)
+    exact (ringEquiv_endOp_iff_isBn P hproj hindec hdistinct hcomplete A).mp
+      ⟨Q, hQ, ⟨ringEquiv⟩⟩
+  · rintro ⟨n, hn, ⟨e⟩⟩
+    haveI : IsNoetherianRing (Bn P n) :=
+      isNoetherianRing_endOp_of_overField (k := k) (multBiproduct P n)
+    let full : ModuleCat.{v} A ≌ ModuleCat.{v} (Bn P n) :=
+      (ModuleCat.restrictScalarsEquivalenceOfRingEquiv e).symm
+    obtain ⟨fg⟩ :=
+      MoritaEquivalent.fgModuleCatEquiv (⟨full⟩ : MoritaEquivalent A (Bn P n))
+    obtain ⟨eC⟩ := nonempty_equivalence_fgModuleCat_Bn P hproj n hn
+    exact ⟨fg.trans eC.symm⟩
+
+/-- **Discussion after Definition 9.7.1: the whole Morita class is the `B_𝐧` family.**
+
+Fix one positive multiplicity vector `n₀`. A ring `A` is Morita equivalent, in the book's
+finitely generated-module sense, to `B_(n₀)` if and only if `A` is isomorphic to some
+`B_𝐧(C)` with positive multiplicities. Thus the Morita equivalence class is exactly the
+family advertised in the Discussion, not merely a family contained in one class. -/
+theorem moritaEquivalentFmod_iff_isBn
+    {k : Type w} [Field k] [Linear k C] [IsFiniteAbelianCategoryOverField k C]
+    (hproj : ∀ i, Projective (P i)) (hindec : ∀ i, Indecomposable (P i))
+    (hdistinct : ∀ i j, Nonempty (P i ≅ P j) → i = j)
+    (hcomplete : ∀ R : C, Projective R → Indecomposable R → ∃ i, Nonempty (R ≅ P i))
+    [IsProgenerator (⨁ P)] (A : Type v) [Ring A]
+    (n₀ : ι → ℕ) (hn₀ : ∀ i, 1 ≤ n₀ i) :
+    MoritaEquivalentFmod A (Bn P n₀) ↔
+      ∃ n : ι → ℕ, (∀ i, 1 ≤ n i) ∧ Nonempty (A ≃+* Bn P n) := by
+  haveI : IsNoetherianRing (Bn P n₀) :=
+    isNoetherianRing_endOp_of_overField (k := k) (multBiproduct P n₀)
+  obtain ⟨eC⟩ := nonempty_equivalence_fgModuleCat_Bn P hproj n₀ hn₀
+  rw [MoritaEquivalentFmod]
+  constructor
+  · rintro ⟨e⟩
+    exact (nonempty_fgModuleCat_equivalence_iff_isBn (k := k) P hproj hindec hdistinct
+      hcomplete A).mp ⟨e.trans eC.symm⟩
+  · intro h
+    obtain ⟨e⟩ := (nonempty_fgModuleCat_equivalence_iff_isBn (k := k) P hproj hindec
+      hdistinct hcomplete A).mpr h
+    exact ⟨e.trans eC⟩
+
+/-- **The positive `B_𝐧` all belong to one Morita class.**
 
 Any two members `B_𝐧` and `B_𝐧'` of the family have equivalent module categories (both
-are equivalent to `𝒞`), so they are Morita equivalent. This is the precise content of
-"Morita equivalence classes of finite dimensional algebras are the collections
-`{B_𝐧(𝒞), 𝐧 ∈ ℕᵐ}`". -/
+are equivalent to `𝒞`), so they are Morita equivalent. The converse containment, which
+says that every ring in this class is one of the `B_𝐧`, is `moritaEquivalentFmod_iff_isBn`. -/
 theorem nonempty_fgModuleCat_equivalence_of_isBn
     (hproj : ∀ i, Projective (P i)) [IsProgenerator (⨁ P)]
     (n n' : ι → ℕ) (hn : ∀ i, 1 ≤ n i) (hn' : ∀ i, 1 ≤ n' i)

--- a/progress/coverage-audit/coverage-verdicts-Chapter9.json
+++ b/progress/coverage-audit/coverage-verdicts-Chapter9.json
@@ -31,8 +31,8 @@
         "source_span": "Thus, we obtain that Morita equivalence classes of finite dimensional algebras are the collections of the form $\\{B_{\\mathbf{n}}(\\mathcal{C}), \\mathbf{n} \\in \\mathbb{N}^m\\}$.",
         "claim": "The Morita equivalence class of C is exactly {B_n(C) | n in N^m, all n_i >= 1}",
         "verdict": "covered_elsewhere",
-        "lean_decl": "Etingof.nonempty_fgModuleCat_equivalence_of_isBn",
-        "reason": "Formalized in Introduction_9_7_Morita.lean: `Etingof.nonempty_fgModuleCat_equivalence_of_isBn` (all B_n are Morita equivalent) and `Etingof.ringEquiv_endOp_iff_isBn` (the B_n are exactly all algebras whose module category is C).",
+        "lean_decl": "Etingof.moritaEquivalentFmod_iff_isBn",
+        "reason": "Proved in Introduction_9_7_Morita.lean: `Etingof.moritaEquivalentFmod_iff_isBn` says that a ring A lies in the book-faithful Morita class of one positive B_n(C) iff A is ring-isomorphic to some positive B_n(C). The reverse Morita reconstruction is `Etingof.nonempty_fgModuleCat_equivalence_iff_isBn`.",
         "dedup_issue": null
       }
     ]
@@ -111,8 +111,8 @@
         "source_span": "Defining $B_{\\mathbf{n}} = B_{\\mathbf{n}}(\\mathcal{C}) := \\operatorname{End}(P_{\\mathbf{n}})^{\\mathrm{op}}$, we see that the algebras $B_{\\mathbf{n}}$ are all the finite dimensional algebras whose category of finite dimensional modules is equivalent to $\\mathcal{C}$.",
         "claim": "The algebras B_n = End(P_n)^op are exactly all algebras A with A-fmod equivalent to C",
         "verdict": "covered_elsewhere",
-        "lean_decl": "Etingof.ringEquiv_endOp_iff_isBn",
-        "reason": "Proved in Introduction_9_7_Morita.lean: `theorem Etingof.ringEquiv_endOp_iff_isBn` gives the biconditional that A is iso to (End Q)^op for some progenerator Q iff A is iso to some B_n.",
+        "lean_decl": "Etingof.nonempty_fgModuleCat_equivalence_iff_isBn",
+        "reason": "Proved in Introduction_9_7_Morita.lean: `Etingof.nonempty_fgModuleCat_equivalence_iff_isBn` reconstructs a progenerator from an arbitrary equivalence FGModuleCat A ≌ C and proves the required biconditional with A ring-isomorphic to some positive B_n. `Etingof.ringEquiv_endOp_iff_isBn` supplies the subsequent progenerator classification step.",
         "dedup_issue": null
       }
     ]


### PR DESCRIPTION
Closes #5147.

## What changed

- reconstruct the image of the regular `A`-module as a progenerator from an arbitrary equivalence `FGModuleCat A ≌ C`
- identify `A` with the opposite endomorphism ring of that transported progenerator
- prove `nonempty_fgModuleCat_equivalence_iff_isBn`, the requested biconditional classifying all rings whose finitely generated module category is equivalent to `C`
- prove `moritaEquivalentFmod_iff_isBn`, stating that the full book-faithful Morita class is exactly the positive `B_n(C)` family
- update Chapter 9 coverage metadata to point to the stronger reverse reconstruction and global class theorem

## Root cause

The previous capstone only classified rings already supplied as `(End Q)ᵐᵒᵖ` for a progenerator `Q`. It did not reconstruct `Q` from an arbitrary equivalence of finitely generated module categories, so it established only that the constructed `B_n` lie in one class, not that they exhaust it.

The resulting isomorphisms are ring isomorphisms because the displayed hypothesis is a bare categorical equivalence. A bare equivalence need not preserve the chosen `k`-action; the file documents this distinction explicitly.

## Validation

- `lake env lean EtingofRepresentationTheory/Chapter9/Introduction_9_7_Morita.lean`
- `lake build EtingofRepresentationTheory.Chapter9.Introduction_9_7_Morita`
- `lake build EtingofRepresentationTheory.Chapter9`
- `jq empty progress/coverage-audit/coverage-verdicts-Chapter9.json`
- `git diff --check`
- changed-line scan found no `sorry`, `admit`, or `native_decide`
