### PR TITLE
Package Example 7.6.3 universal-property adjunctions

### DIFF
--- a/EtingofRepresentationTheory/Chapter7/Example7_6_3.lean
+++ b/EtingofRepresentationTheory/Chapter7/Example7_6_3.lean
@@ -6,6 +6,10 @@ import Mathlib.Algebra.MonoidAlgebra.Basic
 import Mathlib.LinearAlgebra.TensorAlgebra.Basic
 import Mathlib.LinearAlgebra.SymmetricAlgebra.Basic
 import Mathlib.CategoryTheory.Monoidal.Rigid.Braided
+import Mathlib.Algebra.Category.AlgCat.Basic
+import Mathlib.Algebra.Category.CommAlgCat.Basic
+import Mathlib.Algebra.Category.Grp.Basic
+import EtingofRepresentationTheory.Chapter2.Problem2_14_3
 
 /-!
 # Example 7.6.3: Examples of Adjoint Functors
@@ -32,10 +36,18 @@ import Mathlib.CategoryTheory.Monoidal.Rigid.Braided
   (`Ind ⊣ Res`). The book states the *opposite* direction, `Res ⊣ Ind`; for a
   finite index subgroup `Ind ≅ Coind`, so `Res` is also left adjoint to `Ind`, and
   this is `Rep.resIndAdjunction`. Both are recorded below.
-* (3) The UEA universal property is captured by `UniversalEnvelopingAlgebra.lift`.
-* (4) The group algebra universal property is `MonoidAlgebra.lift`.
-* (5) The tensor and symmetric algebra universal properties are `TensorAlgebra.lift`
-  and `SymmetricAlgebra.lift`.
+* (3) `Etingof.universalEnvelopingAdjunction` packages the universal property as the
+  genuine adjunction `U ⊣ L` between bundled Lie algebras and associative algebras.
+* (4) `Etingof.groupAlgebraAdjunction` packages `k[-] ⊣ GL₁`.
+* (5) `Etingof.tensorAlgebraAdjunction` and `Etingof.symmetricAlgebraAdjunction`
+  package the tensor- and symmetric-algebra adjunctions. Their categorical Hom
+  equivalences are natural in both variables by construction.
+
+For Lie-algebra representations, Mathlib has the necessary unbundled tensor, dual,
+and tensor–Hom equivalences but no bundled rigid representation category. This file
+therefore supplies `Etingof.FDLieRep`, its tensoring functors, and the finite-dimensional
+Lie-equivariant Hom equivalence `Etingof.tensorLieRightHomEquiv`. Packaging this last
+equivalence as a biadjunction still requires a natural rigid structure for that category.
 -/
 
 open CategoryTheory MonoidalCategory
@@ -68,6 +80,170 @@ noncomputable def Etingof.tensor_dual_adjunction_right
     tensorLeft V ⊣ tensorLeft (Vᘁ) :=
   haveI : ExactPairing (Vᘁ) V := BraidedCategory.exactPairing_swap V Vᘁ
   tensorLeftAdjunction (Vᘁ) V
+
+/-! ### Finite-dimensional Lie-algebra representations
+
+Mathlib currently treats Lie modules through typeclasses rather than a bundled
+representation category. The following category and functorial constructions make the
+finite-dimensional part of Example 7.6.3(1) precise. The final Hom equivalence is the
+expected right-adjoint equivalence on objects; unlike the group case above, it is not yet
+promoted to a `CategoryTheory.Adjunction`, because Mathlib does not currently package this
+category as rigid or provide the needed naturality API for its basis-dependent duality map.
+-/
+
+namespace Etingof
+
+/-- The category of finite-dimensional representations of a Lie algebra `L` over a field `k`. -/
+structure FDLieRep (k : Type u) [Field k] (L : Type u) [LieRing L] [LieAlgebra k L] where
+  /-- The underlying vector space. -/
+  carrier : Type u
+  [addCommGroup : AddCommGroup carrier]
+  [module : Module k carrier]
+  [lieRingModule : LieRingModule L carrier]
+  [lieModule : LieModule k L carrier]
+  [finiteDimensional : FiniteDimensional k carrier]
+
+namespace FDLieRep
+
+variable (k : Type u) [Field k] (L : Type u) [LieRing L] [LieAlgebra k L]
+
+attribute [instance] addCommGroup module lieRingModule lieModule finiteDimensional
+
+instance : CoeSort (FDLieRep k L) (Type u) := ⟨carrier⟩
+
+/-- Bundle a finite-dimensional Lie module as an object of `FDLieRep`. -/
+abbrev of (V : Type u) [AddCommGroup V] [Module k V] [LieRingModule L V]
+    [LieModule k L V] [FiniteDimensional k V] : FDLieRep k L := ⟨V⟩
+
+/-- Morphisms in `FDLieRep` are Lie-module homomorphisms. -/
+structure Hom (V W : FDLieRep k L) where
+  /-- The underlying Lie-module homomorphism. -/
+  hom : V →ₗ⁅k,L⁆ W
+
+instance : Category (FDLieRep k L) where
+  Hom := Hom k L
+  id _ := ⟨LieModuleHom.id⟩
+  comp f g := ⟨g.hom.comp f.hom⟩
+
+/-- Bundle a Lie-module homomorphism as a morphism in `FDLieRep`. -/
+abbrev ofHom {V W : Type u} [AddCommGroup V] [Module k V] [LieRingModule L V]
+    [LieModule k L V] [FiniteDimensional k V] [AddCommGroup W] [Module k W]
+    [LieRingModule L W] [LieModule k L W] [FiniteDimensional k W]
+    (f : V →ₗ⁅k,L⁆ W) : of k L V ⟶ of k L W := ⟨f⟩
+
+/-- Two morphisms in `FDLieRep` are equal when their Lie-module maps are equal. -/
+theorem hom_ext {V W : FDLieRep k L} {f g : V ⟶ W} (h : f.hom = g.hom) : f = g := by
+  match f, g with
+  | ⟨f⟩, ⟨g⟩ =>
+    cases h
+    rfl
+
+@[simp] theorem hom_id (V : FDLieRep k L) : (𝟙 V : V ⟶ V).hom = LieModuleHom.id := rfl
+
+@[simp] theorem hom_comp {U V W : FDLieRep k L} (f : U ⟶ V) (g : V ⟶ W) :
+    (f ≫ g).hom = g.hom.comp f.hom := rfl
+
+end FDLieRep
+
+variable {k : Type u} [Field k] {L : Type u} [LieRing L] [LieAlgebra k L]
+
+/-- The tensor symmetry is an equivalence of Lie modules for the diagonal action. -/
+noncomputable def lieTensorComm (V W : FDLieRep k L) :
+    TensorProduct k V W ≃ₗ⁅k,L⁆ TensorProduct k W V :=
+  { TensorProduct.comm k V W with
+    map_lie' := by
+      intro x t
+      induction t using TensorProduct.induction_on with
+      | zero => simp
+      | tmul v w => simp [TensorProduct.LieModule.lie_tmul_right, add_comm]
+      | add a b ha hb =>
+        calc
+          (TensorProduct.comm k V W) ⁅x, a + b⁆ =
+              (TensorProduct.comm k V W) (⁅x, a⁆ + ⁅x, b⁆) := by rw [lie_add]
+          _ = (TensorProduct.comm k V W) ⁅x, a⁆ +
+              (TensorProduct.comm k V W) ⁅x, b⁆ := map_add _ _ _
+          _ = ⁅x, (TensorProduct.comm k V W) a⁆ +
+              ⁅x, (TensorProduct.comm k V W) b⁆ :=
+            congrArg₂ (fun p q ↦ p + q) ha hb
+          _ = ⁅x, (TensorProduct.comm k V W) a + (TensorProduct.comm k V W) b⁆ := by
+            rw [lie_add]
+          _ = ⁅x, (TensorProduct.comm k V W) (a + b)⁆ := by rw [map_add] }
+
+/-- A finite-dimensional Lie module is Lie-equivariantly isomorphic to its double dual. -/
+noncomputable def lieDoubleDualEquiv (V : FDLieRep k L) :
+    V ≃ₗ⁅k,L⁆ Module.Dual k (Module.Dual k V) :=
+  { Module.evalEquiv k V with
+    map_lie' := by
+      intro x v
+      ext f
+      simp }
+
+/-- Tensoring on the left by a fixed finite-dimensional Lie representation. -/
+def tensorLieLeftFunctor (V : FDLieRep k L) : FDLieRep k L ⥤ FDLieRep k L where
+  obj W := FDLieRep.of k L (TensorProduct k V W)
+  map f := FDLieRep.ofHom k L (TensorProduct.LieModule.map LieModuleHom.id f.hom)
+  map_id W := by
+    apply FDLieRep.hom_ext
+    apply LieModuleHom.ext
+    intro t
+    induction t using TensorProduct.induction_on with
+    | zero => simp
+    | tmul v w => simp
+    | add a b ha hb => simpa only [map_add] using congrArg₂ (fun p q ↦ p + q) ha hb
+  map_comp f g := by
+    apply FDLieRep.hom_ext
+    apply LieModuleHom.ext
+    intro t
+    induction t using TensorProduct.induction_on with
+    | zero => simp
+    | tmul v w => simp
+    | add a b ha hb => simpa only [map_add] using congrArg₂ (fun p q ↦ p + q) ha hb
+
+/-- The contragredient dual of a finite-dimensional Lie representation. -/
+noncomputable def lieDual (V : FDLieRep k L) : FDLieRep k L :=
+  FDLieRep.of k L (Module.Dual k V)
+
+/-- Precomposition by a Lie-module equivalence, as an equivalence of Hom spaces. -/
+def lieCongrHomLeft {A B C : Type u}
+    [AddCommGroup A] [Module k A] [LieRingModule L A] [LieModule k L A]
+    [AddCommGroup B] [Module k B] [LieRingModule L B] [LieModule k L B]
+    [AddCommGroup C] [Module k C] [LieRingModule L C] [LieModule k L C]
+    (e : A ≃ₗ⁅k,L⁆ B) : (A →ₗ⁅k,L⁆ C) ≃ₗ[k] (B →ₗ⁅k,L⁆ C) where
+  toFun f := f.comp (e.symm : B →ₗ⁅k,L⁆ A)
+  invFun g := g.comp (e : A →ₗ⁅k,L⁆ B)
+  map_add' f g := by ext; simp [LieModuleHom.comp_apply]
+  map_smul' c f := by ext; simp [LieModuleHom.comp_apply]
+  left_inv f := by ext; simp [LieModuleHom.comp_apply]
+  right_inv g := by ext; simp [LieModuleHom.comp_apply]
+
+/-- The finite-dimensional Lie-equivariant tensor–dual Hom equivalence
+`Hom(V ⊗ W, U) ≃ Hom(W, V* ⊗ U)`.
+
+This is the objectwise Hom equivalence underlying the expected adjunction
+`V ⊗ - ⊣ V* ⊗ -`. -/
+noncomputable def tensorLieRightHomLinearEquiv (V W U : FDLieRep k L) :
+    (TensorProduct k V W →ₗ⁅k,L⁆ U) ≃ₗ[k]
+      (W →ₗ⁅k,L⁆ TensorProduct k (Module.Dual k V) U) :=
+  (lieCongrHomLeft (lieTensorComm V W)).trans
+    ((TensorProduct.LieModule.liftLie k L W V U).symm.trans
+      ((Problem2_14_3.congrHomRight
+          (Problem2_14_3.dualHomEquiv (k := k) (L := L) (W := V) (U := U))).trans
+        (Problem2_14_3.congrHomRight (lieTensorComm (FDLieRep.of k L U) (lieDual V)))))
+
+/-- The categorical form of `tensorLieRightHomLinearEquiv`, on objects of `FDLieRep`. -/
+noncomputable def tensorLieRightHomEquiv (V W U : FDLieRep k L) :
+    ((tensorLieLeftFunctor V).obj W ⟶ U) ≃
+      (W ⟶ (tensorLieLeftFunctor (lieDual V)).obj U) where
+  toFun f := FDLieRep.ofHom k L (tensorLieRightHomLinearEquiv V W U f.hom)
+  invFun g := FDLieRep.ofHom k L ((tensorLieRightHomLinearEquiv V W U).symm g.hom)
+  left_inv f := by
+    apply FDLieRep.hom_ext
+    exact (tensorLieRightHomLinearEquiv V W U).symm_apply_apply f.hom
+  right_inv g := by
+    apply FDLieRep.hom_ext
+    exact (tensorLieRightHomLinearEquiv V W U).apply_symm_apply g.hom
+
+end Etingof
 
 /-! ## (2) Frobenius reciprocity -/
 
@@ -155,3 +331,325 @@ def Etingof.symmetric_algebra_adjunction
     (A : Type*) [CommSemiring A] [Algebra k A] :
     (V →ₗ[k] A) ≃ (SymmetricAlgebra k V →ₐ[k] A) :=
   SymmetricAlgebra.lift
+
+/-! ## Genuine categorical adjunctions for (3)–(5) -/
+
+namespace Etingof
+
+/-! ### Universal enveloping algebra -/
+
+/-- The bundled category of Lie algebras over `R`, with Lie algebra homomorphisms. -/
+structure LieAlgCat (R : Type u) [CommRing R] where
+  /-- The underlying type. -/
+  carrier : Type u
+  [lieRing : LieRing carrier]
+  [lieAlgebra : LieAlgebra R carrier]
+
+namespace LieAlgCat
+
+variable (R : Type u) [CommRing R]
+
+attribute [instance] lieRing lieAlgebra
+
+instance : CoeSort (LieAlgCat R) (Type u) := ⟨carrier⟩
+
+/-- Bundle a Lie algebra as an object of `LieAlgCat`. -/
+abbrev of (L : Type u) [LieRing L] [LieAlgebra R L] : LieAlgCat R := ⟨L⟩
+
+/-- Morphisms of bundled Lie algebras. -/
+structure Hom (L M : LieAlgCat R) where
+  /-- The underlying Lie algebra homomorphism. -/
+  hom : L →ₗ⁅R⁆ M
+
+instance : Category (LieAlgCat R) where
+  Hom := Hom R
+  id L := ⟨LieHom.id⟩
+  comp f g := ⟨g.hom.comp f.hom⟩
+
+@[simp] theorem hom_id (L : LieAlgCat R) : (𝟙 L : L ⟶ L).hom = LieHom.id := rfl
+
+@[simp] theorem hom_comp {L M N : LieAlgCat R} (f : L ⟶ M) (g : M ⟶ N) :
+    (f ≫ g).hom = g.hom.comp f.hom := rfl
+
+/-- Bundle a Lie algebra homomorphism as a morphism in `LieAlgCat`. -/
+abbrev ofHom {L M : Type u} [LieRing L] [LieAlgebra R L]
+    [LieRing M] [LieAlgebra R M] (f : L →ₗ⁅R⁆ M) : of R L ⟶ of R M := ⟨f⟩
+
+/-- Extensionality for morphisms of bundled Lie algebras. -/
+theorem hom_ext {L M : LieAlgCat R} {f g : L ⟶ M} (h : f.hom = g.hom) : f = g := by
+  match f, g with
+  | ⟨f⟩, ⟨g⟩ =>
+    cases h
+    rfl
+
+end LieAlgCat
+
+/-- Send an associative algebra to its commutator Lie algebra. -/
+def commutatorLieFunctor (R : Type u) [CommRing R] : AlgCat.{u} R ⥤ LieAlgCat R where
+  obj A := LieAlgCat.of R A
+  map f := LieAlgCat.ofHom R f.hom.toLieHom
+  map_id _ := rfl
+  map_comp _ _ := rfl
+
+/-- The universal enveloping algebra as a functor from Lie algebras to associative algebras. -/
+def universalEnvelopingFunctor (R : Type u) [CommRing R] : LieAlgCat R ⥤ AlgCat.{u} R where
+  obj L := AlgCat.of R (UniversalEnvelopingAlgebra R L)
+  map f := AlgCat.ofHom <| UniversalEnvelopingAlgebra.lift R <|
+    (UniversalEnvelopingAlgebra.ι R).comp f.hom
+  map_id L := by
+    apply AlgCat.hom_ext
+    apply UniversalEnvelopingAlgebra.hom_ext
+    ext x
+    simp
+  map_comp f g := by
+    apply AlgCat.hom_ext
+    apply UniversalEnvelopingAlgebra.hom_ext
+    ext x
+    simp
+
+/-- The natural Hom equivalence for universal enveloping algebras. -/
+def ueaCategoricalHomEquiv (R : Type u) [CommRing R]
+    (L : LieAlgCat R) (A : AlgCat.{u} R) :
+    ((universalEnvelopingFunctor R).obj L ⟶ A) ≃ (L ⟶ (commutatorLieFunctor R).obj A) where
+  toFun f := LieAlgCat.ofHom R ((UniversalEnvelopingAlgebra.lift (A := A) R).symm f.hom)
+  invFun g := AlgCat.ofHom ((UniversalEnvelopingAlgebra.lift (A := A) R) g.hom)
+  left_inv f := by
+    apply AlgCat.hom_ext
+    exact (UniversalEnvelopingAlgebra.lift (A := A) R).apply_symm_apply f.hom
+  right_inv g := by
+    apply LieAlgCat.hom_ext
+    exact (UniversalEnvelopingAlgebra.lift (A := A) R).symm_apply_apply g.hom
+
+/-- The genuine adjunction `U ⊣ L` of Example 7.6.3(3). -/
+def universalEnvelopingAdjunction (R : Type u) [CommRing R] :
+    universalEnvelopingFunctor R ⊣ commutatorLieFunctor R :=
+  Adjunction.mkOfHomEquiv {
+    homEquiv := ueaCategoricalHomEquiv R
+    homEquiv_naturality_left_symm := by
+      intro L' L A f g
+      apply AlgCat.hom_ext
+      change UniversalEnvelopingAlgebra.lift (A := A) R (f ≫ g).hom =
+        (UniversalEnvelopingAlgebra.lift (A := A) R g.hom).comp
+          (UniversalEnvelopingAlgebra.lift R
+            ((UniversalEnvelopingAlgebra.ι R).comp f.hom))
+      apply UniversalEnvelopingAlgebra.hom_ext
+      ext x
+      simp
+      rfl
+    homEquiv_naturality_right := by
+      intro L A A' f g
+      apply LieAlgCat.hom_ext
+      change (g.hom.comp f.hom).toLieHom.comp (UniversalEnvelopingAlgebra.ι R) =
+        g.hom.toLieHom.comp (f.hom.toLieHom.comp (UniversalEnvelopingAlgebra.ι R))
+      rfl
+  }
+
+/-- The old pointwise UEA equivalence is exactly a component of the categorical one. -/
+@[simp] theorem ueaCategoricalHomEquiv_symm_hom
+    (R : Type u) [CommRing R] (L A : Type u) [LieRing L] [LieAlgebra R L]
+    [Ring A] [Algebra R A] (f : L →ₗ⁅R⁆ A) :
+    ((ueaCategoricalHomEquiv R (LieAlgCat.of R L) (AlgCat.of R A)).symm
+      (LieAlgCat.ofHom R f)).hom = uea_adjunction R L A f := rfl
+
+/-! ### Group algebra and units -/
+
+/-- The group-algebra functor `G ↦ k[G]`. -/
+noncomputable def groupAlgebraFunctor (k : Type u) [CommRing k] :
+    GrpCat.{u} ⥤ AlgCat.{u} k where
+  obj G := AlgCat.of k (MonoidAlgebra k G)
+  map f := AlgCat.ofHom (MonoidAlgebra.mapDomainAlgHom k k f.hom)
+  map_id G := by
+    apply AlgCat.hom_ext
+    simp
+  map_comp f g := by
+    apply AlgCat.hom_ext
+    simp
+
+/-- The units functor `A ↦ Aˣ`. -/
+def unitsFunctor (k : Type u) [CommRing k] : AlgCat.{u} k ⥤ GrpCat.{u} where
+  obj A := GrpCat.of Aˣ
+  map f := GrpCat.ofHom (Units.map f.hom.toMonoidHom)
+  map_id A := by
+    apply GrpCat.hom_ext
+    ext x
+    rfl
+  map_comp f g := by
+    apply GrpCat.hom_ext
+    ext x
+    rfl
+
+/-- The natural Hom equivalence between maps out of a group algebra and maps into units. -/
+noncomputable def groupAlgebraCategoricalHomEquiv (k : Type u) [CommRing k]
+    (G : GrpCat.{u}) (A : AlgCat.{u} k) :
+    ((groupAlgebraFunctor k).obj G ⟶ A) ≃ (G ⟶ (unitsFunctor k).obj A) where
+  toFun f := GrpCat.ofHom ((group_algebra_adjunction k G A).symm f.hom)
+  invFun g := AlgCat.ofHom (group_algebra_adjunction k G A g.hom)
+  left_inv f := by
+    apply AlgCat.hom_ext
+    exact (group_algebra_adjunction k G A).apply_symm_apply f.hom
+  right_inv g := by
+    apply GrpCat.hom_ext
+    exact (group_algebra_adjunction k G A).symm_apply_apply g.hom
+
+/-- The genuine adjunction `k[-] ⊣ GL₁` of Example 7.6.3(4). -/
+noncomputable def groupAlgebraAdjunction (k : Type u) [CommRing k] :
+    groupAlgebraFunctor k ⊣ unitsFunctor k :=
+  Adjunction.mkOfHomEquiv {
+    homEquiv := groupAlgebraCategoricalHomEquiv k
+    homEquiv_naturality_left_symm := by
+      intro G' G A f g
+      apply AlgCat.hom_ext
+      change MonoidAlgebra.lift k A G'
+          ((Units.coeHom A).comp (g.hom.comp f.hom)) =
+        (MonoidAlgebra.lift k A G ((Units.coeHom A).comp g.hom)).comp
+          (MonoidAlgebra.mapDomainAlgHom k k f.hom)
+      apply MonoidAlgebra.algHom_ext
+      intro x
+      simp
+      rfl
+    homEquiv_naturality_right := by
+      intro G A A' f g
+      apply GrpCat.hom_ext
+      ext x
+      apply Units.ext
+      rfl
+  }
+
+/-- The old pointwise group-algebra equivalence is a component of the categorical one. -/
+@[simp] theorem groupAlgebraCategoricalHomEquiv_symm_hom
+    (k : Type u) [CommRing k] (G A : Type u) [Group G] [Ring A] [Algebra k A]
+    (f : G →* Aˣ) :
+    ((groupAlgebraCategoricalHomEquiv k (GrpCat.of G) (AlgCat.of k A)).symm
+      (GrpCat.ofHom f)).hom = group_algebra_adjunction k G A f := rfl
+
+/-! ### Tensor and symmetric algebras -/
+
+/-- The tensor-algebra functor from modules to associative algebras. -/
+def tensorAlgebraFunctor (k : Type u) [CommRing k] : ModuleCat.{u} k ⥤ AlgCat.{u} k where
+  obj V := AlgCat.of k (TensorAlgebra k V)
+  map f := AlgCat.ofHom <| TensorAlgebra.lift k <| (TensorAlgebra.ι k).comp f.hom
+  map_id V := by
+    apply AlgCat.hom_ext
+    apply TensorAlgebra.hom_ext
+    ext x
+    simp
+  map_comp f g := by
+    apply AlgCat.hom_ext
+    apply TensorAlgebra.hom_ext
+    ext x
+    simp
+
+/-- The natural Hom equivalence for the tensor algebra. -/
+def tensorAlgebraCategoricalHomEquiv (k : Type u) [CommRing k]
+    (V : ModuleCat.{u} k) (A : AlgCat.{u} k) :
+    ((tensorAlgebraFunctor k).obj V ⟶ A) ≃
+      (V ⟶ (forget₂ (AlgCat.{u} k) (ModuleCat.{u} k)).obj A) where
+  toFun f := ModuleCat.ofHom ((TensorAlgebra.lift k).symm f.hom)
+  invFun g := AlgCat.ofHom (TensorAlgebra.lift (A := A) k g.hom)
+  left_inv f := by
+    apply AlgCat.hom_ext
+    exact (TensorAlgebra.lift k).apply_symm_apply f.hom
+  right_inv g := by
+    apply ModuleCat.hom_ext
+    exact (TensorAlgebra.lift (A := A) k).symm_apply_apply g.hom
+
+/-- The genuine tensor-algebra/forgetful adjunction of Example 7.6.3(5). -/
+def tensorAlgebraAdjunction (k : Type u) [CommRing k] :
+    tensorAlgebraFunctor k ⊣ forget₂ (AlgCat.{u} k) (ModuleCat.{u} k) :=
+  Adjunction.mkOfHomEquiv {
+    homEquiv := tensorAlgebraCategoricalHomEquiv k
+    homEquiv_naturality_left_symm := by
+      intro V' V A f g
+      apply AlgCat.hom_ext
+      change TensorAlgebra.lift (A := A) k (g.hom.comp f.hom) =
+        (TensorAlgebra.lift (A := A) k g.hom).comp
+          (TensorAlgebra.lift k ((TensorAlgebra.ι k).comp f.hom))
+      apply TensorAlgebra.hom_ext
+      ext x
+      simp
+    homEquiv_naturality_right := by
+      intro V A A' f g
+      apply ModuleCat.hom_ext
+      change (g.hom.comp f.hom).toLinearMap.comp (TensorAlgebra.ι k) =
+        g.hom.toLinearMap.comp (f.hom.toLinearMap.comp (TensorAlgebra.ι k))
+      rfl
+  }
+
+/-- The old pointwise tensor-algebra equivalence is a component of the categorical one. -/
+@[simp] theorem tensorAlgebraCategoricalHomEquiv_symm_hom
+    (k : Type u) [CommRing k] (V A : Type u) [AddCommGroup V] [Module k V]
+    [Ring A] [Algebra k A] (f : V →ₗ[k] A) :
+    ((tensorAlgebraCategoricalHomEquiv k (ModuleCat.of k V) (AlgCat.of k A)).symm
+      (ModuleCat.ofHom f)).hom = tensor_algebra_adjunction k V A f := rfl
+
+/-- The forgetful functor from commutative `k`-algebras to `k`-modules. -/
+def commAlgForgetModuleFunctor (k : Type u) [CommRing k] :
+    CommAlgCat.{u} k ⥤ ModuleCat.{u} k :=
+  forget₂ (CommAlgCat.{u} k) (AlgCat.{u} k) ⋙
+    forget₂ (AlgCat.{u} k) (ModuleCat.{u} k)
+
+/-- The symmetric-algebra functor from modules to commutative algebras. -/
+def symmetricAlgebraFunctor (k : Type u) [CommRing k] :
+    ModuleCat.{u} k ⥤ CommAlgCat.{u} k where
+  obj V := CommAlgCat.of k (SymmetricAlgebra k V)
+  map f := CommAlgCat.ofHom <| SymmetricAlgebra.lift <|
+    (SymmetricAlgebra.ι k _).comp f.hom
+  map_id V := by
+    apply CommAlgCat.hom_ext
+    apply SymmetricAlgebra.algHom_ext
+    ext x
+    simp
+  map_comp f g := by
+    apply CommAlgCat.hom_ext
+    apply SymmetricAlgebra.algHom_ext
+    ext x
+    simp
+
+/-- The natural Hom equivalence for the symmetric algebra. -/
+def symmetricAlgebraCategoricalHomEquiv (k : Type u) [CommRing k]
+    (V : ModuleCat.{u} k) (A : CommAlgCat.{u} k) :
+    ((symmetricAlgebraFunctor k).obj V ⟶ A) ≃
+      (V ⟶ (commAlgForgetModuleFunctor k).obj A) where
+  toFun f := ModuleCat.ofHom (f.hom.toLinearMap.comp (SymmetricAlgebra.ι k V))
+  invFun g := CommAlgCat.ofHom (SymmetricAlgebra.lift (A := A) g.hom)
+  left_inv f := by
+    apply CommAlgCat.hom_ext
+    apply SymmetricAlgebra.algHom_ext
+    simp
+    rfl
+  right_inv g := by
+    apply ModuleCat.hom_ext
+    ext x
+    change SymmetricAlgebra.lift (A := A) g.hom (SymmetricAlgebra.ι k V x) = g.hom x
+    simp
+    rfl
+
+/-- The genuine symmetric-algebra/forgetful adjunction of Example 7.6.3(5). -/
+def symmetricAlgebraAdjunction (k : Type u) [CommRing k] :
+    symmetricAlgebraFunctor k ⊣ commAlgForgetModuleFunctor k :=
+  Adjunction.mkOfHomEquiv {
+    homEquiv := symmetricAlgebraCategoricalHomEquiv k
+    homEquiv_naturality_left_symm := by
+      intro V' V A f g
+      apply CommAlgCat.hom_ext
+      change SymmetricAlgebra.lift (A := A) (g.hom.comp f.hom) =
+        (SymmetricAlgebra.lift (A := A) g.hom).comp
+          (SymmetricAlgebra.lift ((SymmetricAlgebra.ι k V).comp f.hom))
+      apply SymmetricAlgebra.algHom_ext
+      ext x
+      simp
+      rfl
+    homEquiv_naturality_right := by
+      intro V A A' f g
+      apply ModuleCat.hom_ext
+      rfl
+  }
+
+/-- The old pointwise symmetric-algebra equivalence is a component of the categorical one. -/
+@[simp] theorem symmetricAlgebraCategoricalHomEquiv_symm_hom
+    (k : Type u) [CommRing k] (V A : Type u) [AddCommGroup V] [Module k V]
+    [CommRing A] [Algebra k A] (f : V →ₗ[k] A) :
+    ((symmetricAlgebraCategoricalHomEquiv k (ModuleCat.of k V) (CommAlgCat.of k A)).symm
+      (ModuleCat.ofHom f)).hom = symmetric_algebra_adjunction k V A f := rfl
+
+end Etingof

--- a/progress/2026-07-27T02-46-02Z_fix5644.md
+++ b/progress/2026-07-27T02-46-02Z_fix5644.md
@@ -1,0 +1,21 @@
+## Issue #5644: genuine adjunction packaging (partial)
+
+Implemented the remaining categorical packaging for Example 7.6.3(3)–(5):
+
+- bundled Lie algebras, the commutator and universal-enveloping functors, and `U ⊣ L`;
+- the group-algebra and units functors, and `k[-] ⊣ GL₁`;
+- tensor- and symmetric-algebra functors and their forgetful adjunctions;
+- natural Hom equivalences in both variables and component lemmas recovering the old
+  objectwise universal-property equivalences.
+
+For the Lie-representation clause of item (1), added `FDLieRep`, functorial tensoring,
+contragredient and double-dual equivalences, and the finite-dimensional Lie-equivariant
+Hom equivalence `Hom(V ⊗ W, U) ≃ Hom(W, V* ⊗ U)`. This is coherent objectwise progress,
+but is not yet a `CategoryTheory.Adjunction`: Mathlib has no bundled rigid category of Lie
+representations, and its basis-dependent `dualTensorHomEquiv` currently lacks the naturality
+API needed to prove both variables natural and obtain the requested biadjunction. Therefore
+#5644 remains open and the PR does not use a closing keyword.
+
+Direct chapter-file build succeeds. The only replayed warning is the pre-existing
+`unusedSectionVars` warning in `Chapter2/Problem2_14_3.lean`, which is already on the warning
+baseline; `Example7_6_3.lean` itself emits no warning.

--- a/progress/items.json
+++ b/progress/items.json
@@ -8495,9 +8495,9 @@
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_partial",
-    "coverage_note": "The group-representation tensor-dual and Frobenius-reciprocity examples are genuine adjunctions. The universal-enveloping, group-algebra, tensor-algebra, and symmetric-algebra examples remain objectwise Hom equivalences without functor/adjunction packaging or naturality, and the Lie-representation clause of item (1) is absent; follow-up #5644.",
+    "coverage_note": "The group-representation tensor-dual, Frobenius-reciprocity, universal-enveloping, group-algebra, tensor-algebra, and symmetric-algebra examples are genuine adjunctions with natural Hom equivalences. The Lie-representation clause now has a bundled finite-dimensional category, tensor functors, duality, and the expected objectwise Hom equivalence, but not yet the required natural biadjunction; follow-up #5644 remains open.",
     "followup_issue": 5644,
-    "last_updated": "2026-07-22"
+    "last_updated": "2026-07-27"
   },
   {
     "id": "Chapter7/Discussion_after_Example7.6.3",


### PR DESCRIPTION
Refs #5644 (intentionally non-closing: the finite-dimensional Lie-representation biadjunction remains incomplete).

## What changed

- bundles Lie algebras and defines the commutator and universal-enveloping functors, with a genuine `U ⊣ L` adjunction;
- defines the group-algebra and units functors, with a genuine `k[-] ⊣ GL₁` adjunction;
- defines tensor- and symmetric-algebra functors and their genuine forgetful adjunctions;
- proves the Hom equivalences natural in both variables and shows the previous pointwise equivalences are their components;
- adds a bundled finite-dimensional Lie-representation category, tensor functors, contragredient/double-dual equivalences, and the objectwise Lie-equivariant equivalence `Hom(V ⊗ W, U) ≃ Hom(W, V* ⊗ U)`;
- updates coverage metadata and adds an honest progress note.

## Why this is non-closing

Mathlib does not currently package finite-dimensional Lie representations as a rigid category, and its basis-dependent `dualTensorHomEquiv` has no ready naturality API. The new objectwise Lie Hom equivalence compiles, but proving both-variable naturality and the second adjoint direction remains necessary before #5644 can close.

## Validation

- `lake build EtingofRepresentationTheory.Chapter7.Example7_6_3`
- `lake build EtingofRepresentationTheory.Chapter7`
- `python3 scripts/validate_items.py` (passes; repository-wide legacy extra-field warnings only)
- `scripts/check_lint_clean.py --log /tmp/issue5644-direct.log --modules /tmp/issue5644-modules.txt`
- trust-hole scan: no `native_decide`, linter disable, `sorry`, `admit`, or new axiom declaration in the changed Lean file
- `#print axioms` for all four new adjunctions and the Lie Hom equivalence: only `propext`, `Classical.choice`, and `Quot.sound`
- `git diff --check`
