### PR TITLE
Expose the Artin span decomposition matrix

### DIFF
--- a/EtingofRepresentationTheory/Chapter5.lean
+++ b/EtingofRepresentationTheory/Chapter5.lean
@@ -235,6 +235,7 @@ import EtingofRepresentationTheory.Chapter5.GroupAlgebraCenter
 -- Section 5.26: Artin's Theorem
 import EtingofRepresentationTheory.Chapter5.Theorem5_26_1
 import EtingofRepresentationTheory.Chapter5.Theorem5_26_1_Test
+import EtingofRepresentationTheory.Chapter5.Remark5_26_2
 import EtingofRepresentationTheory.Chapter5.Corollary5_26_3
 
 import EtingofRepresentationTheory.Chapter5.QuotDetDegreeAlgebraic

--- a/EtingofRepresentationTheory/Chapter5/Remark5_26_2.lean
+++ b/EtingofRepresentationTheory/Chapter5/Remark5_26_2.lean
@@ -1,0 +1,307 @@
+import EtingofRepresentationTheory.Chapter5.Theorem5_26_1
+
+/-!
+# Remark 5.26.2: rational and complex spans
+
+The decomposition matrix used in Artin's theorem has irreducible representations of
+`G` as its rows and a chosen finite family of induced representations as its columns.
+Its entries are integral multiplicities.  Consequently it has full row rank over
+`ℚ` exactly when it has full row rank over `ℂ`.
+
+This file first records that linear-algebra fact for an arbitrary integral matrix,
+then specializes it to the decomposition matrix of induced characters.
+-/
+
+noncomputable section
+
+open scoped Matrix
+
+namespace Etingof.Remark5262
+
+variable {ι κ : Type*} [Finite ι] [Finite κ]
+
+/-- An integral matrix regarded as a rational matrix. -/
+def rationalMatrix (M : Matrix ι κ ℤ) : Matrix ι κ ℚ :=
+  M.map (Int.castRingHom ℚ)
+
+/-- An integral matrix regarded as a complex matrix. -/
+def complexMatrix (M : Matrix ι κ ℤ) : Matrix ι κ ℂ :=
+  M.map (Int.castRingHom ℂ)
+
+/-- For a finite matrix over a field, its columns span the whole row-coordinate
+space exactly when its rows are linearly independent. -/
+theorem columns_span_iff_rows_linearIndependent
+    {K : Type*} [Field K] (M : Matrix ι κ K) :
+    Submodule.span K (Set.range M.col) = ⊤ ↔
+      LinearIndependent K M.row := by
+  letI := Fintype.ofFinite ι
+  letI := Fintype.ofFinite κ
+  constructor
+  · intro hspan
+    apply linearIndependent_iff_card_eq_finrank_span.mpr
+    rw [Set.finrank, ← M.rank_eq_finrank_span_row,
+      M.rank_eq_finrank_span_cols, hspan, finrank_top,
+      Module.finrank_fintype_fun_eq_card]
+  · intro hrows
+    apply Submodule.eq_top_iff_finrank_eq.mpr
+    rw [← M.rank_eq_finrank_span_cols, hrows.rank_matrix,
+      Module.finrank_fintype_fun_eq_card]
+
+/-- Full column span of an integral matrix is unchanged when the coefficient field
+is extended from `ℚ` to `ℂ`. -/
+theorem rational_columns_span_iff_complex_columns_span (M : Matrix ι κ ℤ) :
+    Submodule.span ℚ (Set.range (rationalMatrix M).col) = ⊤ ↔
+      Submodule.span ℂ (Set.range (complexMatrix M).col) = ⊤ := by
+  rw [columns_span_iff_rows_linearIndependent,
+    columns_span_iff_rows_linearIndependent]
+  change LinearIndependent ℚ (fun i j => (M i j : ℚ)) ↔
+    LinearIndependent ℂ (fun i j => (M i j : ℂ))
+  simpa [Function.comp_def] using
+    (linearIndependent_algebraMap_comp_iff
+      (R := ℚ) (S := ℂ) (v := fun i j => (M i j : ℚ))).symm
+
+/-- The three matrix conditions appearing in Remark 5.26.2, in book orientation:
+columns are decompositions and rows are indexed by irreducibles. -/
+theorem span_conditions_iff_row_independence (M : Matrix ι κ ℤ) :
+    (Submodule.span ℚ (Set.range (rationalMatrix M).col) = ⊤ ↔
+      Submodule.span ℂ (Set.range (complexMatrix M).col) = ⊤) ∧
+    (Submodule.span ℚ (Set.range (rationalMatrix M).col) = ⊤ ↔
+      LinearIndependent ℚ (rationalMatrix M).row) ∧
+    (Submodule.span ℂ (Set.range (complexMatrix M).col) = ⊤ ↔
+      LinearIndependent ℂ (complexMatrix M).row) := by
+  exact ⟨rational_columns_span_iff_complex_columns_span M,
+    columns_span_iff_rows_linearIndependent _,
+    columns_span_iff_rows_linearIndependent _⟩
+
+section Artin
+
+variable {G : Type} [Group G] [Fintype G] [NeZero (Nat.card G : ℂ)]
+
+/-- The irreducible characters in an `IrrepDecomp` are linearly independent. -/
+theorem irrepCharacters_linearIndependent (D : IrrepDecomp ℂ G) :
+    LinearIndependent ℂ (fun i : Fin D.n => (D.columnFDRep i).character) := by
+  haveI : Invertible (Fintype.card G : ℂ) :=
+    invertibleOfNonzero (Nat.cast_ne_zero.mpr Fintype.card_ne_zero)
+  rw [Fintype.linearIndependent_iff]
+  intro c hc j
+  haveI (i : Fin D.n) : CategoryTheory.Simple (D.columnFDRep i) :=
+    D.columnFDRep_simple i
+  have h_iso_iff : ∀ i k : Fin D.n,
+      Nonempty ((D.columnFDRep i) ≅ (D.columnFDRep k)) ↔ i = k := by
+    intro i k
+    constructor
+    · exact D.columnFDRep_injective i k
+    · rintro rfl
+      exact ⟨CategoryTheory.Iso.refl _⟩
+  have h_orth : ∀ i : Fin D.n,
+      ⅟(Fintype.card G : ℂ) • ∑ g : G,
+        (D.columnFDRep i).character g * (D.columnFDRep j).character g⁻¹ =
+      if i = j then 1 else 0 := by
+    intro i
+    rw [FDRep.char_orthonormal]
+    simp [h_iso_iff]
+  have lhs_zero : ∀ g,
+      (∑ i : Fin D.n, c i * (D.columnFDRep i).character g) = 0 := by
+    intro g
+    have h := congr_fun hc g
+    simp only [Pi.zero_apply, Finset.sum_apply, Pi.smul_apply, smul_eq_mul] at h
+    exact h
+  have stepA : ⅟(Fintype.card G : ℂ) • ∑ g : G,
+      (∑ i : Fin D.n, c i * (D.columnFDRep i).character g) *
+      (D.columnFDRep j).character g⁻¹ = 0 := by
+    simp_rw [lhs_zero, zero_mul, Finset.sum_const_zero, smul_zero]
+  have stepB : ⅟(Fintype.card G : ℂ) • ∑ g : G,
+      (∑ i : Fin D.n, c i * (D.columnFDRep i).character g) *
+      (D.columnFDRep j).character g⁻¹ =
+      ∑ i : Fin D.n, c i * (⅟(Fintype.card G : ℂ) • ∑ g : G,
+        (D.columnFDRep i).character g * (D.columnFDRep j).character g⁻¹) := by
+    calc
+      _ = ⅟(Fintype.card G : ℂ) • ∑ g : G, ∑ i,
+          c i * (D.columnFDRep i).character g *
+            (D.columnFDRep j).character g⁻¹ := by
+        congr 1
+        apply Finset.sum_congr rfl
+        intro g _
+        rw [Finset.sum_mul]
+      _ = ⅟(Fintype.card G : ℂ) • ∑ i, ∑ g : G,
+          c i * (D.columnFDRep i).character g *
+            (D.columnFDRep j).character g⁻¹ := by
+        congr 1
+        rw [Finset.sum_comm]
+      _ = ⅟(Fintype.card G : ℂ) • ∑ i,
+          c i * ∑ g : G, (D.columnFDRep i).character g *
+            (D.columnFDRep j).character g⁻¹ := by
+        congr 1
+        apply Finset.sum_congr rfl
+        intro i _
+        conv_lhs => arg 2; ext g; rw [mul_assoc]
+        rw [← Finset.mul_sum]
+      _ = ∑ i, c i * (⅟(Fintype.card G : ℂ) •
+          ∑ g : G, (D.columnFDRep i).character g *
+            (D.columnFDRep j).character g⁻¹) := by
+        rw [Finset.smul_sum]
+        apply Finset.sum_congr rfl
+        intro i _
+        rw [Algebra.mul_smul_comm]
+  simp_rw [stepB, h_orth] at stepA
+  simp only [mul_ite, mul_one, mul_zero, Finset.sum_ite_eq', Finset.mem_univ,
+    ↓reduceIte] at stepA
+  exact stepA
+
+/-- Restriction of the `i`th chosen irreducible representation to `H`. -/
+def restrictedIrrep (D : IrrepDecomp ℂ G) (H : Subgroup G) (i : Fin D.n) :
+    FDRep ℂ ↥H :=
+  FDRep.of ((D.columnFDRep i).ρ.comp H.subtype)
+
+/-- The decomposition matrix for a finite family of induced representations.
+
+Rows are indexed by irreducible representations of `G`; columns are indexed by
+the chosen pairs `(H j, W j)`.  The `(i,j)` entry is the Frobenius-reciprocity
+multiplicity `dim Hom_{H_j}(W_j, Res_{H_j} V_i)`. -/
+def decompositionMatrix (D : IrrepDecomp ℂ G)
+    (H : κ → Subgroup G) (W : ∀ j, FDRep ℂ ↥(H j)) :
+    Matrix (Fin D.n) κ ℤ :=
+  fun i j => (Module.finrank ℂ (W j ⟶ restrictedIrrep D (H j) i) : ℤ)
+
+/-- The selected induced characters, one for each decomposition-matrix column. -/
+def inducedCharacters (H : κ → Subgroup G) (W : ∀ j, FDRep ℂ ↥(H j)) :
+    κ → G → ℂ :=
+  fun j => Etingof.inducedCharacter (H j) (W j).character
+
+/-- Rational linear combinations of the chosen irreducible characters. -/
+def rationalCharacterCombination (D : IrrepDecomp ℂ G) :
+    (Fin D.n → ℚ) →ₗ[ℚ] (G → ℂ) :=
+  Fintype.linearCombination ℚ (fun i : Fin D.n => (D.columnFDRep i).character)
+
+/-- Complex linear combinations of the chosen irreducible characters. -/
+def complexCharacterCombination (D : IrrepDecomp ℂ G) :
+    (Fin D.n → ℂ) →ₗ[ℂ] (G → ℂ) :=
+  Fintype.linearCombination ℂ (fun i : Fin D.n => (D.columnFDRep i).character)
+
+omit [Finite κ] in
+/-- Each column of the rational decomposition matrix maps to the corresponding
+induced character. -/
+theorem rationalCharacterCombination_column (D : IrrepDecomp ℂ G)
+    (H : κ → Subgroup G) (W : ∀ j, FDRep ℂ ↥(H j)) (j : κ) :
+    rationalCharacterCombination D ((rationalMatrix (decompositionMatrix D H W)).col j) =
+      inducedCharacters H W j := by
+  symm
+  simpa [rationalCharacterCombination, rationalMatrix, decompositionMatrix,
+    restrictedIrrep, inducedCharacters, Fintype.linearCombination_apply,
+    Matrix.col_apply, zsmul_eq_mul, Algebra.smul_def, smul_eq_mul] using
+    (Etingof.inducedCharacter_eq_irrepDecomp_sum D (H j) (W j))
+
+omit [Finite κ] in
+/-- Each column of the complex decomposition matrix maps to the corresponding
+induced character. -/
+theorem complexCharacterCombination_column (D : IrrepDecomp ℂ G)
+    (H : κ → Subgroup G) (W : ∀ j, FDRep ℂ ↥(H j)) (j : κ) :
+    complexCharacterCombination D ((complexMatrix (decompositionMatrix D H W)).col j) =
+      inducedCharacters H W j := by
+  symm
+  simpa [complexCharacterCombination, complexMatrix, decompositionMatrix,
+    restrictedIrrep, inducedCharacters, Fintype.linearCombination_apply,
+    Matrix.col_apply, zsmul_eq_mul, Algebra.smul_def, smul_eq_mul] using
+    (Etingof.inducedCharacter_eq_irrepDecomp_sum D (H j) (W j))
+
+/-- The rational-span condition for a chosen finite family of induced
+representations: its characters span all irreducible characters of `G`. -/
+def RationalSpanCondition (D : IrrepDecomp ℂ G)
+    (H : κ → Subgroup G) (W : ∀ j, FDRep ℂ ↥(H j)) : Prop :=
+  Submodule.span ℚ (Set.range (inducedCharacters H W)) =
+    Submodule.span ℚ (Set.range (fun i : Fin D.n => (D.columnFDRep i).character))
+
+/-- The complex-span version of `RationalSpanCondition`. -/
+def ComplexSpanCondition (D : IrrepDecomp ℂ G)
+    (H : κ → Subgroup G) (W : ∀ j, FDRep ℂ ↥(H j)) : Prop :=
+  Submodule.span ℂ (Set.range (inducedCharacters H W)) =
+    Submodule.span ℂ (Set.range (fun i : Fin D.n => (D.columnFDRep i).character))
+
+omit [Finite κ] in
+/-- The book's rational character-span condition is exactly full column span of
+the rational decomposition matrix. -/
+theorem rationalSpanCondition_iff_columns_span (D : IrrepDecomp ℂ G)
+    (H : κ → Subgroup G) (W : ∀ j, FDRep ℂ ↥(H j)) :
+    RationalSpanCondition D H W ↔
+      Submodule.span ℚ
+        (Set.range (rationalMatrix (decompositionMatrix D H W)).col) = ⊤ := by
+  let L := rationalCharacterCombination D
+  have hL : Function.Injective L := by
+    change Function.Injective (Fintype.linearCombination ℚ
+      (fun i : Fin D.n => (D.columnFDRep i).character))
+    exact ((irrepCharacters_linearIndependent D).restrict_scalars
+      (smul_left_injective ℚ one_ne_zero)).fintypeLinearCombination_injective
+  have hcols :
+      Submodule.span ℚ (Set.range (inducedCharacters H W)) =
+        (Submodule.span ℚ
+          (Set.range (rationalMatrix (decompositionMatrix D H W)).col)).map L := by
+    rw [Submodule.map_span, ← Set.range_comp]
+    congr 2
+    funext j
+    exact (rationalCharacterCombination_column D H W j).symm
+  have hchars :
+      Submodule.span ℚ
+          (Set.range (fun i : Fin D.n => (D.columnFDRep i).character)) =
+        Submodule.map L ⊤ := by
+    rw [Submodule.map_top]
+    exact (Fintype.range_linearCombination ℚ
+      (fun i : Fin D.n => (D.columnFDRep i).character)).symm
+  rw [RationalSpanCondition, hcols, hchars]
+  exact (Submodule.map_injective_of_injective hL).eq_iff
+
+omit [Finite κ] in
+/-- The book's complex character-span condition is exactly full column span of
+the complex decomposition matrix. -/
+theorem complexSpanCondition_iff_columns_span (D : IrrepDecomp ℂ G)
+    (H : κ → Subgroup G) (W : ∀ j, FDRep ℂ ↥(H j)) :
+    ComplexSpanCondition D H W ↔
+      Submodule.span ℂ
+        (Set.range (complexMatrix (decompositionMatrix D H W)).col) = ⊤ := by
+  let L := complexCharacterCombination D
+  have hL : Function.Injective L := by
+    change Function.Injective (Fintype.linearCombination ℂ
+      (fun i : Fin D.n => (D.columnFDRep i).character))
+    exact (irrepCharacters_linearIndependent D).fintypeLinearCombination_injective
+  have hcols :
+      Submodule.span ℂ (Set.range (inducedCharacters H W)) =
+        (Submodule.span ℂ
+          (Set.range (complexMatrix (decompositionMatrix D H W)).col)).map L := by
+    rw [Submodule.map_span, ← Set.range_comp]
+    congr 2
+    funext j
+    exact (complexCharacterCombination_column D H W j).symm
+  have hchars :
+      Submodule.span ℂ
+          (Set.range (fun i : Fin D.n => (D.columnFDRep i).character)) =
+        Submodule.map L ⊤ := by
+    rw [Submodule.map_top]
+    exact (Fintype.range_linearCombination ℂ
+      (fun i : Fin D.n => (D.columnFDRep i).character)).symm
+  rw [ComplexSpanCondition, hcols, hchars]
+  exact (Submodule.map_injective_of_injective hL).eq_iff
+
+/-- **Remark 5.26.2.** For any finite chosen family of induced representations
+`Ind_{H_j}^G W_j` (in particular, for a finite family selected from the system in
+Theorem 5.26.1), the rational and complex span conditions are equivalent.  Both
+are equivalent to linear independence of the rows of the book-oriented
+decomposition matrix. -/
+theorem _root_.Etingof.Remark5_26_2 (D : IrrepDecomp ℂ G)
+    (H : κ → Subgroup G) (W : ∀ j, FDRep ℂ ↥(H j))
+    (_hW : ∀ j, CategoryTheory.Simple (W j)) :
+    (RationalSpanCondition D H W ↔ ComplexSpanCondition D H W) ∧
+    (RationalSpanCondition D H W ↔
+      LinearIndependent ℚ (rationalMatrix (decompositionMatrix D H W)).row) ∧
+    (ComplexSpanCondition D H W ↔
+      LinearIndependent ℂ (complexMatrix (decompositionMatrix D H W)).row) := by
+  letI := Fintype.ofFinite κ
+  have hQ := rationalSpanCondition_iff_columns_span D H W
+  have hC := complexSpanCondition_iff_columns_span D H W
+  have hQC := rational_columns_span_iff_complex_columns_span
+    (decompositionMatrix D H W)
+  exact ⟨hQ.trans (hQC.trans hC.symm),
+    hQ.trans (columns_span_iff_rows_linearIndependent _),
+    hC.trans (columns_span_iff_rows_linearIndependent _)⟩
+
+end Artin
+
+end Etingof.Remark5262

--- a/EtingofRepresentationTheory/Chapter5/Theorem5_26_1.lean
+++ b/EtingofRepresentationTheory/Chapter5/Theorem5_26_1.lean
@@ -116,6 +116,132 @@ private lemma frobenius_char_reciprocity {G : Type} [Group G] [Fintype G]
   simp only [Equiv.inv_apply, Subgroup.coe_inv, inv_inv]
 
 open Classical in
+/-- The irreducible-character decomposition of an induced character.
+
+The coefficient of the irreducible `D.columnFDRep i` is the nonnegative integer
+`dim Hom_H(W, Res_H(D.columnFDRep i))`, as prescribed by Frobenius reciprocity.
+This public form supplies the decomposition columns used in Remark 5.26.2. -/
+theorem Etingof.inducedCharacter_eq_irrepDecomp_sum
+    {G : Type} [Group G] [Fintype G] [NeZero (Nat.card G : ℂ)]
+    (D : IrrepDecomp ℂ G) (H : Subgroup G) (W : FDRep ℂ ↥H) :
+    Etingof.inducedCharacter H W.character =
+      ∑ i : Fin D.n,
+        (Module.finrank ℂ
+          (W ⟶ FDRep.of ((D.columnFDRep i).ρ.comp H.subtype)) : ℤ) •
+          (D.columnFDRep i).character := by
+  haveI : Invertible (Fintype.card G : ℂ) :=
+    invertibleOfNonzero (Nat.cast_ne_zero.mpr Fintype.card_ne_zero)
+  haveI : NeZero (Nat.card G : ℂ) :=
+    ⟨by rw [Nat.card_eq_fintype_card]; exact Invertible.ne_zero _⟩
+  haveI : Invertible (Fintype.card ↥H : ℂ) :=
+    invertibleOfNonzero (Nat.cast_ne_zero.mpr Fintype.card_ne_zero)
+  haveI : NeZero (Nat.card ↥H : ℂ) :=
+    ⟨by rw [Nat.card_eq_fintype_card]; exact Invertible.ne_zero _⟩
+  let resH : Fin D.n → FDRep ℂ ↥H := fun i =>
+    FDRep.of ((D.columnFDRep i).ρ.comp H.subtype)
+  let m : Fin D.n → ℕ := fun i => Module.finrank ℂ (W ⟶ resH i)
+  have hdiff : Etingof.inducedCharacter H W.character -
+      ∑ i : Fin D.n, (m i : ℤ) • (D.columnFDRep i).character = 0 := by
+    apply Etingof.classFunction_eq_zero_of_orthogonal_simples
+    · intro g x
+      simp only [Pi.sub_apply, Finset.sum_apply, Pi.smul_apply]
+      congr 1
+      · show Etingof.inducedCharacter H W.character (x * g * x⁻¹) =
+             Etingof.inducedCharacter H W.character g
+        simp only [Etingof.inducedCharacter]
+        congr 1
+        let φ : G ≃ G :=
+          { toFun := fun y => x * y
+            invFun := fun z => x⁻¹ * z
+            left_inv := fun y => by group
+            right_inv := fun z => by group }
+        rw [← Equiv.sum_comp φ]
+        apply Finset.sum_congr rfl
+        intro y _
+        have dite_eq : ∀ (a b : G) (hab : a = b),
+            (if h : a ∈ H then W.character ⟨a, h⟩ else 0) =
+            (if h : b ∈ H then W.character ⟨b, h⟩ else 0) := by
+          rintro a b rfl
+          rfl
+        exact dite_eq _ _ (by
+          change (x * y)⁻¹ * (x * g * x⁻¹) * (x * y) = y⁻¹ * g * y
+          group)
+      · congr 1
+        ext i
+        congr 1
+        exact FDRep.char_conj (D.columnFDRep i) g x
+    · intro V' hV'
+      obtain ⟨j, ⟨iso_j⟩⟩ := D.columnFDRep_surjective V' hV'
+      rw [FDRep.char_iso iso_j]
+      simp only [Pi.sub_apply, Finset.sum_apply, Pi.smul_apply, sub_mul,
+        Finset.sum_sub_distrib]
+      rw [sub_eq_zero]
+      haveI (i : Fin D.n) : CategoryTheory.Simple (D.columnFDRep i) :=
+        D.columnFDRep_simple i
+      have horth_G : ∀ i : Fin D.n,
+          ∑ g : G, (D.columnFDRep i).character g * (D.columnFDRep j).character g⁻¹ =
+          if i = j then (Fintype.card G : ℂ) else 0 := by
+        intro i
+        have h := FDRep.char_orthonormal (D.columnFDRep i) (D.columnFDRep j)
+        rw [smul_eq_mul] at h
+        have hinv : ∀ (x y : ℂ), ⅟(Fintype.card G : ℂ) * x = y →
+            x = (Fintype.card G : ℂ) * y := fun x y hxy => by
+          rw [← hxy, ← mul_assoc, mul_invOf_self, one_mul]
+        by_cases hij : i = j
+        · subst hij
+          rw [if_pos rfl]
+          exact (hinv _ _ (by
+            rw [if_pos ⟨CategoryTheory.Iso.refl _⟩] at h
+            exact h)).trans (mul_one _)
+        · rw [if_neg hij]
+          exact (hinv _ _ (by
+            rw [if_neg (fun ⟨iso⟩ => hij
+              (D.columnFDRep_injective i j ⟨iso⟩))] at h
+            exact h)).trans (mul_zero _)
+      trans (↑(m j) * (Fintype.card G : ℂ))
+      · have lhs_sub : ∑ g : G,
+            Etingof.inducedCharacter H W.character g *
+              (D.columnFDRep j).character g⁻¹ =
+            ∑ g : G, (D.columnFDRep j).character g *
+              Etingof.inducedCharacter H W.character g⁻¹ := by
+          rw [← Equiv.sum_comp (Equiv.inv G)]
+          congr 1
+          ext g
+          simp [mul_comm]
+        have hfrob := frobenius_char_reciprocity H
+          (D.columnFDRep j).character W.character
+          (fun g x => FDRep.char_conj (D.columnFDRep j) g x)
+        rw [lhs_sub, hfrob]
+        have hlhs_rw :
+            ∑ h : ↥H, (D.columnFDRep j).character (↑h : G) * W.character h⁻¹ =
+              ∑ h : ↥H, (resH j).character h * W.character h⁻¹ :=
+          Finset.sum_congr rfl (fun h _ => rfl)
+        rw [hlhs_rw]
+        have hmult : ⅟(Fintype.card ↥H : ℂ) •
+            ∑ h : ↥H, (resH j).character h * W.character h⁻¹ = ↑(m j) := by
+          have h := FDRep.scalar_product_char_eq_finrank_equivariant W (resH j)
+          rw [smul_eq_mul] at h ⊢
+          convert h using 1
+        have hsum_H : ∑ h : ↥H, (resH j).character h * W.character h⁻¹ =
+            (Fintype.card ↥H : ℂ) * ↑(m j) := by
+          rw [smul_eq_mul] at hmult
+          calc
+            _ = (Fintype.card ↥H : ℂ) * (⅟(Fintype.card ↥H : ℂ) *
+                ∑ h : ↥H, (resH j).character h * W.character h⁻¹) := by
+              rw [← mul_assoc, mul_invOf_self, one_mul]
+            _ = _ := by rw [hmult]
+        rw [hsum_H]
+        have hH_ne : (Fintype.card ↥H : ℂ) ≠ 0 :=
+          Nat.cast_ne_zero.mpr Fintype.card_ne_zero
+        field_simp
+      · symm
+        simp only [zsmul_eq_mul, Finset.sum_mul]
+        rw [Finset.sum_comm]
+        simp_rw [mul_assoc, ← Finset.mul_sum, horth_G, mul_ite, mul_zero]
+        simp [Finset.sum_ite_eq', Finset.mem_univ]
+  exact sub_eq_zero.mp hdiff
+
+open Classical in
 /-- Character completeness on subgroups: if a class function f on G, when restricted to
 a subgroup H, is orthogonal to all irreducible characters of H, then f vanishes on H.
 

--- a/progress/items.json
+++ b/progress/items.json
@@ -6926,11 +6926,12 @@
     "start_line": 1,
     "end_line": 2,
     "status": "sorry_free",
-    "fidelity": "partial",
-    "coverage": "covered_partial",
-    "coverage_note": "Theorem5_26_1 proves the rational-span conclusion, and a private proof discusses the integral-rank argument. The remark's public Q-span iff C-span theorem and its equivalent decomposition-matrix row-independence criterion are absent; follow-up #7489.",
-    "fidelity_issue": 7489,
-    "last_updated": "2026-07-22"
+    "fidelity": "verified",
+    "sorry_free": true,
+    "coverage": "covered_full",
+    "coverage_note": "Remark5_26_2.lean defines the book-oriented integral decomposition matrix (irreducibles index rows and chosen induced representations index columns), proves its columns are the actual Frobenius-reciprocity multiplicities, and proves that rational character span, complex character span, and row linear independence are equivalent.",
+    "fidelity_decl": "Etingof.inducedCharacter_eq_irrepDecomp_sum, Etingof.Remark5262.decompositionMatrix, Etingof.Remark5_26_2",
+    "last_updated": "2026-07-27"
   },
   {
     "id": "Chapter5/Discussion_proof_of_Theorem5.26.1",


### PR DESCRIPTION
## Summary

- expose the actual Frobenius-reciprocity decomposition of an induced character in the `IrrepDecomp` basis
- define the integral decomposition matrix with irreducibles as rows and chosen induced representations as columns
- prove that rational character span, complex character span, and row linear independence are equivalent
- import the public Remark 5.26.2 endpoint from the Chapter 5 umbrella and mark its tracker entry fully covered

## Why

Theorem 5.26.1 used the integral-rank argument privately, but Remark 5.26.2 had no public matrix or source-facing equivalence. This makes the book's matrix orientation and all three equivalent conditions explicit and reusable.

## Validation

- `lake build EtingofRepresentationTheory.Chapter5.Remark5_26_2`
- `lake build EtingofRepresentationTheory.Chapter5`
- `python3 scripts/validate_items.py`
- `python3 scripts/validate_dependencies.py`
- `python3 scripts/validate_external_deps.py`
- lint-warning ratchet for the touched Lean modules
- axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`

Closes #7489
