### PR TITLE
feat: prove Weyl counterexample simplicity

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/Remark3_10_3.lean
+++ b/EtingofRepresentationTheory/Chapter3/Remark3_10_3.lean
@@ -8,6 +8,8 @@ import Mathlib.Algebra.Polynomial.Bivariate
 import Mathlib.RingTheory.Derivation.Lie
 import Mathlib.RingTheory.SimpleModule.Basic
 import Mathlib.RingTheory.MvPolynomial
+import Mathlib.LinearAlgebra.Basis.Basic
+import Mathlib.Algebra.BigOperators.Finsupp.Fin
 import EtingofRepresentationTheory.Chapter2.WeylAlgebraUniversal
 
 /-!
@@ -445,6 +447,75 @@ theorem tensorRep_not_factors_finiteDimensional
   have hfinrank : Module.finrank ℂ WeylCounterexampleModule = 0 :=
     MvPolynomial.finrank_eq_zero
   exact one_ne_zero (finrank_zero_iff_forall_zero.mp hfinrank 1)
+
+/-! ### The one-factor restriction is the regular Weyl module -/
+
+/-- The PBW basis of the characteristic-zero Weyl algebra. -/
+private noncomputable def weylBasis :
+    Module.Basis (ℕ × ℕ) ℂ (Etingof.WeylAlgebra ℂ) :=
+  Module.Basis.mk (Etingof.Proposition_2_7_1 (k := ℂ)).1
+    (Etingof.Proposition_2_7_1 (k := ℂ)).2
+
+/-- The bivariate monomial basis, indexed compatibly with the Weyl PBW basis. -/
+private noncomputable def bivariateBasis :
+    Module.Basis (ℕ × ℕ) ℂ WeylCounterexampleModule :=
+  (MvPolynomial.basisMonomials (Fin 2) ℂ).reindex
+    (finTwoArrowEquiv' ℕ)
+
+private theorem bivariateBasis_apply (i j : ℕ) :
+    bivariateBasis (i, j) = X 0 ^ i * X 1 ^ j := by
+  rw [bivariateBasis, Module.Basis.reindex_apply, MvPolynomial.coe_basisMonomials]
+  simp [finTwoArrowEquiv', MvPolynomial.monomial_eq]
+
+/-- The PBW linear equivalence between the Weyl algebra and the polynomial carrier. -/
+noncomputable def regularLinearEquiv :
+    Etingof.WeylAlgebra ℂ ≃ₗ[ℂ] WeylCounterexampleModule :=
+  weylBasis.equiv bivariateBasis (Equiv.refl (ℕ × ℕ))
+
+@[simp] theorem regularLinearEquiv_monomial (i j : ℕ) :
+    regularLinearEquiv (Etingof.WeylAlgebra.monomial ℂ i j) = X 0 ^ i * X 1 ^ j := by
+  rw [← show weylBasis (i, j) = Etingof.WeylAlgebra.monomial ℂ i j by
+    exact Module.Basis.mk_apply _ _ _]
+  rw [regularLinearEquiv, Module.Basis.equiv_apply, bivariateBasis_apply]
+  rfl
+
+/-- The orbit of the cyclic vector `1` under the first Weyl factor. -/
+noncomputable def firstOrbit :
+    Etingof.WeylAlgebra ℂ →ₗ[ℂ] WeylCounterexampleModule where
+  toFun a := firstRep a 1
+  map_add' a b := by simp
+  map_smul' c a := by simp
+
+private lemma firstY_pow_one (j : ℕ) :
+    (firstY ^ j) (1 : WeylCounterexampleModule) = X 1 ^ j := by
+  induction j with
+  | zero => simp
+  | succ j ih =>
+      rw [pow_succ', Module.End.mul_apply, ih]
+      simp [firstY, pderivEnd, mulVar]
+      rw [mul_comm, pow_succ]
+
+@[simp] theorem firstOrbit_monomial (i j : ℕ) :
+    firstOrbit (Etingof.WeylAlgebra.monomial ℂ i j) = X 0 ^ i * X 1 ^ j := by
+  change firstRep (Etingof.WeylAlgebra.monomial ℂ i j) 1 = _
+  rw [Etingof.WeylAlgebra.monomial, map_mul, map_pow, map_pow,
+    Module.End.mul_apply, firstRep_x, firstRep_y, firstY_pow_one]
+  induction i with
+  | zero => simp
+  | succ i ih =>
+      rw [pow_succ', Module.End.mul_apply, ih]
+      simp [firstX, mulVar]
+      ring
+
+/-- The PBW equivalence is exactly the orbit map `a ↦ a · 1`. In particular, restricting the
+entangled module to its first Weyl factor gives the left regular Weyl module. -/
+theorem regularLinearEquiv_eq_firstOrbit :
+    regularLinearEquiv.toLinearMap = firstOrbit := by
+  apply weylBasis.ext
+  intro p
+  rw [show weylBasis p = Etingof.WeylAlgebra.monomial ℂ p.1 p.2 by
+    exact Module.Basis.mk_apply _ _ _]
+  simp [regularLinearEquiv_monomial, firstOrbit_monomial]
 
 end
 

--- a/EtingofRepresentationTheory/Chapter3/Remark3_10_3.lean
+++ b/EtingofRepresentationTheory/Chapter3/Remark3_10_3.lean
@@ -4,7 +4,10 @@ import Mathlib.FieldTheory.RatFunc.Basic
 import Mathlib.RingTheory.Algebraic.Basic
 import Mathlib.Data.Complex.Basic
 import Mathlib.Algebra.MvPolynomial.PDeriv
+import Mathlib.Algebra.Polynomial.Bivariate
 import Mathlib.RingTheory.Derivation.Lie
+import Mathlib.RingTheory.SimpleModule.Basic
+import Mathlib.RingTheory.MvPolynomial
 import EtingofRepresentationTheory.Chapter2.WeylAlgebraUniversal
 
 /-!
@@ -288,6 +291,160 @@ theorem entangled_generator_relations :
         firstRep (Etingof.WeylAlgebra.x ℂ) 1 := by
   constructor <;>
     simp [firstY, firstX, secondY, secondX, pderivEnd, mulVar]
+
+private lemma pderiv_zero_bivariate_C (p : ℂ[X]) :
+    pderiv 0 (Polynomial.Bivariate.equivMvPolynomial ℂ (Polynomial.C p)) =
+      Polynomial.Bivariate.equivMvPolynomial ℂ (Polynomial.C p.derivative) := by
+  simpa using Polynomial.Bivariate.pderiv_zero_equivMvPolynomial (R := ℂ) (Polynomial.C p)
+
+/-- The entangled tensor-product Weyl module is simple.  Indeed, stability under the four
+Weyl generators implies stability under multiplication by both variables and under both
+ordinary partial derivatives.  Repeated partial differentiation takes every nonzero
+bivariate polynomial to a nonzero constant. -/
+theorem tensorModule_isSimpleModule :
+    letI := tensorModule
+    IsSimpleModule (Etingof.WeylAlgebra ℂ ⊗[ℂ] Etingof.WeylAlgebra ℂ)
+      WeylCounterexampleModule := by
+  classical
+  letI := tensorModule
+  let A := Etingof.WeylAlgebra ℂ ⊗[ℂ] Etingof.WeylAlgebra ℂ
+  refine { exists_pair_ne := ⟨⊥, ⊤, bot_ne_top⟩, eq_bot_or_eq_top := fun S => ?_ }
+  rcases eq_or_ne S ⊥ with rfl | hS
+  · exact Or.inl rfl
+  right
+  obtain ⟨p, hpS, hp0⟩ := (Submodule.ne_bot_iff S).mp hS
+  have hact (a : A) (q : WeylCounterexampleModule) : a • q = tensorRep a q := rfl
+  have hX0 (q : WeylCounterexampleModule) (hq : q ∈ S) : X 0 * q ∈ S := by
+    have := S.smul_mem ((Etingof.WeylAlgebra.x ℂ) ⊗ₜ[ℂ] (1 : Etingof.WeylAlgebra ℂ)) hq
+    simpa [hact, tensorRep_tmul, firstX, mulVar, Module.End.mul_apply] using this
+  have hX1 (q : WeylCounterexampleModule) (hq : q ∈ S) : X 1 * q ∈ S := by
+    have := S.smul_mem ((1 : Etingof.WeylAlgebra ℂ) ⊗ₜ[ℂ] Etingof.WeylAlgebra.x ℂ) hq
+    simpa [hact, tensorRep_tmul, secondX, mulVar, Module.End.mul_apply] using this
+  have hD0 (q : WeylCounterexampleModule) (hq : q ∈ S) : pderiv 0 q ∈ S := by
+    have := S.smul_mem
+      (((Etingof.WeylAlgebra.y ℂ) ⊗ₜ[ℂ] (1 : Etingof.WeylAlgebra ℂ)) -
+        ((1 : Etingof.WeylAlgebra ℂ) ⊗ₜ[ℂ] Etingof.WeylAlgebra.x ℂ)) hq
+    simpa [sub_smul, hact, tensorRep_tmul, firstY, secondX, pderivEnd, mulVar,
+      Module.End.mul_apply] using this
+  have hD1 (q : WeylCounterexampleModule) (hq : q ∈ S) : pderiv 1 q ∈ S := by
+    have := S.smul_mem
+      (((1 : Etingof.WeylAlgebra ℂ) ⊗ₜ[ℂ] Etingof.WeylAlgebra.y ℂ) -
+        ((Etingof.WeylAlgebra.x ℂ) ⊗ₜ[ℂ] (1 : Etingof.WeylAlgebra ℂ))) hq
+    simpa [sub_smul, hact, tensorRep_tmul, secondY, firstX, pderivEnd, mulVar,
+      Module.End.mul_apply] using this
+  let e := Polynomial.Bivariate.equivMvPolynomial ℂ
+  let q : ℂ[X][X] := e.symm p
+  have hp_eq : e q = p := e.apply_symm_apply p
+  have hq0 : q ≠ 0 := by
+    intro h
+    apply hp0
+    rw [← hp_eq, h, map_zero]
+  have houter : ∀ n : ℕ, e (Polynomial.derivative^[n] q) ∈ S := by
+    intro n
+    induction n with
+    | zero => simpa [e, q] using hpS
+    | succ n ih =>
+        rw [Function.iterate_succ_apply']
+        rw [← Polynomial.Bivariate.pderiv_one_equivMvPolynomial]
+        exact hD1 _ ih
+  let q₁ := Polynomial.derivative^[q.natDegree] q
+  have hq₁S : e q₁ ∈ S := houter q.natDegree
+  have hq₁deg : q₁.natDegree = 0 := by
+    exact Nat.le_zero.mp (by simpa [q₁] using Polynomial.natDegree_iterate_derivative q q.natDegree)
+  have hq₁zero : q₁ ≠ 0 := by
+    intro hz
+    have hc := Polynomial.coeff_iterate_derivative (k := q.natDegree) q 0
+    rw [show Polynomial.derivative^[q.natDegree] q = q₁ from rfl, hz,
+      Polynomial.coeff_zero] at hc
+    simp only [zero_add, Nat.descFactorial_self, Polynomial.coeff_natDegree] at hc
+    exact hq0 (Polynomial.leadingCoeff_eq_zero.mp
+      (smul_eq_zero.mp hc.symm |>.resolve_left (Nat.factorial_ne_zero _)))
+  let r : ℂ[X] := q₁.coeff 0
+  have hq₁_eq : q₁ = Polynomial.C r := Polynomial.eq_C_of_natDegree_eq_zero hq₁deg
+  have hr0 : r ≠ 0 := by
+    intro hr
+    exact hq₁zero (by simp [hq₁_eq, r, hr])
+  have hinner : ∀ n : ℕ, e (Polynomial.C (Polynomial.derivative^[n] r)) ∈ S := by
+    intro n
+    induction n with
+    | zero => simpa [hq₁_eq] using hq₁S
+    | succ n ih =>
+        rw [Function.iterate_succ_apply']
+        rw [← pderiv_zero_bivariate_C]
+        exact hD0 _ ih
+  let r₁ := Polynomial.derivative^[r.natDegree] r
+  have hr₁S : e (Polynomial.C r₁) ∈ S := hinner r.natDegree
+  have hr₁deg : r₁.natDegree = 0 := by
+    exact Nat.le_zero.mp (by simpa [r₁] using Polynomial.natDegree_iterate_derivative r r.natDegree)
+  have hr₁zero : r₁ ≠ 0 := by
+    intro hz
+    have hc := Polynomial.coeff_iterate_derivative (k := r.natDegree) r 0
+    rw [show Polynomial.derivative^[r.natDegree] r = r₁ from rfl, hz,
+      Polynomial.coeff_zero] at hc
+    simp only [zero_add, Nat.descFactorial_self, Polynomial.coeff_natDegree] at hc
+    exact hr0 (Polynomial.leadingCoeff_eq_zero.mp
+      (smul_eq_zero.mp hc.symm |>.resolve_left (Nat.factorial_ne_zero _)))
+  let c : ℂ := r₁.coeff 0
+  have hr₁_eq : r₁ = Polynomial.C c := Polynomial.eq_C_of_natDegree_eq_zero hr₁deg
+  have hc0 : c ≠ 0 := by
+    intro hc
+    exact hr₁zero (by simp [hr₁_eq, c, hc])
+  have hcS : MvPolynomial.C c ∈ S := by
+    simpa [e, hr₁_eq] using hr₁S
+  apply top_unique
+  intro z _
+  have hscale := S.smul_mem (algebraMap ℂ A c⁻¹) hcS
+  have hone : (1 : WeylCounterexampleModule) ∈ S := by
+    rw [hact, tensorRep.commutes] at hscale
+    change c⁻¹ • MvPolynomial.C c ∈ S at hscale
+    rw [MvPolynomial.smul_eq_C_mul, ← MvPolynomial.C_mul] at hscale
+    simpa [hc0] using hscale
+  have hC (d : ℂ) : MvPolynomial.C d ∈ S := by
+    have hs := S.smul_mem (algebraMap ℂ A d) hone
+    rw [hact, tensorRep.commutes] at hs
+    simpa [MvPolynomial.smul_eq_C_mul] using hs
+  have hall : ∀ z : WeylCounterexampleModule, z ∈ S := by
+    intro z
+    induction z using MvPolynomial.induction_on with
+    | C d => exact hC d
+    | add u v hu hv => exact S.add_mem hu hv
+    | mul_X u i hu =>
+        fin_cases i
+        · simpa [mul_comm] using hX0 u hu
+        · simpa [mul_comm] using hX1 u hu
+  exact hall z
+
+/-- The entangled representation does not factor through a finite-dimensional algebra.  If it
+did, the orbit of the nonzero cyclic vector `1` would be a quotient of a finite-dimensional
+vector space.  Simplicity says that orbit is the whole polynomial module, contradicting the
+infinite dimension of a polynomial ring in two variables. -/
+theorem tensorRep_not_factors_finiteDimensional
+    (Q : Type*) [Ring Q] [Algebra ℂ Q] [FiniteDimensional ℂ Q]
+    (q : (Etingof.WeylAlgebra ℂ ⊗[ℂ] Etingof.WeylAlgebra ℂ) →ₐ[ℂ] Q)
+    (r : Q →ₐ[ℂ] Module.End ℂ WeylCounterexampleModule) :
+    tensorRep ≠ r.comp q := by
+  classical
+  intro hfactor
+  let A := Etingof.WeylAlgebra ℂ ⊗[ℂ] Etingof.WeylAlgebra ℂ
+  letI := tensorModule
+  letI : IsSimpleModule A WeylCounterexampleModule := tensorModule_isSimpleModule
+  let orbitQ : Q →ₗ[ℂ] WeylCounterexampleModule := {
+    toFun a := r a 1
+    map_add' a b := by simp
+    map_smul' c a := by simp }
+  have horbitQ : Function.Surjective orbitQ := by
+    intro p
+    obtain ⟨a, ha⟩ := IsSimpleModule.toSpanSingleton_surjective A (one_ne_zero :
+      (1 : WeylCounterexampleModule) ≠ 0) p
+    refine ⟨q a, ?_⟩
+    change r (q a) 1 = p
+    rw [← AlgHom.comp_apply, ← hfactor]
+    exact ha
+  letI : FiniteDimensional ℂ WeylCounterexampleModule :=
+    FiniteDimensional.of_surjective orbitQ horbitQ
+  have hfinrank : Module.finrank ℂ WeylCounterexampleModule = 0 :=
+    MvPolynomial.finrank_eq_zero
+  exact one_ne_zero (finrank_zero_iff_forall_zero.mp hfinrank 1)
 
 end
 

--- a/EtingofRepresentationTheory/Chapter3/Remark3_10_3.lean
+++ b/EtingofRepresentationTheory/Chapter3/Remark3_10_3.lean
@@ -517,6 +517,41 @@ theorem regularLinearEquiv_eq_firstOrbit :
     exact Module.Basis.mk_apply _ _ _]
   simp [regularLinearEquiv_monomial, firstOrbit_monomial]
 
+/-- The module obtained by restricting the entangled representation to its first Weyl factor. -/
+@[reducible] noncomputable def firstRestrictionModule :
+    Module (Etingof.WeylAlgebra ℂ) WeylCounterexampleModule :=
+  Module.compHom WeylCounterexampleModule firstRep.toRingHom
+
+local instance : Module (Etingof.WeylAlgebra ℂ) WeylCounterexampleModule :=
+  firstRestrictionModule
+
+private noncomputable def firstOrbitLinear :
+    Etingof.WeylAlgebra ℂ →ₗ[Etingof.WeylAlgebra ℂ] WeylCounterexampleModule where
+  toFun a := firstRep a 1
+  map_add' a b := by simp
+  map_smul' a b := by
+    change firstRep (a * b) 1 = firstRep a (firstRep b 1)
+    rw [map_mul, Module.End.mul_apply]
+
+private theorem firstOrbitLinear_bijective : Function.Bijective firstOrbitLinear := by
+  have h : Function.Bijective firstOrbit := by
+    rw [← regularLinearEquiv_eq_firstOrbit]
+    exact regularLinearEquiv.bijective
+  constructor
+  · intro a b hab
+    exact h.1 hab
+  · intro p
+    exact h.2 p
+
+/-- Restriction of the entangled representation to the first Weyl factor is Weyl-linearly
+equivalent to the left regular Weyl module. -/
+noncomputable def regularModuleEquiv :
+    Etingof.WeylAlgebra ℂ ≃ₗ[Etingof.WeylAlgebra ℂ] WeylCounterexampleModule :=
+  LinearEquiv.ofBijective firstOrbitLinear firstOrbitLinear_bijective
+
+@[simp] theorem regularModuleEquiv_apply (a : Etingof.WeylAlgebra ℂ) :
+    regularModuleEquiv a = firstRep a 1 := rfl
+
 end
 
 end EtingofRepresentationTheory.Chapter3.Remark3_10_3


### PR DESCRIPTION
Stacked on #7974. Advances #7430.

This proves three major algebraic endpoints for the entangled `ℂ[x,y]e^{xy}` Weyl-tensor representation:

- `tensorModule_isSimpleModule`: every nonzero tensor-Weyl-stable submodule contains a nonzero constant after iterated partial differentiation, hence contains `1` and all polynomials;
- `tensorRep_not_factors_finiteDimensional`: the action cannot factor through any finite-dimensional complex algebra, because simplicity makes the orbit of `1` surjective while `MvPolynomial (Fin 2) ℂ` has infinite dimension;
- `regularLinearEquiv_eq_firstOrbit` and `regularModuleEquiv`: the restriction to the first Weyl factor is explicitly identified, via the PBW basis, with the left regular Weyl module. The standard basis element `x^i y^j` maps to `X₀^i X₁^j`, the equivalence is exactly the orbit map `a ↦ a · 1`, and the result is packaged as a genuine Weyl-linear equivalence for direct submodule transport.

Validation:

- direct file elaboration;
- `lake build EtingofRepresentationTheory.Chapter3`;
- all four repository validators;
- no `sorry` or `native_decide` in the changed file;
- axiom audit: only `propext`, `Classical.choice`, `Quot.sound`.

This intentionally does not close #7430 yet. Exact residual: prove that the left regular characteristic-zero Weyl module has no simple submodule (equivalently, no nonzero minimal left ideal), then transport that invariant across `regularLinearEquiv_eq_firstOrbit` and use the canonical copy of `V` in `V ⊗ W` to rule out an external tensor-product factorization.
