### PR TITLE
Enforce honest exercise coverage metadata

### DIFF
--- a/progress/2026-07-27T09-30-00Z_audit5140.md
+++ b/progress/2026-07-27T09-30-00Z_audit5140.md
@@ -1,0 +1,30 @@
+# #5140 process-metadata audit repair
+
+## Changes
+
+- Added the missing honest exercise-coverage record for
+  `Chapter6/Problem6.1.5`, pointing to `Etingof.IsFiniteTypeQuiver` and
+  `Etingof.Theorem_6_1_5` and distinguishing the separately partitioned theorem
+  and parts (a)-(c).
+- Normalized the four legacy exercise values `covered` to the PLAN vocabulary
+  `covered_full`; their existing notes already document complete coverage.
+- Extended `scripts/validate_items.py` so every exercise must have one of
+  `covered_full`, `covered_partial`, `not_started`, or `non_formalizable`.
+- Recorded a bounded prospective plan for the semantic `claim_coverage`
+  backfill.  In accordance with PR #5141's rollout note, the missing records
+  mean audit pending, do not retroactively un-verify existing items, and are not
+  a blocker to closing #5140 after its named mathematical residuals merge.
+
+## Verification
+
+- `jq empty progress/items.json`
+- exercise coverage distribution: 60 `covered_full`, 42 `covered_partial`, no
+  missing or legacy values
+- `python3 scripts/validate_items.py`: passed, 5721/5721 source lines covered,
+  583 partition blobs and 10 derived overlay items
+- Lean pointers checked in source:
+  `FiniteTypeDefs.lean` defines `Etingof.IsFiniteTypeQuiver`, and
+  `Problem6_1_5_theorem.lean` defines `Etingof.Theorem_6_1_5` and is imported by
+  `Chapter6.lean`
+
+No GitHub state was modified, and planner-lock sentinel #2357 was not touched.

--- a/progress/coverage-audit/claim-coverage-backfill-proposal.md
+++ b/progress/coverage-audit/claim-coverage-backfill-proposal.md
@@ -1,0 +1,93 @@
+# Claim-coverage durable-state backfill
+
+Status: prospective staged work under the periodic PLAN status checks; not a
+blocker to closing the historical #5140 umbrella.
+
+## Finding
+
+`PLAN.md` now requires a durable `claim_coverage` object on every formalizable
+item, but `progress/items.json` currently contains no such object on any of its
+593 records.  The existing evidence is substantial but uses older, coarser
+fields: 234 records have `fidelity: verified`, and 101 of 102 exercise records
+already had an exercise `coverage` state before the #5140 audit repair.
+
+This is the rollout state anticipated by merged PR #5141: missing
+`claim_coverage` means "audit pending", not "failed", and existing items must
+not be retroactively un-verified.  The latest #5140 maintainer status likewise
+uses the named mathematical residuals, not this prospective backfill, as its
+closure gate.
+
+This cannot be backfilled honestly by copying `status`, `fidelity`,
+`coverage_note`, or a declaration name.  `claim_coverage` is explicitly a
+per-conjunct semantic comparison with the source.  Inferring it mechanically
+would recreate the exact failure mode that Stage 3.2 steps 6-7 were added to
+prevent: a related declaration could be recorded as covering a stronger book
+claim.
+
+## Exact record format
+
+Backfilled records should use one object with an ordered claim list:
+
+```json
+"claim_coverage": {
+  "claims": [
+    {
+      "claim": "One normalized source claim or conjunct",
+      "verdict": "formalized",
+      "lean_decl": "Etingof.example"
+    },
+    {
+      "claim": "A claim proved at another source location",
+      "verdict": "covered_elsewhere",
+      "lean_decl": "Etingof.otherExample"
+    },
+    {
+      "claim": "Historical or motivational prose",
+      "verdict": "non_formalizable",
+      "reason": "Why no mathematical proposition is asserted"
+    }
+  ]
+}
+```
+
+Allowed verdicts are `formalized`, `covered_elsewhere`, and
+`non_formalizable`.  The first two require a resolvable `lean_decl`; the last
+requires a concrete `reason`.  A dropped or unformalized source conjunct is not
+given a success verdict: it must become a derived gap record and an issue under
+the existing Stage 3.7 process.
+
+## Bounded work plan
+
+1. **Claim-bearing statements (266 records).** Review theorem, lemma,
+   proposition, corollary, definition, example, and remark records in chapter
+   batches.  Reuse the existing fidelity reports as evidence, but enumerate the
+   source conjuncts again and resolve every named Lean declaration.
+2. **Exercises (102 records).** Reuse the exercise coverage-arm reports and
+   record sub-parts as separate claims.  Also backfill the 82 missing
+   `lean_decl` pointers; a `covered_partial` record must say exactly which
+   sub-parts remain.
+3. **Prose and remaining formalizable items.** Process discussion and
+   introduction records from the deterministic coverage worklist.  Record
+   genuinely non-formal prose with reasons instead of manufacturing Lean
+   coverage.
+4. **Enforcement.** Once a batch is backfilled, extend
+   `scripts/validate_items.py` to validate the object shape and declaration or
+   reason requirement.  Keep an explicit shrinking list of not-yet-audited
+   item IDs.  Turn missing `claim_coverage` into a repository-wide hard error
+   only when that list reaches zero; new items must never be added to it.
+
+## Completion criteria
+
+- Every formalizable partition item has a reviewed `claim_coverage.claims`
+  list.
+- Every `formalized` / `covered_elsewhere` entry names a checked declaration.
+- Every `non_formalizable` entry gives a source-specific reason.
+- Every uncovered conjunct has a derived record and issue.
+- The validator rejects malformed records and any newly added unaudited item.
+- The audit reports the claim-coverage total separately from byte coverage,
+  exercise coverage, and fidelity coverage.
+
+The periodic PLAN status check can run these batches directly.  Maintainers may
+open a dedicated process issue if coordination needs one, but the backfill need
+not become a new permanent issue and must not keep #5140 open after its named
+actionable residuals are resolved.

--- a/progress/items.json
+++ b/progress/items.json
@@ -2806,7 +2806,7 @@
       "EtingofRepresentationTheory/Chapter3/Problem3_9_2.lean",
       "EtingofRepresentationTheory/Chapter3/Problem3_9_2_Classification.lean"
     ],
-    "coverage": "covered",
+    "coverage": "covered_full",
     "coverage_arm": "audited",
     "lean_decl": [
       "Etingof.Problem3_9_2.ext1_self",
@@ -4242,7 +4242,7 @@
       "Etingof.Problem4_12_9.tensorIsoCharChar"
     ],
     "lean_file": "EtingofRepresentationTheory/Chapter4/Problem4_12_9.lean",
-    "coverage": "covered",
+    "coverage": "covered_full",
     "fidelity_note": "The source's four decompositions are now representation isomorphisms, not only trace identities. The right-hand sides are the constructed direct sums `Etingof.FDRep.pi`, which is proved to be the categorical biproduct (`Etingof.FDRep.piBiconeIsBilimit`), so the two direct-sum statements are also available in `⨁` form.",
     "last_updated": "2026-07-26"
   },
@@ -7278,7 +7278,18 @@
     "end_page": "152",
     "start_line": 35,
     "end_line": 37,
-    "status": "sorry_free"
+    "status": "sorry_free",
+    "coverage": "covered_full",
+    "lean_file": [
+      "EtingofRepresentationTheory/Chapter6/FiniteTypeDefs.lean",
+      "EtingofRepresentationTheory/Chapter6/Problem6_1_5_theorem.lean"
+    ],
+    "lean_decl": [
+      "Etingof.IsFiniteTypeQuiver",
+      "Etingof.Theorem_6_1_5"
+    ],
+    "coverage_note": "This introductory blob defines finite representation type and introduces Gabriel's theorem. `Etingof.IsFiniteTypeQuiver` gives the book's literal finite-type predicate (finitely many isomorphism classes of finite-dimensional indecomposable representations), while `Etingof.Theorem_6_1_5` supplies the announced finite-type iff Dynkin theorem. The separately partitioned theorem and parts (a)-(c) retain their own coverage records.",
+    "last_updated": "2026-07-27"
   },
   {
     "id": "Chapter6/Problem6.1.5_theorem",
@@ -8061,7 +8072,7 @@
     "fidelity": "full",
     "sorry_free": true,
     "coverage_note": "The lattice basis, coordinate descriptions, and root counts are joined to a faithful finite reduced simply-laced crystallographic root-system predicate. The E8, E7, and E6 root sets are proved finite, norm-two, reduced, integral, closed under negation, and closed under root reflections. Explicit compatible simple-root families are exhibited and their Gram graphs are proved to be the standard E8, E7, and E6 Dynkin diagrams, packaged by rootsOf_E8_type_E8, rootsOf_E7_type_E7, and rootsOf_E6_type_E6. All declarations are sorryAx-free; #7557 resolved.",
-    "coverage": "covered",
+    "coverage": "covered_full",
     "lean_file": "EtingofRepresentationTheory/Chapter6/Problem6_9_2.lean;EtingofRepresentationTheory/Chapter6/Problem6_9_2_RootSystem.lean",
     "last_updated": "2026-07-27"
   },
@@ -9559,7 +9570,7 @@
     "start_line": 11,
     "end_line": 14,
     "status": "sorry_free",
-    "coverage": "covered",
+    "coverage": "covered_full",
     "last_updated": "2026-07-26",
     "coverage_note": "Part (i) and the Hom-dimension/path-count computation are proved. For part (ii) the family A·eᵢ is now certified as the source-defined projective covers, in Chapter9/PathAlgebraVertexCovers.lean: the vertex simple modules Sᵢ = augModule k Q i are simple (augModule_isSimpleModule), pairwise non-isomorphic (augModule_not_isomorphic_of_ne) and exhaust the simple modules (exists_augModule_iso), so the vertices index the simples exactly; each Pᵢ = A·eᵢ is projective (pathAlgebraProj_projective) and, for acyclic Q, indecomposable (pathAlgebraProj_isIndecomposable); the augmentation Pᵢ ↠ Sᵢ is surjective with superfluous kernel (projToSimple_essential), packaged as Etingof.ProjectiveCover in vertexProjectiveCover. cartanMatrix_pathAlgebra_eq_pathCount_of_projectiveCovers assembles these with cartanMatrix_pathAlgebra_eq_pathCount', so the computed matrix is the Cartan matrix of Definition 9.3.1."
   },

--- a/scripts/validate_items.py
+++ b/scripts/validate_items.py
@@ -29,6 +29,16 @@ VALID_TYPES = {
 DERIVED_TYPE = "derived"
 DERIVED_REQUIRED_FIELDS = {"type", "derived_from", "source_span", "claim", "status"}
 
+# PLAN Stage 3.7 requires every exercise item to carry one of these honest
+# coverage states.  In particular, `status: sorry_free` is not a substitute:
+# an exercise can have no matching Lean declaration and still be sorry-free.
+VALID_EXERCISE_COVERAGE = {
+    "covered_full",
+    "covered_partial",
+    "not_started",
+    "non_formalizable",
+}
+
 # Files in pages/ that are not actual page content
 EXCLUDED_FILES = {"CONVENTIONS.md"}
 
@@ -225,6 +235,18 @@ def validate(items_path):
         # Type enum
         if item["type"] not in VALID_TYPES:
             errors.append(f"{prefix}: invalid type '{item['type']}'")
+
+        # Stage 3.7 exercise-coverage ratchet.  This is deliberately limited to
+        # the mechanically checkable part of the requirement: presence of a
+        # recognized state.  Whether the state is mathematically accurate still
+        # requires the source/Lean review recorded in `coverage_note`.
+        if item["type"] == "exercise":
+            exercise_coverage = item.get("coverage")
+            if exercise_coverage not in VALID_EXERCISE_COVERAGE:
+                errors.append(
+                    f"{prefix}: exercise coverage must be one of "
+                    f"{sorted(VALID_EXERCISE_COVERAGE)}, got {exercise_coverage!r}"
+                )
 
         # Line number types
         if not isinstance(item["start_line"], int):


### PR DESCRIPTION
## Summary

- add the missing honest exercise-coverage record for `Chapter6/Problem6.1.5`, with checked pointers to `Etingof.IsFiniteTypeQuiver` and `Etingof.Theorem_6_1_5`;
- normalize the four remaining legacy exercise values `covered` to the PLAN vocabulary `covered_full`;
- make `validate_items.py` reject a missing or unrecognized exercise coverage state; and
- record a bounded prospective plan for semantic `claim_coverage` backfill.

## Why

The #5140 closure audit found one exercise still carrying only `status: sorry_free`, so the Stage 3.7 exercise ratchet was not mechanically complete. The validator did not enforce the required four-state vocabulary, which allowed that omission and four legacy values to persist.

The audit also confirmed PR #5141's rollout state: missing `claim_coverage` means audit pending, not failed. This PR therefore does not synthesize 593 semantic assessments or retroactively un-verify existing items; it documents a truthful staged route for the periodic PLAN status checks.

## Validation

- `jq empty progress/items.json`
- `python3 -m py_compile scripts/validate_items.py`
- `python3 scripts/validate_items.py` — passed; 5721/5721 source lines, 583 partition blobs, 10 derived items
- exercise distribution: 60 `covered_full`, 42 `covered_partial`, no missing or legacy values
- source resolution checked for both new Problem 6.1.5 Lean pointers and the Chapter 6 umbrella import
- `git diff --check`

Refs #5140. This intentionally does not auto-close the tracker; its named mathematical PR fleet remains the closure gate.
