### PR TITLE
ci: eliminate duplicate PR branch builds

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -2,6 +2,7 @@ name: Lean Action CI
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/EtingofRepresentationTheory/Chapter8/KoszulBimoduleShear.lean
+++ b/EtingofRepresentationTheory/Chapter8/KoszulBimoduleShear.lean
@@ -391,7 +391,7 @@ noncomputable def regularResolutionZeroIso :
   HomologicalComplex.singleObjXIsoOfEq
     (ComplexShape.down ℕ) 0 (regularObj k V) 0 rfl
 
-noncomputable def externalRegularTermComponent
+noncomputable def bimoduleExternalRegularTermComponent
     {M : ModuleCat.{u} (S k V)} (P : ProjectiveResolution M) (n i₁ i₂ : ℕ)
     (h : (ComplexShape.down ℕ).π (ComplexShape.down ℕ) (ComplexShape.down ℕ)
       (i₁, i₂) = n) :
@@ -407,24 +407,24 @@ noncomputable def externalRegularTermComponent
   · exact 0
 
 @[simp]
-theorem externalRegularTermComponent_zero
+theorem bimoduleExternalRegularTermComponent_zero
     {M : ModuleCat.{u} (S k V)} (P : ProjectiveResolution M) (n : ℕ)
     (h : (ComplexShape.down ℕ).π (ComplexShape.down ℕ) (ComplexShape.down ℕ)
       (n, 0) = n) :
-    externalRegularTermComponent k V P n n 0 h =
+    bimoduleExternalRegularTermComponent k V P n n 0 h =
       ((extTensorFunctorLeft k (S k V) (S k V)).obj (P.complex.X n)).map
         (regularResolutionZeroIso k V).hom := by
-  simp [externalRegularTermComponent]
+  simp [bimoduleExternalRegularTermComponent]
 
 /-- Tensoring a complex with the degree-zero regular resolution introduces no extra terms:
 the degree-`n` total-complex object is its degree-`n` term externally tensored with `SV`. -/
-noncomputable def externalRegularTermIso
+noncomputable def bimoduleExternalRegularTermIso
     {M : ModuleCat.{u} (S k V)} (P : ProjectiveResolution M) (n : ℕ) :
     (extTensorComplexLeft (k := k) P (regularResolution k V)).X n ≅
       ((extTensorFunctorLeft k (S k V) (S k V)).obj (P.complex.X n)).obj
         (regularObj k V) where
   hom := HomologicalComplex.mapBifunctorDesc (j := n)
-    (externalRegularTermComponent k V P n)
+    (bimoduleExternalRegularTermComponent k V P n)
   inv := ((extTensorFunctorLeft k (S k V) (S k V)).obj (P.complex.X n)).map
       (regularResolutionZeroIso k V).inv ≫
     HomologicalComplex.ιMapBifunctor P.complex (regularResolution k V).complex
@@ -436,7 +436,7 @@ noncomputable def externalRegularTermIso
     · have hi : i₁ = n := by simpa using h
       subst i₁
       rw [← Category.assoc, HomologicalComplex.ι_mapBifunctorDesc,
-        externalRegularTermComponent_zero, ← Category.assoc, ← Functor.map_comp]
+        bimoduleExternalRegularTermComponent_zero, ← Category.assoc, ← Functor.map_comp]
       simp
     · have hz : IsZero ((regularResolution k V).complex.X (i₂ + 1)) := by
         change IsZero (((ChainComplex.single₀ (ModuleCat.{u} (S k V))).obj
@@ -447,7 +447,7 @@ noncomputable def externalRegularTermIso
         (P.complex.X i₁)).map_isZero hz).eq_of_src _ _
   inv_hom_id := by
     rw [Category.assoc, HomologicalComplex.ι_mapBifunctorDesc,
-      externalRegularTermComponent_zero, ← Functor.map_comp]
+      bimoduleExternalRegularTermComponent_zero, ← Functor.map_comp]
     simp
 
 /-! ## Literal terms of the bimodule resolution -/
@@ -846,7 +846,7 @@ noncomputable def koszulBimoduleResolutionTermIso
       @ModuleCat.of (E k V) _ (koszulBimoduleX k V i) _
         (koszulBimoduleTermModule k V i) :=
   (shearRestrictionFunctor k V).mapIso
-      (externalRegularTermIso k V (koszulResolution b) i) ≪≫
+      (bimoduleExternalRegularTermIso k V (koszulResolution b) i) ≪≫
     shearedKoszulTermIso k V i
 
 /-- **Freeness endpoint of Problem 8.2.10(iii).** Every term of the Koszul bimodule resolution is


### PR DESCRIPTION
## Summary

- run pull-request CI once instead of launching a duplicate direct-push build for every same-repository PR branch
- keep push CI on `main`, pull-request CI (including forks), and manual dispatch
- preserve the required `build` check name and existing concurrency behavior
- repair a newly exposed Chapter 8 integration collision by giving the three `KoszulBimoduleShear` external-regular helper declarations module-specific names

## Why

The previous unrestricted `push` plus `pull_request` triggers launched two independent cold Lean builds for every PR branch. Since the concurrency key includes `github.ref`, the push and PR runs did not cancel each other and both consumed roughly an hour of CI capacity.

The first exact run of this PR also exposed that two recently merged Chapter 8 modules declared the same three global names. The rename is local to `KoszulBimoduleShear`; all six internal call sites were updated.

## Validation

- exact current head `802f4307a379a5ad511f547f1577706d6ba92b33` launched exactly one Actions run, a `pull_request` run; no push-event run exists
- reproduced the duplicate-environment failure before the Chapter 8 rename
- direct compilation of the joint Chapter 8 importer passes after the rename
- targeted build of `KoszulBimoduleShear`, `KoszulDirectSumResolution`, and `Problem8_2_10_HilbertSyzygyResolution` passes
- complete local repository build passes at the exact head (9,399 jobs)
- exact CI module selection and warning-ratchet check pass (`269` baseline files; `268` built in the CI set)
- workflow structure checks and `git diff --check` pass
