### PR TITLE
feat(Ch2 §2.4): verify Stage 3.3 proofs

### DIFF
--- a/progress/2026-07-27T11-32-00Z_stage3-3-chapter2-section2-4.md
+++ b/progress/2026-07-27T11-32-00Z_stage3-3-chapter2-section2-4.md
@@ -1,0 +1,30 @@
+# Stage 3.3 proof verification — Chapter 2 §2.4
+
+## Scope
+
+This Stage 3.3 pass covers exactly `Chapter2/Discussion_2.4_heading` and
+`Chapter2/Problem2.4.1`. The faithful statement/definition review belongs to the preceding
+Stage 3.2 PR and is not repeated here.
+
+## Result
+
+Every formal claim recorded by the §2.4 Stage 3.2 audit has a complete proof or construction:
+
+- the ideal/subrepresentation bridges are definitional equalities;
+- membership in the left/right views of a two-sided ideal uses Mathlib's exact carrier lemmas;
+- the generated-ideal universal properties and `a * s * b` characterization are proved by
+  Mathlib's span API;
+- the kernel membership bridge is proved by `TwoSidedIdeal.mem_ker`;
+- maximal left and right ideals follow from Mathlib's Krull theorem;
+- maximal two-sided ideals have the explicit Zorn proof already present in `Problem2_4_1.lean`.
+
+A source scan of the two scoped Lean files finds no `sorry`, `admit`, or project `axiom`.
+The existing `sorry_free` item statuses remain valid. Durable `stage3_3` records now identify the
+verified declarations for both items.
+
+## Validation
+
+- `lake build EtingofRepresentationTheory.Chapter2`
+- scoped source scan for `sorry`, `admit`, and `axiom`
+- `jq empty progress/items.json`
+- `git diff --check`

--- a/progress/items.json
+++ b/progress/items.json
@@ -745,6 +745,23 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.4",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Discussion2_4.leftIdeal_eq_regularSubrepresentation",
+        "Etingof.Discussion2_4.rightIdeal_eq_op_regularSubrepresentation",
+        "Etingof.Discussion2_4.mem_toLeft_iff",
+        "Etingof.Discussion2_4.mem_toRight_iff",
+        "Etingof.Discussion2_4.leftGenerated_le_iff",
+        "Etingof.Discussion2_4.rightGenerated_le_iff",
+        "Etingof.Discussion2_4.generated_le_iff",
+        "Etingof.Discussion2_4.mem_generated_iff_mem_addSubgroup_closure",
+        "Etingof.Discussion2_4.mem_ker_iff"
+      ]
+    },
     "last_updated": "2026-07-27",
     "coverage_swept": {
       "wave": 1,
@@ -793,6 +810,17 @@
           "verdict": "formalized",
           "lean_decl": "Etingof.Problem2_4_1.exists_maximal_twoSided_ideal"
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.4",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Problem2_4_1.exists_maximal_left_ideal",
+        "Etingof.Problem2_4_1.exists_maximal_right_ideal",
+        "Etingof.Problem2_4_1.exists_maximal_twoSided_ideal"
       ]
     }
   },


### PR DESCRIPTION
## What changed

- verifies Stage 3.3 proof completion for exactly Chapter 2 §2.4
- records the complete declaration set for both scoped items in durable `stage3_3` metadata
- preserves the already-valid `sorry_free` status

## Proof verification

- all ideal/subrepresentation and generated-ideal bridges are complete
- the maximal left, right, and two-sided ideal conclusions all have proofs
- the scoped source scan contains no `sorry`, `admit`, or project `axiom`

## Validation

- `lake build EtingofRepresentationTheory.Chapter2`
- scoped source scan for `sorry`, `admit`, and `axiom`
- `jq empty progress/items.json`
- `git diff --check`

Stage 3.3 only; Stage 3.2 is handled by #7999.

Related to #5140.
