### PR TITLE
chore(Ch2 §2.4): trim Stage 3.4 dependencies

### DIFF
--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -139,11 +139,9 @@
     "Chapter2/Problem2.3.17"
   ],
   "Chapter2/Discussion_2.4_heading": [
-    "Chapter2/Problem2.3.18"
+    "Chapter2/Definition2.3.4"
   ],
-  "Chapter2/Problem2.4.1": [
-    "Chapter2/Discussion_2.4_heading"
-  ],
+  "Chapter2/Problem2.4.1": [],
   "Chapter2/Discussion_2.5_heading": [
     "Chapter2/Problem2.4.1"
   ],

--- a/progress/2026-07-27T11-34-00Z_stage3-4-chapter2-section2-4.md
+++ b/progress/2026-07-27T11-34-00Z_stage3-4-chapter2-section2-4.md
@@ -1,0 +1,29 @@
+# Stage 3.4 dependency trimming — Chapter 2 §2.4
+
+## Scope
+
+This pass analyzes the actual internal dependencies of exactly
+`Chapter2/Discussion_2.4_heading` and `Chapter2/Problem2.4.1` after their Stage 3.3 proofs were
+verified.
+
+## Actual dependencies
+
+- `Chapter2/Discussion_2.4_heading` depends directly on `Chapter2/Definition2.3.4` because the
+  left- and right-ideal bridges identify the relevant submodules with the project's
+  `Etingof.Subrepresentation` abbreviation. The remaining ideal, span, kernel, and simple-ring
+  declarations come directly from Mathlib and therefore do not create internal graph edges.
+- `Chapter2/Problem2.4.1` has no internal dependency. Its Lean file imports Mathlib only: the left
+  and right cases use `Ideal.exists_maximal`, and the two-sided case supplies its own Zorn
+  argument.
+
+The conservative linear-chain edges (`Problem2.3.18` for the discussion and the discussion for
+the problem) were therefore replaced with these actual dependencies in
+`dependencies/internal.json`.
+
+Both items now carry durable `stage3_4` records and move to `dependency_trimmed`.
+
+## Validation
+
+- every new internal target exists in the root item catalog
+- `jq empty dependencies/internal.json progress/items.json`
+- `git diff --check`

--- a/progress/items.json
+++ b/progress/items.json
@@ -909,7 +909,7 @@
     "end_page": "15",
     "start_line": 2,
     "end_line": 14,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "fidelity": "verified",
     "lean_file": "EtingofRepresentationTheory/Chapter2/Discussion_2_4_heading.lean",
@@ -981,6 +981,15 @@
         "Etingof.Discussion2_4.mem_ker_iff"
       ]
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.4",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Definition2.3.4"
+      ],
+      "basis": "The section dictionary imports the subrepresentation definition for its regular-representation bridges; its remaining dependencies are Mathlib declarations."
+    },
     "last_updated": "2026-07-27",
     "coverage_swept": {
       "wave": 1,
@@ -995,7 +1004,7 @@
     "end_page": "15",
     "start_line": 15,
     "end_line": 15,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "fidelity": "verified",
     "last_updated": "2026-07-27",
@@ -1041,6 +1050,13 @@
         "Etingof.Problem2_4_1.exists_maximal_right_ideal",
         "Etingof.Problem2_4_1.exists_maximal_twoSided_ideal"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.4",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The three existence proofs import only Mathlib: the one-sided cases use Ideal.exists_maximal and the two-sided case is a self-contained Zorn argument."
     }
   },
   {


### PR DESCRIPTION
## What changed

- performs Stage 3.4 dependency trimming for exactly Chapter 2 §2.4
- replaces two conservative chain edges with actual proof/import dependencies
- records durable `stage3_4` evidence and advances both items to `dependency_trimmed`

## Dependency result

- `Discussion_2.4_heading` depends directly on `Definition2.3.4` for the regular-subrepresentation bridge
- `Problem2.4.1` has no internal dependency; its proof imports Mathlib only

## Validation

- all internal dependency targets exist in `items.json`
- `jq empty dependencies/internal.json progress/items.json`
- `git diff --check`

Stage 3.4 only.

Related to #5140.
