### PR TITLE
style(Ch2 §2.4): complete Stage 3.5 polish

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Discussion_2_4_heading.lean
+++ b/EtingofRepresentationTheory/Chapter2/Discussion_2_4_heading.lean
@@ -68,10 +68,11 @@ definitionally the same objects. -/
 theorem rightIdeal_eq_op_regularSubrepresentation :
     RightIdeal A = Etingof.Subrepresentation Aᵐᵒᵖ Aᵐᵒᵖ := rfl
 
-@[simp]
+/-- Membership in a two-sided ideal agrees with membership after viewing it as a left ideal. -/
 theorem mem_toLeft_iff {I : Ideal A} {x : A} : x ∈ I.toLeft ↔ x ∈ I :=
   TwoSidedIdeal.mem_asIdeal
 
+/-- Membership in a two-sided ideal agrees with membership after viewing it as a right ideal. -/
 @[simp]
 theorem mem_toRight_iff {I : Ideal A} {x : Aᵐᵒᵖ} : x ∈ I.toRight ↔ x.unop ∈ I :=
   TwoSidedIdeal.mem_asIdealOpposite

--- a/EtingofRepresentationTheory/Chapter2/Problem2_4_1.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_4_1.lean
@@ -1,4 +1,6 @@
-import Mathlib
+import Mathlib.Order.Zorn
+import Mathlib.RingTheory.Ideal.Maximal
+import Mathlib.RingTheory.TwoSidedIdeal.Lattice
 
 /-!
 # Problem 2.4.1: Existence of maximal ideals

--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -139,11 +139,9 @@
     "Chapter2/Problem2.3.17"
   ],
   "Chapter2/Discussion_2.4_heading": [
-    "Chapter2/Problem2.3.18"
+    "Chapter2/Definition2.3.4"
   ],
-  "Chapter2/Problem2.4.1": [
-    "Chapter2/Discussion_2.4_heading"
-  ],
+  "Chapter2/Problem2.4.1": [],
   "Chapter2/Discussion_2.5_heading": [
     "Chapter2/Problem2.4.1"
   ],

--- a/progress/2026-07-27T11-34-00Z_stage3-4-chapter2-section2-4.md
+++ b/progress/2026-07-27T11-34-00Z_stage3-4-chapter2-section2-4.md
@@ -1,0 +1,29 @@
+# Stage 3.4 dependency trimming — Chapter 2 §2.4
+
+## Scope
+
+This pass analyzes the actual internal dependencies of exactly
+`Chapter2/Discussion_2.4_heading` and `Chapter2/Problem2.4.1` after their Stage 3.3 proofs were
+verified.
+
+## Actual dependencies
+
+- `Chapter2/Discussion_2.4_heading` depends directly on `Chapter2/Definition2.3.4` because the
+  left- and right-ideal bridges identify the relevant submodules with the project's
+  `Etingof.Subrepresentation` abbreviation. The remaining ideal, span, kernel, and simple-ring
+  declarations come directly from Mathlib and therefore do not create internal graph edges.
+- `Chapter2/Problem2.4.1` has no internal dependency. Its Lean file imports Mathlib only: the left
+  and right cases use `Ideal.exists_maximal`, and the two-sided case supplies its own Zorn
+  argument.
+
+The conservative linear-chain edges (`Problem2.3.18` for the discussion and the discussion for
+the problem) were therefore replaced with these actual dependencies in
+`dependencies/internal.json`.
+
+Both items now carry durable `stage3_4` records and move to `dependency_trimmed`.
+
+## Validation
+
+- every new internal target exists in the root item catalog
+- `jq empty dependencies/internal.json progress/items.json`
+- `git diff --check`

--- a/progress/2026-07-27T11-36-00Z_stage3-5-chapter2-section2-4.md
+++ b/progress/2026-07-27T11-36-00Z_stage3-5-chapter2-section2-4.md
@@ -1,0 +1,33 @@
+# Stage 3.5 Mathlib-quality polish — Chapter 2 §2.4
+
+## Scope
+
+This pass reviews exactly the §2.4 files
+`Discussion_2_4_heading.lean` and `Problem2_4_1.lean` after dependency trimming.
+
+## Review
+
+The section was checked against the Stage 3.5 criteria:
+
+- The discussion declarations are direct abbreviations for Mathlib structures or short bridge
+  theorems whose names expose the book/Mathlib correspondence.
+- Imports are focused on subrepresentations, simple rings, kernels, and two-sided span operations.
+- The generated-ideal statements reuse Mathlib's universal properties instead of duplicating
+  proofs.
+- The maximal-left/right proofs delegate directly to `Ideal.exists_maximal`.
+- The two-sided proof isolates the only nontrivial ingredient—the chain-union upper bound—before
+  applying Zorn, and uses explicit simp sets rather than broad cleanup tactics.
+- There are no redundant local helper declarations, unused simp arguments, deprecated tactics,
+  flexible `simp at`, or style warnings in either scoped file.
+
+No source rewrite was justified: shortening the explicit Zorn construction would hide the missing
+two-sided Mathlib API rather than improve readability. Both items therefore advance from
+`dependency_trimmed` to `proof_polished`, with durable `stage3_5` review records.
+
+## Validation
+
+- `lake env lean EtingofRepresentationTheory/Chapter2/Discussion_2_4_heading.lean`
+- `lake env lean EtingofRepresentationTheory/Chapter2/Problem2_4_1.lean`
+- `lake build EtingofRepresentationTheory.Chapter2`
+- `jq empty progress/items.json`
+- `git diff --check`

--- a/progress/2026-07-27T11-36-00Z_stage3-5-chapter2-section2-4.md
+++ b/progress/2026-07-27T11-36-00Z_stage3-5-chapter2-section2-4.md
@@ -19,6 +19,9 @@ The section was checked against the Stage 3.5 criteria:
   applying Zorn, and uses explicit simp sets rather than broad cleanup tactics.
 - There are no redundant local helper declarations, unused simp arguments, deprecated tactics,
   flexible `simp at`, or style warnings in either scoped file.
+- The two public ideal-membership bridge theorems have declaration documentation, and the
+  redundant simp registration on `mem_toLeft_iff` has been removed so that the scoped API passes
+  `simpNF`.
 
 No source rewrite was justified: shortening the explicit Zorn construction would hide the missing
 two-sided Mathlib API rather than improve readability. Both items therefore advance from
@@ -28,6 +31,9 @@ two-sided Mathlib API rather than improve readability. Both items therefore adva
 
 - `lake env lean EtingofRepresentationTheory/Chapter2/Discussion_2_4_heading.lean`
 - `lake env lean EtingofRepresentationTheory/Chapter2/Problem2_4_1.lean`
+- temporary scoped declaration-linter passes, including `docBlameThm` and `simpNF`; the
+  `defsWithUnderscore` naming check is inapplicable because it mechanically flags the established
+  source-aligned namespace `Discussion2_4`
 - `lake build EtingofRepresentationTheory.Chapter2`
 - `jq empty progress/items.json`
 - `git diff --check`

--- a/progress/items.json
+++ b/progress/items.json
@@ -909,7 +909,7 @@
     "end_page": "15",
     "start_line": 2,
     "end_line": 14,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "fidelity": "verified",
     "lean_file": "EtingofRepresentationTheory/Chapter2/Discussion_2_4_heading.lean",
@@ -981,6 +981,15 @@
         "Etingof.Discussion2_4.mem_ker_iff"
       ]
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.4",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Definition2.3.4"
+      ],
+      "basis": "The section dictionary imports the subrepresentation definition for its regular-representation bridges; its remaining dependencies are Mathlib declarations."
+    },
     "last_updated": "2026-07-27",
     "coverage_swept": {
       "wave": 1,
@@ -995,7 +1004,7 @@
     "end_page": "15",
     "start_line": 15,
     "end_line": 15,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "fidelity": "verified",
     "last_updated": "2026-07-27",
@@ -1041,6 +1050,13 @@
         "Etingof.Problem2_4_1.exists_maximal_right_ideal",
         "Etingof.Problem2_4_1.exists_maximal_twoSided_ideal"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.4",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The three existence proofs import only Mathlib: the one-sided cases use Ideal.exists_maximal and the two-sided case is a self-contained Zorn argument."
     }
   },
   {

--- a/progress/items.json
+++ b/progress/items.json
@@ -909,7 +909,7 @@
     "end_page": "15",
     "start_line": 2,
     "end_line": 14,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "coverage": "covered_full",
     "fidelity": "verified",
     "lean_file": "EtingofRepresentationTheory/Chapter2/Discussion_2_4_heading.lean",
@@ -990,6 +990,13 @@
       ],
       "basis": "The section dictionary imports the subrepresentation definition for its regular-representation bridges; its remaining dependencies are Mathlib declarations."
     },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.4",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "No source rewrite was needed: the declarations use direct Mathlib aliases or single-purpose bridge theorems, have focused imports, and emit no Lean style or tactic linter warnings."
+    },
     "last_updated": "2026-07-27",
     "coverage_swept": {
       "wave": 1,
@@ -1004,7 +1011,7 @@
     "end_page": "15",
     "start_line": 15,
     "end_line": 15,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "coverage": "covered_full",
     "fidelity": "verified",
     "last_updated": "2026-07-27",
@@ -1057,6 +1064,13 @@
       "verified_on": "2026-07-27",
       "actual_internal_dependencies": [],
       "basis": "The three existence proofs import only Mathlib: the one-sided cases use Ideal.exists_maximal and the two-sided case is a self-contained Zorn argument."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.4",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "No source rewrite was needed: the one-sided proofs delegate directly to Mathlib, the two-sided Zorn proof is factored by chain-bound construction, simp sets are explicit, and both scoped files emit no Lean style or tactic linter warnings."
     }
   },
   {


### PR DESCRIPTION
## What changed

- performs the Stage 3.5 Mathlib-quality review for exactly Chapter 2 §2.4
- narrows `Problem2_4_1.lean` from the umbrella `import Mathlib` to the exact Zorn, maximal-ideal, and two-sided-ideal modules it uses
- records the concrete style/API review for the ideal dictionary and maximal-ideal proofs
- documents both public ideal-membership bridge theorems and removes the redundant `[simp]` registration on `mem_toLeft_iff`
- advances both scoped items from `dependency_trimmed` to `proof_polished`

## Polish result

The declarations and proofs use direct Mathlib APIs, small named bridge theorems, explicit simp sets, and warning-free tactics. The broad import in the maximal-ideal file is replaced with focused Zorn, maximal-ideal, and two-sided-ideal modules. The explicit Zorn construction is retained because hiding it would make the missing two-sided maximal-ideal API less clear rather than improve the proof.

## Validation

- standalone elaboration and scoped builds for both §2.4 files
- applicable declaration linters, including `docBlameThm` and `simpNF`, pass with zero errors; `defsWithUnderscore` is excluded because it mechanically flags the established source-aligned namespace `Discussion2_4`
- repository item, dependency, and external-dependency validators pass
- `jq empty progress/items.json`
- `git diff --check`

Stage 3.5 only.

Related to #5140.