### PR TITLE
verify: complete Stage 3.3 for section 2.6

### DIFF
--- a/progress/2026-07-27-stage3-3-section-2-6.md
+++ b/progress/2026-07-27-stage3-3-section-2-6.md
@@ -1,0 +1,30 @@
+# Stage 3.3 proof verification: Section 2.6
+
+## Scope
+
+This pass covers exactly `Chapter2/Discussion_2.6` and Stage 3.3. The faithful
+statement/definition audit belongs to the preceding Stage 3.2 PR.
+
+## Result
+
+Every formal claim inventoried at Stage 3.2 already has a complete proof or construction:
+
+- `finPresentation_def` identifies the finite presentation with the quotient specified by the
+  book;
+- `adjoin_range_gen` proves that the generator images algebra-generate the quotient, while
+  `mk_surjective` and `hom_ext` supply the corresponding quotient and extensionality properties;
+- `mk_rel` proves each defining relation in the quotient;
+- `presentedCon_le_ker`, `lift_mk`, `lift_gen`, `existsUnique_lift`, and
+  `lift_rel_eq_zero` establish both directions of the universal property.
+
+The scoped source contains no `sorry`, `admit`, or project `axiom`. No Stage 3.3 source change is
+needed; the durable item record lists the declarations whose proofs were verified.
+
+## Validation
+
+- `lake env lean EtingofRepresentationTheory/Chapter2/Discussion_2_6.lean`
+- scoped source scan for `sorry`, `admit`, and `axiom`
+- `jq empty progress/items.json`
+- `git diff --check`
+
+This PR is limited to Section 2.6 and Stage 3.3.

--- a/progress/items.json
+++ b/progress/items.json
@@ -803,6 +803,24 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.6",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.PresentedAlgebra.mk_surjective",
+        "Etingof.PresentedAlgebra.adjoin_range_gen",
+        "Etingof.PresentedAlgebra.mk_rel",
+        "Etingof.PresentedAlgebra.presentedCon_le_ker",
+        "Etingof.PresentedAlgebra.lift_mk",
+        "Etingof.PresentedAlgebra.lift_gen",
+        "Etingof.PresentedAlgebra.hom_ext",
+        "Etingof.PresentedAlgebra.existsUnique_lift",
+        "Etingof.PresentedAlgebra.lift_rel_eq_zero",
+        "Etingof.PresentedAlgebra.finPresentation_def"
+      ]
+    },
     "coverage_swept": {
       "wave": 1,
       "result": "none"


### PR DESCRIPTION
## Scope

- Section 2.6 only
- Stage 3.3 only: proof completion and proof-integrity verification
- Stacked on the section's Stage 3.2 branch

## Result

- Verified every declaration supporting the Stage 3.2 claim inventory.
- Confirmed the finite quotient, generator property, defining relations, and both directions of
  the universal property are completely proved.
- Found no scoped `sorry`, `admit`, or project `axiom`; no source rewrite was needed.
- Added a durable `stage3_3` declaration record and section progress note.

## Verification

- `lake env lean EtingofRepresentationTheory/Chapter2/Discussion_2_6.lean`
- scoped source scan for `sorry`, `admit`, and `axiom`
- `jq empty progress/items.json`
- `git diff --check`

This remains a draft until the preceding Stage 3.2 PR merges; it will then be rebased and
retargeted to `main`.
