### PR TITLE
trim: complete Stage 3.4 for section 2.6

### DIFF
--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -156,9 +156,7 @@
   "Chapter2/Problem2.5.2": [
     "Chapter2/Problem2.5.1"
   ],
-  "Chapter2/Discussion_2.6": [
-    "Chapter2/Problem2.5.2"
-  ],
+  "Chapter2/Discussion_2.6": [],
   "Chapter2/Discussion_2.7_intro": [
     "Chapter2/Discussion_2.6"
   ],

--- a/progress/2026-07-27-stage3-4-section-2-6.md
+++ b/progress/2026-07-27-stage3-4-section-2-6.md
@@ -1,0 +1,25 @@
+# Stage 3.4 dependency trimming: Section 2.6
+
+## Scope
+
+This pass analyzes the actual internal dependencies of exactly `Chapter2/Discussion_2.6` after
+its Stage 3.3 proofs were verified.
+
+## Actual dependencies
+
+The section has no internal project dependency. Its Lean file imports four Mathlib modules and
+builds the presented algebra directly from Mathlib's `FreeAlgebra`, `TwoSidedIdeal`, and
+`RingCon` APIs. Its quotient map, generator images, defining-relation proof, finite specialization,
+and universal property do not use any earlier book declaration.
+
+The conservative linear edge to `Chapter2/Problem2.5.2` was therefore removed from
+`dependencies/internal.json`. The item now carries a durable `stage3_4` record and moves to
+`dependency_trimmed`.
+
+## Validation
+
+- confirmed that the scoped file has no `EtingofRepresentationTheory.*` import
+- `jq empty dependencies/internal.json progress/items.json`
+- `git diff --check`
+
+This PR is limited to Section 2.6 and Stage 3.4.

--- a/progress/items.json
+++ b/progress/items.json
@@ -1324,7 +1324,7 @@
     "end_page": "17",
     "start_line": 1,
     "end_line": 4,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -1374,6 +1374,13 @@
         "Etingof.PresentedAlgebra.lift_rel_eq_zero",
         "Etingof.PresentedAlgebra.finPresentation_def"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.6",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The section file imports Mathlib only and defines its free-algebra quotient, generator map, relation theorem, and universal property without using any project declaration."
     },
     "coverage_swept": {
       "wave": 1,


### PR DESCRIPTION
## Scope

- Section 2.6 only
- Stage 3.4 only: actual internal-dependency analysis and trimming
- Stacked on the section's Stage 3.3 branch

## Result

- Confirmed the section imports Mathlib only.
- Verified that the quotient construction, generator map, relation proof, finite specialization,
  and universal property use no earlier project declaration.
- Removed the conservative linear dependency on `Chapter2/Problem2.5.2`.
- Added a durable `stage3_4` record and moved the item to `dependency_trimmed`.

## Verification

- scoped import inspection
- `jq empty dependencies/internal.json progress/items.json`
- `git diff --check`

This remains a draft until the preceding Stage 3.3 PR merges; it will then be rebased and
retargeted to `main`.
