### PR TITLE
polish: complete Stage 3.5 for section 2.6

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Discussion_2_6.lean
+++ b/EtingofRepresentationTheory/Chapter2/Discussion_2_6.lean
@@ -83,6 +83,7 @@ variable {k : Type*} [CommRing k] {X R : Type*} (rel : R → FreeAlgebra k X)
 noncomputable def mk : FreeAlgebra k X →ₐ[k] PresentedAlgebra k X R rel :=
   (presentedCon k X R rel).mkₐ k
 
+/-- The canonical map from the free algebra onto the presented algebra is surjective. -/
 theorem mk_surjective : Function.Surjective (mk rel) :=
   (presentedCon k X R rel).mkₐ_surjective (α := k)
 
@@ -90,6 +91,7 @@ theorem mk_surjective : Function.Surjective (mk rel) :=
 noncomputable def gen (x : X) : PresentedAlgebra k X R rel :=
   mk rel (FreeAlgebra.ι k x)
 
+/-- The image of a generator is its image under the canonical quotient map. -/
 theorem gen_def (x : X) : gen rel x = mk rel (FreeAlgebra.ι k x) := rfl
 
 /-- The presented algebra is generated as a `k`-algebra by the images of its generators. -/
@@ -139,9 +141,11 @@ noncomputable def lift (a : X → A) (ha : ∀ r, FreeAlgebra.lift k a (rel r) =
     PresentedAlgebra k X R rel →ₐ[k] A :=
   (presentedCon k X R rel).liftₐ (FreeAlgebra.lift k a) (presentedCon_le_ker rel a ha)
 
+/-- The lift agrees with the corresponding free-algebra homomorphism after the quotient map. -/
 @[simp] theorem lift_mk (a : X → A) (ha : ∀ r, FreeAlgebra.lift k a (rel r) = 0)
     (p : FreeAlgebra k X) : lift rel a ha (mk rel p) = FreeAlgebra.lift k a p := rfl
 
+/-- The lift sends each presented generator to the element assigned to it. -/
 @[simp] theorem lift_gen (a : X → A) (ha : ∀ r, FreeAlgebra.lift k a (rel r) = 0) (x : X) :
     lift rel a ha (gen rel x) = a x := by
   rw [gen_def, lift_mk, FreeAlgebra.lift_ι_apply]

--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -156,9 +156,7 @@
   "Chapter2/Problem2.5.2": [
     "Chapter2/Problem2.5.1"
   ],
-  "Chapter2/Discussion_2.6": [
-    "Chapter2/Problem2.5.2"
-  ],
+  "Chapter2/Discussion_2.6": [],
   "Chapter2/Discussion_2.7_intro": [
     "Chapter2/Discussion_2.6"
   ],

--- a/progress/2026-07-27-stage3-4-section-2-6.md
+++ b/progress/2026-07-27-stage3-4-section-2-6.md
@@ -1,0 +1,25 @@
+# Stage 3.4 dependency trimming: Section 2.6
+
+## Scope
+
+This pass analyzes the actual internal dependencies of exactly `Chapter2/Discussion_2.6` after
+its Stage 3.3 proofs were verified.
+
+## Actual dependencies
+
+The section has no internal project dependency. Its Lean file imports four Mathlib modules and
+builds the presented algebra directly from Mathlib's `FreeAlgebra`, `TwoSidedIdeal`, and
+`RingCon` APIs. Its quotient map, generator images, defining-relation proof, finite specialization,
+and universal property do not use any earlier book declaration.
+
+The conservative linear edge to `Chapter2/Problem2.5.2` was therefore removed from
+`dependencies/internal.json`. The item now carries a durable `stage3_4` record and moves to
+`dependency_trimmed`.
+
+## Validation
+
+- confirmed that the scoped file has no `EtingofRepresentationTheory.*` import
+- `jq empty dependencies/internal.json progress/items.json`
+- `git diff --check`
+
+This PR is limited to Section 2.6 and Stage 3.4.

--- a/progress/2026-07-27-stage3-5-section-2-6.md
+++ b/progress/2026-07-27-stage3-5-section-2-6.md
@@ -1,0 +1,36 @@
+# Stage 3.5 Mathlib-quality polish: Section 2.6
+
+## Scope
+
+This pass reviews exactly `EtingofRepresentationTheory/Chapter2/Discussion_2_6.lean` after its
+dependency graph was trimmed.
+
+## Review and changes
+
+The file already follows the right structural design for a Mathlib-facing development:
+
+- its imports are limited to the free-algebra, ring-congruence, and two-sided-ideal APIs it uses;
+- the construction is an abbreviation of Mathlib's genuine noncommutative quotient rather than a
+  parallel quotient implementation;
+- the public API exposes the quotient map, generator map, defining relations, and universal
+  property in small, composable declarations;
+- proofs use the corresponding Mathlib universal properties and exact carrier lemmas;
+- simp lemmas are limited to the canonical lift computations.
+
+Four public helper theorems lacked declaration documentation. This pass adds concise docstrings to
+`mk_surjective`, `gen_def`, `lift_mk`, and `lift_gen`, completing the public API documentation
+without changing statements or proof behavior. No redundant abstraction or broad tactic cleanup
+was introduced.
+
+The item advances from `dependency_trimmed` to `proof_polished` and now carries a durable
+`stage3_5` review record.
+
+## Validation
+
+- `lake env lean EtingofRepresentationTheory/Chapter2/Discussion_2_6.lean`
+- a temporary end-of-file `#lint` pass: 0 errors across 16 declarations with 16 linters
+- scoped source scan for `sorry`, `admit`, and project `axiom`
+- `jq empty progress/items.json`
+- `git diff --check`
+
+This PR is limited to Section 2.6 and Stage 3.5.

--- a/progress/items.json
+++ b/progress/items.json
@@ -1324,7 +1324,7 @@
     "end_page": "17",
     "start_line": 1,
     "end_line": 4,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -1374,6 +1374,13 @@
         "Etingof.PresentedAlgebra.lift_rel_eq_zero",
         "Etingof.PresentedAlgebra.finPresentation_def"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.6",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The section file imports Mathlib only and defines its free-algebra quotient, generator map, relation theorem, and universal property without using any project declaration."
     },
     "coverage_swept": {
       "wave": 1,

--- a/progress/items.json
+++ b/progress/items.json
@@ -1324,7 +1324,7 @@
     "end_page": "17",
     "start_line": 1,
     "end_line": 4,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -1381,6 +1381,13 @@
       "verified_on": "2026-07-27",
       "actual_internal_dependencies": [],
       "basis": "The section file imports Mathlib only and defines its free-algebra quotient, generator map, relation theorem, and universal property without using any project declaration."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.6",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The file uses focused Mathlib imports and the canonical FreeAlgebra, TwoSidedIdeal, and RingCon APIs; the Stage 3.5 pass completed docstrings for every public helper theorem and verified clean standalone elaboration."
     },
     "coverage_swept": {
       "wave": 1,


### PR DESCRIPTION
## Scope

- Section 2.6 only
- Stage 3.5 only: Mathlib-quality review and polish
- Stacked on the section's Stage 3.4 branch

## Changes

- Reviewed imports, API shape, theorem granularity, simp usage, and proof style.
- Added missing public declaration docstrings to `mk_surjective`, `gen_def`, `lift_mk`, and
  `lift_gen`.
- Preserved the existing Mathlib-native quotient construction and canonical universal-property
  proofs.
- Added the durable Stage 3.5 record and moved the item to `proof_polished`.

## Verification

- standalone Lean elaboration of the scoped file
- temporary end-of-file `#lint`: 0 errors across 16 declarations with 16 linters
- scoped source scan for `sorry`, `admit`, and project `axiom`
- `jq empty progress/items.json`
- `git diff --check`

This remains a draft until the preceding Stage 3.4 PR merges; it will then be rebased and
retargeted to `main`.
