### PR TITLE
review(Ch2 §2.2): complete Stage 3.2 fidelity audit

### DIFF
--- a/EtingofRepresentationTheory/Chapter2.lean
+++ b/EtingofRepresentationTheory/Chapter2.lean
@@ -16,6 +16,7 @@ import EtingofRepresentationTheory.Chapter2.Theorem2_1_2
 import EtingofRepresentationTheory.Chapter2.Theorem2_1_2_General
 
 -- Section 2.2: Algebras
+import EtingofRepresentationTheory.Chapter2.Discussion_2_2_intro
 import EtingofRepresentationTheory.Chapter2.Definition2_2_1
 import EtingofRepresentationTheory.Chapter2.Definition2_2_2
 import EtingofRepresentationTheory.Chapter2.Definition2_2_5

--- a/EtingofRepresentationTheory/Chapter2/Discussion_2_2_intro.lean
+++ b/EtingofRepresentationTheory/Chapter2/Discussion_2_2_intro.lean
@@ -1,0 +1,48 @@
+import Mathlib.Analysis.Complex.Polynomial.Basic
+import Mathlib.Algebra.Field.ZMod
+import Mathlib.FieldTheory.IsAlgClosed.AlgebraicClosure
+
+/-!
+# Section 2.2: Algebras
+
+Throughout the book, `k` denotes a field and is assumed algebraically closed unless stated
+otherwise. Algebraic closedness means that every nonconstant polynomial over `k` has a root.
+The main example is `ℂ`; in positive characteristic, an example is the algebraic closure of the
+finite field `𝔽ₚ`.
+
+## Mathlib correspondence
+
+Mathlib's class `IsAlgClosed k` is phrased by saying that every polynomial over `k` splits. The
+theorem `isAlgClosed_iff_nonconstant_polynomial_has_root` below records the equivalence with the
+book's root-based wording. The types `ℂ` and `AlgebraicClosure (ZMod p)` provide the two examples.
+-/
+
+open Polynomial
+
+/-- The book's root-based description of an algebraically closed field is equivalent to Mathlib's
+splitting-based `IsAlgClosed` class. -/
+theorem Etingof.isAlgClosed_iff_nonconstant_polynomial_has_root (k : Type*) [Field k] :
+    IsAlgClosed k ↔ ∀ p : k[X], p.degree ≠ 0 → ∃ x : k, p.IsRoot x := by
+  constructor
+  · intro _ p hp
+    exact IsAlgClosed.exists_root p hp
+  · intro h
+    exact IsAlgClosed.of_exists_root k fun p _ hp ↦
+      h p (degree_pos_of_irreducible hp).ne'
+
+/-- The complex numbers are the book's main example of an algebraically closed field. -/
+theorem Etingof.complex_isAlgClosed : IsAlgClosed ℂ := inferInstance
+
+/-- For prime `p`, `ZMod p` models the field `𝔽ₚ`. -/
+example (p : ℕ) [Fact p.Prime] : Field (ZMod p) := inferInstance
+
+/-- The finite field `𝔽ₚ` has exactly `p` elements. -/
+theorem Etingof.card_zmod (p : ℕ) [Fact p.Prime] : Fintype.card (ZMod p) = p := ZMod.card p
+
+/-- The algebraic closure of `𝔽ₚ` is algebraically closed. -/
+theorem Etingof.algebraicClosure_zmod_isAlgClosed (p : ℕ) [Fact p.Prime] :
+    IsAlgClosed (AlgebraicClosure (ZMod p)) := inferInstance
+
+/-- The algebraic closure of `𝔽ₚ` still has characteristic `p`. -/
+theorem Etingof.algebraicClosure_zmod_charP (p : ℕ) [Fact p.Prime] :
+    CharP (AlgebraicClosure (ZMod p)) p := inferInstance

--- a/EtingofRepresentationTheory/Chapter2/Discussion_2_2_intro.lean
+++ b/EtingofRepresentationTheory/Chapter2/Discussion_2_2_intro.lean
@@ -33,8 +33,8 @@ theorem Etingof.isAlgClosed_iff_nonconstant_polynomial_has_root (k : Type*) [Fie
 /-- The complex numbers are the book's main example of an algebraically closed field. -/
 theorem Etingof.complex_isAlgClosed : IsAlgClosed ℂ := inferInstance
 
-/-- For prime `p`, `ZMod p` models the field `𝔽ₚ`. -/
-example (p : ℕ) [Fact p.Prime] : Field (ZMod p) := inferInstance
+/-- For prime `p`, `ZMod p` carries the field structure modeling `𝔽ₚ`. -/
+noncomputable abbrev Etingof.zmodField (p : ℕ) [Fact p.Prime] : Field (ZMod p) := inferInstance
 
 /-- The finite field `𝔽ₚ` has exactly `p` elements. -/
 theorem Etingof.card_zmod (p : ℕ) [Fact p.Prime] : Fintype.card (ZMod p) = p := ZMod.card p

--- a/EtingofRepresentationTheory/Chapter2/Discussion_commutativity_examples.lean
+++ b/EtingofRepresentationTheory/Chapter2/Discussion_commutativity_examples.lean
@@ -71,18 +71,23 @@ example : ∃ f g : Module.End k (Fin 2 → k), f * g ≠ g * f := by
   rw [← map_mul, ← map_mul] at h
   exact single_not_commute k ((Matrix.toLinAlgEquiv' (R := k)).injective h)
 
-/-- **Case 4.** `FreeAlgebra k (Fin n)` is not commutative when `n > 1`: already for `n = 2`
-the two generators `ι 0` and `ι 1` do not commute, since the algebra map sending them to the
-non-commuting matrix units `E₀₁`, `E₁₀` would otherwise force those to commute. -/
-example : ∃ a b : FreeAlgebra k (Fin 2), a * b ≠ b * a := by
-  refine ⟨FreeAlgebra.ι k 0, FreeAlgebra.ι k 1, ?_⟩
-  intro h
+/-- **Case 4.** `FreeAlgebra k (Fin n)` is not commutative when `n > 1`: the first two
+generators do not commute, since the algebra map sending them to the non-commuting matrix units
+`E₀₁`, `E₁₀` would otherwise force those matrix units to commute. -/
+theorem freeAlgebra_noncommutative_of_one_lt (n : ℕ) (hn : 1 < n) :
+    ∃ a b : FreeAlgebra k (Fin n), a * b ≠ b * a := by
+  let i0 : Fin n := ⟨0, by omega⟩
+  let i1 : Fin n := ⟨1, by omega⟩
+  have hne : i0 ≠ i1 := by simp [i0, i1, Fin.ext_iff]
+  let images : Fin n → Matrix (Fin 2) (Fin 2) k := fun i =>
+    if i = i0 then Matrix.single 0 1 1
+    else if i = i1 then Matrix.single 1 0 1
+    else 0
+  refine ⟨FreeAlgebra.ι k i0, FreeAlgebra.ι k i1, fun hcomm => ?_⟩
   apply single_not_commute k
   have := congrArg
-    (FreeAlgebra.lift k ![(Matrix.single 0 1 1 : Matrix (Fin 2) (Fin 2) k),
-      Matrix.single 1 0 1]) h
-  simpa only [map_mul, FreeAlgebra.lift_ι_apply, Matrix.cons_val_zero, Matrix.cons_val_one,
-    Matrix.head_cons] using this
+    (FreeAlgebra.lift k images) hcomm
+  simpa only [map_mul, FreeAlgebra.lift_ι_apply, images, if_pos, if_neg hne.symm, hne] using this
 
 end Noncommutative
 

--- a/EtingofRepresentationTheory/Chapter2/Discussion_commutativity_examples.lean
+++ b/EtingofRepresentationTheory/Chapter2/Discussion_commutativity_examples.lean
@@ -96,18 +96,18 @@ section GeneralEndomorphism
 variable {k : Type*} [Field k] {V : Type*} [AddCommGroup V] [Module k V]
 
 /-- **Case 3, general form.** The endomorphism algebra `End_k V` of any vector space with
-`2 ≤ dim V` is noncommutative: choosing a basis, the two "matrix unit" endomorphisms `E₀₁`
-(sending the second basis vector to the first, all others to `0`) and `E₁₀` (sending the first
-to the second, all others to `0`) fail to commute. This is the source claim of the discussion
-after Example 2.2.4; the concrete `V = k²` case above is the special case `dim V = 2`. -/
-theorem End_noncommutative_of_two_le_finrank [Module.Finite k V]
-    (h : 2 ≤ Module.finrank k V) :
+`2 ≤ dim V` is noncommutative, including when `V` is infinite-dimensional: choosing a basis,
+the two "matrix unit" endomorphisms `E₀₁` (sending the second basis vector to the first, all
+others to `0`) and `E₁₀` (sending the first to the second, all others to `0`) fail to commute.
+This is the source claim of the discussion after Example 2.2.4; the concrete `V = k²` case above
+is the special case `dim V = 2`. -/
+theorem End_noncommutative_of_two_le_rank
+    (h : (2 : Cardinal) ≤ Module.rank k V) :
     ∃ f g : Module.End k V, f * g ≠ g * f := by
-  set n := Module.finrank k V with hn
-  let b := Module.finBasis k V
-  let i0 : Fin n := ⟨0, by omega⟩
-  let i1 : Fin n := ⟨1, by omega⟩
-  have hne : i0 ≠ i1 := by simp [i0, i1, Fin.ext_iff]
+  let b := Module.Free.chooseBasis k V
+  have hcard : (2 : Cardinal) ≤ Cardinal.mk (Module.Free.ChooseBasisIndex k V) := by
+    rwa [← Module.Free.rank_eq_card_chooseBasisIndex]
+  obtain ⟨i0, i1, hne⟩ := Cardinal.two_le_iff.mp hcard
   -- `f = E₀₁` (sends `b i1 ↦ b i0`, others to `0`), `g = E₁₀` (sends `b i0 ↦ b i1`).
   let f : Module.End k V := b.constr k (fun i => if i = i1 then b i0 else 0)
   let g : Module.End k V := b.constr k (fun i => if i = i0 then b i1 else 0)

--- a/EtingofRepresentationTheory/Chapter2/Example2_2_4.lean
+++ b/EtingofRepresentationTheory/Chapter2/Example2_2_4.lean
@@ -1,6 +1,7 @@
 import Mathlib.Algebra.Polynomial.AlgebraMap
-import Mathlib.Algebra.FreeAlgebra
+import Mathlib.Algebra.MvPolynomial.Basic
 import Mathlib.Algebra.MonoidAlgebra.Basic
+import Mathlib.LinearAlgebra.FreeAlgebra
 
 /-!
 # Example 2.2.4: Examples of Algebras
@@ -16,7 +17,7 @@ Examples of algebras over k:
 
 Exact match. All five examples have Mathlib counterparts:
 - k as an algebra over itself
-- `MvPolynomial` for polynomial algebras
+- `MvPolynomial (Fin n) k` for polynomial algebras in `n` variables
 - `Module.End` for endomorphism algebras
 - `FreeAlgebra` for free algebras
 - `MonoidAlgebra` for group algebras
@@ -25,16 +26,62 @@ Exact match. All five examples have Mathlib counterparts:
 /-- k is an algebra over itself. (Etingof Example 2.2.4(1)) -/
 example (k : Type*) [CommRing k] : Algebra k k := inferInstance
 
-/-- The polynomial algebra k[X] is an algebra over k. (Etingof Example 2.2.4(2)) -/
-noncomputable example (k : Type*) [CommRing k] : Algebra k (Polynomial k) := inferInstance
+/-- The polynomial algebra `k[x₁, ..., xₙ]` is an algebra over `k`.
+(Etingof Example 2.2.4(2)) -/
+noncomputable example (k : Type*) [CommRing k] (n : ℕ) :
+    Algebra k (MvPolynomial (Fin n) k) := inferInstance
 
 /-- End(V) is an algebra over k. (Etingof Example 2.2.4(3)) -/
 example (k : Type*) [CommRing k] (V : Type*) [AddCommGroup V] [Module k V] :
     Algebra k (Module.End k V) := inferInstance
 
+/-- Multiplication in `End(V)` is composition of operators. -/
+example (k : Type*) [CommRing k] (V : Type*) [AddCommGroup V] [Module k V]
+    (f g : Module.End k V) : f * g = f.comp g := rfl
+
 /-- The free algebra k⟨x₁, …, xₙ⟩ is an algebra over k. (Etingof Example 2.2.4(4)) -/
-example (k : Type*) [CommRing k] (n : Type*) : Algebra k (FreeAlgebra k n) := inferInstance
+example (k : Type*) [CommRing k] (n : ℕ) : Algebra k (FreeAlgebra k (Fin n)) := inferInstance
+
+/-- Words in the generators form the standard basis of the free algebra. -/
+noncomputable example (k : Type*) [CommRing k] (n : ℕ) :
+    Module.Basis (FreeMonoid (Fin n)) k (FreeAlgebra k (Fin n)) :=
+  FreeAlgebra.basisFreeMonoid k (Fin n)
+
+/-- Multiplication of word-basis vectors in a free algebra is concatenation of words. -/
+example (k : Type*) [CommRing k] (n : ℕ) (u v : FreeMonoid (Fin n)) :
+    (FreeAlgebra.equivMonoidAlgebraFreeMonoid (R := k) (X := Fin n))
+        ((FreeAlgebra.basisFreeMonoid k (Fin n)) u *
+          (FreeAlgebra.basisFreeMonoid k (Fin n)) v) =
+      MonoidAlgebra.single (u * v) 1 := by
+  rw [map_mul]
+  have hu :
+      (FreeAlgebra.equivMonoidAlgebraFreeMonoid (R := k) (X := Fin n))
+          ((FreeAlgebra.basisFreeMonoid k (Fin n)) u) = MonoidAlgebra.single u 1 := by
+    change (FreeAlgebra.equivMonoidAlgebraFreeMonoid (R := k) (X := Fin n))
+        ((FreeAlgebra.equivMonoidAlgebraFreeMonoid (R := k) (X := Fin n)).symm
+          (MonoidAlgebra.single u 1)) = _
+    exact (FreeAlgebra.equivMonoidAlgebraFreeMonoid (R := k) (X := Fin n)).apply_symm_apply _
+  have hv :
+      (FreeAlgebra.equivMonoidAlgebraFreeMonoid (R := k) (X := Fin n))
+          ((FreeAlgebra.basisFreeMonoid k (Fin n)) v) = MonoidAlgebra.single v 1 := by
+    change (FreeAlgebra.equivMonoidAlgebraFreeMonoid (R := k) (X := Fin n))
+        ((FreeAlgebra.equivMonoidAlgebraFreeMonoid (R := k) (X := Fin n)).symm
+          (MonoidAlgebra.single v 1)) = _
+    exact (FreeAlgebra.equivMonoidAlgebraFreeMonoid (R := k) (X := Fin n)).apply_symm_apply _
+  rw [hu, hv]
+  simp
 
 /-- The group algebra k[G] is an algebra over k. (Etingof Example 2.2.4(5)) -/
 noncomputable example (k : Type*) [CommRing k] (G : Type*) [Group G] :
     Algebra k (MonoidAlgebra k G) := inferInstance
+
+/-- The elements `a_g` indexed by `g : G` form the standard basis of the group algebra. -/
+noncomputable example (k : Type*) [CommRing k] (G : Type*) [Group G] :
+    Module.Basis G k (MonoidAlgebra k G) :=
+  Finsupp.basisSingleOne
+
+/-- The group-algebra basis obeys `a_g a_h = a_{gh}`. -/
+example (k : Type*) [CommRing k] (G : Type*) [Group G] (g h : G) :
+    MonoidAlgebra.single g (1 : k) * MonoidAlgebra.single h 1 =
+      MonoidAlgebra.single (g * h) 1 := by
+  simp

--- a/EtingofRepresentationTheory/Chapter2/Proposition2_2_3.lean
+++ b/EtingofRepresentationTheory/Chapter2/Proposition2_2_3.lean
@@ -1,4 +1,4 @@
-import Mathlib.Algebra.Ring.Basic
+import EtingofRepresentationTheory.Chapter2.Definition2_2_2
 
 /-!
 # Proposition 2.2.3: Uniqueness of Unit
@@ -7,16 +7,17 @@ If a unit exists in an algebra, it is unique.
 
 **Proof.** Let 1, 1' be two units. Then 1 = 1·1' = 1'. □
 
-## Mathlib correspondence
-
-Exact match. This is a consequence of the uniqueness of identity elements in monoids/rings,
-which Mathlib handles via the `Unique` instance on `{1 : M}` for monoids.
+The algebra here is the potentially non-unital algebra of Definition 2.2.1, and a unit is the
+two-sided-identity predicate of Definition 2.2.2. Thus the statement compares two arbitrary
+elements satisfying that predicate; it does not presuppose a canonical `1`.
 -/
 
-/-- If an algebra has a unit, it is unique. (Etingof Proposition 2.2.3)
-In Mathlib, this follows from the fact that a monoid has a unique identity element. -/
-theorem Etingof.Proposition_2_2_3 (M : Type*) [MulOneClass M] (e : M)
-    (he_left : ∀ a, e * a = a) (he_right : ∀ a, a * e = a) : e = 1 := by
-  have := he_left 1
-  simp at this
-  exact this
+namespace Etingof
+
+/-- **Proposition 2.2.3.** Any two units in a possibly non-unital associative algebra are equal. -/
+theorem Proposition_2_2_3 (k : Type*) {A : Type*} [Field k] [AddCommGroup A] [Module k A]
+    [AssociativeAlgebra k A] {e e' : A} (he : AssociativeAlgebra.IsUnit k e)
+    (he' : AssociativeAlgebra.IsUnit k e') : e = e' :=
+  AssociativeAlgebra.isUnit_unique k he he'
+
+end Etingof

--- a/progress/2026-07-27T11-31-24Z_stage3-2-ch2-s2-2.md
+++ b/progress/2026-07-27T11-31-24Z_stage3-2-ch2-s2-2.md
@@ -32,8 +32,10 @@ Reviewed exactly these source blobs against their Lean scaffolding:
 - Definitions 2.2.5 and 2.2.6 exactly match `CommRing` plus `Algebra` and `AlgHom`, respectively,
   under that editorial unital convention. No representation bridge is needed after unfolding.
 - The discussion after Example 2.2.4 now proves the source's quantified free-algebra claim for
-  every `n > 1`, rather than only exhibiting the `n = 2` witness; its remaining commutativity and
-  noncommutativity assertions are also explicitly inventoried.
+  every `n > 1`, rather than only exhibiting the `n = 2` witness. It also proves the endomorphism
+  claim for every vector space of cardinal dimension greater than one, including
+  infinite-dimensional spaces, rather than restricting to finite `finrank`; its remaining
+  commutativity assertions are explicitly inventoried.
 
 All nine tracker items now contain the canonical durable Stage 3.2 `claim_coverage` object, with
 definition integrity, fidelity, and semantic nonvacuity recorded. Existing `sorry_free` statuses

--- a/progress/2026-07-27T11-31-24Z_stage3-2-ch2-s2-2.md
+++ b/progress/2026-07-27T11-31-24Z_stage3-2-ch2-s2-2.md
@@ -1,0 +1,47 @@
+# Stage 3.2 audit: Chapter 2 §2.2
+
+## Scope
+
+Reviewed exactly these source blobs against their Lean scaffolding:
+
+- `Chapter2/Discussion_2.2_intro`
+- `Chapter2/Definition2.2.1`
+- `Chapter2/Definition2.2.2`
+- `Chapter2/Proposition2.2.3`
+- `Chapter2/Discussion_after_Proposition2.2.3`
+- `Chapter2/Example2.2.4`
+- `Chapter2/Definition2.2.5`
+- `Chapter2/Definition2.2.6`
+
+## Coverage and fidelity findings
+
+- The non-unital associative-algebra class and unit predicate faithfully capture Definitions
+  2.2.1 and 2.2.2. Their data are fully constructed and contain no `sorry`.
+- Proposition 2.2.3 had an exact proof in the preceding definition module, but its item-local
+  theorem silently specialized to a pre-existing canonical `1`. The item-local theorem now states
+  uniqueness for two arbitrary units of the book's possibly non-unital algebra.
+- Example 2.2.4 represented the polynomial example with only `Polynomial k`, despite the source's
+  `n` variables, and did not expose the claimed bases or multiplication laws for the free and group
+  algebras. It now uses `MvPolynomial (Fin n) k` and machine-checks all basis/multiplication claims.
+- The section introduction now has a Lean companion recording the nontrivial bridge between
+  Mathlib's splitting-based `IsAlgClosed` and the book's root-based wording, as well as the `ℂ` and
+  algebraic-closure-of-`𝔽ₚ` examples.
+- The post-Proposition sentence is an editorial convention, not a mathematical assertion; its
+  `claim_coverage` verdict is therefore explicitly `non_formalizable` with a reason.
+- Definitions 2.2.5 and 2.2.6 exactly match `CommRing` plus `Algebra` and `AlgHom`, respectively,
+  under that editorial unital convention. No representation bridge is needed after unfolding.
+
+All eight tracker items now contain the canonical durable Stage 3.2 `claim_coverage` object, with
+definition integrity, fidelity, and semantic nonvacuity recorded. Existing `sorry_free` statuses
+were preserved.
+
+## Validation
+
+- `jq empty progress/items.json`
+- `python3 scripts/validate_items.py` (passes; pre-existing schema warnings remain)
+- `git diff --check`
+- focused `lake build` of all affected §2.2 modules
+
+## Gaps and blockers
+
+None in the audited scope.

--- a/progress/2026-07-27T11-31-24Z_stage3-2-ch2-s2-2.md
+++ b/progress/2026-07-27T11-31-24Z_stage3-2-ch2-s2-2.md
@@ -11,6 +11,7 @@ Reviewed exactly these source blobs against their Lean scaffolding:
 - `Chapter2/Discussion_after_Proposition2.2.3`
 - `Chapter2/Example2.2.4`
 - `Chapter2/Definition2.2.5`
+- `Chapter2/Discussion_commutativity_examples`
 - `Chapter2/Definition2.2.6`
 
 ## Coverage and fidelity findings
@@ -30,8 +31,11 @@ Reviewed exactly these source blobs against their Lean scaffolding:
   `claim_coverage` verdict is therefore explicitly `non_formalizable` with a reason.
 - Definitions 2.2.5 and 2.2.6 exactly match `CommRing` plus `Algebra` and `AlgHom`, respectively,
   under that editorial unital convention. No representation bridge is needed after unfolding.
+- The discussion after Example 2.2.4 now proves the source's quantified free-algebra claim for
+  every `n > 1`, rather than only exhibiting the `n = 2` witness; its remaining commutativity and
+  noncommutativity assertions are also explicitly inventoried.
 
-All eight tracker items now contain the canonical durable Stage 3.2 `claim_coverage` object, with
+All nine tracker items now contain the canonical durable Stage 3.2 `claim_coverage` object, with
 definition integrity, fidelity, and semantic nonvacuity recorded. Existing `sorry_free` statuses
 were preserved.
 

--- a/progress/items.json
+++ b/progress/items.json
@@ -229,7 +229,7 @@
         {
           "claim": "For prime p, ZMod p models the field F_p and has p elements.",
           "verdict": "formalized",
-          "lean_decl": "example (p) [Fact p.Prime] : Field (ZMod p); Etingof.card_zmod"
+          "lean_decl": "Etingof.zmodField; Etingof.card_zmod"
         },
         {
           "claim": "The algebraic closure of F_p is algebraically closed and has characteristic p.",
@@ -400,37 +400,37 @@
         {
           "claim": "The base field k is an algebra over itself.",
           "verdict": "formalized",
-          "lean_decl": "example (k) [CommRing k] : Algebra k k"
+          "lean_decl": "Algebra.id"
         },
         {
           "claim": "The polynomial ring k[x_1, ..., x_n] is a k-algebra.",
           "verdict": "formalized",
-          "lean_decl": "example (k) (n : Nat) : Algebra k (MvPolynomial (Fin n) k)"
+          "lean_decl": "AddMonoidAlgebra.algebra (the canonical Algebra instance for MvPolynomial)"
         },
         {
           "claim": "End_k(V) is a k-algebra whose multiplication is composition.",
           "verdict": "formalized",
-          "lean_decl": "examples for Algebra k (Module.End k V) and f * g = f.comp g"
+          "lean_decl": "Module.End.instAlgebra; Module.End.mul_apply"
         },
         {
           "claim": "The free algebra k<x_1, ..., x_n> is a k-algebra with a basis indexed by words.",
           "verdict": "formalized",
-          "lean_decl": "example for Algebra k (FreeAlgebra k (Fin n)); FreeAlgebra.basisFreeMonoid"
+          "lean_decl": "FreeAlgebra.instAlgebra; FreeAlgebra.basisFreeMonoid"
         },
         {
           "claim": "Multiplication of free-algebra word-basis elements is concatenation.",
           "verdict": "formalized",
-          "lean_decl": "example using FreeAlgebra.equivMonoidAlgebraFreeMonoid and MonoidAlgebra.single_mul_single"
+          "lean_decl": "FreeAlgebra.equivMonoidAlgebraFreeMonoid; FreeAlgebra.basisFreeMonoid; MonoidAlgebra.single_mul_single"
         },
         {
           "claim": "The group algebra k[G] is a k-algebra with basis {a_g | g in G}.",
           "verdict": "formalized",
-          "lean_decl": "example for Algebra k (MonoidAlgebra k G); Finsupp.basisSingleOne"
+          "lean_decl": "MonoidAlgebra.algebra; Finsupp.basisSingleOne"
         },
         {
           "claim": "The group-algebra basis multiplication satisfies a_g a_h = a_(gh).",
           "verdict": "formalized",
-          "lean_decl": "example using MonoidAlgebra.single_mul_single"
+          "lean_decl": "MonoidAlgebra.single_mul_single"
         }
       ]
     },

--- a/progress/items.json
+++ b/progress/items.json
@@ -479,7 +479,7 @@
     "status": "sorry_free",
     "coverage": "covered_full",
     "fidelity": "verified",
-    "coverage_note": "The group-algebra iff, the free-algebra claim, and the source's quantified End_k(V) noncommutativity theorem for every finite-dimensional V with 2 ≤ dim V (End_noncommutative_of_two_le_finrank) are all public. The concrete V = k² matrix-unit witness remains as the dim V = 2 special case.",
+    "coverage_note": "The group-algebra iff, the free-algebra claim, and the source's quantified End_k(V) noncommutativity theorem for every vector space of cardinal rank at least 2 (End_noncommutative_of_two_le_rank), including infinite-dimensional V, are all public. The concrete V = k² matrix-unit witness remains as the dim V = 2 special case.",
     "last_updated": "2026-07-27",
     "sorry_free": true,
     "claim_coverage": {
@@ -497,9 +497,9 @@
           "lean_decl": "CommRing k; inferInstance : CommRing (MvPolynomial (Fin n) k)"
         },
         {
-          "claim": "End_k(V) is noncommutative whenever V is finite-dimensional and dim V > 1.",
+          "claim": "End_k(V) is noncommutative whenever dim V > 1, including for infinite-dimensional V.",
           "verdict": "formalized",
-          "lean_decl": "Etingof.End_noncommutative_of_two_le_finrank"
+          "lean_decl": "Etingof.End_noncommutative_of_two_le_rank"
         },
         {
           "claim": "The free algebra on n generators is noncommutative whenever n > 1.",

--- a/progress/items.json
+++ b/progress/items.json
@@ -204,6 +204,42 @@
     "start_line": 11,
     "end_line": 15,
     "status": "sorry_free",
+    "coverage": "covered_full",
+    "fidelity": "verified",
+    "sorry_free": true,
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.2",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "A field is algebraically closed exactly when every nonconstant polynomial over it has a root.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.isAlgClosed_iff_nonconstant_polynomial_has_root"
+        },
+        {
+          "claim": "The complex numbers are algebraically closed.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.complex_isAlgClosed"
+        },
+        {
+          "claim": "For prime p, ZMod p models the field F_p and has p elements.",
+          "verdict": "formalized",
+          "lean_decl": "example (p) [Fact p.Prime] : Field (ZMod p); Etingof.card_zmod"
+        },
+        {
+          "claim": "The algebraic closure of F_p is algebraically closed and has characteristic p.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.algebraicClosure_zmod_isAlgClosed; Etingof.algebraicClosure_zmod_charP"
+        }
+      ]
+    },
+    "coverage_note": "All mathematical claims in the introductory paragraph are explicit: the root/splitting bridge, the complex example, and the positive-characteristic algebraic-closure example.",
+    "last_updated": "2026-07-27",
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -220,8 +256,26 @@
     "status": "sorry_free",
     "fidelity": "verified",
     "sorry_free": true,
-    "fidelity_note": "[fidelity] Book Definition 2.2.1 defines a NON-UNITAL associative algebra: a vector space with bilinear multiplication satisfying associativity only. The Lean abbrev uses [Ring A] which requires a mul",
-    "fidelity_issue": 5616
+    "coverage": "covered_full",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.2",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "An associative algebra over k is a k-vector space with an associative bilinear multiplication, without a unit assumption.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.AssociativeAlgebra"
+        }
+      ]
+    },
+    "fidelity_note": "The custom class is genuinely non-unital and records multiplication, associativity, additivity, and scalar compatibility in both arguments. No class data or definition body is sorried; closed issue #5616 describes the superseded unital encoding.",
+    "coverage_note": "The carrier assumptions and every bilinearity/associativity component of the source definition are fields or parameters of Etingof.AssociativeAlgebra.",
+    "last_updated": "2026-07-27"
   },
   {
     "id": "Chapter2/Definition2.2.2",
@@ -234,9 +288,27 @@
     "status": "sorry_free",
     "fidelity": "verified",
     "sorry_free": true,
-    "fidelity_note": "[fidelity] Book Definition 2.2.2 DEFINES the concept of 'unit in an associative algebra'. The Lean formalization is a theorem one_isUnit : [Ring A] → (a : A) → 1 * a = a ∧ a * 1 = a, which merely demo",
-    "fidelity_decl": "theorem one_isUnit (A) [Ring A] (a) : 1 * a = a ∧ a * 1 = a",
-    "fidelity_issue": 5617
+    "coverage": "covered_full",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.2",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "A unit in a possibly non-unital associative algebra is an element acting as a left and right identity on every element.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.AssociativeAlgebra.IsUnit"
+        }
+      ]
+    },
+    "fidelity_note": "IsUnit is a predicate on an arbitrary element of the non-unital structure and quantifies both identity laws over every algebra element. It does not presuppose a Ring or canonical one; closed issue #5617 describes the superseded vacuous theorem.",
+    "fidelity_decl": "Etingof.AssociativeAlgebra.IsUnit",
+    "coverage_note": "The definition records both source conjuncts e*a = a and a*e = a for every a.",
+    "last_updated": "2026-07-27"
   },
   {
     "id": "Chapter2/Proposition2.2.3",
@@ -250,8 +322,24 @@
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
-    "coverage_note": "The exact non-unital uniqueness claim is public as AssociativeAlgebra.isUnit_unique; the canonical-unit wrapper is a convenient specialization.",
-    "last_updated": "2026-07-22"
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.2",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "If a unit exists in a possibly non-unital associative algebra, it is unique.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Proposition_2_2_3"
+        }
+      ]
+    },
+    "coverage_note": "The item-local theorem now compares two arbitrary elements satisfying Definition 2.2.2 and reuses the exact non-unital uniqueness proof AssociativeAlgebra.isUnit_unique.",
+    "last_updated": "2026-07-27"
   },
   {
     "id": "Chapter2/Discussion_after_Proposition2.2.3",
@@ -262,6 +350,27 @@
     "start_line": 9,
     "end_line": 10,
     "status": "sorry_free",
+    "coverage": "non_formalizable",
+    "fidelity": "verified",
+    "sorry_free": true,
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.2",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "From this point onward, the word algebra follows the author's convention of meaning a unital associative algebra.",
+          "verdict": "non_formalizable",
+          "reason": "This is an editorial notation convention rather than a mathematical assertion; later declarations implement it with Mathlib's unital Algebra typeclass."
+        }
+      ]
+    },
+    "coverage_note": "The sole sentence is an editorial convention, and its implementation is checked in the subsequent unital algebra items.",
+    "last_updated": "2026-07-27",
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -279,8 +388,54 @@
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
-    "coverage_note": "The examples use the standard public Mathlib algebra models for the base field, polynomial and multivariable polynomial algebras, endomorphisms, free algebras, and group algebras. Independent Opus review rejected extra project-local wrappers as packaging rather than missing mathematical content.",
-    "last_updated": "2026-07-22"
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.2",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "The base field k is an algebra over itself.",
+          "verdict": "formalized",
+          "lean_decl": "example (k) [CommRing k] : Algebra k k"
+        },
+        {
+          "claim": "The polynomial ring k[x_1, ..., x_n] is a k-algebra.",
+          "verdict": "formalized",
+          "lean_decl": "example (k) (n : Nat) : Algebra k (MvPolynomial (Fin n) k)"
+        },
+        {
+          "claim": "End_k(V) is a k-algebra whose multiplication is composition.",
+          "verdict": "formalized",
+          "lean_decl": "examples for Algebra k (Module.End k V) and f * g = f.comp g"
+        },
+        {
+          "claim": "The free algebra k<x_1, ..., x_n> is a k-algebra with a basis indexed by words.",
+          "verdict": "formalized",
+          "lean_decl": "example for Algebra k (FreeAlgebra k (Fin n)); FreeAlgebra.basisFreeMonoid"
+        },
+        {
+          "claim": "Multiplication of free-algebra word-basis elements is concatenation.",
+          "verdict": "formalized",
+          "lean_decl": "example using FreeAlgebra.equivMonoidAlgebraFreeMonoid and MonoidAlgebra.single_mul_single"
+        },
+        {
+          "claim": "The group algebra k[G] is a k-algebra with basis {a_g | g in G}.",
+          "verdict": "formalized",
+          "lean_decl": "example for Algebra k (MonoidAlgebra k G); Finsupp.basisSingleOne"
+        },
+        {
+          "claim": "The group-algebra basis multiplication satisfies a_g a_h = a_(gh).",
+          "verdict": "formalized",
+          "lean_decl": "example using MonoidAlgebra.single_mul_single"
+        }
+      ]
+    },
+    "coverage_note": "All five examples and the stated multiplication/basis descriptions are machine checked. In particular, the polynomial example now uses Fin n variables rather than only one variable.",
+    "last_updated": "2026-07-27"
   },
   {
     "id": "Chapter2/Definition2.2.5",
@@ -294,8 +449,24 @@
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
-    "coverage_note": "CommRing together with Algebra records the source definition under the explicit preceding convention that all subsequent algebras are unital; this convention invalidates the withdrawn false positive #7464.",
-    "last_updated": "2026-07-22"
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.2",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "A unital algebra A is commutative when ab = ba for every a and b.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.CommutativeAlgebra (via CommRing.mul_comm)"
+        }
+      ]
+    },
+    "coverage_note": "Under the immediately preceding unital convention, CommRing together with Algebra records exactly the universal multiplication-commutativity condition; no nontrivial representation bridge is needed.",
+    "last_updated": "2026-07-27"
   },
   {
     "id": "Chapter2/Discussion_commutativity_examples",
@@ -323,8 +494,24 @@
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
-    "coverage_note": "The public AlgHom abbreviation exactly records the source's linearity, multiplicativity, and unit-preservation conditions under the active unital-algebra convention.",
-    "last_updated": "2026-07-22"
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.2",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "An algebra homomorphism f : A -> B is k-linear, multiplicative, and preserves one.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.AlgebraHom (Mathlib AlgHom)"
+        }
+      ]
+    },
+    "coverage_note": "AlgHom records every source component: k-linearity, f(xy) = f(x)f(y), and f(1) = 1. The representations are definitionally the same under the active unital convention.",
+    "last_updated": "2026-07-27"
   },
   {
     "id": "Chapter2/Definition2.3.1",

--- a/progress/items.json
+++ b/progress/items.json
@@ -480,7 +480,39 @@
     "coverage": "covered_full",
     "fidelity": "verified",
     "coverage_note": "The group-algebra iff, the free-algebra claim, and the source's quantified End_k(V) noncommutativity theorem for every finite-dimensional V with 2 ≤ dim V (End_noncommutative_of_two_le_finrank) are all public. The concrete V = k² matrix-unit witness remains as the dim V = 2 special case.",
-    "last_updated": "2026-07-22"
+    "last_updated": "2026-07-27",
+    "sorry_free": true,
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.2",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "The base field and polynomial algebra examples are commutative.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "CommRing k; inferInstance : CommRing (MvPolynomial (Fin n) k)"
+        },
+        {
+          "claim": "End_k(V) is noncommutative whenever V is finite-dimensional and dim V > 1.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.End_noncommutative_of_two_le_finrank"
+        },
+        {
+          "claim": "The free algebra on n generators is noncommutative whenever n > 1.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.freeAlgebra_noncommutative_of_one_lt"
+        },
+        {
+          "claim": "The group algebra k[G] is commutative if and only if G is commutative.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.monoidAlgebra_mul_comm_iff"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter2/Definition2.2.6",

--- a/scripts/lint-warning-baseline.txt
+++ b/scripts/lint-warning-baseline.txt
@@ -19,7 +19,6 @@ EtingofRepresentationTheory/Chapter2/Problem2_7_4.lean
 EtingofRepresentationTheory/Chapter2/Problem2_7_5.lean
 EtingofRepresentationTheory/Chapter2/Problem2_7_5_Family.lean
 EtingofRepresentationTheory/Chapter2/Problem2_8_6.lean
-EtingofRepresentationTheory/Chapter2/Proposition2_2_3.lean
 EtingofRepresentationTheory/Chapter2/Proposition2_7_1.lean
 EtingofRepresentationTheory/Chapter2/Sl2Irrep.lean
 EtingofRepresentationTheory/Chapter2/Theorem2_1_1.lean


### PR DESCRIPTION
## Scope

- Chapter 2 §2.2 only
- Stage 3.2 only: faithful claim coverage, definition integrity, and nonvacuity

## Audit result

- Added explicit claim inventories for all nine source items.
- Corrected Proposition 2.2.3 so uniqueness concerns two arbitrary units in a possibly non-unital algebra, as in the book.
- Corrected Example 2.2.4 to use `n`-variable polynomials and expose the claimed free- and group-algebra bases and multiplication laws.
- Added the missing section-introduction companion, with durable named declarations including `Etingof.zmodField`.
- Generalized free-algebra noncommutativity from `n = 2` to every `n > 1`.
- Proved `End_k(V)` noncommutative for every vector space of cardinal rank at least two, including infinite-dimensional `V`, via two basis matrix units.
- Classified the future notational convention as editorial rather than mathematical.

## Verification

- standalone elaboration and focused build of all eight §2.2 Lean modules
- all 16 enabled linters on every scoped file
- `#print axioms` on the repaired declarations: standard axioms only, no `sorryAx`
- scoped scan for `sorry`, `admit`, project `axiom`, and `native_decide`
- `jq empty progress/items.json`
- `python3 scripts/validate_items.py` (passes; pre-existing schema warnings remain)
- `git diff --check`
- final stacked `lake build EtingofRepresentationTheory.Chapter2` passes

Ready for review. Auto-merge remains disabled.
