### PR TITLE
verify: complete Stage 3.3 for section 2.2

### DIFF
--- a/progress/2026-07-27-stage3-3-section-2-2.md
+++ b/progress/2026-07-27-stage3-3-section-2-2.md
@@ -1,0 +1,32 @@
+# Stage 3.3 proof verification: Chapter 2 §2.2
+
+## Scope
+
+This pass covers exactly the nine §2.2 items audited by the preceding Stage 3.2 PR.
+
+## Result
+
+Every mathematical claim in the Stage 3.2 inventory has a complete construction or proof:
+
+- the algebraic-closedness bridge and named characteristic/cardinality examples are
+  theorem-backed;
+- the non-unital associative-algebra class and unit predicate contain no missing data;
+- unit uniqueness is proved for two arbitrary units;
+- all algebra, basis, and multiplication examples elaborate without proof holes;
+- the arbitrary-cardinal-dimension endomorphism and free-algebra noncommutativity claims have
+  explicit witnesses;
+- the group-algebra equivalence proves both directions;
+- the commutative-algebra and algebra-homomorphism definitions use Mathlib's complete structures.
+
+The post-Proposition convention is editorial and therefore has no proof obligation. A scoped scan
+of all §2.2 Lean files finds no `sorry`, `admit`, or project `axiom`. Durable `stage3_3` records now
+identify every verified named declaration and the anonymous-example basis where applicable.
+
+## Validation
+
+- standalone elaboration of every §2.2 Lean file changed or referenced by the claim inventory
+- scoped source scan for `sorry`, `admit`, and project `axiom`
+- `jq empty progress/items.json`
+- `git diff --check`
+
+This PR is limited to Section 2.2 and Stage 3.3.

--- a/progress/items.json
+++ b/progress/items.json
@@ -238,6 +238,20 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.isAlgClosed_iff_nonconstant_polynomial_has_root",
+        "Etingof.complex_isAlgClosed",
+        "Etingof.zmodField",
+        "Etingof.card_zmod",
+        "Etingof.algebraicClosure_zmod_isAlgClosed",
+        "Etingof.algebraicClosure_zmod_charP"
+      ]
+    },
     "coverage_note": "All mathematical claims in the introductory paragraph are explicit: the root/splitting bridge, the complex example, and the positive-characteristic algebraic-closure example.",
     "last_updated": "2026-07-27",
     "coverage_swept": {
@@ -273,6 +287,15 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.AssociativeAlgebra"
+      ]
+    },
     "fidelity_note": "The custom class is genuinely non-unital and records multiplication, associativity, additivity, and scalar compatibility in both arguments. No class data or definition body is sorried; closed issue #5616 describes the superseded unital encoding.",
     "coverage_note": "The carrier assumptions and every bilinearity/associativity component of the source definition are fields or parameters of Etingof.AssociativeAlgebra.",
     "last_updated": "2026-07-27"
@@ -303,6 +326,15 @@
           "verdict": "formalized",
           "lean_decl": "Etingof.AssociativeAlgebra.IsUnit"
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.AssociativeAlgebra.IsUnit"
       ]
     },
     "fidelity_note": "IsUnit is a predicate on an arbitrary element of the non-unital structure and quantifies both identity laws over every algebra element. It does not presuppose a Ring or canonical one; closed issue #5617 describes the superseded vacuous theorem.",
@@ -338,6 +370,15 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Proposition_2_2_3"
+      ]
+    },
     "coverage_note": "The item-local theorem now compares two arbitrary elements satisfying Definition 2.2.2 and reuses the exact non-unital uniqueness proof AssociativeAlgebra.isUnit_unique.",
     "last_updated": "2026-07-27"
   },
@@ -368,6 +409,14 @@
           "reason": "This is an editorial notation convention rather than a mathematical assertion; later declarations implement it with Mathlib's unital Algebra typeclass."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "not_applicable",
+      "declarations": [],
+      "basis": "The item is an editorial convention and has no mathematical proof obligation."
     },
     "coverage_note": "The sole sentence is an editorial convention, and its implementation is checked in the subsequent unital algebra items.",
     "last_updated": "2026-07-27",
@@ -434,6 +483,14 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [],
+      "basis": "All seven claims are elaborated anonymous examples using Mathlib's canonical algebra, basis, and multiplication APIs."
+    },
     "coverage_note": "All five examples and the stated multiplication/basis descriptions are machine checked. In particular, the polynomial example now uses Fin n variables rather than only one variable.",
     "last_updated": "2026-07-27"
   },
@@ -463,6 +520,15 @@
           "verdict": "formalized",
           "lean_decl": "Etingof.CommutativeAlgebra (via CommRing.mul_comm)"
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.CommutativeAlgebra"
       ]
     },
     "coverage_note": "Under the immediately preceding unital convention, CommRing together with Algebra records exactly the universal multiplication-commutativity condition; no nontrivial representation bridge is needed.",
@@ -512,6 +578,17 @@
           "lean_decl": "Etingof.monoidAlgebra_mul_comm_iff"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.monoidAlgebra_mul_comm_iff",
+        "Etingof.End_noncommutative_of_two_le_rank",
+        "Etingof.freeAlgebra_noncommutative_of_one_lt"
+      ]
     }
   },
   {
@@ -540,6 +617,15 @@
           "verdict": "formalized",
           "lean_decl": "Etingof.AlgebraHom (Mathlib AlgHom)"
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.AlgebraHom"
       ]
     },
     "coverage_note": "AlgHom records every source component: k-linearity, f(xy) = f(x)f(y), and f(1) = 1. The representations are definitionally the same under the active unital convention.",


### PR DESCRIPTION
## Scope

- Chapter 2 §2.2 only
- Stage 3.3 only: proof completion and proof-integrity verification
- Stacked directly on the corrected Stage 3.2 branch

## Result

- Verified all nine Stage 3.2 inventories against completed declarations or anonymous examples.
- Confirmed the algebraic-closedness, unit-uniqueness, basis/multiplication, endomorphism, free-algebra, and group-algebra claims are fully proved.
- Recorded the editorial convention as having no proof obligation.
- Found no scoped `sorry`, `admit`, project `axiom`, or `native_decide`.
- Added durable `stage3_3` records for every item.
- Included `Etingof.zmodField` and `Etingof.End_noncommutative_of_two_le_rank` in the declaration mapping.

## Verification

- standalone elaboration of all eight §2.2 Lean files
- scoped trust-token scan
- `#print axioms` on the repaired declarations: standard axioms only, no `sorryAx`
- `jq empty progress/items.json`
- `python3 scripts/validate_items.py`
- `git diff --check`
- final stacked Chapter 2 build passes

This remains a draft until the preceding Stage 3.2 PR merges; it can then be retargeted to `main`.
