### PR TITLE
trim: complete Stage 3.4 for section 2.2

### DIFF
--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -39,33 +39,19 @@
   "Chapter2/Discussion_after_Theorem2.1.2": [
     "Chapter2/Theorem2.1.2"
   ],
-  "Chapter2/Discussion_2.2_intro": [
-    "Chapter2/Discussion_after_Theorem2.1.2"
-  ],
-  "Chapter2/Definition2.2.1": [
-    "Chapter2/Discussion_2.2_intro"
-  ],
+  "Chapter2/Discussion_2.2_intro": [],
+  "Chapter2/Definition2.2.1": [],
   "Chapter2/Definition2.2.2": [
     "Chapter2/Definition2.2.1"
   ],
   "Chapter2/Proposition2.2.3": [
     "Chapter2/Definition2.2.2"
   ],
-  "Chapter2/Discussion_after_Proposition2.2.3": [
-    "Chapter2/Proposition2.2.3"
-  ],
-  "Chapter2/Example2.2.4": [
-    "Chapter2/Discussion_after_Proposition2.2.3"
-  ],
-  "Chapter2/Definition2.2.5": [
-    "Chapter2/Example2.2.4"
-  ],
-  "Chapter2/Discussion_commutativity_examples": [
-    "Chapter2/Definition2.2.5"
-  ],
-  "Chapter2/Definition2.2.6": [
-    "Chapter2/Discussion_commutativity_examples"
-  ],
+  "Chapter2/Discussion_after_Proposition2.2.3": [],
+  "Chapter2/Example2.2.4": [],
+  "Chapter2/Definition2.2.5": [],
+  "Chapter2/Discussion_commutativity_examples": [],
+  "Chapter2/Definition2.2.6": [],
   "Chapter2/Definition2.3.1": [
     "Chapter2/Definition2.2.6"
   ],

--- a/progress/2026-07-27-stage3-3-section-2-2.md
+++ b/progress/2026-07-27-stage3-3-section-2-2.md
@@ -1,0 +1,32 @@
+# Stage 3.3 proof verification: Chapter 2 §2.2
+
+## Scope
+
+This pass covers exactly the nine §2.2 items audited by the preceding Stage 3.2 PR.
+
+## Result
+
+Every mathematical claim in the Stage 3.2 inventory has a complete construction or proof:
+
+- the algebraic-closedness bridge and named characteristic/cardinality examples are
+  theorem-backed;
+- the non-unital associative-algebra class and unit predicate contain no missing data;
+- unit uniqueness is proved for two arbitrary units;
+- all algebra, basis, and multiplication examples elaborate without proof holes;
+- the arbitrary-cardinal-dimension endomorphism and free-algebra noncommutativity claims have
+  explicit witnesses;
+- the group-algebra equivalence proves both directions;
+- the commutative-algebra and algebra-homomorphism definitions use Mathlib's complete structures.
+
+The post-Proposition convention is editorial and therefore has no proof obligation. A scoped scan
+of all §2.2 Lean files finds no `sorry`, `admit`, or project `axiom`. Durable `stage3_3` records now
+identify every verified named declaration and the anonymous-example basis where applicable.
+
+## Validation
+
+- standalone elaboration of every §2.2 Lean file changed or referenced by the claim inventory
+- scoped source scan for `sorry`, `admit`, and project `axiom`
+- `jq empty progress/items.json`
+- `git diff --check`
+
+This PR is limited to Section 2.2 and Stage 3.3.

--- a/progress/2026-07-27-stage3-4-section-2-2.md
+++ b/progress/2026-07-27-stage3-4-section-2-2.md
@@ -1,0 +1,30 @@
+# Stage 3.4 dependency trimming: Chapter 2 §2.2
+
+## Scope
+
+This pass analyzes the actual internal dependencies of exactly the nine §2.2 items after their
+Stage 3.3 proofs were verified.
+
+## Actual dependency graph
+
+Only two direct project edges are required:
+
+- `Chapter2/Definition2.2.2` imports `Chapter2/Definition2.2.1` to define a unit of the custom
+  non-unital associative algebra;
+- `Chapter2/Proposition2.2.3` imports `Chapter2/Definition2.2.2` to prove unit uniqueness.
+
+The introduction, algebra examples, commutative-algebra definition, commutativity discussion, and
+algebra-homomorphism definition import Mathlib only. The editorial convention has no Lean
+companion and therefore no formal edge. The conservative reading-order links for those seven
+items were removed from `dependencies/internal.json`; the two genuine import edges were retained.
+
+All nine items now carry durable `stage3_4` records and move to `dependency_trimmed`.
+
+## Validation
+
+- inspected every scoped Lean import
+- verified both retained targets exist in the root item catalog
+- `jq empty dependencies/internal.json progress/items.json`
+- `git diff --check`
+
+This PR is limited to Section 2.2 and Stage 3.4.

--- a/progress/items.json
+++ b/progress/items.json
@@ -203,7 +203,7 @@
     "end_page": "8",
     "start_line": 11,
     "end_line": 15,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "fidelity": "verified",
     "sorry_free": true,
@@ -252,6 +252,13 @@
         "Etingof.algebraicClosure_zmod_charP"
       ]
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The introduction imports Mathlib only; all algebraic-closedness and finite-field facts are proved directly from Mathlib APIs."
+    },
     "coverage_note": "All mathematical claims in the introductory paragraph are explicit: the root/splitting bridge, the complex example, and the positive-characteristic algebraic-closure example.",
     "last_updated": "2026-07-27",
     "coverage_swept": {
@@ -267,7 +274,7 @@
     "end_page": "9",
     "start_line": 1,
     "end_line": 1,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -296,6 +303,13 @@
         "Etingof.AssociativeAlgebra"
       ]
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The non-unital associative-algebra class imports Mathlib only and is self-contained."
+    },
     "fidelity_note": "The custom class is genuinely non-unital and records multiplication, associativity, additivity, and scalar compatibility in both arguments. No class data or definition body is sorried; closed issue #5616 describes the superseded unital encoding.",
     "coverage_note": "The carrier assumptions and every bilinearity/associativity component of the source definition are fields or parameters of Etingof.AssociativeAlgebra.",
     "last_updated": "2026-07-27"
@@ -308,7 +322,7 @@
     "end_page": "9",
     "start_line": 2,
     "end_line": 4,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -337,6 +351,15 @@
         "Etingof.AssociativeAlgebra.IsUnit"
       ]
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Definition2.2.1"
+      ],
+      "basis": "The unit predicate is defined on the section's non-unital AssociativeAlgebra class."
+    },
     "fidelity_note": "IsUnit is a predicate on an arbitrary element of the non-unital structure and quantifies both identity laws over every algebra element. It does not presuppose a Ring or canonical one; closed issue #5617 describes the superseded vacuous theorem.",
     "fidelity_decl": "Etingof.AssociativeAlgebra.IsUnit",
     "coverage_note": "The definition records both source conjuncts e*a = a and a*e = a for every a.",
@@ -350,7 +373,7 @@
     "end_page": "9",
     "start_line": 5,
     "end_line": 8,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -379,6 +402,15 @@
         "Etingof.Proposition_2_2_3"
       ]
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Definition2.2.2"
+      ],
+      "basis": "The uniqueness theorem imports and uses the section's unit predicate."
+    },
     "coverage_note": "The item-local theorem now compares two arbitrary elements satisfying Definition 2.2.2 and reuses the exact non-unital uniqueness proof AssociativeAlgebra.isUnit_unique.",
     "last_updated": "2026-07-27"
   },
@@ -390,7 +422,7 @@
     "end_page": "9",
     "start_line": 9,
     "end_line": 10,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "non_formalizable",
     "fidelity": "verified",
     "sorry_free": true,
@@ -418,6 +450,13 @@
       "declarations": [],
       "basis": "The item is an editorial convention and has no mathematical proof obligation."
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The editorial convention has no Lean companion or formal dependency."
+    },
     "coverage_note": "The sole sentence is an editorial convention, and its implementation is checked in the subsequent unital algebra items.",
     "last_updated": "2026-07-27",
     "coverage_swept": {
@@ -433,7 +472,7 @@
     "end_page": "9",
     "start_line": 11,
     "end_line": 22,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -491,6 +530,13 @@
       "declarations": [],
       "basis": "All seven claims are elaborated anonymous examples using Mathlib's canonical algebra, basis, and multiplication APIs."
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The examples file imports Mathlib only and uses canonical polynomial, endomorphism, free-algebra, and monoid-algebra APIs."
+    },
     "coverage_note": "All five examples and the stated multiplication/basis descriptions are machine checked. In particular, the polynomial example now uses Fin n variables rather than only one variable.",
     "last_updated": "2026-07-27"
   },
@@ -502,7 +548,7 @@
     "end_page": "9",
     "start_line": 23,
     "end_line": 23,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -531,6 +577,13 @@
         "Etingof.CommutativeAlgebra"
       ]
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The commutative-algebra abbreviation imports Mathlib only."
+    },
     "coverage_note": "Under the immediately preceding unital convention, CommRing together with Algebra records exactly the universal multiplication-commutativity condition; no nontrivial representation bridge is needed.",
     "last_updated": "2026-07-27"
   },
@@ -542,7 +595,7 @@
     "end_page": "9",
     "start_line": 24,
     "end_line": 26,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "fidelity": "verified",
     "coverage_note": "The group-algebra iff, the free-algebra claim, and the source's quantified End_k(V) noncommutativity theorem for every vector space of cardinal rank at least 2 (End_noncommutative_of_two_le_rank), including infinite-dimensional V, are all public. The concrete V = k² matrix-unit witness remains as the dim V = 2 special case.",
@@ -589,6 +642,13 @@
         "Etingof.End_noncommutative_of_two_le_rank",
         "Etingof.freeAlgebra_noncommutative_of_one_lt"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "All commutativity witnesses are constructed directly from Mathlib matrix, free-algebra, and monoid-algebra APIs."
     }
   },
   {
@@ -599,7 +659,7 @@
     "end_page": "9",
     "start_line": 27,
     "end_line": 27,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -627,6 +687,13 @@
       "declarations": [
         "Etingof.AlgebraHom"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The algebra-homomorphism abbreviation imports Mathlib only."
     },
     "coverage_note": "AlgHom records every source component: k-linearity, f(xy) = f(x)f(y), and f(1) = 1. The representations are definitionally the same under the active unital convention.",
     "last_updated": "2026-07-27"

--- a/progress/items.json
+++ b/progress/items.json
@@ -238,6 +238,20 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.isAlgClosed_iff_nonconstant_polynomial_has_root",
+        "Etingof.complex_isAlgClosed",
+        "Etingof.zmodField",
+        "Etingof.card_zmod",
+        "Etingof.algebraicClosure_zmod_isAlgClosed",
+        "Etingof.algebraicClosure_zmod_charP"
+      ]
+    },
     "coverage_note": "All mathematical claims in the introductory paragraph are explicit: the root/splitting bridge, the complex example, and the positive-characteristic algebraic-closure example.",
     "last_updated": "2026-07-27",
     "coverage_swept": {
@@ -273,6 +287,15 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.AssociativeAlgebra"
+      ]
+    },
     "fidelity_note": "The custom class is genuinely non-unital and records multiplication, associativity, additivity, and scalar compatibility in both arguments. No class data or definition body is sorried; closed issue #5616 describes the superseded unital encoding.",
     "coverage_note": "The carrier assumptions and every bilinearity/associativity component of the source definition are fields or parameters of Etingof.AssociativeAlgebra.",
     "last_updated": "2026-07-27"
@@ -303,6 +326,15 @@
           "verdict": "formalized",
           "lean_decl": "Etingof.AssociativeAlgebra.IsUnit"
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.AssociativeAlgebra.IsUnit"
       ]
     },
     "fidelity_note": "IsUnit is a predicate on an arbitrary element of the non-unital structure and quantifies both identity laws over every algebra element. It does not presuppose a Ring or canonical one; closed issue #5617 describes the superseded vacuous theorem.",
@@ -338,6 +370,15 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Proposition_2_2_3"
+      ]
+    },
     "coverage_note": "The item-local theorem now compares two arbitrary elements satisfying Definition 2.2.2 and reuses the exact non-unital uniqueness proof AssociativeAlgebra.isUnit_unique.",
     "last_updated": "2026-07-27"
   },
@@ -368,6 +409,14 @@
           "reason": "This is an editorial notation convention rather than a mathematical assertion; later declarations implement it with Mathlib's unital Algebra typeclass."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "not_applicable",
+      "declarations": [],
+      "basis": "The item is an editorial convention and has no mathematical proof obligation."
     },
     "coverage_note": "The sole sentence is an editorial convention, and its implementation is checked in the subsequent unital algebra items.",
     "last_updated": "2026-07-27",
@@ -434,6 +483,14 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [],
+      "basis": "All seven claims are elaborated anonymous examples using Mathlib's canonical algebra, basis, and multiplication APIs."
+    },
     "coverage_note": "All five examples and the stated multiplication/basis descriptions are machine checked. In particular, the polynomial example now uses Fin n variables rather than only one variable.",
     "last_updated": "2026-07-27"
   },
@@ -463,6 +520,15 @@
           "verdict": "formalized",
           "lean_decl": "Etingof.CommutativeAlgebra (via CommRing.mul_comm)"
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.CommutativeAlgebra"
       ]
     },
     "coverage_note": "Under the immediately preceding unital convention, CommRing together with Algebra records exactly the universal multiplication-commutativity condition; no nontrivial representation bridge is needed.",
@@ -512,6 +578,17 @@
           "lean_decl": "Etingof.monoidAlgebra_mul_comm_iff"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.monoidAlgebra_mul_comm_iff",
+        "Etingof.End_noncommutative_of_two_le_rank",
+        "Etingof.freeAlgebra_noncommutative_of_one_lt"
+      ]
     }
   },
   {
@@ -540,6 +617,15 @@
           "verdict": "formalized",
           "lean_decl": "Etingof.AlgebraHom (Mathlib AlgHom)"
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.AlgebraHom"
       ]
     },
     "coverage_note": "AlgHom records every source component: k-linearity, f(xy) = f(x)f(y), and f(1) = 1. The representations are definitionally the same under the active unital convention.",


### PR DESCRIPTION
## Scope

- Chapter 2 §2.2 only
- Stage 3.4 only: actual internal-dependency analysis and trimming
- Stacked directly on the corrected Stage 3.3 branch

## Result

- Inspected imports for all eight Lean files plus the editorial item.
- Retained only two real internal edges: Definition 2.2.2 → Definition 2.2.1 and Proposition 2.2.3 → Definition 2.2.2.
- Removed seven conservative reading-order edges from items that use Mathlib only or have no Lean companion.
- Added durable `stage3_4` records and moved all nine items to `dependency_trimmed`.
- Preserved the corrected `zmodField` and cardinal-rank declaration mappings from the preceding stages.

## Verification

- scoped import inspection and exact dependency assertions
- `jq empty dependencies/internal.json progress/items.json`
- `python3 scripts/validate_items.py`
- `python3 scripts/validate_dependencies.py`
- `git diff --check`
- final stacked Chapter 2 build passes

This remains a draft until the preceding Stage 3.3 PR merges; it can then be retargeted to `main`.
