### PR TITLE
polish: complete Stage 3.5 for section 2.2

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Example2_2_4.lean
+++ b/EtingofRepresentationTheory/Chapter2/Example2_2_4.lean
@@ -1,4 +1,3 @@
-import Mathlib.Algebra.Polynomial.AlgebraMap
 import Mathlib.Algebra.MvPolynomial.Basic
 import Mathlib.Algebra.MonoidAlgebra.Basic
 import Mathlib.LinearAlgebra.FreeAlgebra

--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -39,33 +39,19 @@
   "Chapter2/Discussion_after_Theorem2.1.2": [
     "Chapter2/Theorem2.1.2"
   ],
-  "Chapter2/Discussion_2.2_intro": [
-    "Chapter2/Discussion_after_Theorem2.1.2"
-  ],
-  "Chapter2/Definition2.2.1": [
-    "Chapter2/Discussion_2.2_intro"
-  ],
+  "Chapter2/Discussion_2.2_intro": [],
+  "Chapter2/Definition2.2.1": [],
   "Chapter2/Definition2.2.2": [
     "Chapter2/Definition2.2.1"
   ],
   "Chapter2/Proposition2.2.3": [
     "Chapter2/Definition2.2.2"
   ],
-  "Chapter2/Discussion_after_Proposition2.2.3": [
-    "Chapter2/Proposition2.2.3"
-  ],
-  "Chapter2/Example2.2.4": [
-    "Chapter2/Discussion_after_Proposition2.2.3"
-  ],
-  "Chapter2/Definition2.2.5": [
-    "Chapter2/Example2.2.4"
-  ],
-  "Chapter2/Discussion_commutativity_examples": [
-    "Chapter2/Definition2.2.5"
-  ],
-  "Chapter2/Definition2.2.6": [
-    "Chapter2/Discussion_commutativity_examples"
-  ],
+  "Chapter2/Discussion_after_Proposition2.2.3": [],
+  "Chapter2/Example2.2.4": [],
+  "Chapter2/Definition2.2.5": [],
+  "Chapter2/Discussion_commutativity_examples": [],
+  "Chapter2/Definition2.2.6": [],
   "Chapter2/Definition2.3.1": [
     "Chapter2/Definition2.2.6"
   ],

--- a/progress/2026-07-27-stage3-3-section-2-2.md
+++ b/progress/2026-07-27-stage3-3-section-2-2.md
@@ -1,0 +1,32 @@
+# Stage 3.3 proof verification: Chapter 2 §2.2
+
+## Scope
+
+This pass covers exactly the nine §2.2 items audited by the preceding Stage 3.2 PR.
+
+## Result
+
+Every mathematical claim in the Stage 3.2 inventory has a complete construction or proof:
+
+- the algebraic-closedness bridge and named characteristic/cardinality examples are
+  theorem-backed;
+- the non-unital associative-algebra class and unit predicate contain no missing data;
+- unit uniqueness is proved for two arbitrary units;
+- all algebra, basis, and multiplication examples elaborate without proof holes;
+- the arbitrary-cardinal-dimension endomorphism and free-algebra noncommutativity claims have
+  explicit witnesses;
+- the group-algebra equivalence proves both directions;
+- the commutative-algebra and algebra-homomorphism definitions use Mathlib's complete structures.
+
+The post-Proposition convention is editorial and therefore has no proof obligation. A scoped scan
+of all §2.2 Lean files finds no `sorry`, `admit`, or project `axiom`. Durable `stage3_3` records now
+identify every verified named declaration and the anonymous-example basis where applicable.
+
+## Validation
+
+- standalone elaboration of every §2.2 Lean file changed or referenced by the claim inventory
+- scoped source scan for `sorry`, `admit`, and project `axiom`
+- `jq empty progress/items.json`
+- `git diff --check`
+
+This PR is limited to Section 2.2 and Stage 3.3.

--- a/progress/2026-07-27-stage3-4-section-2-2.md
+++ b/progress/2026-07-27-stage3-4-section-2-2.md
@@ -1,0 +1,30 @@
+# Stage 3.4 dependency trimming: Chapter 2 §2.2
+
+## Scope
+
+This pass analyzes the actual internal dependencies of exactly the nine §2.2 items after their
+Stage 3.3 proofs were verified.
+
+## Actual dependency graph
+
+Only two direct project edges are required:
+
+- `Chapter2/Definition2.2.2` imports `Chapter2/Definition2.2.1` to define a unit of the custom
+  non-unital associative algebra;
+- `Chapter2/Proposition2.2.3` imports `Chapter2/Definition2.2.2` to prove unit uniqueness.
+
+The introduction, algebra examples, commutative-algebra definition, commutativity discussion, and
+algebra-homomorphism definition import Mathlib only. The editorial convention has no Lean
+companion and therefore no formal edge. The conservative reading-order links for those seven
+items were removed from `dependencies/internal.json`; the two genuine import edges were retained.
+
+All nine items now carry durable `stage3_4` records and move to `dependency_trimmed`.
+
+## Validation
+
+- inspected every scoped Lean import
+- verified both retained targets exist in the root item catalog
+- `jq empty dependencies/internal.json progress/items.json`
+- `git diff --check`
+
+This PR is limited to Section 2.2 and Stage 3.4.

--- a/progress/2026-07-27-stage3-5-section-2-2.md
+++ b/progress/2026-07-27-stage3-5-section-2-2.md
@@ -1,0 +1,40 @@
+# Stage 3.5 Mathlib-quality polish: Chapter 2 §2.2
+
+## Scope
+
+This pass reviews all eight Lean files and the one editorial item in §2.2 after dependency
+trimming.
+
+## Review
+
+The section already satisfies the intended Mathlib-facing design:
+
+- imports are focused and seven of the eight files use Mathlib only;
+- the non-unital algebra class exposes exactly the source data, with the standard unital-algebra
+  instance supplied separately;
+- the unit predicate and uniqueness theorem are small and composable;
+- standard structures such as commutative algebras and algebra homomorphisms are direct,
+  documented abbreviations rather than parallel APIs;
+- examples use Mathlib's canonical multivariate-polynomial, free-algebra, monoid-algebra, basis,
+  and endomorphism constructions;
+- the noncommutativity results isolate explicit witnesses and state the book's full quantifiers.
+- the stale univariate-polynomial import left by the move to `MvPolynomial` has been removed.
+
+Each Lean file was temporarily checked with an end-of-file `#lint`. All 16 enabled linters passed:
+6 declarations in the introduction, 10 in the associative-algebra file, 2 in the unit file, 1 in
+the proposition, 0 named declarations in the anonymous example file, 1 in the commutative-algebra
+file, 3 in the commutativity discussion, and 1 in the algebra-homomorphism file. The files also
+elaborate without ordinary warnings. No further source rewrite was justified at Stage 3.5.
+
+All nine items advance from `dependency_trimmed` to `proof_polished` and carry durable `stage3_5`
+records. The editorial convention is explicitly marked as having no Lean declaration to polish.
+
+## Validation
+
+- standalone elaboration of all eight Lean files
+- temporary `#lint` in every Lean file: zero errors with 16 linters
+- scoped source scan for `sorry`, `admit`, and project `axiom`
+- `jq empty progress/items.json`
+- `git diff --check`
+
+This PR is limited to Section 2.2 and Stage 3.5.

--- a/progress/items.json
+++ b/progress/items.json
@@ -203,7 +203,7 @@
     "end_page": "8",
     "start_line": 11,
     "end_line": 15,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "coverage": "covered_full",
     "fidelity": "verified",
     "sorry_free": true,
@@ -259,6 +259,13 @@
       "actual_internal_dependencies": [],
       "basis": "The introduction imports Mathlib only; all algebraic-closedness and finite-field facts are proved directly from Mathlib APIs."
     },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.2",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "Focused imports, documented public theorems, direct instance proofs, and a clean 16-linter pass; no rewrite was justified."
+    },
     "coverage_note": "All mathematical claims in the introductory paragraph are explicit: the root/splitting bridge, the complex example, and the positive-characteristic algebraic-closure example.",
     "last_updated": "2026-07-27",
     "coverage_swept": {
@@ -274,7 +281,7 @@
     "end_page": "9",
     "start_line": 1,
     "end_line": 1,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -310,6 +317,13 @@
       "actual_internal_dependencies": [],
       "basis": "The non-unital associative-algebra class imports Mathlib only and is self-contained."
     },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.2",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The class has a complete docstring, minimal fields, a canonical instance for unital algebras, and a clean 16-linter pass; no rewrite was justified."
+    },
     "fidelity_note": "The custom class is genuinely non-unital and records multiplication, associativity, additivity, and scalar compatibility in both arguments. No class data or definition body is sorried; closed issue #5616 describes the superseded unital encoding.",
     "coverage_note": "The carrier assumptions and every bilinearity/associativity component of the source definition are fields or parameters of Etingof.AssociativeAlgebra.",
     "last_updated": "2026-07-27"
@@ -322,7 +336,7 @@
     "end_page": "9",
     "start_line": 2,
     "end_line": 4,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -360,6 +374,13 @@
       ],
       "basis": "The unit predicate is defined on the section's non-unital AssociativeAlgebra class."
     },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.2",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The predicate and uniqueness theorem are small, documented, and linter-clean; no rewrite was justified."
+    },
     "fidelity_note": "IsUnit is a predicate on an arbitrary element of the non-unital structure and quantifies both identity laws over every algebra element. It does not presuppose a Ring or canonical one; closed issue #5617 describes the superseded vacuous theorem.",
     "fidelity_decl": "Etingof.AssociativeAlgebra.IsUnit",
     "coverage_note": "The definition records both source conjuncts e*a = a and a*e = a for every a.",
@@ -373,7 +394,7 @@
     "end_page": "9",
     "start_line": 5,
     "end_line": 8,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -411,6 +432,13 @@
       ],
       "basis": "The uniqueness theorem imports and uses the section's unit predicate."
     },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.2",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The proposition is a documented one-line reuse of the canonical section theorem and passes all 16 linters."
+    },
     "coverage_note": "The item-local theorem now compares two arbitrary elements satisfying Definition 2.2.2 and reuses the exact non-unital uniqueness proof AssociativeAlgebra.isUnit_unique.",
     "last_updated": "2026-07-27"
   },
@@ -422,7 +450,7 @@
     "end_page": "9",
     "start_line": 9,
     "end_line": 10,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "coverage": "non_formalizable",
     "fidelity": "verified",
     "sorry_free": true,
@@ -457,6 +485,13 @@
       "actual_internal_dependencies": [],
       "basis": "The editorial convention has no Lean companion or formal dependency."
     },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.2",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "not_applicable",
+      "result": "This is an editorial notation convention with no Lean declaration to polish."
+    },
     "coverage_note": "The sole sentence is an editorial convention, and its implementation is checked in the subsequent unital algebra items.",
     "last_updated": "2026-07-27",
     "coverage_swept": {
@@ -472,7 +507,7 @@
     "end_page": "9",
     "start_line": 11,
     "end_line": 22,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -537,6 +572,13 @@
       "actual_internal_dependencies": [],
       "basis": "The examples file imports Mathlib only and uses canonical polynomial, endomorphism, free-algebra, and monoid-algebra APIs."
     },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.2",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The anonymous examples use canonical Mathlib bases and multiplication lemmas, have focused imports, and pass all 16 linters."
+    },
     "coverage_note": "All five examples and the stated multiplication/basis descriptions are machine checked. In particular, the polynomial example now uses Fin n variables rather than only one variable.",
     "last_updated": "2026-07-27"
   },
@@ -548,7 +590,7 @@
     "end_page": "9",
     "start_line": 23,
     "end_line": 23,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -584,6 +626,13 @@
       "actual_internal_dependencies": [],
       "basis": "The commutative-algebra abbreviation imports Mathlib only."
     },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.2",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The declaration is a documented direct abbreviation of Mathlib's structures and passes all 16 linters."
+    },
     "coverage_note": "Under the immediately preceding unital convention, CommRing together with Algebra records exactly the universal multiplication-commutativity condition; no nontrivial representation bridge is needed.",
     "last_updated": "2026-07-27"
   },
@@ -595,7 +644,7 @@
     "end_page": "9",
     "start_line": 24,
     "end_line": 26,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "coverage": "covered_full",
     "fidelity": "verified",
     "coverage_note": "The group-algebra iff, the free-algebra claim, and the source's quantified End_k(V) noncommutativity theorem for every vector space of cardinal rank at least 2 (End_noncommutative_of_two_le_rank), including infinite-dimensional V, are all public. The concrete V = k² matrix-unit witness remains as the dim V = 2 special case.",
@@ -649,6 +698,13 @@
       "verified_on": "2026-07-27",
       "actual_internal_dependencies": [],
       "basis": "All commutativity witnesses are constructed directly from Mathlib matrix, free-algebra, and monoid-algebra APIs."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.2",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The quantified witnesses use focused Mathlib APIs, explicit local constructions, documented theorems, and pass all 16 linters."
     }
   },
   {
@@ -659,7 +715,7 @@
     "end_page": "9",
     "start_line": 27,
     "end_line": 27,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -694,6 +750,13 @@
       "verified_on": "2026-07-27",
       "actual_internal_dependencies": [],
       "basis": "The algebra-homomorphism abbreviation imports Mathlib only."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.2",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The declaration is a documented direct abbreviation of Mathlib's AlgHom and passes all 16 linters."
     },
     "coverage_note": "AlgHom records every source component: k-linearity, f(xy) = f(x)f(y), and f(1) = 1. The representations are definitionally the same under the active unital convention.",
     "last_updated": "2026-07-27"

--- a/progress/items.json
+++ b/progress/items.json
@@ -203,7 +203,7 @@
     "end_page": "8",
     "start_line": 11,
     "end_line": 15,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "fidelity": "verified",
     "sorry_free": true,
@@ -252,6 +252,13 @@
         "Etingof.algebraicClosure_zmod_charP"
       ]
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The introduction imports Mathlib only; all algebraic-closedness and finite-field facts are proved directly from Mathlib APIs."
+    },
     "coverage_note": "All mathematical claims in the introductory paragraph are explicit: the root/splitting bridge, the complex example, and the positive-characteristic algebraic-closure example.",
     "last_updated": "2026-07-27",
     "coverage_swept": {
@@ -267,7 +274,7 @@
     "end_page": "9",
     "start_line": 1,
     "end_line": 1,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -296,6 +303,13 @@
         "Etingof.AssociativeAlgebra"
       ]
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The non-unital associative-algebra class imports Mathlib only and is self-contained."
+    },
     "fidelity_note": "The custom class is genuinely non-unital and records multiplication, associativity, additivity, and scalar compatibility in both arguments. No class data or definition body is sorried; closed issue #5616 describes the superseded unital encoding.",
     "coverage_note": "The carrier assumptions and every bilinearity/associativity component of the source definition are fields or parameters of Etingof.AssociativeAlgebra.",
     "last_updated": "2026-07-27"
@@ -308,7 +322,7 @@
     "end_page": "9",
     "start_line": 2,
     "end_line": 4,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -337,6 +351,15 @@
         "Etingof.AssociativeAlgebra.IsUnit"
       ]
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Definition2.2.1"
+      ],
+      "basis": "The unit predicate is defined on the section's non-unital AssociativeAlgebra class."
+    },
     "fidelity_note": "IsUnit is a predicate on an arbitrary element of the non-unital structure and quantifies both identity laws over every algebra element. It does not presuppose a Ring or canonical one; closed issue #5617 describes the superseded vacuous theorem.",
     "fidelity_decl": "Etingof.AssociativeAlgebra.IsUnit",
     "coverage_note": "The definition records both source conjuncts e*a = a and a*e = a for every a.",
@@ -350,7 +373,7 @@
     "end_page": "9",
     "start_line": 5,
     "end_line": 8,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -379,6 +402,15 @@
         "Etingof.Proposition_2_2_3"
       ]
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Definition2.2.2"
+      ],
+      "basis": "The uniqueness theorem imports and uses the section's unit predicate."
+    },
     "coverage_note": "The item-local theorem now compares two arbitrary elements satisfying Definition 2.2.2 and reuses the exact non-unital uniqueness proof AssociativeAlgebra.isUnit_unique.",
     "last_updated": "2026-07-27"
   },
@@ -390,7 +422,7 @@
     "end_page": "9",
     "start_line": 9,
     "end_line": 10,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "non_formalizable",
     "fidelity": "verified",
     "sorry_free": true,
@@ -418,6 +450,13 @@
       "declarations": [],
       "basis": "The item is an editorial convention and has no mathematical proof obligation."
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The editorial convention has no Lean companion or formal dependency."
+    },
     "coverage_note": "The sole sentence is an editorial convention, and its implementation is checked in the subsequent unital algebra items.",
     "last_updated": "2026-07-27",
     "coverage_swept": {
@@ -433,7 +472,7 @@
     "end_page": "9",
     "start_line": 11,
     "end_line": 22,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -491,6 +530,13 @@
       "declarations": [],
       "basis": "All seven claims are elaborated anonymous examples using Mathlib's canonical algebra, basis, and multiplication APIs."
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The examples file imports Mathlib only and uses canonical polynomial, endomorphism, free-algebra, and monoid-algebra APIs."
+    },
     "coverage_note": "All five examples and the stated multiplication/basis descriptions are machine checked. In particular, the polynomial example now uses Fin n variables rather than only one variable.",
     "last_updated": "2026-07-27"
   },
@@ -502,7 +548,7 @@
     "end_page": "9",
     "start_line": 23,
     "end_line": 23,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -531,6 +577,13 @@
         "Etingof.CommutativeAlgebra"
       ]
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The commutative-algebra abbreviation imports Mathlib only."
+    },
     "coverage_note": "Under the immediately preceding unital convention, CommRing together with Algebra records exactly the universal multiplication-commutativity condition; no nontrivial representation bridge is needed.",
     "last_updated": "2026-07-27"
   },
@@ -542,7 +595,7 @@
     "end_page": "9",
     "start_line": 24,
     "end_line": 26,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "fidelity": "verified",
     "coverage_note": "The group-algebra iff, the free-algebra claim, and the source's quantified End_k(V) noncommutativity theorem for every vector space of cardinal rank at least 2 (End_noncommutative_of_two_le_rank), including infinite-dimensional V, are all public. The concrete V = k² matrix-unit witness remains as the dim V = 2 special case.",
@@ -589,6 +642,13 @@
         "Etingof.End_noncommutative_of_two_le_rank",
         "Etingof.freeAlgebra_noncommutative_of_one_lt"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "All commutativity witnesses are constructed directly from Mathlib matrix, free-algebra, and monoid-algebra APIs."
     }
   },
   {
@@ -599,7 +659,7 @@
     "end_page": "9",
     "start_line": 27,
     "end_line": 27,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -627,6 +687,13 @@
       "declarations": [
         "Etingof.AlgebraHom"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The algebra-homomorphism abbreviation imports Mathlib only."
     },
     "coverage_note": "AlgHom records every source component: k-linearity, f(xy) = f(x)f(y), and f(1) = 1. The representations are definitionally the same under the active unital convention.",
     "last_updated": "2026-07-27"

--- a/progress/items.json
+++ b/progress/items.json
@@ -238,6 +238,20 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.isAlgClosed_iff_nonconstant_polynomial_has_root",
+        "Etingof.complex_isAlgClosed",
+        "Etingof.zmodField",
+        "Etingof.card_zmod",
+        "Etingof.algebraicClosure_zmod_isAlgClosed",
+        "Etingof.algebraicClosure_zmod_charP"
+      ]
+    },
     "coverage_note": "All mathematical claims in the introductory paragraph are explicit: the root/splitting bridge, the complex example, and the positive-characteristic algebraic-closure example.",
     "last_updated": "2026-07-27",
     "coverage_swept": {
@@ -273,6 +287,15 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.AssociativeAlgebra"
+      ]
+    },
     "fidelity_note": "The custom class is genuinely non-unital and records multiplication, associativity, additivity, and scalar compatibility in both arguments. No class data or definition body is sorried; closed issue #5616 describes the superseded unital encoding.",
     "coverage_note": "The carrier assumptions and every bilinearity/associativity component of the source definition are fields or parameters of Etingof.AssociativeAlgebra.",
     "last_updated": "2026-07-27"
@@ -303,6 +326,15 @@
           "verdict": "formalized",
           "lean_decl": "Etingof.AssociativeAlgebra.IsUnit"
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.AssociativeAlgebra.IsUnit"
       ]
     },
     "fidelity_note": "IsUnit is a predicate on an arbitrary element of the non-unital structure and quantifies both identity laws over every algebra element. It does not presuppose a Ring or canonical one; closed issue #5617 describes the superseded vacuous theorem.",
@@ -338,6 +370,15 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Proposition_2_2_3"
+      ]
+    },
     "coverage_note": "The item-local theorem now compares two arbitrary elements satisfying Definition 2.2.2 and reuses the exact non-unital uniqueness proof AssociativeAlgebra.isUnit_unique.",
     "last_updated": "2026-07-27"
   },
@@ -368,6 +409,14 @@
           "reason": "This is an editorial notation convention rather than a mathematical assertion; later declarations implement it with Mathlib's unital Algebra typeclass."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "not_applicable",
+      "declarations": [],
+      "basis": "The item is an editorial convention and has no mathematical proof obligation."
     },
     "coverage_note": "The sole sentence is an editorial convention, and its implementation is checked in the subsequent unital algebra items.",
     "last_updated": "2026-07-27",
@@ -434,6 +483,14 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [],
+      "basis": "All seven claims are elaborated anonymous examples using Mathlib's canonical algebra, basis, and multiplication APIs."
+    },
     "coverage_note": "All five examples and the stated multiplication/basis descriptions are machine checked. In particular, the polynomial example now uses Fin n variables rather than only one variable.",
     "last_updated": "2026-07-27"
   },
@@ -463,6 +520,15 @@
           "verdict": "formalized",
           "lean_decl": "Etingof.CommutativeAlgebra (via CommRing.mul_comm)"
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.CommutativeAlgebra"
       ]
     },
     "coverage_note": "Under the immediately preceding unital convention, CommRing together with Algebra records exactly the universal multiplication-commutativity condition; no nontrivial representation bridge is needed.",
@@ -512,6 +578,17 @@
           "lean_decl": "Etingof.monoidAlgebra_mul_comm_iff"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.monoidAlgebra_mul_comm_iff",
+        "Etingof.End_noncommutative_of_two_le_rank",
+        "Etingof.freeAlgebra_noncommutative_of_one_lt"
+      ]
     }
   },
   {
@@ -540,6 +617,15 @@
           "verdict": "formalized",
           "lean_decl": "Etingof.AlgebraHom (Mathlib AlgHom)"
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.AlgebraHom"
       ]
     },
     "coverage_note": "AlgHom records every source component: k-linearity, f(xy) = f(x)f(y), and f(1) = 1. The representations are definitionally the same under the active unital convention.",


### PR DESCRIPTION
## Scope

- Chapter 2 §2.2 only
- Stage 3.5 only: Mathlib-quality review and polish
- Stacked directly on the corrected Stage 3.4 branch

## Result

- Reviewed imports, documentation, API shape, theorem granularity, proof style, and simp usage across all eight Lean files.
- Removed the stale `Mathlib.Algebra.Polynomial.AlgebraMap` import left by the migration to `MvPolynomial`.
- Corrected the custom non-unital algebra description: it supplies a canonical instance for unital algebras, not a coercion.
- Ran every file through all 16 enabled linters; all passed with zero errors. The introduction now correctly records six named declarations, including `Etingof.zmodField`.
- Added durable `stage3_5` records and moved all nine items to `proof_polished`; the editorial item is explicitly not applicable for code polish.

## Verification

- standalone elaboration and focused build of all eight §2.2 files, warning-free
- temporary end-of-file `#lint` in each file: zero errors with 16 linters
- scoped trust-token scan and standard-axiom checks
- `jq empty progress/items.json dependencies/internal.json`
- `python3 scripts/validate_items.py`
- `python3 scripts/validate_dependencies.py`
- `git diff --check`
- full `lake build EtingofRepresentationTheory.Chapter2` passes (with pre-existing warnings outside §2.2)

This remains a draft until the preceding Stage 3.4 PR merges; it can then be retargeted to `main`.
