### PR TITLE
Stage 3.3: verify Chapter 2 section 2.5 proofs

### DIFF
--- a/progress/2026-07-27T12-15-00Z_stage3-3-chapter2-section2-5.md
+++ b/progress/2026-07-27T12-15-00Z_stage3-3-chapter2-section2-5.md
@@ -1,0 +1,46 @@
+# Stage 3.3 proof verification — Chapter 2 §2.5
+
+## Scope
+
+This Stage 3.3 pass covers exactly:
+
+- `Chapter2/Discussion_2.5_heading`
+- `Chapter2/Discussion_2.5_well_defined`
+- `Chapter2/Problem2.5.1`
+- `Chapter2/Problem2.5.2`
+
+The preceding Stage 3.2 pass recorded 23 formalized claims. This pass independently checked the
+22 unique declarations supporting those claims; the two Problem 2.5.1 claims share the theorem
+`Etingof.Problem2_5_1.quotient_isIndecomposable`.
+
+## Result
+
+Every scoped claim has a complete proof or construction:
+
+- the quotient algebra is a genuine ring-congruence quotient, with a canonical algebra map,
+  additive-coset equality bridge, prescribed multiplication, and both representative-independence
+  proofs;
+- quotient and regular-quotient representations use Mathlib's quotient-module structures, with
+  the action formula proved explicitly;
+- Problem 2.5.1 proves the full indecomposability theorem from properness and the homogeneous-tail
+  hypothesis;
+- Problem 2.5.2 proves both cyclicity equivalences and constructs the literal three-dimensional
+  coregular counterexample, including its ideal-presentation bridge, algebra equivalence, basis,
+  noncyclicity, and indecomposability.
+
+No source change was necessary. A scoped source scan found no `sorry`, `admit`, or project
+`axiom`. `#print axioms` on all 22 supporting declarations reported only Lean's standard trusted
+axioms (`propext`, `Classical.choice`, and `Quot.sound` as applicable), never `sorryAx` or a project
+axiom. Durable `stage3_3` records now enumerate the verified declarations for all four items.
+
+## Validation
+
+- direct elaboration of all three scoped Lean source files
+- scoped `lake build` of all three modules
+- `#print axioms` on all 22 unique supporting declarations
+- `lake build EtingofRepresentationTheory.Chapter2`
+- scoped source scan for `sorry`, `admit`, and `axiom`
+- `scripts/validate_items.py`
+- `scripts/validate_dependencies.py`
+- `jq empty progress/items.json`
+- `git diff --check`

--- a/progress/items.json
+++ b/progress/items.json
@@ -840,6 +840,18 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.5",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.QuotientAlgebra",
+        "Etingof.quotientAlgHom_eq_iff_sub_mem",
+        "Etingof.quotientAlgHom",
+        "Etingof.quotientAlgHom_mul"
+      ]
+    },
     "last_updated": "2026-07-27"
   },
   {
@@ -901,6 +913,21 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.5",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.quotientAlgHom_mul_eq_of_sub_mem_left",
+        "Etingof.quotientAlgHom_mul_eq_of_sub_mem_right",
+        "Etingof.quotientAlgebraStructure",
+        "Etingof.quotientRepresentation",
+        "Etingof.quotientMk_smul",
+        "Etingof.RegularLeftIdeal",
+        "Etingof.regularQuotientRepresentation"
+      ]
+    },
     "last_updated": "2026-07-27"
   },
   {
@@ -936,6 +963,15 @@
           "verdict": "formalized",
           "lean_decl": "Etingof.Problem2_5_1.quotient_isIndecomposable"
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.5",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Problem2_5_1.quotient_isIndecomposable"
       ]
     }
   },
@@ -1011,6 +1047,24 @@
           "verdict": "formalized",
           "lean_decl": "Etingof.Problem2_5_2.PartC.indecomposable_not_cyclic"
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.5",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Problem2_5_2.IsCyclicVector",
+        "Etingof.Problem2_5_2.IsCyclic",
+        "Etingof.Problem2_5_2.irreducible_iff_forall_cyclic",
+        "Etingof.Problem2_5_2.cyclic_iff_isoQuotient",
+        "Etingof.Problem2_5_2.PartC.I₂_eq_span_homogeneous_ge_two",
+        "Etingof.Problem2_5_2.PartC.algEquiv",
+        "Etingof.Problem2_5_2.PartC.basis",
+        "Etingof.Coregular",
+        "Etingof.Coregular.toDual_smul",
+        "Etingof.Problem2_5_2.PartC.indecomposable_not_cyclic"
       ]
     },
     "last_updated": "2026-07-27"


### PR DESCRIPTION
## What changed

- added durable Stage 3.3 proof-integrity records for exactly the four Chapter 2 §2.5 items
- enumerated all 22 unique supporting declarations for the 23 Stage 3.2 claims
- added a focused Stage 3.3 verification note

No Lean source change was needed: all scoped claims already have complete proofs or constructions.

## Why

Stage 3.3 independently verifies proof completion after the Stage 3.2 faithful-formalization pass.
This checks the actual supporting declarations rather than trusting status metadata.

## Proof-integrity evidence

- directly elaborated all three scoped Lean files
- scanned the scoped sources: no `sorry`, `admit`, or project `axiom`
- ran `#print axioms` on all 22 unique supporting declarations; only `propext`,
  `Classical.choice`, and `Quot.sound` appear as applicable, with no `sorryAx` or project axiom
- verified Problem 2.5.1's full indecomposability proof and all of Problem 2.5.2(a–c), including
  the literal `ℂ[x,y]/I₂` coregular example

## Validation

- `lake env lean` on each scoped file
- scoped `lake build` on all three modules
- `lake build EtingofRepresentationTheory.Chapter2`
- `python3 scripts/validate_items.py`
- `python3 scripts/validate_dependencies.py`
- `jq empty progress/items.json`
- `git diff --check`

The aggregate build succeeds. Existing warnings outside §2.5 remain unchanged; Problem 2.5.2's
flexible-`simp` lints are intentionally deferred to Stage 3.5.
