### PR TITLE
verify(Ch2 §2.7): complete Stage 3.3 proof audit

### DIFF
--- a/progress/2026-07-27T12-15-00Z_stage3-3-chapter2-section2-7.md
+++ b/progress/2026-07-27T12-15-00Z_stage3-3-chapter2-section2-7.md
@@ -4,20 +4,24 @@
 
 This Stage 3.3 pass covers exactly `Chapter2/Discussion_2.7_intro`,
 `Chapter2/Proposition2.7.1`, `Chapter2/Remark2.7.2`,
-`Chapter2/Definition2.7.3`, `Chapter2/Problem2.7.4`, and
+`Chapter2/Definition2.7.3`, `Chapter2/Discussion_faithful_example`,
+`Chapter2/Problem2.7.4`, and
 `Chapter2/Problem2.7.5`. The faithful statement and definition audit belongs to the
 preceding Stage 3.2 PR and is not repeated here.
 
 ## Result
 
 All claims recorded by the §2.7 Stage 3.2 audit have complete proof terms or constructions.
-The verification covered the 13 Lean modules assigned to the six items: both Weyl-basis modules,
+The verification covered the 13 Lean modules assigned to the seven items: both Weyl-basis modules,
 the faithful Weyl module, the differential-operator and faithful-representation modules, both
 Problem 2.7.4 modules, and all six Problem 2.7.5 modules.
 
 - The Weyl and q-Weyl relations, invertibility laws, and ordered-monomial bases are proved.
 - The characteristic-free faithful Weyl representation and polynomial differential-operator
   realization are complete.
+- The characteristic contrast for faithfulness is complete: the polynomial action is injective
+  in characteristic zero, its p-th derivative vanishes and the action is noninjective in
+  characteristic p, while the Laurent-family action is injective in every characteristic.
 - The characteristic-zero and characteristic-`p` conclusions of Problem 2.7.4, including the
   exhaustive and unique irreducible-family classification, are complete.
 - The center, simplicity, finite-representation criterion, and exhaustive central-character

--- a/progress/2026-07-27T12-15-00Z_stage3-3-chapter2-section2-7.md
+++ b/progress/2026-07-27T12-15-00Z_stage3-3-chapter2-section2-7.md
@@ -1,0 +1,41 @@
+# Stage 3.3 proof verification — Chapter 2 §2.7
+
+## Scope
+
+This Stage 3.3 pass covers exactly `Chapter2/Discussion_2.7_intro`,
+`Chapter2/Proposition2.7.1`, `Chapter2/Remark2.7.2`,
+`Chapter2/Definition2.7.3`, `Chapter2/Problem2.7.4`, and
+`Chapter2/Problem2.7.5`. The faithful statement and definition audit belongs to the
+preceding Stage 3.2 PR and is not repeated here.
+
+## Result
+
+All claims recorded by the §2.7 Stage 3.2 audit have complete proof terms or constructions.
+The verification covered the 13 Lean modules assigned to the six items: both Weyl-basis modules,
+the faithful Weyl module, the differential-operator and faithful-representation modules, both
+Problem 2.7.4 modules, and all six Problem 2.7.5 modules.
+
+- The Weyl and q-Weyl relations, invertibility laws, and ordered-monomial bases are proved.
+- The characteristic-free faithful Weyl representation and polynomial differential-operator
+  realization are complete.
+- The characteristic-zero and characteristic-`p` conclusions of Problem 2.7.4, including the
+  exhaustive and unique irreducible-family classification, are complete.
+- The center, simplicity, finite-representation criterion, and exhaustive central-character
+  classification in Problem 2.7.5 are complete.
+
+A scoped source scan found no `sorry`, `admit`, or project `axiom` declaration. Representative
+public endpoints from the basis theorems, both ideal/center problems, and both classification
+theorems depend only on Lean's accepted standard axioms `propext`, `Classical.choice`, and
+`Quot.sound`; in particular, none depends on `sorryAx`. Durable `stage3_3` records now identify
+the proof-complete declarations for every scoped item.
+
+The build replays existing linter and deprecation warnings in these modules. They are intentionally
+unchanged here because style and deprecation cleanup belongs to Stage 3.5.
+
+## Validation
+
+- `lake build` of all 13 scoped modules
+- scoped source scan for `sorry`, `admit`, and `axiom`
+- representative `#print axioms` checks for ten public endpoints
+- `jq empty progress/items.json`
+- `git diff --check`

--- a/progress/items.json
+++ b/progress/items.json
@@ -1100,6 +1100,20 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.7",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.WeylAlgebra.yx_eq",
+        "Etingof.qMono_relation_yx",
+        "Etingof.qMono_x_mul_inv",
+        "Etingof.qMono_inv_mul_x",
+        "Etingof.qMono_y_mul_inv",
+        "Etingof.qMono_inv_mul_y"
+      ]
+    },
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -1166,6 +1180,21 @@
           "lean_decl": "Etingof.qMono_mul"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.7",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.WeylAlgebra.monomials_span",
+        "Etingof.repE_x",
+        "Etingof.repE_y",
+        "Etingof.repE_injective",
+        "Etingof.Proposition_2_7_1_charFree",
+        "Etingof.qMono_mul",
+        "Etingof.Proposition_2_7_1_ii"
+      ]
     }
   },
   {
@@ -1203,6 +1232,17 @@
           "lean_decl": "Etingof.FaithfulRepresentation"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.7",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.WeylAlgebra.adjoin_x_y_eq_top",
+        "Etingof.WeylAlgebra.polyRep_range_eq_polyDiffOp",
+        "Etingof.WeylAlgebra.equivPolyDiffOp"
+      ]
     }
   },
   {
@@ -1233,6 +1273,15 @@
           "verdict": "formalized",
           "lean_decl": "Etingof.FaithfulRepresentation"
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.7",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.FaithfulRepresentation"
       ]
     }
   },
@@ -1349,6 +1398,25 @@
           "lean_decl": "Etingof.Problem2_7_4.famEquiv_nonempty_iff; Etingof.Problem2_7_4.existsUnique_toFamEquiv"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.7",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Problem2_7_4.finrank_eq_zero_of_charZero",
+        "Etingof.Problem2_7_4.isSimpleRing_charZero",
+        "Etingof.Problem2_7_4.x_pow_char_mem_center",
+        "Etingof.Problem2_7_4.y_pow_char_mem_center",
+        "Etingof.Problem2_7_4.center_charP",
+        "Etingof.Problem2_7_4.exists_normalForm",
+        "Etingof.Problem2_7_4.famModule_finrank",
+        "Etingof.Problem2_7_4.famModule_isSimpleModule",
+        "Etingof.Problem2_7_4.exists_toFamEquiv",
+        "Etingof.Problem2_7_4.famEquiv_nonempty_iff",
+        "Etingof.Problem2_7_4.existsUnique_toFamEquiv"
+      ]
     }
   },
   {
@@ -1417,6 +1485,26 @@
           "verdict": "formalized",
           "lean_decl": "Etingof.Problem2_7_5.finrank_irreducible_eq_orderOf; Etingof.Problem2_7_5.finrank_eq_orderOf_of_fam_linearEquiv"
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.7",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Problem2_7_5.center_eq_bot_of_not_isOfFinOrder",
+        "Etingof.Problem2_7_5.isSimpleRing_of_not_isOfFinOrder",
+        "Etingof.Problem2_7_5.center_of_isOfFinOrder",
+        "Etingof.Problem2_7_5.q_pow_finrank_eq_one",
+        "Etingof.Problem2_7_5.isOfFinOrder_iff_exists_nontrivial_finrep",
+        "Etingof.Problem2_7_5.famModule_finrank",
+        "Etingof.Problem2_7_5.famModule_isSimpleModule",
+        "Etingof.Problem2_7_5.exists_fam_linearEquiv",
+        "Etingof.Problem2_7_5.fam_nonempty_linearEquiv_iff",
+        "Etingof.Problem2_7_5.exists_unique_fam_linearEquiv",
+        "Etingof.Problem2_7_5.finrank_irreducible_eq_orderOf",
+        "Etingof.Problem2_7_5.finrank_eq_orderOf_of_fam_linearEquiv"
       ]
     }
   },

--- a/progress/items.json
+++ b/progress/items.json
@@ -1333,6 +1333,20 @@
           "lean_decl": "Etingof.repE_injective; Etingof.repE_injective_and_polyRep_not_injective"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.7",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.WeylAlgebra.polyRep_injective",
+        "Etingof.iterate_derivative_eq_zero_of_charP",
+        "Etingof.WeylAlgebra.polyRep_y_pow_eq_zero",
+        "Etingof.WeylAlgebra.polyRep_not_injective",
+        "Etingof.repE_injective",
+        "Etingof.repE_injective_and_polyRep_not_injective"
+      ]
     }
   },
   {


### PR DESCRIPTION
## Scope

- Chapter 2 §2.7 only, all seven reading-order items
- Stage 3.3 only: proof completion, source-hole scan, and axiom verification
- Stacked on Stage 3.2 PR #8013

## Result

- Verified all declarations supporting the Weyl and q-Weyl presentations and bases.
- Verified the differential-operator realization, faithful-representation definition, and the
  characteristic-zero/characteristic-p faithfulness contrast.
- Verified both full irreducible-family classifications, including exhaustiveness and uniqueness.
- Added durable `stage3_3` records for all seven items.
- Found no scoped `sorry`, `admit`, or project `axiom`.

## Validation

- all 13 scoped/supporting modules build
- representative public endpoints use only `propext`, `Classical.choice`, and `Quot.sound`
- scoped source scan
- `jq empty progress/items.json`
- `git diff --check`

Existing style/deprecation warnings are deferred to the dedicated Stage 3.5 PR.
