### PR TITLE
chore(Ch2 §2.5): trim Stage 3.4 dependencies

### DIFF
--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -144,17 +144,15 @@
   "Chapter2/Problem2.4.1": [
     "Chapter2/Discussion_2.4_heading"
   ],
-  "Chapter2/Discussion_2.5_heading": [
-    "Chapter2/Problem2.4.1"
-  ],
+  "Chapter2/Discussion_2.5_heading": [],
   "Chapter2/Discussion_2.5_well_defined": [
     "Chapter2/Discussion_2.5_heading"
   ],
   "Chapter2/Problem2.5.1": [
-    "Chapter2/Discussion_2.5_well_defined"
+    "Chapter2/Definition2.3.8"
   ],
   "Chapter2/Problem2.5.2": [
-    "Chapter2/Problem2.5.1"
+    "Chapter2/Definition2.3.8"
   ],
   "Chapter2/Discussion_2.6": [
     "Chapter2/Problem2.5.2"

--- a/progress/2026-07-27T12-17-18Z_stage3-4-chapter2-section2-5.md
+++ b/progress/2026-07-27T12-17-18Z_stage3-4-chapter2-section2-5.md
@@ -1,0 +1,51 @@
+# Stage 3.4 dependency trimming — Chapter 2 §2.5
+
+## Scope
+
+This pass analyzes the actual internal dependencies of exactly
+`Chapter2/Discussion_2.5_heading`, `Chapter2/Discussion_2.5_well_defined`,
+`Chapter2/Problem2.5.1`, and `Chapter2/Problem2.5.2` after their Stage 3.3 proofs were verified.
+
+## Actual dependencies
+
+- `Chapter2/Discussion_2.5_heading` has no internal dependency. Its quotient-algebra type,
+  quotient map, coset-equality bridge, and multiplication formula use Mathlib directly.
+- `Chapter2/Discussion_2.5_well_defined` depends directly on
+  `Chapter2/Discussion_2.5_heading`: its representative-independence proofs reuse the quotient
+  map and coset-equality bridge from that item in their shared Lean file. Its quotient-module
+  infrastructure otherwise comes directly from Mathlib.
+- `Chapter2/Problem2.5.1` depends directly on `Chapter2/Definition2.3.8`, whose
+  `Etingof.IsIndecomposable` predicate is the conclusion of the theorem. The remaining proof
+  uses Mathlib's polynomial, quotient-ring, local-ring, and submodule infrastructure.
+- `Chapter2/Problem2.5.2` also depends directly on `Chapter2/Definition2.3.8`: the final
+  coregular example is stated using `Etingof.IsIndecomposable`. Its cyclicity definitions and
+  proofs, coregular module, and concrete algebra construction are otherwise self-contained over
+  Mathlib.
+
+Thus the four conservative reading-order edges
+
+```text
+Discussion_2.5_heading       -> Problem2.4.1
+Discussion_2.5_well_defined -> Discussion_2.5_heading
+Problem2.5.1                 -> Discussion_2.5_well_defined
+Problem2.5.2                 -> Problem2.5.1
+```
+
+become the four actual dependency records (three direct edges and one empty set)
+
+```text
+Discussion_2.5_heading       -> []
+Discussion_2.5_well_defined -> Discussion_2.5_heading
+Problem2.5.1                 -> Definition2.3.8
+Problem2.5.2                 -> Definition2.3.8
+```
+
+All four items now carry durable `stage3_4` records and move to `dependency_trimmed`.
+
+## Validation
+
+- every internal dependency target exists in the root item catalog
+- `python3 scripts/validate_items.py`
+- `python3 scripts/validate_dependencies.py`
+- relevant Chapter 2 Lean modules build
+- `git diff --check`

--- a/progress/items.json
+++ b/progress/items.json
@@ -1051,7 +1051,7 @@
     "end_page": "15",
     "start_line": 16,
     "end_line": 19,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "fidelity": "verified",
     "lean_file": "EtingofRepresentationTheory/Chapter2/Discussion_2_5_well_defined.lean",
@@ -1099,6 +1099,13 @@
         "Etingof.quotientAlgHom_mul"
       ]
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.5",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The quotient type, canonical map, additive-coset bridge, and multiplication formula use only Mathlib quotient and two-sided-ideal infrastructure."
+    },
     "last_updated": "2026-07-27"
   },
   {
@@ -1109,7 +1116,7 @@
     "end_page": "16",
     "start_line": 1,
     "end_line": 18,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "fidelity": "verified",
     "lean_file": "EtingofRepresentationTheory/Chapter2/Discussion_2_5_well_defined.lean",
@@ -1175,6 +1182,15 @@
         "Etingof.regularQuotientRepresentation"
       ]
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.5",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Discussion_2.5_heading"
+      ],
+      "basis": "The representative-independence proofs reuse the quotient map and coset-equality bridge formalized by the preceding item in the same Lean file; the quotient-module declarations otherwise use Mathlib."
+    },
     "last_updated": "2026-07-27"
   },
   {
@@ -1185,7 +1201,7 @@
     "end_page": "16",
     "start_line": 19,
     "end_line": 19,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "fidelity": "verified",
     "lean_file": "EtingofRepresentationTheory/Chapter2/Problem2_5_1.lean",
@@ -1220,6 +1236,15 @@
       "declarations": [
         "Etingof.Problem2_5_1.quotient_isIndecomposable"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.5",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Definition2.3.8"
+      ],
+      "basis": "The proof imports the project's definition of module indecomposability and otherwise uses Mathlib's multivariable-polynomial, quotient-ring, local-ring, and submodule APIs."
     }
   },
   {
@@ -1230,7 +1255,7 @@
     "end_page": "16",
     "start_line": 20,
     "end_line": 29,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "fidelity": "verified",
     "lean_file": "EtingofRepresentationTheory/Chapter2/Problem2_5_2.lean",
@@ -1313,6 +1338,15 @@
         "Etingof.Coregular.toDual_smul",
         "Etingof.Problem2_5_2.PartC.indecomposable_not_cyclic"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.5",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Definition2.3.8"
+      ],
+      "basis": "The final coregular example uses the project's definition of module indecomposability; the cyclicity results and all supporting algebra constructions are self-contained over Mathlib."
     },
     "last_updated": "2026-07-27"
   },


### PR DESCRIPTION
## What changed

- replaced the conservative reading-order dependencies for the four Chapter 2 §2.5 items with their actual direct project dependencies
- recorded durable `stage3_4` evidence on exactly those four items
- advanced exactly those items from `sorry_free` to `dependency_trimmed`
- added the scoped Stage 3.4 audit note

## Dependency audit

Before:

```text
Discussion_2.5_heading       -> Problem2.4.1
Discussion_2.5_well_defined -> Discussion_2.5_heading
Problem2.5.1                 -> Discussion_2.5_well_defined
Problem2.5.2                 -> Problem2.5.1
```

After:

```text
Discussion_2.5_heading       -> []
Discussion_2.5_well_defined -> Discussion_2.5_heading
Problem2.5.1                 -> Definition2.3.8
Problem2.5.2                 -> Definition2.3.8
```

The heading's quotient declarations use Mathlib only. The representative-independence proofs reuse the heading's quotient map and additive-coset bridge in their shared Lean file. Both exercises import and use the project's `Etingof.IsIndecomposable` definition; their remaining infrastructure is local or from Mathlib.

## Scope

This stacked PR is Chapter 2 §2.5, Stage 3.4 only. Its base is the §2.5 Stage 3.3 branch from #8016. No proof-style cleanup is included; that belongs to Stage 3.5.

## Validation

- `python3 scripts/validate_items.py`
- `python3 scripts/validate_dependencies.py`
- scoped dependency target existence check
- `lake build EtingofRepresentationTheory.Chapter2.Discussion_2_5_well_defined EtingofRepresentationTheory.Chapter2.Problem2_5_1 EtingofRepresentationTheory.Chapter2.Problem2_5_2`
- `git diff --check`

The scoped Lean build succeeds. It reports three pre-existing flexible-tactic warnings in `Problem2_5_2.lean`; they are intentionally left for the following Stage 3.5 polish PR.
