### PR TITLE
trim: complete Stage 3.4 for section 2.7

### DIFF
--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -159,26 +159,22 @@
   "Chapter2/Discussion_2.6": [
     "Chapter2/Problem2.5.2"
   ],
-  "Chapter2/Discussion_2.7_intro": [
-    "Chapter2/Discussion_2.6"
-  ],
+  "Chapter2/Discussion_2.7_intro": [],
   "Chapter2/Proposition2.7.1": [
     "Chapter2/Discussion_2.7_intro"
   ],
   "Chapter2/Remark2.7.2": [
     "Chapter2/Proposition2.7.1"
   ],
-  "Chapter2/Definition2.7.3": [
-    "Chapter2/Remark2.7.2"
-  ],
+  "Chapter2/Definition2.7.3": [],
   "Chapter2/Discussion_faithful_example": [
-    "Chapter2/Definition2.7.3"
+    "Chapter2/Proposition2.7.1"
   ],
   "Chapter2/Problem2.7.4": [
-    "Chapter2/Discussion_faithful_example"
+    "Chapter2/Proposition2.7.1"
   ],
   "Chapter2/Problem2.7.5": [
-    "Chapter2/Problem2.7.4"
+    "Chapter2/Proposition2.7.1"
   ],
   "Chapter2/Definition2.8.1": [
     "Chapter2/Problem2.7.5"

--- a/progress/2026-07-27-stage3-4-section-2-7.md
+++ b/progress/2026-07-27-stage3-4-section-2-7.md
@@ -1,0 +1,31 @@
+# Stage 3.4 dependency trimming: Chapter 2 §2.7
+
+## Scope
+
+This pass analyzes the actual internal dependencies of all seven §2.7 items after Stage 3.3.
+
+## Result
+
+The conservative reading-order graph had one incoming edge for each item. The actual graph has
+five direct item edges:
+
+- Proposition 2.7.1 depends on the Weyl/q-Weyl constructions inventoried by the section
+  introduction;
+- Remark 2.7.2, the characteristic-dependent faithful-representation discussion, Problem 2.7.4,
+  and Problem 2.7.5 each depend directly on Proposition 2.7.1's presentation/basis modules.
+
+The introduction and Definition 2.7.3 are Mathlib-only. Problem 2.7.5 does not depend on Problem
+2.7.4: their classifications are independent developments for different algebras. The linear
+reading-order edges were therefore removed or replaced by the genuine declaration dependencies.
+
+All seven items now carry durable `stage3_4` records and move to `dependency_trimmed`.
+
+## Validation
+
+- inspected all 13 scoped/supporting module imports and declaration use
+- verified every retained target exists and no edge is self-referential or duplicated
+- item metadata exactly matches `dependencies/internal.json`
+- `jq empty dependencies/internal.json progress/items.json`
+- `git diff --check`
+
+This PR is limited to Section 2.7 and Stage 3.4.

--- a/progress/items.json
+++ b/progress/items.json
@@ -1069,7 +1069,7 @@
     "end_page": "17",
     "start_line": 5,
     "end_line": 12,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -1114,6 +1114,13 @@
         "Etingof.qMono_inv_mul_y"
       ]
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.7",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The Weyl and q-Weyl constructions are defined in Mathlib-only modules and use no earlier project item."
+    },
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -1127,7 +1134,7 @@
     "end_page": "18",
     "start_line": 13,
     "end_line": 16,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "last_updated": "2026-07-27",
     "fidelity": "verified",
@@ -1195,6 +1202,15 @@
         "Etingof.qMono_mul",
         "Etingof.Proposition_2_7_1_ii"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.7",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Discussion_2.7_intro"
+      ],
+      "basis": "The basis theorems are proved for the Weyl and q-Weyl algebras introduced by the section discussion in the same two modules."
     }
   },
   {
@@ -1205,7 +1221,7 @@
     "end_page": "18",
     "start_line": 17,
     "end_line": 20,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "fidelity_note": "verified (wave-3); was stale unsure, fixed by PR #5607",
@@ -1243,6 +1259,15 @@
         "Etingof.WeylAlgebra.polyRep_range_eq_polyDiffOp",
         "Etingof.WeylAlgebra.equivPolyDiffOp"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.7",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Proposition2.7.1"
+      ],
+      "basis": "The differential-operator equivalence imports the Weyl-algebra basis module and uses its presentation and spanning theorem."
     }
   },
   {
@@ -1253,7 +1278,7 @@
     "end_page": "18",
     "start_line": 21,
     "end_line": 21,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -1283,6 +1308,13 @@
       "declarations": [
         "Etingof.FaithfulRepresentation"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.7",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The faithful-representation abbreviation imports Mathlib's action API only."
     }
   },
   {
@@ -1293,7 +1325,7 @@
     "end_page": "18",
     "start_line": 22,
     "end_line": 24,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "lean_file": [
@@ -1347,6 +1379,15 @@
         "Etingof.repE_injective",
         "Etingof.repE_injective_and_polyRep_not_injective"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.7",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Proposition2.7.1"
+      ],
+      "basis": "The characteristic comparison uses the section's Weyl presentation and monomial-basis development."
     }
   },
   {
@@ -1357,7 +1398,7 @@
     "end_page": "19",
     "start_line": 25,
     "end_line": 8,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage_note": "All three parts are source-present. (a) characteristic zero: no nonzero finite-dimensional representation, and the Weyl algebra is simple. (b) characteristic p: x^p and y^p are central and the center is k[x^p, y^p]. (c) characteristic p over an algebraically closed field is a full classification, not just the dimension: Problem2_7_4.exists_normalForm puts an arbitrary finite-dimensional simple module in the book's normal form, Problem2_7_4_Family.lean constructs the family V(alpha,c) with the central-scalar actions x^p = alpha and y^p = c^p, proves each member irreducible (famModule_isSimpleModule) and the isomorphism criterion V(alpha,c) = V(alpha',c') iff alpha = alpha' and c = c' (famEquiv_nonempty_iff), and exists_toFamEquiv proves the family exhausts every finite-dimensional irreducible. The public endpoint existsUnique_toFamEquiv returns explicit family parameters together with an isomorphism, unique as a pair; finrank_eq_of_classification recovers dim V = p from it, and Problem2_7_4.finrank_irreducible_charP is retained.",
@@ -1431,6 +1472,15 @@
         "Etingof.Problem2_7_4.famEquiv_nonempty_iff",
         "Etingof.Problem2_7_4.existsUnique_toFamEquiv"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.7",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Proposition2.7.1"
+      ],
+      "basis": "The Weyl representation and ideal arguments use the Weyl basis/presentation modules; no other book item is used directly."
     }
   },
   {
@@ -1441,7 +1491,7 @@
     "end_page": "19",
     "start_line": 9,
     "end_line": 20,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -1520,6 +1570,15 @@
         "Etingof.Problem2_7_5.finrank_irreducible_eq_orderOf",
         "Etingof.Problem2_7_5.finrank_eq_orderOf_of_fam_linearEquiv"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.7",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Proposition2.7.1"
+      ],
+      "basis": "The q-Weyl center, simplicity, and classification modules use the q-Weyl algebra and ordered basis from Proposition 2.7.1, independently of Problem 2.7.4."
     }
   },
   {


### PR DESCRIPTION
## Scope

- Chapter 2 §2.7 only, all seven reading-order items
- Stage 3.4 only: actual dependency analysis and trimming
- Stacked on Stage 3.3 PR #8017

## Result

- Replaced seven conservative reading-order edges with five genuine item dependencies.
- Recorded the introduction and faithful-representation definition as Mathlib-only.
- Recorded Proposition 2.7.1 as depending on the section's Weyl/q-Weyl constructions.
- Recorded Remark 2.7.2, the characteristic faithfulness discussion, and both problems as direct
  consumers of the presentation/basis development.
- Removed the false Problem 2.7.5 → Problem 2.7.4 edge; the two classifications are independent.
- Added durable `stage3_4` records and moved all seven items to `dependency_trimmed`.

## Validation

- inspected all 13 scoped/supporting module imports and declaration use
- every retained target exists; no self or duplicate edges
- item metadata exactly matches `dependencies/internal.json`
- `jq empty dependencies/internal.json progress/items.json`
- `git diff --check`

This remains a draft until the preceding Stage 3.3 PR merges; it will then be rebased and
retargeted to `main`.
