### PR TITLE
Stage 3.2: audit Chapter 2 §2.11

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Discussion_pure_tensors.lean
+++ b/EtingofRepresentationTheory/Chapter2/Discussion_pure_tensors.lean
@@ -1,5 +1,8 @@
 import Mathlib.LinearAlgebra.TensorProduct.Basic
+import Mathlib.LinearAlgebra.TensorProduct.Basis
 import Mathlib.LinearAlgebra.Pi
+import Mathlib.LinearAlgebra.PiTensorProduct.Basis
+import Mathlib.LinearAlgebra.Dual.Basis
 import Mathlib.Algebra.Algebra.Bilinear
 
 /-!
@@ -20,6 +23,10 @@ is not pure: `t ≠ v ⊗ₜ w` for every `v, w`. Conceptually `t` corresponds t
 identity matrix, which has rank `2`, while a pure tensor `v ⊗ w` corresponds to the rank `≤ 1`
 outer product `(v i · w j)`. We make this elementary by extracting the four coordinate entries
 `c i j` of a tensor and deriving a direct numerical contradiction.
+
+The continuation of the discussion defines tensors of type `(m,n)` and displays their basis in
+terms of a finite basis of `V` and its dual basis. The declarations `TensorTypes.TensorType` and
+`TensorTypes.tensorTypeBasis` record that definition and basis directly.
 -/
 
 open scoped TensorProduct
@@ -81,5 +88,26 @@ theorem t_not_pure (v w : V) : t ≠ v ⊗ₜ[ℚ] w := by
   exact one_ne_zero h11.symm
 
 end PureTensors
+
+namespace TensorTypes
+
+open scoped TensorProduct
+
+/-- The book's space of tensors of type `(m,n)` on `V`:
+`V^{⊗ n} ⊗ (V*)^{⊗ m}`. -/
+abbrev TensorType (k V : Type*) [CommRing k] [AddCommGroup V] [Module k V]
+    (m n : ℕ) : Type _ :=
+  (⨂[k] (_ : Fin n), V) ⊗[k] (⨂[k] (_ : Fin m), Module.Dual k V)
+
+/-- If `b = (eᵢ)` is a finite basis of `V`, the tensors
+`e_{i₁} ⊗ ⋯ ⊗ e_{iₙ} ⊗ e^{j₁} ⊗ ⋯ ⊗ e^{jₘ}` form a basis of the tensors of type `(m,n)`. -/
+noncomputable def tensorTypeBasis {k V ι : Type*} [Field k] [AddCommGroup V] [Module k V]
+    [Finite ι] (b : Module.Basis ι k V) (m n : ℕ) :
+    Module.Basis ((Fin n → ι) × (Fin m → ι)) k (TensorType k V m n) := by
+  classical
+  exact (Basis.piTensorProduct (fun _ : Fin n => b)).tensorProduct
+    (Basis.piTensorProduct (fun _ : Fin m => b.dualBasis))
+
+end TensorTypes
 
 end Etingof

--- a/EtingofRepresentationTheory/Chapter2/Exercise2_11_2.lean
+++ b/EtingofRepresentationTheory/Chapter2/Exercise2_11_2.lean
@@ -125,14 +125,49 @@ theorem ofTensor_toTensor (q : tensorQuot k V W) : ofTensor k V W (toTensor k V 
     | neg p ih => simp only [map_neg]; rw [ih]
     | add x y hx hy => simp only [map_add]; rw [hx, hy]
 
-/-- **Exercise 2.11.2.** The generators-and-relations construction of the tensor product agrees
-with Mathlib's `V ⊗[k] W`: they are isomorphic as abelian groups. -/
+/-- The canonical additive equivalence from the generators-and-relations quotient to Mathlib's
+tensor product. -/
+noncomputable def addEquivTensorProduct : tensorQuot k V W ≃+ (V ⊗[k] W) where
+  toFun := toTensor k V W
+  invFun := ofTensor k V W
+  left_inv := ofTensor_toTensor k V W
+  right_inv := toTensor_ofTensor k V W
+  map_add' := (toTensor k V W).map_add
+
+/-- The scalar action on the generators-and-relations quotient, transported through its canonical
+additive equivalence with `V ⊗[k] W`. -/
+noncomputable instance instSMul : SMul k (tensorQuot k V W) where
+  smul a q := (addEquivTensorProduct k V W).symm (a • addEquivTensorProduct k V W q)
+
+@[simp]
+theorem addEquivTensorProduct_smul (a : k) (q : tensorQuot k V W) :
+    addEquivTensorProduct k V W (a • q) = a • addEquivTensorProduct k V W q :=
+  (addEquivTensorProduct k V W).apply_symm_apply _
+
+/-- The quotient of the free abelian group by the three relation families is naturally a
+`k`-module, hence a vector space when `k` is a field. -/
+noncomputable instance instModule : Module k (tensorQuot k V W) :=
+  Function.Injective.module k (addEquivTensorProduct k V W).toAddMonoidHom
+    (addEquivTensorProduct k V W).injective (addEquivTensorProduct_smul k V W)
+
+/-- **Exercise 2.11.2.** The generators-and-relations construction is linearly equivalent to the
+usual tensor product, so it is genuinely an equivalent definition as a vector space rather than
+only as an abelian group. -/
+noncomputable def linearEquivTensorProduct : tensorQuot k V W ≃ₗ[k] (V ⊗[k] W) where
+  toAddEquiv := addEquivTensorProduct k V W
+  map_smul' := addEquivTensorProduct_smul k V W
+
+@[simp]
+theorem linearEquivTensorProduct_mk (v : V) (w : W) :
+    linearEquivTensorProduct k V W
+        (QuotientAddGroup.mk' (relSubgroup k V W) (FreeAbelianGroup.of (v, w))) =
+      v ⊗ₜ[k] w := by
+  rfl
+
+/-- The additive shadow of `linearEquivTensorProduct`, retained for callers that only need the
+abelian-group statement. -/
 theorem nonempty_addEquiv_tensorProduct :
     Nonempty (tensorQuot k V W ≃+ (V ⊗[k] W)) :=
-  ⟨{ toFun := toTensor k V W
-     invFun := ofTensor k V W
-     left_inv := ofTensor_toTensor k V W
-     right_inv := toTensor_ofTensor k V W
-     map_add' := (toTensor k V W).map_add }⟩
+  ⟨(linearEquivTensorProduct k V W).toAddEquiv⟩
 
 end Etingof.Exercise2_11_2

--- a/progress/2026-07-27T13-18-09Z_stage3-2-chapter2-section2-11.md
+++ b/progress/2026-07-27T13-18-09Z_stage3-2-chapter2-section2-11.md
@@ -1,0 +1,67 @@
+# Stage 3.2 fidelity review — Chapter 2 §2.11
+
+## Scope
+
+Reading order gives exactly eleven §2.11 catalog items, from
+`Chapter2/Discussion_2.11_heading` through `Chapter2/Exercise2.11.7`. The preceding item is
+`Chapter2/Discussion_2.10_continued`; the next item is `Chapter2/Discussion_2.12_heading`. The
+scope includes all three discussion records between the numbered items.
+
+The eleven items are served by twelve Lean provider files. Problem 2.11.3 has five providers;
+the mixed-tensor definition and basis share `Discussion_pure_tensors.lean`; and
+`Problem2_11_6.lean` is the policy/documentation provider for the intentional omission.
+
+## Claim audit and repairs
+
+All eleven blobs and all twelve providers were read in full. The durable tracker inventory has 44
+claim units:
+
+- 28 `formalized`;
+- 4 `covered_elsewhere` by precise Mathlib or project declarations;
+- 7 `non_formalizable` terminology, notation, or organizational units;
+- 5 `intentional_omission` units belonging to Problem 2.11.6's standalone noncommutative
+  bimodule API.
+
+Stage 3.2 found and repaired three accidental gaps:
+
+1. The free-abelian-group quotient in Exercise 2.11.2 was only additively equivalent to the tensor
+   product. It now carries the transported `k`-module structure and a named linear equivalence,
+   including the formula on generator classes.
+2. The book's space `V^{⊗n} ⊗ (V*)^{⊗m}` of tensors of type `(m,n)` now has a direct project
+   definition, `Etingof.TensorTypes.TensorType`.
+3. The displayed basis of the mixed tensor space now has a direct construction,
+   `Etingof.TensorTypes.tensorTypeBasis`, from the basis of `V`, its dual basis, the two finite
+   indexed tensor-product bases, and their tensor-product basis.
+
+After these repairs there are zero accidental or unclassified proof/coverage gaps. The five
+remaining claim-level gaps are the explicit scope decision already recorded in
+`skipped-exercises.md`: induced bimodule actions, balanced-tensor associativity, the Hom bimodule,
+and the noncommutative tensor-Hom adjunction. Their only downstream use, Frobenius reciprocity, is
+formalized directly as `Etingof.Theorem5_10_1`; no placeholder declaration represents the omitted
+API.
+
+## Durable tracker result
+
+Every scoped item now has a complete Stage 3.2 `claim_coverage` record with verified definition
+integrity, statement fidelity, and nonvacuity. Exercise 2.11.2 moves from `covered_partial` to
+`covered_full`, closing the substance of follow-up #5972. The mixed-tensor discussion moves from
+no mathematical coverage to full coverage. Problem 2.11.6 remains honestly `covered_partial` and
+records each intentional omission separately. The non-§2.11 projection of `progress/items.json`
+is byte-for-byte equivalent after normalized JSON comparison, and dependency metadata is
+unchanged.
+
+## Validation
+
+- local worktree build state: `.lake/build` is worktree-local, while `.lake/packages` points to
+  the shared package cache;
+- all 12 scoped providers built successfully together (8592 jobs); the only replayed warning was
+  the pre-existing header warning in `Infrastructure/Triangularization.lean`;
+- `lake build EtingofRepresentationTheory.Chapter2`: success (8744 jobs); warnings are pre-existing
+  and outside the two changed §2.11 providers;
+- scoped scan found no `sorry`, `admit`, `axiom`, `opaque`, or `native_decide` declarations;
+- `jq empty progress/items.json` and the exact 11-item/44-claim verdict aggregation passed;
+- `python3 scripts/validate_items.py`: passed with full 5721/5721-line coverage (and its 593
+  pre-existing extra-field warnings);
+- `python3 scripts/validate_dependencies.py`: passed (one pre-existing conservative-default
+  warning);
+- normalized non-scope tracker hashes match, and `git diff --check` passes.

--- a/progress/items.json
+++ b/progress/items.json
@@ -1447,7 +1447,27 @@
     "status": "sorry_free",
     "coverage_swept": {
       "wave": 1,
-      "result": "none"
+      "result": "non_formalizable"
+    },
+    "coverage": "covered_full",
+    "fidelity": "verified",
+    "coverage_note": "Stage 3.2 reviewed the section heading and organizational introduction; it states no mathematical result beyond announcing that tensor products will be recalled and used later.",
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.11",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "Section 2.11 recalls tensor products of vector spaces for extensive later use.",
+          "verdict": "non_formalizable",
+          "reason": "This is an organizational description of the subsection and the book's later usage, not a mathematical proposition."
+        }
+      ]
     }
   },
   {
@@ -1462,8 +1482,24 @@
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
-    "coverage_note": "TensorProduct k V W supplies the source quotient construction through its universal property and canonical pure-tensor map.",
-    "last_updated": "2026-07-22"
+    "coverage_note": "TensorProduct k V W supplies the source quotient construction, canonical pure-tensor map, and all four displayed additivity/scalar relations; TensorProductDef records the book-facing type.",
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.11",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "V ⊗ W is the quotient of the free vector space on symbols v ⊗ w by additivity in both variables and the two scalar-moving relations.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.TensorProductDef; TensorProduct.tmul; TensorProduct.add_tmul; TensorProduct.tmul_add; TensorProduct.smul_tmul; TensorProduct.tmul_smul"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter2/Exercise2.11.2",
@@ -1474,10 +1510,31 @@
     "start_line": 23,
     "end_line": 37,
     "status": "sorry_free",
-    "coverage": "covered_partial",
-    "coverage_note": "The generators-and-relations quotient and an additive equivalence with Mathlib's tensor product are proved. The quotient has no k-module structure, named linear equivalence, or packaged bilinear universal property, so it does not yet serve as the source's equivalent vector-space definition. Follow-up #5972.",
-    "followup_issue": 5972,
-    "last_updated": "2026-07-22"
+    "coverage": "covered_full",
+    "fidelity": "verified",
+    "coverage_note": "Stage 3.2 closes follow-up #5972: the free-abelian-group quotient has the transported k-module structure and a named linear equivalence with Mathlib's tensor product, sending each quotient generator to the corresponding pure tensor.",
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.11",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "The alternative construction is the quotient of FreeAbelianGroup (V × W) by the two additivity relation families and the balancing relation av ⊗ w = v ⊗ aw.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Exercise2_11_2.relSet; Etingof.Exercise2_11_2.relSubgroup; Etingof.Exercise2_11_2.tensorQuot"
+        },
+        {
+          "claim": "This quotient is naturally a k-vector space linearly equivalent to V ⊗[k] W, with each generator class mapping to v ⊗ₜ w.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Exercise2_11_2.instModule; Etingof.Exercise2_11_2.linearEquivTensorProduct; Etingof.Exercise2_11_2.linearEquivTensorProduct_mk"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter2/Discussion_pure_tensors",
@@ -1488,14 +1545,55 @@
     "start_line": 38,
     "end_line": 3,
     "status": "sorry_free",
-    "fidelity": "full",
+    "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
-    "coverage_note": "Non-pure tensors witnessed explicitly: `t = e 0 ⊗ e 0 + e 1 ⊗ e 1` over ℚ with V = W = Fin 2 → ℚ is proved not to be any pure tensor v ⊗ w (Discussion_pure_tensors.t_not_pure, axiom-clean).",
-    "last_updated": "2026-07-23",
+    "coverage_note": "Stage 3.2 preserves the explicit non-pure witness and adds the book's mixed tensor-type definition and finite-basis construction; n-fold products and associativity use the project TensorPow and Mathlib associator APIs.",
+    "last_updated": "2026-07-27",
     "coverage_swept": {
       "wave": 1,
       "result": "covered_full"
+    },
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.11",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "Elements v ⊗ w are called pure tensors.",
+          "verdict": "non_formalizable",
+          "reason": "This is terminology for the already-formalized TensorProduct.tmul constructor rather than an additional proposition."
+        },
+        {
+          "claim": "In general a tensor product contains tensors that are not pure.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.PureTensors.t_not_pure"
+        },
+        {
+          "claim": "Finite n-fold tensor products V₁ ⊗ ⋯ ⊗ Vₙ, and in particular V^{⊗ n}, are defined.",
+          "verdict": "formalized",
+          "lean_decl": "PiTensorProduct; Etingof.Problem2_11_3.TensorPow"
+        },
+        {
+          "claim": "Tensor products are naturally associative: (V₁ ⊗ V₂) ⊗ V₃ is naturally identified with V₁ ⊗ (V₂ ⊗ V₃).",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "TensorProduct.assoc"
+        },
+        {
+          "claim": "The space of tensors of type (m,n) on V is V^{⊗ n} ⊗ (V*)^{⊗ m}.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.TensorTypes.TensorType"
+        },
+        {
+          "claim": "The prose identifies low tensor types informally with vectors, covectors, operators, bilinear forms, and algebra structures.",
+          "verdict": "non_formalizable",
+          "reason": "As written these are informal identifications without the finite-dimensional hypotheses and explicit equivalences needed for literal theorem statements; the precise finite-dimensional dual-tensor/Hom equivalence appears in Problem 2.11.3(c)."
+        }
+      ]
     }
   },
   {
@@ -1509,7 +1607,47 @@
     "status": "sorry_free",
     "coverage_swept": {
       "wave": 1,
-      "result": "none"
+      "result": "covered_full"
+    },
+    "coverage": "covered_full",
+    "fidelity": "verified",
+    "coverage_note": "The displayed basis is Etingof.TensorTypes.tensorTypeBasis, built from the given basis, its dual basis, finite indexed tensor-product bases, and their tensor-product basis; coefficient expansion is the standard Basis.repr/sum_repr theorem. The remaining basis-change and index paragraphs are instructional or notational prose.",
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.11",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "For a finite basis eᵢ of V and dual basis eⁱ, the displayed elementary mixed tensors form a basis of the type-(m,n) tensor space.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.TensorTypes.tensorTypeBasis"
+        },
+        {
+          "claim": "Every type-(m,n) tensor has a unique coordinate expansion in that basis, with coefficients forming a multidimensional table.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Module.Basis.repr; Module.Basis.sum_repr"
+        },
+        {
+          "claim": "The reader is asked to derive the change-of-basis rule for physicists' coordinate tables.",
+          "verdict": "non_formalizable",
+          "reason": "The text poses an open-ended derivation prompt but does not state the transformation formula that a Lean theorem could faithfully match."
+        },
+        {
+          "claim": "Upper and lower indices distinguish the vector and covector factors.",
+          "verdict": "non_formalizable",
+          "reason": "This is an index-placement convention for the displayed coordinates, not a mathematical proposition."
+        },
+        {
+          "claim": "Einstein summation suppresses sums over an index occurring once upstairs and once downstairs, with the stated restrictions on free and repeated indices.",
+          "verdict": "non_formalizable",
+          "reason": "This is an editorial notation convention rather than a theorem or construction."
+        }
+      ]
     }
   },
   {
@@ -1523,7 +1661,32 @@
     "status": "sorry_free",
     "coverage_swept": {
       "wave": 1,
-      "result": "trivial"
+      "result": "covered_full"
+    },
+    "coverage": "covered_full",
+    "fidelity": "verified",
+    "coverage_note": "Mathlib's TensorProduct.map is the well-defined linear map A ⊗ B and TensorProduct.map_tmul is exactly the displayed pure-tensor formula; the transition to Problem 2.11.3 is organizational prose.",
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.11",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "Linear maps A : V → V' and B : W → W' induce a well-defined linear map A ⊗ B with (A ⊗ B)(v ⊗ w) = Av ⊗ Bw.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "TensorProduct.map; TensorProduct.map_tmul"
+        },
+        {
+          "claim": "The next problem summarizes the most important tensor-product properties.",
+          "verdict": "non_formalizable",
+          "reason": "This is an organizational transition rather than a mathematical assertion."
+        }
+      ]
     }
   },
   {
@@ -1544,7 +1707,99 @@
       "EtingofRepresentationTheory/Chapter2/Problem2_11_3_SymExtSubspace.lean",
       "EtingofRepresentationTheory/Chapter2/Problem2_11_3_Trace.lean"
     ],
-    "last_updated": "2026-07-26"
+    "last_updated": "2026-07-27",
+    "fidelity": "verified",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.11",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "(a) Bilinear maps V × W → U are naturally equivalent to linear maps V ⊗ W → U.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_11_3.exists_bilinear_equiv_linear"
+        },
+        {
+          "claim": "(b) Tensor products of basis vectors form a basis of V ⊗ W.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_11_3.exists_basis_tensorProduct"
+        },
+        {
+          "claim": "(c) For finite-dimensional V, V* ⊗ W is naturally isomorphic to Hom(V,W).",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_11_3.exists_dualTensor_equiv_hom"
+        },
+        {
+          "claim": "(d) SⁿV is the quotient of V^{⊗n} by permutation relations.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_11_3.symRelSubmodule; Etingof.Problem2_11_3.SymPow"
+        },
+        {
+          "claim": "(d) ∧ⁿV is the quotient of V^{⊗n} by the alternating swap relations.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_11_3.extRelSubmodule; Etingof.Problem2_11_3.ExtPow"
+        },
+        {
+          "claim": "(d) Ordered symmetric monomials in a basis of V form a basis of SⁿV.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_11_3.symPowBasis"
+        },
+        {
+          "claim": "(d) If dim V = m, then dim SⁿV = binomial(m+n-1,n).",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_11_3.finrank_symPow; Etingof.Problem2_11_3.finrank_symPow_eq_multichoose"
+        },
+        {
+          "claim": "(d) Strictly increasing exterior monomials in a basis of V form a basis of ∧ⁿV.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_11_3.extPowBasis"
+        },
+        {
+          "claim": "(d) If dim V = m, then dim ∧ⁿV = binomial(m,n).",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_11_3.finrank_extPow"
+        },
+        {
+          "claim": "(e) When n! is invertible, SⁿV identifies with the subspace of symmetric tensors.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_11_3.symPowEquivSymTensor; Etingof.Problem2_11_3.symPowEquivSymTensorOfCharZero"
+        },
+        {
+          "claim": "(e) When n! is invertible, ∧ⁿV identifies with the subspace of antisymmetric tensors.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_11_3.extPowEquivAltTensor; Etingof.Problem2_11_3.extPowEquivAltTensorOfCharZero"
+        },
+        {
+          "claim": "(f) A linear map A induces A^{⊗n}, SⁿA, and ∧ⁿA, functorially under composition.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_11_3.tensorPowMap; Etingof.Problem2_11_3.symPowMap; Etingof.Problem2_11_3.extPowMap; Etingof.Problem2_11_3.symPowMap_comp; Etingof.Problem2_11_3.extPowMap_comp"
+        },
+        {
+          "claim": "(f) Tr(SⁿA) is the complete homogeneous symmetric polynomial hₙ in the eigenvalues of A.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_11_3.trace_symPowMap; Etingof.Problem2_11_3.trace_symPowMap_of_charpoly"
+        },
+        {
+          "claim": "(f) Tr(∧ⁿA) is the elementary symmetric polynomial eₙ in the eigenvalues of A.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_11_3.trace_extPowMap; Etingof.Problem2_11_3.trace_extPowMap_of_charpoly"
+        },
+        {
+          "claim": "(g) On the top exterior power, ∧^dim(V) A acts by multiplication by det(A).",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_11_3.extPowMap_top"
+        },
+        {
+          "claim": "(g) Functoriality of the top exterior power yields det(A ∘ B) = det(A) det(B).",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_11_3.det_comp_of_extPowMap"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter2/Remark2.11.4",
@@ -1558,7 +1813,26 @@
     "fidelity": "verified",
     "fidelity_note": "Formalized in Chapter2/Remark2_11_4.lean: Etingof.TensorProductOverRing A V W constructs V ⊗_A W for an arbitrary ring A (right A-module V, left A-module W) as the quotient of FreeAbelianGroup (V × W) by the bilinearity and balancing relations (tensorRelations). The three book relations are discharged as add_tmul, tmul_add, smul_tmul. Not in Mathlib: TensorProduct requires CommSemiring.",
     "fidelity_decl": "Etingof.TensorProductOverRing",
-    "fidelity_issue": 5366
+    "fidelity_issue": 5366,
+    "coverage": "covered_full",
+    "coverage_note": "The arbitrary-ring balanced tensor product is constructed as the stated free-abelian-group quotient, and its pure-tensor additivity and balancing relations are proved.",
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.11",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "For an arbitrary ring A, a right A-module V, and a left A-module W, V ⊗_A W is the free abelian group on V × W modulo additivity and the balancing relation (va) ⊗ w = v ⊗ (aw).",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.TensorProductOverRing; Etingof.TensorProductOverRing.tmul; Etingof.TensorProductOverRing.add_tmul; Etingof.TensorProductOverRing.tmul_add; Etingof.TensorProductOverRing.smul_tmul"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter2/Exercise2.11.5",
@@ -1570,7 +1844,30 @@
     "end_line": 14,
     "status": "sorry_free",
     "coverage": "covered_full",
-    "last_updated": "2026-07-22"
+    "fidelity": "verified",
+    "coverage_note": "The right-factor base-change algebra structure on A ⊗_K L and the natural (A ⊗_K L)-module structure on V ⊗_K L are constructed, including their pure-tensor formulas.",
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.11",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "If L/K is a field extension and A is a K-algebra, then A ⊗_K L is naturally an L-algebra.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Exercise2_11_5.instRightAlgebra; Etingof.Exercise2_11_5.algebraMap_right_apply"
+        },
+        {
+          "claim": "If V is an A-module, then V ⊗_K L is naturally an (A ⊗_K L)-module with the displayed pure-tensor action.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Exercise2_11_5.exists_module_baseChange"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter2/Problem2.11.6",
@@ -1585,7 +1882,53 @@
     "note": "Intentional omission recorded in skipped-exercises.md. The standalone bimodule associativity and tensor-Hom adjunction are not formalized; the book's only downstream use, Frobenius reciprocity (Theorem 5.10.1), is proved directly with Mathlib's representation induction/restriction adjunction. Chapter2/Problem2_11_6.lean documents the source statements and replacement route without placeholder declarations.",
     "coverage": "covered_partial",
     "coverage_note": "Intentional omission per skipped-exercises.md: the standalone bimodule associativity and tensor-Hom adjunction are not rebuilt. Their only downstream use is replaced by the direct Mathlib induction/restriction adjunction proof of Theorem 5.10.1; no placeholder represents the omitted material.",
-    "last_updated": "2026-07-22"
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.11",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "An (A,B)-bimodule is a vector space with commuting left A- and right B-module structures; left and right modules are the special cases (A,k) and (k,B).",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Module; Module.compHom; SMulCommClass"
+        },
+        {
+          "claim": "For a right B-module V and left B-module W, V ⊗_B W is the balanced tensor product from Remark 2.11.4.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.TensorProductOverRing"
+        },
+        {
+          "claim": "If V is an (A,B)-bimodule, then V ⊗_B W inherits the left A-action a(v ⊗ w) = (av) ⊗ w.",
+          "verdict": "intentional_omission",
+          "reason": "The project deliberately does not build the standalone noncommutative bimodule tensor-product API; this scope decision is recorded in skipped-exercises.md."
+        },
+        {
+          "claim": "If W is a (B,C)-bimodule, then V ⊗_B W inherits the right C-action (v ⊗ w)c = v ⊗ (wc), commuting with the left action when both are present.",
+          "verdict": "intentional_omission",
+          "reason": "The project deliberately does not build the standalone noncommutative bimodule tensor-product API; this scope decision is recorded in skipped-exercises.md."
+        },
+        {
+          "claim": "(a) The balanced tensor product of bimodules is associative via (v ⊗ w) ⊗ x ↦ v ⊗ (w ⊗ x).",
+          "verdict": "intentional_omission",
+          "reason": "Standalone bimodule tensor associativity is explicitly omitted by the policy in skipped-exercises.md and is not needed elsewhere in the formalized development."
+        },
+        {
+          "claim": "(b) Hom_A(V,W) has the displayed (B,C)-bimodule structure by precomposition on the left and postcomposition on the right.",
+          "verdict": "intentional_omission",
+          "reason": "The Hom-bimodule construction belongs to the deliberately omitted standalone bimodule API recorded in skipped-exercises.md."
+        },
+        {
+          "claim": "(b) There is the displayed (A,D)-bimodule tensor-Hom adjunction Hom_B(V, Hom_C(W,X)) ≅ Hom_C(W ⊗_B V, X).",
+          "verdict": "intentional_omission",
+          "reason": "This standalone adjunction is explicitly omitted in skipped-exercises.md; its only downstream application, Frobenius reciprocity, is formalized directly as Etingof.Theorem5_10_1."
+        }
+      ]
+    }
   },
   {
     "id": "Chapter2/Exercise2.11.7",
@@ -1597,8 +1940,25 @@
     "end_line": 26,
     "status": "sorry_free",
     "coverage": "covered_full",
-    "last_updated": "2026-07-22",
-    "coverage_note": "Chapter2/Exercise2_11_7.lean shows that M ⊗[A] N is an A-module for a commutative ring A (TensorProduct.instModule via inferInstance), with the action lemmas a•(m⊗ₜn) = (a•m)⊗ₜn = m⊗ₜ(a•n). The corrected blob now contains this source statement."
+    "fidelity": "verified",
+    "last_updated": "2026-07-27",
+    "coverage_note": "Chapter2/Exercise2_11_7.lean shows that M ⊗[A] N is an A-module for a commutative ring A (TensorProduct.instModule via inferInstance), with the action lemmas a•(m⊗ₜn) = (a•m)⊗ₜn = m⊗ₜ(a•n). The corrected blob now contains this source statement.",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.11",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "For modules M and N over a commutative ring A, M ⊗_A N is naturally an A-module, with scalar multiplication acting equivalently on either factor.",
+          "verdict": "formalized",
+          "lean_decl": "TensorProduct.instModule; TensorProduct.smul_tmul'; TensorProduct.tmul_smul"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter2/Discussion_2.12_heading",


### PR DESCRIPTION
## Summary

- complete the exact 11-item, 44-claim Stage 3.2 audit for Chapter 2 §2.11
- add the missing module/linear-equivalence layer for Exercise 2.11.2
- add the mixed tensor-type definition and finite-basis construction
- record 28 formalized, 4 covered-elsewhere, 7 non-formalizable, and 5 intentional-omission verdicts
- leave zero accidental or unclassified gaps; preserve Problem 2.11.6's documented policy omission

## Validation

- all 12 scoped providers build successfully together (8592 jobs)
- `lake build EtingofRepresentationTheory.Chapter2` (8744 jobs)
- `python3 scripts/validate_items.py`
- `python3 scripts/validate_dependencies.py`
- scoped placeholder scan and `git diff --check`

Build output contains only pre-existing warnings outside the changed §2.11 providers.
