### PR TITLE
Stage 3.3: certify Chapter 2 §2.11 proof integrity

### DIFF
--- a/progress/2026-07-27T13-29-45Z_stage3-3-chapter2-section2-11.md
+++ b/progress/2026-07-27T13-29-45Z_stage3-3-chapter2-section2-11.md
@@ -1,0 +1,70 @@
+# Stage 3.3 proof-integrity review — Chapter 2 §2.11
+
+## Scope and inherited result
+
+This stacked review is based exactly on Stage 3.2 draft PR #8032 at commit `18e31803`. Reading
+order gives eleven §2.11 catalog items, from `Chapter2/Discussion_2.11_heading` through
+`Chapter2/Exercise2.11.7`, and twelve Lean provider files. The previous and next items are the
+§2.10 continuation and §2.12 heading respectively, so all three intervening discussion records
+are included.
+
+Stage 3.2 supplies 44 exhaustive claim units: 28 `formalized`, 4 `covered_elsewhere`, 7
+`non_formalizable`, and 5 `intentional_omission`. Thus Stage 3.3 has 39 non-omitted units. Seven of
+those are terminology, notation, or organizational prose with no proof obligation; the remaining
+32 mathematical claim units are covered by the declarations certified here.
+
+## Proof-integrity result
+
+Ten items are `sorry_free`, witnessed by 63 cited project or Mathlib declarations. The section
+heading is `not_applicable` because its sole claim is organizational prose. Every declaration was
+resolved with Lean, all twelve providers compile, and the theorem-level `#print axioms` audit
+reported only `propext`, `Classical.choice`, and `Quot.sound`. It reported no `sorryAx`, project
+axiom, or undeclared dependency. A direct provider scan likewise found no `sorry`, `admit`,
+`axiom`, `opaque`, `proof_wanted`, `native_decide`, or `sorryAx` occurrence.
+
+No new Lean proof was needed after Stage 3.2: the earlier pass had already repaired all three
+accidental gaps, and this pass verified that their implementations and the pre-existing §2.11
+results are admission-free.
+
+## Intentional omissions
+
+Problem 2.11.6 has two non-omitted claim units: the standard commuting-action encoding of a
+bimodule and the balanced tensor product constructed in Remark 2.11.4. Its `sorry_free` result is
+explicitly limited to those two units. The record separately preserves exactly five
+`intentional_omissions`:
+
+1. the induced left action on a balanced tensor product;
+2. the induced right action and combined bimodule structure;
+3. balanced-tensor associativity;
+4. the displayed Hom bimodule;
+5. the noncommutative tensor-Hom adjunction.
+
+These are the policy omissions already recorded in `skipped-exercises.md`; they have no Lean
+placeholder and are not represented or certified as proved declarations. The only downstream
+application is independently formalized as `Etingof.Theorem5_10_1`.
+
+## Durable tracker result
+
+- all 11 exact items have complete section `2.11` `stage3_3` objects;
+- proof-integrity split: 10 `sorry_free`, 1 `not_applicable`;
+- declaration references: 63 across the ten proof-applicable records;
+- intentional omissions: exactly 5, all on Problem 2.11.6;
+- Stage 3.2 data is unchanged: removing the new `stage3_3` objects reproduces the PR #8032
+  scoped records exactly;
+- the non-§2.11 tracker projection and dependency metadata are unchanged.
+
+## Validation
+
+- all 12 scoped providers built successfully in isolation (8592 jobs); the only replayed warning
+  was the pre-existing header warning in `Infrastructure/Triangularization.lean`;
+- `lake build EtingofRepresentationTheory.Chapter2`: success (8744 jobs; pre-existing warnings
+  only);
+- Lean declaration-resolution and 36-headline `#print axioms` audit: success, with foundational
+  axioms only and no `sorryAx` or project axiom;
+- exact scoped admission/placeholder scan: clean;
+- exact 11-item Stage 3.3 completeness, 63-declaration, and five-omission aggregation: passed;
+- `jq empty progress/items.json`: passed;
+- `python3 scripts/validate_items.py`: passed with 5721/5721-line coverage;
+- `python3 scripts/validate_dependencies.py`: passed;
+- `python3 scripts/validate_external_deps.py`: passed;
+- normalized scoped and non-scoped tracker invariance checks and `git diff --check`: passed.

--- a/progress/items.json
+++ b/progress/items.json
@@ -1852,6 +1852,14 @@
           "reason": "This is an organizational description of the subsection and the book's later usage, not a mathematical proposition."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.11",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "not_applicable",
+      "declarations": [],
+      "basis": "The sole Stage 3.2 claim is organizational prose with verdict non_formalizable, so there is no mathematical proof obligation or Lean declaration to certify."
     }
   },
   {
@@ -1882,6 +1890,20 @@
           "verdict": "formalized",
           "lean_decl": "Etingof.TensorProductDef; TensorProduct.tmul; TensorProduct.add_tmul; TensorProduct.tmul_add; TensorProduct.smul_tmul; TensorProduct.tmul_smul"
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.11",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.TensorProductDef",
+        "TensorProduct.tmul",
+        "TensorProduct.add_tmul",
+        "TensorProduct.tmul_add",
+        "TensorProduct.smul_tmul",
+        "TensorProduct.tmul_smul"
       ]
     }
   },
@@ -1917,6 +1939,20 @@
           "verdict": "formalized",
           "lean_decl": "Etingof.Exercise2_11_2.instModule; Etingof.Exercise2_11_2.linearEquivTensorProduct; Etingof.Exercise2_11_2.linearEquivTensorProduct_mk"
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.11",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Exercise2_11_2.relSet",
+        "Etingof.Exercise2_11_2.relSubgroup",
+        "Etingof.Exercise2_11_2.tensorQuot",
+        "Etingof.Exercise2_11_2.instModule",
+        "Etingof.Exercise2_11_2.linearEquivTensorProduct",
+        "Etingof.Exercise2_11_2.linearEquivTensorProduct_mk"
       ]
     }
   },
@@ -1978,6 +2014,20 @@
           "reason": "As written these are informal identifications without the finite-dimensional hypotheses and explicit equivalences needed for literal theorem statements; the precise finite-dimensional dual-tensor/Hom equivalence appears in Problem 2.11.3(c)."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.11",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.PureTensors.t_not_pure",
+        "PiTensorProduct",
+        "Etingof.Problem2_11_3.TensorPow",
+        "TensorProduct.assoc",
+        "Etingof.TensorTypes.TensorType"
+      ],
+      "basis": "The five mathematical declarations covering the formalized or covered-elsewhere claims are sorry-free; the two remaining claims are terminology or informal low-type identifications with no proof obligation."
     }
   },
   {
@@ -2032,6 +2082,18 @@
           "reason": "This is an editorial notation convention rather than a theorem or construction."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.11",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.TensorTypes.tensorTypeBasis",
+        "Module.Basis.repr",
+        "Module.Basis.sum_repr"
+      ],
+      "basis": "The basis construction and standard unique-coordinate expansion API are sorry-free; the other three inherited claims are an open-ended derivation prompt and index conventions, so they introduce no proof obligations."
     }
   },
   {
@@ -2071,6 +2133,17 @@
           "reason": "This is an organizational transition rather than a mathematical assertion."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.11",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "TensorProduct.map",
+        "TensorProduct.map_tmul"
+      ],
+      "basis": "Mathlib's induced map and its pure-tensor formula are sorry-free; the second claim is only an organizational transition."
     }
   },
   {
@@ -2183,6 +2256,41 @@
           "lean_decl": "Etingof.Problem2_11_3.det_comp_of_extPowMap"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.11",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Problem2_11_3.exists_bilinear_equiv_linear",
+        "Etingof.Problem2_11_3.exists_basis_tensorProduct",
+        "Etingof.Problem2_11_3.exists_dualTensor_equiv_hom",
+        "Etingof.Problem2_11_3.symRelSubmodule",
+        "Etingof.Problem2_11_3.SymPow",
+        "Etingof.Problem2_11_3.extRelSubmodule",
+        "Etingof.Problem2_11_3.ExtPow",
+        "Etingof.Problem2_11_3.symPowBasis",
+        "Etingof.Problem2_11_3.finrank_symPow",
+        "Etingof.Problem2_11_3.finrank_symPow_eq_multichoose",
+        "Etingof.Problem2_11_3.extPowBasis",
+        "Etingof.Problem2_11_3.finrank_extPow",
+        "Etingof.Problem2_11_3.symPowEquivSymTensor",
+        "Etingof.Problem2_11_3.symPowEquivSymTensorOfCharZero",
+        "Etingof.Problem2_11_3.extPowEquivAltTensor",
+        "Etingof.Problem2_11_3.extPowEquivAltTensorOfCharZero",
+        "Etingof.Problem2_11_3.tensorPowMap",
+        "Etingof.Problem2_11_3.symPowMap",
+        "Etingof.Problem2_11_3.extPowMap",
+        "Etingof.Problem2_11_3.symPowMap_comp",
+        "Etingof.Problem2_11_3.extPowMap_comp",
+        "Etingof.Problem2_11_3.trace_symPowMap",
+        "Etingof.Problem2_11_3.trace_symPowMap_of_charpoly",
+        "Etingof.Problem2_11_3.trace_extPowMap",
+        "Etingof.Problem2_11_3.trace_extPowMap_of_charpoly",
+        "Etingof.Problem2_11_3.extPowMap_top",
+        "Etingof.Problem2_11_3.det_comp_of_extPowMap"
+      ]
     }
   },
   {
@@ -2215,6 +2323,19 @@
           "verdict": "formalized",
           "lean_decl": "Etingof.TensorProductOverRing; Etingof.TensorProductOverRing.tmul; Etingof.TensorProductOverRing.add_tmul; Etingof.TensorProductOverRing.tmul_add; Etingof.TensorProductOverRing.smul_tmul"
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.11",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.TensorProductOverRing",
+        "Etingof.TensorProductOverRing.tmul",
+        "Etingof.TensorProductOverRing.add_tmul",
+        "Etingof.TensorProductOverRing.tmul_add",
+        "Etingof.TensorProductOverRing.smul_tmul"
       ]
     }
   },
@@ -2250,6 +2371,17 @@
           "verdict": "formalized",
           "lean_decl": "Etingof.Exercise2_11_5.exists_module_baseChange"
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.11",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Exercise2_11_5.instRightAlgebra",
+        "Etingof.Exercise2_11_5.algebraMap_right_apply",
+        "Etingof.Exercise2_11_5.exists_module_baseChange"
       ]
     }
   },
@@ -2312,6 +2444,25 @@
           "reason": "This standalone adjunction is explicitly omitted in skipped-exercises.md; its only downstream application, Frobenius reciprocity, is formalized directly as Etingof.Theorem5_10_1."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.11",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Module",
+        "SMulCommClass",
+        "Etingof.TensorProductOverRing"
+      ],
+      "basis": "Proof integrity is certified only for the two non-omitted claim units: the standard commuting-action encoding of a bimodule and the balanced tensor product from Remark 2.11.4. The five inherited intentional_omission claims are not represented as proved declarations and are not certified by this result.",
+      "intentional_omissions": [
+        "induced left action on a balanced tensor product",
+        "induced right action and combined bimodule structure",
+        "balanced-tensor associativity",
+        "the displayed Hom bimodule",
+        "the noncommutative tensor-Hom adjunction"
+      ]
     }
   },
   {
@@ -2341,6 +2492,17 @@
           "verdict": "formalized",
           "lean_decl": "TensorProduct.instModule; TensorProduct.smul_tmul'; TensorProduct.tmul_smul"
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.11",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "TensorProduct.instModule",
+        "TensorProduct.smul_tmul'",
+        "TensorProduct.tmul_smul"
       ]
     }
   },


### PR DESCRIPTION
## Summary

- certify all 39 non-omitted §2.11 claim units from Stage 3.2
- record 10 sorry-free items, one proof-inapplicable heading, and 63 resolved declarations
- preserve Problem 2.11.6's five intentional omissions explicitly without representing them as proofs
- confirm no accidental `sorry`, `proof_wanted`, `sorryAx`, or project-axiom dependency remains

This PR is intentionally stacked on draft PR #8032.

## Validation

- all 12 scoped providers build successfully together (8592 jobs)
- `lake build EtingofRepresentationTheory.Chapter2` (8744 jobs)
- Lean declaration-resolution and 36-headline `#print axioms` audit
- exact scoped admission/placeholder scan
- all three repository metadata validators
- tracker invariance checks and `git diff --check`
