### PR TITLE
Stage 3.3: verify Chapter 2 §2.13 proof

### DIFF
--- a/progress/2026-07-27T13-35-00Z_stage3-3-chapter2-section2-13.md
+++ b/progress/2026-07-27T13-35-00Z_stage3-3-chapter2-section2-13.md
@@ -1,0 +1,24 @@
+# Stage 3.3 proof verification — Chapter 2 §2.13
+
+## Scope and result
+
+This pass keeps the exact two-item, ten-claim §2.13 scope established at Stage 3.2.
+The section heading has no proof obligation. The only public mathematical endpoint in the chosen
+project scope, `Etingof.Problem2_13_1.irrational_arccos_third_div_pi`, is fully proved and depends
+only on Lean's accepted foundational axioms `propext`, `Classical.choice`, and `Quot.sound`.
+
+The proof follows the book's arithmetic strategy through an equivalent Chebyshev recurrence:
+`b_k = 3^k cos(kθ)` for `θ = arccos(1/3)`, while `3 ∤ b_k`; rationality would force a positive
+index at which `b_k` equals a positive power of three. There are no `sorry`, `admit`, project
+`axiom`, `proof_wanted`, or `sorryAx` dependencies in this formalized endpoint.
+
+The five Dehn-invariant/scissors-congruence units remain explicit intentional omissions under
+`skipped-exercises.md`. Stage 3.3 does not mislabel those omissions as proved declarations.
+
+## Validation
+
+- isolated targeted provider build
+- full Chapter 2 build
+- scoped source admission scan
+- `#print axioms Etingof.Problem2_13_1.irrational_arccos_third_div_pi`
+- exact tracker scope/status checks, `jq empty`, and `git diff --check`

--- a/progress/items.json
+++ b/progress/items.json
@@ -3705,6 +3705,13 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.13",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "not_applicable",
+      "declarations": []
+    },
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -3779,6 +3786,16 @@
           "reason": "This is part (c), explicitly omitted in skipped-exercises.md."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.13",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Problem2_13_1.irrational_arccos_third_div_pi"
+      ],
+      "scope_note": "Proof integrity applies to the two formalized proof units. The five Dehn-invariant/scissors-congruence units remain explicit intentional omissions under skipped-exercises.md and are not represented by declarations."
     },
     "last_updated": "2026-07-27"
   },


### PR DESCRIPTION
## Summary

- verify the only in-scope §2.13 mathematical endpoint is sorry-free and axiom-clean
- record Stage 3.3 evidence for both reading-order items
- preserve the five explicit Dehn-invariant/scissors-congruence omissions without certifying them as proofs

## Validation

- targeted provider build (8580 jobs)
- full Chapter 2 build (8744 jobs)
- scoped scan: no `sorry`, `admit`, project `axiom`, or `proof_wanted`
- `#print axioms`: only `propext`, `Classical.choice`, `Quot.sound`
- exact tracker checks, `jq empty`, and `git diff --check`