### PR TITLE
Stage 3.4: trim Chapter 2 §2.13 dependencies

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Problem2_13_1.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_13_1.lean
@@ -1,4 +1,5 @@
-import Mathlib
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Inverse
+import Mathlib.NumberTheory.Real.Irrational
 
 /-!
 # Problem 2.13.1: The Dehn invariant and Hilbert's third problem

--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -327,12 +327,8 @@
   "Chapter2/Definition2.12.1": [
     "Chapter2/Discussion_2.12_heading"
   ],
-  "Chapter2/Discussion_2.13_heading": [
-    "Chapter2/Definition2.12.1"
-  ],
-  "Chapter2/Problem2.13.1": [
-    "Chapter2/Discussion_2.13_heading"
-  ],
+  "Chapter2/Discussion_2.13_heading": [],
+  "Chapter2/Problem2.13.1": [],
   "Chapter2/Discussion_2.14_heading": [
     "Chapter2/Problem2.13.1"
   ],

--- a/progress/2026-07-27T13-35-00Z_stage3-3-chapter2-section2-13.md
+++ b/progress/2026-07-27T13-35-00Z_stage3-3-chapter2-section2-13.md
@@ -1,0 +1,24 @@
+# Stage 3.3 proof verification — Chapter 2 §2.13
+
+## Scope and result
+
+This pass keeps the exact two-item, ten-claim §2.13 scope established at Stage 3.2.
+The section heading has no proof obligation. The only public mathematical endpoint in the chosen
+project scope, `Etingof.Problem2_13_1.irrational_arccos_third_div_pi`, is fully proved and depends
+only on Lean's accepted foundational axioms `propext`, `Classical.choice`, and `Quot.sound`.
+
+The proof follows the book's arithmetic strategy through an equivalent Chebyshev recurrence:
+`b_k = 3^k cos(kθ)` for `θ = arccos(1/3)`, while `3 ∤ b_k`; rationality would force a positive
+index at which `b_k` equals a positive power of three. There are no `sorry`, `admit`, project
+`axiom`, `proof_wanted`, or `sorryAx` dependencies in this formalized endpoint.
+
+The five Dehn-invariant/scissors-congruence units remain explicit intentional omissions under
+`skipped-exercises.md`. Stage 3.3 does not mislabel those omissions as proved declarations.
+
+## Validation
+
+- isolated targeted provider build
+- full Chapter 2 build
+- scoped source admission scan
+- `#print axioms Etingof.Problem2_13_1.irrational_arccos_third_div_pi`
+- exact tracker scope/status checks, `jq empty`, and `git diff --check`

--- a/progress/2026-07-27T13-38-20Z_stage3-4-chapter2-section2-13.md
+++ b/progress/2026-07-27T13-38-20Z_stage3-4-chapter2-section2-13.md
@@ -1,0 +1,33 @@
+# Stage 3.4 dependency trimming: Chapter 2 §2.13
+
+## Scope
+
+This pass analyzes the actual dependencies of the two §2.13 catalog items after Stage 3.3:
+`Discussion_2.13_heading` and `Problem2.13.1`.
+
+## Result
+
+Both items are independent of earlier project items. The section heading is organizational only,
+and the formalized irrationality proof uses Mathlib directly. The two conservative reading-order
+edges were therefore removed from `dependencies/internal.json`.
+
+The proof provider no longer imports the `Mathlib` umbrella. It now imports only two focused
+modules: the inverse-trigonometric and irrational-number APIs. Both scoped items carry complete
+`stage3_4` records and move to `dependency_trimmed`.
+
+The five geometric claims intentionally omitted under `skipped-exercises.md` remain explicit
+scope decisions and introduce no dependency edges.
+
+## Validation
+
+- direct compilation of `Problem2_13_1.lean`
+- Mathlib's `#import_bumps`/`minImports` linter (no unneeded import remains)
+- full `EtingofRepresentationTheory.Chapter2` build
+- `scripts/validate_items.py`
+- `scripts/validate_dependencies.py`
+- `scripts/validate_external_deps.py`
+- exact two-item §2.13 metadata audit
+- `jq empty dependencies/internal.json progress/items.json`
+- `git diff --check`
+
+This PR is limited to Section 2.13 and Stage 3.4.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3686,7 +3686,7 @@
     "end_page": "36",
     "start_line": 17,
     "end_line": 17,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "fidelity": "verified",
     "claim_coverage": {
@@ -3712,6 +3712,13 @@
       "proof_integrity": "not_applicable",
       "declarations": []
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.13",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "This organizational heading makes no mathematical assertion and depends on no earlier project item."
+    },
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -3725,7 +3732,7 @@
     "end_page": "37",
     "start_line": 18,
     "end_line": 8,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_partial",
     "fidelity": "verified",
     "lean_decl": "Etingof.Problem2_13_1.irrational_arccos_third_div_pi",
@@ -3796,6 +3803,13 @@
         "Etingof.Problem2_13_1.irrational_arccos_third_div_pi"
       ],
       "scope_note": "Proof integrity applies to the two formalized proof units. The five Dehn-invariant/scissors-congruence units remain explicit intentional omissions under skipped-exercises.md and are not represented by declarations."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.13",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The formalized irrationality proof uses only focused Mathlib inverse-trigonometric and irrational-number modules; it imports no earlier project item. The five intentional geometric omissions introduce no dependency edges."
     },
     "last_updated": "2026-07-27"
   },

--- a/progress/items.json
+++ b/progress/items.json
@@ -3705,6 +3705,13 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.13",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "not_applicable",
+      "declarations": []
+    },
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -3779,6 +3786,16 @@
           "reason": "This is part (c), explicitly omitted in skipped-exercises.md."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.13",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Problem2_13_1.irrational_arccos_third_div_pi"
+      ],
+      "scope_note": "Proof integrity applies to the two formalized proof units. The five Dehn-invariant/scissors-congruence units remain explicit intentional omissions under skipped-exercises.md and are not represented by declarations."
     },
     "last_updated": "2026-07-27"
   },


### PR DESCRIPTION
Advances exactly Chapter 2 §2.13 through Stage 3.4.

- removes the two conservative reading-order edges; both scoped items have no actual earlier-item dependency
- replaces the Mathlib umbrella import with the two focused modules selected by the minImports linter
- records complete stage3_4 metadata for the exact two §2.13 catalog items
- preserves the five explicit geometric intentional omissions

Validation:
- direct Problem2_13_1.lean compilation
- Mathlib minImports audit: no unneeded import remains
- full Chapter 2 build: 8,744 jobs
- all three repository metadata/dependency validators
- jq and git diff checks