### PR TITLE
Stage 3.2: audit Chapter 2 §2.12

### DIFF
--- a/EtingofRepresentationTheory/Chapter2.lean
+++ b/EtingofRepresentationTheory/Chapter2.lean
@@ -114,6 +114,7 @@ import EtingofRepresentationTheory.Chapter2.Problem2_11_6
 import EtingofRepresentationTheory.Chapter2.Exercise2_11_2
 import EtingofRepresentationTheory.Chapter2.Exercise2_11_5
 import EtingofRepresentationTheory.Chapter2.Exercise2_11_7
+import EtingofRepresentationTheory.Chapter2.Discussion_2_12_heading
 import EtingofRepresentationTheory.Chapter2.Definition2_12_1
 
 -- Section 2.13: The Dehn invariant

--- a/EtingofRepresentationTheory/Chapter2/Definition2_12_1.lean
+++ b/EtingofRepresentationTheory/Chapter2/Definition2_12_1.lean
@@ -1,9 +1,11 @@
-import Mathlib.LinearAlgebra.SymmetricAlgebra.Basic
-import Mathlib.LinearAlgebra.ExteriorAlgebra.Basic
+import Mathlib.Data.Finsupp.Multiset
+import Mathlib.LinearAlgebra.SymmetricAlgebra.Basis
+import Mathlib.LinearAlgebra.ExteriorAlgebra.Basis
 import Mathlib.Algebra.Lie.UniversalEnveloping
 import Mathlib.LinearAlgebra.Basis.Defs
 import EtingofRepresentationTheory.Chapter2.Definition2_9_9
 import EtingofRepresentationTheory.Chapter2.Discussion_2_6
+import EtingofRepresentationTheory.Chapter2.Problem2_11_3_SymPowBasis
 
 /-!
 # Definition 2.12.1: Symmetric Algebra, Exterior Algebra, and Universal Enveloping Algebra
@@ -24,7 +26,8 @@ The coordinate-free constructions are Mathlib's `SymmetricAlgebra R M`,
 file also constructs the book's earlier basis-and-structure-constants presentation and proves it
 equivalent to Mathlib's coordinate-free construction.  Thus Definition 2.9.9, Remark 2.9.10, and
 part (iii) of this definition are connected by an actual algebra equivalence rather than merely
-being assigned the same Lean type.
+being assigned the same Lean type.  We also record the basis identifications and the final
+decompositions into the symmetric and exterior powers constructed in Problem 2.11.3.
 -/
 
 /-- The symmetric algebra of a module, in the sense of Etingof Definition 2.12.1 (i).
@@ -46,6 +49,8 @@ abbrev Etingof.UniversalEnvelopingAlgebraCoordFree (k : Type*) (L : Type*) [Comm
   UniversalEnvelopingAlgebra k L
 namespace Etingof
 
+open scoped DirectSum TensorProduct
+
 universe u v w
 
 variable (k : Type u) [Field k]
@@ -53,6 +58,96 @@ variable (L : Type v) [LieRing L] [LieAlgebra k L]
 variable {ι : Type w} (b : Module.Basis ι k L)
 
 attribute [local instance 100] LieRing.ofAssociativeRing
+
+/-! ## The defining quotient relations -/
+
+/-- The canonical generators of the symmetric algebra commute, the relation imposed in part (i). -/
+theorem symmetricAlgebra_generators_commute (V : Type v) [AddCommGroup V] [Module k V]
+    (x y : V) :
+    SymmetricAlgebra.ι k V x * SymmetricAlgebra.ι k V y =
+      SymmetricAlgebra.ι k V y * SymmetricAlgebra.ι k V x :=
+  mul_comm _ _
+
+/-- The canonical generators of the exterior algebra square to zero, the relation imposed in
+part (ii). -/
+theorem exteriorAlgebra_generator_sq_zero (V : Type v) [AddCommGroup V] [Module k V] (x : V) :
+    ExteriorAlgebra.ι k x * ExteriorAlgebra.ι k x = 0 :=
+  ExteriorAlgebra.ι_sq_zero x
+
+/-- The canonical generators of the universal enveloping algebra satisfy the relation from
+part (iii). -/
+theorem universalEnvelopingAlgebra_generator_relation (x y : L) :
+    UniversalEnvelopingAlgebra.ι k x * UniversalEnvelopingAlgebra.ι k y -
+        UniversalEnvelopingAlgebra.ι k y * UniversalEnvelopingAlgebra.ι k x =
+      UniversalEnvelopingAlgebra.ι k ⁅x, y⁆ := by
+  rw [← LieRing.of_associative_ring_bracket, ← LieHom.map_lie]
+
+/-! ## Identifications after choosing a basis -/
+
+/-- A basis identifies the symmetric algebra with the polynomial algebra on the basis indices. -/
+noncomputable def symmetricAlgebraEquivPolynomial (V : Type v) [AddCommGroup V] [Module k V]
+    {ι : Type w} (b : Module.Basis ι k V) :
+    SymmetricAlgebraDef k V ≃ₐ[k] MvPolynomial ι k :=
+  SymmetricAlgebra.equivMvPolynomial b
+
+/-- The symmetric-algebra/polynomial identification sends a chosen basis vector to the
+corresponding polynomial variable. -/
+@[simp] theorem symmetricAlgebraEquivPolynomial_ι (V : Type v) [AddCommGroup V] [Module k V]
+    {ι : Type w} (b : Module.Basis ι k V) (i : ι) :
+    symmetricAlgebraEquivPolynomial k V b (SymmetricAlgebra.ι k V (b i)) =
+      MvPolynomial.X i :=
+  SymmetricAlgebra.equivMvPolynomial_ι_apply b i
+
+/-- A basis identifies the exterior algebra with the exterior algebra on the free coordinate
+module on its basis indices. -/
+noncomputable def exteriorAlgebraEquivBasisModule (V : Type v) [AddCommGroup V] [Module k V]
+    {ι : Type w} (b : Module.Basis ι k V) :
+    ExteriorAlgebraDef k V ≃ₐ[k] ExteriorAlgebra k (ι →₀ k) :=
+  CliffordAlgebra.equivOfIsometry
+    ({ toLinearEquiv := b.repr, map_app' := fun _ => rfl } :
+      QuadraticMap.IsometryEquiv (0 : QuadraticForm k V) (0 : QuadraticForm k (ι →₀ k)))
+
+/-- The exterior-algebra basis identification acts on generators by taking coordinates in the
+chosen basis. -/
+@[simp] theorem exteriorAlgebraEquivBasisModule_ι (V : Type v) [AddCommGroup V] [Module k V]
+    {ι : Type w} (b : Module.Basis ι k V) (x : V) :
+    exteriorAlgebraEquivBasisModule k V b (ExteriorAlgebra.ι k x) =
+      ExteriorAlgebra.ι k (b.repr x) := by
+  rw [exteriorAlgebraEquivBasisModule, CliffordAlgebra.equivOfIsometry_apply,
+    CliffordAlgebra.map_apply_ι]
+  rfl
+
+/-! ## Decompositions into symmetric and exterior powers -/
+
+/-- The monomial indices of a symmetric algebra split uniquely by total degree: a finitely
+supported exponent vector is equivalently a degree together with a multiset of that cardinality. -/
+noncomputable def symmetricMonomialDegreeEquiv (ι : Type w) :
+    (ι →₀ ℕ) ≃ Σ n : ℕ, Sym ι n := by
+  classical
+  exact (Equiv.sigmaFiberEquiv (fun f : ι →₀ ℕ => f.sum fun _ m => m)).symm.trans
+    (Equiv.sigmaCongrRight fun n => (Sym.equivNatSum ι n).symm)
+
+/-- The book's decomposition `S(V) = ⨁ n, S^n(V)`.  The right-hand summands are the quotient
+models of symmetric powers constructed in Problem 2.11.3.  A chosen basis identifies the monomial
+basis of `S(V)`, grouped by total degree, with the corresponding bases of those quotients. -/
+noncomputable def symmetricAlgebraEquivDirectSumSymmetricPowers
+    (V : Type v) [AddCommGroup V] [Module k V] {ι : Type w} (b : Module.Basis ι k V) :
+    SymmetricAlgebraDef k V ≃ₗ[k]
+      ⨁ n : ℕ, Problem2_11_3.SymPow k V n :=
+  b.symmetricAlgebra.repr ≪≫ₗ
+    Finsupp.domLCongr (symmetricMonomialDegreeEquiv ι) ≪≫ₗ
+    sigmaFinsuppLequivDFinsupp k ≪≫ₗ
+    DFinsupp.mapRange.linearEquiv fun n => (Problem2_11_3.symPowBasis b n).repr.symm
+
+/-- The book's decomposition `∧(V) = ⨁ n, ∧^n(V)`.  Mathlib's canonical grading gives the
+direct sum of its exterior-power submodules, and the componentwise equivalences proved for
+Problem 2.11.3 identify those with the book's quotient models. -/
+noncomputable def exteriorAlgebraEquivDirectSumExteriorPowers
+    (V : Type v) [AddCommGroup V] [Module k V] :
+    ExteriorAlgebraDef k V ≃ₗ[k]
+      ⨁ n : ℕ, Problem2_11_3.ExtPow k V n :=
+  DirectSum.decomposeLinearEquiv (fun n : ℕ => ⋀[k]^n V) ≪≫ₗ
+    DFinsupp.mapRange.linearEquiv fun n => Problem2_11_3.exteriorPowerEquiv n
 
 /-- The defining relator
 `X_i X_j - X_j X_i - ∑_r (b.repr ⁅b i, b j⁆) r • X_r` for the basis presentation of
@@ -119,7 +214,11 @@ noncomputable def basisGenLie : L →ₗ⁅k⁆ UEABasisPresentation k L b :=
           (by simp) (by simp) (by simp) (by simp)
       let rhs : L →ₗ[k] L →ₗ[k] UEABasisPresentation k L b :=
         LinearMap.mk₂ k (fun x y => ⁅basisGenLinear k L b x, basisGenLinear k L b y⁆)
-          (by simp) (by simp) (by simp) (by simp)
+          (by simp) (by simp) (by simp)
+          (by
+            intro c x y
+            rw [map_smul]
+            exact lie_smul c (basisGenLinear k L b x) (basisGenLinear k L b y))
       have hbilin : lhs = rhs := by
         apply Module.Basis.ext b
         intro i

--- a/EtingofRepresentationTheory/Chapter2/Discussion_2_12_heading.lean
+++ b/EtingofRepresentationTheory/Chapter2/Discussion_2_12_heading.lean
@@ -1,0 +1,67 @@
+import Mathlib.LinearAlgebra.TensorAlgebra.Basis
+import Mathlib.LinearAlgebra.TensorAlgebra.ToTensorPower
+
+/-!
+# Section 2.12: The tensor algebra
+
+For a vector space `V` over `k`, the tensor algebra is the direct sum of all tensor powers,
+with multiplication given by concatenation of tensors.  A choice of basis indexed by `ι`
+identifies it with the free algebra on `ι`.
+
+Mathlib's `TensorAlgebra k V` is defined by its universal property.  The two equivalences below
+record both concrete descriptions from the section's introductory prose.  The pure-tensor formula
+states explicitly that the direct-sum equivalence sends an `n`-fold product of generators to the
+degree-`n` tensor-power summand.
+-/
+
+namespace Etingof
+
+open scoped DirectSum TensorProduct
+
+universe u v w
+
+variable (k : Type u) [Field k]
+variable (V : Type v) [AddCommGroup V] [Module k V]
+
+/-- The tensor algebra `T(V)` from the introduction to §2.12. -/
+abbrev TensorAlgebraDef := TensorAlgebra k V
+
+/-- The source definition `T(V) = ⨁ n, V^{⊗ n}`, as an algebra equivalence.  Multiplication on
+the direct sum is the graded concatenation product on tensor powers. -/
+noncomputable def tensorAlgebraEquivDirectSum :
+    TensorAlgebraDef k V ≃ₐ[k] ⨁ n : ℕ, ⨂[k]^n V :=
+  TensorAlgebra.equivDirectSum
+
+/-- Under the direct-sum description, a pure `n`-fold tensor lies in exactly the degree-`n`
+summand. -/
+@[simp] theorem tensorAlgebraEquivDirectSum_tprod {n : ℕ} (x : Fin n → V) :
+    tensorAlgebraEquivDirectSum k V (TensorAlgebra.tprod k V n x) =
+      DirectSum.of (fun n : ℕ => ⨂[k]^n V) n (PiTensorProduct.tprod k x) :=
+  TensorAlgebra.toDirectSum_tensorPower_tprod x
+
+/-- Multiplication of homogeneous tensors in `T(V)` is the concatenation product on tensor
+powers, exactly as in the source definition. -/
+theorem tensorAlgebra_mul_homogeneous {n m : ℕ} (a : ⨂[k]^n V) (b : ⨂[k]^m V) :
+    TensorPower.toTensorAlgebra a * TensorPower.toTensorAlgebra b =
+      TensorPower.toTensorAlgebra
+        (@GradedMonoid.GMul.mul ℕ (fun d : ℕ => ⨂[k]^d V) _ TensorPower.gMul n m a b) :=
+  (TensorPower.toTensorAlgebra_gMul a b).symm
+
+/-- A choice of basis identifies `T(V)` with the free algebra on the basis indices. -/
+noncomputable def tensorAlgebraEquivFreeAlgebra {ι : Type w} (b : Module.Basis ι k V) :
+    TensorAlgebraDef k V ≃ₐ[k] FreeAlgebra k ι :=
+  TensorAlgebra.equivFreeAlgebra b
+
+/-- The basis/free-algebra identification takes a basis vector to the correspondingly named free
+generator. -/
+@[simp] theorem tensorAlgebraEquivFreeAlgebra_ι {ι : Type w} (b : Module.Basis ι k V) (i : ι) :
+    tensorAlgebraEquivFreeAlgebra k V b (TensorAlgebra.ι k (b i)) = FreeAlgebra.ι k i :=
+  TensorAlgebra.equivFreeAlgebra_ι_apply b i
+
+/-- The degree-one generators embed faithfully in the tensor algebra, ruling out a vacuous
+generator model. -/
+theorem tensorAlgebra_ι_injective :
+    Function.Injective (TensorAlgebra.ι k : V → TensorAlgebra k V) :=
+  TensorAlgebra.ι_leftInverse.injective
+
+end Etingof

--- a/progress/2026-07-27T13-35-43Z_stage3-2-chapter2-section2-12.md
+++ b/progress/2026-07-27T13-35-43Z_stage3-2-chapter2-section2-12.md
@@ -1,0 +1,58 @@
+# Stage 3.2 fidelity review — Chapter 2 §2.12
+
+## Scope
+
+Reading order gives exactly two §2.12 catalog items:
+
+1. `Chapter2/Discussion_2.12_heading`, page 35 lines 27–33;
+2. `Chapter2/Definition2.12.1`, page 36 lines 1–16.
+
+The preceding item is `Chapter2/Exercise2.11.7`; the next item is
+`Chapter2/Discussion_2.13_heading`. Thus the nonnumeric introductory discussion is part of the
+scope even though it previously had no Lean provider and was labeled `trivial`.
+
+## Claim audit and repairs
+
+Both source blobs were checked in full against the page transcription. The durable inventory has
+eleven mathematical claim units, all now `formalized`: three in the introductory discussion and
+eight in Definition 2.12.1.
+
+Stage 3.2 repaired the following accidental coverage gaps:
+
+1. A new `Discussion_2_12_heading.lean` provider records `T(V)` as the algebraic direct sum of its
+   tensor powers, proves the pure-degree and homogeneous-multiplication formulas, and gives the
+   basis-dependent equivalence with the free algebra, including its generator formula.
+2. Definition 2.12.1 now exposes the exact generator relations for the symmetric, exterior, and
+   universal enveloping algebras.
+3. The symmetric algebra is identified with the polynomial algebra on any chosen basis, and the
+   exterior algebra with the exterior algebra on the corresponding free coordinate module.
+4. The final displayed decompositions are genuine linear equivalences to the exact quotient
+   models `Problem2_11_3.SymPow k V n` and `Problem2_11_3.ExtPow k V n`, not merely prose or
+   unnamed homogeneous components.
+
+The existing equivalence between coordinate-free `U(L)` and Definition 2.9.9's
+basis-and-structure-constants presentation was audited and retained. No claim was downgraded to an
+intentional omission or nonformalizable prose.
+
+## Durable tracker result
+
+Both items now have complete Stage 3.2 `claim_coverage` records with verified definition
+integrity, statement fidelity, and nonvacuity. The introductory discussion moves from the
+incorrect wave-1 `trivial` label to `covered_full`; Definition 2.12.1 remains `covered_full` with
+its formerly implicit basis and decomposition claims now inventoried explicitly.
+
+## Validation
+
+- `.lake/build` is worktree-local; only `.lake/packages` is linked to the shared package cache;
+- both scoped providers build successfully together (8585 jobs);
+- full `lake build EtingofRepresentationTheory.Chapter2` succeeds (8745 jobs); replayed warnings
+  are pre-existing and outside the changed §2.12 providers;
+- the scoped scan finds no `sorry`, `admit`, `axiom`, `proof_wanted`, `opaque`, or
+  `native_decide` declarations;
+- representative `#print axioms` checks report only standard foundational axioms;
+- `jq empty progress/items.json` and the exact two-item/eleven-claim aggregation pass;
+- `python3 scripts/validate_items.py` passes with full 5721/5721-line coverage (plus its 593
+  pre-existing extra-field warnings);
+- `python3 scripts/validate_dependencies.py` passes with its one pre-existing conservative-default
+  warning;
+- the normalized non-§2.12 tracker projection is unchanged and `git diff --check` passes.

--- a/progress/items.json
+++ b/progress/items.json
@@ -1611,7 +1611,39 @@
     "status": "sorry_free",
     "coverage_swept": {
       "wave": 1,
-      "result": "trivial"
+      "result": "covered_full"
+    },
+    "fidelity": "verified",
+    "sorry_free": true,
+    "coverage": "covered_full",
+    "coverage_note": "Chapter2/Discussion_2_12_heading.lean now covers every mathematical claim in the introductory prose: T(V) is identified as an algebra with the direct sum of all tensor powers, homogeneous multiplication is the tensor-concatenation product, and a chosen basis identifies T(V) with the free algebra on its basis indices. The generator formulas and injectivity of the degree-one inclusion make these identifications nonvacuous.",
+    "fidelity_note": "Verified against book page 35, lines 27–33. The previous wave-1 label `trivial` was incorrect: this prose contains the definition of the tensor algebra and a basis-dependent free-algebra isomorphism. Both are now explicit, sorry-free declarations using Mathlib's canonical tensor-algebra equivalences.",
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.12",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "The tensor algebra T(V) is the direct sum of the tensor powers V^{⊗n}, with pure n-fold tensors in the degree-n summand.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.tensorAlgebraEquivDirectSum"
+        },
+        {
+          "claim": "Multiplication of homogeneous elements of tensor degrees n and m is tensor concatenation into degree n+m.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.tensorAlgebra_mul_homogeneous"
+        },
+        {
+          "claim": "A choice of basis of V identifies T(V) with the free algebra on the basis indices, matching the named generators.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.tensorAlgebraEquivFreeAlgebra"
+        }
+      ]
     }
   },
   {
@@ -1626,8 +1658,60 @@
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
-    "fidelity_note": "The coordinate-free symmetric, exterior, and enveloping algebras are present, and the enveloping algebra is explicitly identified with Definition 2.9.9's basis presentation.",
-    "last_updated": "2026-07-26"
+    "coverage_note": "All three quotient constructions, all three basis identifications, and both direct-sum decompositions in Definition 2.12.1 are now represented by public declarations. The symmetric and exterior decompositions land in the exact quotient models S^n(V) and ∧^n(V) constructed in Problem 2.11.3, rather than merely unnamed homogeneous subspaces.",
+    "fidelity_note": "Verified against book page 36, lines 1–16. The coordinate-free symmetric, exterior, and enveloping algebras carry their exact generator relations. A chosen basis identifies the symmetric algebra with multivariable polynomials, the exterior algebra with the exterior algebra of the free coordinate module, and U(L) with Definition 2.9.9's basis presentation. Explicit linear equivalences prove S(V)=⊕n S^n(V) and ∧(V)=⊕n ∧^n(V). The Lean statements allow arbitrary basis index types, faithfully generalizing the finite displayed basis.",
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.12",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "S(V) is the quotient of T(V) imposing commutativity of degree-one generators.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.SymmetricAlgebraDef; Etingof.symmetricAlgebra_generators_commute"
+        },
+        {
+          "claim": "∧(V) is the quotient of T(V) imposing v·v=0 for every degree-one generator v.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.ExteriorAlgebraDef; Etingof.exteriorAlgebra_generator_sq_zero"
+        },
+        {
+          "claim": "U(L) is the quotient of T(L) imposing xy−yx=[x,y].",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.UniversalEnvelopingAlgebraCoordFree; Etingof.universalEnvelopingAlgebra_generator_relation"
+        },
+        {
+          "claim": "A chosen basis identifies S(V) with the polynomial algebra on the basis indices.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.symmetricAlgebraEquivPolynomial"
+        },
+        {
+          "claim": "A chosen basis identifies ∧(V) with the exterior algebra on the corresponding coordinate generators.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.exteriorAlgebraEquivBasisModule"
+        },
+        {
+          "claim": "A chosen basis identifies the coordinate-free U(L) with the basis-and-structure-constants presentation defined previously.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.ueaBasisAlgEquiv"
+        },
+        {
+          "claim": "The symmetric algebra decomposes as the direct sum of the symmetric powers S^n(V).",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.symmetricAlgebraEquivDirectSumSymmetricPowers"
+        },
+        {
+          "claim": "The exterior algebra decomposes as the direct sum of the exterior powers ∧^n(V).",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.exteriorAlgebraEquivDirectSumExteriorPowers"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter2/Discussion_2.13_heading",


### PR DESCRIPTION
## Summary

- complete the Stage 3.2 audit for the exact Chapter 2 §2.12 reading-order scope
- restore the mathematical claims in the §2.12 heading, which had been incorrectly classified as trivial prose
- formalize the tensor-algebra grading and homogeneous multiplication, the free-algebra presentation, generator relations for the three quotients, basis-dependent polynomial/exterior identifications, and the symmetric/exterior homogeneous decompositions
- record canonical claim-coverage metadata for all 11 claims across the two scoped items

## Exact scope

- `Chapter2/Discussion_2.12_heading`
- `Chapter2/Definition2.12.1`

The scope is bounded by `Chapter2/Exercise2.11.7` and `Chapter2/Discussion_2.13_heading` in `progress/items.json` reading order.

## Validation

- `lake build EtingofRepresentationTheory.Chapter2`
- `python3 scripts/validate_items.py`
- `python3 scripts/validate_dependencies.py`
- `jq empty progress/items.json`
- `git diff --check origin/main...HEAD`
- scoped placeholder scan and representative `#print axioms` checks

All checks pass. The full Chapter 2 build retains only pre-existing warnings outside the changed providers.
