### PR TITLE
polish(Ch2 §2.8): complete Stage 3.5 quality pass

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Definition2_8_4.lean
+++ b/EtingofRepresentationTheory/Chapter2/Definition2_8_4.lean
@@ -74,7 +74,8 @@ unfolds only reducible definitions) no longer sees the `Finsupp` instances, so t
 structure is the unique `Mul`. The `Finsupp` module-level structure is re-exposed explicitly via
 `inferInstanceAs` in the instances immediately following; elaboration still unfolds the `def` at
 default transparency, so `Finsupp.single`/`Finsupp.lsum`/etc. continue to typecheck at type
-`PathAlgebra k Q`. -/
+`PathAlgebra k Q`. The `DecidableEq Q` parameter is intentionally retained on the carrier because
+it selects the path-composition multiplication API defined below. -/
 def PathAlgebra (k : Type*) (Q : Type*) [Field k] [Quiver Q]
     [DecidableEq Q] : Type _ :=
   QuiverPathIndex Q →₀ k
@@ -468,3 +469,7 @@ theorem sum_trivialPaths_eq_one [Fintype Q] :
 end BookPathAlgebra
 
 end Etingof
+
+-- Although the carrier does not inspect this instance, it deliberately indexes the multiplication
+-- API and keeps all `PathAlgebra` operations under one consistent set of assumptions.
+attribute [nolint unusedArguments] Etingof.PathAlgebra

--- a/EtingofRepresentationTheory/Chapter2/Discussion_quiver_rep_bijection.lean
+++ b/EtingofRepresentationTheory/Chapter2/Discussion_quiver_rep_bijection.lean
@@ -1,7 +1,6 @@
 import EtingofRepresentationTheory.Chapter2.Definition2_8_4
 import EtingofRepresentationTheory.Chapter2.Definition2_8_10
 import Mathlib.Algebra.Algebra.RestrictScalars
-import Mathlib.Algebra.Module.NatInt
 import Mathlib.RingTheory.Idempotents
 import Mathlib.Algebra.DirectSum.Module
 
@@ -391,7 +390,7 @@ noncomputable def toEnd [Fintype Q] (R : Etingof.QuiverRepresentation k Qᵒᵖ)
 @[simp] theorem toEnd_apply [Fintype Q] (R : Etingof.QuiverRepresentation k Qᵒᵖ)
     (a : PathAlgebra k Q) : toEnd R a = toEndₗ R a := rfl
 
-@[simp] theorem toEnd_ofPath [Fintype Q] (R : Etingof.QuiverRepresentation k Qᵒᵖ)
+theorem toEnd_ofPath [Fintype Q] (R : Etingof.QuiverRepresentation k Qᵒᵖ)
     (x : Etingof.QuiverPathIndex Q) : toEnd R (ofPath x) = pathEnd R x := by
   rw [toEnd_apply, toEndₗ_ofPath]
 
@@ -862,10 +861,15 @@ variable (k : Type u) (Q : Type v) [Field k] [Quiver Q] [DecidableEq Q] [Fintype
 /-- A bundled left module over the path algebra, used as the carrier of the module-side
 isomorphism-class quotient. -/
 structure PathModule where
+  /-- The underlying type of the module. -/
   carrier : Type w
+  /-- The additive commutative group structure on the carrier. -/
   addCommGroup : AddCommGroup carrier
+  /-- The ground-field module structure on the carrier. -/
   moduleField : Module k carrier
+  /-- The path-algebra module structure on the carrier. -/
   modulePathAlgebra : Module (PathAlgebra k Q) carrier
+  /-- Compatibility of the ground-field and path-algebra scalar actions. -/
   scalarTower : IsScalarTower k (PathAlgebra k Q) carrier
 
 /-- Two bundled path-algebra modules are isomorphic when their carriers are related by a
@@ -1135,10 +1139,15 @@ variable (k : Type u) (Q : Type v) [Field k] [Quiver.{q} Q] [DecidableEq Q] [Fin
 
 /-- A bundled left module over the book-facing path algebra. -/
 structure PathModule where
+  /-- The underlying type of the module. -/
   carrier : Type w
+  /-- The additive commutative group structure on the carrier. -/
   addCommGroup : AddCommGroup carrier
+  /-- The ground-field module structure on the carrier. -/
   moduleField : Module k carrier
+  /-- The book-facing path-algebra module structure on the carrier. -/
   modulePathAlgebra : Module (BookPathAlgebra k Q) carrier
+  /-- Compatibility of the ground-field and path-algebra scalar actions. -/
   scalarTower : IsScalarTower k (BookPathAlgebra k Q) carrier
 
 /-- Isomorphism of bundled book-facing path-algebra modules. -/
@@ -1368,10 +1377,11 @@ noncomputable def toEnd (R : QuiverRepresentation k Q) :
     toEnd k Q R a = toEndₗ k Q R a :=
   rfl
 
-@[simp] theorem toEnd_ofPath (R : QuiverRepresentation k Q) (x : QuiverPathIndex Q) :
+theorem toEnd_ofPath (R : QuiverRepresentation k Q) (x : QuiverPathIndex Q) :
     toEnd k Q R (ofPath (k := k) x) = pathEnd k Q R x := by
   rw [toEnd_apply, toEndₗ_ofPath]
 
+/-- The left `BookPathAlgebra` module reconstructed from a quiver representation. -/
 @[reducible] noncomputable def reverseModule (R : QuiverRepresentation k Q) :
     Module (BookPathAlgebra k Q) (DirectSum Q R.obj) :=
   Module.compHom _ (toEnd k Q R).toRingHom
@@ -1572,7 +1582,10 @@ theorem coeLinearMap_pathEnd {V : Type*} [AddCommGroup V] [Module k V]
       have hzero : (vertexSpace (k := k) (V := V) j).subtype
           (pathMap k Q (forwardRep (k := k) (Q := Q) (V := V)) p
             (0 : vertexSpace (k := k) (V := V) i)) = 0 := by
-        rw [map_zero, map_zero]
+        change (((vertexSpace (k := k) (V := V) j).subtype.comp
+          (pathMap k Q (forwardRep (k := k) (Q := Q) (V := V)) p))
+            (0 : vertexSpace (k := k) (V := V) i)) = 0
+        exact LinearMap.map_zero _
       calc
         _ = 0 := hzero
         _ = (ofPath (k := k) (⟨i, j, p⟩ : QuiverPathIndex Q) : BookPathAlgebra k Q) •
@@ -1707,7 +1720,8 @@ noncomputable def reverseModuleEquiv {R S : QuiverRepresentation k Q}
     left_inv := ek.left_inv
     right_inv := ek.right_inv }
 
-local instance directSum_addCommGroup (R : QuiverRepresentation k Q) :
+/-- The additive group on a direct sum of vector spaces. -/
+local instance directSumAddCommGroup (R : QuiverRepresentation k Q) :
     AddCommGroup (DirectSum Q R.obj) :=
   Module.addCommMonoidToAddCommGroup k
 

--- a/EtingofRepresentationTheory/Chapter2/Example2_8_2.lean
+++ b/EtingofRepresentationTheory/Chapter2/Example2_8_2.lean
@@ -49,3 +49,8 @@ def edge30 : (3 : Fin 4) ⟶ (0 : Fin 4) := by
   simpa using Unit.unit
 
 end Etingof.Example_2_8_2
+
+-- The leaf names follow Mathlib conventions; the underscore comes solely from the stable
+-- book-number namespace `Example_2_8_2`, which is part of this project's public API.
+attribute [nolint defsWithUnderscore]
+  Etingof.Example_2_8_2.edge01 Etingof.Example_2_8_2.edge21 Etingof.Example_2_8_2.edge30

--- a/EtingofRepresentationTheory/Chapter2/Problem2_8_11.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_8_11.lean
@@ -3,11 +3,6 @@ import Mathlib.RingTheory.MvPolynomial.Basic
 import Mathlib.LinearAlgebra.ExteriorPower.Basis
 import Mathlib.RingTheory.PowerSeries.WellKnown
 import Mathlib.Algebra.Order.Antidiag.FinsuppEquiv
-import Mathlib.Data.Matrix.Mul
-import Mathlib.Algebra.FreeAlgebra
-import Mathlib.SetTheory.Cardinal.Finite
-import Mathlib.Data.Finite.Sigma
-import Mathlib.Algebra.DirectSum.Module
 import EtingofRepresentationTheory.Chapter2.Definition2_8_4
 
 /-!
@@ -221,7 +216,7 @@ noncomputable def pathAlgebraDegreePiece (k : Type*) [Field k] (Q : Type*) [Quiv
 
 /-- The adjacency matrix of a finite quiver `Q`: the `(i,j)`-entry is the number of arrows
 `i ⟶ j`. -/
-def adjacencyMatrix (Q : Type*) [Quiver Q] [Fintype Q] [∀ i j : Q, Fintype (i ⟶ j)] :
+def adjacencyMatrix (Q : Type*) [Quiver Q] [∀ i j : Q, Fintype (i ⟶ j)] :
     Matrix Q Q ℕ :=
   fun i j => Fintype.card (i ⟶ j)
 
@@ -355,7 +350,7 @@ is the matrix `t M_Q` appearing in the book's answer. -/
 noncomputable def adjacencyPS : Matrix Q Q (PowerSeries k) :=
   (adjacencyMatrix Q).map fun a => C (a : k)
 
-omit [DecidableEq Q] in
+omit [Fintype Q] [DecidableEq Q] in
 @[simp]
 theorem adjacencyPS_apply (i j : Q) :
     adjacencyPS k Q i j = C ((adjacencyMatrix Q i j : ℕ) : k) :=
@@ -450,3 +445,12 @@ theorem hilbertSeries_pathAlgebra_adjacencyMatrix :
 end HilbertSeries
 
 end Etingof.Problem2_8_11
+
+-- The leaf names follow Mathlib conventions; the underscore comes solely from the stable
+-- book-number namespace `Problem2_8_11`, which is part of this project's public API.
+attribute [nolint defsWithUnderscore]
+  Etingof.Problem2_8_11.LocallyFiniteNatGrading.piece
+  Etingof.Problem2_8_11.hilbertSeries Etingof.Problem2_8_11.freeAlgebraWordEquiv
+  Etingof.Problem2_8_11.freeAlgebraDegreePiece Etingof.Problem2_8_11.pathAlgebraDegreePiece
+  Etingof.Problem2_8_11.adjacencyMatrix Etingof.Problem2_8_11.pathSuccEquiv
+  Etingof.Problem2_8_11.adjacencyPS Etingof.Problem2_8_11.resolvent

--- a/EtingofRepresentationTheory/Chapter2/Problem2_8_6.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_8_6.lean
@@ -67,14 +67,14 @@ theorem adjoin_generators_eq_top [Fintype Q] :
       exact mul_mem ih (Algebra.subset_adjoin (Or.inr ⟨_, _, e, rfl⟩))
   rw [Algebra.eq_top_iff]
   intro f
-  induction f using Finsupp.induction_linear with
+  induction f using PathAlgebra.induction_linear with
   | zero => exact zero_mem _
   | add f g hf hg => exact add_mem hf hg
   | single x c =>
     obtain ⟨a, b, p⟩ := x
     have hsc : (Finsupp.single (⟨a, b, p⟩ : QuiverPathIndex Q) c : PathAlgebra k Q)
         = c • PathAlgebra.ofPath (k := k) (⟨a, b, p⟩ : QuiverPathIndex Q) := by
-      rw [PathAlgebra.ofPath, Finsupp.smul_single, smul_eq_mul, mul_one]
+      exact (PathAlgebra.smul_single_one c _).symm
     rw [hsc]
     exact Subalgebra.smul_mem _ (hgen a b p) c
 
@@ -97,7 +97,8 @@ theorem vertexIdem_sq [Fintype Q] (i : Q) :
 theorem vertexIdem_mul_of_ne [Fintype Q] (i j : Q) (h : i ≠ j) :
     vertexIdem k Q i * vertexIdem k Q j = 0 := by
   unfold vertexIdem PathAlgebra.ofPath
-  rw [PathAlgebra.single_mul_single, PathAlgebra.compSingle_nil_left, if_neg h, smul_zero]
+  rw [PathAlgebra.single_mul_single, PathAlgebra.compSingle_nil_left, if_neg h]
+  exact PathAlgebra.smul_pathAlgebra_zero _
 
 /-- Relation (3): the source idempotent absorbs an arrow (on the left, in the
 source-to-target convention): `p_{source} · aₕ = aₕ`. -/
@@ -111,7 +112,8 @@ theorem source_mul_arrowGen [Fintype Q] {i j : Q} (e : i ⟶ j) :
 theorem vertexIdem_mul_arrowGen_of_ne [Fintype Q] {i j : Q} (l : Q) (e : i ⟶ j) (h : l ≠ i) :
     vertexIdem k Q l * arrowGen k Q e = 0 := by
   unfold vertexIdem arrowGen PathAlgebra.ofPath
-  rw [PathAlgebra.single_mul_single, PathAlgebra.compSingle_nil_left, if_neg h, smul_zero]
+  rw [PathAlgebra.single_mul_single, PathAlgebra.compSingle_nil_left, if_neg h]
+  exact PathAlgebra.smul_pathAlgebra_zero _
 
 /-- Relation (4): the target idempotent absorbs an arrow (on the right, in the
 source-to-target convention): `aₕ · p_{target} = aₕ`. -/
@@ -125,7 +127,8 @@ theorem arrowGen_mul_target [Fintype Q] {i j : Q} (e : i ⟶ j) :
 theorem arrowGen_mul_vertexIdem_of_ne [Fintype Q] {i j : Q} (l : Q) (e : i ⟶ j) (h : l ≠ j) :
     arrowGen k Q e * vertexIdem k Q l = 0 := by
   unfold arrowGen vertexIdem PathAlgebra.ofPath
-  rw [PathAlgebra.single_mul_single, PathAlgebra.compSingle_nil_right, if_neg h.symm, smul_zero]
+  rw [PathAlgebra.single_mul_single, PathAlgebra.compSingle_nil_right, if_neg h.symm]
+  exact PathAlgebra.smul_pathAlgebra_zero _
 
 /-! ## The exact book-facing presentation -/
 
@@ -181,8 +184,10 @@ theorem adjoin_generators_eq_top [Fintype Q] :
         apply MulOpposite.unop_injective
         exact (PathAlgebra.smul_single_one c
           (⟨a, b, p⟩ : QuiverPathIndex Q)).symm
-      rw [hsc]
-      exact Subalgebra.smul_mem _ (hgen a b p) c
+      have hmem : c • BookPathAlgebra.ofPath (k := k)
+          (⟨a, b, p⟩ : QuiverPathIndex Q) ∈ Algebra.adjoin k S :=
+        Subalgebra.smul_mem _ (hgen a b p) c
+      exact hsc.symm ▸ hmem
 
 /-- Relation (1): `∑ᵢ pᵢ = 1`. -/
 theorem sum_vertexIdem [Fintype Q] :
@@ -240,9 +245,11 @@ def evalPath {a : Q} : {b : Q} → Quiver.Path a b → B
   | _, Quiver.Path.nil => P a
   | _, Quiver.Path.cons q e => evalPath q * A _ _ e
 
+omit [DecidableEq Q] in
 @[simp] theorem evalPath_nil (a : Q) :
     evalPath P A (Quiver.Path.nil : Quiver.Path a a) = P a := rfl
 
+omit [DecidableEq Q] in
 @[simp] theorem evalPath_cons {a b c : Q} (q : Quiver.Path a b) (e : b ⟶ c) :
     evalPath P A (q.cons e) = evalPath P A q * A b c e := rfl
 
@@ -269,9 +276,9 @@ theorem defining_relations_universal [Fintype Q]
     (hidem : ∀ i, P i * P i = P i)
     (horth : ∀ i j, i ≠ j → P i * P j = 0)
     (hsa : ∀ i j (e : i ⟶ j), P i * A i j e = A i j e)
-    (hsa0 : ∀ (l : Q) i j (e : i ⟶ j), l ≠ i → P l * A i j e = 0)
+    (_hsa0 : ∀ (l : Q) i j (e : i ⟶ j), l ≠ i → P l * A i j e = 0)
     (hat : ∀ i j (e : i ⟶ j), A i j e * P j = A i j e)
-    (hat0 : ∀ (l : Q) i j (e : i ⟶ j), l ≠ j → A i j e * P l = 0) :
+    (_hat0 : ∀ (l : Q) i j (e : i ⟶ j), l ≠ j → A i j e * P l = 0) :
     ∃! φ : PathAlgebra k Q →ₐ[k] B,
       (∀ i, φ (vertexIdem k Q i) = P i) ∧
         (∀ i j (e : i ⟶ j), φ (arrowGen k Q e) = A i j e) := by
@@ -296,18 +303,18 @@ theorem defining_relations_universal [Fintype Q]
     | cons r e ih => rw [Quiver.Path.comp_cons, evalPath_cons, evalPath_cons, ih, mul_assoc]
   -- `evalMap` sends the unit to the unit.
   have h1 : evalMap P A (1 : PathAlgebra k Q) = 1 := by
-    rw [PathAlgebra.one_def, map_sum]
+    rw [PathAlgebra.one_eq_ofPath_sum, map_sum]
     refine Eq.trans (Finset.sum_congr rfl fun i _ => ?_) hsum
-    simp [evalMap_single]
+    simp [PathAlgebra.ofPath, evalMap_single]
   -- `evalMap` is multiplicative.
   have hmul : ∀ x y : PathAlgebra k Q,
       evalMap P A (x * y) = evalMap P A x * evalMap P A y := by
     intro x y
-    induction x using Finsupp.induction_linear with
+    induction x using PathAlgebra.induction_linear with
     | zero => rw [zero_mul, map_zero, zero_mul]
     | add x1 x2 hx1 hx2 => rw [add_mul, map_add, map_add, add_mul, hx1, hx2]
     | single sx a =>
-      induction y using Finsupp.induction_linear with
+      induction y using PathAlgebra.induction_linear with
       | zero => rw [mul_zero, map_zero, mul_zero]
       | add y1 y2 hy1 hy2 => rw [mul_add, map_add, map_add, mul_add, hy1, hy2]
       | single sy b =>
@@ -342,14 +349,14 @@ theorem defining_relations_universal [Fintype Q]
   intro ψ hψ
   apply AlgHom.ext
   intro z
-  induction z using Finsupp.induction_linear with
+  induction z using PathAlgebra.induction_linear with
   | zero => rw [map_zero, map_zero]
   | add u v hu hv => rw [map_add, map_add, hu, hv]
   | single x c =>
     obtain ⟨a, b, p⟩ := x
     have hsc : (Finsupp.single (⟨a, b, p⟩ : QuiverPathIndex Q) c : PathAlgebra k Q)
         = c • PathAlgebra.ofPath (k := k) (⟨a, b, p⟩ : QuiverPathIndex Q) := by
-      rw [PathAlgebra.ofPath, Finsupp.smul_single, smul_eq_mul, mul_one]
+      exact (PathAlgebra.smul_single_one c _).symm
     rw [hsc, map_smul, map_smul]
     congr 1
     clear hsc
@@ -442,3 +449,10 @@ theorem defining_relations_universal [Fintype Q]
 end Book
 
 end Etingof.Problem2_8_6
+
+-- The leaf names follow Mathlib conventions; the underscore comes solely from the stable
+-- book-number namespace `Problem2_8_6`, which is part of this project's public API.
+attribute [nolint defsWithUnderscore]
+  Etingof.Problem2_8_6.vertexIdem Etingof.Problem2_8_6.arrowGen
+  Etingof.Problem2_8_6.Book.vertexIdem Etingof.Problem2_8_6.Book.arrowGen
+  Etingof.Problem2_8_6.evalPath Etingof.Problem2_8_6.evalMap

--- a/progress/2026-07-27T13-36-56Z_stage3-5-chapter2-section2-8.md
+++ b/progress/2026-07-27T13-36-56Z_stage3-5-chapter2-section2-8.md
@@ -1,0 +1,47 @@
+# Stage 3.5 — Chapter 2, §2.8
+
+Completed the Mathlib-quality pass for the exact 15-item reading-order interval from
+`Definition2.8.1` through `Problem2.8.11`, including the three discussion items and the
+declaration-free editorial `Remark2.8.7`.
+
+## Scope and result
+
+- Reviewed all 12 Lean provider modules attached to the 15 catalog items and changed five of
+  them; the other seven were already clean.
+- Removed all six scoped elaboration warnings in `Problem2_8_6.lean`: the two path-evaluation
+  simp theorems now omit an unused `DecidableEq` instance, and intentionally unused universal-
+  property hypotheses use underscore-prefixed names.
+- Added documentation to the bundled path-module fields and reconstructed module instances,
+  removed two redundant simp attributes, and replaced transparency-sensitive raw-`Finsupp`
+  inductions and rewrites with the typed `PathAlgebra` API.
+- Removed six unnecessary direct imports. A final per-file `#redundant_imports` pass reports no
+  redundant import in any of the 12 modules.
+- Generalized `adjacencyMatrix` by removing an unused `Fintype Q` parameter and scoped the
+  corresponding application theorem to the assumptions it actually uses.
+- Documented narrow `defsWithUnderscore` exceptions caused solely by the stable book-number
+  namespaces `Example_2_8_2`, `Problem2_8_6`, and `Problem2_8_11`. The public leaf names follow
+  Mathlib naming conventions. `PathAlgebra` also has a documented `unusedArguments` exception:
+  its `DecidableEq Q` parameter intentionally indexes the multiplication API.
+
+## Verification
+
+- Temporary per-file `#lint`: all 16 default declaration linters passed in every provider,
+  covering 329 named and 256 automatically generated declarations with zero findings.
+- Temporary per-file `#redundant_imports`: no transitively redundant imports remain.
+- Standalone `lake env lean` elaboration passed for every provider with empty output after the
+  temporary diagnostic commands were removed.
+- A worktree-local `lake build EtingofRepresentationTheory.Chapter2` completed all 8,746 jobs
+  successfully. A scoped scan found no warning in any §2.8 provider; unrelated repository
+  warnings are outside this one-section PR.
+- `#print axioms` checked all 61 declarations recorded by Stage 3.3. None depends on `sorryAx`;
+  the reported dependencies are only standard Lean/Mathlib axioms such as `Classical.choice`,
+  `propext`, and `Quot.sound`.
+- Scoped scan found no `sorry`, `admit`, project `axiom`, or leftover lint/import diagnostic
+  commands.
+- `progress/items.json` parses successfully and exactly 15 §2.8 entries have
+  `status = proof_polished` with complete, verified `stage3_5` records.
+- The item, internal-dependency, and external-dependency validators all pass; item coverage is
+  5,721/5,721 source lines.
+
+The temporary `#lint` and `#redundant_imports` commands used during review were removed from the
+committed sources.

--- a/progress/items.json
+++ b/progress/items.json
@@ -1188,7 +1188,7 @@
     "end_page": "19",
     "start_line": 21,
     "end_line": 24,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -1225,6 +1225,13 @@
       "verified_on": "2026-07-27",
       "actual_internal_dependencies": [],
       "basis": "QuiverDef is an abbreviation of Mathlib's Quiver and its provider imports only Mathlib.Combinatorics.Quiver.Basic."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.8",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The focused Quiver abbreviation provider elaborates without warnings and passes all 16 declaration linters with no redundant imports."
     }
   },
   {
@@ -1235,7 +1242,7 @@
     "end_page": "19",
     "start_line": 25,
     "end_line": 30,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "coverage": "covered_full",
     "last_updated": "2026-07-22",
     "fidelity": "verified",
@@ -1274,6 +1281,13 @@
       "verified_on": "2026-07-27",
       "actual_internal_dependencies": [],
       "basis": "The concrete Fin 4 quiver is defined directly from Mathlib's Quiver API and uses no project declaration."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.8",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The concrete quiver and its three documented arrows pass all 16 declaration linters; the only naming exception is the stable book-number namespace."
     }
   },
   {
@@ -1284,7 +1298,7 @@
     "end_page": "19",
     "start_line": 31,
     "end_line": 34,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -1326,6 +1340,13 @@
       "verified_on": "2026-07-27",
       "actual_internal_dependencies": [],
       "basis": "The bundled-arrow notation now imports Mathlib.Combinatorics.Quiver.Basic directly and does not use QuiverDef or any earlier project item."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.8",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The bundled-arrow notation provider elaborates without warnings and passes all 16 declaration linters with no redundant imports."
     }
   },
   {
@@ -1336,7 +1357,7 @@
     "end_page": "19",
     "start_line": 35,
     "end_line": 35,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -1373,6 +1394,13 @@
       "verified_on": "2026-07-27",
       "actual_internal_dependencies": [],
       "basis": "QuiverRepresentation is defined directly from Mathlib's Quiver and LinearMap APIs and uses no earlier project declaration."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.8",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The quiver-representation structure provider elaborates without warnings and passes all 16 declaration linters with no redundant imports."
     }
   },
   {
@@ -1383,7 +1411,7 @@
     "end_page": "20",
     "start_line": 1,
     "end_line": 1,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -1437,6 +1465,13 @@
         "Chapter2/Definition2.8.3"
       ],
       "basis": "At this point in book order, the organizational announcement uses the quiver-representation notion from Definition 2.8.3. The path algebra and isomorphism-class theorem are the later declarations announced here, so they are not encoded as forward dependencies."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.8",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The path-algebra and correspondence providers have documented public API, irredundant imports, warning-free elaboration, and pass all 16 declaration linters."
     }
   },
   {
@@ -1447,7 +1482,7 @@
     "end_page": "20",
     "start_line": 2,
     "end_line": 4,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -1498,6 +1533,13 @@
       "verified_on": "2026-07-27",
       "actual_internal_dependencies": [],
       "basis": "PathAlgebra and BookPathAlgebra are constructed in a Mathlib-only provider from quiver paths, Finsupp linear sums, and opposite algebras."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.8",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The path-algebra API documents its intentional instance-indexed carrier, elaborates without warnings, and passes all 16 declaration linters with no redundant imports."
     }
   },
   {
@@ -1508,7 +1550,7 @@
     "end_page": "20",
     "start_line": 5,
     "end_line": 5,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "fidelity": "verified",
     "coverage": "covered_full",
     "coverage_note": "For a finite vertex type, BookPathAlgebra inherits a unital algebra structure from the opposite algebra and its trivial paths sum to one.",
@@ -1547,6 +1589,13 @@
         "Chapter2/Definition2.8.4"
       ],
       "basis": "The unit theorem is part of the path-algebra provider and uses only the BookPathAlgebra construction from Definition 2.8.4."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.8",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The unit theorem is documented, warning-free, axiom-clean, and passes all 16 declaration linters in its provider."
     }
   },
   {
@@ -1557,7 +1606,7 @@
     "end_page": "20",
     "start_line": 6,
     "end_line": 16,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "coverage": "covered_full",
     "last_updated": "2026-07-27",
     "coverage_note": "The Book namespace states and proves generation, all four printed relations in their exact source/target order, both annihilation clauses, and the defining-relations universal property for BookPathAlgebra.",
@@ -1624,6 +1673,13 @@
         "Chapter2/Definition2.8.4"
       ],
       "basis": "The generators, relations, and universal property use only the path-algebra API from Definition 2.8.4; the broad Mathlib import was replaced by focused subalgebra and Finsupp linear-combination imports."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.8",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The generators-relations provider is warning-free and passes all 16 declaration linters; only its stable book-number namespace has a documented naming exception."
     }
   },
   {
@@ -1634,7 +1690,7 @@
     "end_page": "21",
     "start_line": 17,
     "end_line": 4,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "coverage": "covered_full",
     "coverage_note": "The legacy PathAlgebra/Qᵒᵖ correspondence remains fully proved. The exact book-facing BookPathAlgebra/Q correspondence now constructs both assignments, proves their module and representation round trips, and packages the specified V↦(p_iV) and direct-sum inverse as an equivalence on isomorphism classes.",
     "last_updated": "2026-07-27",
@@ -1697,6 +1753,13 @@
         "Chapter2/Definition2.8.4"
       ],
       "basis": "The correspondence depends mathematically on quiver representations and the book-facing path algebra. Its source imports the later Definition 2.8.10 module for shared equivalence infrastructure, but the book-order dependency DAG records the earlier Definition 2.8.3 prerequisite and does not admit forward edges."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.8",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The correspondence provider now has documented bundled-module fields, nonredundant simp attributes and imports, warning-free elaboration, and all 16 declaration linters passing."
     }
   },
   {
@@ -1707,7 +1770,7 @@
     "end_page": "21",
     "start_line": 5,
     "end_line": 7,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "fidelity": "verified",
     "claim_coverage": {
       "stage": "3.2",
@@ -1743,6 +1806,13 @@
       "verified_on": "2026-07-27",
       "actual_internal_dependencies": [],
       "basis": "This item is solely editorial prose and introduces no declaration or mathematical dependency."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.8",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "This editorial item introduces no declaration; its section providers were verified warning-free, lint-clean, and irredundantly imported."
     }
   },
   {
@@ -1753,7 +1823,7 @@
     "end_page": "21",
     "start_line": 8,
     "end_line": 9,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -1793,6 +1863,13 @@
         "Chapter2/Definition2.8.3"
       ],
       "basis": "The subrepresentation construction depends directly on QuiverRepresentation; its redundant Submodule.Basic import was removed in favor of the focused Submodule.LinearMap API."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.8",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The morphism and equivalence provider elaborates without warnings and passes all 16 declaration linters with no redundant imports."
     }
   },
   {
@@ -1803,7 +1880,7 @@
     "end_page": "21",
     "start_line": 10,
     "end_line": 10,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "fidelity": "verified",
     "sorry_free": true,
     "fidelity_note": "The recovered blob states the binary direct sum exactly; the construction uses the canonical product model of a finite direct sum.",
@@ -1841,6 +1918,13 @@
         "Chapter2/Definition2.8.3"
       ],
       "basis": "The binary direct-sum construction uses QuiverRepresentation together with Mathlib's product linear-map API."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.8",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The irreducibility definition provider elaborates without warnings and passes all 16 declaration linters with no redundant imports."
     }
   },
   {
@@ -1851,7 +1935,7 @@
     "end_page": "21",
     "start_line": 11,
     "end_line": 13,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -1901,6 +1985,13 @@
         "Chapter2/Definition2.8.9"
       ],
       "basis": "The irreducible predicate uses subrepresentations and indecomposability uses direct sums. Representation-equivalence infrastructure is housed in the following Definition 2.8.10 provider and is therefore not encoded as a forward dependency."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.8",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The irreducibility and indecomposability discussion provider elaborates without warnings and passes all 16 declaration linters with no redundant imports."
     }
   },
   {
@@ -1911,7 +2002,7 @@
     "end_page": "21",
     "start_line": 14,
     "end_line": 14,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -1950,6 +2041,13 @@
         "Chapter2/Definition2.8.3"
       ],
       "basis": "Representation homomorphisms and equivalences are defined directly over QuiverRepresentation with Mathlib's linear-equivalence definitions."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.8",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The direct-sum and indecomposability provider elaborates without warnings and passes all 16 declaration linters with no redundant imports."
     }
   },
   {
@@ -1960,7 +2058,7 @@
     "end_page": "22",
     "start_line": 15,
     "end_line": 11,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "coverage": "covered_full",
     "coverage_note": "The locally finite positive grading and Hilbert-series definition are explicit. All four requested answers have exact graded-piece and generating-series proofs, including canonical supported-Finsupp bases identifying the free-algebra and path-algebra degree pieces with fixed-length words and paths.",
     "fidelity_decl": "theorem hilbertSeries_pathAlgebra, theorem inv_one_sub_smul_adjacencyPS",
@@ -2035,6 +2133,13 @@
         "Chapter2/Definition2.8.4"
       ],
       "basis": "The only project declaration used is PathAlgebra from Definition 2.8.4; the polynomial, exterior, power-series, cardinality, matrix, and basis arguments are Mathlib dependencies."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.8",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The Hilbert-series provider now has focused imports and a generalized adjacency-matrix API, elaborates without warnings, and passes all 16 declaration linters."
     }
   },
   {

--- a/scripts/lint-warning-baseline.txt
+++ b/scripts/lint-warning-baseline.txt
@@ -18,7 +18,6 @@ EtingofRepresentationTheory/Chapter2/Problem2_5_2.lean
 EtingofRepresentationTheory/Chapter2/Problem2_7_4.lean
 EtingofRepresentationTheory/Chapter2/Problem2_7_5.lean
 EtingofRepresentationTheory/Chapter2/Problem2_7_5_Family.lean
-EtingofRepresentationTheory/Chapter2/Problem2_8_6.lean
 EtingofRepresentationTheory/Chapter2/Proposition2_2_3.lean
 EtingofRepresentationTheory/Chapter2/Proposition2_7_1.lean
 EtingofRepresentationTheory/Chapter2/Sl2Irrep.lean


### PR DESCRIPTION
## Summary

- mark the exact 15-item Chapter 2 §2.8 interval `proof_polished` with complete Stage 3.5 records
- make the 12 providers warning-free and lint-clean, document narrow stable-namespace/API exceptions, and remove six redundant imports
- harden path-algebra proofs against transparency-sensitive standalone elaboration and record the full audit

## Validation

- all 16 default declaration linters on 329 named + 256 generated declarations: zero findings
- per-provider `#redundant_imports`: zero findings
- standalone `lake env lean` on all 12 providers: empty output
- `lake build EtingofRepresentationTheory.Chapter2`: 8,746 jobs successful; zero §2.8-provider warnings
- `#print axioms` on 61 tracked declarations: no `sorryAx`
- item, internal-dependency, and external-dependency validators: passed

Stacked on Stage 3.4 §2.8 (#8034).