### PR TITLE
Stage 3.5: polish Chapter 2 §2.13 proof

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Problem2_13_1.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_13_1.lean
@@ -37,47 +37,61 @@ namespace Etingof.Problem2_13_1
 
 open Real
 
-/-- The integer sequence `b₀ = 1`, `b₁ = 1`, `bₖ₊₂ = 2 bₖ₊₁ - 9 bₖ`. One has `bₖ = 3^k cos(kθ)`
-for `θ = arccos(1/3)` (see `Problem2_13_1.b_eq`) and `3 ∤ bₖ` (see `Problem2_13_1.b_not_dvd`). -/
-private def b : ℕ → ℤ
+/-- The integer sequence `b₀ = 1`, `b₁ = 1`, `bₖ₊₂ = 2 bₖ₊₁ - 9 bₖ`. One has
+`bₖ = 3^k cos(kθ)` for `θ = arccos(1/3)` and `3 ∤ bₖ`. -/
+private def scaledCosine : ℕ → ℤ
   | 0 => 1
   | 1 => 1
-  | (n + 2) => 2 * b (n + 1) - 9 * b n
+  | (n + 2) => 2 * scaledCosine (n + 1) - 9 * scaledCosine n
 
 /-- `bₖ = 3^k · cos(kθ)` whenever `cos θ = 1/3`. Proved by two-step induction using the Chebyshev
 recurrence `cos((k+2)θ) = 2 cos θ · cos((k+1)θ) - cos(kθ)`. -/
-private lemma b_eq (θ : ℝ) (hθ : cos θ = 1 / 3) (n : ℕ) :
-    (↑(b n) : ℝ) = 3 ^ n * cos (↑n * θ) ∧
-    (↑(b (n + 1)) : ℝ) = 3 ^ (n + 1) * cos (↑(n + 1) * θ) := by
+private lemma scaledCosine_eq (θ : ℝ) (hθ : cos θ = 1 / 3) (n : ℕ) :
+    (↑(scaledCosine n) : ℝ) = 3 ^ n * cos (↑n * θ) ∧
+    (↑(scaledCosine (n + 1)) : ℝ) = 3 ^ (n + 1) * cos (↑(n + 1) * θ) := by
   induction n with
-  | zero => refine ⟨?_, ?_⟩ <;> norm_num [b, hθ]
+  | zero => refine ⟨?_, ?_⟩ <;> norm_num [scaledCosine, hθ]
   | succ n ih =>
-    obtain ⟨hA, hB⟩ := ih
-    refine ⟨hB, ?_⟩
-    have hrec : (↑(b (n + 1 + 1)) : ℝ) = 2 * ↑(b (n + 1)) - 9 * ↑(b n) := by
-      have : b (n + 1 + 1) = 2 * b (n + 1) - 9 * b n := by simp only [b]
-      rw [this]; push_cast; ring
-    have R : cos ((↑(n + 1 + 1) : ℝ) * θ)
+    obtain ⟨hn, hnSucc⟩ := ih
+    refine ⟨hnSucc, ?_⟩
+    have hrec : (↑(scaledCosine (n + 1 + 1)) : ℝ) =
+        2 * ↑(scaledCosine (n + 1)) - 9 * ↑(scaledCosine n) := by
+      have hrecInt : scaledCosine (n + 1 + 1) =
+          2 * scaledCosine (n + 1) - 9 * scaledCosine n := by
+        simp only [scaledCosine]
+      rw [hrecInt]
+      push_cast
+      ring
+    have hcosRec : cos ((↑(n + 1 + 1) : ℝ) * θ)
         = 2 * cos θ * cos ((↑(n + 1) : ℝ) * θ) - cos ((↑n : ℝ) * θ) := by
-      have e1 : (↑(n + 1 + 1) : ℝ) * θ = (↑(n + 1) : ℝ) * θ + θ := by push_cast; ring
-      have e2 : (↑n : ℝ) * θ = (↑(n + 1) : ℝ) * θ - θ := by push_cast; ring
-      rw [e1, e2, Real.cos_add, Real.cos_sub]; ring
-    rw [hrec, hB, hA, R, hθ]
+      have e1 : (↑(n + 1 + 1) : ℝ) * θ = (↑(n + 1) : ℝ) * θ + θ := by
+        push_cast
+        ring
+      have e2 : (↑n : ℝ) * θ = (↑(n + 1) : ℝ) * θ - θ := by
+        push_cast
+        ring
+      rw [e1, e2, Real.cos_add, Real.cos_sub]
+      ring
+    rw [hrec, hnSucc, hn, hcosRec, hθ]
     ring
 
 /-- `3 ∤ bₖ` for every `k`: reducing the recurrence mod `3` gives `bₖ₊₂ ≡ 2 bₖ₊₁ (mod 3)`, so the
 residue stays in `{1, 2}` starting from `b₀ = b₁ = 1`. -/
-private lemma b_not_dvd (n : ℕ) : ¬ (3 ∣ b n) := by
-  have H : ∀ m : ℕ, (b m % 3 = 1 ∨ b m % 3 = 2) ∧ (b (m + 1) % 3 = 1 ∨ b (m + 1) % 3 = 2) := by
+private lemma three_not_dvd_scaledCosine (n : ℕ) : ¬ (3 ∣ scaledCosine n) := by
+  have hmod : ∀ m : ℕ,
+      (scaledCosine m % 3 = 1 ∨ scaledCosine m % 3 = 2) ∧
+        (scaledCosine (m + 1) % 3 = 1 ∨ scaledCosine (m + 1) % 3 = 2) := by
     intro m
     induction m with
     | zero => refine ⟨Or.inl ?_, Or.inl ?_⟩ <;> decide
     | succ m ih =>
       obtain ⟨_, h2⟩ := ih
       refine ⟨h2, ?_⟩
-      have hrec : b (m + 1 + 1) = 2 * b (m + 1) - 9 * b m := by simp only [b]
+      have hrec : scaledCosine (m + 1 + 1) =
+          2 * scaledCosine (m + 1) - 9 * scaledCosine m := by
+        simp only [scaledCosine]
       omega
-  have := (H n).1
+  have hnMod := (hmod n).1
   omega
 
 /-- **Problem 2.13.1(b).** The number `α = arccos(1/3)/π` is irrational. -/
@@ -97,12 +111,15 @@ theorem irrational_arccos_third_div_pi : Irrational (arccos (1 / 3) / π) := by
     have hθ2 : θ = (r : ℝ) * π := hr.symm
     rw [hθ2]; push_cast; linear_combination (2 * π) * hrq
   have hcos1 : cos ((↑(2 * r.den) : ℝ) * θ) = 1 := by
-    rw [harg]; exact Real.cos_int_mul_two_pi r.num
+    rw [harg]
+    exact Real.cos_int_mul_two_pi r.num
   -- Hence `b_{2·den} = 3^{2·den}`, but `3 ∤ b_{2·den}`.
-  have hkey := (b_eq θ hθcos (2 * r.den)).1
+  have hkey := (scaledCosine_eq θ hθcos (2 * r.den)).1
   rw [hcos1, mul_one] at hkey
-  have hb_eq : b (2 * r.den) = 3 ^ (2 * r.den) := by exact_mod_cast hkey
-  have hn0 : 2 * r.den ≠ 0 := by have := r.den_pos; omega
-  exact b_not_dvd (2 * r.den) (hb_eq ▸ dvd_pow_self 3 hn0)
+  have hb_eq : scaledCosine (2 * r.den) = 3 ^ (2 * r.den) := by exact_mod_cast hkey
+  have hn0 : 2 * r.den ≠ 0 := by
+    have hdenPos := r.den_pos
+    omega
+  exact three_not_dvd_scaledCosine (2 * r.den) (hb_eq ▸ dvd_pow_self 3 hn0)
 
 end Etingof.Problem2_13_1

--- a/EtingofRepresentationTheory/Chapter2/Problem2_13_1.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_13_1.lean
@@ -1,4 +1,5 @@
-import Mathlib
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Inverse
+import Mathlib.NumberTheory.Real.Irrational
 
 /-!
 # Problem 2.13.1: The Dehn invariant and Hilbert's third problem

--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -327,12 +327,8 @@
   "Chapter2/Definition2.12.1": [
     "Chapter2/Discussion_2.12_heading"
   ],
-  "Chapter2/Discussion_2.13_heading": [
-    "Chapter2/Definition2.12.1"
-  ],
-  "Chapter2/Problem2.13.1": [
-    "Chapter2/Discussion_2.13_heading"
-  ],
+  "Chapter2/Discussion_2.13_heading": [],
+  "Chapter2/Problem2.13.1": [],
   "Chapter2/Discussion_2.14_heading": [
     "Chapter2/Problem2.13.1"
   ],

--- a/progress/2026-07-27T13-35-00Z_stage3-3-chapter2-section2-13.md
+++ b/progress/2026-07-27T13-35-00Z_stage3-3-chapter2-section2-13.md
@@ -1,0 +1,24 @@
+# Stage 3.3 proof verification — Chapter 2 §2.13
+
+## Scope and result
+
+This pass keeps the exact two-item, ten-claim §2.13 scope established at Stage 3.2.
+The section heading has no proof obligation. The only public mathematical endpoint in the chosen
+project scope, `Etingof.Problem2_13_1.irrational_arccos_third_div_pi`, is fully proved and depends
+only on Lean's accepted foundational axioms `propext`, `Classical.choice`, and `Quot.sound`.
+
+The proof follows the book's arithmetic strategy through an equivalent Chebyshev recurrence:
+`b_k = 3^k cos(kθ)` for `θ = arccos(1/3)`, while `3 ∤ b_k`; rationality would force a positive
+index at which `b_k` equals a positive power of three. There are no `sorry`, `admit`, project
+`axiom`, `proof_wanted`, or `sorryAx` dependencies in this formalized endpoint.
+
+The five Dehn-invariant/scissors-congruence units remain explicit intentional omissions under
+`skipped-exercises.md`. Stage 3.3 does not mislabel those omissions as proved declarations.
+
+## Validation
+
+- isolated targeted provider build
+- full Chapter 2 build
+- scoped source admission scan
+- `#print axioms Etingof.Problem2_13_1.irrational_arccos_third_div_pi`
+- exact tracker scope/status checks, `jq empty`, and `git diff --check`

--- a/progress/2026-07-27T13-38-20Z_stage3-4-chapter2-section2-13.md
+++ b/progress/2026-07-27T13-38-20Z_stage3-4-chapter2-section2-13.md
@@ -1,0 +1,33 @@
+# Stage 3.4 dependency trimming: Chapter 2 §2.13
+
+## Scope
+
+This pass analyzes the actual dependencies of the two §2.13 catalog items after Stage 3.3:
+`Discussion_2.13_heading` and `Problem2.13.1`.
+
+## Result
+
+Both items are independent of earlier project items. The section heading is organizational only,
+and the formalized irrationality proof uses Mathlib directly. The two conservative reading-order
+edges were therefore removed from `dependencies/internal.json`.
+
+The proof provider no longer imports the `Mathlib` umbrella. It now imports only two focused
+modules: the inverse-trigonometric and irrational-number APIs. Both scoped items carry complete
+`stage3_4` records and move to `dependency_trimmed`.
+
+The five geometric claims intentionally omitted under `skipped-exercises.md` remain explicit
+scope decisions and introduce no dependency edges.
+
+## Validation
+
+- direct compilation of `Problem2_13_1.lean`
+- Mathlib's `#import_bumps`/`minImports` linter (no unneeded import remains)
+- full `EtingofRepresentationTheory.Chapter2` build
+- `scripts/validate_items.py`
+- `scripts/validate_dependencies.py`
+- `scripts/validate_external_deps.py`
+- exact two-item §2.13 metadata audit
+- `jq empty dependencies/internal.json progress/items.json`
+- `git diff --check`
+
+This PR is limited to Section 2.13 and Stage 3.4.

--- a/progress/2026-07-27T13-44-44Z_stage3-5-chapter2-section2-13.md
+++ b/progress/2026-07-27T13-44-44Z_stage3-5-chapter2-section2-13.md
@@ -1,0 +1,31 @@
+# Stage 3.5 — Chapter 2, §2.13
+
+Completed the Mathlib-quality pass for the exact two-item interval
+`Discussion_2.13_heading` through `Problem2.13.1`.
+
+## Scope and result
+
+- Reviewed the section's sole Lean provider and its one public theorem.
+- Renamed the private Chebyshev recurrence and its supporting lemmas descriptively, replaced
+  opaque local hypothesis names, and expanded compressed tactic sequences into readable blocks.
+- Kept every line within Mathlib's 100-character style limit.
+- Confirmed that the two focused imports selected at Stage 3.4 are transitively irredundant.
+- Preserved the five geometric intentional omissions recorded in `skipped-exercises.md`; this
+  quality pass does not misrepresent them as formalized declarations.
+
+## Verification
+
+- temporary `#lint+ docBlameThm`: all 17 declaration linters passed with zero findings for the
+  public theorem and its 25 automatically generated declarations
+- temporary `#redundant_imports`: no transitively redundant imports found
+- standalone provider elaboration completed without warnings after diagnostics were removed
+- `#print axioms Etingof.Problem2_13_1.irrational_arccos_third_div_pi`: only `propext`,
+  `Classical.choice`, and `Quot.sound`
+- scoped scan found no `sorry`, `admit`, `proof_wanted`, project `axiom`, or leftover diagnostic
+  command
+- full `EtingofRepresentationTheory.Chapter2` build
+- all three repository metadata/dependency validators
+- exact two-item Stage 3.5 metadata audit, JSON parsing, line-length scan, and `git diff --check`
+
+Both scoped items now have `status = proof_polished` and complete, verified `stage3_5` records.
+This PR is limited to Section 2.13 and Stage 3.5.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3686,7 +3686,7 @@
     "end_page": "36",
     "start_line": 17,
     "end_line": 17,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "fidelity": "verified",
     "claim_coverage": {
@@ -3712,6 +3712,13 @@
       "proof_integrity": "not_applicable",
       "declarations": []
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.13",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "This organizational heading makes no mathematical assertion and depends on no earlier project item."
+    },
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -3725,7 +3732,7 @@
     "end_page": "37",
     "start_line": 18,
     "end_line": 8,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_partial",
     "fidelity": "verified",
     "lean_decl": "Etingof.Problem2_13_1.irrational_arccos_third_div_pi",
@@ -3796,6 +3803,13 @@
         "Etingof.Problem2_13_1.irrational_arccos_third_div_pi"
       ],
       "scope_note": "Proof integrity applies to the two formalized proof units. The five Dehn-invariant/scissors-congruence units remain explicit intentional omissions under skipped-exercises.md and are not represented by declarations."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.13",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The formalized irrationality proof uses only focused Mathlib inverse-trigonometric and irrational-number modules; it imports no earlier project item. The five intentional geometric omissions introduce no dependency edges."
     },
     "last_updated": "2026-07-27"
   },

--- a/progress/items.json
+++ b/progress/items.json
@@ -3705,6 +3705,13 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.13",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "not_applicable",
+      "declarations": []
+    },
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -3779,6 +3786,16 @@
           "reason": "This is part (c), explicitly omitted in skipped-exercises.md."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.13",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Problem2_13_1.irrational_arccos_third_div_pi"
+      ],
+      "scope_note": "Proof integrity applies to the two formalized proof units. The five Dehn-invariant/scissors-congruence units remain explicit intentional omissions under skipped-exercises.md and are not represented by declarations."
     },
     "last_updated": "2026-07-27"
   },

--- a/progress/items.json
+++ b/progress/items.json
@@ -3686,7 +3686,7 @@
     "end_page": "36",
     "start_line": 17,
     "end_line": 17,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "coverage": "covered_full",
     "fidelity": "verified",
     "claim_coverage": {
@@ -3719,6 +3719,13 @@
       "actual_internal_dependencies": [],
       "basis": "This organizational heading makes no mathematical assertion and depends on no earlier project item."
     },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.13",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The organizational heading has no Lean declaration to polish; its paired section provider is warning-free, uses irredundant focused imports, and passes all 17 declaration linters."
+    },
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -3732,7 +3739,7 @@
     "end_page": "37",
     "start_line": 18,
     "end_line": 8,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "coverage": "covered_partial",
     "fidelity": "verified",
     "lean_decl": "Etingof.Problem2_13_1.irrational_arccos_third_div_pi",
@@ -3810,6 +3817,13 @@
       "verified_on": "2026-07-27",
       "actual_internal_dependencies": [],
       "basis": "The formalized irrationality proof uses only focused Mathlib inverse-trigonometric and irrational-number modules; it imports no earlier project item. The five intentional geometric omissions introduce no dependency edges."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.13",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The proof provider now uses descriptive private names, structured tactic blocks, lines within the Mathlib style limit, warning-free standalone elaboration, irredundant focused imports, and a clean 17-linter declaration audit."
     },
     "last_updated": "2026-07-27"
   },


### PR DESCRIPTION
Advances exactly Chapter 2 §2.13 through Stage 3.5 (Mathlib-quality polish).

- gives the private Chebyshev sequence and supporting lemmas descriptive names
- replaces opaque locals and compressed tactic sequences with readable proof structure
- keeps the provider warning-free and within the 100-character style limit
- records complete stage3_5 metadata for the exact two scoped items
- preserves the five explicit geometric intentional omissions

Validation:
- all 17 declaration linters: zero findings
- redundant-import audit: clean
- public theorem axioms: propext, Classical.choice, Quot.sound only
- scoped admission/diagnostic scan: clean
- full Chapter 2 build: 8,744 jobs
- all three repository validators, JSON, line-length, and diff checks