### PR TITLE
Stage 3.4: trim Chapter 2 §2.12 dependencies

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Definition2_12_1.lean
+++ b/EtingofRepresentationTheory/Chapter2/Definition2_12_1.lean
@@ -1,8 +1,3 @@
-import Mathlib.Data.Finsupp.Multiset
-import Mathlib.LinearAlgebra.SymmetricAlgebra.Basis
-import Mathlib.LinearAlgebra.ExteriorAlgebra.Basis
-import Mathlib.Algebra.Lie.UniversalEnveloping
-import Mathlib.LinearAlgebra.Basis.Defs
 import EtingofRepresentationTheory.Chapter2.Definition2_9_9
 import EtingofRepresentationTheory.Chapter2.Discussion_2_6
 import EtingofRepresentationTheory.Chapter2.Problem2_11_3_SymPowBasis

--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -321,11 +321,11 @@
   "Chapter2/Exercise2.11.7": [
     "Chapter2/Problem2.11.6"
   ],
-  "Chapter2/Discussion_2.12_heading": [
-    "Chapter2/Exercise2.11.7"
-  ],
+  "Chapter2/Discussion_2.12_heading": [],
   "Chapter2/Definition2.12.1": [
-    "Chapter2/Discussion_2.12_heading"
+    "Chapter2/Discussion_2.6",
+    "Chapter2/Definition2.9.9",
+    "Chapter2/Problem2.11.3"
   ],
   "Chapter2/Discussion_2.13_heading": [
     "Chapter2/Definition2.12.1"

--- a/progress/2026-07-27T13-54-45Z_stage3-4-chapter2-section2-12.md
+++ b/progress/2026-07-27T13-54-45Z_stage3-4-chapter2-section2-12.md
@@ -1,0 +1,66 @@
+# Stage 3.4 dependency and import review — Chapter 2 §2.12
+
+## Scope and inherited state
+
+This stacked review is based exactly on Stage 3.3 draft PR #8042 at commit `cf4cde87` and keeps
+the same two reading-order items: `Chapter2/Discussion_2.12_heading` and
+`Chapter2/Definition2.12.1`. They remain bounded by `Chapter2/Exercise2.11.7` and
+`Chapter2/Discussion_2.13_heading` in `progress/items.json`.
+
+The inherited internal graph still used the conservative reading-order chain:
+
+- `Discussion_2.12_heading ← Exercise2.11.7`;
+- `Definition2.12.1 ← Discussion_2.12_heading`.
+
+Neither edge reflects an actual project declaration dependency.
+
+## Genuine project-item dependencies
+
+The tensor-algebra discussion imports only Mathlib and therefore has no internal project-item
+dependency.
+
+Definition 2.12.1 has exactly three genuine backward dependencies:
+
+1. `Chapter2/Discussion_2.6`, supplying `PresentedAlgebra`, its quotient generators, lift, relator
+   theorem, and hom-extensionality principle used by the chosen-basis UEA presentation;
+2. `Chapter2/Definition2.9.9`, supplying the earlier `UniversalEnvelopingAlgebraDef` alias that
+   `ueaBasisAlgEquiv` explicitly connects to the coordinate-free construction;
+3. `Chapter2/Problem2.11.3`, supplying the book's exact `SymPow` and `ExtPow` quotient models,
+   their bases, and `exteriorPowerEquiv` used in both homogeneous decompositions.
+
+Accordingly, `dependencies/internal.json` removes both conservative chain edges and records these
+three exact edges. No other dependency or external-dependency record changes.
+
+## Import audit
+
+Temporary `#redundant_imports` and `#min_imports` diagnostics were run on both complete providers,
+then removed from the committed sources.
+
+- `Discussion_2_12_heading.lean`: no redundant imports; minImports retained exactly
+  `Mathlib.LinearAlgebra.TensorAlgebra.Basis` and
+  `Mathlib.LinearAlgebra.TensorAlgebra.ToTensorPower`.
+- `Definition2_12_1.lean`: the initial diagnostic identified all five direct Mathlib imports as
+  transitively redundant and retained exactly the three project imports above. After removing the
+  five imports, the diagnostic reported no redundancy and the same three-import minimum.
+
+The import-only source change preserves every declaration and proof term from Stages 3.2–3.3.
+
+## Durable tracker result
+
+- both exact items have status `dependency_trimmed` and complete section `2.12` `stage3_4`
+  objects;
+- actual internal-dependency split: zero for the discussion, three for the definition;
+- the Stage 3.2 claim-coverage and Stage 3.3 proof-integrity records remain unchanged;
+- no intentional omission is introduced or reclassified.
+
+## Validation
+
+- each scoped provider compiles standalone after the import trim;
+- `lake build EtingofRepresentationTheory.Chapter2`: success, with only pre-existing warnings
+  outside the scoped providers;
+- `python3 scripts/validate_items.py`: passed with full byte coverage;
+- `python3 scripts/validate_dependencies.py`: passed;
+- `python3 scripts/validate_external_deps.py`: passed;
+- exact scoped graph/tracker agreement, backward-edge ordering, three-edge aggregation, and
+  normalized non-scoped invariance: passed;
+- `jq empty` on both JSON files and `git diff --check`: passed.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3523,7 +3523,7 @@
     "end_page": "35",
     "start_line": 27,
     "end_line": 33,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage_swept": {
       "wave": 1,
       "result": "covered_full"
@@ -3575,6 +3575,13 @@
         "Etingof.tensorAlgebra_ι_injective"
       ],
       "basis": "All seven public declarations in the scoped provider resolve and are admission-free. The three source claims are witnessed by explicit algebra equivalences and homogeneous/generator formulas; injectivity of the degree-one inclusion rules out a vacuous model."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.12",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The provider uses only Mathlib's TensorAlgebra basis and tensor-power APIs and imports no project module. Lean's redundant-import and minImports diagnostics confirm that its two direct Mathlib imports are both transitively irredundant; the incoming Exercise 2.11.7 edge was reading order only."
     }
   },
   {
@@ -3585,7 +3592,7 @@
     "end_page": "36",
     "start_line": 1,
     "end_line": 16,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -3676,6 +3683,17 @@
         "Etingof.coordFreeToUeaBasis_unique"
       ],
       "basis": "All twenty-five public declarations in the scoped provider resolve and are admission-free. The quotient relations, basis identifications, homogeneous decompositions, and the two-sided universal-enveloping algebra equivalence are supported by explicit proofs or Mathlib constructions; there are no intentional omissions in this item."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.12",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Discussion_2.6",
+        "Chapter2/Definition2.9.9",
+        "Chapter2/Problem2.11.3"
+      ],
+      "basis": "PresentedAlgebra and its universal property come from Discussion 2.6; the earlier UEA alias bridged by ueaBasisAlgEquiv comes from Definition 2.9.9; and the exact SymPow/ExtPow quotient models, bases, and exterior-power equivalence come from Problem 2.11.3. minImports identified exactly these three project imports. Five direct Mathlib imports were transitively redundant and have been removed."
     }
   },
   {


### PR DESCRIPTION
## Summary

- complete the Stage 3.4 dependency/import audit for the exact two-item Chapter 2 §2.12 scope inherited from PR #8042
- replace two conservative reading-order edges with the three genuine project-item dependencies used by Definition 2.12.1
- remove five transitively redundant direct Mathlib imports from the definition provider
- record canonical `stage3_4` metadata and a durable audit note

## Dependency result

- `Chapter2/Discussion_2.12_heading`: no project-item dependencies; its old Exercise 2.11.7 edge was reading order only
- `Chapter2/Definition2.12.1`: exact dependencies are `Chapter2/Discussion_2.6`, `Chapter2/Definition2.9.9`, and `Chapter2/Problem2.11.3`

All three genuine edges point backward in reading order. Non-scoped internal and all external dependency data are unchanged.

## Import result

Temporary `#redundant_imports` and `#min_imports` diagnostics found:

- the discussion provider’s two TensorAlgebra imports are both irredundant
- the definition provider’s five direct Mathlib imports were redundant
- the definition’s exact import minimum is its three genuine project imports

The import-only Lean change preserves every declaration and proof term.

## Validation

- both providers compiled standalone after trimming
- `lake build EtingofRepresentationTheory.Chapter2` — success (8,745 jobs)
- `python3 scripts/validate_items.py`
- `python3 scripts/validate_dependencies.py`
- `python3 scripts/validate_external_deps.py`
- exact graph/tracker agreement, backward-edge ordering, normalized non-scope invariance, JSON, and diff checks

All checks pass. Full-build warnings are pre-existing and outside the scoped providers.

## Stack

This draft targets `agent/stage3-3-ch2-s2-12` (draft PR #8042), not `main`.
