### PR TITLE
Stage 3.3: verify Chapter 2 §2.14 proofs

### DIFF
--- a/progress/2026-07-27T13-58-35Z_stage3-3-chapter2-section2-14.md
+++ b/progress/2026-07-27T13-58-35Z_stage3-3-chapter2-section2-14.md
@@ -1,0 +1,25 @@
+# Stage 3.3 proof verification — Chapter 2 §2.14
+
+## Scope and result
+
+This pass keeps the exact four-item, eight-unit §2.14 scope established at Stage 3.2. The section
+heading has no proof obligation. All eight public declarations supplied by the three mathematical
+providers were audited: the tensor-product and dual aliases and their action equations, plus the
+two internal equivalences, the public tensor–Hom adjunction, and its compatibility wrapper.
+
+Every declaration is free of `sorry`, `admit`, project `axiom`, `proof_wanted`, and `sorryAx`
+dependencies. `#print axioms` reports only Lean's accepted foundational axioms `propext`,
+`Classical.choice`, and `Quot.sound` where applicable; the dual alias itself is axiom-free.
+No proof repair was required at this stage.
+
+## Validation
+
+- isolated builds of all three providers
+- scoped source admission and project-axiom scan
+- `#print axioms` on all eight public declarations
+- exact four-item Stage 3.3 tracker audit
+- all three repository metadata/dependency validators
+- full Chapter 2 build
+- JSON parsing and `git diff --check`
+
+This PR is limited to Section 2.14 and Stage 3.3.

--- a/progress/items.json
+++ b/progress/items.json
@@ -4186,6 +4186,13 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.14",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "not_applicable",
+      "declarations": []
+    },
     "last_updated": "2026-07-27",
     "coverage_swept": {
       "wave": 1,
@@ -4226,6 +4233,16 @@
           "verdict": "formalized",
           "lean_decl": "Etingof.LieTensorProduct.lie_tmul"
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.14",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.LieTensorProduct",
+        "Etingof.LieTensorProduct.lie_tmul"
       ]
     },
     "last_updated": "2026-07-27"
@@ -4271,6 +4288,16 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.14",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.LieDualRepresentation",
+        "Etingof.lieDualRepresentation_lie_apply"
+      ]
+    },
     "last_updated": "2026-07-27"
   },
   {
@@ -4307,6 +4334,18 @@
           "lean_decl": "Etingof.Exercise2_9_11.repEquiv",
           "note": "The earlier exercise formalizes the universal-property equivalence between Lie representations and U(𝔤)-representations; Problem 2.14.3 uses Mathlib's equivalent LieModuleHom model for the morphism spaces."
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.14",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Problem2_14_3.dualHomEquiv",
+        "Etingof.Problem2_14_3.congrHomRight",
+        "Etingof.Problem2_14_3.tensorHomAdjunction",
+        "Etingof.Problem2_14_3.exists_tensorHom_adjunction"
       ]
     },
     "last_updated": "2026-07-27"


### PR DESCRIPTION
## Scope

Stage 3.3 proof-integrity verification for the exact four-item Section 2.14 interval established in #8044.

## Result

- Audits all eight public declarations across the three mathematical providers.
- Finds no `sorry`, `admit`, project `axiom`, `proof_wanted`, or `sorryAx` dependency.
- `#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound` where applicable; `Etingof.LieDualRepresentation` itself is axiom-free.
- No proof repair was required.

## Validation

- Isolated builds of all three providers
- Scoped source admission/project-axiom scan
- `#print axioms` on all eight public declarations
- Fresh full `EtingofRepresentationTheory.Chapter2` build: 8,744 jobs
- All three repository metadata/dependency validators
- Exact-scope JSON audit and `git diff --check`