### PR TITLE
Stage 3.4: trim Chapter 2 §2.14 dependencies

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Problem2_14_3.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_14_3.lean
@@ -1,4 +1,9 @@
-import Mathlib
+import Mathlib.Algebra.Lie.TensorProduct
+import Mathlib.Algebra.Module.StablyFree.Basic
+import Mathlib.LinearAlgebra.Contraction
+import Mathlib.LinearAlgebra.FreeModule.PID
+import Mathlib.RingTheory.Flat.TorsionFree
+import Mathlib.RingTheory.SimpleRing.Principal
 
 /-!
 # Problem 2.14.3: The tensor-Hom adjunction for Lie algebra representations

--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -333,18 +333,10 @@
   "Chapter2/Problem2.13.1": [
     "Chapter2/Discussion_2.13_heading"
   ],
-  "Chapter2/Discussion_2.14_heading": [
-    "Chapter2/Problem2.13.1"
-  ],
-  "Chapter2/Definition2.14.1": [
-    "Chapter2/Discussion_2.14_heading"
-  ],
-  "Chapter2/Definition2.14.2": [
-    "Chapter2/Definition2.14.1"
-  ],
-  "Chapter2/Problem2.14.3": [
-    "Chapter2/Definition2.14.2"
-  ],
+  "Chapter2/Discussion_2.14_heading": [],
+  "Chapter2/Definition2.14.1": [],
+  "Chapter2/Definition2.14.2": [],
+  "Chapter2/Problem2.14.3": [],
   "Chapter2/Discussion_2.15_heading": [
     "Chapter2/Problem2.14.3"
   ],

--- a/progress/2026-07-27T13-58-35Z_stage3-3-chapter2-section2-14.md
+++ b/progress/2026-07-27T13-58-35Z_stage3-3-chapter2-section2-14.md
@@ -1,0 +1,25 @@
+# Stage 3.3 proof verification — Chapter 2 §2.14
+
+## Scope and result
+
+This pass keeps the exact four-item, eight-unit §2.14 scope established at Stage 3.2. The section
+heading has no proof obligation. All eight public declarations supplied by the three mathematical
+providers were audited: the tensor-product and dual aliases and their action equations, plus the
+two internal equivalences, the public tensor–Hom adjunction, and its compatibility wrapper.
+
+Every declaration is free of `sorry`, `admit`, project `axiom`, `proof_wanted`, and `sorryAx`
+dependencies. `#print axioms` reports only Lean's accepted foundational axioms `propext`,
+`Classical.choice`, and `Quot.sound` where applicable; the dual alias itself is axiom-free.
+No proof repair was required at this stage.
+
+## Validation
+
+- isolated builds of all three providers
+- scoped source admission and project-axiom scan
+- `#print axioms` on all eight public declarations
+- exact four-item Stage 3.3 tracker audit
+- all three repository metadata/dependency validators
+- full Chapter 2 build
+- JSON parsing and `git diff --check`
+
+This PR is limited to Section 2.14 and Stage 3.3.

--- a/progress/2026-07-27T14-04-32Z_stage3-4-chapter2-section2-14.md
+++ b/progress/2026-07-27T14-04-32Z_stage3-4-chapter2-section2-14.md
@@ -1,0 +1,32 @@
+# Stage 3.4 dependency trimming — Chapter 2 §2.14
+
+## Scope
+
+This pass analyzes the actual dependencies of the exact four §2.14 catalog items after Stage 3.3:
+the section heading, both definitions, and Problem 2.14.3.
+
+## Result
+
+All four scoped items are independent of earlier project items. The heading is organizational;
+the three mathematical providers construct the tensor-product representation, dual
+representation, and tensor–Hom adjunction directly from Mathlib APIs. The four conservative
+reading-order edges were therefore removed from `dependencies/internal.json`.
+
+The two definition providers already had irredundant focused imports. The problem provider no
+longer imports the `Mathlib` umbrella: it now uses the six focused modules reported by Mathlib's
+`#min_imports` command, and `#redundant_imports` confirms that none is transitively redundant.
+All four items carry complete `stage3_4` records and move to `dependency_trimmed`.
+
+## Validation
+
+- direct compilation of all three providers
+- Mathlib's `#redundant_imports` and `#min_imports` diagnostics
+- full `EtingofRepresentationTheory.Chapter2` build
+- `scripts/validate_items.py`
+- `scripts/validate_dependencies.py`
+- `scripts/validate_external_deps.py`
+- exact four-item §2.14 graph/tracker audit
+- `jq empty dependencies/internal.json progress/items.json`
+- `git diff --check`
+
+This PR is limited to Section 2.14 and Stage 3.4.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3809,6 +3809,13 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.14",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "not_applicable",
+      "declarations": []
+    },
     "last_updated": "2026-07-27",
     "coverage_swept": {
       "wave": 1,
@@ -3849,6 +3856,16 @@
           "verdict": "formalized",
           "lean_decl": "Etingof.LieTensorProduct.lie_tmul"
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.14",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.LieTensorProduct",
+        "Etingof.LieTensorProduct.lie_tmul"
       ]
     },
     "last_updated": "2026-07-27"
@@ -3894,6 +3911,16 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.14",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.LieDualRepresentation",
+        "Etingof.lieDualRepresentation_lie_apply"
+      ]
+    },
     "last_updated": "2026-07-27"
   },
   {
@@ -3930,6 +3957,18 @@
           "lean_decl": "Etingof.Exercise2_9_11.repEquiv",
           "note": "The earlier exercise formalizes the universal-property equivalence between Lie representations and U(𝔤)-representations; Problem 2.14.3 uses Mathlib's equivalent LieModuleHom model for the morphism spaces."
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.14",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Problem2_14_3.dualHomEquiv",
+        "Etingof.Problem2_14_3.congrHomRight",
+        "Etingof.Problem2_14_3.tensorHomAdjunction",
+        "Etingof.Problem2_14_3.exists_tensorHom_adjunction"
       ]
     },
     "last_updated": "2026-07-27"

--- a/progress/items.json
+++ b/progress/items.json
@@ -3790,7 +3790,7 @@
     "end_page": "37",
     "start_line": 9,
     "end_line": 9,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "fidelity": "verified",
     "claim_coverage": {
@@ -3816,6 +3816,13 @@
       "proof_integrity": "not_applicable",
       "declarations": []
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.14",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "This organizational heading makes no mathematical assertion and depends on no earlier project item."
+    },
     "last_updated": "2026-07-27",
     "coverage_swept": {
       "wave": 1,
@@ -3830,7 +3837,7 @@
     "end_page": "37",
     "start_line": 10,
     "end_line": 14,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "fidelity_decl": "Etingof.LieTensorProduct (abbrev) := TensorProduct k V W; Etingof.LieTensorProduct.lie_tmul",
@@ -3868,6 +3875,13 @@
         "Etingof.LieTensorProduct.lie_tmul"
       ]
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.14",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The tensor-product representation alias and action equation use only Mathlib's focused Lie tensor-product API and import no earlier project item."
+    },
     "last_updated": "2026-07-27"
   },
   {
@@ -3878,7 +3892,7 @@
     "end_page": "37",
     "start_line": 15,
     "end_line": 17,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "fidelity_decl": "Etingof.LieDualRepresentation (abbrev) := Module.Dual k V, with contragredient LieRingModule/LieModule structure (Mathlib.Algebra.Lie.Basic) and characterizing lemma lieDualRepresentation_lie_apply : ⁅x,f⁆ v = -f ⁅x,v⁆",
@@ -3921,6 +3935,13 @@
         "Etingof.lieDualRepresentation_lie_apply"
       ]
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.14",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The dual representation alias and contragredient action equation use only focused Mathlib Lie and dual-space APIs and import no earlier project item."
+    },
     "last_updated": "2026-07-27"
   },
   {
@@ -3931,7 +3952,7 @@
     "end_page": "37",
     "start_line": 18,
     "end_line": 20,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "fidelity": "verified",
     "sorry_free": true,
@@ -3970,6 +3991,13 @@
         "Etingof.Problem2_14_3.tensorHomAdjunction",
         "Etingof.Problem2_14_3.exists_tensorHom_adjunction"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.14",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The tensor–Hom adjunction is constructed directly from focused Mathlib tensor-product, duality, and finite-dimensional APIs; its provider imports no earlier project item."
     },
     "last_updated": "2026-07-27"
   },


### PR DESCRIPTION
## Scope

Stage 3.4 dependency/import trimming for the exact four-item Section 2.14 interval established in #8044 and verified in #8046.

## Result

- Removes all four conservative reading-order edges; each scoped provider is independent of earlier project items.
- Replaces the `Mathlib` umbrella in `Problem2_14_3.lean` with the six focused modules reported by `#min_imports`.
- Confirms the two definition providers already have focused irredundant imports.
- Marks all four scoped tracker items `dependency_trimmed` with exact empty internal-dependency lists.

## Validation

- Direct builds of all three providers (focused closure: 2,354 jobs)
- `#redundant_imports` and `#min_imports` diagnostics
- Fresh full `EtingofRepresentationTheory.Chapter2` build: 8,744 jobs
- All three repository metadata/dependency validators (578 internal edges)
- Exact graph/tracker audit, JSON parsing, and `git diff --check`