### PR TITLE
Stage 3.5: polish Chapter 2 §2.12 proofs

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Definition2_12_1.lean
+++ b/EtingofRepresentationTheory/Chapter2/Definition2_12_1.lean
@@ -243,7 +243,7 @@ noncomputable def coordFreeToUeaBasis :
   simp [ueaBasisToCoordFree]
 
 /-- Formula for the inverse map on the canonical image of a Lie algebra element. -/
-@[simp] theorem coordFreeToUeaBasis_ι (x : L) :
+theorem coordFreeToUeaBasis_ι (x : L) :
     coordFreeToUeaBasis k L b (UniversalEnvelopingAlgebra.ι k x) =
       basisGenLinear k L b x := by
   rw [coordFreeToUeaBasis, UniversalEnvelopingAlgebra.lift_ι_apply]

--- a/EtingofRepresentationTheory/Chapter2/Definition2_12_1.lean
+++ b/EtingofRepresentationTheory/Chapter2/Definition2_12_1.lean
@@ -1,8 +1,3 @@
-import Mathlib.Data.Finsupp.Multiset
-import Mathlib.LinearAlgebra.SymmetricAlgebra.Basis
-import Mathlib.LinearAlgebra.ExteriorAlgebra.Basis
-import Mathlib.Algebra.Lie.UniversalEnveloping
-import Mathlib.LinearAlgebra.Basis.Defs
 import EtingofRepresentationTheory.Chapter2.Definition2_9_9
 import EtingofRepresentationTheory.Chapter2.Discussion_2_6
 import EtingofRepresentationTheory.Chapter2.Problem2_11_3_SymPowBasis

--- a/EtingofRepresentationTheory/Chapter2/Discussion_2_12_heading.lean
+++ b/EtingofRepresentationTheory/Chapter2/Discussion_2_12_heading.lean
@@ -34,7 +34,7 @@ noncomputable def tensorAlgebraEquivDirectSum :
 
 /-- Under the direct-sum description, a pure `n`-fold tensor lies in exactly the degree-`n`
 summand. -/
-@[simp] theorem tensorAlgebraEquivDirectSum_tprod {n : ℕ} (x : Fin n → V) :
+theorem tensorAlgebraEquivDirectSum_tprod {n : ℕ} (x : Fin n → V) :
     tensorAlgebraEquivDirectSum k V (TensorAlgebra.tprod k V n x) =
       DirectSum.of (fun n : ℕ => ⨂[k]^n V) n (PiTensorProduct.tprod k x) :=
   TensorAlgebra.toDirectSum_tensorPower_tprod x

--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -321,11 +321,11 @@
   "Chapter2/Exercise2.11.7": [
     "Chapter2/Problem2.11.6"
   ],
-  "Chapter2/Discussion_2.12_heading": [
-    "Chapter2/Exercise2.11.7"
-  ],
+  "Chapter2/Discussion_2.12_heading": [],
   "Chapter2/Definition2.12.1": [
-    "Chapter2/Discussion_2.12_heading"
+    "Chapter2/Discussion_2.6",
+    "Chapter2/Definition2.9.9",
+    "Chapter2/Problem2.11.3"
   ],
   "Chapter2/Discussion_2.13_heading": [
     "Chapter2/Definition2.12.1"

--- a/progress/2026-07-27T13-54-45Z_stage3-4-chapter2-section2-12.md
+++ b/progress/2026-07-27T13-54-45Z_stage3-4-chapter2-section2-12.md
@@ -1,0 +1,66 @@
+# Stage 3.4 dependency and import review — Chapter 2 §2.12
+
+## Scope and inherited state
+
+This stacked review is based exactly on Stage 3.3 draft PR #8042 at commit `cf4cde87` and keeps
+the same two reading-order items: `Chapter2/Discussion_2.12_heading` and
+`Chapter2/Definition2.12.1`. They remain bounded by `Chapter2/Exercise2.11.7` and
+`Chapter2/Discussion_2.13_heading` in `progress/items.json`.
+
+The inherited internal graph still used the conservative reading-order chain:
+
+- `Discussion_2.12_heading ← Exercise2.11.7`;
+- `Definition2.12.1 ← Discussion_2.12_heading`.
+
+Neither edge reflects an actual project declaration dependency.
+
+## Genuine project-item dependencies
+
+The tensor-algebra discussion imports only Mathlib and therefore has no internal project-item
+dependency.
+
+Definition 2.12.1 has exactly three genuine backward dependencies:
+
+1. `Chapter2/Discussion_2.6`, supplying `PresentedAlgebra`, its quotient generators, lift, relator
+   theorem, and hom-extensionality principle used by the chosen-basis UEA presentation;
+2. `Chapter2/Definition2.9.9`, supplying the earlier `UniversalEnvelopingAlgebraDef` alias that
+   `ueaBasisAlgEquiv` explicitly connects to the coordinate-free construction;
+3. `Chapter2/Problem2.11.3`, supplying the book's exact `SymPow` and `ExtPow` quotient models,
+   their bases, and `exteriorPowerEquiv` used in both homogeneous decompositions.
+
+Accordingly, `dependencies/internal.json` removes both conservative chain edges and records these
+three exact edges. No other dependency or external-dependency record changes.
+
+## Import audit
+
+Temporary `#redundant_imports` and `#min_imports` diagnostics were run on both complete providers,
+then removed from the committed sources.
+
+- `Discussion_2_12_heading.lean`: no redundant imports; minImports retained exactly
+  `Mathlib.LinearAlgebra.TensorAlgebra.Basis` and
+  `Mathlib.LinearAlgebra.TensorAlgebra.ToTensorPower`.
+- `Definition2_12_1.lean`: the initial diagnostic identified all five direct Mathlib imports as
+  transitively redundant and retained exactly the three project imports above. After removing the
+  five imports, the diagnostic reported no redundancy and the same three-import minimum.
+
+The import-only source change preserves every declaration and proof term from Stages 3.2–3.3.
+
+## Durable tracker result
+
+- both exact items have status `dependency_trimmed` and complete section `2.12` `stage3_4`
+  objects;
+- actual internal-dependency split: zero for the discussion, three for the definition;
+- the Stage 3.2 claim-coverage and Stage 3.3 proof-integrity records remain unchanged;
+- no intentional omission is introduced or reclassified.
+
+## Validation
+
+- each scoped provider compiles standalone after the import trim;
+- `lake build EtingofRepresentationTheory.Chapter2`: success, with only pre-existing warnings
+  outside the scoped providers;
+- `python3 scripts/validate_items.py`: passed with full byte coverage;
+- `python3 scripts/validate_dependencies.py`: passed;
+- `python3 scripts/validate_external_deps.py`: passed;
+- exact scoped graph/tracker agreement, backward-edge ordering, three-edge aggregation, and
+  normalized non-scoped invariance: passed;
+- `jq empty` on both JSON files and `git diff --check`: passed.

--- a/progress/2026-07-27T14-04-11Z_stage3-5-chapter2-section2-12.md
+++ b/progress/2026-07-27T14-04-11Z_stage3-5-chapter2-section2-12.md
@@ -1,0 +1,59 @@
+# Stage 3.5 Mathlib-quality review — Chapter 2 §2.12
+
+## Scope and inherited state
+
+This stacked review is based exactly on Stage 3.4 draft PR #8045 at commit `18eb5145` and keeps
+the same two reading-order items: `Chapter2/Discussion_2.12_heading` and
+`Chapter2/Definition2.12.1`. The review covers all 32 public declarations defined by their two
+providers: seven in the tensor-algebra discussion and twenty-five in Definition 2.12.1.
+
+Stages 3.2–3.4 had already established full claim coverage, admission-free proof integrity, and
+the exact minimal import/dependency surface. Stage 3.5 preserves those mathematical statements,
+proof terms, and graph records.
+
+## Declaration and source review
+
+Temporary `#lint+ docBlameThm`, `#redundant_imports`, and `#min_imports` commands were run inside
+both complete providers and then removed.
+
+The first 17-linter pass found exactly two `simpNF` issues:
+
+1. `tensorAlgebraEquivDirectSum_tprod` was marked `[simp]`, although Mathlib first normalizes
+   `TensorAlgebra.tprod` to the product of degree-one generators;
+2. `coordFreeToUeaBasis_ι` was marked `[simp]`, although Mathlib first unfolds the canonical UEA
+   inclusion to `UniversalEnvelopingAlgebra.mkAlgHom` applied to `TensorAlgebra.ι`.
+
+Both book-facing statements are clearer in their existing forms, so the justified repair is to
+retain the public theorems and remove only the inappropriate simp registrations. The second full
+linter pass reports zero errors: all 17 linters pass for 7 declarations in the discussion and 25
+declarations plus 27 generated declarations in the definition provider.
+
+Manual review confirms descriptive namespace-qualified names, complete declaration docstrings,
+focused theorem statements, explicit universal-property proofs, and no fragile or deprecated
+tactic pattern. Both files have zero lines over Mathlib's 100-character style limit and elaborate
+standalone without warnings. Their Stage 3.4 import minima remain transitively irredundant.
+
+## Integrity result
+
+The declaration-wide `#print axioms` audit for all 32 public declarations reports only `propext`,
+`Classical.choice`, and `Quot.sound`. The scoped scan finds no `sorry`, `admit`, `proof_wanted`,
+project `axiom`, vacuous `True` endpoint, or leftover diagnostic command.
+
+## Durable tracker result
+
+- both exact items now have status `proof_polished`;
+- both have complete, verified section `2.12` `stage3_5` objects;
+- the Stage 3.2 claim, Stage 3.3 proof-integrity, and Stage 3.4 dependency records are unchanged;
+- no item, provider, graph record, or metadata outside §2.12 is modified.
+
+## Validation
+
+- both scoped providers build and elaborate standalone in the isolated worktree;
+- `lake build EtingofRepresentationTheory.Chapter2`: success, with only pre-existing warnings
+  outside the scoped providers;
+- all 32 public declarations pass the foundational-axiom audit;
+- `python3 scripts/validate_items.py`: passed with full byte coverage;
+- `python3 scripts/validate_dependencies.py`: passed;
+- `python3 scripts/validate_external_deps.py`: passed;
+- exact Stage 3.5 scope/status aggregation, normalized non-scoped invariance, JSON parsing,
+  line-length/admission/diagnostic scans, and `git diff --check`: passed.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3523,7 +3523,7 @@
     "end_page": "35",
     "start_line": 27,
     "end_line": 33,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage_swept": {
       "wave": 1,
       "result": "covered_full"
@@ -3575,6 +3575,13 @@
         "Etingof.tensorAlgebra_ι_injective"
       ],
       "basis": "All seven public declarations in the scoped provider resolve and are admission-free. The three source claims are witnessed by explicit algebra equivalences and homogeneous/generator formulas; injectivity of the degree-one inclusion rules out a vacuous model."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.12",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The provider uses only Mathlib's TensorAlgebra basis and tensor-power APIs and imports no project module. Lean's redundant-import and minImports diagnostics confirm that its two direct Mathlib imports are both transitively irredundant; the incoming Exercise 2.11.7 edge was reading order only."
     }
   },
   {
@@ -3585,7 +3592,7 @@
     "end_page": "36",
     "start_line": 1,
     "end_line": 16,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -3676,6 +3683,17 @@
         "Etingof.coordFreeToUeaBasis_unique"
       ],
       "basis": "All twenty-five public declarations in the scoped provider resolve and are admission-free. The quotient relations, basis identifications, homogeneous decompositions, and the two-sided universal-enveloping algebra equivalence are supported by explicit proofs or Mathlib constructions; there are no intentional omissions in this item."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.12",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Discussion_2.6",
+        "Chapter2/Definition2.9.9",
+        "Chapter2/Problem2.11.3"
+      ],
+      "basis": "PresentedAlgebra and its universal property come from Discussion 2.6; the earlier UEA alias bridged by ueaBasisAlgEquiv comes from Definition 2.9.9; and the exact SymPow/ExtPow quotient models, bases, and exterior-power equivalence come from Problem 2.11.3. minImports identified exactly these three project imports. Five direct Mathlib imports were transitively redundant and have been removed."
     }
   },
   {

--- a/progress/items.json
+++ b/progress/items.json
@@ -3523,7 +3523,7 @@
     "end_page": "35",
     "start_line": 27,
     "end_line": 33,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "coverage_swept": {
       "wave": 1,
       "result": "covered_full"
@@ -3582,6 +3582,16 @@
       "verified_on": "2026-07-27",
       "actual_internal_dependencies": [],
       "basis": "The provider uses only Mathlib's TensorAlgebra basis and tensor-power APIs and imports no project module. Lean's redundant-import and minImports diagnostics confirm that its two direct Mathlib imports are both transitively irredundant; the incoming Exercise 2.11.7 edge was reading order only."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.12",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "source_review": "complete",
+      "imports": "no_transitively_redundant_imports",
+      "declaration_lints": "passed_17",
+      "result": "All seven public declarations are documented, warning-free, within the 100-character limit, and pass the 16 default declaration linters plus docBlameThm. The non-normal tensor-power formula remains as a readable theorem but is no longer registered as a simp lemma, resolving the sole simpNF finding without changing its statement."
     }
   },
   {
@@ -3592,7 +3602,7 @@
     "end_page": "36",
     "start_line": 1,
     "end_line": 16,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -3694,6 +3704,16 @@
         "Chapter2/Problem2.11.3"
       ],
       "basis": "PresentedAlgebra and its universal property come from Discussion 2.6; the earlier UEA alias bridged by ueaBasisAlgEquiv comes from Definition 2.9.9; and the exact SymPow/ExtPow quotient models, bases, and exterior-power equivalence come from Problem 2.11.3. minImports identified exactly these three project imports. Five direct Mathlib imports were transitively redundant and have been removed."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "2.12",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "source_review": "complete",
+      "imports": "no_transitively_redundant_imports",
+      "declaration_lints": "passed_17",
+      "result": "All twenty-five public declarations are documented, warning-free, within the 100-character limit, and pass the 16 default declaration linters plus docBlameThm. The readable UEA generator formula remains public but is no longer registered as a non-normal simp lemma; all other names, statements, proofs, and API attributes were already robust."
     }
   },
   {


### PR DESCRIPTION
## Summary

- complete the Stage 3.5 Mathlib-quality review for the exact two-item Chapter 2 §2.12 scope inherited from PR #8045
- audit all 32 public declarations for documentation, naming, style, proof robustness, declaration linting, import redundancy, line length, and axiom integrity
- resolve the only two declaration-linter findings by removing inappropriate `[simp]` registrations while preserving both readable public theorem statements
- record canonical `stage3_5` metadata and a durable audit note

## Repairs

The initial 17-linter pass found two `simpNF` issues:

- `tensorAlgebraEquivDirectSum_tprod` is intentionally stated using the book-facing pure-tensor API, while simp first normalizes that term to a product of generators
- `coordFreeToUeaBasis_ι` is intentionally stated using the canonical UEA inclusion, while simp first unfolds it to the underlying tensor-algebra map

Both theorems remain public and unchanged as propositions; only their non-normal simp attributes were removed.

## Quality result

- second full lint pass: 0 findings across 7 + 25 public declarations and 27 generated declarations, using all 16 default linters plus `docBlameThm`
- complete public documentation and descriptive names
- zero scoped lines over 100 characters
- no standalone provider warnings
- no redundant imports; Stage 3.4 import minima remain exact
- all 32 declarations depend only on `propext`, `Classical.choice`, and `Quot.sound`

## Validation

- both providers built and elaborated standalone in the isolated worktree
- `lake build EtingofRepresentationTheory.Chapter2` — success (8,745 jobs)
- `python3 scripts/validate_items.py`
- `python3 scripts/validate_dependencies.py`
- `python3 scripts/validate_external_deps.py`
- exact scope/status and normalized non-scope invariance checks, JSON parsing, admission/diagnostic/line-length scans, and `git diff --check`

All checks pass. Full-build warnings are pre-existing and outside the scoped providers.

## Stack

This draft targets `agent/stage3-4-ch2-s2-12` (draft PR #8045), not `main`.
