### PR TITLE
Stage 3.2: audit Chapter 2 section 2.15

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Problem2_15_1_complete_reducibility.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_15_1_complete_reducibility.lean
@@ -50,8 +50,11 @@ module (`casimirGenEigenspace_isInternal`). The book's **part (h)** then follows
   operator has a single eigenvalue (some `casimirGenEigenspace a` is the whole module),
   with `casimirGenEigenspace_top_unique` giving uniqueness of that eigenvalue.
 
-Pinning the single eigenvalue to the book's `λ(λ+2)/2` with `λ ∈ ℕ`, and the (i)–(k)
-reduction (an indecomposable finite-dimensional module is `≅ V_λ`), remain follow-up work.
+The theorem `indecomposable_casimir_eigenvalue` below pins the single eigenvalue to the book's
+`λ(λ+2)/2` with `λ ∈ ℕ`. The project proves the stronger complete-reducibility and explicit
+semisimple-decomposition conclusions, but does not duplicate the source's minimal-counterexample
+scaffolding in (i)–(k) (the particular quotient multiplicity, ladder basis, and intermediate
+subspaces used only to derive that conclusion).
 
 The final complete-reducibility statement `complete_reducibility` is recorded here
 in its cleanest equivalent form, that every `sl(2)`-submodule of a finite-dimensional
@@ -412,6 +415,61 @@ theorem complete_reducibility (N : LieSubmodule ℂ sl2 M) :
     ∃ N' : LieSubmodule ℂ sl2 M, IsCompl N N' :=
   haveI : ComplementedLattice (LieSubmodule ℂ sl2 M) := Theorem_2_1_1_ii M
   exists_isCompl N
+
+/-- A finite-dimensional indecomposable `sl(2)`-module is irreducible. This is the conclusion
+of the contradiction argument in parts (i)–(k), obtained here directly from complete reducibility:
+every submodule has a complement, and indecomposability forces one side to vanish. -/
+theorem indecomposable_isIrreducible (hM : Indecomposable M) :
+    LieModule.IsIrreducible ℂ sl2 M := by
+  letI : Nontrivial M := hM.1
+  apply LieModule.IsIrreducible.mk
+  intro N hN
+  obtain ⟨N', hcompl⟩ := complete_reducibility N
+  rcases hM.2 N N' hcompl with h | h
+  · exact (hN h).elim
+  · simpa [h] using hcompl.sup_eq_top
+
+/-- **Problem 2.15.1(h), including the specified eigenvalue.** On a finite-dimensional
+indecomposable `sl(2)`-module, the unique Casimir generalized eigenspace which is the whole
+module has eigenvalue `λ(λ+2)/2` for some `λ : ℕ`.
+
+Complete reducibility makes the module irreducible (`indecomposable_isIrreducible`), so the
+classification identifies it with the standard `V_λ`; transporting the explicit Casimir
+calculation on `V_λ` gives the claimed eigenvalue. -/
+theorem indecomposable_casimir_eigenvalue (hM : Indecomposable M) :
+    ∃ lam : ℕ, casimirGenEigenspace (M := M)
+      (((lam : ℂ) * ((lam : ℂ) + 2)) / 2) = ⊤ := by
+  letI : Nontrivial M := hM.1
+  have hirr : LieModule.IsIrreducible ℂ sl2 M := indecomposable_isIrreducible hM
+  let lam := Module.finrank ℂ M - 1
+  have hdim : Module.finrank ℂ M = lam + 1 := by
+    dsimp [lam]
+    have := Module.finrank_pos (R := ℂ) (M := M)
+    omega
+  obtain ⟨Phi⟩ := Etingof.Problem_2_15_1_f lam hdim hirr
+  let c : ℂ := ((lam : ℂ) * ((lam : ℂ) + 2)) / 2
+  have hmap (x : sl2) (m : M) : Phi ⁅x, m⁆ = ⁅x, Phi m⁆ :=
+    Phi.toLieModuleHom.map_lie x m
+  have hcasimir_map (m : M) :
+      Phi (casimir M m) = casimir (Fin (lam + 1) → ℂ) (Phi m) := by
+    simp only [casimir_apply, map_add, map_smul]
+    simp_rw [hmap]
+  have hstandard (w : Fin (lam + 1) → ℂ) :
+      casimir (Fin (lam + 1) → ℂ) w = c • w := by
+    have h := LinearMap.congr_fun (casimir_eq_scalar_lambda lam) w
+    simpa only [casimir_apply, lie_eq_rhoLieHom, LinearMap.add_apply,
+      Module.End.mul_apply, LinearMap.smul_apply, Module.End.one_apply, c] using h
+  have hscalar (m : M) : casimir M m = c • m := by
+    apply Phi.injective
+    rw [hcasimir_map, hstandard, map_smul]
+  refine ⟨lam, ?_⟩
+  apply top_unique
+  intro m _
+  change m ∈ (casimir M).maxGenEigenspace c
+  rw [Module.End.mem_maxGenEigenspace]
+  refine ⟨1, ?_⟩
+  simp only [pow_one, LinearMap.sub_apply, hscalar, LinearMap.smul_apply,
+    Module.End.one_apply, c, sub_self]
 
 end CompleteReducibility
 

--- a/EtingofRepresentationTheory/Chapter2/Sl2Irrep.lean
+++ b/EtingofRepresentationTheory/Chapter2/Sl2Irrep.lean
@@ -136,6 +136,87 @@ theorem sl2_traceless (X : sl2) : X.val 1 1 = -X.val 0 0 := by
   have : X.val 1 1 = 0 - X.val 0 0 := by rw [← h2]; ring
   simp at this; exact this
 
+private theorem sl2_val_add (X Y : sl2) (i j : Fin 2) :
+    (X + Y).val i j = X.val i j + Y.val i j := rfl
+
+private theorem sl2_val_smul (r : ℂ) (X : sl2) (i j : Fin 2) :
+    (r • X).val i j = r * X.val i j := rfl
+
+/-- Every element of `sl(2)` is the linear combination
+`X₀₀ H + X₀₁ E + X₁₀ F` of the standard generators. -/
+theorem sl2_eq_smul_h_add_smul_e_add_smul_f (X : sl2) :
+    X = X.val 0 0 • sl2_h + X.val 0 1 • sl2_e + X.val 1 0 • sl2_f := by
+  apply Subtype.ext
+  push_cast
+  simp only [sl2_h, sl2_e, sl2_f,
+    LieAlgebra.SpecialLinear.val_singleSubSingle, LieAlgebra.SpecialLinear.val_single]
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp [Matrix.add_apply, Matrix.single, sl2_traceless X]
+
+/-- The Lie representation of `sl(2)` determined by endomorphisms `E`, `F`, and `H`
+satisfying the three defining commutator relations. This is the converse direction of the
+book's identification of an `sl(2)`-representation with such an operator triple. -/
+noncomputable def sl2LieHomOfOperators {V : Type*} [AddCommGroup V] [Module ℂ V]
+    (E F H : Module.End ℂ V)
+    (hEF : ⁅E, F⁆ = H) (hHE : ⁅H, E⁆ = (2 : ℂ) • E)
+    (hHF : ⁅H, F⁆ = -((2 : ℂ) • F)) :
+    sl2 →ₗ⁅ℂ⁆ Module.End ℂ V where
+  toFun X := X.val 0 0 • H + X.val 0 1 • E + X.val 1 0 • F
+  map_add' X Y := by
+    simp only [sl2_val_add, add_smul]
+    abel
+  map_smul' r X := by
+    simp only [sl2_val_smul, mul_smul, RingHom.id_apply, smul_add]
+  map_lie' {X Y} := by
+    have htX : X.val 1 1 = -X.val 0 0 := sl2_traceless X
+    have htY : Y.val 1 1 = -Y.val 0 0 := sl2_traceless Y
+    have hEH : ⁅E, H⁆ = -((2 : ℂ) • E) := by rw [← lie_skew, hHE]
+    have hFH : ⁅F, H⁆ = (2 : ℂ) • F := by rw [← lie_skew, hHF, neg_neg]
+    have hFE : ⁅F, E⁆ = -H := by rw [← lie_skew, hEF]
+    have hbr00 : ⁅X, Y⁆.val 0 0 =
+        X.val 0 1 * Y.val 1 0 - Y.val 0 1 * X.val 1 0 := by
+      simp [show ⁅X, Y⁆.val = X.val * Y.val - Y.val * X.val from rfl,
+        Matrix.sub_apply, Matrix.mul_apply, Fin.sum_univ_two]
+      ring
+    have hbr01 : ⁅X, Y⁆.val 0 1 =
+        2 * X.val 0 0 * Y.val 0 1 - 2 * Y.val 0 0 * X.val 0 1 := by
+      simp [show ⁅X, Y⁆.val = X.val * Y.val - Y.val * X.val from rfl,
+        Matrix.sub_apply, Matrix.mul_apply, Fin.sum_univ_two, htX, htY]
+      ring
+    have hbr10 : ⁅X, Y⁆.val 1 0 =
+        2 * X.val 1 0 * Y.val 0 0 - 2 * Y.val 1 0 * X.val 0 0 := by
+      simp [show ⁅X, Y⁆.val = X.val * Y.val - Y.val * X.val from rfl,
+        Matrix.sub_apply, Matrix.mul_apply, Fin.sum_univ_two, htX, htY]
+      ring
+    have smul_lie' : ∀ (c : ℂ) (a b : Module.End ℂ V), ⁅c • a, b⁆ = c • ⁅a, b⁆ :=
+      fun c a b => smul_lie c a b
+    have lie_smul' : ∀ (c : ℂ) (a b : Module.End ℂ V), ⁅a, c • b⁆ = c • ⁅a, b⁆ :=
+      fun c a b => lie_smul c a b
+    simp only [add_lie, lie_add, smul_lie', lie_smul', lie_self, smul_zero,
+      add_zero, zero_add, hHE, hHF, hEF, hEH, hFH, hFE, smul_neg, smul_smul,
+      hbr00, hbr01, hbr10]
+    module
+
+@[simp] theorem sl2LieHomOfOperators_e {V : Type*} [AddCommGroup V] [Module ℂ V]
+    (E F H : Module.End ℂ V) (hEF : ⁅E, F⁆ = H) (hHE : ⁅H, E⁆ = (2 : ℂ) • E)
+    (hHF : ⁅H, F⁆ = -((2 : ℂ) • F)) :
+    sl2LieHomOfOperators E F H hEF hHE hHF sl2_e = E := by
+  simp [sl2LieHomOfOperators, sl2_e, LieAlgebra.SpecialLinear.val_single, Matrix.single]
+
+@[simp] theorem sl2LieHomOfOperators_f {V : Type*} [AddCommGroup V] [Module ℂ V]
+    (E F H : Module.End ℂ V) (hEF : ⁅E, F⁆ = H) (hHE : ⁅H, E⁆ = (2 : ℂ) • E)
+    (hHF : ⁅H, F⁆ = -((2 : ℂ) • F)) :
+    sl2LieHomOfOperators E F H hEF hHE hHF sl2_f = F := by
+  simp [sl2LieHomOfOperators, sl2_f, LieAlgebra.SpecialLinear.val_single, Matrix.single]
+
+@[simp] theorem sl2LieHomOfOperators_h {V : Type*} [AddCommGroup V] [Module ℂ V]
+    (E F H : Module.End ℂ V) (hEF : ⁅E, F⁆ = H) (hHE : ⁅H, E⁆ = (2 : ℂ) • E)
+    (hHF : ⁅H, F⁆ = -((2 : ℂ) • F)) :
+    sl2LieHomOfOperators E F H hEF hHE hHF sl2_h = H := by
+  simp [sl2LieHomOfOperators, sl2_h,
+    LieAlgebra.SpecialLinear.val_singleSubSingle, Matrix.single]
+
 /-! ## The d-dimensional irreducible representation
 
 We define ρ : sl(2) → End(V_d) as a Lie algebra homomorphism, then use
@@ -241,12 +322,6 @@ private theorem lie_rhoE_rhoF (d : ℕ) :
     subst hd1; simp [hk0]
 
 /-- The representation map ρ : sl(2) → End(V_d) as a Lie hom. -/
-private theorem sl2_val_add (X Y : sl2) (i j : Fin 2) :
-    (X + Y).val i j = X.val i j + Y.val i j := rfl
-
-private theorem sl2_val_smul (r : ℂ) (X : sl2) (i j : Fin 2) :
-    (r • X).val i j = r * X.val i j := rfl
-
 noncomputable def rhoLieHom (d : ℕ) :
     sl2 →ₗ⁅ℂ⁆ Module.End ℂ (Fin d → ℂ) where
   toFun X := X.val 0 0 • rhoH d + X.val 0 1 • rhoE d + X.val 1 0 • rhoF d

--- a/progress/items.json
+++ b/progress/items.json
@@ -1727,6 +1727,25 @@
     "start_line": 21,
     "end_line": 24,
     "status": "sorry_free",
+    "coverage": "covered_full",
+    "coverage_note": "Stage 3.2 reviewed the section heading and its organizational prose. It introduces the exercise sequence but makes no mathematical claim requiring a Lean declaration.",
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.15",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "Section 2.15 is an organizational heading explaining that the representation theory of sl(2) will be studied through the following exercise sequence.",
+          "verdict": "non_formalizable",
+          "reason": "This is expository organization and motivation, not a mathematical proposition."
+        }
+      ]
+    },
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -1741,9 +1760,105 @@
     "start_line": 25,
     "end_line": 16,
     "status": "sorry_free",
-    "coverage": "covered_full",
-    "coverage_note": "All parts (a)-(n) are source-present. Problem2_15_1_a_e.lean exposes the full maximal-generalized-weight-space argument: E vanishes, the E^k F^k polynomial identity, finite-dimensional F-termination, collapse of the maximal generalized eigenspace to the eigenspace via a squarefree annihilator, and the least-exponent weight formula. Parts (f)-(n), including the restored Clebsch-Gordan module source, are covered by the remaining Chapter 2 files.",
-    "last_updated": "2026-07-27"
+    "coverage": "covered_partial",
+    "coverage_note": "Stage 3.2 audited all twelve attached providers against every source part. Parts (a)-(h), the complete-reducibility conclusion behind (i)-(k), and parts (l)-(n) are formalized with honest definitions and concrete standard modules. This pass added the converse operator-triple constructor and the exact part-(h) Casimir eigenvalue. The source's particular minimal-counterexample intermediates in (i)-(k) are intentionally not duplicated because stronger complete-reducibility and semisimple-decomposition theorems establish their intended conclusion; the analytic Tr(exp(xH)) hint in (m) is likewise replaced by an algebraic character-polynomial identity and an explicit module isomorphism.",
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.15",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "An sl(2)-representation is equivalently an operator triple E, F, H satisfying [H,E]=2E, [H,F]=-2F, and [E,F]=H.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Sl2Irrep.sl2LieHomOfOperators; Etingof.Sl2Irrep.sl2LieHomOfOperators_e; Etingof.Sl2Irrep.sl2LieHomOfOperators_f; Etingof.Sl2Irrep.sl2LieHomOfOperators_h; Etingof.Sl2Irrep.sl2_eq_smul_h_add_smul_e_add_smul_f",
+          "note": "The public constructor is the converse direction; the standard generators, relations, and spanning formula make the equivalence explicit."
+        },
+        {
+          "claim": "Part (a): E vanishes on the generalized H-eigenspace whose eigenvalue has maximal real part.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Sl2Irrep.lie_e_eq_zero_on_maxGenEigenspace",
+          "note": "The theorem uses the equivalent no-(lambda+2)-generalized-eigenspace hypothesis supplied by maximal real part."
+        },
+        {
+          "claim": "Part (b): for a highest-weight vector w, E^k F^k w is a degree-k polynomial in H applied to w.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Sl2Irrep.highestWeightPolynomial; Etingof.Sl2Irrep.highestWeightPolynomial_natDegree; Etingof.Sl2Irrep.eIter_fIter_eq_aeval_highestWeightPolynomial"
+        },
+        {
+          "claim": "Part (c): every vector in the selected generalized highest-weight space is killed by a positive power of F.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Sl2Irrep.exists_pos_fIter_eq_zero_of_mem_maxGenEigenspace"
+        },
+        {
+          "claim": "Part (d): H is diagonalizable on the selected generalized eigenspace.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Sl2Irrep.maxGenEigenspace_eq_eigenspace_of_no_higher_weight; Etingof.Sl2Irrep.highestWeightPolynomial_squarefree"
+        },
+        {
+          "claim": "Part (e): if N_v is the least positive exponent with F^N_v v=0, then lambda=N_v-1.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Sl2Irrep.highestWeight_eq_nat_of_minimal_fIter_zero_of_mem_maxGenEigenspace"
+        },
+        {
+          "claim": "Part (f): for every positive N there is a unique N-dimensional irreducible sl(2)-module, with explicit E, F, H matrices in a standard basis.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Sl2Irrep.irrep_isIrreducible; Etingof.Sl2Irrep.irrep_finrank; Etingof.Problem_2_15_1_f; Etingof.Sl2Irrep.lie_sl2_h_e_basis; Etingof.Sl2Irrep.lie_sl2_e_e_basis; Etingof.Sl2Irrep.lie_sl2_f_e_basis; Etingof.Sl2Irrep.lie_sl2_f_e_basis_top"
+        },
+        {
+          "claim": "Part (g): the Casimir C=EF+FE+H^2/2 is central and acts on V_lambda by lambda(lambda+2)/2.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Sl2Irrep.casimir_central; Etingof.Sl2Irrep.casimir_eq_scalar_lambda"
+        },
+        {
+          "claim": "Part (h): on the chosen indecomposable counterexample the Casimir has only the eigenvalue lambda(lambda+2)/2 for some lambda in the nonnegative integers.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Sl2Irrep.casimirGenEigenspace_isInternal; Etingof.Sl2Irrep.indecomposable_casimir_eigenvalue"
+        },
+        {
+          "claim": "Part (i): the minimal counterexample contains W isomorphic to V_lambda with quotient isomorphic to n copies of V_lambda.",
+          "verdict": "intentional_omission",
+          "reason": "The repository proves the stronger complete-reducibility and semisimple-decomposition conclusions directly, so this proof-route-specific subquotient intermediate is not duplicated.",
+          "note": "Covered elsewhere by Etingof.Sl2Irrep.complete_reducibility and Etingof.Sl2Irrep.sl2Module_decomposition at the level of the intended conclusion."
+        },
+        {
+          "claim": "Part (j): the lambda eigenspace has dimension n+1 and the indicated F-ladders form a basis, using the lowest-weight Casimir calculation.",
+          "verdict": "intentional_omission",
+          "reason": "The exact minimal-counterexample dimension and ladder-basis scaffolding is not separately bundled because the stronger global decomposition is formalized.",
+          "note": "The requested lowest-weight Casimir sublemma itself is formalized as Etingof.Sl2Irrep.casimir_lowest_weight."
+        },
+        {
+          "claim": "Part (k): the ladder spans W_i are subrepresentations and decompose V, contradicting minimality.",
+          "verdict": "intentional_omission",
+          "reason": "This proof-route-specific contradiction is superseded by direct complete reducibility and a full standard-irrep decomposition.",
+          "note": "Conclusion covered by Etingof.Sl2Irrep.complete_reducibility and Etingof.Sl2Irrep.sl2Module_decomposition."
+        },
+        {
+          "claim": "Part (l): a nilpotent operator A is the raising operator of an sl(2)-representation, unique up to module isomorphism.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Sl2Irrep.jacobsonMorozov_sl2"
+        },
+        {
+          "claim": "Part (m), hint route: analytic characters Tr(exp(xH)) are additive on direct sums and multiplicative on tensor products.",
+          "verdict": "intentional_omission",
+          "reason": "The analytic exponential-and-trace route is replaced by an algebraic character polynomial identity and explicit intertwiners, avoiding unnecessary analysis infrastructure."
+        },
+        {
+          "claim": "Part (m): V_lambda tensor V_mu decomposes as the direct sum of V_(lambda+mu-2k), for 0<=k<=min(lambda,mu).",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Sl2Irrep.clebsch_gordan_charPoly; Etingof.Sl2Irrep.clebsch_gordan_module_iso"
+        },
+        {
+          "claim": "Part (n): the tensor-sum nilpotent has Jordan blocks of sizes M+N-1-2k.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Sl2Irrep.jordan_normal_form_tensor"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter2/Discussion_2.16_heading",

--- a/progress/reviews/2026-07-27T13-58-44Z-ch2-section2_15-stage3_2.md
+++ b/progress/reviews/2026-07-27T13-58-44Z-ch2-section2_15-stage3_2.md
@@ -1,0 +1,87 @@
+# Stage 3.2 review — Chapter 2, §2.15
+
+Scope: `Discussion_2.15_heading` and `Problem2.15.1`, in reading order, stopping before §2.16.
+The source was checked claim by claim against every attached provider rather than inferred from
+filenames or existing coverage prose.
+
+## Outcome
+
+The mathematical endpoint of the exercise sequence is formalized: the standard irreducibles,
+classification, complete reducibility, Jacobson–Morozov, Clebsch–Gordan, and the requested tensor
+Jordan form all have genuine Lean statements and proofs. The providers also supply concrete
+standard modules, explicit generator actions, and module equivalences, so the development is
+nonvacuous.
+
+This pass repaired two fidelity gaps:
+
+- `Sl2Irrep.lean` now exposes `sl2LieHomOfOperators`, the converse constructor promised in the
+  problem's opening identification of a representation with an operator triple satisfying the
+  three commutator relations. Its generator simp lemmas and the public spanning theorem
+  `sl2_eq_smul_h_add_smul_e_add_smul_f` expose both directions.
+- `Problem2_15_1_complete_reducibility.lean` now proves
+  `indecomposable_casimir_eigenvalue`: the sole Casimir generalized eigenspace of an
+  indecomposable finite-dimensional module occurs at the book's specified scalar
+  `lambda(lambda+2)/2`, not merely at an unspecified complex scalar.
+
+The previous blanket `covered_full` description was too broad. The item is now
+`covered_partial` because three proof-route-specific intermediate steps and one suggested
+analytic route are deliberately absent even though the intended conclusions are stronger and
+fully formalized.
+
+## Source-to-Lean inventory
+
+| Source claim | Verdict | Main declarations |
+| --- | --- | --- |
+| Heading and motivation | non-formalizable prose | — |
+| Operator-triple characterization | formalized | `sl2LieHomOfOperators`, its `e/f/h` lemmas, `sl2_eq_smul_h_add_smul_e_add_smul_f` |
+| (a) maximal generalized weight implies `E=0` | formalized | `lie_e_eq_zero_on_maxGenEigenspace` |
+| (b) polynomial formula for `E^k F^k` | formalized | `highestWeightPolynomial`, `highestWeightPolynomial_natDegree`, `eIter_fIter_eq_aeval_highestWeightPolynomial` |
+| (c) positive-power `F`-termination | formalized | `exists_pos_fIter_eq_zero_of_mem_maxGenEigenspace` |
+| (d) diagonalizability on the maximal generalized eigenspace | formalized | `maxGenEigenspace_eq_eigenspace_of_no_higher_weight`, `highestWeightPolynomial_squarefree` |
+| (e) `lambda=N_v-1` | formalized | `highestWeight_eq_nat_of_minimal_fIter_zero_of_mem_maxGenEigenspace` |
+| (f) existence, uniqueness, dimension, matrices | formalized | `irrep_isIrreducible`, `irrep_finrank`, `Problem_2_15_1_f`, the four basis-action theorems |
+| (g) Casimir centrality and scalar | formalized | `casimir_central`, `casimir_eq_scalar_lambda` |
+| (h) one eigenvalue of specified form | formalized | `casimirGenEigenspace_isInternal`, `indecomposable_casimir_eigenvalue` |
+| (i) exact `W=V_lambda`, `V/W=nV_lambda` counterexample intermediate | intentional omission | stronger conclusion in `complete_reducibility`, `sl2Module_decomposition` |
+| (j) exact eigenspace dimension and ladder basis | intentional omission | stronger decomposition formalized; `casimir_lowest_weight` covers its special Casimir sublemma |
+| (k) exact `W_i` construction and minimality contradiction | intentional omission | stronger conclusion in `complete_reducibility`, `sl2Module_decomposition` |
+| (l) existence and uniqueness up to isomorphism | formalized | `jacobsonMorozov_sl2` |
+| (m) analytic `Tr(exp(xH))` hint identities | intentional omission | algebraic `clebsch_gordan_charPoly` and explicit module intertwiners replace the analytic route |
+| (m) Clebsch–Gordan decomposition | formalized | `clebsch_gordan_charPoly`, `clebsch_gordan_module_iso` |
+| (n) tensor Jordan normal form | formalized | `jordan_normal_form_tensor` |
+
+Part (a)'s Lean hypothesis says that the `lambda+2` generalized eigenspace is zero. For an
+eigenvalue whose real part is maximal this is the exact algebraic consequence used by the book,
+so it is a faithful reusable formulation. Parts (i)–(k) are not mislabeled as literal
+formalizations: they are a particular proof of complete reducibility, while this repository
+obtains the stronger result from its established complete-reducibility machinery.
+
+## Attached providers
+
+All twelve attached files were treated as part of the section:
+
+1. `Sl2Irrep.lean`
+2. `Theorem2_1_1.lean`
+3. `Problem2_15_1_a_e.lean`
+4. `Problem2_15_1_complete_reducibility.lean`
+5. `Problem2_15_1_l.lean`
+6. `Sl2NullitySequence.lean`
+7. `Sl2SemisimpleDecomposition.lean`
+8. `Sl2JordanTypeIso.lean`
+9. `Problem2_15_1_l_uniqueness.lean`
+10. `Problem2_15_1_m.lean`
+11. `Problem2_15_1_m_Module.lean`
+12. `Problem2_15_1_n.lean`
+
+## Integrity and nonvacuity
+
+Definitions used by the headline claims are genuine structures rather than proposition-valued
+stubs: `sl2` is the traceless `2 x 2` matrix Lie algebra, representations are Lie homomorphisms
+or actual `LieModule` instances, generalized eigenspaces are Lie submodules, direct sums are
+module equivalences, and Jordan-form conclusions provide an explicit intertwining linear
+equivalence. Concrete standard modules `Fin (lambda+1) -> C`, their generator formulas, and the
+constructed Clebsch–Gordan/Jordan equivalences witness nonvacuity.
+
+The scoped files contain no `sorry`, `admit`, or `proof_wanted`; the declarations listed in the
+canonical `claim_coverage` metadata were also checked for `sorryAx` through `#print axioms`.
+Build and validator commands are recorded in the draft PR description.


### PR DESCRIPTION
## Summary

- audit the section 2.15 heading and every claim in Problem 2.15.1 against all twelve attached Lean providers
- add the converse constructor from an operator triple satisfying the sl(2) commutator relations
- strengthen part (h) to the exact Casimir eigenvalue lambda(lambda+2)/2
- record canonical Stage 3.2 claim coverage and a durable review note
- classify the exact minimal-counterexample scaffolding in parts (i)-(k) and the analytic character hint in part (m) as intentional proof-route omissions, while retaining the stronger formalized conclusions

## Verification

- combined build of all twelve section providers: 3,221 jobs, success
- direct lake env lean check of all twelve provider files: success
- final scoped build of the two changed modules: 2,925 jobs, success
- full lake build EtingofRepresentationTheory.Chapter2: 8,744 jobs, success
- progress/items.json parses and contains exactly the two scoped Stage 3.2 records
- validate_items.py, validate_dependencies.py, validate_external_deps.py, and validate_mathlib_coverage.py: pass
- scoped lint ratchet: no new warnings
- admission scan for sorry, admit, and proof_wanted across all twelve providers: empty
- axiom audit of every mapped formalized declaration: no sorryAx; only propext, Classical.choice, and Quot.sound

The legacy verify_blobs.py utility still exits with KeyError on the ten existing top-level derived overlay records because they intentionally have derived_from rather than id. This is unchanged repository-wide validator debt and is unrelated to the scoped metadata edits.

## Coverage note

The exercise conclusions are strongly represented, including complete reducibility, Jacobson-Morozov, Clebsch-Gordan, and the tensor Jordan form. The coverage remains covered_partial because the repository does not literally duplicate the source-specific intermediate construction in parts (i)-(k), and it replaces the analytic Tr(exp(xH)) hint with an algebraic character polynomial and explicit intertwiners.