### PR TITLE
Stage 3.3: verify Chapter 2 section 2.15 proofs

### DIFF
--- a/progress/2026-07-27T14-23-17Z_stage3-3-chapter2-section2-15.md
+++ b/progress/2026-07-27T14-23-17Z_stage3-3-chapter2-section2-15.md
@@ -1,0 +1,64 @@
+# Stage 3.3 proof verification — Chapter 2 §2.15
+
+## Scope and result
+
+This pass is stacked directly on the Stage 3.2 §2.15 commit and preserves its exact two-item
+reading-order scope: `Discussion_2.15_heading` and `Problem2.15.1`, stopping before §2.16.
+The heading is organizational prose and has no proof obligation. The problem uses all twelve
+attached providers:
+
+1. `Sl2Irrep.lean`
+2. `Theorem2_1_1.lean`
+3. `Problem2_15_1_a_e.lean`
+4. `Problem2_15_1_complete_reducibility.lean`
+5. `Problem2_15_1_l.lean`
+6. `Sl2NullitySequence.lean`
+7. `Sl2SemisimpleDecomposition.lean`
+8. `Sl2JordanTypeIso.lean`
+9. `Problem2_15_1_l_uniqueness.lean`
+10. `Problem2_15_1_m.lean`
+11. `Problem2_15_1_m_Module.lean`
+12. `Problem2_15_1_n.lean`
+
+No proof repair was required. Every formalized claim and its supporting implementation is
+proof-complete. The Stage 3.2 fidelity decisions remain unchanged: the source-specific
+minimal-counterexample scaffolding in parts (i)–(k) and the analytic `Tr(exp(xH))` route in
+part (m) are intentional proof-route omissions. Their intended mathematical endpoints are
+proved by stronger complete-reducibility, semisimple-decomposition, algebraic-character, and
+explicit-intertwiner results; no placeholder or unproved declaration stands in for an omission.
+
+## Declaration and internal-proof audit
+
+The twelve modules were imported into a dedicated Lean audit command. Module indices were used
+to enumerate the complete compiled surface rather than relying on a hand-selected theorem list.
+The audit found:
+
+- **268 exported constants**, including named declarations, public instances, and generated
+  equation/congruence declarations;
+- **710 total module-attributed constants** after including private helpers and other generated
+  implementation declarations.
+
+For every exported constant, the audit computed the same transitive axiom set reported by
+`#print axioms`. It also computed and checked the axiom set of every internal constant. Every
+set was a subset of Lean's accepted foundations `propext`, `Classical.choice`, and `Quot.sound`;
+many declarations used fewer or no axioms. There was no `sorryAx` and no project-defined axiom.
+
+A source scan over all twelve files found no token `sorry`, `admit`, `proof_wanted`, or `axiom`.
+Fresh direct elaboration of every provider exercised all internal proofs and emitted no
+declaration-with-sorry or metavariable diagnostic.
+
+## Validation
+
+- isolated combined build of all twelve providers: 3,221 jobs, success;
+- standalone `lake env lean` elaboration of all twelve provider files: success;
+- complete exported/internal transitive-axiom audit: 268/710 declarations, success;
+- exact two-item Stage 3.3 tracker check and JSON parsing;
+- repository item, internal-dependency, external-dependency, and Mathlib-coverage validators;
+- scoped lint ratchet and admission/project-axiom scans;
+- full Chapter 2 build;
+- stacked-diff invariance and `git diff --check`.
+
+The legacy `verify_blobs.py` utility remains incompatible with the ten existing top-level
+derived overlay records because those records intentionally use `derived_from` instead of `id`.
+It exits with `KeyError: id` before verification; this is unchanged repository-wide validator
+debt, not a §2.15 regression.

--- a/progress/items.json
+++ b/progress/items.json
@@ -4339,6 +4339,13 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.15",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "not_applicable",
+      "declarations": []
+    },
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -4451,6 +4458,46 @@
           "lean_decl": "Etingof.Sl2Irrep.jordan_normal_form_tensor"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.15",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Sl2Irrep.sl2_eq_smul_h_add_smul_e_add_smul_f",
+        "Etingof.Sl2Irrep.sl2LieHomOfOperators",
+        "Etingof.Sl2Irrep.sl2LieHomOfOperators_e",
+        "Etingof.Sl2Irrep.sl2LieHomOfOperators_f",
+        "Etingof.Sl2Irrep.sl2LieHomOfOperators_h",
+        "Etingof.Sl2Irrep.lie_e_eq_zero_on_maxGenEigenspace",
+        "Etingof.Sl2Irrep.highestWeightPolynomial",
+        "Etingof.Sl2Irrep.highestWeightPolynomial_natDegree",
+        "Etingof.Sl2Irrep.eIter_fIter_eq_aeval_highestWeightPolynomial",
+        "Etingof.Sl2Irrep.exists_pos_fIter_eq_zero_of_mem_maxGenEigenspace",
+        "Etingof.Sl2Irrep.maxGenEigenspace_eq_eigenspace_of_no_higher_weight",
+        "Etingof.Sl2Irrep.highestWeightPolynomial_squarefree",
+        "Etingof.Sl2Irrep.highestWeight_eq_nat_of_minimal_fIter_zero_of_mem_maxGenEigenspace",
+        "Etingof.Sl2Irrep.irrep_isIrreducible",
+        "Etingof.Sl2Irrep.irrep_finrank",
+        "Etingof.Problem_2_15_1_f",
+        "Etingof.Sl2Irrep.lie_sl2_h_e_basis",
+        "Etingof.Sl2Irrep.lie_sl2_e_e_basis",
+        "Etingof.Sl2Irrep.lie_sl2_f_e_basis",
+        "Etingof.Sl2Irrep.lie_sl2_f_e_basis_top",
+        "Etingof.Sl2Irrep.casimir_central",
+        "Etingof.Sl2Irrep.casimir_eq_scalar_lambda",
+        "Etingof.Sl2Irrep.casimirGenEigenspace_isInternal",
+        "Etingof.Sl2Irrep.indecomposable_casimir_eigenvalue",
+        "Etingof.Sl2Irrep.complete_reducibility",
+        "Etingof.Sl2Irrep.sl2Module_decomposition",
+        "Etingof.Sl2Irrep.casimir_lowest_weight",
+        "Etingof.Sl2Irrep.jacobsonMorozov_sl2",
+        "Etingof.Sl2Irrep.clebsch_gordan_charPoly",
+        "Etingof.Sl2Irrep.clebsch_gordan_module_iso",
+        "Etingof.Sl2Irrep.jordan_normal_form_tensor"
+      ],
+      "scope_note": "The declaration list records the source-facing proof endpoints. The audit programmatically checked all 268 exported constants and all 710 constants attributed to the twelve scoped provider modules, including support declarations, private helpers, instances, and generated equations. Parts (i)-(k) and the analytic character hint in (m) remain the intentional proof-route omissions classified at Stage 3.2; no unproved declaration represents them."
     }
   },
   {


### PR DESCRIPTION
## Summary

- verify proof integrity for the exact two-item Chapter 2 section 2.15 scope established by Stage 3.2
- audit all twelve attached provider modules rather than sampling headline declarations
- record canonical Stage 3.3 metadata and a durable declaration-level audit note
- retain the honest Stage 3.2 classification of the parts (i)-(k) proof scaffolding and the analytic part (m) hint as intentional proof-route omissions

No Lean repair was required. This stacked diff contains only the Stage 3.3 tracker object and audit note.

## Proof integrity

A module-indexed Lean audit enumerated 268 exported constants and 710 total constants attributed to the twelve providers, including private helpers, instances, and generated equations. For every exported declaration it computed the transitive axiom set reported by print axioms, and it checked every internal constant as well. Every dependency set was a subset of propext, Classical.choice, and Quot.sound. There is no sorryAx or project-defined axiom.

A source scan over all twelve providers found no sorry, admit, proof_wanted, or axiom token. Direct standalone elaboration of every provider reported no declarations using sorry and no unresolved metavariables.

## Verification

- isolated combined build of all twelve providers: 3,221 jobs, success
- standalone lake env lean elaboration of all twelve provider files: success
- exported/internal axiom audit: 268/710 constants, success
- full lake build EtingofRepresentationTheory.Chapter2: 8,744 jobs, success
- validate_items.py, validate_dependencies.py, validate_external_deps.py, and validate_mathlib_coverage.py: pass
- scoped lint ratchet: no new warnings
- exact two-item JSON scope and Stage 3.2 invariance comparison: pass
- stacked diff contains exactly progress/items.json and the durable Stage 3.3 note
- git diff --check: pass

The legacy verify_blobs.py utility still exits with KeyError on the ten existing top-level derived overlay records because they use derived_from rather than id. This is unchanged repository-wide validator debt, not a section 2.15 regression.