### PR TITLE
Stage 3.2: audit Chapter 3 §3.2

### DIFF
--- a/progress/2026-07-27T14-24-56Z_stage3-2-chapter3-section3-2.md
+++ b/progress/2026-07-27T14-24-56Z_stage3-2-chapter3-section3-2.md
@@ -1,0 +1,40 @@
+# Stage 3.2 claim coverage — Chapter 3 §3.2
+
+## Scope
+
+Audited the exact three-item reading-order interval from `Introduction_to_3.2` through
+`Theorem3.2.2`, stopping before `Introduction_to_3.3`, against source pages 45–46.
+
+## Claim inventory and fidelity
+
+All twelve source units are accounted for: four endpoint/setup claims are formalized, five proof
+or infrastructure units are covered by explicit declarations elsewhere, and three organizational,
+attribution, or methodological units are non-formalizable. There are no hidden or intentional
+omissions.
+
+The public statements are faithful and nonvacuous:
+
+- `Etingof.irreducible_interpolation` is the exact finite-dimensional irreducible interpolation
+  corollary with `k`-linear independence.
+- `Etingof.density_theorem_part1` is surjectivity of `A → End_k(V)`.
+- `Etingof.density_theorem_part2` is simultaneous surjectivity for a finite family of pairwise
+  nonisomorphic simples; its dependent-function codomain is the finite product/direct sum from the
+  source.
+
+The only substantive presentation difference is proof order. The book proves interpolation from
+Proposition 3.1.4 and then density part (i). Lean proves part (i) independently from Mathlib's
+Jacobson density theorem and derives interpolation from it. Part (ii) likewise uses a direct
+product-module density proof. These are alternate proofs of the exact statements, not weakened
+wrappers.
+
+## Validation
+
+- standalone builds of both providers
+- scoped admission and project-axiom scan
+- `#print axioms` on all three public declarations
+- exact three-item, twelve-unit claim-coverage audit
+- full `EtingofRepresentationTheory.Chapter3` build
+- all three repository metadata/dependency validators
+- JSON parsing and `git diff --check`
+
+This PR is limited to Section 3.2 and Stage 3.2.

--- a/progress/items.json
+++ b/progress/items.json
@@ -2005,6 +2005,36 @@
     "start_line": 23,
     "end_line": 27,
     "status": "sorry_free",
+    "coverage": "covered_full",
+    "fidelity": "verified",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.2",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "The Section 3.2 heading identifies the density theorem but makes no mathematical assertion.",
+          "verdict": "non_formalizable",
+          "reason": "This is an organizational heading only."
+        },
+        {
+          "claim": "Throughout Section 3.2, A is an algebra over an algebraically closed field k.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.irreducible_interpolation; Etingof.density_theorem_part1; Etingof.density_theorem_part2",
+          "note": "All three declarations carry explicit Field, IsAlgClosed, Ring, and Algebra hypotheses."
+        },
+        {
+          "claim": "The authors thank Bjorn Poonen for the preceding argument.",
+          "verdict": "non_formalizable",
+          "reason": "This is an attribution rather than a mathematical proposition."
+        }
+      ]
+    },
+    "last_updated": "2026-07-27",
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -2020,11 +2050,35 @@
     "end_line": 4,
     "status": "sorry_free",
     "coverage": "covered_full",
-    "last_updated": "2026-07-22",
+    "last_updated": "2026-07-27",
     "fidelity": "verified",
     "sorry_free": true,
+    "lean_decl": "Etingof.irreducible_interpolation",
+    "coverage_note": "The exact finite-dimensional irreducible interpolation statement is proved. Lean uses the separately proved density theorem rather than reproducing the book's contradiction through Proposition 3.1.4.",
     "fidelity_decl": "Etingof.irreducible_interpolation",
-    "fidelity_note": "wave-1 gap, repaired concurrently, wave-2 re-verified"
+    "fidelity_note": "wave-1 gap, repaired concurrently, wave-2 re-verified",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.2",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "For linearly independent v_i in a finite-dimensional irreducible A-representation V and arbitrary w_i, some a in A satisfies a v_i = w_i for every i.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.irreducible_interpolation"
+        },
+        {
+          "claim": "The book proves interpolation by applying Proposition 3.1.4 to the image of A in nV and deriving a nontrivial linear relation from a matrix with fewer rows than columns.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Etingof.subrepresentation_of_semisimple_matrix_pi; Etingof.density_theorem_part1",
+          "note": "The matrix classification used by the book is formalized in Proposition 3.1.4. This provider uses the equivalent shorter route through the independently proved density theorem, avoiding a logical gap while changing only proof organization."
+        }
+      ]
+    }
   },
   {
     "id": "Chapter3/Theorem3.2.2",
@@ -2039,7 +2093,60 @@
     "notes": "Both parts proved. Part (i) uses Jacobson density theorem for simple modules. Part (ii) applies density theorem to the product module via Schur's lemma decomposition.",
     "sorry_free": true,
     "coverage": "covered_full",
-    "last_updated": "2026-07-22"
+    "lean_decl": "Etingof.density_theorem_part1; Etingof.density_theorem_part2",
+    "coverage_note": "Both density statements are proved exactly. For the finite family in part (ii), Lean models the finite direct sum of endomorphism spaces by the equivalent dependent function/product type.",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.2",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "If V is a finite-dimensional irreducible representation of A, then the representation map A → End_k(V) is surjective.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.density_theorem_part1"
+        },
+        {
+          "claim": "The book derives part (i) from Corollary 3.2.1 by realizing the values of an arbitrary endomorphism on a basis.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Etingof.irreducible_interpolation; Etingof.density_theorem_part1",
+          "note": "Both endpoints are formalized. Lean proves part (i) directly from Mathlib's Jacobson density theorem and then derives the corollary, reversing the pedagogical order without weakening the result."
+        },
+        {
+          "claim": "For a finite family of pairwise nonisomorphic finite-dimensional irreducible representations V_i, the combined map A → ⊕_i End_k(V_i) is surjective.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.density_theorem_part2",
+          "note": "The codomain is represented as the dependent function type ∀ i, End_k(V_i); for a Fintype index this is the finite product/direct sum in the source."
+        },
+        {
+          "claim": "The book proves part (ii) by decomposing the image B into its component images B_i using semisimplicity and Proposition 3.1.4, then applying part (i) to each B_i.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Etingof.subrepresentation_of_semisimple_pi; Etingof.density_theorem_part1; Etingof.density_theorem_part2",
+          "note": "The source ingredients and endpoint are all formalized. The Lean proof packages the same separation of pairwise nonisomorphic simples into a direct Jacobson-density argument on their finite product."
+        },
+        {
+          "claim": "For finite families, direct sums and direct products agree, so the distinction is immaterial in part (ii).",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "DFinsupp.linearEquivFunOnFintype",
+          "note": "This equivalence is used explicitly when the proof transfers semisimplicity to the finite function-space model."
+        },
+        {
+          "claim": "In general it is preferable to use direct products rather than direct sums of algebras.",
+          "verdict": "non_formalizable",
+          "reason": "This is methodological guidance rather than a proposition."
+        },
+        {
+          "claim": "An arbitrary product of unital algebras is unital, whereas an infinite componentwise direct sum is not generally unital.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Pi.ring; DirectSum.GNonUnitalNonAssocSemiring",
+          "note": "Mathlib supplies the pointwise unital ring structure on products and models unrestricted componentwise direct-sum multiplication through explicitly nonunital graded structures; the finite equivalence used here is DFinsupp.linearEquivFunOnFintype."
+        }
+      ]
+    },
+    "last_updated": "2026-07-27"
   },
   {
     "id": "Chapter3/Introduction_to_3.3",


### PR DESCRIPTION
## Scope

Stage 3.2 claim-coverage audit for the exact three-item Section 3.2 interval: `Introduction_to_3.2`, `Corollary3.2.1`, and `Theorem3.2.2`, stopping before §3.3.

## Result

- Accounts for all 12 source units: four formalized, five covered elsewhere, and three organizational/attribution/methodological units; zero omissions.
- Verifies the exact interpolation corollary and both parts of the density theorem.
- Records that the finite dependent-function codomain in part (ii) is the source’s finite product/direct sum.
- Documents the proof-order difference: Lean proves Jacobson density directly and derives interpolation, while the book proceeds in the opposite pedagogical order; no statement is weakened.
- No Lean repair was required.

## Validation

- Standalone provider builds
- Scoped admission scan and `#print axioms` on all three public declarations
- Fresh full `EtingofRepresentationTheory.Chapter3` build: 8,692 jobs
- All three repository metadata/dependency validators
- Exact-scope/verdict audit, JSON parsing, and `git diff --check`