### PR TITLE
Stage 3.3: verify Chapter 3 §3.2 proofs

### DIFF
--- a/progress/2026-07-27T14-29-58Z_stage3-3-chapter3-section3-2.md
+++ b/progress/2026-07-27T14-29-58Z_stage3-3-chapter3-section3-2.md
@@ -1,0 +1,28 @@
+# Stage 3.3 proof verification — Chapter 3 §3.2
+
+## Scope and result
+
+This pass keeps the exact three-item, twelve-unit §3.2 scope established at Stage 3.2. The section
+heading/setup has no independent proof obligation. All three public mathematical endpoints were
+audited: interpolation on a linearly independent family and both parts of the density theorem.
+
+Every declaration is free of `sorry`, `admit`, project `axiom`, `proof_wanted`, and `sorryAx`
+dependencies. `#print axioms` reports only Lean's accepted foundational axioms `propext`,
+`Classical.choice`, and `Quot.sound` for each endpoint. No proof repair was required.
+
+The proof-order difference recorded at Stage 3.2 is not a proof gap. The book derives the
+interpolation corollary first and uses it to prove density part (i); Lean proves Jacobson density
+directly and then derives interpolation. Both exact statements have complete proof terms. Part (ii)
+likewise has a complete direct proof for the finite family of pairwise nonisomorphic simples.
+
+## Validation
+
+- isolated builds of both providers
+- scoped source admission and project-axiom scan
+- `#print axioms` on all three public declarations
+- exact three-item Stage 3.3 tracker audit
+- all three repository metadata/dependency validators
+- full Chapter 3 build
+- JSON parsing and `git diff --check`
+
+This PR is limited to Section 3.2 and Stage 3.3.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3361,6 +3361,13 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "not_applicable",
+      "declarations": []
+    },
     "last_updated": "2026-07-27",
     "coverage_swept": {
       "wave": 1,
@@ -3405,6 +3412,16 @@
           "note": "The matrix classification used by the book is formalized in Proposition 3.1.4. This provider uses the equivalent shorter route through the independently proved density theorem, avoiding a logical gap while changing only proof organization."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.irreducible_interpolation"
+      ],
+      "scope_note": "The exact corollary is fully proved. Its Lean proof uses the independently verified density theorem rather than reproducing the book's matrix contradiction."
     }
   },
   {
@@ -3472,6 +3489,17 @@
           "note": "Mathlib supplies the pointwise unital ring structure on products and models unrestricted componentwise direct-sum multiplication through explicitly nonunital graded structures; the finite equivalence used here is DFinsupp.linearEquivFunOnFintype."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.2",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.density_theorem_part1",
+        "Etingof.density_theorem_part2"
+      ],
+      "scope_note": "Both exact density endpoints are fully proved through Mathlib's Jacobson-density and simple-module APIs; the alternate proof organization recorded at Stage 3.2 introduces no deferred proof obligation."
     },
     "last_updated": "2026-07-27"
   },


### PR DESCRIPTION
## Scope

Stage 3.3 only for Chapter 3 §3.2, stacked on #8053.

## Proof audit

- Audited `Etingof.irreducible_interpolation`, `Etingof.density_theorem_part1`, and `Etingof.density_theorem_part2`.
- Confirmed no `sorry`, `admit`, project `axiom`, `proof_wanted`, or `sorryAx` dependency.
- `#print axioms` reports only `propext`, `Classical.choice`, and `Quot.sound` for all three endpoints.
- Recorded that Lean derives interpolation from the independently verified density theorem; this proof-order difference from the book creates no proof gap.

## Validation

- Isolated provider build: 1,950 jobs
- Full Chapter 3 build: 8,692 jobs
- All repository metadata/dependency validators
- JSON parsing and `git diff --check`

This draft PR changes only §3.2 Stage 3.3 metadata and its audit note.