### PR TITLE
Stage 3.4: trim Chapter 3 §3.2 dependencies

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/Corollary3_2_1.lean
+++ b/EtingofRepresentationTheory/Chapter3/Corollary3_2_1.lean
@@ -1,5 +1,3 @@
-import Mathlib.RingTheory.SimpleModule.Basic
-import Mathlib.LinearAlgebra.Basis.VectorSpace
 import EtingofRepresentationTheory.Chapter3.Theorem3_2_2
 
 /-!

--- a/EtingofRepresentationTheory/Chapter3/Theorem3_2_2.lean
+++ b/EtingofRepresentationTheory/Chapter3/Theorem3_2_2.lean
@@ -1,5 +1,3 @@
-import Mathlib.RingTheory.SimpleModule.Basic
-import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 import Mathlib.RepresentationTheory.AlgebraRepresentation.Basic
 
 /-!

--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -399,15 +399,9 @@
   "Chapter3/Discussion_after_Lemma3.1.6": [
     "Chapter3/Lemma3.1.6"
   ],
-  "Chapter3/Introduction_to_3.2": [
-    "Chapter3/Discussion_after_Lemma3.1.6"
-  ],
-  "Chapter3/Corollary3.2.1": [
-    "Chapter3/Introduction_to_3.2"
-  ],
-  "Chapter3/Theorem3.2.2": [
-    "Chapter3/Corollary3.2.1"
-  ],
+  "Chapter3/Introduction_to_3.2": [],
+  "Chapter3/Corollary3.2.1": [],
+  "Chapter3/Theorem3.2.2": [],
   "Chapter3/Introduction_to_3.3": [
     "Chapter3/Theorem3.2.2"
   ],

--- a/progress/2026-07-27T14-35-54Z_stage3-4-chapter3-section3-2.md
+++ b/progress/2026-07-27T14-35-54Z_stage3-4-chapter3-section3-2.md
@@ -1,0 +1,36 @@
+# Stage 3.4 dependency trimming — Chapter 3 §3.2
+
+## Scope
+
+This pass analyzes the actual dependencies and direct imports of the exact three §3.2 catalog
+items after Stage 3.3: the section heading, Corollary 3.2.1, and Theorem 3.2.2.
+
+## Result
+
+All three backward pedagogical dependency sets are empty. The heading is organizational. Both
+density proofs use Mathlib APIs directly and import no project item. The interpolation corollary
+imports the later Theorem 3.2.2 provider because Lean proves density first and derives the
+corollary afterward. That forward implementation import cannot be represented in the acyclic
+backward book-order graph; it is a documented proof-order choice, not a hidden dependency on an
+earlier catalog item. The three conservative reading-order edges were removed accordingly.
+
+The theorem provider now has the single focused Mathlib import reported by `#min_imports`; two
+redundant direct imports were removed. The corollary provider now imports only the theorem
+provider; two redundant Mathlib imports were removed. Final `#redundant_imports` checks report no
+transitively redundant import in either provider.
+
+All three items carry complete `stage3_4` records and move to `dependency_trimmed`.
+
+## Validation
+
+- direct compilation of both providers
+- Mathlib's `#redundant_imports` and `#min_imports` diagnostics
+- full `EtingofRepresentationTheory.Chapter3` build
+- `scripts/validate_items.py`
+- `scripts/validate_dependencies.py`
+- `scripts/validate_external_deps.py`
+- exact three-item §3.2 graph/tracker audit
+- `jq empty dependencies/internal.json progress/items.json`
+- `git diff --check`
+
+This PR is limited to Section 3.2 and Stage 3.4.

--- a/progress/items.json
+++ b/progress/items.json
@@ -4743,7 +4743,7 @@
     "end_page": "45",
     "start_line": 23,
     "end_line": 27,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "fidelity": "verified",
     "claim_coverage": {
@@ -4780,6 +4780,13 @@
       "proof_integrity": "not_applicable",
       "declarations": []
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The section heading is organizational and has no Lean provider or actual internal dependency."
+    },
     "last_updated": "2026-07-27",
     "coverage_swept": {
       "wave": 1,
@@ -4794,7 +4801,7 @@
     "end_page": "46",
     "start_line": 1,
     "end_line": 4,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "last_updated": "2026-07-27",
     "fidelity": "verified",
@@ -4834,6 +4841,13 @@
         "Etingof.irreducible_interpolation"
       ],
       "scope_note": "The exact corollary is fully proved. Its Lean proof uses the independently verified density theorem rather than reproducing the book's matrix contradiction."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The provider imports the later Theorem 3.2.2 implementation, not an earlier book item. That forward proof-order import is excluded from the backward pedagogical graph and is recorded explicitly in the Stage 3.4 audit note."
     }
   },
   {
@@ -4844,7 +4858,7 @@
     "end_page": "46",
     "start_line": 5,
     "end_line": 13,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "notes": "Both parts proved. Part (i) uses Jacobson density theorem for simple modules. Part (ii) applies density theorem to the product module via Schur's lemma decomposition.",
     "sorry_free": true,
@@ -4912,6 +4926,13 @@
         "Etingof.density_theorem_part2"
       ],
       "scope_note": "Both exact density endpoints are fully proved through Mathlib's Jacobson-density and simple-module APIs; the alternate proof organization recorded at Stage 3.2 introduces no deferred proof obligation."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "Both density proofs use only Mathlib APIs. Their provider has one focused Mathlib import and no project import."
     },
     "last_updated": "2026-07-27"
   },


### PR DESCRIPTION
## Scope

Stage 3.4 only for Chapter 3 §3.2, stacked on #8056.

## Dependency and import audit

- Set the heading, Corollary 3.2.1, and Theorem 3.2.2 to their actual empty backward dependency sets, removing three conservative reading-order edges.
- Documented the corollary provider’s forward import of the later theorem as an implementation proof-order choice that cannot be encoded in the acyclic backward graph.
- Removed two redundant Mathlib imports from each provider.
- Final `#min_imports`/`#redundant_imports` results are exactly one project import for the corollary and one focused Mathlib import for the theorem, with no redundancy.

## Validation

- Clean provider build: 1,950 jobs
- Full Chapter 3 build: 8,692 jobs
- All repository metadata/dependency validators
- Exact three-item graph/tracker audit
- JSON parsing and `git diff --check`

This draft PR changes only §3.2 Stage 3.4 data, its two providers’ imports, and the audit note.