### PR TITLE
Stage 3.3 proof-integrity audit for Chapter 3 section 3.1

### DIFF
--- a/progress/2026-07-27T14-36-58Z_stage3-3-chapter3-section3-1.md
+++ b/progress/2026-07-27T14-36-58Z_stage3-3-chapter3-section3-1.md
@@ -1,0 +1,62 @@
+# Stage 3.3 proof-integrity review — Chapter 3 §3.1
+
+## Scope and inherited result
+
+This stacked review is based exactly on Stage 3.2 draft PR #8054 at commit `884a7b70`.
+Reading order gives ten §3.1 catalog items, from `Chapter3/Introduction` through
+`Chapter3/Discussion_after_Lemma3.1.6`, and seven Lean provider files. The immediate predecessor
+is `Chapter2/Problem2.16.5`; the strict successor is `Chapter3/Introduction_to_3.2`.
+
+Stage 3.2 supplies 28 exhaustive claim units: 19 `formalized`, 6 `covered_elsewhere`, and 3
+`non_formalizable`. The nonformalizable units are the chapter/section convention, an organizational
+transition, and a bibliographic attribution. They are preserved honestly as prose without Lean
+proof obligations. All 25 mathematical units are covered by the declarations certified here.
+
+## Proof-integrity result
+
+Eight items are `sorry_free`; the chapter/section introduction and the organizational transition
+are `not_applicable`. The eight proof-applicable records cite 66 declaration references, comprising
+60 unique public declarations across the seven providers. Proposition 3.1.4 additionally uses three
+private helper proofs; they were inspected directly and are transitively covered by the audited public
+callers.
+
+Every public declaration was resolved by Lean. The 60-declaration `#print axioms` audit reported
+only `propext`, `Classical.choice`, and `Quot.sound`; it reported no `sorryAx`, project axiom, or
+undeclared dependency. A direct provider scan found no `sorry`, `admit`, `proof_wanted`, `axiom`,
+`sorryAx`, `opaque`, or `native_decide` occurrence. No Lean repair was needed: Stage 3.2 had already
+left all scoped implementations admission-free.
+
+The final discussion has no dedicated provider. Its four Stage 3.2 claims are certified as
+`covered_elsewhere` by the audited declarations from Lemma 3.1.6, the alternative-proof provider,
+Remark 3.1.5, and Proposition 3.1.4. The B. Poonen attribution in the alternative-proof discussion
+remains bibliographic prose and is not represented as a proved theorem.
+
+## Durable tracker result
+
+- all 10 exact items have complete section `3.1` `stage3_3` objects;
+- proof-integrity split: 8 `sorry_free`, 2 `not_applicable`;
+- declaration references: 66, comprising 60 unique public declarations;
+- internal proof inventory: 3 private helpers, all inspected and transitively audited;
+- Stage 3.2 data is unchanged: removing the new `stage3_3` objects reproduces the PR #8054
+  scoped records exactly;
+- the non-§3.1 tracker projection and dependency metadata are unchanged.
+
+## Validation
+
+- all 7 scoped providers built successfully in isolation (1977 jobs; pre-existing linter warnings
+  only);
+- `lake build EtingofRepresentationTheory.Chapter3`: success (8693 jobs; pre-existing linter
+  warnings only);
+- Lean declaration-resolution and 60-declaration `#print axioms` audit: success, with foundational
+  axioms only and no `sorryAx` or project axiom;
+- exact scoped admission/placeholder scan: clean;
+- exact 10-item Stage 3.3 completeness, proof-integrity split, and 60-unique-declaration aggregation:
+  passed;
+- `jq empty progress/items.json`: passed;
+- `python3 scripts/validate_items.py`: passed with 5721/5721-line coverage (593 pre-existing schema
+  warnings);
+- `python3 scripts/validate_dependencies.py`: passed (one pre-existing conservative-default
+  warning);
+- `python3 scripts/validate_external_deps.py`: passed;
+- `python3 scripts/validate_mathlib_coverage.py`: passed;
+- normalized scoped and non-scoped tracker invariance checks and `git diff --check`: passed.

--- a/progress/items.json
+++ b/progress/items.json
@@ -2913,6 +2913,14 @@
     "id": "Chapter3/Introduction",
     "type": "introduction",
     "title": "Chapter 3: General results of representation theory — introduction and Section 3.1 heading",
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.1",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "not_applicable",
+      "declarations": [],
+      "basis": "The source material is a chapter/section heading and ambient parameter convention, not a proposition with a Lean proof obligation."
+    },
     "start_page": "43",
     "end_page": "43",
     "start_line": 1,
@@ -2947,6 +2955,15 @@
     "id": "Chapter3/Definition3.1.1",
     "type": "definition",
     "title": "Semisimple (completely reducible) representation",
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.1",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.IsSemisimpleRepresentation"
+      ]
+    },
     "start_page": "43",
     "end_page": "43",
     "start_line": 9,
@@ -2980,6 +2997,22 @@
     "id": "Chapter3/Example3.1.2",
     "type": "example",
     "title": "End(V) as a semisimple representation",
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.1",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.evalMap",
+        "Etingof.evalMap_apply",
+        "Etingof.evalMap_bijective",
+        "Etingof.endEquivPiOfBasis",
+        "Etingof.endEquivPiOfBasis_apply",
+        "Etingof.endEquivPi",
+        "Etingof.endEquivPi_apply",
+        "Etingof.endomorphism_semisimple"
+      ]
+    },
     "start_page": "43",
     "end_page": "43",
     "start_line": 11,
@@ -3016,6 +3049,31 @@
     "id": "Chapter3/Remark3.1.3",
     "type": "remark",
     "title": "Canonical decomposition of semisimple representations via Schur's lemma",
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.1",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.evalBilinear",
+        "Etingof.evalTensor",
+        "Etingof.evalTensor_tmul",
+        "Etingof.evalTensorEquivOfIsSimple",
+        "Etingof.evalTensorEquivOfIsSimple_tmul",
+        "Etingof.evalTensor_injective",
+        "Etingof.evalDirectSum",
+        "Etingof.evalDirectSum_lof_tmul",
+        "Etingof.linearMap_eq_zero_of_isEmpty_linearEquiv",
+        "Etingof.simpleSubmodule_le_range_evalDirectSum",
+        "Etingof.evalDirectSum_surjective",
+        "Etingof.evalTensor_mem_isotypicComponent",
+        "Etingof.mem_isotypicComponents_of_ne_bot",
+        "Etingof.isotypicComponent_ne_of_ne",
+        "Etingof.iSupIndep_isotypicComponent",
+        "Etingof.evalDirectSum_injective",
+        "Etingof.evalDirectSumEquiv"
+      ]
+    },
     "start_page": "43",
     "end_page": "43",
     "start_line": 13,
@@ -3057,6 +3115,14 @@
     "id": "Chapter3/Discussion_before_Proposition3.1.4",
     "type": "discussion",
     "title": "Transition to classification of subrepresentations",
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.1",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "not_applicable",
+      "declarations": [],
+      "basis": "The source sentence is an organizational transition announcing Proposition 3.1.4, not a standalone mathematical claim with a proof obligation."
+    },
     "start_page": "44",
     "end_page": "44",
     "start_line": 1,
@@ -3091,6 +3157,20 @@
     "id": "Chapter3/Proposition3.1.4",
     "type": "proposition",
     "title": "Classification of subrepresentations in semisimple representations",
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.1",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.isIsotypicOfType_fun",
+        "Etingof.subrepresentation_of_semisimple_pi",
+        "Etingof.subrepresentation_of_semisimple",
+        "Etingof.subrepresentation_of_semisimple_matrix_pi",
+        "Etingof.subrepresentation_of_semisimple_matrix"
+      ],
+      "basis": "All five public declarations and the three private helper proofs used by them were audited; the public callers transitively cover the private helpers."
+    },
     "start_page": "44",
     "end_page": "44",
     "start_line": 3,
@@ -3138,6 +3218,24 @@
     "id": "Chapter3/Remark3.1.5",
     "type": "remark",
     "title": "Generalization of Proposition 3.1.4 to non-algebraically-closed fields",
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.1",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Remark315.subrepresentation_general",
+        "Etingof.Remark315.homMatrixEquiv",
+        "Etingof.Remark315.homMatrixEquiv_apply",
+        "Etingof.Remark315.homMatrixEquiv_symm_apply",
+        "Etingof.Remark315.apply_eq_sum",
+        "Etingof.Remark315.injective_iff_comp_eq_zero",
+        "Etingof.Remark315.injective_iff_rows_linearIndependent",
+        "Etingof.Remark315.rows_linearIndependent_iff",
+        "Etingof.Remark315.subrepresentation_blocks",
+        "Etingof.Remark315.end_divisionRing"
+      ]
+    },
     "start_page": "44",
     "end_page": "45",
     "start_line": 9,
@@ -3180,6 +3278,28 @@
     "id": "Chapter3/Discussion_alternative_proof_of_Proposition3.1.4",
     "type": "discussion",
     "title": "Alternative proof of Proposition 3.1.4 using Hom decomposition",
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.1",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.postcompHom",
+        "Etingof.postcompHom_apply",
+        "Etingof.restrictScalars_eq",
+        "Etingof.mem_ker_iff_components",
+        "Etingof.postcompHom_injective",
+        "Etingof.postcompHom_surjective",
+        "Etingof.homPiHomEquiv",
+        "Etingof.homPiHomEquiv_apply",
+        "Etingof.injective_iff",
+        "Etingof.surjective_iff",
+        "Etingof.bijective_iff",
+        "Etingof.postcompHom_id",
+        "Etingof.postcompHom_comp"
+      ],
+      "basis": "The mathematical content is covered by the listed declarations; the source's attribution of the alternative argument to B. Poonen is bibliographic prose without a Lean proof obligation."
+    },
     "start_page": "45",
     "end_page": "45",
     "start_line": 3,
@@ -3242,6 +3362,20 @@
     "id": "Chapter3/Lemma3.1.6",
     "type": "lemma",
     "title": "Surjective map from direct sum of irreducibles splits",
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.1",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.surjective_map_splits",
+        "Etingof.disjoint_sup_of_disjoint",
+        "Etingof.exists_subfamily_isCompl_ker",
+        "Etingof.exists_subfamily_bijective",
+        "Etingof.exists_subfamily_linearEquiv",
+        "Etingof.exists_subfamily_linearEquiv_of_isInternal"
+      ]
+    },
     "start_page": "45",
     "end_page": "45",
     "start_line": 13,
@@ -3278,6 +3412,21 @@
     "id": "Chapter3/Discussion_after_Lemma3.1.6",
     "type": "discussion",
     "title": "Completion of alternative proof of Proposition 3.1.4",
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.1",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.exists_subfamily_linearEquiv_of_isInternal",
+        "Etingof.restrictScalars_eq",
+        "Etingof.postcompHom_apply",
+        "Etingof.mem_ker_iff_components",
+        "Etingof.Remark315.subrepresentation_blocks",
+        "Etingof.subrepresentation_of_semisimple_matrix"
+      ],
+      "basis": "This record has no dedicated provider. Its four Stage 3.2 claims are covered elsewhere by the listed declarations, all of which were included in the seven-provider audit."
+    },
     "start_page": "45",
     "end_page": "45",
     "start_line": 17,


### PR DESCRIPTION
## Summary

- complete the Stage 3.3 proof-integrity audit for the exact ten-item Chapter 3 §3.1 scope
- record eight `sorry_free` and two `not_applicable` results without changing inherited Stage 3.2 data
- certify 60 unique public declarations plus three private helper proofs across seven provider files
- preserve the three genuinely nonformalizable prose units as prose

No Lean proof repair was needed.

## Validation

- all seven standalone providers built successfully (1977 jobs)
- `lake build EtingofRepresentationTheory.Chapter3` (8693 jobs)
- 60-declaration `#print axioms` audit: only `propext`, `Classical.choice`, and `Quot.sound`; no `sorryAx` or project axioms
- exact provider placeholder/admission scan clean
- `jq empty progress/items.json`
- `python3 scripts/validate_items.py` (5721/5721 lines)
- `python3 scripts/validate_dependencies.py`
- `python3 scripts/validate_external_deps.py`
- `python3 scripts/validate_mathlib_coverage.py`
- exact scope, Stage 3.2 invariance, non-scope invariance, aggregation, and `git diff --check` checks