### PR TITLE
Stage 3.4: trim Chapter 2 Section 2.15 dependencies

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Problem2_15_1_complete_reducibility.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_15_1_complete_reducibility.lean
@@ -1,10 +1,3 @@
-import Mathlib.Algebra.Lie.OfAssociative
-import Mathlib.Algebra.Lie.Submodule
-import Mathlib.LinearAlgebra.Dimension.Finite
-import Mathlib.LinearAlgebra.Eigenspace.Triangularizable
-import Mathlib.Algebra.DirectSum.Module
-import Mathlib.Analysis.Complex.Polynomial.Basic
-import EtingofRepresentationTheory.Chapter2.Sl2Irrep
 import EtingofRepresentationTheory.Chapter2.Theorem2_1_1
 
 /-!

--- a/EtingofRepresentationTheory/Chapter2/Problem2_15_1_l.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_15_1_l.lean
@@ -1,13 +1,4 @@
-import Mathlib.Algebra.Algebra.Equiv
-import Mathlib.Algebra.Lie.OfAssociative
-import Mathlib.Data.Nat.Factorial.Basic
-import Mathlib.LinearAlgebra.Pi
-import Mathlib.Algebra.Polynomial.Module.AEval
-import Mathlib.Algebra.Polynomial.Div
-import Mathlib.Algebra.Polynomial.RingDivision
 import Mathlib.Algebra.Module.PID
-import Mathlib.Algebra.DirectSum.Module
-import Mathlib.LinearAlgebra.Dimension.Constructions
 import EtingofRepresentationTheory.Chapter2.Sl2Irrep
 
 /-!

--- a/EtingofRepresentationTheory/Chapter2/Problem2_15_1_l_uniqueness.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_15_1_l_uniqueness.lean
@@ -1,4 +1,3 @@
-import EtingofRepresentationTheory.Chapter2.Problem2_15_1_l
 import EtingofRepresentationTheory.Chapter2.Sl2JordanTypeIso
 
 /-!

--- a/EtingofRepresentationTheory/Chapter2/Problem2_15_1_m.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_15_1_m.lean
@@ -1,7 +1,3 @@
-import Mathlib.Algebra.Ring.GeomSum
-import Mathlib.Algebra.Polynomial.Eval.Defs
-import Mathlib.Algebra.Polynomial.Monic
-import Mathlib.RingTheory.Polynomial.Basic
 import EtingofRepresentationTheory.Chapter2.Sl2Irrep
 
 /-!

--- a/EtingofRepresentationTheory/Chapter2/Problem2_15_1_m_Module.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_15_1_m_Module.lean
@@ -1,9 +1,4 @@
-import Mathlib.Algebra.Lie.TensorProduct
 import Mathlib.Algebra.Lie.DirectSum
-import Mathlib.Data.Nat.Choose.Basic
-import Mathlib.LinearAlgebra.Basis.Basic
-import Mathlib.LinearAlgebra.Dimension.Constructions
-import EtingofRepresentationTheory.Chapter2.Sl2Irrep
 import EtingofRepresentationTheory.Chapter2.Problem2_15_1_m
 import EtingofRepresentationTheory.Chapter2.Problem2_15_1_complete_reducibility
 

--- a/EtingofRepresentationTheory/Chapter2/Sl2Irrep.lean
+++ b/EtingofRepresentationTheory/Chapter2/Sl2Irrep.lean
@@ -1,11 +1,5 @@
-import Mathlib.Algebra.Lie.Classical
 import Mathlib.Algebra.Lie.Semisimple.Defs
 import Mathlib.Algebra.Lie.Sl2
-import Mathlib.Algebra.Lie.OfAssociative
-import Mathlib.Data.Complex.Basic
-import Mathlib.LinearAlgebra.Dimension.Finrank
-import Mathlib.LinearAlgebra.Dimension.Finite
-import Mathlib.LinearAlgebra.StdBasis
 import EtingofRepresentationTheory.Chapter2.Sl2Defs
 
 /-!

--- a/EtingofRepresentationTheory/Chapter2/Sl2SemisimpleDecomposition.lean
+++ b/EtingofRepresentationTheory/Chapter2/Sl2SemisimpleDecomposition.lean
@@ -1,7 +1,3 @@
-import Mathlib.Data.Fin.Tuple.Basic
-import Mathlib.LinearAlgebra.Projection
-import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
-import EtingofRepresentationTheory.Chapter2.Theorem2_1_1
 import EtingofRepresentationTheory.Chapter2.Problem2_15_1_complete_reducibility
 
 /-!

--- a/EtingofRepresentationTheory/Chapter2/Theorem2_1_1.lean
+++ b/EtingofRepresentationTheory/Chapter2/Theorem2_1_1.lean
@@ -1,13 +1,4 @@
-import Mathlib.Algebra.Lie.Quotient
-import Mathlib.Algebra.Lie.Semisimple.Defs
-import Mathlib.Algebra.Lie.Sl2
 import Mathlib.Analysis.Complex.Polynomial.Basic
-import Mathlib.Data.Complex.Basic
-import Mathlib.LinearAlgebra.Dimension.Finrank
-import Mathlib.LinearAlgebra.Dimension.Finite
-import Mathlib.LinearAlgebra.Eigenspace.Triangularizable
-import Mathlib.Tactic.NoncommRing
-import EtingofRepresentationTheory.Chapter2.Sl2Defs
 import EtingofRepresentationTheory.Chapter2.Sl2Irrep
 
 /-!

--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -319,11 +319,10 @@
   "Chapter2/Problem2.14.3": [
     "Chapter2/Definition2.14.2"
   ],
-  "Chapter2/Discussion_2.15_heading": [
-    "Chapter2/Problem2.14.3"
-  ],
+  "Chapter2/Discussion_2.15_heading": [],
   "Chapter2/Problem2.15.1": [
-    "Chapter2/Discussion_2.15_heading"
+    "Chapter2/Theorem2.1.1",
+    "Chapter2/Discussion_concrete_Lie_examples"
   ],
   "Chapter2/Discussion_2.16_heading": [
     "Chapter2/Problem2.15.1"

--- a/progress/2026-07-27T14-23-17Z_stage3-3-chapter2-section2-15.md
+++ b/progress/2026-07-27T14-23-17Z_stage3-3-chapter2-section2-15.md
@@ -1,0 +1,64 @@
+# Stage 3.3 proof verification — Chapter 2 §2.15
+
+## Scope and result
+
+This pass is stacked directly on the Stage 3.2 §2.15 commit and preserves its exact two-item
+reading-order scope: `Discussion_2.15_heading` and `Problem2.15.1`, stopping before §2.16.
+The heading is organizational prose and has no proof obligation. The problem uses all twelve
+attached providers:
+
+1. `Sl2Irrep.lean`
+2. `Theorem2_1_1.lean`
+3. `Problem2_15_1_a_e.lean`
+4. `Problem2_15_1_complete_reducibility.lean`
+5. `Problem2_15_1_l.lean`
+6. `Sl2NullitySequence.lean`
+7. `Sl2SemisimpleDecomposition.lean`
+8. `Sl2JordanTypeIso.lean`
+9. `Problem2_15_1_l_uniqueness.lean`
+10. `Problem2_15_1_m.lean`
+11. `Problem2_15_1_m_Module.lean`
+12. `Problem2_15_1_n.lean`
+
+No proof repair was required. Every formalized claim and its supporting implementation is
+proof-complete. The Stage 3.2 fidelity decisions remain unchanged: the source-specific
+minimal-counterexample scaffolding in parts (i)–(k) and the analytic `Tr(exp(xH))` route in
+part (m) are intentional proof-route omissions. Their intended mathematical endpoints are
+proved by stronger complete-reducibility, semisimple-decomposition, algebraic-character, and
+explicit-intertwiner results; no placeholder or unproved declaration stands in for an omission.
+
+## Declaration and internal-proof audit
+
+The twelve modules were imported into a dedicated Lean audit command. Module indices were used
+to enumerate the complete compiled surface rather than relying on a hand-selected theorem list.
+The audit found:
+
+- **268 exported constants**, including named declarations, public instances, and generated
+  equation/congruence declarations;
+- **710 total module-attributed constants** after including private helpers and other generated
+  implementation declarations.
+
+For every exported constant, the audit computed the same transitive axiom set reported by
+`#print axioms`. It also computed and checked the axiom set of every internal constant. Every
+set was a subset of Lean's accepted foundations `propext`, `Classical.choice`, and `Quot.sound`;
+many declarations used fewer or no axioms. There was no `sorryAx` and no project-defined axiom.
+
+A source scan over all twelve files found no token `sorry`, `admit`, `proof_wanted`, or `axiom`.
+Fresh direct elaboration of every provider exercised all internal proofs and emitted no
+declaration-with-sorry or metavariable diagnostic.
+
+## Validation
+
+- isolated combined build of all twelve providers: 3,221 jobs, success;
+- standalone `lake env lean` elaboration of all twelve provider files: success;
+- complete exported/internal transitive-axiom audit: 268/710 declarations, success;
+- exact two-item Stage 3.3 tracker check and JSON parsing;
+- repository item, internal-dependency, external-dependency, and Mathlib-coverage validators;
+- scoped lint ratchet and admission/project-axiom scans;
+- full Chapter 2 build;
+- stacked-diff invariance and `git diff --check`.
+
+The legacy `verify_blobs.py` utility remains incompatible with the ten existing top-level
+derived overlay records because those records intentionally use `derived_from` instead of `id`.
+It exits with `KeyError: id` before verification; this is unchanged repository-wide validator
+debt, not a §2.15 regression.

--- a/progress/2026-07-27T14-36-42Z_stage3-4-chapter2-section2-15.md
+++ b/progress/2026-07-27T14-36-42Z_stage3-4-chapter2-section2-15.md
@@ -1,0 +1,47 @@
+# Stage 3.4 dependency trimming — Chapter 2 §2.15
+
+## Scope
+
+This pass analyzes the exact two §2.15 catalog items after Stage 3.3: the section heading and
+Problem 2.15.1. The exercise is implemented across twelve provider modules.
+
+## Internal dependency result
+
+The organizational heading has no mathematical dependency. Problem 2.15.1 directly uses two
+earlier book items:
+
+- `Chapter2/Theorem2.1.1`, for the classification and complete-reducibility results reused by
+  the exercise providers;
+- `Chapter2/Discussion_concrete_Lie_examples`, for the concrete definition and standard relations
+  of `sl(2)` represented by the shared `Sl2Defs` provider.
+
+All other project imports connect providers belonging to Problem 2.15.1 itself. The conservative
+reading-order edges were replaced by these actual backward-only dependencies in
+`dependencies/internal.json`.
+
+## Import trimming
+
+Mathlib's `#redundant_imports` diagnostic was run by direct elaboration in every one of the twelve
+provider modules. Four headers were already transitively irredundant. Eight headers had a total of
+45 redundant imports, all of which were removed; the twelve headers now contain 21 imports in
+total. No umbrella `import Mathlib` remains in scope, and every edited provider elaborates directly
+with the reduced header.
+
+Both scoped items now carry complete `stage3_4` records and have status `dependency_trimmed`.
+
+## Validation
+
+- fresh isolated `.lake/build` baseline build of all twelve providers
+- `#redundant_imports` on all twelve provider modules
+- direct elaboration of all twelve providers after trimming
+- scoped provider build and full `EtingofRepresentationTheory.Chapter2` build
+- `scripts/validate_items.py`
+- `scripts/validate_dependencies.py`
+- `scripts/validate_external_deps.py`
+- `scripts/validate_mathlib_coverage.py`
+- exact two-item scope, graph, and tracker-invariance checks
+- `jq empty dependencies/internal.json progress/items.json`
+- `git diff --check`
+
+`scripts/verify_blobs.py` still encounters the repository's pre-existing derived-overlay entries
+without an `id`; this pass does not alter blobs or those unrelated records.

--- a/progress/items.json
+++ b/progress/items.json
@@ -4319,7 +4319,7 @@
     "end_page": "37",
     "start_line": 21,
     "end_line": 24,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "coverage_note": "Stage 3.2 reviewed the section heading and its organizational prose. It introduces the exercise sequence but makes no mathematical claim requiring a Lean declaration.",
     "last_updated": "2026-07-27",
@@ -4346,6 +4346,13 @@
       "proof_integrity": "not_applicable",
       "declarations": []
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.15",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "This organizational heading makes no mathematical assertion and depends on no earlier project item."
+    },
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -4359,7 +4366,7 @@
     "end_page": "39",
     "start_line": 25,
     "end_line": 16,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_partial",
     "coverage_note": "Stage 3.2 audited all twelve attached providers against every source part. Parts (a)-(h), the complete-reducibility conclusion behind (i)-(k), and parts (l)-(n) are formalized with honest definitions and concrete standard modules. This pass added the converse operator-triple constructor and the exact part-(h) Casimir eigenvalue. The source's particular minimal-counterexample intermediates in (i)-(k) are intentionally not duplicated because stronger complete-reducibility and semisimple-decomposition theorems establish their intended conclusion; the analytic Tr(exp(xH)) hint in (m) is likewise replaced by an algebraic character-polynomial identity and an explicit module isomorphism.",
     "last_updated": "2026-07-27",
@@ -4498,6 +4505,16 @@
         "Etingof.Sl2Irrep.jordan_normal_form_tensor"
       ],
       "scope_note": "The declaration list records the source-facing proof endpoints. The audit programmatically checked all 268 exported constants and all 710 constants attributed to the twelve scoped provider modules, including support declarations, private helpers, instances, and generated equations. Parts (i)-(k) and the analytic character hint in (m) remain the intentional proof-route omissions classified at Stage 3.2; no unproved declaration represents them."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "2.15",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Theorem2.1.1",
+        "Chapter2/Discussion_concrete_Lie_examples"
+      ],
+      "basis": "The proof providers use the classification and complete-reducibility results from Theorem 2.1.1 and the concrete sl(2) definition and relations introduced in the earlier Lie-algebra examples. All remaining project imports connect providers for this same exercise; transitively redundant Mathlib and project imports were removed from eight of the twelve providers."
     }
   },
   {

--- a/progress/items.json
+++ b/progress/items.json
@@ -4339,6 +4339,13 @@
         }
       ]
     },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.15",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "not_applicable",
+      "declarations": []
+    },
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -4451,6 +4458,46 @@
           "lean_decl": "Etingof.Sl2Irrep.jordan_normal_form_tensor"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.15",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Sl2Irrep.sl2_eq_smul_h_add_smul_e_add_smul_f",
+        "Etingof.Sl2Irrep.sl2LieHomOfOperators",
+        "Etingof.Sl2Irrep.sl2LieHomOfOperators_e",
+        "Etingof.Sl2Irrep.sl2LieHomOfOperators_f",
+        "Etingof.Sl2Irrep.sl2LieHomOfOperators_h",
+        "Etingof.Sl2Irrep.lie_e_eq_zero_on_maxGenEigenspace",
+        "Etingof.Sl2Irrep.highestWeightPolynomial",
+        "Etingof.Sl2Irrep.highestWeightPolynomial_natDegree",
+        "Etingof.Sl2Irrep.eIter_fIter_eq_aeval_highestWeightPolynomial",
+        "Etingof.Sl2Irrep.exists_pos_fIter_eq_zero_of_mem_maxGenEigenspace",
+        "Etingof.Sl2Irrep.maxGenEigenspace_eq_eigenspace_of_no_higher_weight",
+        "Etingof.Sl2Irrep.highestWeightPolynomial_squarefree",
+        "Etingof.Sl2Irrep.highestWeight_eq_nat_of_minimal_fIter_zero_of_mem_maxGenEigenspace",
+        "Etingof.Sl2Irrep.irrep_isIrreducible",
+        "Etingof.Sl2Irrep.irrep_finrank",
+        "Etingof.Problem_2_15_1_f",
+        "Etingof.Sl2Irrep.lie_sl2_h_e_basis",
+        "Etingof.Sl2Irrep.lie_sl2_e_e_basis",
+        "Etingof.Sl2Irrep.lie_sl2_f_e_basis",
+        "Etingof.Sl2Irrep.lie_sl2_f_e_basis_top",
+        "Etingof.Sl2Irrep.casimir_central",
+        "Etingof.Sl2Irrep.casimir_eq_scalar_lambda",
+        "Etingof.Sl2Irrep.casimirGenEigenspace_isInternal",
+        "Etingof.Sl2Irrep.indecomposable_casimir_eigenvalue",
+        "Etingof.Sl2Irrep.complete_reducibility",
+        "Etingof.Sl2Irrep.sl2Module_decomposition",
+        "Etingof.Sl2Irrep.casimir_lowest_weight",
+        "Etingof.Sl2Irrep.jacobsonMorozov_sl2",
+        "Etingof.Sl2Irrep.clebsch_gordan_charPoly",
+        "Etingof.Sl2Irrep.clebsch_gordan_module_iso",
+        "Etingof.Sl2Irrep.jordan_normal_form_tensor"
+      ],
+      "scope_note": "The declaration list records the source-facing proof endpoints. The audit programmatically checked all 268 exported constants and all 710 constants attributed to the twelve scoped provider modules, including support declarations, private helpers, instances, and generated equations. Parts (i)-(k) and the analytic character hint in (m) remain the intentional proof-route omissions classified at Stage 3.2; no unproved declaration represents them."
     }
   },
   {


### PR DESCRIPTION
## Summary

- record the actual backward-only dependencies for the two Section 2.15 items
- run #redundant_imports across all twelve providers and remove 45 validated redundant imports from eight headers
- mark both items dependency_trimmed and add the durable Stage 3.4 audit note

## Validation

- fresh isolated baseline build of all twelve providers: 3,221 jobs
- direct elaboration of all twelve providers after trimming
- scoped provider build: 3,221 jobs
- full Chapter 2 build: 8,744 jobs
- validate_items.py, validate_dependencies.py, validate_external_deps.py, and validate_mathlib_coverage.py
- exact two-item scope, graph, and tracker invariance checks
- JSON parsing and git diff checks

verify_blobs.py retains the known repository-wide KeyError on derived overlay records lacking id; this PR does not touch those records.