### PR TITLE
Stage 3.5: polish Chapter 3 §3.2 proofs

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/Corollary3_2_1.lean
+++ b/EtingofRepresentationTheory/Chapter3/Corollary3_2_1.lean
@@ -1,5 +1,3 @@
-import Mathlib.RingTheory.SimpleModule.Basic
-import Mathlib.LinearAlgebra.Basis.VectorSpace
 import EtingofRepresentationTheory.Chapter3.Theorem3_2_2
 
 /-!

--- a/EtingofRepresentationTheory/Chapter3/Theorem3_2_2.lean
+++ b/EtingofRepresentationTheory/Chapter3/Theorem3_2_2.lean
@@ -1,5 +1,3 @@
-import Mathlib.RingTheory.SimpleModule.Basic
-import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 import Mathlib.RepresentationTheory.AlgebraRepresentation.Basic
 
 /-!

--- a/EtingofRepresentationTheory/Chapter3/Theorem3_2_2.lean
+++ b/EtingofRepresentationTheory/Chapter3/Theorem3_2_2.lean
@@ -45,7 +45,7 @@ theorem Etingof.density_theorem_part1 (k : Type*) (A : Type*) (V : Type*)
 representations, the combined representation map is surjective.
 Etingof Theorem 3.2.2(ii). -/
 theorem Etingof.density_theorem_part2 (k : Type*) (A : Type*) (ι : Type*)
-    [Field k] [IsAlgClosed k] [Ring A] [Algebra k A] [Fintype ι]
+    [Field k] [IsAlgClosed k] [Ring A] [Algebra k A] [Finite ι]
     (V : ι → Type*) [∀ i, AddCommGroup (V i)] [∀ i, Module k (V i)]
     [∀ i, Module A (V i)] [∀ i, IsScalarTower k A (V i)]
     [∀ i, FiniteDimensional k (V i)] [∀ i, IsSimpleModule A (V i)]
@@ -54,6 +54,9 @@ theorem Etingof.density_theorem_part2 (k : Type*) (A : Type*) (ι : Type*)
       (fun a i => (Algebra.lsmul k k (V i) : A →ₐ[k] Module.End k (V i)) a :
         A → ∀ i, Module.End k (V i)) := by
   classical
+  -- Choose enumeration data only inside the proof; the statement needs proposition-valued
+  -- finiteness.
+  letI := Fintype.ofFinite ι
   intro f
   -- The product module ∏ V_i is semisimple (each V_i is simple, hence semisimple)
   haveI : IsSemisimpleModule A (∀ i, V i) :=

--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -399,15 +399,9 @@
   "Chapter3/Discussion_after_Lemma3.1.6": [
     "Chapter3/Lemma3.1.6"
   ],
-  "Chapter3/Introduction_to_3.2": [
-    "Chapter3/Discussion_after_Lemma3.1.6"
-  ],
-  "Chapter3/Corollary3.2.1": [
-    "Chapter3/Introduction_to_3.2"
-  ],
-  "Chapter3/Theorem3.2.2": [
-    "Chapter3/Corollary3.2.1"
-  ],
+  "Chapter3/Introduction_to_3.2": [],
+  "Chapter3/Corollary3.2.1": [],
+  "Chapter3/Theorem3.2.2": [],
   "Chapter3/Introduction_to_3.3": [
     "Chapter3/Theorem3.2.2"
   ],

--- a/progress/2026-07-27T14-35-54Z_stage3-4-chapter3-section3-2.md
+++ b/progress/2026-07-27T14-35-54Z_stage3-4-chapter3-section3-2.md
@@ -1,0 +1,36 @@
+# Stage 3.4 dependency trimming — Chapter 3 §3.2
+
+## Scope
+
+This pass analyzes the actual dependencies and direct imports of the exact three §3.2 catalog
+items after Stage 3.3: the section heading, Corollary 3.2.1, and Theorem 3.2.2.
+
+## Result
+
+All three backward pedagogical dependency sets are empty. The heading is organizational. Both
+density proofs use Mathlib APIs directly and import no project item. The interpolation corollary
+imports the later Theorem 3.2.2 provider because Lean proves density first and derives the
+corollary afterward. That forward implementation import cannot be represented in the acyclic
+backward book-order graph; it is a documented proof-order choice, not a hidden dependency on an
+earlier catalog item. The three conservative reading-order edges were removed accordingly.
+
+The theorem provider now has the single focused Mathlib import reported by `#min_imports`; two
+redundant direct imports were removed. The corollary provider now imports only the theorem
+provider; two redundant Mathlib imports were removed. Final `#redundant_imports` checks report no
+transitively redundant import in either provider.
+
+All three items carry complete `stage3_4` records and move to `dependency_trimmed`.
+
+## Validation
+
+- direct compilation of both providers
+- Mathlib's `#redundant_imports` and `#min_imports` diagnostics
+- full `EtingofRepresentationTheory.Chapter3` build
+- `scripts/validate_items.py`
+- `scripts/validate_dependencies.py`
+- `scripts/validate_external_deps.py`
+- exact three-item §3.2 graph/tracker audit
+- `jq empty dependencies/internal.json progress/items.json`
+- `git diff --check`
+
+This PR is limited to Section 3.2 and Stage 3.4.

--- a/progress/2026-07-27T14-39-05Z_stage3-5-chapter3-section3-2.md
+++ b/progress/2026-07-27T14-39-05Z_stage3-5-chapter3-section3-2.md
@@ -1,0 +1,31 @@
+# Stage 3.5 Mathlib-quality review — Chapter 3 §3.2
+
+## Scope and result
+
+This stacked pass reviews the exact three §3.2 items and all three public declarations in their
+two providers. Stages 3.2–3.4 already established faithful coverage, complete proofs, and the
+minimal dependency/import surface.
+
+`Etingof.density_theorem_part2` previously exposed `[Fintype ι]` even though enumeration data did
+not occur in its proposition. The public API now uses the proposition-valued `[Finite ι]`
+assumption and constructs `Fintype.ofFinite ι` locally inside the proof. This preserves the exact
+finite-family theorem while removing the `unusedFintypeInType` warning and avoiding unnecessary
+computational data in the statement.
+
+Manual review found the three theorem names descriptive in their namespace, all declarations
+documented, the proofs focused on the relevant Mathlib APIs, and every source line within
+Mathlib's 100-character style limit. The Stage 3.4 imports remain transitively irredundant.
+
+## Verification
+
+- temporary `#lint+ docBlameThm`: zero findings across three named declarations and all 17 linters
+- temporary `#redundant_imports`: no transitively redundant import in either provider
+- `#print axioms` on all three declarations: only `propext`, `Classical.choice`, and `Quot.sound`
+- standalone warning-free elaboration of both providers after diagnostics were removed
+- scoped scan for admissions, project axioms, diagnostics, style violations, and long lines
+- full `EtingofRepresentationTheory.Chapter3` build
+- all three repository metadata/dependency validators
+- exact three-item Stage 3.5 tracker audit, JSON parsing, and `git diff --check`
+
+All three scoped items now have `status = proof_polished` and complete Stage 3.5 records. This PR
+is limited to Section 3.2 and Stage 3.5.

--- a/progress/items.json
+++ b/progress/items.json
@@ -4743,7 +4743,7 @@
     "end_page": "45",
     "start_line": 23,
     "end_line": 27,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "coverage": "covered_full",
     "fidelity": "verified",
     "claim_coverage": {
@@ -4787,6 +4787,13 @@
       "actual_internal_dependencies": [],
       "basis": "The section heading is organizational and has no Lean provider or actual internal dependency."
     },
+    "stage3_5": {
+      "status": "complete",
+      "section": "3.2",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The organizational heading has no declaration to polish; its scoped providers are fully reviewed and style-clean."
+    },
     "last_updated": "2026-07-27",
     "coverage_swept": {
       "wave": 1,
@@ -4801,7 +4808,7 @@
     "end_page": "46",
     "start_line": 1,
     "end_line": 4,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "coverage": "covered_full",
     "last_updated": "2026-07-27",
     "fidelity": "verified",
@@ -4848,6 +4855,13 @@
       "verified_on": "2026-07-27",
       "actual_internal_dependencies": [],
       "basis": "The provider imports the later Theorem 3.2.2 implementation, not an earlier book item. That forward proof-order import is excluded from the backward pedagogical graph and is recorded explicitly in the Stage 3.4 audit note."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "3.2",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The public interpolation theorem is documented, warning-free, import-minimal, axiom-clean, and passes all 17 declaration linters."
     }
   },
   {
@@ -4858,7 +4872,7 @@
     "end_page": "46",
     "start_line": 5,
     "end_line": 13,
-    "status": "dependency_trimmed",
+    "status": "proof_polished",
     "fidelity": "verified",
     "notes": "Both parts proved. Part (i) uses Jacobson density theorem for simple modules. Part (ii) applies density theorem to the product module via Schur's lemma decomposition.",
     "sorry_free": true,
@@ -4933,6 +4947,13 @@
       "verified_on": "2026-07-27",
       "actual_internal_dependencies": [],
       "basis": "Both density proofs use only Mathlib APIs. Their provider has one focused Mathlib import and no project import."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "3.2",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "Both public density theorems pass all 17 linters. Part (ii) now exposes proposition-valued Finite and constructs Fintype data only locally in the proof, eliminating the unused-Fintype API warning."
     },
     "last_updated": "2026-07-27"
   },

--- a/progress/items.json
+++ b/progress/items.json
@@ -4743,7 +4743,7 @@
     "end_page": "45",
     "start_line": 23,
     "end_line": 27,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "fidelity": "verified",
     "claim_coverage": {
@@ -4780,6 +4780,13 @@
       "proof_integrity": "not_applicable",
       "declarations": []
     },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The section heading is organizational and has no Lean provider or actual internal dependency."
+    },
     "last_updated": "2026-07-27",
     "coverage_swept": {
       "wave": 1,
@@ -4794,7 +4801,7 @@
     "end_page": "46",
     "start_line": 1,
     "end_line": 4,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "last_updated": "2026-07-27",
     "fidelity": "verified",
@@ -4834,6 +4841,13 @@
         "Etingof.irreducible_interpolation"
       ],
       "scope_note": "The exact corollary is fully proved. Its Lean proof uses the independently verified density theorem rather than reproducing the book's matrix contradiction."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The provider imports the later Theorem 3.2.2 implementation, not an earlier book item. That forward proof-order import is excluded from the backward pedagogical graph and is recorded explicitly in the Stage 3.4 audit note."
     }
   },
   {
@@ -4844,7 +4858,7 @@
     "end_page": "46",
     "start_line": 5,
     "end_line": 13,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "notes": "Both parts proved. Part (i) uses Jacobson density theorem for simple modules. Part (ii) applies density theorem to the product module via Schur's lemma decomposition.",
     "sorry_free": true,
@@ -4912,6 +4926,13 @@
         "Etingof.density_theorem_part2"
       ],
       "scope_note": "Both exact density endpoints are fully proved through Mathlib's Jacobson-density and simple-module APIs; the alternate proof organization recorded at Stage 3.2 introduces no deferred proof obligation."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.2",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "Both density proofs use only Mathlib APIs. Their provider has one focused Mathlib import and no project import."
     },
     "last_updated": "2026-07-27"
   },

--- a/scripts/lint-warning-baseline.txt
+++ b/scripts/lint-warning-baseline.txt
@@ -39,7 +39,6 @@ EtingofRepresentationTheory/Chapter3/Remark3_1_5.lean
 EtingofRepresentationTheory/Chapter3/Remark3_3_4.lean
 EtingofRepresentationTheory/Chapter3/Remark3_8_6.lean
 EtingofRepresentationTheory/Chapter3/Theorem3_10_2.lean
-EtingofRepresentationTheory/Chapter3/Theorem3_2_2.lean
 EtingofRepresentationTheory/Chapter3/Theorem3_3_1.lean
 EtingofRepresentationTheory/Chapter3/Theorem3_5_4.lean
 EtingofRepresentationTheory/Chapter3/Theorem3_8_1.lean


### PR DESCRIPTION
## Scope

Stage 3.5 only for Chapter 3 §3.2, stacked on #8057.

## Mathlib-quality result

- Reviewed all three public declarations across both providers.
- Replaced the public `[Fintype ι]` assumption of `Etingof.density_theorem_part2` with proposition-valued `[Finite ι]`, constructing `Fintype.ofFinite ι` only locally in the proof. This preserves the finite-family statement and eliminates the scoped API warning.
- All three declarations pass all 17 declaration linters with zero findings.
- Both providers elaborate warning-free, have no redundant imports, no lines over 100 characters, and retain only accepted foundational axioms.

## Validation

- Clean provider build: 1,950 jobs
- Full Chapter 3 build: 8,692 jobs
- All repository metadata/dependency validators
- Exact three-item Stage 3.5 tracker audit
- Admission, diagnostic, style, JSON, and diff checks

All three scoped items now have `status = proof_polished`. This draft PR is limited to §3.2 Stage 3.5.