### PR TITLE
Verify Chapter 2 §2.16 proof integrity

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Problem2_16_3.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_16_3.lean
@@ -36,7 +36,9 @@ number of positive roots:
 * `n = 3`: type `G₂`,  `dim 𝔤₃ = 6`;
 * `n = 4`: the Cartan matrix has determinant `0` (affine type), so `𝔤₄` is infinite dimensional.
 
-Statement-only (proofs deferred).
+The finite-dimensional cases and the infinite-dimensionality of `𝔤₄` are proved in this file.
+The companion `Problem2_16_3_*` files construct the requested explicit characteristic-zero basis
+of `𝔤₄` and identify it with the positive twisted loop algebra of type `A₂⁽²⁾`.
 -/
 
 namespace Etingof.Problem2_16_3

--- a/EtingofRepresentationTheory/Chapter2/Problem2_16_5.lean
+++ b/EtingofRepresentationTheory/Chapter2/Problem2_16_5.lean
@@ -22,7 +22,7 @@ denominators so they are well-typed for every `q` (the coefficient `q - q⁻¹` 
   `K L = 1`,  `L K = 1`,  `K e = q²·(e K)`,  `K f = q⁻²·(f K)`,
   `(q - q⁻¹)·(e f - f e) = K - L`.
 
-The main classification results for both cases are established below:
+The following structural constraints in the two cases are established below:
 
 * **`q` not a root of unity**: every nontrivial finite dimensional representation has a highest
   weight vector (`exists_highest_weight_vector`), and on a simple such module the highest weight
@@ -35,10 +35,10 @@ The main classification results for both cases are established below:
   `finrank_le_of_epow_orderOf_eq_zero`, `finrank_le_of_fpow_orderOf_eq_zero`, and
   `finrank_le_of_cyclic`).
 
-These are the core structural results of the classification. The exhaustive enumeration of
-irreducibles up to isomorphism is intentionally omitted by the project-wide scope decision in
-`skipped-exercises.md`. The omission is documentation-only: this file does not introduce an
-unproved classification declaration.
+These are inputs to a classification, not an enumeration up to isomorphism. The exhaustive
+enumeration of irreducibles up to isomorphism is intentionally omitted by the project-wide scope
+decision in `skipped-exercises.md`. The omission is documentation-only: this file does not
+introduce an unproved classification declaration.
 -/
 
 namespace Etingof.Problem2_16_5
@@ -100,6 +100,39 @@ noncomputable def L (q : ℂˣ) : Uqsl2 q := mk q fL
     ((q : ℂ) - (q : ℂ)⁻¹) • (e q * f q - f q * e q) = K q - L q := by
   have h := RingQuot.mkAlgHom_rel ℂ (Rel.ef (q := q))
   simp only [map_smul, map_sub, map_mul] at h; exact h
+
+/-! ## A nontrivial one-dimensional quotient
+
+Sending `e` and `f` to `0` and both `K` and `L` to `1` respects every defining relation. The
+resulting surjection `U_q(sl₂) →ₐ[ℂ] ℂ` proves in Lean that the presented algebra is nontrivial;
+in particular, the representation-theoretic statements below are not about a collapsed quotient.
+-/
+
+/-- Values of the four generators in the one-dimensional quotient. -/
+private noncomputable def augmentationGen : Gen → ℂ := ![0, 0, 1, 1]
+
+/-- The free-algebra map underlying the one-dimensional quotient. -/
+private noncomputable def augmentationFree : FreeAlgebra ℂ Gen →ₐ[ℂ] ℂ :=
+  FreeAlgebra.lift ℂ augmentationGen
+
+private theorem augmentationFree_rel (q : ℂˣ) :
+    ∀ ⦃a b⦄, Rel q a b → augmentationFree a = augmentationFree b := by
+  rintro _ _ h
+  cases h <;> simp [augmentationFree, augmentationGen]
+
+/-- The one-dimensional quotient `U_q(sl₂) →ₐ[ℂ] ℂ`, with `e,f ↦ 0` and `K,L ↦ 1`. -/
+noncomputable def augmentation (q : ℂˣ) : Uqsl2 q →ₐ[ℂ] ℂ :=
+  RingQuot.liftAlgHom ℂ ⟨augmentationFree, augmentationFree_rel q⟩
+
+/-- The one-dimensional quotient is onto. -/
+theorem augmentation_surjective (q : ℂˣ) : Function.Surjective (augmentation q) := by
+  intro z
+  refine ⟨algebraMap ℂ (Uqsl2 q) z, ?_⟩
+  exact (augmentation q).commutes z
+
+/-- The presentation of `U_q(sl₂)` does not collapse to the zero ring. -/
+noncomputable instance instNontrivialUqsl2 (q : ℂˣ) : Nontrivial (Uqsl2 q) :=
+  (augmentation_surjective q).nontrivial
 
 /-! ## Classification of irreducible representations (spec) -/
 
@@ -439,10 +472,12 @@ lemma smul_mem_of_generators (q : ℂˣ) (V : Type*) [AddCommGroup V] [Module �
     rw [map_add, add_smul]
     exact W.add_mem (ha y hy) (hb y hy)
 
-/-- **Non-root-of-unity case.** When `q` is not a root of unity, every finite dimensional
-irreducible representation is determined up to isomorphism by its dimension together with a
-sign `ε ∈ {±1}`: on a highest weight vector `v` of an `(n+1)`-dimensional irreducible, `K`
-acts by `ε qⁿ`. We record the eigenvalue constraint on the highest weight. -/
+/-- **Non-root-of-unity necessary constraint.** On a highest weight vector `v` of an
+`(n+1)`-dimensional irreducible, `K` acts by `ε qⁿ` for some `ε` with `ε² = 1`.
+
+This theorem records only the eigenvalue constraint. It does not assert that dimension and sign
+determine the representation up to isomorphism; that enumeration is part of the intentionally
+omitted classification. -/
 theorem highest_weight_eigenvalue_of_not_isOfFinOrder (q : ℂˣ) (hq : ¬ IsOfFinOrder q)
     (V : Type*) [AddCommGroup V] [Module ℂ V] [Module (Uqsl2 q) V]
     [IsScalarTower ℂ (Uqsl2 q) V] [FiniteDimensional ℂ V] [IsSimpleModule (Uqsl2 q) V] :

--- a/deferred-reprises.md
+++ b/deferred-reprises.md
@@ -19,9 +19,9 @@ The Chapter 2 file proves:
 - the bound is sharp, by constructing irreducible modules of dimension `p` (and,
   more generally, the standard modules of dimensions `1` through `p`).
 
-These results are source-present, but the current files do not pass a fresh source
-check; regression #7531 tracks restoring the existing partial endpoints. That
-compiler regression is separate from the missing classification below.
+These results are source-present and pass a fresh source check; regression #7531 restored the
+existing partial endpoints. That completed compiler repair is separate from the missing
+classification below.
 
 It does not classify all irreducible modules up to isomorphism, as the exercise asks.
 The source is `blobs/Chapter2/Problem2.16.4.md`; no later source item in the current

--- a/progress/2026-07-27T14-25-58Z_stage3-2-chapter2-section2-16.md
+++ b/progress/2026-07-27T14-25-58Z_stage3-2-chapter2-section2-16.md
@@ -1,0 +1,89 @@
+# Stage 3.2 fidelity review — Chapter 2 §2.16
+
+## Scope
+
+Reading order gives exactly six §2.16 catalog items, from
+`Chapter2/Discussion_2.16_heading` through `Chapter2/Problem2.16.5`. The preceding item is
+`Chapter2/Problem2.15.1`; the next item is `Chapter3/Introduction`. Thus the audit stops before
+Chapter 3.
+
+The six items have sixteen direct providers: one each for Problems 2.16.1, 2.16.2, 2.16.4, and
+2.16.5, plus the twelve-file `Problem2_16_3*` development. `Chapter2/Sl2Irrep.lean` is imported
+separately by the chapter aggregate for Theorem 2.1.1 and is not a §2.16 provider; Problem 2.16.4
+contains its own arbitrary-field construction.
+
+## Claim audit
+
+All six blobs and all sixteen providers were audited against the source in reading order. The
+durable tracker has 32 claim units:
+
+- 22 `formalized`;
+- 2 `covered_elsewhere` by Mathlib's derived-series API;
+- 3 `non_formalizable` organizational, heuristic, or proof-strategy units;
+- 5 policy-controlled missing classification units.
+
+The five last units preserve two different policy decisions. Three are the explicit unfinished
+reprise for Problem 2.16.4 (parameter family, isomorphism criterion, and exhaustiveness), so they
+are not a permanent scope exclusion. Two are the intentional project-wide omission of exhaustive
+quantum classification in Problem 2.16.5, one for each root-of-unity case. The canonical verdict
+bucket is `intentional_omission`, while each claim's reason records which of the two policies
+applies. No placeholder, assumption, `Nonempty` shell, or weakened wrapper represents any of
+these five units.
+
+The qualifiers are explicit. Problem 2.16.1 fixes the field literally to `ℂ`. Problem 2.16.2 uses
+the standing algebraically closed convention and a prime characteristic `p`. In Problem 2.16.3,
+the `g₃` dimension theorem assumes `2 ≠ 0`, `g₄` is proved infinite-dimensional over every field,
+and the explicit `LoopIdx` basis is the characteristic-zero result. Problem 2.16.4 assumes an
+algebraically closed field of prime characteristic `p > 2`. Problem 2.16.5 specializes the
+source's allowed algebraically closed characteristic-zero field to `ℂ`; its non-root branch uses
+`¬ IsOfFinOrder q`, and its root branch states the source exclusion `q ≠ ±1` as `q² ≠ 1`.
+
+## Repairs
+
+Stage 3.2 made three scoped repairs:
+
+1. The stale header of `Problem2_16_3.lean` no longer says that its now-proved results are
+   statement-only or deferred; it points to the companion files containing the explicit basis.
+2. `Problem2_16_5.lean` no longer claims that the necessary highest-weight eigenvalue constraint
+   determines an irreducible up to isomorphism. Its prose now agrees with the actual theorem and
+   the documented classification omission.
+3. The quantum presentation now has the surjective augmentation
+   `augmentation : Uqsl2 q →ₐ[ℂ] ℂ`, sending `e,f` to zero and `K,L` to one. Consequently
+   `Uqsl2 q` has a proved `Nontrivial` instance, closing the presentation's formal nonvacuity gap.
+
+The stale regression wording for Problem 2.16.4 was also corrected: #7531 already restored fresh
+elaboration of the existing partial endpoints. The reprise decision itself is unchanged.
+
+## Integrity and nonvacuity
+
+- Problem 2.16.1 uses genuine `IsSimpleOrder (LieSubmodule ℂ L V)` irreducibility; its
+  `Nontrivial V` assumption is redundant, not restrictive.
+- Problem 2.16.2 constructs both classified families, proves their irreducibility, constructs the
+  equivalences inside every `Nonempty`, proves the exact isomorphism criterion, and proves
+  exhaustiveness. `Nonempty` only propositionalizes the type of isomorphisms.
+- Problem 2.16.3 is the quotient of the free Lie algebra by the two displayed relators. Its
+  dimensions have independent matrix lower bounds, and `gFourBasis` is a genuine
+  `Module.Basis`, not a spanning-family wrapper.
+- Problem 2.16.4 constructs the standard modules and proves their irreducibility. The sharpness
+  theorem uses the actual `p`-dimensional module; it does not assume existence.
+- Problem 2.16.5 uses genuine `IsSimpleModule` hypotheses, and the new augmentation proves that
+  the algebra presentation itself has not collapsed.
+
+## Validation
+
+- `.lake/build` is worktree-local; only `.lake/packages` shares the package cache;
+- all 16 scoped providers built together successfully from the fresh local build (8595 jobs);
+- `lake build EtingofRepresentationTheory.Chapter2`: success;
+- the scoped declaration scan found no `sorry`, `admit`, `axiom`, `opaque`, `native_decide`, or
+  `proof_wanted` declaration;
+- `#print axioms` on sixteen principal endpoints reported only `propext`, `Classical.choice`, and
+  `Quot.sound`, never `sorryAx`;
+- `jq empty progress/items.json` and the exact six-item/32-claim aggregation passed;
+- `python3 scripts/validate_items.py`: passed with 5721/5721-line coverage and its 593
+  pre-existing extra-field warnings;
+- `python3 scripts/validate_dependencies.py`: passed with its one pre-existing conservative-default
+  warning;
+- `python3 scripts/validate_external_deps.py` and
+  `python3 scripts/validate_mathlib_coverage.py`: passed;
+- normalized non-scope tracker projections match `origin/main` byte-for-byte, dependency metadata
+  is unchanged, and `git diff --check` passes.

--- a/progress/2026-07-27T14-39-58Z_stage3-3-chapter2-section2-16.md
+++ b/progress/2026-07-27T14-39-58Z_stage3-3-chapter2-section2-16.md
@@ -1,0 +1,57 @@
+# Stage 3.3 proof verification — Chapter 2 §2.16
+
+## Scope and result
+
+This pass keeps the exact six-item, sixteen-provider §2.16 scope established at Stage 3.2. The
+section heading has no proof obligation. The five classification gaps also remain exactly as
+recorded there: three unfinished Problem 2.16.4 reprise units (parameter family, isomorphism
+criterion, and exhaustiveness) and the two permanent project-wide Problem 2.16.5 exhaustive
+classification omissions (non-root and root-of-unity cases). Stage 3.3 does not represent any of
+these gaps by a theorem, axiom, wrapper, or strengthened status.
+
+No Lean proof repair was required. The audit did repair one stale tracker reference:
+`coe_derivedSeries_one_eq` is correctly namespaced as
+`LieAlgebra.coe_derivedSeries_one_eq`, not `LieIdeal.coe_derivedSeries_one_eq`.
+
+## Exhaustive environment audit
+
+A scratch module imported all sixteen direct providers and selected constants by Lean's recorded
+module attribution. This inventories generated and private proof constants that a text-only list
+of top-level commands would miss. It found 1,589 attributed constants:
+
+- 1,467 are non-private constants (1,369 non-reserved public names and 98 reserved generated
+  names), and 122 are private;
+- 1,322 are proof constants (1,125 non-reserved public, 98 reserved generated, and 99 private);
+- the remaining constants are 238 definitions, 15 constructors, 7 inductives, and 7 recursors;
+- there are no scoped `axiom` or `opaque` declarations.
+
+The item/provider totals are: Problem 2.16.1, 1 constant / 1 proof constant; Problem 2.16.2,
+211 / 168; the twelve-file Problem 2.16.3 development, 1,108 / 925; Problem 2.16.4, 119 / 109;
+and Problem 2.16.5, 150 / 119.
+
+Every attributed constant was passed to `Lean.collectAxioms`, the engine used by
+`#print axioms`. The audit fails on a direct project axiom or on any dependency outside
+`propext`, `Classical.choice`, and `Quot.sound`; it passed. Separate literal `#print axioms`
+commands checked the five externally supplied declarations used by the tracker:
+`LieAlgebra.derivedSeries`, `LieAlgebra.coe_derivedSeries_one_eq`,
+`LieAlgebra.IsSolvable`, `LieAlgebra.isSolvable_iff`, and `IsOfFinOrder`. They likewise use only
+the accepted foundational axioms (or none). Thus no scoped public endpoint or module-attributed
+proof constant contains `sorryAx` or a project axiom.
+
+The source-level scan also found no `sorry`, `admit`, `proof_wanted`, `sorryAx`,
+`native_decide`, project `axiom`, or `opaque` declaration in any of the sixteen providers.
+
+## Validation
+
+- fresh worktree-local build of all sixteen providers: success (8,595 jobs);
+- full `EtingofRepresentationTheory.Chapter2` build: success;
+- exhaustive attributed-constant audit and external `#print axioms` checks: success;
+- exact six-item Stage 3.3 tracker audit, five-omission invariance check, and JSON parse: success;
+- `scripts/validate_items.py`, `scripts/validate_dependencies.py`,
+  `scripts/validate_external_deps.py`, and `scripts/validate_mathlib_coverage.py`: success;
+- normalized non-scope tracker projection and all non-tracker source providers are unchanged from
+  the Stage 3.2 base;
+- dependency metadata is unchanged, only `.lake/packages` is shared, and `git diff --check`
+  passes.
+
+This PR is limited to Section 2.16 and Stage 3.3.

--- a/progress/items.json
+++ b/progress/items.json
@@ -1756,7 +1756,27 @@
     "status": "sorry_free",
     "coverage_swept": {
       "wave": 1,
-      "result": "none"
+      "result": "non_formalizable"
+    },
+    "coverage": "covered_full",
+    "fidelity": "verified",
+    "coverage_note": "Stage 3.2 reviewed the section heading; it is organizational prose announcing the Lie-algebra problem set and contains no mathematical proposition.",
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.16",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "Section 2.16 is the collection of problems on Lie algebras.",
+          "verdict": "non_formalizable",
+          "reason": "This is an organizational heading, not a mathematical assertion."
+        }
+      ]
     }
   },
   {
@@ -1769,10 +1789,43 @@
     "end_line": 4,
     "status": "sorry_free",
     "coverage": "covered_full",
-    "last_updated": "2026-07-22",
-    "coverage_note": "Proved via Mathlib LieModule.exists_nontrivial_weightSpace_of_isSolvable (#6116, 2026-07-10). Axioms: propext, Classical.choice, Quot.sound.",
+    "last_updated": "2026-07-27",
+    "coverage_note": "The book's commutant and solvability definitions are exactly Mathlib's first derived ideal and derived-series solvability, and Lie's theorem is proved over the literal field ℂ via LieModule.exists_nontrivial_weightSpace_of_isSolvable. The detailed induction/trace paragraph is a proof-strategy hint rather than an additional conclusion; the provider uses Mathlib's stronger common-weight theorem and then proves that the invariant line is all of V.",
     "fidelity": "verified",
-    "fidelity_note": "Reviewed #7198 (2026-07-21). FAITHFUL and non-vacuous. Ground field ℂ is fixed literally (no over-general [IsAlgClosed]/[CharZero]); CharZero and triangularizability are discharged as instances for ℂ, not statement hypotheses. IsSimpleOrder (LieSubmodule ℂ L V) is the genuine 'only subreps are 0 and V, V≠0' irreducibility; [Nontrivial V] is implied by IsSimpleOrder (redundant, not an added restriction). LieAlgebra.IsSolvable = derived-series definition = book's Kⁿ(𝔤)=0 commutant series; LieRingModule+LieModule is the genuine Lie action; finrank ℂ V = 1 renders '1-dimensional'. Non-vacuity witness: solvable L acting on V=ℂ. Axiom-clean (propext, Classical.choice, Quot.sound), no sorryAx. No follow-up filed. See progress/reviews/2026-07-21-ch2-problem2_16_1-lie-theorem-fidelity.md"
+    "fidelity_note": "Reviewed #7198 (2026-07-21) and Stage 3.2 (2026-07-27). FAITHFUL and non-vacuous. Ground field ℂ is fixed literally. IsSimpleOrder (LieSubmodule ℂ L V) is genuine irreducibility; [Nontrivial V] is redundant because simplicity implies it. LieAlgebra.IsSolvable is the source derived-series definition, and finrank ℂ V = 1 is the exact conclusion. Non-vacuity witness: the zero Lie algebra acting on V = ℂ. No sorryAx.",
+    "lean_file": "EtingofRepresentationTheory/Chapter2/Problem2_16_1.lean",
+    "lean_decl": "Etingof.Problem2_16_1.finrank_eq_one_of_isSolvable",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.16",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "The commutant K(g) is the linear span of brackets [x,y] and is an ideal.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "LieAlgebra.derivedSeries; LieIdeal.coe_derivedSeries_one_eq"
+        },
+        {
+          "claim": "A finite-dimensional Lie algebra is solvable exactly when some iterate of its commutant is zero.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "LieAlgebra.IsSolvable; LieAlgebra.isSolvable_iff"
+        },
+        {
+          "claim": "A finite-dimensional irreducible representation of a solvable complex Lie algebra is one-dimensional.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_16_1.finrank_eq_one_of_isSolvable"
+        },
+        {
+          "claim": "The hint proposes induction through K(g), invariance of common eigenspaces, and the trace calculation χ([x,a]) = 0 on the smallest x-invariant subspace containing a common eigenvector.",
+          "verdict": "non_formalizable",
+          "reason": "This paragraph prescribes a proof route rather than stating another result to retain. The formal proof uses Mathlib's stronger common-weight theorem for the whole solvable algebra and completes the invariant-line argument directly."
+        }
+      ]
+    }
   },
   {
     "id": "Chapter2/Problem2.16.2",
@@ -1785,9 +1838,51 @@
     "status": "sorry_free",
     "coverage": "covered_full",
     "coverage_note": "Both characteristics are classified. Characteristic zero: charZero_exists_unique_iso_oneDim identifies every finite-dimensional irreducible with a unique member of the one-dimensional family oneDimModule. Characteristic p: the p-dimensional family Fam (X diagonal with eigenvalues a + i, Y the cyclic shift scaled by a unit) is constructed and proved irreducible, fam_nonempty_equiv_iff is the isomorphism criterion, and charP_exists_iso / charP_exists_unique_iso give exhaustiveness and uniqueness. lie_theorem_fails_charP is the resulting failure of Lie's theorem.",
-    "fidelity": "faithful",
-    "fidelity_note": "Existence-and-uniqueness classifications are exposed in both characteristics, together with the isomorphism criterion for the p-dimensional family and the disjointness of the one- and p-dimensional families (oneDim_not_equiv_fam).",
-    "last_updated": "2026-07-26"
+    "fidelity": "verified",
+    "fidelity_note": "Existence-and-uniqueness classifications are exposed in both characteristics, together with the isomorphism criterion for the p-dimensional family and the disjointness of the one- and p-dimensional families (oneDim_not_equiv_fam). The algebraically closed hypothesis is the standing Chapter 2 convention from Discussion 2.2.",
+    "last_updated": "2026-07-27",
+    "lean_file": "EtingofRepresentationTheory/Chapter2/Problem2_16_2.lean",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.16",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "The two-dimensional Lie algebra has a basis X,Y satisfying [X,Y] = Y and is solvable.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_16_2.g; Etingof.Problem2_16_2.bracket_X_Y; Etingof.Problem2_16_2.instIsSolvable"
+        },
+        {
+          "claim": "In characteristic zero, every finite-dimensional irreducible is the unique one-dimensional module on which X acts by μ and Y acts by zero.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_16_2.oneDimModule; Etingof.Problem2_16_2.charZero_exists_unique_iso_oneDim"
+        },
+        {
+          "claim": "In characteristic p, the modules V(γ,a) on k^(Z/p), with X diagonal and Y a nonzero cyclic shift, have dimension p and are irreducible.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_16_2.Fam; Etingof.Problem2_16_2.fam_finrank; Etingof.Problem2_16_2.fam_irreducible"
+        },
+        {
+          "claim": "V(γ,a) is isomorphic to V(γ',a') exactly when γ = γ' and a' - a lies in the prime field; this family is disjoint from the one-dimensional family.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_16_2.fam_nonempty_equiv_iff; Etingof.Problem2_16_2.oneDim_not_equiv_fam"
+        },
+        {
+          "claim": "Every finite-dimensional irreducible in characteristic p occurs uniquely in the one-dimensional family or the p-dimensional family, with the stated parameter equivalence.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_16_2.charP_exists_iso; Etingof.Problem2_16_2.charP_exists_unique_iso"
+        },
+        {
+          "claim": "Lie's theorem is false in positive characteristic.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_16_2.lie_theorem_fails_charP"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter2/Problem2.16.3",
@@ -1800,9 +1895,69 @@
     "status": "sorry_free",
     "coverage": "covered_full",
     "coverage_note": "All requested dimension statements are proved, including not_finiteDimensional_g_four. In characteristic zero, Problem2_16_3_CocycleVanishing.lean proves every imaginary-weight scalar 2-cocycle on loopPos is a coboundary (twoCocycle_isTwoCoboundary), hence all layer defects vanish (topDefect_eq_zero), the loop realization is injective (gbar_injective), and the explicit LoopIdx-indexed family is the public basis gFourBasis of g_4. Its degree fibers have cardinalities 1, 5, 3, 5, 3, ... by card_loopIdx_deg_zero/card_loopIdx_deg_odd/card_loopIdx_deg_even, and gbarLieEquiv identifies g_4 with the positive twisted A_2^(2) loop algebra. The characteristic-zero scope is essential: the stronger h2/h3/h5-only cocycle claim is false in positive characteristic.",
-    "lean_file": "EtingofRepresentationTheory/Chapter2/Problem2_16_3_CocycleVanishing.lean",
+    "lean_file": [
+      "EtingofRepresentationTheory/Chapter2/Problem2_16_3.lean",
+      "EtingofRepresentationTheory/Chapter2/Problem2_16_3_Grading.lean",
+      "EtingofRepresentationTheory/Chapter2/Problem2_16_3_Layers.lean",
+      "EtingofRepresentationTheory/Chapter2/Problem2_16_3_Bidegree.lean",
+      "EtingofRepresentationTheory/Chapter2/Problem2_16_3_Center.lean",
+      "EtingofRepresentationTheory/Chapter2/Problem2_16_3_Commutation.lean",
+      "EtingofRepresentationTheory/Chapter2/Problem2_16_3_Tower.lean",
+      "EtingofRepresentationTheory/Chapter2/Problem2_16_3_Kernel.lean",
+      "EtingofRepresentationTheory/Chapter2/Problem2_16_3_Cocycle.lean",
+      "EtingofRepresentationTheory/Chapter2/Problem2_16_3_CocycleCombinatorics.lean",
+      "EtingofRepresentationTheory/Chapter2/Problem2_16_3_CocycleRecurrence.lean",
+      "EtingofRepresentationTheory/Chapter2/Problem2_16_3_CocycleVanishing.lean"
+    ],
     "lean_decl": "Etingof.Problem2_16_3.gFourBasis",
-    "last_updated": "2026-07-27"
+    "last_updated": "2026-07-27",
+    "fidelity": "verified",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.16",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "ad(x) is the operator y ↦ [x,y], and g_n is the free Lie algebra on x,y modulo ad(x)^2(y) = ad(y)^(n+1)(x) = 0.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_16_3.relIdeal; Etingof.Problem2_16_3.g; Etingof.Problem2_16_3.proj"
+        },
+        {
+          "claim": "The images of x and y generate g_n as a Lie algebra.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_16_3.lieSpan_gens_eq_top"
+        },
+        {
+          "claim": "g_1 is finite-dimensional with dimension 3.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_16_3.finrank_g_one"
+        },
+        {
+          "claim": "g_2 is finite-dimensional with dimension 4.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_16_3.finrank_g_two"
+        },
+        {
+          "claim": "Over fields of characteristic different from 2 (in particular in characteristic zero), g_3 is finite-dimensional with dimension 6.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_16_3.finrank_g_three"
+        },
+        {
+          "claim": "g_4 is infinite-dimensional.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_16_3.not_finiteDimensional_g_four"
+        },
+        {
+          "claim": "In characteristic zero, g_4 has an explicit basis consisting of y, five vectors in every odd loop degree, and three vectors in every positive even loop degree.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_16_3.LoopIdx; Etingof.Problem2_16_3.loopFam₄; Etingof.Problem2_16_3.gFourBasis; Etingof.Problem2_16_3.card_loopIdx_deg_zero; Etingof.Problem2_16_3.card_loopIdx_deg_odd; Etingof.Problem2_16_3.card_loopIdx_deg_even"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter2/Problem2.16.4",
@@ -1819,10 +1974,46 @@
       "Etingof.Problem2_16_4.finrank_irreducible_le_char",
       "Etingof.Problem2_16_4.exists_irreducible_dim_char"
     ],
-    "notes": "The dimension bound and standard examples are intentionally only the early partial treatment. Parameterization, isomorphism criteria, and exhaustiveness remain assigned to the later reprise in deferred-reprises.md. The existing partial source currently fails fresh elaboration; regression #7531 repairs that source without changing the deferral decision.",
-    "coverage_note": "The dimension bound dim V ≤ p and standard irreducible modules are source-present but Sl2Irrep.lean and Problem2_16_4.lean currently fail direct checks (#7531). Full classification remains intentionally deferred to the later Reprises/Problem2_16_4.lean; no placeholder reprise exists yet.",
-    "coverage_issue": 7531,
-    "last_updated": "2026-07-22"
+    "lean_file": "EtingofRepresentationTheory/Chapter2/Problem2_16_4.lean",
+    "notes": "The dimension bound and standard examples are the early partial treatment. Parameterization, isomorphism criteria, and exhaustiveness remain assigned to the later reprise in deferred-reprises.md. Regression #7531 restored fresh elaboration of the existing partial endpoints without changing that deferral decision.",
+    "coverage_note": "The provider builds the standard modules of dimensions 1 through p and proves their irreducibility, proves dim V ≤ p for every finite-dimensional irreducible, and proves sharpness. All these endpoints now pass a fresh build. The explicit parameter family, isomorphism criteria, and exhaustiveness required for a full classification remain a documented unfinished reprise; no placeholder declaration represents them.",
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.16",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "Over an algebraically closed field of characteristic p > 2, the standard modules L(d-1), 1 ≤ d ≤ p, have dimension d and are irreducible.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_16_4.irrep_finrank; Etingof.Problem2_16_4.irrep_isIrreducible"
+        },
+        {
+          "claim": "Every finite-dimensional irreducible sl(2,k)-module has dimension at most p, and the bound p is achieved.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_16_4.finrank_irreducible_le_char; Etingof.Problem2_16_4.exists_irreducible_dim_char"
+        },
+        {
+          "claim": "The characteristic-p irreducibles are described by an explicit complete parameter family.",
+          "verdict": "intentional_omission",
+          "reason": "This is unfinished work assigned to the later reprise in deferred-reprises.md, not a permanent scope exclusion; no placeholder theorem is introduced at the Chapter 2 location."
+        },
+        {
+          "claim": "The classification determines exactly when two parameterized modules are isomorphic.",
+          "verdict": "intentional_omission",
+          "reason": "The isomorphism criterion is an explicit acceptance requirement of the documented later reprise and is not claimed by the partial Chapter 2 endpoints."
+        },
+        {
+          "claim": "Every finite-dimensional irreducible sl(2,k)-module occurs in the parameter family.",
+          "verdict": "intentional_omission",
+          "reason": "Exhaustiveness is an explicit acceptance requirement of the documented later reprise and is not represented by a weakened or assumed wrapper."
+        }
+      ]
+    }
   },
   {
     "id": "Chapter2/Problem2.16.5",
@@ -1839,7 +2030,66 @@
       "Etingof.Problem2_16_5.Kop_isSemisimple_and_eigenvalues",
       "Etingof.Problem2_16_5.finrank_irreducible_le_of_isOfFinOrder"
     ],
-    "coverage_note": "EtingofRepresentationTheory/Chapter2/Problem2_16_5.lean constructs U_q(sl2) and proves substantial structural results in both cases without placeholders: highest-weight/eigenvalue control when q is not a root of unity, and semisimplicity, central-scalar facts, and dimension bounds at roots of unity. The exhaustive classification up to isomorphism requested by the exercise is intentionally omitted by the project-wide decision in skipped-exercises.md; no sorry, axiom, proof_wanted, or unproved classification declaration represents it."
+    "lean_file": "EtingofRepresentationTheory/Chapter2/Problem2_16_5.lean",
+    "coverage_note": "The provider constructs U_q(sl2) over the canonical allowed field ℂ, proves its presentation nontrivial via the one-dimensional augmentation, and proves structural results in both cases without placeholders: highest-weight/eigenvalue constraints when q is not a root of unity, and semisimplicity, central-scalar facts, and a dimension bound at roots of unity. Stage 3.2 corrected prose that had overstated the necessary eigenvalue constraint as classification up to isomorphism. The exhaustive classification requested by the exercise remains the project-wide intentional omission in skipped-exercises.md.",
+    "fidelity": "verified",
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "2.16",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "The source fixes an algebraically closed characteristic-zero field and q ∈ k× with q ≠ ±1, and asks for separate root-of-unity and non-root-of-unity cases.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_16_5.Uqsl2; IsOfFinOrder"
+        },
+        {
+          "claim": "U_q(sl2) is generated by e,f,K,K⁻¹ with the three displayed relations and inverse relations for K; this presentation is nontrivial.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_16_5.Rel; Etingof.Problem2_16_5.KL_rel; Etingof.Problem2_16_5.LK_rel; Etingof.Problem2_16_5.Ke_rel; Etingof.Problem2_16_5.Kf_rel; Etingof.Problem2_16_5.ef_rel; Etingof.Problem2_16_5.augmentation_surjective"
+        },
+        {
+          "claim": "Formally setting K = q^h makes U_q(sl2) degenerate to U(sl2) as q tends to 1 in an appropriate sense.",
+          "verdict": "non_formalizable",
+          "reason": "The parenthetical is explicitly heuristic and does not specify a topology, integral form, or flat family defining the limiting sense."
+        },
+        {
+          "claim": "If q is not a root of unity, every nonzero finite-dimensional representation has a nonzero highest-weight vector.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_16_5.exists_highest_weight_vector"
+        },
+        {
+          "claim": "For a simple module in the non-root-of-unity case, the highest K-eigenvalue has the necessary form ε q^(dim V - 1), with ε² = 1.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_16_5.highest_weight_eigenvalue_of_not_isOfFinOrder"
+        },
+        {
+          "claim": "All non-root-of-unity irreducibles are explicitly constructed, classified up to isomorphism, and exhausted by the parameter list.",
+          "verdict": "intentional_omission",
+          "reason": "The exhaustive enumeration is explicitly excluded by skipped-exercises.md. The provider states only necessary structural constraints and no longer describes them as an isomorphism classification."
+        },
+        {
+          "claim": "At a root of unity, K^ord(q) acts as a nonzero scalar and K is semisimple with eigenvalues in one finite root set.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_16_5.Kpow_orderOf_isScalar; Etingof.Problem2_16_5.Kop_isSemisimple_and_eigenvalues"
+        },
+        {
+          "claim": "For q² ≠ 1 at a root of unity, e^ord(q) and f^ord(q) act as scalars and every finite-dimensional simple module has dimension at most ord(q).",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Problem2_16_5.epow_orderOf_isScalar; Etingof.Problem2_16_5.fpow_orderOf_isScalar; Etingof.Problem2_16_5.finrank_irreducible_le_of_isOfFinOrder"
+        },
+        {
+          "claim": "All root-of-unity irreducibles are explicitly parameterized, their isomorphisms determined, and the list proved exhaustive.",
+          "verdict": "intentional_omission",
+          "reason": "This quantum-specific enumeration and case analysis is the permanent project-wide scope exclusion recorded in skipped-exercises.md; no placeholder or weakened wrapper purports to prove it."
+        }
+      ]
+    }
   },
   {
     "id": "Chapter3/Introduction",

--- a/progress/items.json
+++ b/progress/items.json
@@ -1777,6 +1777,14 @@
           "reason": "This is an organizational heading, not a mathematical assertion."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.16",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "not_applicable",
+      "declarations": [],
+      "basis": "The sole Stage 3.2 claim is organizational prose with verdict non_formalizable, so there is no mathematical proof obligation or Lean declaration to certify."
     }
   },
   {
@@ -1807,7 +1815,7 @@
         {
           "claim": "The commutant K(g) is the linear span of brackets [x,y] and is an ideal.",
           "verdict": "covered_elsewhere",
-          "lean_decl": "LieAlgebra.derivedSeries; LieIdeal.coe_derivedSeries_one_eq"
+          "lean_decl": "LieAlgebra.derivedSeries; LieAlgebra.coe_derivedSeries_one_eq"
         },
         {
           "claim": "A finite-dimensional Lie algebra is solvable exactly when some iterate of its commutant is zero.",
@@ -1825,6 +1833,20 @@
           "reason": "This paragraph prescribes a proof route rather than stating another result to retain. The formal proof uses Mathlib's stronger common-weight theorem for the whole solvable algebra and completes the invariant-line argument directly."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.16",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "LieAlgebra.derivedSeries",
+        "LieAlgebra.coe_derivedSeries_one_eq",
+        "LieAlgebra.IsSolvable",
+        "LieAlgebra.isSolvable_iff",
+        "Etingof.Problem2_16_1.finrank_eq_one_of_isSolvable"
+      ],
+      "basis": "The provider's sole module-attributed constant is a proof constant and is axiom-clean. The four Mathlib declarations covering the source definitions were separately checked with the same axiom collector."
     }
   },
   {
@@ -1882,6 +1904,28 @@
           "lean_decl": "Etingof.Problem2_16_2.lie_theorem_fails_charP"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.16",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Problem2_16_2.g",
+        "Etingof.Problem2_16_2.bracket_X_Y",
+        "Etingof.Problem2_16_2.instIsSolvable",
+        "Etingof.Problem2_16_2.oneDimModule",
+        "Etingof.Problem2_16_2.charZero_exists_unique_iso_oneDim",
+        "Etingof.Problem2_16_2.Fam",
+        "Etingof.Problem2_16_2.fam_finrank",
+        "Etingof.Problem2_16_2.fam_irreducible",
+        "Etingof.Problem2_16_2.fam_nonempty_equiv_iff",
+        "Etingof.Problem2_16_2.oneDim_not_equiv_fam",
+        "Etingof.Problem2_16_2.charP_exists_iso",
+        "Etingof.Problem2_16_2.charP_exists_unique_iso",
+        "Etingof.Problem2_16_2.lie_theorem_fails_charP"
+      ],
+      "basis": "All 211 constants attributed to the provider, including all 168 module-attributed proof constants, were axiom-audited; none uses sorryAx or a project axiom."
     }
   },
   {
@@ -1957,6 +2001,29 @@
           "lean_decl": "Etingof.Problem2_16_3.LoopIdx; Etingof.Problem2_16_3.loopFam₄; Etingof.Problem2_16_3.gFourBasis; Etingof.Problem2_16_3.card_loopIdx_deg_zero; Etingof.Problem2_16_3.card_loopIdx_deg_odd; Etingof.Problem2_16_3.card_loopIdx_deg_even"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.16",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Problem2_16_3.relIdeal",
+        "Etingof.Problem2_16_3.g",
+        "Etingof.Problem2_16_3.proj",
+        "Etingof.Problem2_16_3.lieSpan_gens_eq_top",
+        "Etingof.Problem2_16_3.finrank_g_one",
+        "Etingof.Problem2_16_3.finrank_g_two",
+        "Etingof.Problem2_16_3.finrank_g_three",
+        "Etingof.Problem2_16_3.not_finiteDimensional_g_four",
+        "Etingof.Problem2_16_3.LoopIdx",
+        "Etingof.Problem2_16_3.loopFam₄",
+        "Etingof.Problem2_16_3.gFourBasis",
+        "Etingof.Problem2_16_3.card_loopIdx_deg_zero",
+        "Etingof.Problem2_16_3.card_loopIdx_deg_odd",
+        "Etingof.Problem2_16_3.card_loopIdx_deg_even"
+      ],
+      "basis": "Across the twelve direct providers, all 1108 module-attributed constants, including all 925 proof constants, were axiom-audited; none uses sorryAx or a project axiom."
     }
   },
   {
@@ -2012,6 +2079,24 @@
           "verdict": "intentional_omission",
           "reason": "Exhaustiveness is an explicit acceptance requirement of the documented later reprise and is not represented by a weakened or assumed wrapper."
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.16",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Problem2_16_4.irrep_finrank",
+        "Etingof.Problem2_16_4.irrep_isIrreducible",
+        "Etingof.Problem2_16_4.finrank_irreducible_le_char",
+        "Etingof.Problem2_16_4.exists_irreducible_dim_char"
+      ],
+      "basis": "All 119 constants attributed to the provider, including all 109 module-attributed proof constants, were axiom-audited. This certifies only the four existing partial-treatment endpoints, not the three deferred classification units.",
+      "intentional_omissions": [
+        "explicit complete parameter family for characteristic-p irreducibles (unfinished later reprise)",
+        "isomorphism criterion for the parameterized modules (unfinished later reprise)",
+        "exhaustiveness of the parameter family (unfinished later reprise)"
       ]
     }
   },
@@ -2088,6 +2173,36 @@
           "verdict": "intentional_omission",
           "reason": "This quantum-specific enumeration and case analysis is the permanent project-wide scope exclusion recorded in skipped-exercises.md; no placeholder or weakened wrapper purports to prove it."
         }
+      ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "2.16",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Problem2_16_5.Uqsl2",
+        "IsOfFinOrder",
+        "Etingof.Problem2_16_5.Rel",
+        "Etingof.Problem2_16_5.KL_rel",
+        "Etingof.Problem2_16_5.LK_rel",
+        "Etingof.Problem2_16_5.Ke_rel",
+        "Etingof.Problem2_16_5.Kf_rel",
+        "Etingof.Problem2_16_5.ef_rel",
+        "Etingof.Problem2_16_5.augmentation_surjective",
+        "Etingof.Problem2_16_5.instNontrivialUqsl2",
+        "Etingof.Problem2_16_5.exists_highest_weight_vector",
+        "Etingof.Problem2_16_5.highest_weight_eigenvalue_of_not_isOfFinOrder",
+        "Etingof.Problem2_16_5.Kpow_orderOf_isScalar",
+        "Etingof.Problem2_16_5.Kop_isSemisimple_and_eigenvalues",
+        "Etingof.Problem2_16_5.epow_orderOf_isScalar",
+        "Etingof.Problem2_16_5.fpow_orderOf_isScalar",
+        "Etingof.Problem2_16_5.finrank_irreducible_le_of_isOfFinOrder"
+      ],
+      "basis": "All 150 constants attributed to the provider, including all 119 module-attributed proof constants, were axiom-audited. This certifies the presentation and structural constraints only, not either omitted exhaustive classification.",
+      "intentional_omissions": [
+        "exhaustive classification up to isomorphism when q is not a root of unity (project-wide permanent omission)",
+        "exhaustive classification up to isomorphism when q is a root of unity (project-wide permanent omission)"
       ]
     }
   },


### PR DESCRIPTION
## Summary

- complete Stage 3.3 proof verification for the exact six-item, sixteen-provider Chapter 2 §2.16 scope
- audit all 1,589 module-attributed constants, including all 1,322 proof constants, through the same axiom collector used by `#print axioms`
- record 53 scoped claim endpoints in canonical `stage3_3` metadata while preserving exactly five policy-controlled classification gaps
- correct the stale tracker namespace `LieIdeal.coe_derivedSeries_one_eq` to `LieAlgebra.coe_derivedSeries_one_eq`

No Lean proof changes were required. Every audited constant depends only on `propext`,
`Classical.choice`, and `Quot.sound` where applicable; there is no `sorryAx` or project axiom.

## Validation

- fresh build of all 16 providers: passed (8,595 jobs)
- `lake build EtingofRepresentationTheory.Chapter2`: passed (8,744 jobs)
- exhaustive environment-level axiom audit plus literal `#print axioms` checks for five external Mathlib declarations: passed
- scoped source admission/project-axiom scan: passed
- all four repository validators, including Mathlib coverage: passed
- exact scope, five-omission invariance, non-scope tracker, provider-tree, dependency, JSON, symlink, and diff checks: passed

## Stack

This draft targets `agent/stage3-2-ch2-s2-16` (PR #8055), not `main`.
