### PR TITLE
Stage 3.3: verify Chapter 3 Section 3.3 proofs

### DIFF
--- a/progress/2026-07-27T15-01-30Z_stage3-3-chapter3-section3-3.md
+++ b/progress/2026-07-27T15-01-30Z_stage3-3-chapter3-section3-3.md
@@ -1,0 +1,55 @@
+# Stage 3.3 proof-integrity review — Chapter 3 §3.3
+
+## Scope and inherited coverage
+
+This stacked review is based exactly on Stage 3.2 draft PR #8063 at commit `2242a670`.
+Reading order gives seven §3.3 catalog items, from `Chapter3/Introduction_to_3.3` through
+`Chapter3/Remark3.3.4`, and four Lean provider files. The strict predecessor is
+`Chapter3/Theorem3.2.2`; the strict successor is `Chapter3/Introduction_to_3.4`.
+
+Stage 3.2 supplies 48 exhaustive claim units: 34 `formalized`, 10 `covered_elsewhere`, and 4
+`non_formalizable`. The four nonformalizable units are organizational or methodological prose.
+The other 44 mathematical units retain full coverage, including the exact free-cover uniqueness
+statement added during Stage 3.2.
+
+## Proof-integrity result
+
+Six items are `sorry_free`; the methodological transition before Definition 3.3.2 is
+`not_applicable`. The six proof-applicable records cite 94 declaration references, comprising 89
+unique declarations. Those durable references cover the classification theorem, both advertised
+proof routes, the dual-representation definition, the alternative exercise, and the free-cover
+remark.
+
+The audit itself was deliberately broader than the tracker references. Lean's module-origin data
+identified all 222 constants emitted by the four providers. This includes 90 exported source-level
+declarations, 10 explicit private helpers, 4 local instances, and every compiler-generated proof,
+match, simplifier, and auxiliary constant. `Lean.collectAxioms` was run on every one of the 222
+constants. Every transitive axiom set was contained in `propext`, `Classical.choice`, and
+`Quot.sound`; there was no `sorryAx` or project axiom.
+
+A direct scan of the exact four providers also found no `sorry`, `admit`, `proof_wanted`, `axiom`,
+`sorryAx`, `opaque`, or `native_decide`. No proof repair was required. Existing style and linter
+warnings are intentionally deferred to Stage 3.5.
+
+## Durable tracker result
+
+- all 7 exact items have complete section `3.3` `stage3_3` objects;
+- proof-integrity split: 6 `sorry_free`, 1 `not_applicable`;
+- declaration references: 94, comprising 89 unique declarations;
+- exhaustive constant-level audit: 222/222 constants axiom-clean;
+- Stage 3.2 claim and fidelity data is unchanged;
+- non-§3.3 tracker records and dependency metadata are unchanged.
+
+## Validation
+
+- all 4 scoped providers built successfully in isolation (1698 jobs; pre-existing linter warnings
+  only);
+- exhaustive module-origin declaration enumeration and `Lean.collectAxioms`: 222/222 clean, with
+  foundational axioms only;
+- exact scoped admission/placeholder scan: clean;
+- exact 7-item Stage 3.3 completeness and proof-integrity split: passed;
+- full Chapter 3 build: passed;
+- all repository metadata, dependency, external-dependency, and Mathlib-coverage validators: passed;
+- JSON parsing, scoped/non-scoped tracker invariance, and `git diff --check`: passed.
+
+This PR is limited to Chapter 3 §3.3 and Stage 3.3.

--- a/progress/items.json
+++ b/progress/items.json
@@ -5371,6 +5371,17 @@
           "note": "Lean models the finite direct sum by the equivalent finite product indexed by Fin r and assumes only Field k."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.3",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "MatProd",
+        "Etingof.irreducible_reps_of_matrix_algebra"
+      ],
+      "basis": "The heading itself is organizational, but its arbitrary-field finite-product setup is mathematical and is represented by the listed admission-free declarations."
     }
   },
   {
@@ -5421,6 +5432,23 @@
           "note": "The explicit multiplicity function m and A-linear direct-sum equivalence give the exact book conclusion; Etingof.irreducible_reps_of_matrix_algebra also packages simplicity, exhaustiveness, and semisimplicity."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.3",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "isSimpleModule_vModuleProd",
+        "exists_iso_vModuleProd",
+        "vModuleProd_iso_imp_eq",
+        "isSemisimpleModule_of_matrixProd",
+        "Etingof.irreducible_reps_of_matrix_algebra",
+        "regularDecomp",
+        "freeModuleDecomp",
+        "exists_iso_directSum_of_matrixProd"
+      ],
+      "basis": "The simplicity, exhaustiveness, pairwise nonisomorphism, semisimplicity, and exact finite-dimensional direct-sum endpoint all have complete proof terms."
     }
   },
   {
@@ -5454,6 +5482,14 @@
           "reason": "This is a methodological transition rather than an independent mathematical assertion."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.3",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "not_applicable",
+      "declarations": [],
+      "basis": "This item is a methodological transition motivating the following definition, not a proposition with a Lean proof obligation."
     }
   },
   {
@@ -5496,6 +5532,19 @@
           "lean_decl": "Etingof.dualRepresentation_smul_apply"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.3",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.DualRepresentation",
+        "Etingof.instSMulMulOppositeDual",
+        "Etingof.dualRepresentation_smul_apply",
+        "Etingof.instModuleMulOppositeDual"
+      ],
+      "basis": "The carrier, contragredient action, defining equation, and opposite-algebra module laws were all included in the exhaustive constant-level axiom audit."
     }
   },
   {
@@ -5591,6 +5640,54 @@
           "lean_decl": "exists_iso_directSum_of_matrixProd"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.3",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "isSimpleModule_vModuleProd",
+        "matrixTransposeSelfDuality",
+        "piMulOppositeRingEquiv",
+        "matProdTransposeSelfDuality",
+        "dualMap_injective_of_surjective",
+        "lsmulHom",
+        "lsmulHom_apply",
+        "twistedDualModule",
+        "twistedDualModule_smul_apply",
+        "twistedDual_isScalarTower",
+        "matProdTransposeSelfDuality_unop",
+        "matProdTransposeSelfDuality_unop_smul",
+        "frobPairing",
+        "frobPairing_apply",
+        "frobHom",
+        "frobHom_apply",
+        "frobHom_injective",
+        "frobHom_bijective",
+        "matProdSelfDual",
+        "toDualHom",
+        "toDualHom_apply",
+        "toDualHom_surjective",
+        "matProdTransposeSelfDuality_unop_unop",
+        "twistedDualMap",
+        "twistedDualMap_injective",
+        "twistedEvalEquiv",
+        "toDualEmbedding",
+        "toDualEmbedding_injective",
+        "dualPiEquiv",
+        "dualPowSelfDual",
+        "colVec",
+        "colMap",
+        "regularDecomp",
+        "regularDecomp_apply",
+        "freeColMap",
+        "freeColMap_apply",
+        "freeModuleDecomp",
+        "Etingof.subrepresentation_of_semisimple",
+        "exists_iso_directSum_of_matrixProd"
+      ],
+      "basis": "The complete dual route, including the free-to-dual surjection, dual injection, self-duality and regular/free decompositions, resolves to admission-free proof terms. Mathlib's finite-dual results and Proposition 3.1.4 were already compiled dependencies."
     }
   },
   {
@@ -5749,6 +5846,51 @@
           "note": "The instruction has no additional endpoint beyond the fully proved classification theorem."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.3",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Problem3_3_3.single_one_central",
+        "Etingof.Problem3_3_3.idemProj",
+        "Etingof.Problem3_3_3.single_mul_single_eq",
+        "Etingof.Problem3_3_3.sum_single_one",
+        "Etingof.Problem3_3_3.single_smul_single_smul",
+        "Etingof.Problem3_3_3.sum_single_smul",
+        "Etingof.Problem3_3_3.mem_range_idemProj",
+        "Etingof.Problem3_3_3.range_eq_top_iff",
+        "Etingof.Problem3_3_3.range_eq_bot_iff",
+        "Etingof.Problem3_3_3.simpleModule_prod_iff",
+        "Etingof.Problem3_3_3.Inflate",
+        "Etingof.Problem3_3_3.Inflate.instAddCommGroup",
+        "Etingof.Problem3_3_3.Inflate.instNontrivialOfAddCommGroup",
+        "Etingof.Problem3_3_3.Inflate.instModule",
+        "Etingof.Problem3_3_3.Inflate.instProdModule",
+        "Etingof.Problem3_3_3.Inflate.prod_smul_def",
+        "Etingof.Problem3_3_3.Inflate.single_smul",
+        "Etingof.Problem3_3_3.Inflate.toFactor",
+        "Etingof.Problem3_3_3.Inflate.toFactor_bijective",
+        "Etingof.Problem3_3_3.Inflate.isSimpleModule_iff",
+        "Etingof.Problem3_3_3.Inflate.congr",
+        "Etingof.Problem3_3_3.Inflate.ofCongr",
+        "Etingof.Problem3_3_3.Inflate.index_eq_of_equiv",
+        "Etingof.Problem3_3_3.single_mul_single",
+        "Etingof.Problem3_3_3.factorSummandModule",
+        "Etingof.Problem3_3_3.factorSummandModule_smul_coe",
+        "Etingof.Problem3_3_3.prod_smul_summand_eq",
+        "Etingof.Problem3_3_3.summandToFactor",
+        "Etingof.Problem3_3_3.isSimpleModule_summand_iff",
+        "Etingof.Problem3_3_3.simpleModule_prod_iff_factor",
+        "Etingof.Problem3_3_3.summandEquivInflate",
+        "Etingof.Problem3_3_3.exists_isSimpleFactor",
+        "Etingof.Problem3_3_3.exists_inflate_of_isSimple",
+        "Etingof.Problem3_3_3.std_isSimpleModule",
+        "Etingof.Problem3_3_3.simpleModule_iso_std",
+        "Etingof.Problem3_3_3.finite_iso_std_pow"
+      ],
+      "basis": "All 36 exported declarations, the seven private matrix-unit helpers, and their compiler-generated proof constants were included in the exhaustive module-origin audit. Part (c) is a pedagogical deduction whose already-proved endpoint is Theorem 3.3.1."
     }
   },
   {
@@ -5816,6 +5958,20 @@
           "note": "The exact endpoint is fully proved; Lean obtains it from an embedding and Proposition 3.1.4 rather than the book's quotient-form application of Lemma 3.1.6."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.3",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.freeCover",
+        "Etingof.freeCover_apply",
+        "Etingof.freeCover_unique",
+        "Etingof.freeCover_surjective",
+        "Etingof.quotientEquivOfFreeCover"
+      ],
+      "basis": "The free-cover construction, formula, uniqueness, surjectivity, and quotient equivalence are all admission-free; the alternative final decomposition endpoint is the already-audited Theorem 3.3.1 declaration."
     }
   },
   {


### PR DESCRIPTION
## Summary

- audit the exact seven-item Chapter 3 §3.3 scope inherited from Stage 3.2
- mark six proof-applicable items sorry-free and one methodological transition not applicable
- audit all 222 constants emitted by the four provider modules, including private and generated constants
- confirm every transitive axiom set is contained in propext, Classical.choice, and Quot.sound
- preserve all Stage 3.2 claim/fidelity data and every non-scope tracker record

## Validation

- four scoped providers: 1698 jobs
- exhaustive Lean.collectAxioms audit: 222/222 clean
- full Chapter 3 build: 8692 jobs
- validate_items.py: 5721/5721 lines
- validate_dependencies.py
- validate_external_deps.py
- validate_mathlib_coverage.py
- JSON, exact-scope invariance, non-scope invariance, admission scan, and git diff checks

Stacked on draft PR #8063. This PR is exactly Chapter 3 §3.3, Stage 3.3.