### PR TITLE
Stage 3.4: trim Chapter 3 Section 3.3 dependencies

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/Definition3_3_2.lean
+++ b/EtingofRepresentationTheory/Chapter3/Definition3_3_2.lean
@@ -1,6 +1,4 @@
 import Mathlib.LinearAlgebra.Dual.Defs
-import Mathlib.Algebra.Module.LinearMap.End
-import Mathlib.Algebra.Module.Opposite
 import Mathlib.Algebra.Algebra.Defs
 
 /-!

--- a/EtingofRepresentationTheory/Chapter3/Problem3_3_3.lean
+++ b/EtingofRepresentationTheory/Chapter3/Problem3_3_3.lean
@@ -1,11 +1,6 @@
 import Mathlib.RingTheory.SimpleModule.Basic
 import Mathlib.LinearAlgebra.Matrix.Module
 import Mathlib.LinearAlgebra.FiniteDimensional.Defs
-import Mathlib.LinearAlgebra.Dimension.Free
-import Mathlib.LinearAlgebra.Basis.Basic
-import Mathlib.Algebra.Ring.Pi
-import Mathlib.Algebra.Module.RingHom
-import EtingofRepresentationTheory.Chapter3.Theorem3_3_1
 
 /-!
 # Problem 3.3.3: An alternative proof of Theorem 3.3.1

--- a/EtingofRepresentationTheory/Chapter3/Remark3_3_4.lean
+++ b/EtingofRepresentationTheory/Chapter3/Remark3_3_4.lean
@@ -1,7 +1,4 @@
-import Mathlib.LinearAlgebra.Basis.Defs
-import Mathlib.LinearAlgebra.Quotient.Basic
 import Mathlib.LinearAlgebra.FiniteDimensional.Defs
-import Mathlib.Algebra.Algebra.Tower
 
 /-!
 # Remark 3.3.4: A finite dimensional representation is a quotient of a free module

--- a/EtingofRepresentationTheory/Chapter3/Theorem3_3_1.lean
+++ b/EtingofRepresentationTheory/Chapter3/Theorem3_3_1.lean
@@ -1,10 +1,5 @@
 import Mathlib.RingTheory.SimpleModule.WedderburnArtin
-import Mathlib.RingTheory.SimpleRing.Matrix
-import Mathlib.RingTheory.Artinian.Module
-import Mathlib.LinearAlgebra.Matrix.ToLin
 import Mathlib.LinearAlgebra.Matrix.Module
-import Mathlib.LinearAlgebra.FiniteDimensional.Defs
-import Mathlib.Algebra.DirectSum.Module
 import Mathlib.LinearAlgebra.Dual.Lemmas
 import Mathlib.LinearAlgebra.Matrix.Trace
 import EtingofRepresentationTheory.Chapter3.Proposition3_1_4

--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -408,26 +408,21 @@
   "Chapter3/Theorem3.2.2": [
     "Chapter3/Corollary3.2.1"
   ],
-  "Chapter3/Introduction_to_3.3": [
-    "Chapter3/Theorem3.2.2"
-  ],
+  "Chapter3/Introduction_to_3.3": [],
   "Chapter3/Theorem3.3.1": [
-    "Chapter3/Introduction_to_3.3"
+    "Chapter3/Proposition3.1.4"
   ],
-  "Chapter3/Discussion_before_Definition3.3.2": [
+  "Chapter3/Discussion_before_Definition3.3.2": [],
+  "Chapter3/Definition3.3.2": [],
+  "Chapter3/Discussion_proof_of_Theorem3.3.1": [
+    "Chapter3/Proposition3.1.4",
     "Chapter3/Theorem3.3.1"
   ],
-  "Chapter3/Definition3.3.2": [
-    "Chapter3/Discussion_before_Definition3.3.2"
-  ],
-  "Chapter3/Discussion_proof_of_Theorem3.3.1": [
-    "Chapter3/Definition3.3.2"
-  ],
   "Chapter3/Problem3.3.3": [
-    "Chapter3/Discussion_proof_of_Theorem3.3.1"
+    "Chapter3/Theorem3.3.1"
   ],
   "Chapter3/Remark3.3.4": [
-    "Chapter3/Problem3.3.3"
+    "Chapter3/Theorem3.3.1"
   ],
   "Chapter3/Introduction_to_3.4": [
     "Chapter3/Remark3.3.4"

--- a/progress/2026-07-27T15-01-30Z_stage3-3-chapter3-section3-3.md
+++ b/progress/2026-07-27T15-01-30Z_stage3-3-chapter3-section3-3.md
@@ -1,0 +1,55 @@
+# Stage 3.3 proof-integrity review — Chapter 3 §3.3
+
+## Scope and inherited coverage
+
+This stacked review is based exactly on Stage 3.2 draft PR #8063 at commit `2242a670`.
+Reading order gives seven §3.3 catalog items, from `Chapter3/Introduction_to_3.3` through
+`Chapter3/Remark3.3.4`, and four Lean provider files. The strict predecessor is
+`Chapter3/Theorem3.2.2`; the strict successor is `Chapter3/Introduction_to_3.4`.
+
+Stage 3.2 supplies 48 exhaustive claim units: 34 `formalized`, 10 `covered_elsewhere`, and 4
+`non_formalizable`. The four nonformalizable units are organizational or methodological prose.
+The other 44 mathematical units retain full coverage, including the exact free-cover uniqueness
+statement added during Stage 3.2.
+
+## Proof-integrity result
+
+Six items are `sorry_free`; the methodological transition before Definition 3.3.2 is
+`not_applicable`. The six proof-applicable records cite 94 declaration references, comprising 89
+unique declarations. Those durable references cover the classification theorem, both advertised
+proof routes, the dual-representation definition, the alternative exercise, and the free-cover
+remark.
+
+The audit itself was deliberately broader than the tracker references. Lean's module-origin data
+identified all 222 constants emitted by the four providers. This includes 90 exported source-level
+declarations, 10 explicit private helpers, 4 local instances, and every compiler-generated proof,
+match, simplifier, and auxiliary constant. `Lean.collectAxioms` was run on every one of the 222
+constants. Every transitive axiom set was contained in `propext`, `Classical.choice`, and
+`Quot.sound`; there was no `sorryAx` or project axiom.
+
+A direct scan of the exact four providers also found no `sorry`, `admit`, `proof_wanted`, `axiom`,
+`sorryAx`, `opaque`, or `native_decide`. No proof repair was required. Existing style and linter
+warnings are intentionally deferred to Stage 3.5.
+
+## Durable tracker result
+
+- all 7 exact items have complete section `3.3` `stage3_3` objects;
+- proof-integrity split: 6 `sorry_free`, 1 `not_applicable`;
+- declaration references: 94, comprising 89 unique declarations;
+- exhaustive constant-level audit: 222/222 constants axiom-clean;
+- Stage 3.2 claim and fidelity data is unchanged;
+- non-§3.3 tracker records and dependency metadata are unchanged.
+
+## Validation
+
+- all 4 scoped providers built successfully in isolation (1698 jobs; pre-existing linter warnings
+  only);
+- exhaustive module-origin declaration enumeration and `Lean.collectAxioms`: 222/222 clean, with
+  foundational axioms only;
+- exact scoped admission/placeholder scan: clean;
+- exact 7-item Stage 3.3 completeness and proof-integrity split: passed;
+- full Chapter 3 build: passed;
+- all repository metadata, dependency, external-dependency, and Mathlib-coverage validators: passed;
+- JSON parsing, scoped/non-scoped tracker invariance, and `git diff --check`: passed.
+
+This PR is limited to Chapter 3 §3.3 and Stage 3.3.

--- a/progress/2026-07-27T15-10-17Z_stage3-4-chapter3-section3-3.md
+++ b/progress/2026-07-27T15-10-17Z_stage3-4-chapter3-section3-3.md
@@ -1,0 +1,71 @@
+# Stage 3.4 dependency audit — Chapter 3 §3.3
+
+## Scope
+
+This review is stacked exactly on Stage 3.3 draft PR #8064 at commit `240f796b`. It covers the
+same seven reading-order items from `Chapter3/Introduction_to_3.3` through
+`Chapter3/Remark3.3.4` and all four complete Lean provider files. The immediate predecessor is
+`Chapter3/Theorem3.2.2`; the strict successor is `Chapter3/Introduction_to_3.4`.
+
+No mathematical definition, theorem statement, or proof changed. This pass is limited to actual
+backward dependency metadata and focused direct-import removal.
+
+## Direct import audit
+
+All four provider headers were checked with Mathlib's `#redundant_imports` analysis before and
+after trimming. All four providers changed:
+
+- `Theorem3_3_1.lean` removes five redundant Mathlib imports and retains four focused Mathlib
+  imports plus the Proposition 3.1.4 project import;
+- `Definition3_3_2.lean` removes two redundant Mathlib imports and retains two focused imports;
+- `Problem3_3_3.lean` removes four redundant Mathlib imports and the documentation-only Theorem
+  3.3.1 project import, retaining three focused Mathlib imports;
+- `Remark3_3_4.lean` removes three redundant Mathlib imports and retains one focused import.
+
+Direct imports move from 26 to 11, net `-15`. The final analysis reports no transitively redundant
+import in any provider, and the four-provider ordinary build passes from the trimmed headers.
+
+## Actual internal dependency graph
+
+The seven conservative reading-order edges are replaced by five actual backward edges:
+
+1. `Chapter3/Theorem3.3.1` → `Chapter3/Proposition3.1.4`, used by the exact final multiplicity
+   decomposition;
+2. the proof discussion → Proposition 3.1.4 and Theorem 3.3.1, whose implementation and endpoint
+   it records;
+3. Problem 3.3.3 → Theorem 3.3.1 for part (c)'s covered-elsewhere endpoint;
+4. Remark 3.3.4 → Theorem 3.3.1 for the covered regular/free and final multiplicity
+   decompositions.
+
+The heading's formalized setup points forward to the following theorem item and is excluded from
+the acyclic backward graph. The methodological transition and Definition 3.3.2 have no internal
+project dependency. The proof discussion's Lean implementation constructs its transpose-twisted
+dual directly and therefore does not import the separate Definition 3.3.2 provider.
+
+Scoped graph edges move from 7 to 5, net `-2`. All five edges point strictly backward in catalog
+order, and every tracker `actual_internal_dependencies` array agrees exactly with
+`dependencies/internal.json`.
+
+## Durable tracker result
+
+- all 7 exact records have complete section `3.3` `stage3_4` objects;
+- all 7 workflow statuses advance to `dependency_trimmed`;
+- Stage 3.2 and Stage 3.3 metadata are unchanged;
+- the non-§3.3 tracker projection, non-§3.3 dependency-source projection, and downstream incoming
+  edges are unchanged from PR #8064.
+
+## Validation
+
+- final isolated build of all 4 scoped providers: success (1698 jobs; pre-existing linter warnings
+  only);
+- `lake build EtingofRepresentationTheory.Chapter3`: success (8692 jobs; pre-existing linter
+  warnings only);
+- initial and final all-provider `#redundant_imports` analysis: no remaining redundant imports;
+- exact 7-item tracker/graph agreement and no-forward-edge checks: passed;
+- direct-import count: 26 → 11 (`-15`); scoped graph edges: 7 → 5 (`-2`);
+- `jq empty progress/items.json dependencies/internal.json`: passed;
+- all four repository validators: passed;
+- normalized scoped and non-scoped tracker/dependency invariance checks and `git diff --check`:
+  passed.
+
+This PR is limited to Chapter 3 §3.3 and Stage 3.4.

--- a/progress/items.json
+++ b/progress/items.json
@@ -4952,6 +4952,17 @@
           "note": "Lean models the finite direct sum by the equivalent finite product indexed by Fin r and assumes only Field k."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.3",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "MatProd",
+        "Etingof.irreducible_reps_of_matrix_algebra"
+      ],
+      "basis": "The heading itself is organizational, but its arbitrary-field finite-product setup is mathematical and is represented by the listed admission-free declarations."
     }
   },
   {
@@ -5002,6 +5013,23 @@
           "note": "The explicit multiplicity function m and A-linear direct-sum equivalence give the exact book conclusion; Etingof.irreducible_reps_of_matrix_algebra also packages simplicity, exhaustiveness, and semisimplicity."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.3",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "isSimpleModule_vModuleProd",
+        "exists_iso_vModuleProd",
+        "vModuleProd_iso_imp_eq",
+        "isSemisimpleModule_of_matrixProd",
+        "Etingof.irreducible_reps_of_matrix_algebra",
+        "regularDecomp",
+        "freeModuleDecomp",
+        "exists_iso_directSum_of_matrixProd"
+      ],
+      "basis": "The simplicity, exhaustiveness, pairwise nonisomorphism, semisimplicity, and exact finite-dimensional direct-sum endpoint all have complete proof terms."
     }
   },
   {
@@ -5035,6 +5063,14 @@
           "reason": "This is a methodological transition rather than an independent mathematical assertion."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.3",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "not_applicable",
+      "declarations": [],
+      "basis": "This item is a methodological transition motivating the following definition, not a proposition with a Lean proof obligation."
     }
   },
   {
@@ -5077,6 +5113,19 @@
           "lean_decl": "Etingof.dualRepresentation_smul_apply"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.3",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.DualRepresentation",
+        "Etingof.instSMulMulOppositeDual",
+        "Etingof.dualRepresentation_smul_apply",
+        "Etingof.instModuleMulOppositeDual"
+      ],
+      "basis": "The carrier, contragredient action, defining equation, and opposite-algebra module laws were all included in the exhaustive constant-level axiom audit."
     }
   },
   {
@@ -5172,6 +5221,54 @@
           "lean_decl": "exists_iso_directSum_of_matrixProd"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.3",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "isSimpleModule_vModuleProd",
+        "matrixTransposeSelfDuality",
+        "piMulOppositeRingEquiv",
+        "matProdTransposeSelfDuality",
+        "dualMap_injective_of_surjective",
+        "lsmulHom",
+        "lsmulHom_apply",
+        "twistedDualModule",
+        "twistedDualModule_smul_apply",
+        "twistedDual_isScalarTower",
+        "matProdTransposeSelfDuality_unop",
+        "matProdTransposeSelfDuality_unop_smul",
+        "frobPairing",
+        "frobPairing_apply",
+        "frobHom",
+        "frobHom_apply",
+        "frobHom_injective",
+        "frobHom_bijective",
+        "matProdSelfDual",
+        "toDualHom",
+        "toDualHom_apply",
+        "toDualHom_surjective",
+        "matProdTransposeSelfDuality_unop_unop",
+        "twistedDualMap",
+        "twistedDualMap_injective",
+        "twistedEvalEquiv",
+        "toDualEmbedding",
+        "toDualEmbedding_injective",
+        "dualPiEquiv",
+        "dualPowSelfDual",
+        "colVec",
+        "colMap",
+        "regularDecomp",
+        "regularDecomp_apply",
+        "freeColMap",
+        "freeColMap_apply",
+        "freeModuleDecomp",
+        "Etingof.subrepresentation_of_semisimple",
+        "exists_iso_directSum_of_matrixProd"
+      ],
+      "basis": "The complete dual route, including the free-to-dual surjection, dual injection, self-duality and regular/free decompositions, resolves to admission-free proof terms. Mathlib's finite-dual results and Proposition 3.1.4 were already compiled dependencies."
     }
   },
   {
@@ -5330,6 +5427,51 @@
           "note": "The instruction has no additional endpoint beyond the fully proved classification theorem."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.3",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Problem3_3_3.single_one_central",
+        "Etingof.Problem3_3_3.idemProj",
+        "Etingof.Problem3_3_3.single_mul_single_eq",
+        "Etingof.Problem3_3_3.sum_single_one",
+        "Etingof.Problem3_3_3.single_smul_single_smul",
+        "Etingof.Problem3_3_3.sum_single_smul",
+        "Etingof.Problem3_3_3.mem_range_idemProj",
+        "Etingof.Problem3_3_3.range_eq_top_iff",
+        "Etingof.Problem3_3_3.range_eq_bot_iff",
+        "Etingof.Problem3_3_3.simpleModule_prod_iff",
+        "Etingof.Problem3_3_3.Inflate",
+        "Etingof.Problem3_3_3.Inflate.instAddCommGroup",
+        "Etingof.Problem3_3_3.Inflate.instNontrivialOfAddCommGroup",
+        "Etingof.Problem3_3_3.Inflate.instModule",
+        "Etingof.Problem3_3_3.Inflate.instProdModule",
+        "Etingof.Problem3_3_3.Inflate.prod_smul_def",
+        "Etingof.Problem3_3_3.Inflate.single_smul",
+        "Etingof.Problem3_3_3.Inflate.toFactor",
+        "Etingof.Problem3_3_3.Inflate.toFactor_bijective",
+        "Etingof.Problem3_3_3.Inflate.isSimpleModule_iff",
+        "Etingof.Problem3_3_3.Inflate.congr",
+        "Etingof.Problem3_3_3.Inflate.ofCongr",
+        "Etingof.Problem3_3_3.Inflate.index_eq_of_equiv",
+        "Etingof.Problem3_3_3.single_mul_single",
+        "Etingof.Problem3_3_3.factorSummandModule",
+        "Etingof.Problem3_3_3.factorSummandModule_smul_coe",
+        "Etingof.Problem3_3_3.prod_smul_summand_eq",
+        "Etingof.Problem3_3_3.summandToFactor",
+        "Etingof.Problem3_3_3.isSimpleModule_summand_iff",
+        "Etingof.Problem3_3_3.simpleModule_prod_iff_factor",
+        "Etingof.Problem3_3_3.summandEquivInflate",
+        "Etingof.Problem3_3_3.exists_isSimpleFactor",
+        "Etingof.Problem3_3_3.exists_inflate_of_isSimple",
+        "Etingof.Problem3_3_3.std_isSimpleModule",
+        "Etingof.Problem3_3_3.simpleModule_iso_std",
+        "Etingof.Problem3_3_3.finite_iso_std_pow"
+      ],
+      "basis": "All 36 exported declarations, the seven private matrix-unit helpers, and their compiler-generated proof constants were included in the exhaustive module-origin audit. Part (c) is a pedagogical deduction whose already-proved endpoint is Theorem 3.3.1."
     }
   },
   {
@@ -5397,6 +5539,20 @@
           "note": "The exact endpoint is fully proved; Lean obtains it from an embedding and Proposition 3.1.4 rather than the book's quotient-form application of Lemma 3.1.6."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.3",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.freeCover",
+        "Etingof.freeCover_apply",
+        "Etingof.freeCover_unique",
+        "Etingof.freeCover_surjective",
+        "Etingof.quotientEquivOfFreeCover"
+      ],
+      "basis": "The free-cover construction, formula, uniqueness, surjectivity, and quotient equivalence are all admission-free; the alternative final decomposition endpoint is the already-audited Theorem 3.3.1 declaration."
     }
   },
   {

--- a/progress/items.json
+++ b/progress/items.json
@@ -4923,7 +4923,7 @@
     "end_page": "47",
     "start_line": 1,
     "end_line": 4,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -4963,6 +4963,13 @@
         "Etingof.irreducible_reps_of_matrix_algebra"
       ],
       "basis": "The heading itself is organizational, but its arbitrary-field finite-product setup is mathematical and is represented by the listed admission-free declarations."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.3",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The heading has no backward mathematical dependency. Its Stage 3.2 coverage uses declarations in the following theorem item, a forward implementation relation excluded from the acyclic book-order graph."
     }
   },
   {
@@ -4973,7 +4980,7 @@
     "end_page": "47",
     "start_line": 5,
     "end_line": 6,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "fidelity_decl": "Etingof.irreducible_reps_of_matrix_algebra",
@@ -5030,6 +5037,15 @@
         "exists_iso_directSum_of_matrixProd"
       ],
       "basis": "The simplicity, exhaustiveness, pairwise nonisomorphism, semisimplicity, and exact finite-dimensional direct-sum endpoint all have complete proof terms."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.3",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter3/Proposition3.1.4"
+      ],
+      "basis": "The exact multiplicity decomposition invokes Etingof.subrepresentation_of_semisimple from Proposition 3.1.4. The provider retains that single focused project import; five redundant Mathlib imports were removed."
     }
   },
   {
@@ -5040,7 +5056,7 @@
     "end_page": "47",
     "start_line": 7,
     "end_line": 8,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -5071,6 +5087,13 @@
       "proof_integrity": "not_applicable",
       "declarations": [],
       "basis": "This item is a methodological transition motivating the following definition, not a proposition with a Lean proof obligation."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.3",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "This methodological transition has no provider or standalone mathematical dependency; its conservative reading-order edge was removed."
     }
   },
   {
@@ -5081,7 +5104,7 @@
     "end_page": "47",
     "start_line": 9,
     "end_line": 12,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "fidelity_note": "DualRepresentation takes the algebra A and its action on V as parameters and carries the explicit contragredient Aᵐᵒᵖ-module structure, with dualRepresentation_smul_apply proving (op a • f)(v) = f(a • v).",
@@ -5126,6 +5149,13 @@
         "Etingof.instModuleMulOppositeDual"
       ],
       "basis": "The carrier, contragredient action, defining equation, and opposite-algebra module laws were all included in the exhaustive constant-level axiom audit."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.3",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The contragredient module is constructed directly from Mathlib dual and algebra APIs and imports no project provider. Two redundant Mathlib imports were removed."
     }
   },
   {
@@ -5136,7 +5166,7 @@
     "end_page": "47",
     "start_line": 13,
     "end_line": 21,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage_swept": {
       "wave": 1,
       "result": "covered"
@@ -5269,6 +5299,16 @@
         "exists_iso_directSum_of_matrixProd"
       ],
       "basis": "The complete dual route, including the free-to-dual surjection, dual injection, self-duality and regular/free decompositions, resolves to admission-free proof terms. Mathlib's finite-dual results and Proposition 3.1.4 were already compiled dependencies."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.3",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter3/Proposition3.1.4",
+        "Chapter3/Theorem3.3.1"
+      ],
+      "basis": "This proof discussion is the implementation of Theorem 3.3.1 and its final embedding-to-decomposition step uses Proposition 3.1.4. The Lean route constructs its twisted dual directly and does not import the separate Definition 3.3.2 provider."
     }
   },
   {
@@ -5279,7 +5319,7 @@
     "end_page": "48",
     "start_line": 1,
     "end_line": 14,
-    "status": "proved",
+    "status": "dependency_trimmed",
     "sorry_free": true,
     "coverage_note": "Both parts fully covered. Part (b)'s matrix-algebra classification is proved. Part (a) now classifies the irreducibles of A = ⊕ᵢ Aᵢ genuinely in terms of the factor algebras: the summand 1ᵢV carries an honest Module (𝒜 i) structure (factorSummandModule), the inflation of a factor module is defined (Inflate) with the simplicity/isomorphism correspondence (isSimpleModule_iff, congr/ofCongr, index_eq_of_equiv), part (a) is restated over the factors (simpleModule_prod_iff_factor), and every simple product module is exhibited as the inflation of a simple factor module from a unique index (exists_isSimpleFactor, exists_inflate_of_isSimple). Closed #7564.",
     "fidelity": "full",
@@ -5472,6 +5512,15 @@
         "Etingof.Problem3_3_3.finite_iso_std_pow"
       ],
       "basis": "All 36 exported declarations, the seven private matrix-unit helpers, and their compiler-generated proof constants were included in the exhaustive module-origin audit. Part (c) is a pedagogical deduction whose already-proved endpoint is Theorem 3.3.1."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.3",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter3/Theorem3.3.1"
+      ],
+      "basis": "Parts (a) and (b) compile from focused Mathlib imports alone; the former Theorem 3.3.1 provider import was documentation-only and was removed. Part (c)'s covered-elsewhere endpoint is the earlier Theorem 3.3.1 item, so that backward coverage edge remains."
     }
   },
   {
@@ -5482,7 +5531,7 @@
     "end_page": "49",
     "start_line": 15,
     "end_line": 2,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "notes": "Remark3_3_4.lean constructs the uniquely characterized free cover Aⁿ → X, proves surjectivity, and identifies its quotient by the kernel with X. The regular/free decompositions and the exact final multiplicity decomposition are public in Theorem3_3_1.lean; Lean reaches the endpoint through Proposition 3.1.4 rather than the book's quotient invocation of Lemma 3.1.6.",
@@ -5553,6 +5602,15 @@
         "Etingof.quotientEquivOfFreeCover"
       ],
       "basis": "The free-cover construction, formula, uniqueness, surjectivity, and quotient equivalence are all admission-free; the alternative final decomposition endpoint is the already-audited Theorem 3.3.1 declaration."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.3",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter3/Theorem3.3.1"
+      ],
+      "basis": "The free-cover and quotient declarations use only Mathlib, while the regular/free decompositions and final multiplicity decomposition are covered by the earlier Theorem 3.3.1 item. Three redundant Mathlib imports were removed."
     }
   },
   {


### PR DESCRIPTION
## Summary

- replace seven conservative §3.3 reading-order edges with five evidence-backed backward dependencies
- record complete Stage 3.4 metadata and advance all seven exact items to dependency_trimmed
- remove 15 redundant direct imports across all four providers, reducing 26 imports to 11
- remove the documentation-only Problem 3.3.3 import of Theorem 3.3.1
- preserve all mathematical declarations/proofs and all Stage 3.2/3.3 data

## Validation

- four scoped providers: 1698 jobs
- final redundant-import analysis: no remaining redundant imports
- full Chapter 3 build: 8692 jobs
- validate_items.py: 5721/5721 lines
- validate_dependencies.py: 583 entries / 580 edges
- validate_external_deps.py
- validate_mathlib_coverage.py
- exact tracker/graph agreement, backward-edge, invariance, admission, JSON, and diff checks

Stacked on draft PR #8064. This PR is exactly Chapter 3 §3.3, Stage 3.4.