### PR TITLE
Chapter 3 §3.4: complete Stage 3.2 faithful formalization

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/Lemma3_4_2.lean
+++ b/EtingofRepresentationTheory/Chapter3/Lemma3_4_2.lean
@@ -3,6 +3,7 @@ import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 import Mathlib.Order.JordanHolder
 import Mathlib.RingTheory.FiniteLength
 import Mathlib.RingTheory.Artinian.Module
+import EtingofRepresentationTheory.Chapter3.Definition3_4_1
 
 /-!
 # Lemma 3.4.2: Existence of Filtration with Irreducible Successive Quotients
@@ -24,3 +25,29 @@ theorem Etingof.exists_composition_series (k : Type*) (A : Type*) (V : Type*)
   have : IsNoetherian A V := isNoetherian_of_tower k (inferInstance : IsNoetherian k V)
   have : IsArtinian A V := isArtinian_of_tower k (inferInstance : IsArtinian k V)
   exact exists_compositionSeries_of_isNoetherian_isArtinian A V
+
+/-- Every finite-dimensional representation has a filtration whose successive quotients are
+irreducible. This is the statement of Etingof Lemma 3.4.2 expressed using
+`Etingof.Filtration`; the quotient attached to adjacent terms `Vᵢ < Vᵢ₊₁` is represented as
+`Vᵢ₊₁ ⧸ (Vᵢ.comap Vᵢ₊₁.subtype)`. -/
+theorem Etingof.exists_filtration_with_irreducible_quotients
+    (k : Type*) (A : Type*) (V : Type*)
+    [Field k] [Ring A] [Algebra k A]
+    [AddCommGroup V] [Module k V] [Module A V] [IsScalarTower k A V]
+    [FiniteDimensional k V] :
+    ∃ F : Etingof.Filtration A V, ∀ i : Fin F.chain.length,
+      IsSimpleModule A
+        (F.chain (Fin.succ i) ⧸
+          Submodule.comap (F.chain (Fin.succ i)).subtype (F.chain (Fin.castSucc i))) := by
+  obtain ⟨s, hs₀, hsₙ⟩ := Etingof.exists_composition_series k A V
+  let F : Etingof.Filtration A V :=
+    { chain := s.ofLE fun p h ↦
+        show p.1 < p.2 from JordanHolderLattice.lt_of_isMaximal h
+      head_eq_bot := hs₀
+      last_eq_top := hsₙ }
+  refine ⟨F, ?_⟩
+  intro i
+  change IsSimpleModule A
+    (s (Fin.succ i) ⧸
+      Submodule.comap (s (Fin.succ i)).subtype (s (Fin.castSucc i)))
+  exact (covBy_iff_quot_is_simple (le_of_lt (s.lt_succ i))).mp (s.step i)

--- a/progress/2026-07-27T15-17-50Z_stage3-2-chapter3-section3-4.md
+++ b/progress/2026-07-27T15-17-50Z_stage3-2-chapter3-section3-4.md
@@ -1,0 +1,48 @@
+# Stage 3.2 faithful formalization — Chapter 3 §3.4
+
+## Exact scope
+
+The audited interval is the three consecutive catalog items at indices 144–146:
+
+1. `Chapter3/Introduction_to_3.4`
+2. `Chapter3/Definition3.4.1`
+3. `Chapter3/Lemma3.4.2`
+
+The immediate predecessor is `Chapter3/Remark3.3.4`; the strict successor is
+`Chapter3/Introduction_to_3.5`. This pass changes no item outside that interval and leaves the
+existing conservative dependency metadata unchanged.
+
+## Source-to-Lean result
+
+The three source blobs contain 15 independently audited claim units: eight are formalized
+directly, five proof-route or library-level units are covered by named declarations elsewhere,
+and two are genuinely organizational or methodological prose. There are no omissions,
+placeholders, or remaining fidelity gaps.
+
+`Etingof.Filtration` already records all of Definition 3.4.1: a finite `RelSeries` of submodules,
+strict adjacent inclusions, first term `⊥`, and last term `⊤`.
+
+The former public statement of Lemma 3.4.2 only returned a Mathlib `CompositionSeries` with its
+endpoints. This pass retains that theorem and adds
+`Etingof.exists_filtration_with_irreducible_quotients`, whose conclusion uses the repository's
+own `Etingof.Filtration` and explicitly proves `IsSimpleModule A` for every adjacent quotient.
+The proof converts maximal composition-series steps to strict filtration steps and uses
+`covBy_iff_quot_is_simple` to expose irreducibility. Thus the finite chain, both endpoints, and
+the source's successive-quotient condition are all visible in the theorem type.
+
+The book's induction-through-preimages proof route is represented honestly at claim granularity.
+Lean uses the equivalent finite-length theorem obtained from Noetherian and Artinian module
+instances; the quotient and preimage constructions are standard Mathlib declarations rather
+than duplicate project wrappers.
+
+## Validation
+
+- direct build of both complete providers
+- declaration-name and accepted-axiom audit for the new theorem
+- scoped scan for `sorry`, `admit`, `proof_wanted`, project axioms, and `sorryAx`
+- full `EtingofRepresentationTheory.Chapter3` build
+- all four repository metadata/dependency validators
+- exact scope, predecessor/successor, claim aggregation, and non-scope invariance checks
+- JSON parsing and `git diff --check`
+
+This PR is limited to Section 3.4 and Stage 3.2.

--- a/progress/items.json
+++ b/progress/items.json
@@ -2421,6 +2421,31 @@
     "coverage_swept": {
       "wave": 1,
       "result": "none"
+    },
+    "coverage": "covered_full",
+    "fidelity": "verified",
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.4",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "The Section 3.4 heading identifies filtrations as the subject of the section.",
+          "verdict": "non_formalizable",
+          "reason": "This is an organizational heading rather than a mathematical proposition."
+        },
+        {
+          "claim": "A is an algebra and V is a representation of A.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.exists_filtration_with_irreducible_quotients",
+          "note": "The theorem's Field k, Ring A, Algebra k A, and Module A V assumptions give the exact algebra-and-representation setup."
+        }
+      ]
     }
   },
   {
@@ -2433,11 +2458,50 @@
     "end_line": 8,
     "status": "sorry_free",
     "coverage": "covered_full",
-    "last_updated": "2026-07-22",
+    "last_updated": "2026-07-27",
     "fidelity": "verified",
     "sorry_free": true,
     "fidelity_note": "[fidelity, resolved #5619] Etingof.Filtration is now a structure bundling the ascending chain (RelSeries) with the two boundary conditions head_eq_bot (V₀ = ⊥) and last_eq_top (Vₙ = ⊤), matching the book's 0 = V₀ ⊂ ⋯ ⊂ Vₙ = V.",
-    "fidelity_issue": 5619
+    "fidelity_issue": 5619,
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.4",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "A filtration is a finite sequence indexed from 0 through n.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Filtration.chain",
+          "note": "RelSeries has a natural-number length and terms indexed by Fin (length + 1)."
+        },
+        {
+          "claim": "Every term of the filtration is a subrepresentation of V.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Filtration.chain",
+          "note": "For a module representation, subrepresentations are modeled by Submodule A V."
+        },
+        {
+          "claim": "The first term V₀ is the zero subrepresentation.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Filtration.head_eq_bot"
+        },
+        {
+          "claim": "Adjacent terms are strictly included: Vᵢ ⊂ Vᵢ₊₁.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Filtration.chain",
+          "note": "The chain relation is strict order on Submodule A V, not non-strict inclusion."
+        },
+        {
+          "claim": "The last term Vₙ is the whole representation V.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Filtration.last_eq_top"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter3/Lemma3.4.2",
@@ -2449,9 +2513,66 @@
     "end_line": 12,
     "status": "sorry_free",
     "coverage": "covered_full",
-    "last_updated": "2026-07-22",
+    "last_updated": "2026-07-27",
     "fidelity": "verified",
-    "sorry_free": true
+    "sorry_free": true,
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.4",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "Every finite-dimensional representation V of an algebra A admits a finite filtration from 0 to V whose successive quotients are irreducible.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.exists_filtration_with_irreducible_quotients",
+          "note": "The conclusion uses Etingof.Filtration itself and states IsSimpleModule A for every adjacent quotient."
+        },
+        {
+          "claim": "The lemma may be proved by induction on dim(V).",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Etingof.exists_composition_series",
+          "note": "Lean uses the equivalent finite-length route: finite dimensionality supplies Noetherian and Artinian module instances, and Mathlib constructs a composition series."
+        },
+        {
+          "claim": "The induction base is immediate and only the induction step requires construction.",
+          "verdict": "non_formalizable",
+          "reason": "This is commentary about the presentation of the proof, not a separate mathematical conclusion."
+        },
+        {
+          "claim": "In the positive-dimensional induction step one can choose an irreducible subrepresentation V₁ of V.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "exists_compositionSeries_of_isNoetherian_isArtinian",
+          "note": "Mathlib's finite-length construction supplies the same maximal adjacent submodule step without exposing the book's particular choice as a separate project declaration."
+        },
+        {
+          "claim": "The quotient U = V/V₁ is again a representation of A.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Submodule.Quotient",
+          "note": "Mathlib's submodule quotient carries the induced A-module structure used in the successive-quotient statement."
+        },
+        {
+          "claim": "The induction hypothesis gives U a filtration with irreducible successive quotients.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "exists_compositionSeries_of_isNoetherian_isArtinian",
+          "note": "The library composition-series theorem packages this recursive finite-length construction."
+        },
+        {
+          "claim": "The later Vᵢ are obtained as preimages of the Uᵢ₋₁ under the quotient projection V → V/V₁.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Submodule.comap",
+          "note": "Submodule preimages under linear maps are Mathlib's comap construction; the project proof reaches the same chain through the composition-series API."
+        },
+        {
+          "claim": "The resulting chain is a filtration of V with irreducible successive quotients.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.exists_filtration_with_irreducible_quotients"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter3/Introduction_to_3.5",


### PR DESCRIPTION
## Summary

- audit the exact Chapter 3 §3.4 interval (catalog indices 144–146) at Stage 3.2 claim granularity
- add `Etingof.exists_filtration_with_irreducible_quotients`, exposing the repository `Filtration` and simplicity of every adjacent quotient
- record 15 claim units: 8 formalized, 5 covered elsewhere, and 2 non-formalizable
- add the scoped audit note while preserving all dependency metadata and non-scope items

## Validation

- `lake build EtingofRepresentationTheory.Chapter3.Definition3_4_1 EtingofRepresentationTheory.Chapter3.Lemma3_4_2` (1,581 jobs)
- `lake build EtingofRepresentationTheory.Chapter3` (8,692 jobs)
- all four repository validators
- JSON parsing and `git diff --check`
- declaration and accepted-axiom audit (`propext`, `Classical.choice`, `Quot.sound` only)
- scoped admission scan, exact-boundary check, claim aggregation, and non-scope invariance checks
