### PR TITLE
Stage 3.2: audit Chapter 3 Section 3.5 claims

### DIFF
--- a/progress/2026-07-27T15-19-30Z_stage3-2-chapter3-section3-5.md
+++ b/progress/2026-07-27T15-19-30Z_stage3-2-chapter3-section3-5.md
@@ -1,0 +1,84 @@
+# Stage 3.2 fidelity review — Chapter 3 §3.5
+
+## Scope
+
+Reading order gives exactly nine §3.5 catalog items, the contiguous `progress/items.json` range
+147–155:
+
+1. `Chapter3/Introduction_to_3.5`;
+2. `Chapter3/Definition3.5.1`;
+3. `Chapter3/Proposition3.5.2`;
+4. `Chapter3/Proposition3.5.3`;
+5. `Chapter3/Theorem3.5.4`;
+6. `Chapter3/Corollary3.5.5`;
+7. `Chapter3/Example3.5.6`;
+8. `Chapter3/Definition3.5.7`;
+9. `Chapter3/Proposition3.5.8`.
+
+The preceding item is `Chapter3/Lemma3.4.2`; the next item, and strict stopping boundary, is
+`Chapter3/Introduction_to_3.6`. The source is pages 49–52, including the zero-algebra footnote.
+No §3.6 content is in scope.
+
+## Claim audit
+
+Pages 49–52 and all ten §3.5 providers were read in full. The durable inventory has 26 claim
+units:
+
+- 22 `formalized` by exact scoped declarations;
+- 2 `covered_elsewhere` by the density theorem and standard finite-dimensional dimension lemmas;
+- 2 `non_formalizable` organizational or underspecified prose units;
+- no accidental gap, intentional omission, or unclassified hard mathematical claim.
+
+The audit covers the Jacobson-radical encoding and its two-sidedness; both halves and the
+largest-ideal conclusion of Proposition 3.5.3; cyclicity, finite dimensionality, finiteness,
+exhaustiveness, the cardinal bound, the aggregate density map, its kernel, and the quotient
+algebra isomorphism in Theorem 3.5.4; the full dimension argument of Corollary 3.5.5; both
+radical computations and both irreducible-representation classifications in Example 3.5.6;
+the definition of semisimplicity; all five conditions of Proposition 3.5.8; and every assertion
+in its zero-algebra footnote.
+
+No Lean repair was necessary. Current `main` already contains the recently completed family
+construction for Theorem 3.5.4 and all six public zero-algebra endpoints from closed issue #7468
+and PR #7610. The tracker was stale only for Proposition 3.5.8: its old `covered_partial` /
+`fidelity: partial` record still described the now-closed footnote gap. It is reconciled to
+`covered_full` / `verified`.
+
+The sentence “a similar result holds for block-triangular matrices” is recorded as
+`non_formalizable`: the source specifies no block decomposition, diagonal-block hypotheses,
+representation family, or radical formula, so it does not determine a unique theorem. This is
+not counted as a missing formal claim. The scalar upper-triangular classification and radical
+identity immediately preceding it are fully formalized.
+
+Definition integrity is verified: `Etingof.Radical` is the Jacobson radical, equivalent to the
+common annihilator of simple modules, and `Etingof.IsSemisimpleAlgebra` uses Mathlib's
+`IsSemisimpleRing`, equivalent to vanishing Jacobson radical for the finite-dimensional
+(Artinian) algebras in scope. Statement fidelity and nonvacuity are verified for every theorem:
+the family is actually constructed and exhaustive, the structure results return genuine algebra
+or module equivalences, and the zero-algebra results use explicit subsingleton hypotheses rather
+than impossible assumptions.
+
+## Durable tracker result
+
+All nine scoped items now have complete Stage 3.2 `claim_coverage` records with verified
+definition integrity, statement fidelity, and nonvacuity. Every item is `covered_full`; the two
+prose-only units retain claim-level `non_formalizable` verdicts. The normalized non-§3.5
+projection of `progress/items.json` and both dependency maps are unchanged from `origin/main`.
+
+## Validation
+
+- `.lake/build` is worktree-local; only `.lake/packages` links to the shared package cache;
+- all ten scoped providers build successfully together (1977 jobs);
+- `lake build EtingofRepresentationTheory.Chapter3` succeeds (8692 jobs); replayed warnings are
+  pre-existing and Stage 3.5 proof-polish concerns, not Stage 3.2 claim gaps;
+- the scoped scan finds no `sorry`, `admit`, `axiom`, `proof_wanted`, `opaque`, or
+  `native_decide` declaration;
+- representative `#print axioms` checks for the central endpoints report only `propext`,
+  `Classical.choice`, and `Quot.sound`;
+- all 40 distinct declarations cited by the claim inventory resolve under the Chapter 3 umbrella;
+- `jq empty progress/items.json`, the exact nine-item/26-claim aggregation, and the strict
+  boundary check pass;
+- `python3 scripts/validate_items.py` passes with complete source-line coverage;
+- `python3 scripts/validate_dependencies.py`, `validate_external_deps.py`, and
+  `validate_mathlib_coverage.py` all pass;
+- normalized non-scope tracker comparison, unchanged dependency-map checks, and
+  `git diff --check` pass.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3074,7 +3074,27 @@
     "status": "sorry_free",
     "coverage_swept": {
       "wave": 1,
-      "result": "none"
+      "result": "non_formalizable"
+    },
+    "coverage": "covered_full",
+    "coverage_note": "Stage 3.2 reviewed the section heading; it introduces finite-dimensional algebras but makes no standalone mathematical assertion.",
+    "fidelity": "verified",
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.5",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "Section 3.5 is the organizational heading for finite-dimensional algebras.",
+          "verdict": "non_formalizable",
+          "reason": "This is a section heading rather than a mathematical proposition with a Lean proof obligation."
+        }
+      ]
     }
   },
   {
@@ -3087,9 +3107,25 @@
     "end_line": 16,
     "status": "sorry_free",
     "coverage": "covered_full",
-    "last_updated": "2026-07-22",
+    "last_updated": "2026-07-27",
     "fidelity": "verified",
-    "sorry_free": true
+    "sorry_free": true,
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.5",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "The radical of A is the set of elements acting by zero in every irreducible A-representation, denoted Rad(A).",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.Radical; Etingof.structure_mod_radical; IsSemisimpleModule.jacobson_le_annihilator"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter3/Proposition3.5.2",
@@ -3101,9 +3137,25 @@
     "end_line": 20,
     "status": "sorry_free",
     "coverage": "covered_full",
-    "last_updated": "2026-07-22",
+    "last_updated": "2026-07-27",
     "fidelity": "verified",
-    "sorry_free": true
+    "sorry_free": true,
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.5",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "Rad(A) is a two-sided ideal.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.radical_is_ideal; Etingof.radical_isTwoSided"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter3/Proposition3.5.3",
@@ -3115,9 +3167,35 @@
     "end_line": 4,
     "status": "sorry_free",
     "coverage": "covered_full",
-    "last_updated": "2026-07-22",
+    "last_updated": "2026-07-27",
     "fidelity": "verified",
-    "sorry_free": true
+    "sorry_free": true,
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.5",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "Every nilpotent two-sided ideal I of A is contained in Rad(A).",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.nilpotent_ideal_le_radical"
+        },
+        {
+          "claim": "For a finite-dimensional algebra A, Rad(A) is nilpotent.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.radical_is_nilpotent"
+        },
+        {
+          "claim": "Consequently Rad(A) is the largest nilpotent two-sided ideal of A.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.radical_is_nilpotent; Etingof.nilpotent_ideal_le_radical; Etingof.radical_isTwoSided"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter3/Theorem3.5.4",
@@ -3131,8 +3209,44 @@
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
-    "coverage_note": "Both clauses of the book statement are now proved. Theorem3_5_4.lean gives the radical-quotient isomorphism from a complete family, and Theorem3_5_4_CompleteFamily.lean constructs that family: Etingof.exists_finset_complete_family produces a finite set of maximal left ideals whose quotients are pairwise nonisomorphic, exhaustive, and at most finrank k A in number, and Etingof.exists_structure_mod_radical packages the isomorphism with the constructed family (#7127).",
-    "last_updated": "2026-07-26"
+    "coverage_note": "Both clauses of the book statement are proved. Theorem3_5_4_Finiteness.lean proves finite dimensionality and the cardinal bound; Theorem3_5_4_CompleteFamily.lean constructs a finite, exhaustive, pairwise-nonisomorphic family and packages the radical-quotient isomorphism. Stage 3.2 re-verified every statement and proof claim.",
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.5",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "Every irreducible representation of a finite-dimensional algebra is cyclic and finite-dimensional.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.simple_finiteDimensional; Etingof.exists_isCoatom_quotient_equiv"
+        },
+        {
+          "claim": "There are only finitely many irreducible representations up to isomorphism, at most dim A, and a finite exhaustive pairwise-nonisomorphic family exists.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.card_irreducibles_le_finrank; Etingof.exists_finset_complete_family; Etingof.exists_complete_family_of_simples"
+        },
+        {
+          "claim": "For any finite pairwise-nonisomorphic family of irreducibles, the combined representation map A → ∏ᵢ End(Vᵢ) is surjective.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Etingof.density_theorem_part2"
+        },
+        {
+          "claim": "For a complete irreducible family, the kernel of the combined representation map is exactly Rad(A).",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.structure_mod_radical"
+        },
+        {
+          "claim": "For a finite complete family (Vᵢ), A/Rad(A) is isomorphic as a k-algebra to ∏ᵢ End_k(Vᵢ).",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.structure_mod_radical; Etingof.exists_structure_mod_radical"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter3/Corollary3.5.5",
@@ -3146,7 +3260,28 @@
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
-    "last_updated": "2026-07-22"
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.5",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "For a complete family of irreducibles Vᵢ, ∑ᵢ (dim Vᵢ)² ≤ dim A.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.sum_dim_sq_le_dim"
+        },
+        {
+          "claim": "The proof uses dim A = dim Rad(A) + ∑ᵢ dim End(Vᵢ), with dim End(Vᵢ) = (dim Vᵢ)².",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Etingof.structure_mod_radical; Submodule.finrank_quotient_add_finrank; Module.finrank_linearMap"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter3/Example3.5.6",
@@ -3160,8 +3295,44 @@
     "coverage": "covered_full",
     "fidelity": "verified",
     "sorry_free": true,
-    "fidelity_note": "Both Jacobson-radical equalities are proved, and both source representation classifications are now formalized: Etingof.TruncPolySimple (simple, one-dimensional, x acts by zero, and every simple k[x]/(x^n)-module is isomorphic to it) and Etingof.UpperTriangularSimple (the n diagonal characters V_i, each simple and one-dimensional, pairwise non-isomorphic, and exhaustive).",
-    "last_updated": "2026-07-26"
+    "fidelity_note": "Both Jacobson-radical equalities and both representation classifications are formalized. The source's final unspecific sentence that a similar result holds for block-triangular matrices has no fixed block data or precise theorem to translate and is recorded claim-by-claim as non-formalizable rather than as a coverage gap.",
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.5",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "For A = k[x]/(xⁿ), the unique irreducible representation is one-dimensional and x acts by zero.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.TruncPolySimple; Etingof.isSimpleModule_truncPolySimple; Etingof.root_smul_truncPolySimple; Etingof.finrank_truncPolySimple; Etingof.nonempty_linearEquiv_truncPolySimple"
+        },
+        {
+          "claim": "The radical of k[x]/(xⁿ) is the ideal (x).",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.radical_truncated_polynomial"
+        },
+        {
+          "claim": "The irreducible representations of upper-triangular n × n matrices are exactly the n pairwise-nonisomorphic one-dimensional diagonal characters Vᵢ, with x acting by xᵢᵢ.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.UpperTriangularSimple; Etingof.UpperTriangularSimple.smul_def; Etingof.finrank_upperTriangularSimple; Etingof.isSimpleModule_upperTriangularSimple; Etingof.not_nonempty_linearEquiv_upperTriangularSimple; Etingof.exists_linearEquiv_upperTriangularSimple"
+        },
+        {
+          "claim": "The radical of the upper-triangular matrix algebra is the ideal of strictly upper-triangular matrices.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.radical_upper_triangular"
+        },
+        {
+          "claim": "A similar result holds for block-triangular matrices.",
+          "verdict": "non_formalizable",
+          "reason": "The source gives no block decomposition, diagonal-block hypotheses, representation list, or exact radical formula, so this analogy does not determine a unique proposition. The scalar upper-triangular theorem is fully formalized."
+        }
+      ]
+    }
   },
   {
     "id": "Chapter3/Definition3.5.7",
@@ -3173,9 +3344,25 @@
     "end_line": 10,
     "status": "sorry_free",
     "coverage": "covered_full",
-    "last_updated": "2026-07-22",
+    "last_updated": "2026-07-27",
     "fidelity": "verified",
-    "sorry_free": true
+    "sorry_free": true,
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.5",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "A finite-dimensional algebra is semisimple exactly when Rad(A) = 0.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.IsSemisimpleAlgebra; IsArtinianRing.isSemisimpleRing_iff_jacobson; Ideal.jacobson_bot"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter3/Proposition3.5.8",
@@ -3186,13 +3373,58 @@
     "start_line": 11,
     "end_line": 2,
     "status": "sorry_free",
-    "fidelity": "partial",
+    "fidelity": "verified",
     "sorry_free": true,
     "fidelity_decl": "Etingof.semisimple_algebra_equiv",
-    "fidelity_issue": 7468,
-    "fidelity_note": "The five main equivalent conditions were repaired in closed #5371. The source's zero-algebra footnote—semisimple but not simple, with only zero representations and an empty matrix-algebra sum—has no public endpoint; follow-up #7468.",
-    "coverage": "covered_partial",
-    "last_updated": "2026-07-22"
+    "fidelity_note": "The five main equivalent conditions were repaired in closed #5371. Closed #7468 / PR #7610 supplies every zero-algebra footnote endpoint: semisimple but not simple, all modules zero, no irreducible or indecomposable modules, and the empty matrix-algebra product.",
+    "coverage": "covered_full",
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.5",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "For a finite-dimensional algebra over an algebraically closed field, semisimplicity, the dimension equality, a finite product of matrix algebras, complete reducibility of every finite-dimensional representation, and complete reducibility of the regular representation are equivalent.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.semisimple_algebra_equiv"
+        },
+        {
+          "claim": "The zero algebra is semisimple.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.subsingleton_isSemisimpleRing"
+        },
+        {
+          "claim": "The zero algebra is not simple.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.subsingleton_not_isSimpleRing"
+        },
+        {
+          "claim": "Every unital representation of the zero algebra is zero.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.subsingleton_module_of_subsingleton"
+        },
+        {
+          "claim": "The zero algebra has no irreducible representations.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.subsingleton_not_isSimpleModule"
+        },
+        {
+          "claim": "The zero algebra has no indecomposable representations.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.subsingleton_not_isIndecomposable"
+        },
+        {
+          "claim": "The zero algebra is the empty product/direct sum of matrix algebras, the n = 0 Wedderburn case.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.subsingleton_algEquiv_pi_matrix"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter3/Introduction_to_3.6",


### PR DESCRIPTION
## Summary

- audit the exact nine-item Chapter 3 §3.5 interval against pages 49–52 and all ten Lean providers
- record 26 source claim units: 22 formalized, 2 covered elsewhere, and 2 precisely non-formalizable prose units
- add complete Stage 3.2 definition-integrity, statement-fidelity, and nonvacuity metadata to every scoped item
- reconcile Proposition 3.5.8 from stale partial coverage to verified full coverage now that issue #7468 / PR #7610 formalizes the zero-algebra footnote

No Lean repair was necessary: current `main` already contains every precise mathematical endpoint. The only non-formalized mathematical-looking sentence is the source’s underspecified “similar result” for block-triangular matrices, which provides no block data or exact proposition.

## Validation

- ten-provider scoped build: 1,977 jobs
- full `EtingofRepresentationTheory.Chapter3` build: 8,692 jobs
- all 40 declarations cited by the inventory resolve
- representative axiom audit: only `propext`, `Classical.choice`, and `Quot.sound`
- exact nine-item/26-claim aggregation and strict §3.4/§3.6 boundaries
- normalized non-scope tracker invariance and unchanged dependency maps
- admission scan and `git diff --check`
- `scripts/validate_items.py`
- `scripts/validate_dependencies.py`
- `scripts/validate_external_deps.py`
- `scripts/validate_mathlib_coverage.py`