### PR TITLE
Stage 3.3: verify Chapter 3 Section 3.4 proofs

### DIFF
--- a/progress/2026-07-27T15-26-33Z_stage3-3-chapter3-section3-4.md
+++ b/progress/2026-07-27T15-26-33Z_stage3-3-chapter3-section3-4.md
@@ -1,0 +1,62 @@
+# Stage 3.3 proof-integrity review — Chapter 3 §3.4
+
+## Scope and inherited coverage
+
+This stacked review is based exactly on Stage 3.2 draft PR #8068 at commit `42f2cd1a`.
+Reading order gives the three §3.4 catalog items at indices 144–146, from
+`Chapter3/Introduction_to_3.4` through `Chapter3/Lemma3.4.2`, and two Lean provider files.
+The strict predecessor is `Chapter3/Remark3.3.4`; the strict successor is
+`Chapter3/Introduction_to_3.5`.
+
+Stage 3.2 supplies 15 exhaustive claim units: eight `formalized`, five `covered_elsewhere`, and
+two `non_formalizable`. The two nonformalizable units are the section heading and methodological
+proof commentary. All 13 mathematical or library-level units retain their complete coverage,
+including the explicit filtration-with-simple-quotients theorem added during Stage 3.2.
+
+## Proof-integrity result
+
+All three exact items are `sorry_free`. Their durable tracker entries cite seven declaration
+references, comprising six unique public declarations: the filtration structure and its three
+fields, the composition-series existence theorem, and the exact filtration theorem.
+
+The audit was deliberately broader than those public references. Lean's module-origin data
+identified all 20 kernel constants emitted by the two providers: 18 in
+`Definition3_4_1` (the structure, its fields, and 14 generated constructor/recursor/injectivity/
+no-confusion/size constants) and two in `Lemma3_4_2`. `Lean.collectAxioms` was run on every one of
+the 20 constants. Every transitive axiom set was contained in `propext`, `Classical.choice`, and
+`Quot.sound`; there was no `sorryAx` or project axiom.
+
+A direct scan of both providers found no `sorry`, `admit`, `proof_wanted`, `axiom`, `sorryAx`,
+`opaque`, or `native_decide`. No proof repair was required.
+
+## Import audit
+
+The exact providers contain eight explicit direct import statements. The definition provider
+imports `Mathlib.Order.RelSeries` and `Mathlib.LinearAlgebra.Span.Basic`. The lemma provider
+imports the five Mathlib modules supplying simple modules, finite dimensionality, Jordan–Hölder
+series, finite length, and Artinian modules, plus the exact local predecessor provider
+`Definition3_4_1`. There is no broad chapter import, later-section import, or additional project
+edge. The provider build and exhaustive transitive axiom audit cover all declarations reached
+through these imports; import minimization remains the separate Stage 3.4 concern.
+
+## Durable tracker result
+
+- all three exact items have complete section `3.4` `stage3_3` objects;
+- proof-integrity split: three `sorry_free`, zero `not_applicable`;
+- declaration references: seven, comprising six unique declarations;
+- exhaustive constant-level audit: 20/20 constants axiom-clean;
+- Stage 3.2 claim/fidelity data is unchanged;
+- non-§3.4 tracker records and dependency metadata are unchanged.
+
+## Validation
+
+- both scoped providers built successfully in isolation (1,581 jobs);
+- exhaustive module-origin declaration enumeration and `Lean.collectAxioms`: 20/20 clean, with
+  foundational axioms only;
+- exact scoped admission/placeholder and direct-import scans: clean;
+- exact three-item Stage 3.3 completeness and proof-integrity split: passed;
+- full Chapter 3 build: passed;
+- all repository metadata, dependency, external-dependency, and Mathlib-coverage validators: passed;
+- JSON parsing, scoped/non-scoped tracker invariance, and `git diff --check`: passed.
+
+This PR is limited to Chapter 3 §3.4 and Stage 3.3.

--- a/progress/items.json
+++ b/progress/items.json
@@ -5436,6 +5436,16 @@
           "note": "The theorem's Field k, Ring A, Algebra k A, and Module A V assumptions give the exact algebra-and-representation setup."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.4",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.exists_filtration_with_irreducible_quotients"
+      ],
+      "basis": "The heading is organizational, while its algebra-and-representation setup is realized by the listed admission-free theorem with arbitrary algebra and module parameters."
     }
   },
   {
@@ -5491,6 +5501,19 @@
           "lean_decl": "Etingof.Filtration.last_eq_top"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.4",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Filtration",
+        "Etingof.Filtration.chain",
+        "Etingof.Filtration.head_eq_bot",
+        "Etingof.Filtration.last_eq_top"
+      ],
+      "basis": "The structure and all three fields are admission-free. The exhaustive module-origin audit also covers its 14 generated constructors, recursors, injectivity proofs, no-confusion principles, and sizeOf constants."
     }
   },
   {
@@ -5562,6 +5585,17 @@
           "lean_decl": "Etingof.exists_filtration_with_irreducible_quotients"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.4",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.exists_composition_series",
+        "Etingof.exists_filtration_with_irreducible_quotients"
+      ],
+      "basis": "Both theorem constants have complete proof terms. The exact endpoint returns Etingof.Filtration and proves IsSimpleModule A for every adjacent quotient; the composition-series theorem records the equivalent finite-length proof route."
     }
   },
   {


### PR DESCRIPTION
## Summary

- audit the exact three-item Chapter 3 §3.4 scope inherited from Stage 3.2
- certify all three item records as proof-integrity `sorry_free`
- audit all 20 constants emitted by the two provider modules, including all generated structure constants
- confirm every transitive axiom set is contained in `propext`, `Classical.choice`, and `Quot.sound`
- audit all eight direct imports and preserve Stage 3.2 claim/fidelity data plus every non-scope record

## Validation

- two scoped providers: 1,581 jobs
- exhaustive `Lean.collectAxioms` audit: 20/20 clean
- full Chapter 3 build: 8,692 jobs
- all four repository validators
- JSON parsing, direct-import scan, exact-scope/non-scope invariance, admission scan, and `git diff --check`

Stacked on draft PR #8068. This PR is exactly Chapter 3 §3.4, Stage 3.3.
