### PR TITLE
Stage 3.4: audit Chapter 3 section 3.4 dependencies

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/Definition3_4_1.lean
+++ b/EtingofRepresentationTheory/Chapter3/Definition3_4_1.lean
@@ -1,5 +1,5 @@
 import Mathlib.Order.RelSeries
-import Mathlib.LinearAlgebra.Span.Basic
+import Mathlib.Algebra.Module.Submodule.Lattice
 
 /-!
 # Definition 3.4.1: Filtration of a Representation

--- a/EtingofRepresentationTheory/Chapter3/Lemma3_4_2.lean
+++ b/EtingofRepresentationTheory/Chapter3/Lemma3_4_2.lean
@@ -1,8 +1,5 @@
-import Mathlib.RingTheory.SimpleModule.Basic
 import Mathlib.LinearAlgebra.FiniteDimensional.Defs
-import Mathlib.Order.JordanHolder
 import Mathlib.RingTheory.FiniteLength
-import Mathlib.RingTheory.Artinian.Module
 import EtingofRepresentationTheory.Chapter3.Definition3_4_1
 
 /-!

--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -429,12 +429,8 @@
   "Chapter3/Remark3.3.4": [
     "Chapter3/Problem3.3.3"
   ],
-  "Chapter3/Introduction_to_3.4": [
-    "Chapter3/Remark3.3.4"
-  ],
-  "Chapter3/Definition3.4.1": [
-    "Chapter3/Introduction_to_3.4"
-  ],
+  "Chapter3/Introduction_to_3.4": [],
+  "Chapter3/Definition3.4.1": [],
   "Chapter3/Lemma3.4.2": [
     "Chapter3/Definition3.4.1"
   ],

--- a/progress/2026-07-27T15-26-33Z_stage3-3-chapter3-section3-4.md
+++ b/progress/2026-07-27T15-26-33Z_stage3-3-chapter3-section3-4.md
@@ -1,0 +1,62 @@
+# Stage 3.3 proof-integrity review — Chapter 3 §3.4
+
+## Scope and inherited coverage
+
+This stacked review is based exactly on Stage 3.2 draft PR #8068 at commit `42f2cd1a`.
+Reading order gives the three §3.4 catalog items at indices 144–146, from
+`Chapter3/Introduction_to_3.4` through `Chapter3/Lemma3.4.2`, and two Lean provider files.
+The strict predecessor is `Chapter3/Remark3.3.4`; the strict successor is
+`Chapter3/Introduction_to_3.5`.
+
+Stage 3.2 supplies 15 exhaustive claim units: eight `formalized`, five `covered_elsewhere`, and
+two `non_formalizable`. The two nonformalizable units are the section heading and methodological
+proof commentary. All 13 mathematical or library-level units retain their complete coverage,
+including the explicit filtration-with-simple-quotients theorem added during Stage 3.2.
+
+## Proof-integrity result
+
+All three exact items are `sorry_free`. Their durable tracker entries cite seven declaration
+references, comprising six unique public declarations: the filtration structure and its three
+fields, the composition-series existence theorem, and the exact filtration theorem.
+
+The audit was deliberately broader than those public references. Lean's module-origin data
+identified all 20 kernel constants emitted by the two providers: 18 in
+`Definition3_4_1` (the structure, its fields, and 14 generated constructor/recursor/injectivity/
+no-confusion/size constants) and two in `Lemma3_4_2`. `Lean.collectAxioms` was run on every one of
+the 20 constants. Every transitive axiom set was contained in `propext`, `Classical.choice`, and
+`Quot.sound`; there was no `sorryAx` or project axiom.
+
+A direct scan of both providers found no `sorry`, `admit`, `proof_wanted`, `axiom`, `sorryAx`,
+`opaque`, or `native_decide`. No proof repair was required.
+
+## Import audit
+
+The exact providers contain eight explicit direct import statements. The definition provider
+imports `Mathlib.Order.RelSeries` and `Mathlib.LinearAlgebra.Span.Basic`. The lemma provider
+imports the five Mathlib modules supplying simple modules, finite dimensionality, Jordan–Hölder
+series, finite length, and Artinian modules, plus the exact local predecessor provider
+`Definition3_4_1`. There is no broad chapter import, later-section import, or additional project
+edge. The provider build and exhaustive transitive axiom audit cover all declarations reached
+through these imports; import minimization remains the separate Stage 3.4 concern.
+
+## Durable tracker result
+
+- all three exact items have complete section `3.4` `stage3_3` objects;
+- proof-integrity split: three `sorry_free`, zero `not_applicable`;
+- declaration references: seven, comprising six unique declarations;
+- exhaustive constant-level audit: 20/20 constants axiom-clean;
+- Stage 3.2 claim/fidelity data is unchanged;
+- non-§3.4 tracker records and dependency metadata are unchanged.
+
+## Validation
+
+- both scoped providers built successfully in isolation (1,581 jobs);
+- exhaustive module-origin declaration enumeration and `Lean.collectAxioms`: 20/20 clean, with
+  foundational axioms only;
+- exact scoped admission/placeholder and direct-import scans: clean;
+- exact three-item Stage 3.3 completeness and proof-integrity split: passed;
+- full Chapter 3 build: passed;
+- all repository metadata, dependency, external-dependency, and Mathlib-coverage validators: passed;
+- JSON parsing, scoped/non-scoped tracker invariance, and `git diff --check`: passed.
+
+This PR is limited to Chapter 3 §3.4 and Stage 3.3.

--- a/progress/2026-07-27T15-35-36Z_stage3-4-chapter3-section3-4.md
+++ b/progress/2026-07-27T15-35-36Z_stage3-4-chapter3-section3-4.md
@@ -1,0 +1,63 @@
+# Stage 3.4 dependency audit — Chapter 3 §3.4
+
+## Scope
+
+This review is stacked exactly on Stage 3.3 draft PR #8071 at commit `0399da14`. It covers the
+same three reading-order items from `Chapter3/Introduction_to_3.4` through
+`Chapter3/Lemma3.4.2` and both complete Lean provider files. The immediate predecessor is
+`Chapter3/Remark3.3.4`; the strict successor is `Chapter3/Introduction_to_3.5`.
+
+No mathematical definition, theorem statement, or proof changed. This pass is limited to actual
+backward dependency metadata and focused direct-import minimization.
+
+## Direct import audit
+
+All three authored declarations across the two providers were checked with declaration-level
+`#min_imports`, and both complete provider headers were checked with `#redundant_imports`.
+
+- `Definition3_4_1.lean` retains `Mathlib.Order.RelSeries` for the finite strict chain and replaces
+  the broader `Mathlib.LinearAlgebra.Span.Basic` import with the reported minimal
+  `Mathlib.Algebra.Module.Submodule.Lattice` import for the submodule lattice and its bounds;
+- `Lemma3_4_2.lean` removes the transitively redundant `SimpleModule.Basic`, `JordanHolder`, and
+  `Artinian.Module` imports. Its two theorems require exactly `FiniteLength`,
+  `FiniteDimensional.Defs`, and the local `Definition3_4_1` provider.
+
+Direct imports move from eight to five, net `-3`. A final complete-provider
+`#redundant_imports` pass reports no transitively redundant import in either provider.
+
+## Actual internal dependency graph
+
+The three conservative reading-order edges are replaced by one actual backward edge:
+
+1. `Chapter3/Lemma3.4.2` → `Chapter3/Definition3.4.1`, because the exact theorem explicitly
+   constructs and returns `Etingof.Filtration`.
+
+The section introduction is organizational prose without a provider, and the definition provider
+uses only Mathlib. The helper composition-series theorem is defined in the same tracked lemma item.
+Scoped graph edges move from three to one, net `-2`. The retained edge points strictly backward in
+catalog order, and every tracker `actual_internal_dependencies` array agrees exactly with
+`dependencies/internal.json`.
+
+## Durable tracker result
+
+- all three exact records have complete section `3.4` `stage3_4` objects;
+- all three workflow statuses advance to `dependency_trimmed`;
+- Stage 3.2, Stage 3.3, claim-coverage, and fidelity metadata are unchanged;
+- the non-§3.4 tracker projection, non-§3.4 dependency-source projection, and all downstream
+  incoming edges are unchanged from PR #8071.
+
+## Validation
+
+- final isolated build of both scoped providers: success (1,581 jobs);
+- `lake build EtingofRepresentationTheory.Chapter3`: success (8,692 jobs; pre-existing linter
+  warnings only);
+- declaration-level `#min_imports` checks for all three authored declarations: complete;
+- initial and final all-provider `#redundant_imports` checks: clean after trimming;
+- exact three-item tracker/graph agreement and no-forward-edge checks: passed;
+- direct-import count: 8 → 5 (`-3`); scoped graph edges: 3 → 1 (`-2`);
+- `jq empty progress/items.json dependencies/internal.json`: passed;
+- `python3 scripts/validate_items.py`: passed with 5721/5721-line coverage (593 pre-existing schema
+  warnings);
+- dependency, external-dependency, and Mathlib-coverage validators: passed;
+- normalized scoped and non-scoped tracker/dependency invariance checks and `git diff --check`:
+  passed.

--- a/progress/items.json
+++ b/progress/items.json
@@ -5436,6 +5436,16 @@
           "note": "The theorem's Field k, Ring A, Algebra k A, and Module A V assumptions give the exact algebra-and-representation setup."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.4",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.exists_filtration_with_irreducible_quotients"
+      ],
+      "basis": "The heading is organizational, while its algebra-and-representation setup is realized by the listed admission-free theorem with arbitrary algebra and module parameters."
     }
   },
   {
@@ -5491,6 +5501,19 @@
           "lean_decl": "Etingof.Filtration.last_eq_top"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.4",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Filtration",
+        "Etingof.Filtration.chain",
+        "Etingof.Filtration.head_eq_bot",
+        "Etingof.Filtration.last_eq_top"
+      ],
+      "basis": "The structure and all three fields are admission-free. The exhaustive module-origin audit also covers its 14 generated constructors, recursors, injectivity proofs, no-confusion principles, and sizeOf constants."
     }
   },
   {
@@ -5562,6 +5585,17 @@
           "lean_decl": "Etingof.exists_filtration_with_irreducible_quotients"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.4",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.exists_composition_series",
+        "Etingof.exists_filtration_with_irreducible_quotients"
+      ],
+      "basis": "Both theorem constants have complete proof terms. The exact endpoint returns Etingof.Filtration and proves IsSimpleModule A for every adjacent quotient; the composition-series theorem records the equivalent finite-length proof route."
     }
   },
   {

--- a/progress/items.json
+++ b/progress/items.json
@@ -5407,7 +5407,7 @@
     "end_page": "49",
     "start_line": 3,
     "end_line": 6,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -5446,6 +5446,13 @@
         "Etingof.exists_filtration_with_irreducible_quotients"
       ],
       "basis": "The heading is organizational, while its algebra-and-representation setup is realized by the listed admission-free theorem with arbitrary algebra and module parameters."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.4",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "This item is an organizational heading and setup paragraph with no provider of its own, so it has no actual backward internal dependency."
     }
   },
   {
@@ -5456,7 +5463,7 @@
     "end_page": "49",
     "start_line": 7,
     "end_line": 8,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "last_updated": "2026-07-27",
     "fidelity": "verified",
@@ -5514,6 +5521,13 @@
         "Etingof.Filtration.last_eq_top"
       ],
       "basis": "The structure and all three fields are admission-free. The exhaustive module-origin audit also covers its 14 generated constructors, recursors, injectivity proofs, no-confusion principles, and sizeOf constants."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.4",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "Definition3_4_1.lean imports only Mathlib modules and uses no earlier project declaration."
     }
   },
   {
@@ -5524,7 +5538,7 @@
     "end_page": "49",
     "start_line": 9,
     "end_line": 12,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "last_updated": "2026-07-27",
     "fidelity": "verified",
@@ -5596,6 +5610,15 @@
         "Etingof.exists_filtration_with_irreducible_quotients"
       ],
       "basis": "Both theorem constants have complete proof terms. The exact endpoint returns Etingof.Filtration and proves IsSimpleModule A for every adjacent quotient; the composition-series theorem records the equivalent finite-length proof route."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.4",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter3/Definition3.4.1"
+      ],
+      "basis": "Lemma3_4_2.lean imports Definition3_4_1.lean and its exact theorem explicitly constructs Etingof.Filtration; the helper theorem is defined in the same tracked item."
     }
   },
   {


### PR DESCRIPTION
## Summary

- completes the Stage 3.4 dependency audit for the exact Chapter 3 §3.4 scope (three items, two Lean providers)
- audits all three authored declarations with `#min_imports` and both provider headers with `#redundant_imports`
- trims direct imports from 8 to 5, including replacing `Span.Basic` with the narrower submodule-lattice module
- replaces three conservative reading-order edges with the one actual backward edge, Lemma 3.4.2 → Definition 3.4.1
- advances all three scoped tracker records to `dependency_trimmed` while preserving Stage 3.2, Stage 3.3, claim-coverage, and fidelity metadata

This PR is stacked on Stage 3.3 draft PR #8071 and targets `agent/stage3-3-ch3-s3-4`.

## Validation

- `lake build EtingofRepresentationTheory.Chapter3.Definition3_4_1 EtingofRepresentationTheory.Chapter3.Lemma3_4_2` (1,581 jobs)
- `lake build EtingofRepresentationTheory.Chapter3` (8,692 jobs; pre-existing linter warnings only)
- final `#redundant_imports`: no transitively redundant imports in either provider
- `python3 scripts/validate_items.py`
- `python3 scripts/validate_dependencies.py`
- `python3 scripts/validate_external_deps.py`
- `python3 scripts/validate_mathlib_coverage.py`
- scoped/non-scoped metadata and dependency invariance checks
- JSON parsing, no-forward-edge checks, admission scan, and `git diff --check`
