### PR TITLE
Stage 3.4: trim Chapter 3 Section 3.5 dependencies

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/Corollary3_5_5.lean
+++ b/EtingofRepresentationTheory/Chapter3/Corollary3_5_5.lean
@@ -1,10 +1,3 @@
-import Mathlib.RingTheory.Jacobson.Ideal
-import Mathlib.LinearAlgebra.FiniteDimensional.Defs
-import Mathlib.RingTheory.SimpleModule.Basic
-import Mathlib.Algebra.BigOperators.Group.Finset.Basic
-import Mathlib.FieldTheory.IsAlgClosed.Basic
-import Mathlib.LinearAlgebra.FreeModule.Finite.Matrix
-import Mathlib.LinearAlgebra.Dimension.Constructions
 import EtingofRepresentationTheory.Chapter3.Theorem3_2_2
 
 /-!

--- a/EtingofRepresentationTheory/Chapter3/Example3_5_6.lean
+++ b/EtingofRepresentationTheory/Chapter3/Example3_5_6.lean
@@ -1,13 +1,5 @@
-import Mathlib.RingTheory.Jacobson.Radical
 import Mathlib.RingTheory.AdjoinRoot
-import Mathlib.RingTheory.LocalRing.MaximalIdeal.Basic
-import Mathlib.RingTheory.Nilpotent.Lemmas
 import Mathlib.RingTheory.KrullDimension.Basic
-import Mathlib.RingTheory.Polynomial.Ideal
-import Mathlib.LinearAlgebra.Matrix.Block
-import Mathlib.RingTheory.SimpleModule.Basic
-import Mathlib.RingTheory.Ideal.Quotient.Operations
-import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 import Mathlib.RingTheory.Jacobson.Semiprimary
 
 /-!

--- a/EtingofRepresentationTheory/Chapter3/Proposition3_5_8.lean
+++ b/EtingofRepresentationTheory/Chapter3/Proposition3_5_8.lean
@@ -1,10 +1,4 @@
-import Mathlib.RingTheory.SimpleModule.Basic
 import Mathlib.RingTheory.SimpleModule.IsAlgClosed
-import Mathlib.RingTheory.Artinian.Module
-import Mathlib.LinearAlgebra.Dimension.Finite
-import Mathlib.LinearAlgebra.Quotient.Basic
-import Mathlib.LinearAlgebra.FiniteDimensional.Defs
-import Mathlib.Data.List.TFAE
 import EtingofRepresentationTheory.Chapter3.Theorem3_5_4
 import EtingofRepresentationTheory.Chapter2.Definition2_3_8
 

--- a/EtingofRepresentationTheory/Chapter3/Theorem3_5_4.lean
+++ b/EtingofRepresentationTheory/Chapter3/Theorem3_5_4.lean
@@ -1,14 +1,5 @@
-import Mathlib.RingTheory.Jacobson.Ideal
-import Mathlib.RingTheory.Jacobson.Semiprimary
-import Mathlib.RingTheory.Artinian.Module
-import Mathlib.LinearAlgebra.FiniteDimensional.Defs
-import Mathlib.RingTheory.SimpleModule.Basic
-import Mathlib.RingTheory.Ideal.Quotient.Operations
-import Mathlib.FieldTheory.IsAlgClosed.Basic
-import Mathlib.Algebra.Algebra.Pi
 import EtingofRepresentationTheory.Chapter3.Definition3_5_1
 import EtingofRepresentationTheory.Chapter3.Theorem3_2_2
-import EtingofRepresentationTheory.Chapter3.Proposition3_5_3
 
 /-!
 # Theorem 3.5.4: Structure of Finite Dimensional Algebras Modulo Radical

--- a/EtingofRepresentationTheory/Chapter3/Theorem3_5_4_Finiteness.lean
+++ b/EtingofRepresentationTheory/Chapter3/Theorem3_5_4_Finiteness.lean
@@ -1,8 +1,3 @@
-import Mathlib.RingTheory.SimpleModule.Basic
-import Mathlib.LinearAlgebra.FiniteDimensional.Defs
-import Mathlib.LinearAlgebra.Dimension.Constructions
-import Mathlib.LinearAlgebra.FreeModule.Finite.Matrix
-import Mathlib.Algebra.Algebra.Pi
 import EtingofRepresentationTheory.Chapter3.Theorem3_2_2
 
 /-!

--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -438,32 +438,22 @@
   "Chapter3/Lemma3.4.2": [
     "Chapter3/Definition3.4.1"
   ],
-  "Chapter3/Introduction_to_3.5": [
-    "Chapter3/Lemma3.4.2"
-  ],
-  "Chapter3/Definition3.5.1": [
-    "Chapter3/Introduction_to_3.5"
-  ],
-  "Chapter3/Proposition3.5.2": [
-    "Chapter3/Definition3.5.1"
-  ],
-  "Chapter3/Proposition3.5.3": [
-    "Chapter3/Proposition3.5.2"
-  ],
+  "Chapter3/Introduction_to_3.5": [],
+  "Chapter3/Definition3.5.1": [],
+  "Chapter3/Proposition3.5.2": [],
+  "Chapter3/Proposition3.5.3": [],
   "Chapter3/Theorem3.5.4": [
-    "Chapter3/Proposition3.5.3"
+    "Chapter3/Definition3.5.1",
+    "Chapter3/Theorem3.2.2"
   ],
   "Chapter3/Corollary3.5.5": [
-    "Chapter3/Theorem3.5.4"
+    "Chapter3/Theorem3.2.2"
   ],
-  "Chapter3/Example3.5.6": [
-    "Chapter3/Corollary3.5.5"
-  ],
-  "Chapter3/Definition3.5.7": [
-    "Chapter3/Example3.5.6"
-  ],
+  "Chapter3/Example3.5.6": [],
+  "Chapter3/Definition3.5.7": [],
   "Chapter3/Proposition3.5.8": [
-    "Chapter3/Definition3.5.7"
+    "Chapter2/Definition2.3.8",
+    "Chapter3/Theorem3.5.4"
   ],
   "Chapter3/Introduction_to_3.6": [
     "Chapter3/Proposition3.5.8"

--- a/progress/2026-07-27T15-46-13Z_stage3-4-chapter3-section3-5.md
+++ b/progress/2026-07-27T15-46-13Z_stage3-4-chapter3-section3-5.md
@@ -1,0 +1,106 @@
+# Stage 3.4 dependency trimming — Chapter 3 §3.5
+
+**Date:** 2026-07-27  
+**Scope:** `Chapter3/Introduction_to_3.5` through `Chapter3/Proposition3.5.8`  
+**Stacked base:** Stage 3.3 PR #8073, commit `0df4dd87146bb729be6946bc42479888be740133`  
+**Result:** complete — nine items moved to `dependency_trimmed`, with five actual item-level edges and 18 individually required direct imports.
+
+## Exact scope
+
+This pass changes only the nine contiguous `progress/items.json` entries 147–155, their
+nine keys in `dependencies/internal.json`, five scoped provider import blocks, and this
+audit note. The strict predecessor `Chapter3/Lemma3.4.2`, strict successor
+`Chapter3/Introduction_to_3.6`, Stage 3.2 claim coverage, Stage 3.3 proof-integrity
+metadata, external dependencies, and all proof bodies remain unchanged.
+
+## Actual internal dependencies
+
+The conservative graph assigned each scoped item one incoming reading-order edge: nine
+edges total. Reviewing the surviving project imports and the referenced project
+declarations gives the following direct item graph:
+
+| Item | Actual internal dependencies |
+|---|---|
+| `Chapter3/Introduction_to_3.5` | none |
+| `Chapter3/Definition3.5.1` | none |
+| `Chapter3/Proposition3.5.2` | none |
+| `Chapter3/Proposition3.5.3` | none |
+| `Chapter3/Theorem3.5.4` | `Chapter3/Definition3.5.1`; `Chapter3/Theorem3.2.2` |
+| `Chapter3/Corollary3.5.5` | `Chapter3/Theorem3.2.2` |
+| `Chapter3/Example3.5.6` | none |
+| `Chapter3/Definition3.5.7` | none |
+| `Chapter3/Proposition3.5.8` | `Chapter2/Definition2.3.8`; `Chapter3/Theorem3.5.4` |
+
+This replaces nine reading-order edges with five declaration-backed edges, a net
+reduction of four repository edges (582 to 578). The important nonlocal structure is:
+
+- Theorem 3.5.4 uses `Etingof.Radical` from Definition 3.5.1 and
+  `Etingof.density_theorem_part2` from Theorem 3.2.2. Its three providers also import
+  one another within the same catalog item; those sibling-provider imports are not
+  item-level dependency edges.
+- Corollary 3.5.5 proves its bound directly from the density theorem, not from Theorem
+  3.5.4.
+- Proposition 3.5.8 uses `Etingof.structure_mod_radical` from Theorem 3.5.4 and
+  `Etingof.IsIndecomposable` from Chapter 2 Definition 2.3.8. Its implementation does
+  not import Definition 3.5.7; it uses Mathlib's `IsSemisimpleRing` directly.
+
+Each `stage3_4.actual_internal_dependencies` array in `progress/items.json` was compared
+against the corresponding `dependencies/internal.json` value and matches exactly.
+
+## Direct-import audit and changes
+
+All 53 direct-import entries across the ten Stage 3.3 provider modules were audited.
+First, the 32 transitively redundant imports documented by Stage 3.3 were removed.
+Every surviving import was then deletion-tested by re-elaborating the complete provider
+source with that one import omitted. This exposed three additional unused imports:
+
+- `Theorem3_5_4`: `EtingofRepresentationTheory.Chapter3.Proposition3_5_3`;
+- `Corollary3_5_5`: `Mathlib.RingTheory.Jacobson.Ideal`;
+- `Example3_5_6`: `Mathlib.RingTheory.LocalRing.MaximalIdeal.Basic`.
+
+The final import counts are:
+
+| Provider | Before | After | Removed |
+|---|---:|---:|---:|
+| `Definition3_5_1` | 1 | 1 | 0 |
+| `Proposition3_5_2` | 1 | 1 | 0 |
+| `Proposition3_5_3` | 3 | 3 | 0 |
+| `Theorem3_5_4` | 11 | 2 | 9 |
+| `Theorem3_5_4_Finiteness` | 6 | 1 | 5 |
+| `Theorem3_5_4_CompleteFamily` | 2 | 2 | 0 |
+| `Corollary3_5_5` | 8 | 1 | 7 |
+| `Example3_5_6` | 11 | 3 | 8 |
+| `Definition3_5_7` | 1 | 1 | 0 |
+| `Proposition3_5_8` | 9 | 3 | 6 |
+| **Total** | **53** | **18** | **35** |
+
+All 18 remaining imports fail the single-import deletion test, so each is required by
+its provider in the final import set. Re-elaborating all ten final sources with
+`#redundant_imports` reports `No transitively redundant imports found.` for every
+provider.
+
+## Validation
+
+- Scoped ten-provider build: passed, 1,977 jobs.
+- Full `EtingofRepresentationTheory.Chapter3` build: passed, 8,692 jobs.
+- `scripts/validate_items.py`: passed (existing schema warnings only).
+- `scripts/validate_dependencies.py`: passed (583 entries, 578 edges; expected
+  conservative-default warning only).
+- `scripts/validate_external_deps.py`: passed (58 external dependencies).
+- `scripts/validate_mathlib_coverage.py`: passed (58/58 entries).
+- Import-only source invariant: the five Lean diffs contain exactly 35 removed `import`
+  lines and no proof, declaration, documentation, or option changes.
+- Item-state invariant: after restoring the nine prior `status` values and deleting only
+  their new `stage3_4` objects, `progress/items.json` is JSON-equivalent to the stacked
+  Stage 3.3 base.
+- Dependency-scope invariant: only the nine scoped keys differ in
+  `dependencies/internal.json`; external dependency and Mathlib coverage files are
+  unchanged.
+
+The builds reproduce the existing linter and deprecation warnings recorded in Stage 3.3;
+none is caused by import trimming.
+
+## Handoff
+
+Chapter 3 §3.5 has completed Stage 3.4 and is now eligible for Stage 3.5, the designated
+Mathlib-quality proof-polishing pass.

--- a/progress/items.json
+++ b/progress/items.json
@@ -3071,7 +3071,7 @@
     "end_page": "49",
     "start_line": 13,
     "end_line": 14,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage_swept": {
       "wave": 1,
       "result": "non_formalizable"
@@ -3103,6 +3103,13 @@
       "proof_integrity": "not_applicable",
       "declarations": [],
       "basis": "Organizational heading with no Lean provider or proof obligation."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.5",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "This organizational heading has no Lean provider, declaration, or mathematical dependency; its conservative incoming edge from Lemma 3.4.2 was reading order only."
     }
   },
   {
@@ -3113,7 +3120,7 @@
     "end_page": "49",
     "start_line": 15,
     "end_line": 16,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "last_updated": "2026-07-27",
     "fidelity": "verified",
@@ -3142,6 +3149,13 @@
       "declarations": [
         "Etingof.Radical"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.5",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "Etingof.Radical is a direct abbreviation of Mathlib's Jacobson radical; its sole direct import is individually required and no project declaration is used."
     }
   },
   {
@@ -3152,7 +3166,7 @@
     "end_page": "49",
     "start_line": 17,
     "end_line": 20,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "last_updated": "2026-07-27",
     "fidelity": "verified",
@@ -3182,6 +3196,13 @@
         "Etingof.radical_isTwoSided",
         "Etingof.radical_is_ideal"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.5",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "Both results are proved directly for Mathlib's Ideal.jacobson; the provider's sole direct import is individually required and Definition 3.5.1 is not referenced."
     }
   },
   {
@@ -3192,7 +3213,7 @@
     "end_page": "50",
     "start_line": 21,
     "end_line": 4,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "last_updated": "2026-07-27",
     "fidelity": "verified",
@@ -3232,6 +3253,13 @@
         "Etingof.nilpotent_ideal_le_radical",
         "Etingof.radical_is_nilpotent"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.5",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The maximality and nilpotence proofs use three individually required Mathlib imports and no earlier project declaration."
     }
   },
   {
@@ -3242,7 +3270,7 @@
     "end_page": "50",
     "start_line": 5,
     "end_line": 22,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -3299,6 +3327,16 @@
         "Etingof.simple_finiteDimensional",
         "Etingof.structure_mod_radical"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.5",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter3/Definition3.5.1",
+        "Chapter3/Theorem3.2.2"
+      ],
+      "basis": "The providers directly use Etingof.Radical from Definition 3.5.1 and Etingof.density_theorem_part2 from Theorem 3.2.2; the remaining cross-imports connect same-item helper providers. The unused Proposition 3.5.3 import and all eight transitive Mathlib imports were removed."
     }
   },
   {
@@ -3309,7 +3347,7 @@
     "end_page": "51",
     "start_line": 23,
     "end_line": 4,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
@@ -3343,6 +3381,15 @@
       "declarations": [
         "Etingof.sum_dim_sq_le_dim"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.5",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter3/Theorem3.2.2"
+      ],
+      "basis": "The proof directly uses Etingof.density_theorem_part2 and no declaration from Theorem 3.5.4; seven unnecessary Mathlib imports were removed, leaving Theorem 3.2.2 as the sole required direct import."
     }
   },
   {
@@ -3353,7 +3400,7 @@
     "end_page": "51",
     "start_line": 5,
     "end_line": 8,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "fidelity": "verified",
     "sorry_free": true,
@@ -3443,6 +3490,13 @@
         "Etingof.truncPolySimpleEquiv",
         "Etingof.upperTriangularSubalgebra"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.5",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "Both examples are self-contained over three individually required Mathlib imports and use no project declaration from another item; seven transitive and one unused Mathlib import were removed."
     }
   },
   {
@@ -3453,7 +3507,7 @@
     "end_page": "51",
     "start_line": 9,
     "end_line": 10,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "last_updated": "2026-07-27",
     "fidelity": "verified",
@@ -3482,6 +3536,13 @@
       "declarations": [
         "Etingof.IsSemisimpleAlgebra"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.5",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "Etingof.IsSemisimpleAlgebra directly abbreviates Mathlib's IsSemisimpleRing; its sole direct import is individually required and no project item is used."
     }
   },
   {
@@ -3492,7 +3553,7 @@
     "end_page": "52",
     "start_line": 11,
     "end_line": 2,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "fidelity": "verified",
     "sorry_free": true,
     "fidelity_decl": "Etingof.semisimple_algebra_equiv",
@@ -3560,6 +3621,16 @@
         "Etingof.subsingleton_not_isSimpleModule",
         "Etingof.subsingleton_not_isSimpleRing"
       ]
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.5",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Definition2.3.8",
+        "Chapter3/Theorem3.5.4"
+      ],
+      "basis": "The main equivalence uses structure_mod_radical from Theorem 3.5.4, while the zero-algebra footnote uses IsIndecomposable from Definition 2.3.8. Six transitive Mathlib imports were removed; the remaining Mathlib and two project imports are individually required."
     }
   },
   {


### PR DESCRIPTION
## Summary

- replaces the nine conservative §3.5 reading-order edges with five actual declaration-backed item dependencies
- audits all 53 original direct-import entries across ten providers
- removes all 32 transitively redundant imports recorded in Stage 3.3 plus three additional unused imports found by single-import deletion tests
- leaves 18 direct imports, each individually required, with `#redundant_imports` clean for every provider
- moves all nine scoped items to `dependency_trimmed` and records exact Stage 3.4 metadata

## Exact scope

Stacked on Stage 3.3 PR #8073. The interval is exactly `Chapter3/Introduction_to_3.5` through `Chapter3/Proposition3.5.8`. Stage 3.2 claim coverage, Stage 3.3 proof-integrity metadata, proof bodies, external dependencies, predecessor, and successor remain unchanged.

## Dependency result

The scoped graph changes from nine reading-order edges to five actual edges:

- Theorem 3.5.4 → Definition 3.5.1, Theorem 3.2.2
- Corollary 3.5.5 → Theorem 3.2.2
- Proposition 3.5.8 → Chapter 2 Definition 2.3.8, Theorem 3.5.4
- the other six scoped items have no project-item dependency

Repository edge count decreases from 582 to 578.

## Validation

- scoped ten-provider build: passed (1,977 jobs)
- full `EtingofRepresentationTheory.Chapter3` build: passed (8,692 jobs)
- all ten final providers: `#redundant_imports` clean
- all 18 surviving imports: individually required by deletion test
- `validate_items.py`: passed
- `validate_dependencies.py`: passed
- `validate_external_deps.py`: passed
- `validate_mathlib_coverage.py`: passed
- invariance checks: only nine scoped dependency keys changed; Lean diffs are exactly 35 removed import lines; prior metadata normalizes exactly to the stacked base
- exactly one commit atop `agent/stage3-3-ch3-s3-5`

## Handoff

This completes Stage 3.4 for §3.5. The section is now eligible for Stage 3.5, the designated Mathlib-quality proof-polishing pass.