### PR TITLE
Stage 3.4: trim Chapter 3 §3.6 dependencies

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/CommutatorMatrixTraceless.lean
+++ b/EtingofRepresentationTheory/Chapter3/CommutatorMatrixTraceless.lean
@@ -1,6 +1,4 @@
 import EtingofRepresentationTheory.Chapter3.Introduction3_6
-import Mathlib.Data.Matrix.Basis
-import Mathlib.LinearAlgebra.Matrix.Trace
 
 /-!
 # The commutator span of a matrix algebra is the traceless matrices

--- a/EtingofRepresentationTheory/Chapter3/Theorem3_6_2.lean
+++ b/EtingofRepresentationTheory/Chapter3/Theorem3_6_2.lean
@@ -1,10 +1,4 @@
-import Mathlib.RingTheory.SimpleModule.Basic
-import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 import Mathlib.LinearAlgebra.Trace
-import Mathlib.LinearAlgebra.LinearIndependent.Defs
-import Mathlib.LinearAlgebra.LinearIndependent.Lemmas
-import Mathlib.FieldTheory.IsAlgClosed.Basic
-import Mathlib.LinearAlgebra.TensorProduct.Basic
 import EtingofRepresentationTheory.Chapter3.Theorem3_2_2
 
 /-!

--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -465,14 +465,13 @@
   "Chapter3/Proposition3.5.8": [
     "Chapter3/Definition3.5.7"
   ],
-  "Chapter3/Introduction_to_3.6": [
-    "Chapter3/Proposition3.5.8"
-  ],
+  "Chapter3/Introduction_to_3.6": [],
   "Chapter3/Exercise3.6.1": [
     "Chapter3/Introduction_to_3.6"
   ],
   "Chapter3/Theorem3.6.2": [
-    "Chapter3/Exercise3.6.1"
+    "Chapter3/Theorem3.2.2",
+    "Chapter3/Introduction_to_3.6"
   ],
   "Chapter3/Introduction_to_3.7": [
     "Chapter3/Theorem3.6.2"

--- a/progress/2026-07-27T15-57-30Z_stage3-4-chapter3-section3-6.md
+++ b/progress/2026-07-27T15-57-30Z_stage3-4-chapter3-section3-6.md
@@ -1,0 +1,62 @@
+# Stage 3.4 dependency review — Chapter 3 §3.6
+
+## Scope
+
+This review is limited to the three §3.6 catalog items at global
+`progress/items.json` indices 156–158:
+
+1. `Chapter3/Introduction_to_3.6`;
+2. `Chapter3/Exercise3.6.1`;
+3. `Chapter3/Theorem3.6.2`.
+
+The strict boundaries remain Proposition 3.5.8 before the section and the introduction to
+§3.7 after it. The branch is based exactly on Stage 3.3 commit
+`d9c66ad163115f98680dfbbbd682d92473b21691`.
+
+## Direct-import audit
+
+All four exact providers were audited with `#redundant_imports`. Their direct-import count
+falls from 13 to five:
+
+- `Theorem3_6_2.lean` falls from eight imports to two. It retains
+  `Mathlib.LinearAlgebra.Trace` and the project provider `Theorem3_2_2`; six transitive
+  Mathlib imports are removed.
+- `CommutatorMatrixTraceless.lean` falls from three imports to its single project provider,
+  `Introduction3_6`; the Matrix basis and trace imports are already supplied transitively.
+- `Introduction3_6.lean` and `Exercise3_6_1.lean` retain their sole project import.
+
+After trimming, every one of the four providers reports
+`No transitively redundant imports found.` All providers build together in 1,957 jobs.
+The only Lean source edits are deletion of those eight import lines; no declaration,
+statement, proof term, documentation, or namespace is changed.
+
+## Actual internal dependencies
+
+The section still has three item-level dependency edges, but the graph now records the
+actual declaration use rather than reading-order adjacency:
+
+- the introduction has no backward dependency. Its apparent import of `Theorem3_6_2`
+  supplies `Etingof.character`, which is cataloged as part of the same introduction item;
+- Exercise 3.6.1 depends on the introduction's character definition;
+- Theorem 3.6.2 depends on `density_theorem_part2` from Theorem 3.2.2 and on the
+  introduction's `commutatorSubmodule`, used by the standalone matrix provider.
+
+Thus the false introduction-to-Proposition-3.5.8 and theorem-to-Exercise-3.6.1 edges are
+removed. The true theorem-to-Theorem-3.2.2 and theorem-to-introduction edges are added.
+The exercise-to-introduction edge is retained. The repository aggregate remains 582 edges.
+
+## Validation
+
+- `.lake/build` is worktree-local; only `.lake/packages` links to the shared package
+  cache;
+- all four scoped providers build successfully together (1,957 jobs);
+- `lake build EtingofRepresentationTheory.Chapter3` succeeds (8,692 jobs);
+- all four providers are `#redundant_imports`-clean after trimming;
+- all four repository validators pass;
+- Stage 3.2 claim coverage and Stage 3.3 proof-integrity records are unchanged;
+- the three scoped item records change only by addition of `stage3_4`;
+- the normalized non-scope tracker projection, non-scope dependency projection, external
+  dependencies, provider declarations, and proof bodies are unchanged;
+- `git diff --check` passes.
+
+This PR is limited to Chapter 3 §3.6 and Stage 3.4.

--- a/progress/items.json
+++ b/progress/items.json
@@ -2567,6 +2567,13 @@
         "Etingof.characterQuotient_mk"
       ],
       "basis": "The complete character construction, cyclicity proof, commutator-span vanishing, and quotient factorization use closed Lean terms. An exhaustive module-origin audit also covered every generated and internal declaration emitted by the provider."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.6",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The apparent import of Theorem3_6_2 supplies the character declaration tracked by this same introduction item; its six transitive Mathlib imports are removed from that provider, and the introduction has no actual backward book-item dependency."
     }
   },
   {
@@ -2616,6 +2623,15 @@
         "Etingof.character_eq_character_add_character_quotient"
       ],
       "basis": "Both finite-dimensionality instances and the character-additivity theorem for an arbitrary subrepresentation and its genuine quotient are closed Lean terms. The exhaustive module-origin audit included all internal declarations emitted by the provider."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.6",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter3/Introduction_to_3.6"
+      ],
+      "basis": "The exercise uses Etingof.character from the section introduction. Its sole project import is already irredundant, and it does not use a declaration from Theorem 3.6.2 beyond the character declaration cataloged under the introduction."
     }
   },
   {
@@ -2730,6 +2746,16 @@
         "Etingof.commutatorSubmodule_matrix_fin_eq_ker_trace"
       ],
       "basis": "Linear independence, semisimple spanning and basis, and the general and Fin-indexed matrix commutator/traceless equalities are closed Lean terms. Private helpers and generated declarations were included in the exhaustive module-origin audit."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.6",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter3/Theorem3.2.2",
+        "Chapter3/Introduction_to_3.6"
+      ],
+      "basis": "The linear-independence proof directly uses density_theorem_part2 from Theorem 3.2.2, while the matrix provider directly uses commutatorSubmodule from the section introduction. Eight transitive Mathlib imports were removed across the theorem providers; the remaining direct imports are redundancy-clean."
     }
   },
   {


### PR DESCRIPTION
## Scope

Chapter 3 §3.6, Stage 3.4 only, stacked on Stage 3.3 PR #8078.

- exactly three tracker items (global indices 156–158)
- exactly four providers audited
- no declaration, proof, statement, documentation, or namespace changes

## Result

- direct imports: 13 → 5
- eight transitive Mathlib imports removed
- all four providers are now `#redundant_imports`-clean
- item dependency graph corrected from reading-order adjacency to three actual edges; repository aggregate remains 582

## Validation

- exact providers: 1,957 jobs passed
- full Chapter 3: 8,692 jobs passed
- all four repository validators passed
- source diffs are import-only
- Stage 3.2, Stage 3.3, non-scope tracker data, external dependencies, and non-scope internal dependencies are exactly invariant
