### PR TITLE
Stage 3.5: polish Chapter 3 §3.6 proofs

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/CommutatorMatrixTraceless.lean
+++ b/EtingofRepresentationTheory/Chapter3/CommutatorMatrixTraceless.lean
@@ -1,6 +1,4 @@
 import EtingofRepresentationTheory.Chapter3.Introduction3_6
-import Mathlib.Data.Matrix.Basis
-import Mathlib.LinearAlgebra.Matrix.Trace
 
 /-!
 # The commutator span of a matrix algebra is the traceless matrices

--- a/EtingofRepresentationTheory/Chapter3/Exercise3_6_1.lean
+++ b/EtingofRepresentationTheory/Chapter3/Exercise3_6_1.lean
@@ -57,7 +57,7 @@ theorem character_eq_character_add_character_quotient :
   set fQ : Module.End k (V ⧸ W) :=
     (Algebra.lsmul k k (V ⧸ W) : A →ₐ[k] Module.End k (V ⧸ W)) a with hfQ
   -- Unfold the characters to the corresponding traces.
-  show LinearMap.trace k V fV
+  change LinearMap.trace k V fV
       = LinearMap.trace k (W : Type _) fW + LinearMap.trace k (V ⧸ W) fQ
   -- Inclusion `W ↪ V` and quotient map `V ↠ V/W`, as `k`-linear maps.
   set i : (W : Type _) →ₗ[k] V := (W.subtype).restrictScalars k with hi_def
@@ -88,7 +88,7 @@ theorem character_eq_character_add_character_quotient :
   have hri : r ∘ₗ i = LinearMap.id := by
     ext w
     have hqiw : q (i w) = 0 := (Submodule.Quotient.mk_eq_zero W).mpr w.2
-    show (pW (i w) : V) = (w : V)
+    change (pW (i w) : V) = (w : V)
     have hpi : pW (i w) = i w := by
       rw [hpW_def]
       simp only [LinearMap.sub_apply, LinearMap.id_coe, id_eq, LinearMap.comp_apply, hqiw,

--- a/EtingofRepresentationTheory/Chapter3/Theorem3_6_2.lean
+++ b/EtingofRepresentationTheory/Chapter3/Theorem3_6_2.lean
@@ -1,10 +1,4 @@
-import Mathlib.RingTheory.SimpleModule.Basic
-import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 import Mathlib.LinearAlgebra.Trace
-import Mathlib.LinearAlgebra.LinearIndependent.Defs
-import Mathlib.LinearAlgebra.LinearIndependent.Lemmas
-import Mathlib.FieldTheory.IsAlgClosed.Basic
-import Mathlib.LinearAlgebra.TensorProduct.Basic
 import EtingofRepresentationTheory.Chapter3.Theorem3_2_2
 
 /-!

--- a/EtingofRepresentationTheory/Chapter3/Theorem3_6_2.lean
+++ b/EtingofRepresentationTheory/Chapter3/Theorem3_6_2.lean
@@ -20,7 +20,9 @@ characters on an r-dimensional space form a basis.
 
 open Module in
 /-- The character of a finite-dimensional module V over a k-algebra A, defined as
-the trace of the action map: χ_V(a) = tr(ρ_V(a)). -/
+the trace of the action map: χ_V(a) = tr(ρ_V(a)). The freeness and finiteness instances
+are needed to construct the trace, although they do not occur in the result type. -/
+@[nolint unusedArguments]
 noncomputable def Etingof.character (k : Type*) (A : Type*) (V : Type*)
     [CommRing k] [Ring A] [Algebra k A]
     [AddCommGroup V] [Module k V] [Module A V] [IsScalarTower k A V]
@@ -33,12 +35,14 @@ open Module in
 Etingof Theorem 3.6.2(i). -/
 theorem Etingof.characters_linearly_independent (k : Type*) (A : Type*)
     [Field k] [IsAlgClosed k] [Ring A] [Algebra k A]
-    {ι : Type*} [Fintype ι]
+    {ι : Type*} [Finite ι]
     (V : ι → Type*) [∀ i, AddCommGroup (V i)] [∀ i, Module k (V i)]
     [∀ i, Module A (V i)] [∀ i, IsScalarTower k A (V i)]
     [∀ i, FiniteDimensional k (V i)] [∀ i, IsSimpleModule A (V i)]
     (h_noniso : ∀ i j, i ≠ j → IsEmpty (V i ≃ₗ[A] V j)) :
     LinearIndependent k (fun i => Etingof.character k A (V i)) := by
+  classical
+  letI := Fintype.ofFinite ι
   rw [Fintype.linearIndependent_iff]
   intro g hg i
   have hga : ∀ a : A, ∑ j, g j * Etingof.character k A (V j) a = 0 := by
@@ -47,7 +51,6 @@ theorem Etingof.characters_linearly_independent (k : Type*) (A : Type*)
     simp only [LinearMap.sum_apply, LinearMap.smul_apply, smul_eq_mul, LinearMap.zero_apply] at this
     exact this
   have hsurj := Etingof.density_theorem_part2 k A ι V h_noniso
-  classical
   haveI : Nontrivial (V i) := IsSimpleModule.nontrivial A (V i)
   let b := Module.Free.chooseBasis k (V i)
   have hne_idx : Nonempty (Module.Free.ChooseBasisIndex k (V i)) := by
@@ -106,7 +109,7 @@ private lemma tracial_of_end_eq_scalar_trace {k V : Type*}
       if j = p then b.end (i, q) else 0 := by
     intro i j p q
     apply b.ext; intro m
-    show b.end (i, j) (b.end (p, q) (b m)) = _
+    change b.end (i, j) (b.end (p, q) (b m)) = _
     simp only [Basis.end_apply_apply]
     split_ifs <;> simp_all [Basis.end_apply_apply]
   -- Helper: trace of basis endomorphisms
@@ -156,7 +159,7 @@ submodule of the semisimple left regular representation, hence is zero. -/
 private lemma rep_map_injective_of_semisimple.{v} {k : Type*} {A : Type v}
     [Field k] [Ring A] [Algebra k A] [FiniteDimensional k A]
     [IsSemisimpleRing A]
-    {ι : Type*} [Fintype ι]
+    {ι : Type*}
     (V : ι → Type*) [∀ i, AddCommGroup (V i)] [∀ i, Module k (V i)]
     [∀ i, Module A (V i)] [∀ i, IsScalarTower k A (V i)]
     [∀ i, FiniteDimensional k (V i)] [∀ i, IsSimpleModule A (V i)]
@@ -175,7 +178,7 @@ private lemma rep_map_injective_of_semisimple.{v} {k : Type*} {A : Type v}
     intro i v
     have hi := congr_fun h i  -- ρᵢ(a₁) = ρᵢ(a₂)
     have hv := LinearMap.congr_fun hi v  -- a₁ • v = a₂ • v
-    show (a₁ - a₂) • v = 0
+    change (a₁ - a₂) • v = 0
     rw [sub_smul]
     exact sub_eq_zero.mpr hv
   -- b is in every maximal left ideal (coatom), hence in Ring.jacobson A = ⊥
@@ -212,7 +215,7 @@ Etingof Theorem 3.6.2(ii). -/
 theorem Etingof.characters_basis_semisimple.{v} (k : Type*) (A : Type v)
     [Field k] [IsAlgClosed k] [Ring A] [Algebra k A] [FiniteDimensional k A]
     [IsSemisimpleRing A]
-    {ι : Type*} [Fintype ι]
+    {ι : Type*} [Finite ι]
     (V : ι → Type*) [∀ i, AddCommGroup (V i)] [∀ i, Module k (V i)]
     [∀ i, Module A (V i)] [∀ i, IsScalarTower k A (V i)]
     [∀ i, FiniteDimensional k (V i)] [∀ i, IsSimpleModule A (V i)]
@@ -224,6 +227,7 @@ theorem Etingof.characters_basis_semisimple.{v} (k : Type*) (A : Type v)
       f ∈ Submodule.span k (Set.range (fun i => Etingof.character k A (V i))) := by
   intro f hf
   classical
+  letI := Fintype.ofFinite ι
   -- The representation map ρ : A → ∏ End(Vᵢ) is bijective
   have hρ_surj := Etingof.density_theorem_part2 k A ι V h_noniso
   have hρ_inj := rep_map_injective_of_semisimple V h_complete
@@ -242,16 +246,15 @@ theorem Etingof.characters_basis_semisimple.{v} (k : Type*) (A : Type v)
     intro x y
     apply ρ_equiv.injective
     rw [LinearEquiv.apply_symm_apply]
-    show x * y = ρ_equiv (ρ_equiv.symm x * ρ_equiv.symm y)
+    change x * y = ρ_equiv (ρ_equiv.symm x * ρ_equiv.symm y)
     change x * y = ρ (ρ_equiv.symm x * ρ_equiv.symm y)
     rw [hρ_mul]
-    show x * y = ρ (ρ_equiv.symm x) * ρ (ρ_equiv.symm y)
     change x * y = ρ_equiv (ρ_equiv.symm x) * ρ_equiv (ρ_equiv.symm y)
     simp [LinearEquiv.apply_symm_apply]
   -- g is tracial
   have hg_tracial : ∀ (x y : ∀ i, Module.End k (V i)), g (x * y) = g (y * x) := by
     intro x y
-    show f (ρ_equiv.symm (x * y)) = f (ρ_equiv.symm (y * x))
+    change f (ρ_equiv.symm (x * y)) = f (ρ_equiv.symm (y * x))
     rw [hρ_symm_mul, hρ_symm_mul, hf]
   -- Per-component functionals gᵢ
   let g_comp : ∀ i, Module.End k (V i) →ₗ[k] k := fun i =>
@@ -260,14 +263,14 @@ theorem Etingof.characters_basis_semisimple.{v} (k : Type*) (A : Type v)
   have hg_comp_tr : ∀ i (x y : Module.End k (V i)),
       g_comp i (x * y) = g_comp i (y * x) := by
     intro i x y
-    show g (Pi.single i (x * y)) = g (Pi.single i (y * x))
+    change g (Pi.single i (x * y)) = g (Pi.single i (y * x))
     have hpi_mul : ∀ (a b : Module.End k (V i)),
         (Pi.single i a : ∀ j, Module.End k (V j)) * Pi.single i b = Pi.single i (a * b) := by
       intro a b; ext j
-      simp only [Pi.mul_apply, Pi.single_apply]
+      simp only [Pi.mul_apply]
       by_cases hj : j = i
       · subst hj; simp
-      · simp [hj, zero_mul]
+      · simp [hj]
     rw [← hpi_mul, ← hpi_mul, hg_tracial]
   -- By the matrix unit argument, each gᵢ = cᵢ • trace
   choose c hc using fun i => tracial_of_end_eq_scalar_trace (g_comp i) (hg_comp_tr i)
@@ -277,13 +280,14 @@ theorem Etingof.characters_basis_semisimple.{v} (k : Type*) (A : Type v)
   ext a
   -- f(a) = g(ρ(a)) since g = f ∘ ρ⁻¹
   have hfa : f a = g (ρ a) := by
-    show f a = f (ρ_equiv.symm (ρ_equiv a))
+    change f a = f (ρ_equiv.symm (ρ_equiv a))
     simp
   -- g(e) = ∑ gᵢ(eᵢ) by decomposing e into Pi.single components
   have hg_sum : ∀ (e : ∀ i, Module.End k (V i)), g e = ∑ i, g_comp i (e i) := by
     intro e
     have : e = ∑ i : ι, Pi.single i (e i) := by
-      ext j; simp [Finset.sum_apply, Pi.single_apply, Finset.sum_ite_eq']
+      ext j
+      simp [Finset.sum_apply]
     conv_lhs => rw [this]
     simp [map_sum, g_comp]
   -- Combine: f(a) = ∑ cᵢ tr(ρᵢ(a)) = ∑ cᵢ χᵢ(a)
@@ -291,7 +295,7 @@ theorem Etingof.characters_basis_semisimple.{v} (k : Type*) (A : Type v)
   -- RHS: ∑ i, (c i • character k A (V i)) a = ∑ i, c i * character(a)
   rw [hfa, hg_sum]
   -- Goal: (∑ i, c i • character k A (V i)) a = ∑ i, g_comp i (ρ a i)
-  simp only [LinearMap.coeFn_sum, Finset.sum_apply, LinearMap.smul_apply, smul_eq_mul]
+  simp only [LinearMap.coe_sum, Finset.sum_apply, LinearMap.smul_apply, smul_eq_mul]
   apply Finset.sum_congr rfl
   intro i _
   simp only [Etingof.character, LinearMap.comp_apply, AlgHom.toLinearMap_apply]

--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -465,14 +465,13 @@
   "Chapter3/Proposition3.5.8": [
     "Chapter3/Definition3.5.7"
   ],
-  "Chapter3/Introduction_to_3.6": [
-    "Chapter3/Proposition3.5.8"
-  ],
+  "Chapter3/Introduction_to_3.6": [],
   "Chapter3/Exercise3.6.1": [
     "Chapter3/Introduction_to_3.6"
   ],
   "Chapter3/Theorem3.6.2": [
-    "Chapter3/Exercise3.6.1"
+    "Chapter3/Theorem3.2.2",
+    "Chapter3/Introduction_to_3.6"
   ],
   "Chapter3/Introduction_to_3.7": [
     "Chapter3/Theorem3.6.2"

--- a/progress/2026-07-27T15-41-24Z_stage3-2-chapter3-section3-6.md
+++ b/progress/2026-07-27T15-41-24Z_stage3-2-chapter3-section3-6.md
@@ -1,0 +1,77 @@
+# Stage 3.2 fidelity review — Chapter 3 §3.6
+
+## Scope
+
+Reading order gives exactly three §3.6 catalog items, the contiguous `progress/items.json`
+range 156–158:
+
+1. `Chapter3/Introduction_to_3.6`;
+2. `Chapter3/Exercise3.6.1`;
+3. `Chapter3/Theorem3.6.2`.
+
+The preceding item is `Chapter3/Proposition3.5.8`; the next item, and strict stopping boundary,
+is `Chapter3/Introduction_to_3.7`. The source is pages 52–53. No §3.5 or §3.7 content is in
+scope.
+
+## Claim audit
+
+The source pages, all three exact blobs, and all four §3.6 Lean providers were read in full.
+The durable inventory has 19 claim units:
+
+- 12 `formalized` by exact scoped declarations;
+- 6 `covered_elsewhere` by the density theorem, Wedderburn–Artin, Theorem 3.3.1, and Mathlib's
+  matrix-unit infrastructure;
+- 1 `non_formalizable` organizational heading;
+- no accidental gap, intentional omission, or unclassified hard mathematical claim.
+
+The introduction's complete definition chain is present: `Etingof.character` is the genuine
+trace-of-action functional; `commutatorSubmodule` is the span of `xy - yx`;
+`commutatorSubmodule_le_ker_character` proves vanishing; and `characterQuotient` with
+`characterQuotient_mk` gives the claimed quotient functional and factorization equation.
+
+Exercise 3.6.1 is exact and non-vacuous. Its theorem quantifies an arbitrary
+`W : Submodule A V`, uses the honest quotient representation `V ⨸ W`, and proves equality in
+`Dual k A`; it is not restricted to a selected or split subrepresentation.
+
+Both parts of Theorem 3.6.2 are faithful. Part (i) has no finite-dimensional hypothesis on the
+algebra itself and uses the density theorem to isolate each trace coefficient. Part (ii) models
+`(A/[A,A])*` by the canonically equivalent space of tracial functionals: part (i) supplies linear
+independence, and `characters_basis_semisimple` supplies spanning for a complete pairwise
+nonisomorphic family of irreducibles. This is the book's basis statement split into its two
+standard obligations rather than weakened.
+
+The proof's matrix identity is also public:
+`commutatorSubmodule_matrix_eq_ker_trace` and its exact `Fin d` specialization prove
+`[Mat_d(k),Mat_d(k)] = sl_d(k)`, including the empty and one-dimensional edge cases. The proof
+contains the matrix-unit commutator and diagonal-correction construction; standard matrix-unit
+basis facts, Wedderburn–Artin decomposition, and the earlier irreducible classification are
+honestly recorded as `covered_elsewhere` rather than duplicated.
+
+No Lean repair was necessary. The earlier fidelity defect that unnecessarily assumed the
+algebra finite-dimensional in part (i) is already fixed, and the formerly missing public matrix
+commutator endpoint is already present.
+
+## Durable tracker result
+
+All three scoped items now have complete Stage 3.2 `claim_coverage` records with verified
+definition integrity, statement fidelity, and nonvacuity. Every item is `covered_full` and
+`fidelity = verified`; only the organizational heading itself has a claim-level
+`non_formalizable` verdict. The normalized non-§3.6 tracker projection and both dependency maps
+are unchanged from `origin/main` at `b2d26b8c`.
+
+## Validation
+
+- `.lake/build` is worktree-local; only `.lake/packages` links to the shared package cache;
+- all four scoped providers build successfully together (1,957 jobs);
+- `lake build EtingofRepresentationTheory.Chapter3` succeeds (8,692 jobs; reported warnings are
+  pre-existing and outside this Stage 3.2 metadata-only change);
+- the scoped scan finds no `sorry`, `admit`, `axiom`, `proof_wanted`, `opaque`, or
+  `native_decide` declaration;
+- `#check` resolves all 17 distinct declarations cited by the inventory, and `#print axioms`
+  reports only `propext`, `Classical.choice`, and `Quot.sound` for every checked declaration;
+- `jq` parsing, the exact three-item/19-claim aggregation, and the strict boundary check pass;
+- all four repository validators pass;
+- normalized non-scope tracker comparison, unchanged dependency-map checks, and
+  `git diff --check` pass.
+
+This PR is limited to Chapter 3 §3.6 and Stage 3.2.

--- a/progress/2026-07-27T15-51-13Z_stage3-3-chapter3-section3-6.md
+++ b/progress/2026-07-27T15-51-13Z_stage3-3-chapter3-section3-6.md
@@ -1,0 +1,73 @@
+# Stage 3.3 proof-integrity review — Chapter 3 §3.6
+
+## Scope
+
+Reading order gives exactly three §3.6 catalog items, the contiguous
+`progress/items.json` range 156–158:
+
+1. `Chapter3/Introduction_to_3.6`;
+2. `Chapter3/Exercise3.6.1`;
+3. `Chapter3/Theorem3.6.2`.
+
+The preceding item is `Chapter3/Proposition3.5.8`; the next item, and strict stopping
+boundary, is `Chapter3/Introduction_to_3.7`. This review is based exactly on Stage 3.2
+commit `c0c76897bab554d7359a4f0294e19a2d837afb06`.
+
+The 19-claim Stage 3.2 inventory is unchanged: 12 claims are formalized, six are covered
+elsewhere, and the organizational heading is non-formalizable. All four exact providers
+were audited:
+
+- `Chapter3/Introduction3_6.lean`;
+- `Chapter3/Exercise3_6_1.lean`;
+- `Chapter3/Theorem3_6_2.lean`;
+- `Chapter3/CommutatorMatrixTraceless.lean`.
+
+## Proof-integrity audit
+
+The durable Stage 3.3 inventory records 13 authored public declarations:
+
+- six for the character definition, cyclicity, commutator span, vanishing, and quotient
+  factorization in the introduction;
+- three for finite-dimensional submodule and quotient instances and character additivity
+  in Exercise 3.6.1;
+- four for linear independence, the semisimple character basis, and the general and
+  `Fin`-indexed matrix commutator/traceless equalities in Theorem 3.6.2.
+
+An exhaustive environment-origin audit inspected all 33 constants emitted by the four
+provider modules, including internal proof declarations, private helpers, generated
+equations, and the lazily generated `contractLeft.eq_1`. Five use no axioms; two use only
+`propext`; six use only `propext` and `Quot.sound`; and 20 use only `propext`,
+`Classical.choice`, and `Quot.sound`. No constant depends on `sorryAx` or any other
+unexpected axiom.
+
+The scoped source scan finds no `sorry`, `admit`, `proof_wanted`, `sorryAx`,
+`native_decide`, `axiom`, or `opaque` declaration. Every scoped theorem and helper is
+therefore backed by a closed Lean term. No provider source edit was required.
+
+## Deferred import findings
+
+The direct-import audit found eight transitive-redundancy candidates, intentionally left
+unchanged for Stage 3.4:
+
+- six in `Theorem3_6_2.lean`: `LinearIndependent.Lemmas`,
+  `SimpleModule.Basic`, `LinearIndependent.Defs`, `IsAlgClosed.Basic`,
+  `FiniteDimensional.Defs`, and `TensorProduct.Basic`;
+- two in `CommutatorMatrixTraceless.lean`: `Matrix.Basis` and `Matrix.Trace`.
+
+The introduction and exercise providers have no reported redundant direct import. Neither
+the provider dependency map nor the aggregate dependency map changes in this Stage 3.3 PR.
+
+## Validation
+
+- `.lake/build` is worktree-local; only `.lake/packages` links to the shared package
+  cache;
+- all four scoped providers build successfully together (1,957 jobs);
+- `lake build EtingofRepresentationTheory.Chapter3` succeeds (8,692 jobs);
+- all four repository validators pass;
+- the exact three-item Stage 3.3 aggregation reports `complete` and `sorry_free` for
+  every item, with 13 distinct durable declarations;
+- the Stage 3.2 claim records, status, fidelity, provider metadata, dependency maps, and
+  normalized non-scope tracker projection are unchanged;
+- `git diff --check` passes.
+
+This PR is limited to Chapter 3 §3.6 and Stage 3.3.

--- a/progress/2026-07-27T15-57-30Z_stage3-4-chapter3-section3-6.md
+++ b/progress/2026-07-27T15-57-30Z_stage3-4-chapter3-section3-6.md
@@ -1,0 +1,62 @@
+# Stage 3.4 dependency review — Chapter 3 §3.6
+
+## Scope
+
+This review is limited to the three §3.6 catalog items at global
+`progress/items.json` indices 156–158:
+
+1. `Chapter3/Introduction_to_3.6`;
+2. `Chapter3/Exercise3.6.1`;
+3. `Chapter3/Theorem3.6.2`.
+
+The strict boundaries remain Proposition 3.5.8 before the section and the introduction to
+§3.7 after it. The branch is based exactly on Stage 3.3 commit
+`d9c66ad163115f98680dfbbbd682d92473b21691`.
+
+## Direct-import audit
+
+All four exact providers were audited with `#redundant_imports`. Their direct-import count
+falls from 13 to five:
+
+- `Theorem3_6_2.lean` falls from eight imports to two. It retains
+  `Mathlib.LinearAlgebra.Trace` and the project provider `Theorem3_2_2`; six transitive
+  Mathlib imports are removed.
+- `CommutatorMatrixTraceless.lean` falls from three imports to its single project provider,
+  `Introduction3_6`; the Matrix basis and trace imports are already supplied transitively.
+- `Introduction3_6.lean` and `Exercise3_6_1.lean` retain their sole project import.
+
+After trimming, every one of the four providers reports
+`No transitively redundant imports found.` All providers build together in 1,957 jobs.
+The only Lean source edits are deletion of those eight import lines; no declaration,
+statement, proof term, documentation, or namespace is changed.
+
+## Actual internal dependencies
+
+The section still has three item-level dependency edges, but the graph now records the
+actual declaration use rather than reading-order adjacency:
+
+- the introduction has no backward dependency. Its apparent import of `Theorem3_6_2`
+  supplies `Etingof.character`, which is cataloged as part of the same introduction item;
+- Exercise 3.6.1 depends on the introduction's character definition;
+- Theorem 3.6.2 depends on `density_theorem_part2` from Theorem 3.2.2 and on the
+  introduction's `commutatorSubmodule`, used by the standalone matrix provider.
+
+Thus the false introduction-to-Proposition-3.5.8 and theorem-to-Exercise-3.6.1 edges are
+removed. The true theorem-to-Theorem-3.2.2 and theorem-to-introduction edges are added.
+The exercise-to-introduction edge is retained. The repository aggregate remains 582 edges.
+
+## Validation
+
+- `.lake/build` is worktree-local; only `.lake/packages` links to the shared package
+  cache;
+- all four scoped providers build successfully together (1,957 jobs);
+- `lake build EtingofRepresentationTheory.Chapter3` succeeds (8,692 jobs);
+- all four providers are `#redundant_imports`-clean after trimming;
+- all four repository validators pass;
+- Stage 3.2 claim coverage and Stage 3.3 proof-integrity records are unchanged;
+- the three scoped item records change only by addition of `stage3_4`;
+- the normalized non-scope tracker projection, non-scope dependency projection, external
+  dependencies, provider declarations, and proof bodies are unchanged;
+- `git diff --check` passes.
+
+This PR is limited to Chapter 3 §3.6 and Stage 3.4.

--- a/progress/2026-07-27T16-05-19Z_stage3-5-chapter3-section3-6.md
+++ b/progress/2026-07-27T16-05-19Z_stage3-5-chapter3-section3-6.md
@@ -1,0 +1,56 @@
+# Stage 3.5 Mathlib-quality review — Chapter 3 §3.6
+
+## Scope and result
+
+This review is stacked exactly on the completed Stage 3.4 dependency audit in draft PR
+#8079 at commit `7853fe90c463d3a1f5cc1091089ca20672b5b580`. It covers the three
+reading-order items at global indices 156–158 and all four exact providers. The immediate
+predecessor is Proposition 3.5.8; the strict successor is the introduction to §3.7.
+
+The implementation is now warning-free and clean under Mathlib's declaration linters. The
+mathematics and claim coverage are unchanged. The source polish strengthens two public APIs:
+the irreducible-family index assumption on both character theorems is now `Finite ι` rather
+than `Fintype ι`, with a local `Fintype.ofFinite` used only by the proof; the private
+semisimple injectivity helper drops its entirely unused finiteness assumption.
+
+The remaining edits are maintenance:
+
+- nine goal-changing `show` tactics are expressed as `change`;
+- four unused simp arguments are removed;
+- deprecated `LinearMap.coeFn_sum` is replaced by `LinearMap.coe_sum`;
+- `Etingof.character` documents and narrowly exempts its construction-only
+  `Free` and `Module.Finite` instances from `unusedArguments`;
+- both formerly warning-producing providers are removed from the checked warning baseline.
+
+## Lint, import, style, and axiom audit
+
+- Temporary per-provider `#lint+ docBlameThm` checks ran all 16 default declaration
+  linters plus `docBlameThm`. They found zero errors across 13 lint-visible declarations
+  and 19 automatically generated declarations: theorem provider 3+13, matrix provider 2+2,
+  introduction provider 5+3, and exercise provider 3+1.
+- Temporary complete-provider `#redundant_imports` checks found no transitively redundant
+  import in any header. Stage 3.4's five focused direct imports remain unchanged.
+- `#print axioms` re-audited all 13 durable declarations. None depends on `sorryAx`;
+  the only reported dependencies are `propext`, `Classical.choice`, and `Quot.sound`.
+- Final isolated elaboration of all four providers succeeds in 1,957 jobs without a scoped
+  warning. The warning ratchet passes after removing the two now-stale baseline entries.
+- Scoped scans find no `sorry`, `admit`, project `axiom`, `opaque`,
+  `proof_wanted`, `native_decide`, deprecated `push_neg`, leftover diagnostic command,
+  or line over 100 characters.
+
+## Durable completion and validation
+
+- all three exact records now have `status = proof_polished` and complete section 3.6
+  Stage 3.5 metadata with `mathlib_quality = verified`;
+- Stage 3.2, Stage 3.3, Stage 3.4, claim, fidelity, and dependency metadata are unchanged;
+- `lake build EtingofRepresentationTheory.Chapter3` succeeds in all 8,692 jobs; reported
+  warnings are pre-existing and outside the four scoped providers;
+- all four repository validators pass;
+- exact scope adjacency, scoped prior-stage invariance, normalized non-scope tracker
+  invariance, both dependency files, import headers, and the two unaffected providers are
+  unchanged from Stage 3.4;
+- JSON parsing, source scans, the warning-baseline ratchet, line-length checks, and
+  `git diff --check` all pass.
+
+The temporary lint, redundant-import, and axiom-audit commands were removed from committed
+source. This PR is limited to Chapter 3 §3.6 and Stage 3.5.

--- a/progress/items.json
+++ b/progress/items.json
@@ -2511,6 +2511,47 @@
     "coverage_swept": {
       "wave": 1,
       "result": "covered"
+    },
+    "coverage": "covered_full",
+    "fidelity": "verified",
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.6",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "Section 3.6 is the organizational heading for characters of representations.",
+          "verdict": "non_formalizable",
+          "reason": "This is a section heading rather than a mathematical proposition with a Lean proof obligation."
+        },
+        {
+          "claim": "For a finite-dimensional representation V with action ρ, its character is the k-linear functional χ_V(a) = Tr(ρ(a)).",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.character",
+          "note": "The definition is the composition of the action algebra homomorphism with LinearMap.trace and returns an element of Dual k A."
+        },
+        {
+          "claim": "The commutator space [A,A] is the k-span of all elements xy - yx.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.commutatorSubmodule"
+        },
+        {
+          "claim": "Every character vanishes on [A,A], so [A,A] is contained in its kernel.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.character_mul_comm; Etingof.commutatorSubmodule_le_ker_character"
+        },
+        {
+          "claim": "The character therefore descends to a linear functional A/[A,A] → k.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.characterQuotient; Etingof.characterQuotient_mk",
+          "note": "characterQuotient is the quotient lift, and characterQuotient_mk proves that its composite with the projection is the original character."
+        }
+      ]
     }
   },
   {
@@ -2530,7 +2571,25 @@
     "lean_file": [
       "EtingofRepresentationTheory/Chapter3/Exercise3_6_1.lean"
     ],
-    "lean_decl": "Etingof.character_eq_character_add_character_quotient"
+    "lean_decl": "Etingof.character_eq_character_add_character_quotient",
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.6",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "For every finite-dimensional subrepresentation W of V, the character satisfies χ_V = χ_W + χ_{V/W}.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.character_eq_character_add_character_quotient",
+          "note": "W is an arbitrary A-submodule, and the third term is the character of the genuine quotient representation V ⨸ W."
+        }
+      ]
+    }
   },
   {
     "id": "Chapter3/Theorem3.6.2",
@@ -2546,7 +2605,92 @@
     "sorry_free": true,
     "coverage": "covered_full",
     "coverage_note": "The two headline character results are proved, and the proof's explicit standalone identity [Mat_d(k),Mat_d(k)] = sl_d(k) is now exposed publicly as commutatorSubmodule_matrix_eq_ker_trace via the matrix-unit commutator spanning argument (off-diagonal units E_{ij}=[E_{ii},E_{ij}], diagonal differences E_{ii}-E_{jj}=[E_{ij},E_{ji}]), including the d=0 and d=1 edge cases.",
-    "last_updated": "2026-07-23"
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.6",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "Characters of a finite family of pairwise nonisomorphic finite-dimensional irreducible A-representations are linearly independent.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.characters_linearly_independent"
+        },
+        {
+          "claim": "For pairwise nonisomorphic irreducibles V_i, the combined representation map A → ∏_i End_k(V_i) is surjective.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Etingof.density_theorem_part2",
+          "note": "This is exactly the density theorem invoked by the proof of part (i)."
+        },
+        {
+          "claim": "Independent variation of the component traces forces every coefficient in a linear relation among the irreducible characters to vanish.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.characters_linearly_independent",
+          "note": "The proof constructs a rank-one target in one endomorphism factor, lifts it through density, and obtains the selected coefficient from trace one."
+        },
+        {
+          "claim": "For a finite-dimensional semisimple algebra, the characters of a complete set of irreducibles form a basis of (A/[A,A])*.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.characters_linearly_independent; Etingof.characters_basis_semisimple; Etingof.characterQuotient",
+          "note": "Lean models the quotient dual canonically as tracial functionals on A: characters_linearly_independent proves independence and characters_basis_semisimple proves spanning of that space."
+        },
+        {
+          "claim": "For a full matrix algebra, [Mat_d(k),Mat_d(k)] is exactly sl_d(k), the traceless matrices.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.commutatorSubmodule_matrix_eq_ker_trace; Etingof.commutatorSubmodule_matrix_fin_eq_ker_trace"
+        },
+        {
+          "claim": "Every matrix commutator is traceless.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.commutatorSubmodule_matrix_eq_ker_trace",
+          "note": "The forward inclusion is proved from Matrix.trace_mul_comm."
+        },
+        {
+          "claim": "For matrix units, [E_ij,E_jm] = E_im whenever i ≠ m.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Matrix.single_mul_single_same; Matrix.single_mul_single_of_ne",
+          "note": "Mathlib's matrix-unit multiplication lemmas give the displayed commutator identity directly."
+        },
+        {
+          "claim": "Diagonal matrix-unit differences E_ii - E_jj are commutators [E_ij,E_ji].",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.commutatorSubmodule_matrix_eq_ker_trace",
+          "note": "The public proof establishes the stronger formula with an arbitrary fixed reference index."
+        },
+        {
+          "claim": "Off-diagonal matrix units together with diagonal differences span, and over a field form a basis of, the traceless matrices.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Matrix.stdBasis; Etingof.commutatorSubmodule_matrix_eq_ker_trace",
+          "note": "Mathlib supplies the matrix-unit basis, while the public commutator theorem explicitly decomposes every traceless matrix into off-diagonal units and diagonal corrections."
+        },
+        {
+          "claim": "A finite-dimensional semisimple algebra over the algebraically closed base field is a finite product of full matrix algebras.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed"
+        },
+        {
+          "claim": "Under that matrix-product decomposition, [A,A] is the product of the traceless factors and A/[A,A] is isomorphic to k^r.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed; Etingof.commutatorSubmodule_matrix_fin_eq_ker_trace; Etingof.characters_basis_semisimple",
+          "note": "The matrix-factor identities and Wedderburn–Artin decomposition give the book's quotient computation; the formal theorem uses the equivalent tracial-functional model of its dual."
+        },
+        {
+          "claim": "For A = ⊕_i Mat_{d_i}(k), there are exactly r irreducible representations, represented by the standard k^{d_i}.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Etingof.irreducible_reps_of_matrix_algebra",
+          "note": "This is the classification established in Theorem 3.3.1 and invoked by the source proof."
+        },
+        {
+          "claim": "The r independent irreducible characters on the r-dimensional quotient-dual space form a basis.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.characters_linearly_independent; Etingof.characters_basis_semisimple"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter3/Introduction_to_3.7",

--- a/progress/items.json
+++ b/progress/items.json
@@ -2505,7 +2505,7 @@
     "end_page": "52",
     "start_line": 3,
     "end_line": 10,
-    "status": "sorry_free",
+    "status": "proof_polished",
     "sorry_free": true,
     "notes": "Introduction3_6.lean: character_mul_comm (χ_V(xy)=χ_V(yx) via LinearMap.trace_mul_comm); commutatorSubmodule [A,A]; commutatorSubmodule_le_ker_character ([A,A] ⊆ ker χ_V); characterQuotient (χ_V factors through A/[A,A]).",
     "coverage_swept": {
@@ -2574,6 +2574,13 @@
       "verified_on": "2026-07-27",
       "actual_internal_dependencies": [],
       "basis": "The apparent import of Theorem3_6_2 supplies the character declaration tracked by this same introduction item; its six transitive Mathlib imports are removed from that provider, and the introduction has no actual backward book-item dependency."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "3.6",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The character, cyclicity, commutator-span, kernel, and quotient declarations are fully documented, warning-free, import-irredundant, axiom-clean, and clean under all 16 default declaration linters plus docBlameThm. The trace construction has a documented narrow unusedArguments exemption for the freeness and finiteness instances required only by its body."
     }
   },
   {
@@ -2584,7 +2591,7 @@
     "end_page": "52",
     "start_line": 11,
     "end_line": 12,
-    "status": "sorry_free",
+    "status": "proof_polished",
     "sorry_free": true,
     "coverage_note": "Coverage-arm audit (Stage 3.7, #7371): covered_full. Chapter3/Exercise3_6_1.lean (sorry-free on origin/main, 0 sorries) proves character_eq_character_add_character_quotient: for a finite dimensional representation V of an algebra A (Field k, Ring A, Algebra k A, IsScalarTower k A V, FiniteDimensional k V) and an ARBITRARY subrepresentation W : Submodule A V, Etingof.character k A V = Etingof.character k A W + Etingof.character k A (V ⧸ W) as elements of Dual k A. This is the book's χ_V = χ_W + χ_{V/W} for arbitrary W ⊂ V, proved by additivity of trace along the split short exact sequence 0 → W → V → V/W → 0. W is genuinely universally quantified (not a fixed hand-picked submodule); the quotient character uses the honest V ⧸ W representation.",
     "fidelity": "verified",
@@ -2632,6 +2639,13 @@
         "Chapter3/Introduction_to_3.6"
       ],
       "basis": "The exercise uses Etingof.character from the section introduction. Its sole project import is already irredundant, and it does not use a declaration from Theorem 3.6.2 beyond the character declaration cataloged under the introduction."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "3.6",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The arbitrary-subrepresentation character-additivity theorem and both supporting finite-dimensionality instances are documented, warning-free, import-irredundant, axiom-clean, and clean under all 16 default declaration linters plus docBlameThm. Two goal-changing show tactics were replaced by explicit change steps."
     }
   },
   {
@@ -2642,7 +2656,7 @@
     "end_page": "53",
     "start_line": 13,
     "end_line": 2,
-    "status": "sorry_free",
+    "status": "proof_polished",
     "fidelity": "verified",
     "notes": "All parts proved sorry-free: (i) linear independence of characters, (ii) characters span tracial functionals for semisimple algebras. Helper lemmas tracial_of_end_eq_scalar_trace and rep_map_injective_of_semisimple also proved. The proof's standalone identity [Mat_d(k),Mat_d(k)] = sl_d(k) is now a public endpoint, commutatorSubmodule_matrix_eq_ker_trace (and its Fin d specialization commutatorSubmodule_matrix_fin_eq_ker_trace) in CommutatorMatrixTraceless.lean.",
     "sorry_free": true,
@@ -2756,6 +2770,13 @@
         "Chapter3/Introduction_to_3.6"
       ],
       "basis": "The linear-independence proof directly uses density_theorem_part2 from Theorem 3.2.2, while the matrix provider directly uses commutatorSubmodule from the section introduction. Eight transitive Mathlib imports were removed across the theorem providers; the remaining direct imports are redundancy-clean."
+    },
+    "stage3_5": {
+      "status": "complete",
+      "section": "3.6",
+      "reviewed_on": "2026-07-27",
+      "mathlib_quality": "verified",
+      "result": "The public index assumptions were generalized from Fintype to Finite, the private injectivity helper dropped an unused finiteness assumption, and deprecated, goal-changing, and unused simp syntax was removed. Both theorem providers are documented, warning-free, import-irredundant, axiom-clean, and clean under all 16 default declaration linters plus docBlameThm."
     }
   },
   {

--- a/progress/items.json
+++ b/progress/items.json
@@ -2567,6 +2567,13 @@
         "Etingof.characterQuotient_mk"
       ],
       "basis": "The complete character construction, cyclicity proof, commutator-span vanishing, and quotient factorization use closed Lean terms. An exhaustive module-origin audit also covered every generated and internal declaration emitted by the provider."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.6",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The apparent import of Theorem3_6_2 supplies the character declaration tracked by this same introduction item; its six transitive Mathlib imports are removed from that provider, and the introduction has no actual backward book-item dependency."
     }
   },
   {
@@ -2616,6 +2623,15 @@
         "Etingof.character_eq_character_add_character_quotient"
       ],
       "basis": "Both finite-dimensionality instances and the character-additivity theorem for an arbitrary subrepresentation and its genuine quotient are closed Lean terms. The exhaustive module-origin audit included all internal declarations emitted by the provider."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.6",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter3/Introduction_to_3.6"
+      ],
+      "basis": "The exercise uses Etingof.character from the section introduction. Its sole project import is already irredundant, and it does not use a declaration from Theorem 3.6.2 beyond the character declaration cataloged under the introduction."
     }
   },
   {
@@ -2730,6 +2746,16 @@
         "Etingof.commutatorSubmodule_matrix_fin_eq_ker_trace"
       ],
       "basis": "Linear independence, semisimple spanning and basis, and the general and Fin-indexed matrix commutator/traceless equalities are closed Lean terms. Private helpers and generated declarations were included in the exhaustive module-origin audit."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.6",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter3/Theorem3.2.2",
+        "Chapter3/Introduction_to_3.6"
+      ],
+      "basis": "The linear-independence proof directly uses density_theorem_part2 from Theorem 3.2.2, while the matrix provider directly uses commutatorSubmodule from the section introduction. Eight transitive Mathlib imports were removed across the theorem providers; the remaining direct imports are redundancy-clean."
     }
   },
   {

--- a/progress/items.json
+++ b/progress/items.json
@@ -2552,6 +2552,21 @@
           "note": "characterQuotient is the quotient lift, and characterQuotient_mk proves that its composite with the projection is the original character."
         }
       ]
+    },
+    "stage3_3": {
+      "stage": "3.3",
+      "status": "complete",
+      "reviewed_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.character",
+        "Etingof.character_mul_comm",
+        "Etingof.commutatorSubmodule",
+        "Etingof.commutatorSubmodule_le_ker_character",
+        "Etingof.characterQuotient",
+        "Etingof.characterQuotient_mk"
+      ],
+      "basis": "The complete character construction, cyclicity proof, commutator-span vanishing, and quotient factorization use closed Lean terms. An exhaustive module-origin audit also covered every generated and internal declaration emitted by the provider."
     }
   },
   {
@@ -2589,6 +2604,18 @@
           "note": "W is an arbitrary A-submodule, and the third term is the character of the genuine quotient representation V ⨸ W."
         }
       ]
+    },
+    "stage3_3": {
+      "stage": "3.3",
+      "status": "complete",
+      "reviewed_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.instFiniteSubtypeMemSubmodule_etingofRepresentationTheory",
+        "Etingof.instFiniteQuotientSubmodule_etingofRepresentationTheory",
+        "Etingof.character_eq_character_add_character_quotient"
+      ],
+      "basis": "Both finite-dimensionality instances and the character-additivity theorem for an arbitrary subrepresentation and its genuine quotient are closed Lean terms. The exhaustive module-origin audit included all internal declarations emitted by the provider."
     }
   },
   {
@@ -2690,6 +2717,19 @@
           "lean_decl": "Etingof.characters_linearly_independent; Etingof.characters_basis_semisimple"
         }
       ]
+    },
+    "stage3_3": {
+      "stage": "3.3",
+      "status": "complete",
+      "reviewed_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.characters_linearly_independent",
+        "Etingof.characters_basis_semisimple",
+        "Etingof.commutatorSubmodule_matrix_eq_ker_trace",
+        "Etingof.commutatorSubmodule_matrix_fin_eq_ker_trace"
+      ],
+      "basis": "Linear independence, semisimple spanning and basis, and the general and Fin-indexed matrix commutator/traceless equalities are closed Lean terms. Private helpers and generated declarations were included in the exhaustive module-origin audit."
     }
   },
   {

--- a/scripts/lint-warning-baseline.txt
+++ b/scripts/lint-warning-baseline.txt
@@ -26,7 +26,6 @@ EtingofRepresentationTheory/Chapter2/Theorem2_1_1.lean
 EtingofRepresentationTheory/Chapter3/Corollary3_5_5.lean
 EtingofRepresentationTheory/Chapter3/Discussion_alternative_proof_of_Proposition3_1_4.lean
 EtingofRepresentationTheory/Chapter3/Example3_5_6.lean
-EtingofRepresentationTheory/Chapter3/Exercise3_6_1.lean
 EtingofRepresentationTheory/Chapter3/Lemma3_1_6.lean
 EtingofRepresentationTheory/Chapter3/Problem3_3_3.lean
 EtingofRepresentationTheory/Chapter3/Problem3_8_4_Main.lean
@@ -43,7 +42,6 @@ EtingofRepresentationTheory/Chapter3/Theorem3_10_2.lean
 EtingofRepresentationTheory/Chapter3/Theorem3_2_2.lean
 EtingofRepresentationTheory/Chapter3/Theorem3_3_1.lean
 EtingofRepresentationTheory/Chapter3/Theorem3_5_4.lean
-EtingofRepresentationTheory/Chapter3/Theorem3_6_2.lean
 EtingofRepresentationTheory/Chapter3/Theorem3_8_1.lean
 EtingofRepresentationTheory/Chapter4/Corollary4_2_2.lean
 EtingofRepresentationTheory/Chapter4/Corollary4_2_4.lean


### PR DESCRIPTION
## Scope

Chapter 3 §3.6, Stage 3.5 only, stacked on Stage 3.4 PR #8079.

- exactly three tracker items (global indices 156–158)
- all four providers audited
- exactly one commit and five files

## Source polish

- generalized both public irreducible-family index assumptions from `Fintype` to `Finite`
- removed the private injectivity helper's unused finiteness assumption
- replaced nine goal-changing `show` tactics
- removed four unused simp arguments
- replaced deprecated `LinearMap.coeFn_sum`
- documented a narrow `unusedArguments` exemption on the trace construction
- removed two now-clean warning-baseline entries

## Quality evidence

- all 13 lint-visible + 19 generated declarations pass 16 default linters plus `docBlameThm`
- all four providers are warning-free and `#redundant_imports`-clean
- 13 durable declarations are axiom-clean: only `propext`, `Classical.choice`, and `Quot.sound`
- exact providers: 1,957 jobs passed
- full Chapter 3: 8,692 jobs passed
- all four validators and exact invariance checks passed
