### PR TITLE
Stage 3.4: trim Chapter 3 §3.7 dependencies

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/Discussion_footnote_3_7_1.lean
+++ b/EtingofRepresentationTheory/Chapter3/Discussion_footnote_3_7_1.lean
@@ -1,6 +1,4 @@
 import EtingofRepresentationTheory.Chapter3.Theorem3_6_2
-import Mathlib.LinearAlgebra.Pi
-import Mathlib.Algebra.CharP.Defs
 
 /-!
 # Footnote 5 to Theorem 3.7.1: the character of `pV` vanishes in characteristic `p`

--- a/EtingofRepresentationTheory/Chapter3/Theorem3_7_1.lean
+++ b/EtingofRepresentationTheory/Chapter3/Theorem3_7_1.lean
@@ -1,4 +1,3 @@
-import Mathlib.Order.JordanHolder
 import Mathlib.RingTheory.SimpleModule.Basic
 
 /-!

--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -474,15 +474,11 @@
   "Chapter3/Theorem3.6.2": [
     "Chapter3/Exercise3.6.1"
   ],
-  "Chapter3/Introduction_to_3.7": [
-    "Chapter3/Theorem3.6.2"
-  ],
+  "Chapter3/Introduction_to_3.7": [],
   "Chapter3/Theorem3.7.1": [
-    "Chapter3/Introduction_to_3.7"
+    "Chapter3/Introduction_to_3.6"
   ],
-  "Chapter3/Discussion_after_Theorem3.7.1": [
-    "Chapter3/Theorem3.7.1"
-  ],
+  "Chapter3/Discussion_after_Theorem3.7.1": [],
   "Chapter3/Introduction_to_3.8": [
     "Chapter3/Discussion_after_Theorem3.7.1"
   ],

--- a/progress/2026-07-27T16-00-16Z_stage3-2-chapter3-section3-7.md
+++ b/progress/2026-07-27T16-00-16Z_stage3-2-chapter3-section3-7.md
@@ -1,0 +1,78 @@
+# Stage 3.2 claim-coverage audit — Chapter 3 §3.7
+
+## Scope
+
+Reading order gives exactly three §3.7 tracker items (indices 159–161):
+
+1. `Chapter3/Introduction_to_3.7` (page 53);
+2. `Chapter3/Theorem3.7.1` (pages 53–54, including footnote 5);
+3. `Chapter3/Discussion_after_Theorem3.7.1` (page 54).
+
+The predecessor is `Chapter3/Theorem3.6.2`; the strict successor is
+`Chapter3/Introduction_to_3.8`. The exact Lean providers are:
+
+- `EtingofRepresentationTheory/Chapter3/Theorem3_7_1.lean`;
+- `EtingofRepresentationTheory/Chapter3/Discussion_after_Theorem3_7_1.lean`;
+- `EtingofRepresentationTheory/Chapter3/Discussion_footnote_3_7_1.lean`.
+
+The footnote provider is attached to the theorem item by its existing tracker notes. No other
+source file is assigned to this section.
+
+## Claim audit
+
+All three blobs were read in full and divided into 28 claim units. The durable dispositions in
+`progress/items.json` are:
+
+- 9 `formalized` claims;
+- 15 `covered_elsewhere` claims;
+- 4 `non_formalizable` expository claims;
+- 0 gaps.
+
+The theorem statement is fully represented, not merely by equality of lengths:
+`Etingof.jordan_holder_equivalent` exposes the complete composition-series equivalence,
+`Etingof.jordan_holder_factors` exposes the factor-index bijection and linear equivalences, and
+`Etingof.jordan_holder` exposes `n = m`. `Etingof.compositionFactor` is the genuine consecutive
+submodule quotient, while `covBy_iff_quot_is_simple` identifies each covering step with a simple
+(irreducible) quotient.
+
+The characteristic-zero proof ingredients are covered by character additivity and
+`Etingof.characters_linearly_independent`. The footnote's concrete obstruction in characteristic
+`p` is directly formalized by `Etingof.character_fin_pi` and
+`Etingof.character_pcopies_eq_zero`. The general proof's quotient, intersection, direct-sum,
+composition-series-existence, and comparison steps are covered by checked Mathlib infrastructure
+and `Etingof.exists_composition_series`; its exact factor-multiset endpoint is exposed by
+`Etingof.jordan_holder_factors`.
+
+The discussion's filtration-independent length and greatest strict-chain length are directly
+covered by `Etingof.jordan_holder`, `Module.length_compositionSeries`, and
+`Etingof.jordanHolder_length_isGreatest_strict`. The remaining use of “length” and
+“Jordan-Holder series” is standard terminology attached to `Module.length` and
+`CompositionSeries`.
+
+The existing tracker statuses and fields, including the theorem's older `fidelity = partial`
+field, are intentionally preserved: this Stage 3.2 change adds only the durable
+`claim_coverage` records. The detailed 2026-07-21 theorem review already established full
+statement fidelity and a concrete length-two non-vacuity witness.
+
+## Declaration, axiom, and placeholder checks
+
+A temporary `#check` harness importing `EtingofRepresentationTheory.Chapter3` verified every
+declaration cited by the new records. `#print axioms` was also run on all thirteen cited project
+declarations. Each depends only on the expected standard Lean/Mathlib axioms
+`propext`, `Classical.choice`, and/or `Quot.sound`; none depends on `sorryAx` or a project axiom.
+The temporary harness was removed after the check.
+
+An exact-provider scan found no `sorry`, `admit`, `sorryAx`, or `axiom` declaration.
+
+## Validation
+
+- exact three-provider build: success (1960 jobs);
+- `lake build EtingofRepresentationTheory.Chapter3`: success (8692 jobs; pre-existing warnings);
+- `python3 scripts/validate_items.py`: passed, 5721/5721 lines and 583 unique blob IDs;
+- `python3 scripts/validate_dependencies.py`: passed, 583 entries and 582 edges;
+- `python3 scripts/validate_external_deps.py`: passed, 58 external dependencies;
+- `python3 scripts/validate_mathlib_coverage.py`: passed, 58/58 entries represented;
+- removing `claim_coverage` from the three scoped records reproduces `origin/main` exactly;
+- every non-§3.7 tracker record is byte-for-byte unchanged after canonical JSON projection;
+- all three Lean provider files are byte-for-byte unchanged from `origin/main`;
+- `jq empty progress/items.json` and `git diff --check`: passed.

--- a/progress/2026-07-27T16-07-53Z_stage3-3-chapter3-section3-7.md
+++ b/progress/2026-07-27T16-07-53Z_stage3-3-chapter3-section3-7.md
@@ -1,0 +1,78 @@
+# Stage 3.3 proof-integrity review — Chapter 3 §3.7
+
+## Scope and inherited coverage
+
+This stacked review is based exactly on Stage 3.2 draft PR #8080 at commit
+`4835e01ce0dfc4e1cf783991be5a8cf363272300`. Reading order gives the three §3.7 catalog
+items at indices 159–161, from `Chapter3/Introduction_to_3.7` through
+`Chapter3/Discussion_after_Theorem3.7.1`. The strict predecessor is
+`Chapter3/Theorem3.6.2`; the strict successor is `Chapter3/Introduction_to_3.8`.
+
+The 28-claim Stage 3.2 inventory is unchanged: nine claims are `formalized`, fifteen are
+`covered_elsewhere`, four are `non_formalizable`, and none is a gap. The three exact providers
+are:
+
+- `EtingofRepresentationTheory/Chapter3/Theorem3_7_1.lean`;
+- `EtingofRepresentationTheory/Chapter3/Discussion_after_Theorem3_7_1.lean`;
+- `EtingofRepresentationTheory/Chapter3/Discussion_footnote_3_7_1.lean`.
+
+The introduction has no provider or proof obligation. The footnote provider belongs to the
+theorem item, as established by the inherited tracker notes and Stage 3.2 audit.
+
+## Exhaustive proof-integrity audit
+
+The durable `stage3_3` inventories contain only the ten authored declarations: nine on the
+theorem item (including the footnote) and one on the discussion item. The introduction is
+`not_applicable`; the other two items are `sorry_free`.
+
+The audit itself was deliberately broader. Lean module-origin data exhaustively identified all
+12 constants emitted by the exact providers. `Lean.collectAxioms` classified them as follows:
+
+- `[propext, Classical.choice, Quot.sound]` (8):
+  `Etingof.compositionFactor`, `Etingof.jordan_holder_equivalent`,
+  `Etingof.jordan_holder_factors`, `Etingof.jordan_holder`,
+  `Etingof.jordanHolder_length_isGreatest_strict`, `Etingof.trace_diagPi_fin`,
+  `Etingof.character_fin_pi`, and `Etingof.character_pcopies_eq_zero`;
+- `[propext, Quot.sound]` (4): `Etingof.diagPi`, `Etingof.diagPi_apply`, the generated
+  equation theorem `Etingof.diagPi.eq_1`, and the internal proof constant
+  `Etingof.diagPi._proof_1`.
+
+Thus all 12 constants are backed by closed Lean terms using only the expected foundational
+axioms. None depends on `sorryAx` or a project axiom. The generated equation theorem and internal
+proof constant are recorded here and were included in the exhaustive audit, but are correctly
+excluded from the durable authored-declaration arrays.
+
+A direct source scan found no `sorry`, `admit`, `proof_wanted`, `sorryAx`, `native_decide`,
+`unsafe`, `axiom`, or source-level `opaque` declaration. No proof repair was required.
+
+## Direct-import audit
+
+The three providers contain exactly six direct import statements:
+
+- `Theorem3_7_1.lean`: `Mathlib.Order.JordanHolder` and
+  `Mathlib.RingTheory.SimpleModule.Basic`;
+- `Discussion_after_Theorem3_7_1.lean`: `Mathlib.RingTheory.Length`;
+- `Discussion_footnote_3_7_1.lean`: the earlier local provider
+  `EtingofRepresentationTheory.Chapter3.Theorem3_6_2`, `Mathlib.LinearAlgebra.Pi`, and
+  `Mathlib.Algebra.CharP.Defs`.
+
+There is no aggregate chapter import, later-section import, or hidden additional project edge.
+The imports were audited but intentionally not changed: redundancy testing and minimization are
+reserved for Stage 3.4.
+
+## Validation
+
+- `.lake/build` is worktree-local; only `.lake/packages` links to the shared package cache;
+- all three exact providers build successfully together (1,960 jobs);
+- exhaustive module-origin enumeration and `Lean.collectAxioms`: 12/12 constants clean;
+- exact-provider admission/placeholder and direct-import scans: clean;
+- exact three-item aggregation: two `sorry_free`, one `not_applicable`, ten distinct authored
+  declarations;
+- `lake build EtingofRepresentationTheory.Chapter3`: success (8,692 jobs; pre-existing warnings);
+- all four repository validators pass;
+- removing only `stage3_3` from the three scoped records reproduces the Stage 3.2 base exactly;
+- the inherited claim coverage, normalized non-scope tracker projection, dependency maps, and all
+  three provider files are unchanged;
+- `jq empty progress/items.json` and `git diff --check`: pass.
+
+This PR is limited to Chapter 3 §3.7 and Stage 3.3.

--- a/progress/2026-07-27T16-14-35Z_stage3-4-chapter3-section3-7.md
+++ b/progress/2026-07-27T16-14-35Z_stage3-4-chapter3-section3-7.md
@@ -1,0 +1,69 @@
+# Stage 3.4 dependency audit — Chapter 3 §3.7
+
+## Scope
+
+This review is stacked exactly on Stage 3.3 draft PR #8082 at commit
+`ac82f667a20b848765aaeb51528d6ec7c2a78c01`. It covers the same three reading-order items
+at indices 159–161 and the three exact providers for the Jordan-Holder theorem, its footnote,
+and the following length discussion. The immediate predecessor is `Chapter3/Theorem3.6.2`; the
+strict successor is `Chapter3/Introduction_to_3.8`.
+
+No definition, theorem statement, proof body, or inherited Stage 3.2/3.3 metadata changed. This
+pass is limited to verified direct-import removal, actual internal dependency edges, and durable
+`stage3_4` records.
+
+## Direct-import audit
+
+An initial complete-provider `#redundant_imports` pass reported exactly three transitively
+redundant imports:
+
+- `Theorem3_7_1.lean`: `Mathlib.Order.JordanHolder`, already supplied by
+  `Mathlib.RingTheory.SimpleModule.Basic`;
+- `Discussion_footnote_3_7_1.lean`: `Mathlib.LinearAlgebra.Pi` and
+  `Mathlib.Algebra.CharP.Defs`, both already supplied through the retained local
+  `Theorem3_6_2` import;
+- `Discussion_after_Theorem3_7_1.lean`: no redundant direct import.
+
+Only those three reported lines were removed. Direct imports move from six to three (`-3`). A
+final complete-provider `#redundant_imports` run reports “No transitively redundant imports
+found” independently for all three providers. Removing import lines from both the base and final
+sources makes every provider body byte-for-byte identical, so no mathematical content changed.
+
+## Actual internal dependency graph
+
+The three conservative reading-order edges are replaced by one actual backward edge:
+
+1. `Chapter3/Theorem3.7.1` → `Chapter3/Introduction_to_3.6`, because the theorem item's
+   characteristic-`p` footnote uses `Etingof.character`, the declaration cataloged under the
+   Section 3.6 introduction. The footnote obtains it through its sole retained project import,
+   `Theorem3_6_2.lean`.
+
+The §3.7 introduction has no provider, while both the Jordan-Holder provider and the length
+discussion provider use only Mathlib. Scoped graph edges therefore move from three to one
+(`-2`), and the repository total moves from 582 to 580. The retained edge points strictly
+backward, and every tracker `actual_internal_dependencies` array agrees exactly with
+`dependencies/internal.json`.
+
+## Durable tracker result
+
+- all three exact records have complete section `3.7` `stage3_4` objects;
+- prior workflow statuses and all Stage 3.2/3.3, claim-coverage, fidelity, and proof-integrity
+  metadata are unchanged;
+- the normalized non-§3.7 tracker projection and non-§3.7 dependency-source projection are
+  unchanged;
+- external-dependency and Mathlib-coverage maps are unchanged.
+
+## Validation
+
+- final isolated build of all three scoped providers: success (1,960 jobs);
+- `lake build EtingofRepresentationTheory.Chapter3`: success (8,692 jobs; pre-existing warnings);
+- initial and final complete-provider `#redundant_imports` checks: all providers clean after the
+  three verified removals;
+- exact three-item tracker/graph agreement and backward-edge checks: passed;
+- direct-import count: 6 → 3 (`-3`); scoped graph edges: 3 → 1 (`-2`);
+- `jq empty progress/items.json dependencies/internal.json`: passed;
+- item, dependency, external-dependency, and Mathlib-coverage validators: passed;
+- scoped/non-scoped tracker and dependency invariance checks, provider-body invariance, and
+  `git diff --check`: passed.
+
+This PR is limited to Chapter 3 §3.7 and Stage 3.4.

--- a/progress/items.json
+++ b/progress/items.json
@@ -2589,6 +2589,13 @@
       "proof_integrity": "not_applicable",
       "declarations": [],
       "basis": "The item consists only of a section heading and organizational roadmap, has no exact Lean provider, and introduces no proof obligation."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.7",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "This item is an organizational heading and roadmap with no Lean provider of its own, so it has no actual internal dependency."
     }
   },
   {
@@ -2744,6 +2751,15 @@
         "Etingof.character_pcopies_eq_zero"
       ],
       "basis": "The four Jordan-Holder declarations and five characteristic-p footnote declarations are authored, admission-free constants. The exhaustive module-origin audit also covers the generated equation theorem Etingof.diagPi.eq_1 and internal proof constant Etingof.diagPi._proof_1."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.7",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter3/Introduction_to_3.6"
+      ],
+      "basis": "The Jordan-Holder provider uses only Mathlib. The theorem item's footnote provider uses Etingof.character, the declaration tracked by the Section 3.6 introduction, through its sole retained project import of Theorem3_6_2."
     }
   },
   {
@@ -2803,6 +2819,13 @@
         "Etingof.jordanHolder_length_isGreatest_strict"
       ],
       "basis": "The authored theorem is an admission-free constant whose transitive axiom set contains only the standard Lean/Mathlib axioms."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.7",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The discussion provider imports only Mathlib.RingTheory.Length and uses no declaration from another tracked book item."
     }
   },
   {

--- a/progress/items.json
+++ b/progress/items.json
@@ -2560,6 +2560,27 @@
     "coverage_swept": {
       "wave": 1,
       "result": "none"
+    },
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.7",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "Section 3.7 is headed 'The Jordan-Holder theorem'.",
+          "verdict": "non_formalizable",
+          "reason": "This is a section heading rather than a mathematical proposition or construction."
+        },
+        {
+          "claim": "The text will next state and prove the Jordan-Holder and Krull-Schmidt theorems for representations of finite-dimensional algebras.",
+          "verdict": "non_formalizable",
+          "reason": "This is an organizational roadmap for the following sections, not a standalone mathematical assertion."
+        }
+      ]
     }
   },
   {
@@ -2576,7 +2597,128 @@
     "notes": "Full theorem now exposed (#5328): jordan_holder_equivalent gives s₁.Equivalent s₂; jordan_holder_factors gives the permutation σ with Wᵢ ≅ W'_{σ i} via Etingof.compositionFactor; jordan_holder retains the n = m length half. Characteristic-p footnote formalized (#7469) in Discussion_footnote_3_7_1.lean: character_fin_pi gives χ_{nV} = n • χ_V for the diagonal representation on Fin n → V (via trace_diagPi_fin, direct-sum additivity of the trace), and character_pcopies_eq_zero gives χ_{pV} = 0 under [CharP k p].",
     "coverage": "covered",
     "fidelity_note": "The Jordan–Hölder theorem itself is complete. The characteristic-p footnote's concrete explanation—that the character of the p-fold sum pV vanishes for every V—is now formalized as Etingof.character_pcopies_eq_zero (with the general χ_{nV} = n • χ_V identity Etingof.character_fin_pi).",
-    "last_updated": "2026-07-23"
+    "last_updated": "2026-07-23",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.7",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "A finite-dimensional representation V equipped with two filtrations from 0 to V whose successive quotients are irreducible is faithfully encoded by two endpoint composition series.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.jordan_holder_equivalent; CompositionSeries; covBy_iff_quot_is_simple"
+        },
+        {
+          "claim": "Each W_i is the genuine successive quotient V_i/V_(i-1), and similarly for the primed series.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.compositionFactor"
+        },
+        {
+          "claim": "The two filtrations have equal lengths n = m.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.jordan_holder"
+        },
+        {
+          "claim": "There is a permutation of the factor indices under which corresponding irreducible successive quotients are isomorphic.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.jordan_holder_factors; Etingof.jordan_holder_equivalent"
+        },
+        {
+          "claim": "The first proof is specifically a characteristic-zero proof.",
+          "verdict": "non_formalizable",
+          "reason": "This labels and scopes one proof method; it is not an additional mathematical conclusion beyond the hypotheses used by that argument."
+        },
+        {
+          "claim": "The character of V is the sum of the characters of the successive quotients for either filtration.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Etingof.character_eq_character_add_character_quotient; Etingof.character_fin_pi"
+        },
+        {
+          "claim": "The characters of irreducible representations are linearly independent in characteristic zero.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Etingof.characters_linearly_independent"
+        },
+        {
+          "claim": "Consequently, every irreducible representation has the same multiplicity among the factors of the two filtrations.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.jordan_holder_factors"
+        },
+        {
+          "claim": "In characteristic p the character argument determines factor multiplicities only modulo p, which is insufficient.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Etingof.character_fin_pi; Etingof.character_pcopies_eq_zero; CharP.cast_eq_zero"
+        },
+        {
+          "claim": "For every representation V in characteristic p, the character of its p-fold direct sum pV is zero.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.character_pcopies_eq_zero"
+        },
+        {
+          "claim": "A general proof of Jordan-Holder proceeds by induction on dim V.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "CompositionSeries.jordan_holder"
+        },
+        {
+          "claim": "The base case of the induction is clear.",
+          "verdict": "non_formalizable",
+          "reason": "This is commentary on the proof's difficulty, not a separately specified proposition."
+        },
+        {
+          "claim": "If the first simple submodules W_1 and W'_1 coincide, the comparison reduces to the quotient V/W_1.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "CompositionSeries.jordan_holder; Submodule.Quotient.module"
+        },
+        {
+          "claim": "If the distinct submodules W_1 and W'_1 are irreducible, then W_1 intersect W'_1 = 0.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "eq_bot_or_eq_top"
+        },
+        {
+          "claim": "The zero intersection gives an embedding W_1 direct-sum W'_1 into V.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "LinearMap.ker_coprod_of_disjoint_range"
+        },
+        {
+          "claim": "The quotient U = V/(W_1 direct-sum W'_1) is again an A-representation.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Submodule.Quotient.module"
+        },
+        {
+          "claim": "The quotient U admits a filtration with simple successive quotients Z_i.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Etingof.exists_composition_series"
+        },
+        {
+          "claim": "V/W_1 has a filtration with factors W'_1, Z_1, ..., Z_p.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "CompositionSeries.jordan_holder; Submodule.map; Submodule.comap"
+        },
+        {
+          "claim": "V/W_1 also has the induced filtration with factors W_2, ..., W_n.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "CompositionSeries.jordan_holder; Submodule.map; Submodule.comap"
+        },
+        {
+          "claim": "V/W'_1 has a filtration with factors W_1, Z_1, ..., Z_p.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "CompositionSeries.jordan_holder; Submodule.map; Submodule.comap"
+        },
+        {
+          "claim": "V/W'_1 also has the induced filtration with factors W'_2, ..., W'_m.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "CompositionSeries.jordan_holder; Submodule.map; Submodule.comap"
+        },
+        {
+          "claim": "Applying the induction hypothesis identifies the combined multiset W_1, W'_1, Z_1, ..., Z_p with each original multiset of composition factors.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.jordan_holder_factors; Etingof.jordan_holder_equivalent"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter3/Discussion_after_Theorem3.7.1",
@@ -2594,7 +2736,38 @@
       "result": "covered"
     },
     "coverage": "covered_full",
-    "last_updated": "2026-07-22"
+    "last_updated": "2026-07-22",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.7",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "The number of factors in a composition filtration is independent of the filtration and depends only on V.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.jordan_holder; Module.length_compositionSeries"
+        },
+        {
+          "claim": "This common number is called the length of V.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Module.length"
+        },
+        {
+          "claim": "The composition length is the maximal length of any filtration of V in which every inclusion is strict.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.jordanHolder_length_isGreatest_strict"
+        },
+        {
+          "claim": "The ordered sequence of irreducible successive quotients of a composition filtration is called a Jordan-Holder series of V.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "CompositionSeries"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter3/Introduction_to_3.8",

--- a/progress/items.json
+++ b/progress/items.json
@@ -2581,6 +2581,14 @@
           "reason": "This is an organizational roadmap for the following sections, not a standalone mathematical assertion."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.7",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "not_applicable",
+      "declarations": [],
+      "basis": "The item consists only of a section heading and organizational roadmap, has no exact Lean provider, and introduces no proof obligation."
     }
   },
   {
@@ -2718,6 +2726,24 @@
           "lean_decl": "Etingof.jordan_holder_factors; Etingof.jordan_holder_equivalent"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.7",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.compositionFactor",
+        "Etingof.jordan_holder_equivalent",
+        "Etingof.jordan_holder_factors",
+        "Etingof.jordan_holder",
+        "Etingof.diagPi",
+        "Etingof.diagPi_apply",
+        "Etingof.trace_diagPi_fin",
+        "Etingof.character_fin_pi",
+        "Etingof.character_pcopies_eq_zero"
+      ],
+      "basis": "The four Jordan-Holder declarations and five characteristic-p footnote declarations are authored, admission-free constants. The exhaustive module-origin audit also covers the generated equation theorem Etingof.diagPi.eq_1 and internal proof constant Etingof.diagPi._proof_1."
     }
   },
   {
@@ -2767,6 +2793,16 @@
           "lean_decl": "CompositionSeries"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.7",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.jordanHolder_length_isGreatest_strict"
+      ],
+      "basis": "The authored theorem is an admission-free constant whose transitive axiom set contains only the standard Lean/Mathlib axioms."
     }
   },
   {


### PR DESCRIPTION
## Summary

- complete Stage 3.4 dependency/import trimming for Chapter 3 §3.7
- remove three imports proven transitively redundant across the exact provider set
- record the exact remaining internal dependency edge and preserve all Stage 3.2/3.3 metadata

## Verification

- [x] final `#redundant_imports` audit clean for all three exact providers
- [x] exact provider build passed (1960 jobs)
- [x] full Chapter 3 build passed (8692 jobs; only pre-existing warnings)
- [x] all repository validators passed
- [x] metadata, dependency, ordering, and non-scope invariance checks passed
- [x] provider bodies unchanged apart from removed import lines

Stacked on Stage 3.3 PR #8082.
