### PR TITLE
Stage 3.2: audit Chapter 3 section 3.10 claim coverage

### DIFF
--- a/progress/2026-07-27T16-16-56Z_stage3-2-chapter3-section3-10.md
+++ b/progress/2026-07-27T16-16-56Z_stage3-2-chapter3-section3-10.md
@@ -1,0 +1,53 @@
+# Stage 3.2 fidelity review — Chapter 3 §3.10
+
+## Scope
+
+Reading order gives exactly six contiguous §3.10 catalog items, from
+`Chapter3/Introduction_to_3.10` through `Chapter3/Discussion_proof_of_Theorem3.10.2`. The
+preceding item is `Chapter3/Problem3.9.5`; the next item is `Chapter4/Introduction`, so the scope
+also closes Chapter 3. The six source blobs are served by four Lean providers:
+`Exercise3_10_1.lean`, `Theorem3_10_2.lean`, `Remark3_10_3.lean`, and
+`TensorProductRadical.lean`.
+
+## Claim audit
+
+All six blobs and all four providers were read in full. The durable inventory has 21 claim units:
+
+- 16 `formalized`;
+- 2 `covered_elsewhere` by precise Mathlib or project declarations;
+- 3 `non_formalizable` organizational or qualitative units;
+- zero accidental or unclassified gaps.
+
+The theorem provider covers part (i), the existence statement in part (ii), and uniqueness up to
+factor isomorphism. Its public APIs assume finite-dimensionality only of the representations, not
+of the algebras, and regression examples instantiate both parts with the infinite-dimensional
+algebra `k[X]`. The exact scoped build now succeeds, so tracker regression #7520 is stale on the
+audited `main` commit.
+
+The source proof is also represented independently. `TensorProductRadical.lean` formalizes the
+image-algebra reduction, the nilpotent easy inclusion, the semisimple-quotient hard inclusion, the
+radical equality, and both quotient identifications. The theorem file itself uses a separate
+density/Artinian proof, so the source route and the theorem endpoint do not depend on each other.
+Both infinite-dimensional failures in Remark 3.10.3 are covered: the rational-function tensor
+algebra is not a field, and the simple entangled Weyl module cannot be an external tensor product
+with a simple first factor.
+
+## Declaration and trust audit
+
+Exact module-attribution inspection found 152 constants across the four providers: 120 public and
+32 private, comprising 123 theorem declarations and 29 definitions. There are no declaration-level
+axioms or opaque declarations. A scoped source scan found no `sorry`, `admit`, `proof_wanted`,
+`sorryAx`, `axiom`, `opaque`, or `native_decide`; transitive axiom collection over every attributed
+constant found only `propext`, `Classical.choice`, and `Quot.sound`.
+
+## Validation
+
+- local worktree build state uses a worktree-local `.lake/build` and only shares `.lake/packages`;
+- all four scoped providers build successfully together; the warnings are pre-existing
+  linter/deprecation warnings and the theorem provider's existing style warnings;
+- the full `EtingofRepresentationTheory.Chapter3` build succeeds;
+- JSON syntax, the exact six-item/21-claim verdict aggregation, the four schema/dependency/coverage
+  validators, and normalized out-of-scope tracker invariance pass;
+- `scripts/verify_blobs.py` retains its pre-existing `KeyError: 'id'` because it does not skip the
+  ten derived overlay records keyed by `derived_from`; no blob or page file changed in this audit;
+- `git diff --check` passes.

--- a/progress/items.json
+++ b/progress/items.json
@@ -4434,6 +4434,27 @@
     "coverage_swept": {
       "wave": 1,
       "result": "none"
+    },
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.10",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "Section 3.10 concerns representations of tensor products of algebras.",
+          "verdict": "non_formalizable",
+          "reason": "This is the organizational section heading rather than a mathematical proposition."
+        },
+        {
+          "claim": "For algebras A and B, A ⊗ B is an algebra and multiplication on pure tensors satisfies (a₁ ⊗ b₁)(a₂ ⊗ b₂) = a₁a₂ ⊗ b₁b₂.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Algebra.TensorProduct.tmul_mul_tmul"
+        }
+      ]
     }
   },
   {
@@ -4453,7 +4474,23 @@
     "lean_file": [
       "EtingofRepresentationTheory/Chapter3/Exercise3_10_1.lean"
     ],
-    "lean_decl": "Etingof.matrix_tensorProduct_matrix"
+    "lean_decl": "Etingof.matrix_tensorProduct_matrix",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.10",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "Mat_m(k) ⊗ Mat_n(k) is isomorphic as a k-algebra to Mat_{mn}(k).",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.matrix_tensorProduct_matrix"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter3/Discussion_before_Theorem3.10.2",
@@ -4467,6 +4504,22 @@
     "coverage_swept": {
       "wave": 1,
       "result": "none"
+    },
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.10",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "The following theorem describes finite-dimensional irreducible representations of A ⊗ B in terms of those of A and B.",
+          "verdict": "non_formalizable",
+          "reason": "This is an organizational preview of Theorem 3.10.2, whose individual mathematical assertions are inventoried on the theorem item."
+        }
+      ]
     }
   },
   {
@@ -4485,7 +4538,33 @@
     "fidelity_issue": 7391,
     "coverage": "covered_partial",
     "coverage_issue": 7520,
-    "last_updated": "2026-07-22"
+    "last_updated": "2026-07-22",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.10",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "If V and W are finite-dimensional irreducible representations of A and B, then V ⊗ W is irreducible for the tensor-product action.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.tensor_product_irreducible"
+        },
+        {
+          "claim": "Every finite-dimensional irreducible representation M of A ⊗ B is equivariantly equivalent to V ⊗ W for finite-dimensional irreducible representations V of A and W of B.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.tensor_product_irreducible_classification"
+        },
+        {
+          "claim": "The irreducible factors V and W are uniquely determined up to A-linear and B-linear isomorphism.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.tensor_product_irreducible_classification_unique"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter3/Remark3.10.3",
@@ -4499,7 +4578,33 @@
     "coverage": "covered_full",
     "fidelity_note": "Both counterexamples are formalized: ratFunc_tensor_ratFunc_not_isField proves the rational-function failure of part (i), while tensorModule_isSimpleModule and tensorModule_not_equiv_tensorProduct_of_simple_left prove the Weyl-algebra failure of the infinite-dimensional analogue of Theorem 3.10.2(ii). The latter uses the characteristic-free PBW domain theorem Etingof.WeylAlgebra.mul_ne_zero to show that the regular first-factor restriction has no simple submodule.",
     "fidelity_decl": "EtingofRepresentationTheory.Chapter3.Remark3_10_3.tensorModule_not_equiv_tensorProduct_of_simple_left",
-    "last_updated": "2026-07-27"
+    "last_updated": "2026-07-27",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.10",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "Part (ii) typically fails for infinite-dimensional representations.",
+          "verdict": "non_formalizable",
+          "reason": "The qualitative word 'typically' has no specified quantifier or parameter space; the concrete Weyl-algebra counterexample is inventoried separately."
+        },
+        {
+          "claim": "For the characteristic-zero Weyl algebra, the simple entangled module C[x,y]e^{xy} is not an external tensor product with a simple first factor.",
+          "verdict": "formalized",
+          "lean_decl": "EtingofRepresentationTheory.Chapter3.Remark3_10_3.tensorModule_isSimpleModule; EtingofRepresentationTheory.Chapter3.Remark3_10_3.tensorModule_not_equiv_tensorProduct_of_simple_left"
+        },
+        {
+          "claim": "For A = B = V = W = C(x), the factor modules V and W are irreducible self-representations, while their tensor product is not irreducible because A ⊗ B is not a field.",
+          "verdict": "formalized",
+          "lean_decl": "EtingofRepresentationTheory.Chapter3.Remark3_10_3.ratFunc_tensor_ratFunc_not_isField; isSimpleModule_self_iff_isUnit"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter3/Discussion_proof_of_Theorem3.10.2",
@@ -4520,7 +4625,73 @@
       "note": "The source proof's two structural claims are now formalized in EtingofRepresentationTheory/Chapter3/TensorProductRadical.lean: jacobson_tensorProduct_eq gives Rad(A⊗B) = Rad(A)⊗B + A⊗Rad(B) for finite-dimensional A, B over an algebraically closed field, and quotientJacobsonTensorEquiv gives the displayed identification (A⊗B)/Rad(A⊗B) ≅ (A/Rad A) ⊗ (B/Rad B). The book's two steps are separated by hypothesis: radTensorSum_le_jacobson (nilpotence; no hypothesis on k) and jacobson_le_radTensorSum (semisimplicity of the quotient), the latter discharged over an algebraically closed field by isSemisimpleRing_tensorProduct. jacobson_tensorProduct_range_eq states the formula for the image algebras A', B' ⊆ End M, matching the book's image-algebra reduction. Theorem 3.10.2 itself is still proved by the independent density/Artinian route in Theorem3_10_2.lean, which does not consume these results."
     },
     "last_updated": "2026-07-26",
-    "lean_ref": "EtingofRepresentationTheory/Chapter3/TensorProductRadical.lean :: Etingof.jacobson_tensorProduct_eq, Etingof.quotientJacobsonTensorEquiv, Etingof.quotientRadTensorSumEquiv, Etingof.radTensorSum_eq_ker, Etingof.radTensorSum_le_jacobson, Etingof.jacobson_le_radTensorSum, Etingof.isSemisimpleRing_tensorProduct, Etingof.jacobson_tensorProduct_range_eq"
+    "lean_ref": "EtingofRepresentationTheory/Chapter3/TensorProductRadical.lean :: Etingof.jacobson_tensorProduct_eq, Etingof.quotientJacobsonTensorEquiv, Etingof.quotientRadTensorSumEquiv, Etingof.radTensorSum_eq_ker, Etingof.radTensorSum_le_jacobson, Etingof.jacobson_le_radTensorSum, Etingof.isSemisimpleRing_tensorProduct, Etingof.jacobson_tensorProduct_range_eq",
+    "claim_coverage": {
+      "stage": "3.2",
+      "status": "complete",
+      "section": "3.10",
+      "reviewed_on": "2026-07-27",
+      "definition_integrity": "verified",
+      "statement_fidelity": "verified",
+      "nonvacuity": "verified",
+      "claims": [
+        {
+          "claim": "For irreducible finite-dimensional V and W, density makes A → End(V) and B → End(W) surjective.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Etingof.density_theorem_part1"
+        },
+        {
+          "claim": "The resulting tensor-product action reaches enough endomorphisms of V ⊗ W to make V ⊗ W irreducible.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.tensor_product_irreducible"
+        },
+        {
+          "claim": "The image algebras A' and B' in End(M) are finite-dimensional, M carries their tensor-product action, and the radical calculation can be reduced to these image algebras.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.jacobson_tensorProduct_range_eq; Algebra.TensorProduct.lift"
+        },
+        {
+          "claim": "For finite-dimensional A and B over an algebraically closed field, Rad(A ⊗ B) = Rad(A) ⊗ B + A ⊗ Rad(B).",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.jacobson_tensorProduct_eq"
+        },
+        {
+          "claim": "J = Rad(A) ⊗ B + A ⊗ Rad(B) is a nilpotent ideal and hence J ⊆ Rad(A ⊗ B).",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.isNilpotent_radTensorSum; Etingof.radTensorSum_le_jacobson"
+        },
+        {
+          "claim": "The quotient (A ⊗ B)/J is isomorphic to (A/Rad(A)) ⊗ (B/Rad(B)).",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.quotientRadTensorSumEquiv"
+        },
+        {
+          "claim": "The tensor product of the two finite-dimensional semisimple radical quotients is semisimple over an algebraically closed field.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.isSemisimpleRing_tensorProduct"
+        },
+        {
+          "claim": "Semisimplicity of the quotient gives Rad(A ⊗ B) ⊆ J, completing the radical equality.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.jacobson_le_radTensorSum; Etingof.jacobson_tensorProduct_eq"
+        },
+        {
+          "claim": "Consequently (A ⊗ B)/Rad(A ⊗ B) is isomorphic to (A/Rad(A)) ⊗ (B/Rad(B)).",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.quotientJacobsonTensorEquiv"
+        },
+        {
+          "claim": "An irreducible M over the semisimple quotient has the form V ⊗ W with irreducible factor representations.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.tensor_product_irreducible_classification"
+        },
+        {
+          "claim": "The factors V and W are uniquely determined by M.",
+          "verdict": "formalized",
+          "lean_decl": "Etingof.tensor_product_irreducible_classification_unique"
+        }
+      ]
+    }
   },
   {
     "id": "Chapter4/Introduction",


### PR DESCRIPTION
## Summary

- audits the exact six-item Chapter 3 section 3.10 tracker slice against all six source blobs and four Lean providers
- records 21 claim dispositions: 16 formalized, 2 covered elsewhere, 3 non-formalizable, and no gaps
- documents the theorem, radical proof route, and both infinite-dimensional counterexamples
- adds only Stage 3.2 claim_coverage metadata and the audit note

## Trust and validation

- exact four-provider build: passed
- full EtingofRepresentationTheory.Chapter3 build: passed (8693 jobs on the current base)
- 152 attributed provider constants audited: 120 public, 32 private; 123 theorems and 29 definitions
- no sorry, admit, proof_wanted, sorryAx, axiom, opaque, or native_decide in scope
- transitive axioms: propext, Classical.choice, Quot.sound only
- validate_items.py, validate_dependencies.py, validate_external_deps.py, and validate_mathlib_coverage.py: passed
- exact six-item/21-claim aggregation and normalized out-of-scope tracker invariance: passed
- verify_blobs.py retains its pre-existing KeyError on derived overlay records; no blobs or pages changed

The old tracker regression #7520 is stale: Theorem3_10_2.lean builds successfully on the audited current main.