### PR TITLE
Stage 3.3: verify Chapter 3 section 3.8 proof integrity

### DIFF
--- a/progress/2026-07-27T16-26-07Z_stage3-3-chapter3-section3-8.md
+++ b/progress/2026-07-27T16-26-07Z_stage3-3-chapter3-section3-8.md
@@ -1,0 +1,106 @@
+# Stage 3.3 proof-integrity review — Chapter 3 §3.8
+
+## Scope and inherited coverage
+
+This stacked review is based exactly on Stage 3.2 draft PR #8086 at commit
+`520d92715627bd4fd113e67b76dd836d8122561e`. The exact scope is the eight
+contiguous tracker records at indices 162–169, from
+`Chapter3/Introduction_to_3.8` through `Chapter3/Remark3.8.6`. The strict
+predecessor is `Chapter3/Discussion_after_Theorem3.7.1`; the strict successor
+is `Chapter3/Introduction_to_3.9`.
+
+The inherited 29-claim inventory is unchanged: 18 claims are `formalized`, ten
+are `covered_elsewhere`, one heading is `non_formalizable`, and none is a gap.
+All 4,390 lines of the thirteen exact providers were included in this audit:
+`Theorem3_8_1`, `Lemma3_8_2`, `Problem3_8_3`, the eight-file `Problem3_8_4`
+chain, `Problem3_8_5`, and `Remark3_8_6`.
+
+## Durable declaration inventory
+
+The section heading is `not_applicable`; the other seven records are
+`sorry_free`. Their durable `stage3_3.declarations` arrays contain 84 distinct
+public authored declarations. The proof discussion intentionally repeats
+`Etingof.krull_schmidt_uniqueness`, because its source claims are implemented
+inside that shared theorem endpoint. The distinct union still has exactly 84
+names.
+
+The inventory is complete by construction: after excluding private and
+compiler-generated names, its sorted distinct union exactly matches the public
+constants found by exhaustive module-origin enumeration. The public counts are:
+
+- two Theorem 3.8.1 endpoints;
+- two Lemma 3.8.2 endpoints;
+- four arbitrary-field Problem 3.8.3 wrappers;
+- 42 declarations across the complete eight-provider Problem 3.8.4 chain;
+- 29 declarations for the literal continuous-function counterexample; and
+- five finite-length endpoints for Remark 3.8.6.
+
+Private names and generated names are intentionally excluded from the durable
+arrays because they are not stable public API. They were nevertheless included
+in the proof-integrity audit below.
+
+## Exhaustive compiled declaration and axiom audit
+
+The comment-stripped sources contain 102 authored declaration heads: 84 public
+and 18 private. Lean's module-origin data finds 282 compiled constants in the
+same providers, so the audit also covers all 180 compiler-generated proof,
+match, simp, and equation helpers. Per-provider compiled counts are:
+
+- `Lemma3_8_2`: 2; `Theorem3_8_1`: 43; `Problem3_8_3`: 4;
+- `Problem3_8_4`: 15; `Cancellation`: 17; `Descent`: 2; `Finite`: 18;
+- `Functoriality`: 57; `General`: 1; `Main`: 1; `Power`: 22;
+- `Problem3_8_5`: 57; and `Remark3_8_6`: 43.
+
+`Lean.collectAxioms` was run on every one of the 282 constants. The exact
+transitive-axiom distribution is:
+
+- `[propext, Classical.choice, Quot.sound]`: 186;
+- `[propext, Quot.sound]`: 79;
+- `[propext]`: 5; and
+- no axioms: 12.
+
+No constant depends on `sorryAx` or a project-specific axiom. The private
+existence/uniqueness induction and exchange helpers, the cancellation and
+finite-length helpers, and every generated structure proof were therefore all
+checked rather than inferred from the public endpoints.
+
+A comment-stripped source scan finds no `sorry`, `admit`, `proof_wanted`,
+`sorryAx`, `native_decide`, `unsafe`, `axiom`, or source-level `opaque`
+declaration. The one raw occurrence of “opaque” is explanatory prose in a
+comment in `Problem3_8_4_Descent.lean`.
+
+## Completeness and import durability
+
+The complete proof chains terminate in the advertised endpoints: both
+Krull–Schmidt halves, the arbitrary-field wrappers, both general scalar-
+extension descent results, the finite-extension and power-cancellation chain,
+all four counterexample conclusions, and finite-length existence and
+uniqueness. There is no deferred declaration, placeholder, hidden admission,
+or orphaned generated helper.
+
+The thirteen providers have 57 direct import statements. They contain the
+expected earlier local dependencies and Mathlib dependencies; no provider
+imports the Chapter 3 aggregate or a later Chapter 3 section. Imports are
+recorded but intentionally unchanged here: redundancy testing and
+minimization belong to Stage 3.4.
+
+## Validation
+
+- `.lake/build` is worktree-local; only `.lake/packages` links to the shared
+  package cache;
+- all thirteen exact providers build successfully together (8,593 jobs);
+- exhaustive module-origin enumeration and `Lean.collectAxioms`: 282/282
+  constants clean;
+- exact public-declaration completeness comparison: 84/84 distinct names;
+- exact-provider admission/placeholder and direct-import scans: clean;
+- exact eight-item aggregation: seven `sorry_free`, one `not_applicable`;
+- all four repository validators pass;
+- `lake build EtingofRepresentationTheory.Chapter3`: success (8,692 jobs;
+  pre-existing linter warnings only);
+- removing only `stage3_3` from the eight scoped records reproduces the exact
+  Stage 3.2 base;
+- inherited claim coverage, every non-scope tracker field, all dependency maps,
+  and all thirteen provider files are unchanged;
+- `jq empty progress/items.json` and `git diff --check`: pass.
+
+This PR is limited to Chapter 3 §3.8 and Stage 3.3.

--- a/progress/items.json
+++ b/progress/items.json
@@ -2961,6 +2961,14 @@
           "reason": "This item is only a section heading and contains no mathematical assertion beyond naming the following material."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.8",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "not_applicable",
+      "declarations": [],
+      "basis": "This item is only a section heading and has no Lean provider or proof obligation."
     }
   },
   {
@@ -3009,6 +3017,17 @@
           "note": "The exchange construction and sum-to-identity calculation occur in the proof body through the private helper krull_schmidt_find_iso_summand."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.8",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.krull_schmidt_existence",
+        "Etingof.krull_schmidt_uniqueness"
+      ],
+      "basis": "Both public endpoints are admission-free constants. The exhaustive module-origin audit also covers four private authored proof-route helpers and 37 compiler-generated proof, match, and simp constants."
     }
   },
   {
@@ -3061,6 +3080,17 @@
           "note": "This continuation is implemented in the private exchange helper krull_schmidt_find_iso_summand used by the public uniqueness theorem."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.8",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.endo_indecomposable_iso_or_nilpotent",
+        "Etingof.sum_nilpotent_endo_indecomposable"
+      ],
+      "basis": "Both authored lemma endpoints are admission-free constants and have no additional compiler-generated constants in their exact provider module."
     }
   },
   {
@@ -3108,6 +3138,16 @@
           "lean_decl": "Etingof.krull_schmidt_uniqueness"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.8",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.krull_schmidt_uniqueness"
+      ],
+      "basis": "The discussion's complete exchange-and-induction argument is implemented inside the shared uniqueness endpoint. Its private proof-route helpers and generated constants are exhaustively audited on the theorem item."
     }
   },
   {
@@ -3155,6 +3195,19 @@
           "note": "All four wrappers assume only Field k; the underlying proofs use Fitting decomposition instead of generalized eigenspaces."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.8",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Problem3_8_3.endo_iso_or_nilpotent",
+        "Etingof.Problem3_8_3.sum_nilpotent_endo",
+        "Etingof.Problem3_8_3.krull_schmidt_existence",
+        "Etingof.Problem3_8_3.krull_schmidt_uniqueness"
+      ],
+      "basis": "All four arbitrary-field wrapper endpoints are authored, admission-free constants; the exact provider emits no additional generated constants."
     }
   },
   {
@@ -3246,6 +3299,57 @@
           "lean_decl": "Etingof.Problem3_8_4.Descent.exists_fg_subalgebra_baseChange_directSummand; Etingof.Problem3_8_4.directSummand_of_baseChange_directSummand_finite; Etingof.Problem3_8_4.directSummand_pow_cancel"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.8",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Problem3_8_4.rep",
+        "Etingof.Problem3_8_4.repTensor",
+        "Etingof.Problem3_8_4.bcMod",
+        "Etingof.IsIndecomposable.of_linearEquiv",
+        "Etingof.Problem3_8_4.indecDecomp_map",
+        "Etingof.Problem3_8_4.iso_pow_cancel",
+        "Etingof.Problem3_8_4.directSummand_pow_cancel",
+        "Etingof.Problem3_8_4.Descent.exists_fg_subalgebra_baseChange_iso",
+        "Etingof.Problem3_8_4.Descent.exists_fg_subalgebra_baseChange_directSummand",
+        "Etingof.Problem3_8_4.bcRestrictScalars",
+        "Etingof.Problem3_8_4.bcRestrictScalars_apply",
+        "Etingof.Problem3_8_4.iso_of_baseChange_iso_finite",
+        "Etingof.Problem3_8_4.bcRestrictScalarsMap",
+        "Etingof.Problem3_8_4.bcRestrictScalarsMap_apply",
+        "Etingof.Problem3_8_4.directSummand_of_baseChange_directSummand_finite",
+        "Etingof.Problem3_8_4.Functoriality.rep",
+        "Etingof.Problem3_8_4.Functoriality.repTensor",
+        "Etingof.Problem3_8_4.Functoriality.bcMod",
+        "Etingof.Problem3_8_4.Functoriality.bcMod_smul",
+        "Etingof.Problem3_8_4.Functoriality.repTensor_one_tmul_apply",
+        "Etingof.Problem3_8_4.Functoriality.smul_one_tmul",
+        "Etingof.Problem3_8_4.Functoriality.smul_tmul_one",
+        "Etingof.Problem3_8_4.Functoriality.pushEquiv",
+        "Etingof.Problem3_8_4.Functoriality.nonempty_baseChange_iso",
+        "Etingof.Problem3_8_4.Functoriality.pushHom",
+        "Etingof.Problem3_8_4.Functoriality.pushHom_tmul",
+        "Etingof.Problem3_8_4.Functoriality.pushHom_cancelBaseChange",
+        "Etingof.Problem3_8_4.Functoriality.pushHom_comp",
+        "Etingof.Problem3_8_4.Functoriality.pushHom_id",
+        "Etingof.Problem3_8_4.Functoriality.nonempty_baseChange_directSummand",
+        "Etingof.Problem3_8_4.directSummand_of_baseChange_directSummand",
+        "Etingof.Problem3_8_4.iso_of_baseChange_iso",
+        "Etingof.Problem3_8_4.repTensor_one_tmul_apply",
+        "Etingof.Problem3_8_4.toPiLinearEquiv",
+        "Etingof.Problem3_8_4.toPiLinearEquiv_tmul",
+        "Etingof.Problem3_8_4.bcModRestrict",
+        "Etingof.Problem3_8_4.bcModRestrict_smul",
+        "Etingof.Problem3_8_4.bcMod_smul",
+        "Etingof.Problem3_8_4.bcModRestrict_smul_tmul",
+        "Etingof.Problem3_8_4.toPiAlinMap",
+        "Etingof.Problem3_8_4.toPiAlinEquiv",
+        "Etingof.Problem3_8_4.baseChange_alinEquiv_pow"
+      ],
+      "basis": "All 42 public declarations across the eight-provider base-change, cancellation, descent, finite, functoriality, power, and general endpoint chain are admission-free. The exhaustive audit additionally covers nine private authored helpers and 82 compiler-generated proof, match, simp, and equation constants."
     }
   },
   {
@@ -3335,6 +3439,44 @@
           "note": "Products encode binary direct sums; the equivalence is the explicit sine-cosine rotation with a proved inverse."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.8",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.Problem3_8_5.periodicSubalg",
+        "Etingof.Problem3_8_5.antiperiodicSubmod",
+        "Etingof.Problem3_8_5.periodicSubalg_idempotent_eq_zero_or_one",
+        "Etingof.Problem3_8_5.periodic_isIndecomposable",
+        "Etingof.Problem3_8_5.cosπ",
+        "Etingof.Problem3_8_5.sinπ",
+        "Etingof.Problem3_8_5.cosπ_apply",
+        "Etingof.Problem3_8_5.sinπ_apply",
+        "Etingof.Problem3_8_5.cosπ_mem",
+        "Etingof.Problem3_8_5.sinπ_mem",
+        "Etingof.Problem3_8_5.cosπ_sq_add_sinπ_sq",
+        "Etingof.Problem3_8_5.cM",
+        "Etingof.Problem3_8_5.sM",
+        "Etingof.Problem3_8_5.cM_coe",
+        "Etingof.Problem3_8_5.sM_coe",
+        "Etingof.Problem3_8_5.antiMul",
+        "Etingof.Problem3_8_5.antiMul_coe_apply",
+        "Etingof.Problem3_8_5.smul_apply_coe",
+        "Etingof.Problem3_8_5.antiperiodic_frame_decomp",
+        "Etingof.Problem3_8_5.antiperiodic_isIndecomposable",
+        "Etingof.Problem3_8_5.periodic_not_linearEquiv_antiperiodic",
+        "Etingof.Problem3_8_5.antiMulL",
+        "Etingof.Problem3_8_5.rotInv",
+        "Etingof.Problem3_8_5.rotFwd",
+        "Etingof.Problem3_8_5.rotInv_apply",
+        "Etingof.Problem3_8_5.rotFwd_apply",
+        "Etingof.Problem3_8_5.rotInv_rotFwd",
+        "Etingof.Problem3_8_5.rotFwd_rotInv",
+        "Etingof.Problem3_8_5.periodic_sq_linearEquiv_antiperiodic_sq"
+      ],
+      "basis": "All 29 public declarations supporting the literal continuous-function counterexample are admission-free. The exhaustive audit also covers one private authored helper and 27 generated structure-proof and simplifier constants."
     }
   },
   {
@@ -3384,6 +3526,20 @@
           "lean_decl": "Etingof.krull_schmidt_uniqueness_finiteLength"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.8",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.isNilpotent_or_isUnit_of_finiteLength_indecomposable",
+        "Etingof.isLocalRing_end_of_finiteLength_indecomposable",
+        "Etingof.exists_indecomposable_decomposition",
+        "Etingof.isNilpotent_sum_of_finiteLength_indecomposable",
+        "Etingof.krull_schmidt_uniqueness_finiteLength"
+      ],
+      "basis": "All five public finite-length endpoints are admission-free. Four private authored induction/exchange helpers and 34 generated proof, match, and simp constants were also included in the exhaustive audit."
     }
   },
   {


### PR DESCRIPTION
## Summary

- add Stage 3.3 proof-integrity metadata for the exact eight-item Chapter 3 §3.8 interval
- inventory all 84 distinct public authored declarations across the 13 exact providers
- exhaustively audit all 282 compiled constants, including 18 private authored helpers and 180 compiler-generated helpers
- classify all eight records as complete: seven `sorry_free` and one heading `not_applicable`
- preserve inherited Stage 3.2 claim coverage and every pre-existing tracker field; no Lean source is changed

This is stacked exactly on Stage 3.2 PR #8086 / commit `520d92715627bd4fd113e67b76dd836d8122561e`.

## Stage 3.3 checklist

- [x] enumerate every public authored declaration in every exact provider
- [x] include private declarations and generated proof/match/simp/equation constants in the exhaustive audit
- [x] verify the durable declaration union exactly matches the 84-name public API
- [x] inspect proof-chain completeness and shared discussion endpoints
- [x] scan comment-stripped sources for admissions, placeholders, unsafe declarations, and source axioms
- [x] run `Lean.collectAxioms` on all 282 module-origin constants
- [x] preserve private/generated names outside durable metadata because they are not stable public API
- [x] record direct imports without changing them; minimization remains Stage 3.4 work
- [x] prove strict invariance after removing only the eight new `stage3_3` objects

## Audit result

- source heads: 102 = 84 public + 18 private
- compiled constants: 282 = 102 authored + 180 generated
- axiom distribution: 186 use `[propext, Classical.choice, Quot.sound]`, 79 use `[propext, Quot.sound]`, 5 use `[propext]`, and 12 use none
- no `sorryAx`, project axiom, `sorry`, `admit`, `proof_wanted`, `native_decide`, `unsafe`, source `axiom`, or source-level `opaque`
- durable metadata: 85 declaration entries / 84 distinct names because the proof discussion intentionally shares `Etingof.krull_schmidt_uniqueness` with the theorem item

## Validation

- exact build of all 13 scoped providers: success (8,593 jobs)
- `lake build EtingofRepresentationTheory.Chapter3`: success (8,692 jobs)
- all four repository validators: pass
- `validate_items.py`: 5,721/5,721 source lines, 583 blobs/IDs, 10 derived items
- exact public-declaration completeness comparison: 84/84
- strict tracker, claim-coverage, dependency, and provider-source invariance: pass
- `jq empty progress/items.json` and `git diff --check`: pass
