### PR TITLE
Stage 3.3: audit Chapter 3 section 3.10 proof integrity

### DIFF
--- a/progress/2026-07-27T16-30-47Z_stage3-3-chapter3-section3-10.md
+++ b/progress/2026-07-27T16-30-47Z_stage3-3-chapter3-section3-10.md
@@ -1,0 +1,71 @@
+# Stage 3.3 proof verification — Chapter 3 §3.10
+
+## Scope and result
+
+This pass preserves the exact six-item, four-provider §3.10 scope established by Stage 3.2 at
+commit `a98ea72b8a85ac7bf678b4aa32b7d4c9ba366813`. That audit inventoried 21 claims: 16
+formalized, 2 covered elsewhere, 3 nonformalizable organizational or qualitative statements,
+and no gaps. Stage 3.3 does not change those verdicts, declaration providers, or source files.
+
+Five items are proof-bearing and verified `sorry_free`; the pre-theorem organizational preview
+is `not_applicable`. The durable tracker arrays contain 77 declaration references, representing
+74 unique declarations: all 70 durable authored declarations in the exact providers and four
+external declarations used by the section. Repeated theorem endpoints in the proof discussion
+remain explicit so that each item's proof basis is independently reviewable.
+
+No Lean proof repair, import edit, or source change was required.
+
+## Exhaustive environment audit
+
+A scratch module imported all four exact providers and selected constants by Lean's recorded
+module attribution. This inventories generated and private proof constants that a text-only list
+of top-level commands would miss. It found 152 attributed constants:
+
+- 106 have non-reserved public names, 14 have reserved generated names, and 32 are private;
+- 123 are proof constants (82 non-reserved public, 14 reserved generated, and 27 private);
+- the remaining 29 are definitions; there are no attributed constructors, inductives, recursors,
+  opaque declarations, axioms, or quotients;
+- the 106 non-reserved public constants comprise 70 durable authored declarations, 5 explicit
+  local instance declarations used as implementation or regression scaffolding, and 31
+  elaborator-generated public proof helpers.
+
+The provider totals are:
+
+- `Exercise3_10_1.lean`: 1 constant / 1 proof / 1 durable authored declaration;
+- `Theorem3_10_2.lean`: 30 constants / 28 proofs / 6 durable authored declarations;
+- `TensorProductRadical.lean`: 33 constants / 27 proofs / 24 durable authored declarations;
+- `Remark3_10_3.lean`: 88 constants / 67 proofs / 39 durable authored declarations.
+
+Every attributed constant was passed to `Lean.collectAxioms`, the engine used by
+`#print axioms`. The audit fails on a direct project axiom or any dependency outside `propext`,
+`Classical.choice`, and `Quot.sound`; it passed. The four external declarations
+`Algebra.TensorProduct.tmul_mul_tmul`, `isSimpleModule_self_iff_isUnit`,
+`Etingof.density_theorem_part1`, and `Algebra.TensorProduct.lift` were separately resolved and
+audited with the same rule. Thus no scoped endpoint or provider-attributed constant contains
+`sorryAx` or a project axiom.
+
+The source-level scan likewise found no `sorry`, `admit`, `proof_wanted`, `sorryAx`,
+`native_decide`, project `axiom`, or `opaque` declaration in the four providers.
+
+## Direct-import audit
+
+All 26 direct imports were reviewed and preserved without minimization: 2 in
+`Exercise3_10_1.lean`, 8 in `Theorem3_10_2.lean`, 1 in `TensorProductRadical.lean`, and 15 in
+`Remark3_10_3.lean`. The provider sources and their import lists are byte-for-byte unchanged
+from the Stage 3.2 base.
+
+## Validation
+
+- exact four-provider build: success (8,588 jobs);
+- full `EtingofRepresentationTheory.Chapter3` build: success;
+- exhaustive attributed-constant and external-declaration axiom audit: success;
+- exact six-item Stage 3.3 tracker audit and JSON parse: success;
+- `scripts/validate_items.py`, `scripts/validate_dependencies.py`,
+  `scripts/validate_external_deps.py`, and `scripts/validate_mathlib_coverage.py`: success;
+- `scripts/verify_blobs.py` remains inapplicable to the repository's derived overlay records: it
+  exits at the first derived record with the pre-existing `KeyError: 'id'`;
+- normalized non-scope tracker projection and scoped records with `stage3_3` removed are unchanged
+  from the exact Stage 3.2 base; dependency metadata and all provider sources are unchanged;
+- only `.lake/packages` is shared, and `git diff --check` passes.
+
+This PR is limited to Chapter 3 §3.10 and Stage 3.3.

--- a/progress/items.json
+++ b/progress/items.json
@@ -4455,6 +4455,16 @@
           "lean_decl": "Algebra.TensorProduct.tmul_mul_tmul"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.10",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Algebra.TensorProduct.tmul_mul_tmul"
+      ],
+      "basis": "The organizational heading is nonformalizable, while the stated pure-tensor multiplication law is supplied by this external Mathlib declaration; that declaration was resolved and its complete axiom closure was audited."
     }
   },
   {
@@ -4490,6 +4500,16 @@
           "lean_decl": "Etingof.matrix_tensorProduct_matrix"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.10",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.matrix_tensorProduct_matrix"
+      ],
+      "basis": "The sole exact-provider constant is this durable authored theorem. It is admission-free and its complete axiom closure contains only Lean's accepted foundational axioms."
     }
   },
   {
@@ -4520,6 +4540,14 @@
           "reason": "This is an organizational preview of Theorem 3.10.2, whose individual mathematical assertions are inventoried on the theorem item."
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.10",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "not_applicable",
+      "declarations": [],
+      "basis": "This item is only an organizational preview of Theorem 3.10.2 and contains no independently auditable proof declaration."
     }
   },
   {
@@ -4564,6 +4592,21 @@
           "lean_decl": "Etingof.tensor_product_irreducible_classification_unique"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.10",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.tensor_product_irreducible",
+        "evalMap",
+        "evalMap_tmul",
+        "Etingof.tensor_product_irreducible_classification",
+        "Etingof.tensor_left_factor_unique",
+        "Etingof.tensor_product_irreducible_classification_unique"
+      ],
+      "basis": "These are all six durable authored declarations in the exact provider. The exhaustive environment audit also checked all 30 provider-attributed constants (28 proofs), including local regression instances and generated/private helpers; every proof is admission-free and depends only on accepted foundational axioms."
     }
   },
   {
@@ -4604,6 +4647,55 @@
           "lean_decl": "EtingofRepresentationTheory.Chapter3.Remark3_10_3.ratFunc_tensor_ratFunc_not_isField; isSimpleModule_self_iff_isUnit"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.10",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.ratFunc_tensor_ratFunc_not_isField",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.WeylCounterexampleModule",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.mulVar",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.pderivEnd",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.firstX",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.firstY",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.secondX",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.secondY",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.first_weyl_relation",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.second_weyl_relation",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.firstX_secondX_commute",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.firstX_secondY_commute",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.firstY_secondX_commute",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.firstY_secondY_commute",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.firstRep",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.secondRep",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.firstRep_secondRep_commute",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.tensorRep",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.tensorModule",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.tensorRep_tmul",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.firstRep_x",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.firstRep_y",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.secondRep_x",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.secondRep_y",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.entangled_generator_relations",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.tensorModule_isSimpleModule",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.tensorRep_not_factors_finiteDimensional",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.regularLinearEquiv",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.regularLinearEquiv_monomial",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.firstOrbit",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.firstOrbit_monomial",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.regularLinearEquiv_eq_firstOrbit",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.firstRestrictionModule",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.regularModuleEquiv",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.regularModuleEquiv_apply",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.noSimpleRegularSubmodule_of_noLeftInverse",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.weylY_noLeftInverse",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.regularWeyl_noSimpleSubmodule",
+        "EtingofRepresentationTheory.Chapter3.Remark3_10_3.tensorModule_not_equiv_tensorProduct_of_simple_left",
+        "isSimpleModule_self_iff_isUnit"
+      ],
+      "basis": "The list contains all 39 durable authored exact-provider declarations and the external self-module simplicity bridge used by the rational-function counterexample. The exhaustive audit covered all 88 provider-attributed constants (67 proofs), including generated/private helpers, and found no admissions or non-foundational axioms."
     }
   },
   {
@@ -4691,6 +4783,44 @@
           "lean_decl": "Etingof.tensor_product_irreducible_classification_unique"
         }
       ]
+    },
+    "stage3_3": {
+      "status": "complete",
+      "section": "3.10",
+      "verified_on": "2026-07-27",
+      "proof_integrity": "sorry_free",
+      "declarations": [
+        "Etingof.tensorRadQuot",
+        "Etingof.radTensorLeft",
+        "Etingof.radTensorRight",
+        "Etingof.radTensorSum",
+        "Etingof.tensorRadQuot_tmul",
+        "Etingof.tensorRadQuot_surjective",
+        "Etingof.radTensorSum_eq_ker",
+        "Etingof.instIsTwoSidedTensorProductRadTensorSum",
+        "Etingof.quotientRadTensorSumEquiv",
+        "Etingof.le_jacobson_of_isNilpotent",
+        "Etingof.map_includeLeft_mul_le",
+        "Etingof.map_includeLeft_pow_le",
+        "Etingof.isNilpotent_radTensorLeft",
+        "Etingof.map_includeRight_mul_le",
+        "Etingof.map_includeRight_pow_le",
+        "Etingof.isNilpotent_radTensorRight",
+        "Etingof.radTensorSum_le_jacobson",
+        "Etingof.isNilpotent_radTensorSum",
+        "Etingof.jacobson_le_radTensorSum",
+        "Etingof.exists_algEquiv_pi_matrix",
+        "Etingof.isSemisimpleRing_tensorProduct",
+        "Etingof.jacobson_tensorProduct_eq",
+        "Etingof.quotientJacobsonTensorEquiv",
+        "Etingof.jacobson_tensorProduct_range_eq",
+        "Etingof.density_theorem_part1",
+        "Etingof.tensor_product_irreducible",
+        "Algebra.TensorProduct.lift",
+        "Etingof.tensor_product_irreducible_classification",
+        "Etingof.tensor_product_irreducible_classification_unique"
+      ],
+      "basis": "The first 24 entries are every durable authored declaration in the exact radical provider; the remaining entries are the audited density, tensor-action, classification, uniqueness, and tensor-lift endpoints used by the proof discussion. All 33 exact-provider constants and all external endpoints were checked for complete axiom closure, with no admissions or non-foundational axioms."
     }
   },
   {


### PR DESCRIPTION
## Summary

- record Stage 3.3 proof-integrity metadata for the exact six-item Chapter 3 §3.10 scope
- inventory all 70 durable authored declarations and four external proof endpoints
- audit all 152 exact-provider attributed constants, including generated/private helpers, with no admissions or non-foundational axioms
- preserve all provider sources and 26 direct imports unchanged

## Validation

- `lake build Exercise3_10_1 Theorem3_10_2 TensorProductRadical Remark3_10_3`
- `lake build EtingofRepresentationTheory.Chapter3`
- exhaustive exact-provider attribution and axiom audit
- all four maintained repository validators
- strict scoped/non-scoped invariance against `a98ea72b8a85ac7bf678b4aa32b7d4c9ba366813`
- `git diff --check`

Stacked on Stage 3.2 draft PR #8088.