### PR TITLE
Stage 3.4: trim Chapter 3 section 3.8 dependencies

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/Problem3_8_4.lean
+++ b/EtingofRepresentationTheory/Chapter3/Problem3_8_4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-import EtingofRepresentationTheory.Chapter3.Problem3_8_3
 
 /-!
 # Problem 3.8.4: scalar extension and the Noether-Deuring theorem

--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -483,29 +483,26 @@
   "Chapter3/Discussion_after_Theorem3.7.1": [
     "Chapter3/Theorem3.7.1"
   ],
-  "Chapter3/Introduction_to_3.8": [
-    "Chapter3/Discussion_after_Theorem3.7.1"
-  ],
+  "Chapter3/Introduction_to_3.8": [],
   "Chapter3/Theorem3.8.1": [
-    "Chapter3/Introduction_to_3.8"
+    "Chapter2/Definition2.3.8"
   ],
   "Chapter3/Lemma3.8.2": [
-    "Chapter3/Theorem3.8.1"
+    "Chapter2/Definition2.3.8"
   ],
-  "Chapter3/Discussion_proof_of_Theorem3.8.1": [
-    "Chapter3/Lemma3.8.2"
-  ],
+  "Chapter3/Discussion_proof_of_Theorem3.8.1": [],
   "Chapter3/Problem3.8.3": [
-    "Chapter3/Discussion_proof_of_Theorem3.8.1"
+    "Chapter3/Theorem3.8.1",
+    "Chapter3/Lemma3.8.2"
   ],
   "Chapter3/Problem3.8.4": [
     "Chapter3/Problem3.8.3"
   ],
   "Chapter3/Problem3.8.5": [
-    "Chapter3/Problem3.8.4"
+    "Chapter2/Definition2.3.8"
   ],
   "Chapter3/Remark3.8.6": [
-    "Chapter3/Problem3.8.5"
+    "Chapter2/Definition2.3.8"
   ],
   "Chapter3/Introduction_to_3.9": [
     "Chapter3/Remark3.8.6"

--- a/progress/2026-07-27T16-39-01Z_stage3-4-chapter3-section3-8.md
+++ b/progress/2026-07-27T16-39-01Z_stage3-4-chapter3-section3-8.md
@@ -1,0 +1,100 @@
+# Stage 3.4 dependency audit — Chapter 3 §3.8
+
+## Scope
+
+This review is stacked exactly on Stage 3.3 draft PR #8090 at commit
+`4111d2c80cb486353e6ef482616303ed680daec1`. It covers the same eight
+reading-order records at indices 162–169 and all thirteen exact providers. The
+strict predecessor is `Chapter3/Discussion_after_Theorem3.7.1`; the strict
+successor is `Chapter3/Introduction_to_3.9`.
+
+No definition, theorem statement, proof body, or inherited Stage 3.2/3.3
+metadata changed. This pass is limited to a proven direct-import removal,
+actual internal dependency edges, and durable `stage3_4` records.
+
+## Independent direct-import tests
+
+The thirteen providers initially contain 57 direct import statements. Every
+line was tested independently by omitting only that line and re-elaborating the
+complete provider with `lake env lean /dev/stdin`. The result is exact:
+
+- 56 omissions fail elaboration, so those imports are retained;
+- one omission succeeds:
+  `Problem3_8_4.lean` does not need its direct import of `Problem3_8_3`.
+
+Only that proven-redundant line was removed, taking the direct-import count from
+57 to 56. The base setup provider still requires its `Mathlib` import. The
+separate cancellation provider still requires `Problem3_8_3` for the arbitrary-
+field Krull–Schmidt results, so the cross-item dependency remains represented
+at the Problem 3.8.4 item.
+
+Removing import lines from the base and final versions makes every provider
+body byte-for-byte identical. Thus the edit changes neither mathematical
+content nor any declaration body.
+
+## Exact provider graph
+
+After trimming, the providers have 17 retained direct project-import edges.
+They split into:
+
+- seven backward cross-item edges represented in the tracker graph;
+- nine intra-item edges connecting the eight-file Problem 3.8.4 implementation;
+- one forward implementation edge from `Theorem3_8_1` to the later
+  `Lemma3_8_2` provider.
+
+The Problem 3.8.4 intra-item chain is exact: cancellation imports Problem 3.8.3;
+descent imports functoriality; finite imports power and cancellation; general
+imports finite, functoriality, and descent; main imports finite and descent; and
+power imports the base setup provider. The base setup and functoriality
+providers import no project module.
+
+The theorem-to-lemma import reflects proof order: the theorem is stated before
+the lemma in the book, while its Lean proof uses the following lemma. As in the
+repository's earlier Stage 3.4 audits, this forward implementation edge is
+documented here but excluded from the acyclic backward pedagogical graph.
+
+## Actual item dependency graph
+
+The eight conservative reading-order edges are replaced by seven actual
+backward edges:
+
+1. Theorem 3.8.1 → Definition 2.3.8;
+2. Lemma 3.8.2 → Definition 2.3.8;
+3. Problem 3.8.3 → Theorem 3.8.1;
+4. Problem 3.8.3 → Lemma 3.8.2;
+5. Problem 3.8.4 → Problem 3.8.3;
+6. Problem 3.8.5 → Definition 2.3.8;
+7. Remark 3.8.6 → Definition 2.3.8.
+
+The heading has no provider. The proof discussion has no provider separate
+from the shared theorem endpoint. Intra-item provider edges collapse at item
+granularity. The repository graph therefore moves from 582 to 581 edges. Every
+retained item edge points strictly backward, and every scoped
+`actual_internal_dependencies` array agrees exactly with
+`dependencies/internal.json`.
+
+## Durable tracker result
+
+- all eight exact records have complete section `3.8` `stage3_4` objects;
+- inherited workflow status, claim coverage, Stage 3.2, Stage 3.3, fidelity,
+  and proof-integrity metadata are unchanged;
+- the normalized non-§3.8 tracker projection and non-§3.8 dependency-source
+  projection are unchanged;
+- external-dependency and Mathlib-coverage maps are unchanged.
+
+## Validation
+
+- all thirteen providers build successfully one at a time;
+- the exact thirteen-provider aggregate builds successfully (8,593 jobs);
+- the complete 57-case independent omission matrix has 56 required imports and
+  one proven redundancy;
+- direct-import count: 57 → 56 (`-1`); repository graph: 582 → 581 (`-1`);
+- exact eight-item tracker/graph agreement and backward-edge checks: pass;
+- provider-body invariance after stripping imports: pass for all thirteen;
+- item, dependency, external-dependency, and Mathlib-coverage validators: pass;
+- `lake build EtingofRepresentationTheory.Chapter3`: success (8,692 jobs;
+  pre-existing linter warnings only);
+- scoped/non-scoped tracker and dependency invariance, JSON parsing, and
+  `git diff --check`: pass.
+
+This PR is limited to Chapter 3 §3.8 and Stage 3.4.

--- a/progress/items.json
+++ b/progress/items.json
@@ -2969,6 +2969,13 @@
       "proof_integrity": "not_applicable",
       "declarations": [],
       "basis": "This item is only a section heading and has no Lean provider or proof obligation."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.8",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "This item is an organizational heading with no Lean provider, so it has no actual internal dependency."
     }
   },
   {
@@ -3028,6 +3035,15 @@
         "Etingof.krull_schmidt_uniqueness"
       ],
       "basis": "Both public endpoints are admission-free constants. The exhaustive module-origin audit also covers four private authored proof-route helpers and 37 compiler-generated proof, match, and simp constants."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.8",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Definition2.3.8"
+      ],
+      "basis": "The provider retains Definition2_3_8 for the indecomposability predicate. Its direct import of the later Lemma 3.8.2 provider is a forward proof-order edge, excluded from the acyclic backward pedagogical graph and recorded in the Stage 3.4 audit note."
     }
   },
   {
@@ -3091,6 +3107,15 @@
         "Etingof.sum_nilpotent_endo_indecomposable"
       ],
       "basis": "Both authored lemma endpoints are admission-free constants and have no additional compiler-generated constants in their exact provider module."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.8",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Definition2.3.8"
+      ],
+      "basis": "The provider's only project import is Definition2_3_8, which supplies the indecomposability predicate used by both lemma endpoints."
     }
   },
   {
@@ -3148,6 +3173,13 @@
         "Etingof.krull_schmidt_uniqueness"
       ],
       "basis": "The discussion's complete exchange-and-induction argument is implemented inside the shared uniqueness endpoint. Its private proof-route helpers and generated constants are exhaustively audited on the theorem item."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.8",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "This discussion has no provider of its own; its proof is contained in the shared Theorem 3.8.1 endpoint, so it introduces no direct provider dependency edge."
     }
   },
   {
@@ -3208,6 +3240,16 @@
         "Etingof.Problem3_8_3.krull_schmidt_uniqueness"
       ],
       "basis": "All four arbitrary-field wrapper endpoints are authored, admission-free constants; the exact provider emits no additional generated constants."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.8",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter3/Theorem3.8.1",
+        "Chapter3/Lemma3.8.2"
+      ],
+      "basis": "The wrapper provider directly retains both exact theorem and lemma providers; all four arbitrary-field wrappers cite their declarations."
     }
   },
   {
@@ -3350,6 +3392,15 @@
         "Etingof.Problem3_8_4.baseChange_alinEquiv_pow"
       ],
       "basis": "All 42 public declarations across the eight-provider base-change, cancellation, descent, finite, functoriality, power, and general endpoint chain are admission-free. The exhaustive audit additionally covers nine private authored helpers and 82 compiler-generated proof, match, simp, and equation constants."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.8",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter3/Problem3.8.3"
+      ],
+      "basis": "The cancellation provider retains Problem3_8_3 for arbitrary-field Krull-Schmidt. All other project imports in the eight-provider chain are intra-item edges; the unused Problem3_8_3 import in the base setup provider was removed after an isolated omission test."
     }
   },
   {
@@ -3477,6 +3528,15 @@
         "Etingof.Problem3_8_5.periodic_sq_linearEquiv_antiperiodic_sq"
       ],
       "basis": "All 29 public declarations supporting the literal continuous-function counterexample are admission-free. The exhaustive audit also covers one private authored helper and 27 generated structure-proof and simplifier constants."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.8",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Definition2.3.8"
+      ],
+      "basis": "The counterexample provider's sole project import is Definition2_3_8, which supplies the indecomposability predicate used by both module endpoints."
     }
   },
   {
@@ -3540,6 +3600,15 @@
         "Etingof.krull_schmidt_uniqueness_finiteLength"
       ],
       "basis": "All five public finite-length endpoints are admission-free. Four private authored induction/exchange helpers and 34 generated proof, match, and simp constants were also included in the exhaustive audit."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.8",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Definition2.3.8"
+      ],
+      "basis": "The finite-length provider's sole project import is Definition2_3_8, which supplies the shared indecomposability predicate. It has no direct provider edge to the separate Problem 3.8.5 counterexample."
     }
   },
   {


### PR DESCRIPTION
## Summary

- add complete Stage 3.4 dependency metadata for the exact eight-item Chapter 3 §3.8 interval
- independently omit and re-elaborate every one of the 57 original direct provider imports
- remove the sole proven redundancy: the unused `Problem3_8_3` import from the base `Problem3_8_4` setup provider
- replace eight conservative reading-order graph edges with seven actual backward dependencies
- preserve every definition, statement, proof body, claim-coverage record, and Stage 3.2/3.3 field

This is stacked exactly on Stage 3.3 PR #8090 / commit `4111d2c80cb486353e6ef482616303ed680daec1`.

## Stage 3.4 checklist

- [x] test all 57 direct imports independently by one-line omission and complete provider re-elaboration
- [x] retain all 56 imports whose omission fails elaboration
- [x] remove only the single import whose omission succeeds
- [x] derive all 17 retained direct project-provider edges
- [x] classify those edges as seven backward cross-item, nine intra-item, and one forward implementation edge
- [x] document the theorem-to-later-lemma proof-order edge while excluding it from the acyclic backward book graph
- [x] collapse intra-item Problem 3.8.4 provider edges at item granularity
- [x] make all eight tracker dependency arrays agree exactly with `dependencies/internal.json`
- [x] preserve non-scope tracker and graph state
- [x] verify every provider body is byte-identical after stripping imports

## Result

- direct imports: 57 → 56 (`-1`)
- scoped item edges: 8 → 7 (`-1`)
- repository graph edges: 582 → 581 (`-1`)
- all eight scoped `stage3_4` records complete
- only Lean-source change: one unused import line; no declaration body changes

## Validation

- every one of the 13 providers builds successfully in isolation
- exact 13-provider aggregate: success (8,593 jobs)
- `lake build EtingofRepresentationTheory.Chapter3`: success (8,692 jobs)
- all four repository validators: pass
- `validate_items.py`: 5,721/5,721 source lines, 583 blobs/IDs, 10 derived items
- exact tracker/graph agreement and backward-edge audit: pass
- tracker, graph, claim-metadata, external-map, Mathlib-map, and provider-body invariance: pass
- `jq empty` and `git diff --check`: pass
