### PR TITLE
Stage 3.4: trim Chapter 3 section 3.10 dependencies

### DIFF
--- a/EtingofRepresentationTheory/Chapter3/Remark3_10_3.lean
+++ b/EtingofRepresentationTheory/Chapter3/Remark3_10_3.lean
@@ -1,18 +1,10 @@
-import Mathlib.RingTheory.TensorProduct.Maps
 import Mathlib.FieldTheory.RatFunc.AsPolynomial
-import Mathlib.FieldTheory.RatFunc.Basic
-import Mathlib.RingTheory.Algebraic.Basic
 import Mathlib.Data.Complex.Basic
-import Mathlib.Algebra.MvPolynomial.PDeriv
 import Mathlib.Algebra.Polynomial.Bivariate
 import Mathlib.RingTheory.Derivation.Lie
-import Mathlib.RingTheory.SimpleModule.Basic
 import Mathlib.RingTheory.MvPolynomial
-import Mathlib.LinearAlgebra.Basis.Basic
-import Mathlib.Algebra.BigOperators.Finsupp.Fin
 import EtingofRepresentationTheory.Chapter2.WeylAlgebraUniversal
 import EtingofRepresentationTheory.Chapter2.WeylAlgebraDomain
-import Mathlib.LinearAlgebra.Dual.Lemmas
 
 /-!
 # Remark 3.10.3: Failure of Theorem 3.10.2 for infinite dimensional representations

--- a/EtingofRepresentationTheory/Chapter3/TensorProductRadical.lean
+++ b/EtingofRepresentationTheory/Chapter3/TensorProductRadical.lean
@@ -1,4 +1,7 @@
-import Mathlib
+import Mathlib.Tactic.NoncommRing
+import Mathlib.FieldTheory.PurelyInseparable.Basic
+import Mathlib.RingTheory.SimpleModule.WedderburnArtin
+import Mathlib.RingTheory.TensorProduct.Pi
 
 /-!
 # The Jacobson radical of a tensor product of algebras

--- a/EtingofRepresentationTheory/Chapter3/Theorem3_10_2.lean
+++ b/EtingofRepresentationTheory/Chapter3/Theorem3_10_2.lean
@@ -1,10 +1,3 @@
-import Mathlib.RingTheory.SimpleModule.Basic
-import Mathlib.LinearAlgebra.FiniteDimensional.Defs
-import Mathlib.RingTheory.TensorProduct.Basic
-import Mathlib.Algebra.Algebra.Tower
-import Mathlib.LinearAlgebra.TensorProduct.Basis
-import Mathlib.RingTheory.Artinian.Module
-import Mathlib.Algebra.Polynomial.AlgebraMap
 import EtingofRepresentationTheory.Chapter3.Theorem3_2_2
 
 /-!

--- a/dependencies/internal.json
+++ b/dependencies/internal.json
@@ -525,23 +525,20 @@
   "Chapter3/Problem3.9.5": [
     "Chapter3/Problem3.9.4"
   ],
-  "Chapter3/Introduction_to_3.10": [
-    "Chapter3/Problem3.9.5"
-  ],
-  "Chapter3/Exercise3.10.1": [
-    "Chapter3/Introduction_to_3.10"
-  ],
-  "Chapter3/Discussion_before_Theorem3.10.2": [
-    "Chapter3/Exercise3.10.1"
-  ],
+  "Chapter3/Introduction_to_3.10": [],
+  "Chapter3/Exercise3.10.1": [],
+  "Chapter3/Discussion_before_Theorem3.10.2": [],
   "Chapter3/Theorem3.10.2": [
-    "Chapter3/Discussion_before_Theorem3.10.2"
+    "Chapter3/Theorem3.2.2"
   ],
   "Chapter3/Remark3.10.3": [
-    "Chapter3/Theorem3.10.2"
+    "Chapter2/Discussion_2.7_intro",
+    "Chapter2/Proposition2.7.1",
+    "Chapter2/Remark2.7.2"
   ],
   "Chapter3/Discussion_proof_of_Theorem3.10.2": [
-    "Chapter3/Remark3.10.3"
+    "Chapter3/Theorem3.2.2",
+    "Chapter3/Theorem3.10.2"
   ],
   "Chapter4/Introduction": [
     "Chapter3/Discussion_proof_of_Theorem3.10.2"

--- a/progress/2026-07-27T16-47-04Z_stage3-4-chapter3-section3-10.md
+++ b/progress/2026-07-27T16-47-04Z_stage3-4-chapter3-section3-10.md
@@ -1,0 +1,67 @@
+# Stage 3.4 dependency trimming — Chapter 3 §3.10
+
+## Scope
+
+This pass analyzes the exact six §3.10 catalog items after Stage 3.3: the section heading,
+Exercise 3.10.1, the preview and statement of Theorem 3.10.2, Remark 3.10.3, and the theorem's
+proof discussion. Their four direct providers and all Stage 3.2 and Stage 3.3 records are
+preserved.
+
+## Internal dependency result
+
+The six conservative reading-order edges were replaced by declaration-backed dependencies:
+
+- the section heading, matrix-algebra exercise, and organizational theorem preview use no earlier
+  project item;
+- Theorem 3.10.2 depends on `Chapter3/Theorem3.2.2`, whose
+  `Etingof.density_theorem_part1` is invoked by its irreducibility and classification proofs;
+- Remark 3.10.3 depends on `Chapter2/Discussion_2.7_intro`,
+  `Chapter2/Proposition2.7.1`, and `Chapter2/Remark2.7.2` for the Weyl-algebra presentation and
+  relations, the PBW basis and domain infrastructure, and the polynomial differential-operator
+  representation used in its counterexample;
+- the proof discussion depends on `Chapter3/Theorem3.2.2` and
+  `Chapter3/Theorem3.10.2`, because its recorded endpoints explicitly reuse the density theorem
+  and Theorem 3.10.2's irreducibility, classification, and uniqueness declarations.
+
+The exact scoped graph therefore has six actual edges. The graph metadata and each item's
+`stage3_4.actual_internal_dependencies` array agree exactly. All six items now have complete
+Stage 3.4 records and top-level status `dependency_trimmed`.
+
+## Import trimming
+
+Every one of the original 26 direct imports was removed independently from an otherwise unchanged
+provider and the full provider source was re-elaborated. The two Exercise 3.10.1 imports, the
+Theorem 3.2.2 project import, all seven semantically focused Remark 3.10.3 imports, and the
+radical provider's original umbrella could not be dropped without replacement. Seven direct
+Mathlib imports in `Theorem3_10_2.lean` and eight in `Remark3_10_3.lean` were proven redundant
+and removed.
+
+The cumulative `minImports` linter was then run across `TensorProductRadical.lean`; it identified
+the `Mathlib` umbrella as unneeded and supplied a focused candidate header. Each candidate was
+again tested independently, six transitively covered suggestions were discarded, and the final
+provider retains four necessary imports: `Mathlib.Tactic.NoncommRing`,
+`Mathlib.FieldTheory.PurelyInseparable.Basic`,
+`Mathlib.RingTheory.SimpleModule.WedderburnArtin`, and
+`Mathlib.RingTheory.TensorProduct.Pi`.
+
+The final four providers have 14 direct imports in total (2 / 1 / 4 / 7). Every final import fails
+an independent removal elaboration, and a final `#redundant_imports` run reports no transitively
+redundant import in any provider. Only import headers changed; all declaration and proof bodies are
+byte-for-byte unchanged.
+
+## Validation
+
+- fresh exact-provider baseline build before trimming: success (8,588 jobs);
+- post-trim exact-provider build: success (2,481 jobs with the focused import closure);
+- full `EtingofRepresentationTheory.Chapter3` build: success (8,693 jobs);
+- independent original-import and final-import removal elaborations, cumulative `minImports`, and
+  final `#redundant_imports` checks: success;
+- `scripts/validate_items.py`, `scripts/validate_dependencies.py`,
+  `scripts/validate_external_deps.py`, and `scripts/validate_mathlib_coverage.py`: success;
+- `scripts/verify_blobs.py` remains inapplicable to the repository's derived overlay records and
+  exits at the first such record with the pre-existing `KeyError: 'id'`;
+- exact six-item tracker/graph agreement, provider-body invariance, normalized prior-stage and
+  non-scope tracker invariance, and non-scope dependency-graph invariance: success;
+- `jq empty dependencies/internal.json progress/items.json` and `git diff --check`: success.
+
+This PR is limited to Chapter 3 §3.10 and Stage 3.4.

--- a/progress/items.json
+++ b/progress/items.json
@@ -4430,7 +4430,7 @@
     "end_page": "59",
     "start_line": 5,
     "end_line": 8,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -4465,6 +4465,13 @@
         "Algebra.TensorProduct.tmul_mul_tmul"
       ],
       "basis": "The organizational heading is nonformalizable, while the stated pure-tensor multiplication law is supplied by this external Mathlib declaration; that declaration was resolved and its complete axiom closure was audited."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.10",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The heading is organizational and its only mathematical setup law is supplied externally by Mathlib, so it uses no earlier project item."
     }
   },
   {
@@ -4475,7 +4482,7 @@
     "end_page": "59",
     "start_line": 9,
     "end_line": 10,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "sorry_free": true,
     "coverage_note": "Coverage-arm audit (Stage 3.7, #7371): covered_full. Chapter3/Exercise3_10_1.lean (sorry-free on origin/main, 0 sorries) proves matrix_tensorProduct_matrix: Nonempty ((Mat_m(k) ⊗[k] Mat_n(k)) ≃ₐ[k] Mat_{mn}(k)), a genuine k-ALGEBRA isomorphism (≃ₐ[k], not merely k-linear or ring), built from Matrix.kroneckerTMulAlgEquiv, Algebra.TensorProduct.rid and Matrix.reindexAlgEquiv along finProdFinEquiv (Fin m × Fin n ≃ Fin (m*n)). Faithful to the book's Mat_m(k) ⊗ Mat_n(k) ≅ Mat_{mn}(k); in fact strengthened from the book's field k to an arbitrary CommRing k.",
     "fidelity": "verified",
@@ -4510,6 +4517,13 @@
         "Etingof.matrix_tensorProduct_matrix"
       ],
       "basis": "The sole exact-provider constant is this durable authored theorem. It is admission-free and its complete axiom closure contains only Lean's accepted foundational axioms."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.10",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "The matrix-algebra tensor-product equivalence is constructed directly from focused Mathlib matrix and tensor-product APIs; its provider imports no project module."
     }
   },
   {
@@ -4520,7 +4534,7 @@
     "end_page": "59",
     "start_line": 11,
     "end_line": 12,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage_swept": {
       "wave": 1,
       "result": "none"
@@ -4548,6 +4562,13 @@
       "proof_integrity": "not_applicable",
       "declarations": [],
       "basis": "This item is only an organizational preview of Theorem 3.10.2 and contains no independently auditable proof declaration."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.10",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [],
+      "basis": "This is an organizational preview rather than a mathematical assertion, so it has no declaration-backed project dependency."
     }
   },
   {
@@ -4558,7 +4579,7 @@
     "end_page": "59",
     "start_line": 13,
     "end_line": 16,
-    "status": "partially_proved",
+    "status": "dependency_trimmed",
     "fidelity": "partial",
     "notes": "All sorries resolved. Uniqueness of V, W (Theorem 3.10.2(ii)'s '**unique** V and W') added as companion theorem Etingof.tensor_product_irreducible_classification_unique (#5614). Algebra-finiteness assumptions [FiniteDimensional k A]/[FiniteDimensional k B] removed as unfaithful (#7391): the book assumes only the representations V/W/M are finite-dimensional.",
     "sorry_free": true,
@@ -4607,6 +4628,15 @@
         "Etingof.tensor_product_irreducible_classification_unique"
       ],
       "basis": "These are all six durable authored declarations in the exact provider. The exhaustive environment audit also checked all 30 provider-attributed constants (28 proofs), including local regression instances and generated/private helpers; every proof is admission-free and depends only on accepted foundational axioms."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.10",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter3/Theorem3.2.2"
+      ],
+      "basis": "The irreducibility and classification proofs invoke Etingof.density_theorem_part1 from Theorem 3.2.2. All seven former direct Mathlib imports were proven redundant against that required project provider and removed."
     }
   },
   {
@@ -4617,7 +4647,7 @@
     "end_page": "59",
     "start_line": 17,
     "end_line": 18,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage": "covered_full",
     "fidelity_note": "Both counterexamples are formalized: ratFunc_tensor_ratFunc_not_isField proves the rational-function failure of part (i), while tensorModule_isSimpleModule and tensorModule_not_equiv_tensorProduct_of_simple_left prove the Weyl-algebra failure of the infinite-dimensional analogue of Theorem 3.10.2(ii). The latter uses the characteristic-free PBW domain theorem Etingof.WeylAlgebra.mul_ne_zero to show that the regular first-factor restriction has no simple submodule.",
     "fidelity_decl": "EtingofRepresentationTheory.Chapter3.Remark3_10_3.tensorModule_not_equiv_tensorProduct_of_simple_left",
@@ -4696,6 +4726,17 @@
         "isSimpleModule_self_iff_isUnit"
       ],
       "basis": "The list contains all 39 durable authored exact-provider declarations and the external self-module simplicity bridge used by the rational-function counterexample. The exhaustive audit covered all 88 provider-attributed constants (67 proofs), including generated/private helpers, and found no admissions or non-foundational axioms."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.10",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter2/Discussion_2.7_intro",
+        "Chapter2/Proposition2.7.1",
+        "Chapter2/Remark2.7.2"
+      ],
+      "basis": "The Weyl counterexample directly uses the Weyl-algebra presentation and relations, the PBW basis/domain infrastructure, and the polynomial differential-operator representation from these three Chapter 2 items. Eight redundant Mathlib imports were removed; the two required Weyl support providers remain."
     }
   },
   {
@@ -4706,7 +4747,7 @@
     "end_page": "60",
     "start_line": 19,
     "end_line": 7,
-    "status": "sorry_free",
+    "status": "dependency_trimmed",
     "coverage_swept": {
       "wave": 1,
       "result": "gap"
@@ -4821,6 +4862,16 @@
         "Etingof.tensor_product_irreducible_classification_unique"
       ],
       "basis": "The first 24 entries are every durable authored declaration in the exact radical provider; the remaining entries are the audited density, tensor-action, classification, uniqueness, and tensor-lift endpoints used by the proof discussion. All 33 exact-provider constants and all external endpoints were checked for complete axiom closure, with no admissions or non-foundational axioms."
+    },
+    "stage3_4": {
+      "status": "complete",
+      "section": "3.10",
+      "verified_on": "2026-07-27",
+      "actual_internal_dependencies": [
+        "Chapter3/Theorem3.2.2",
+        "Chapter3/Theorem3.10.2"
+      ],
+      "basis": "The proof discussion explicitly reuses the earlier density theorem and the irreducibility, classification, and uniqueness endpoints of Theorem 3.10.2. Its radical provider itself uses only focused external imports."
     }
   },
   {


### PR DESCRIPTION
## Summary

- replace six conservative §3.10 reading-order edges with six declaration-backed dependencies
- remove 15 proven-redundant direct imports
- replace `TensorProductRadical.lean`'s `Mathlib` umbrella with four independently necessary focused imports
- add complete Stage 3.4 metadata for the exact six-item scope
- preserve all declaration and proof bodies byte-for-byte

## Validation

- independent removal test for every original and final direct import
- cumulative `minImports` and final `#redundant_imports` on every provider
- exact-provider build and full `EtingofRepresentationTheory.Chapter3` build
- all four maintained repository validators
- exact graph/tracker agreement and strict provider-body, prior-stage, non-scope tracker, and non-scope graph invariance
- `jq empty` and `git diff --check`

Stacked on Stage 3.3 draft PR #8092.