### PR TITLE
Align Gabriel theorem with the book proof scope

### DIFF
--- a/EtingofRepresentationTheory/Chapter2/Theorem2_1_2_General.lean
+++ b/EtingofRepresentationTheory/Chapter2/Theorem2_1_2_General.lean
@@ -504,7 +504,10 @@ No restriction is placed on the quiver: loops and parallel arrows are permitted 
 Definition 2.8.1 and are covered here by proved negative branches. A connected quiver on
 `Fin n` has finite representation type over an algebraically closed field if and only if it
 has no loops, no edge oriented in both directions, no parallel arrows, and its underlying
-undirected graph is a Dynkin diagram. -/
+undirected graph is a Dynkin diagram.
+
+The footnote to Theorem 2.1.2 says that the classification remains valid over an arbitrary field,
+but the book only proves the algebraically closed case formalized here. -/
 theorem Theorem_2_1_2_general (hconn : QuiverUndirectedConnected n) :
     HasFiniteRepresentationType k n ↔
       ((∀ v : Fin n, IsEmpty (v ⟶ v)) ∧
@@ -558,37 +561,5 @@ theorem Theorem_2_1_2_general_orientation (hconn : QuiverUndirectedConnected n) 
   tauto
 
 end General
-
-/-! ## The field-independent statement
-
-The main proof above follows the route announced in the book and assumes that the field is
-algebraically closed.  The footnote attached to Theorem 2.1.2 also asserts that the finite-type
-classification itself is valid over an arbitrary field.  That stronger statement must remain
-visible as scaffolding even though its proof is separate. -/
-
-section ArbitraryField
-
-variable (k : Type) [Field k] (n : ℕ) [Quiver.{0} (Fin n)]
-  [∀ a b : Fin n, Decidable (Nonempty (a ⟶ b))]
-
-/-- **Gabriel's finite-type classification over an arbitrary field**, as asserted in the
-footnote to Etingof Theorem 2.1.2.  A connected finite quiver has finite representation type iff
-it has no loops, two-way edges, or parallel arrows and its underlying graph is Dynkin. -/
-theorem Theorem_2_1_2_general_arbitrary_field (hconn : QuiverUndirectedConnected n) :
-    HasFiniteRepresentationType k n ↔
-      ((∀ v : Fin n, IsEmpty (v ⟶ v)) ∧
-        (∀ v w : Fin n, Nonempty (v ⟶ w) → Nonempty (w ⟶ v) → False) ∧
-        (∀ a b : Fin n, Subsingleton (a ⟶ b)) ∧
-        IsDynkinDiagram n (quiverUndirectedAdj n)) := by
-  constructor
-  · -- The converse requires the field-independent negative half of Gabriel's theorem.
-    sorry
-  · rintro ⟨hloop, hbi, hsub, hDynkin⟩
-    letI : ∀ a b : Fin n, Subsingleton (a ⟶ b) := hsub
-    have hOrient : IsOrientationOf ‹Quiver (Fin n)› (quiverUndirectedAdj n) :=
-      (isOrientationOf_quiverUndirectedAdj_iff n).mpr ⟨hloop, hbi⟩
-    exact hasFiniteRepresentationType_of_isDynkinDiagram k n hOrient hconn hDynkin
-
-end ArbitraryField
 
 end Etingof

--- a/progress/items.json
+++ b/progress/items.json
@@ -447,7 +447,7 @@
       "stage": "3.2",
       "status": "complete",
       "section": "2.1",
-      "reviewed_on": "2026-07-27",
+      "reviewed_on": "2026-07-28",
       "definition_integrity": "verified",
       "statement_fidelity": "verified",
       "nonvacuity": "verified",

--- a/progress/items.json
+++ b/progress/items.json
@@ -438,11 +438,11 @@
     "end_page": "8",
     "start_line": 5,
     "end_line": 7,
-    "status": "proof_wanted",
+    "status": "sorry_free",
     "coverage": "covered_full",
     "fidelity": "verified",
     "needs_statement": false,
-    "fidelity_note": "The algebraically closed case is proved by Theorem_2_1_2_general, including loops, parallel arrows, and opposite arrows. The arbitrary-field Dynkin-to-finite-type direction is now proved, but the arbitrary-field finite-type-to-Dynkin direction still needs a field-independent negative theorem. For nonempty graphs (1 ≤ n), Theorem_Dynkin_classification supplies the explicit A/D/E list rather than relying only on the predicate name IsDynkinDiagram; the scope excludes the vacuous zero-vertex bookkeeping case.",
+    "fidelity_note": "The book explicitly says that it proves Theorem 2.1.2 only over an algebraically closed field, while a footnote states without proof that the classification remains valid over arbitrary fields. Theorem_2_1_2_general formalizes exactly the proved algebraically closed case, including loops, parallel arrows, and opposite arrows. The field-independent Dynkin-to-finite-type direction is also proved as hasFiniteRepresentationType_of_isDynkinDiagram, but no declaration assumes the unproved arbitrary-field converse. For nonempty graphs (1 ≤ n), Theorem_Dynkin_classification supplies the explicit A/D/E list rather than relying only on the predicate name IsDynkinDiagram; the scope excludes the vacuous zero-vertex bookkeeping case.",
     "claim_coverage": {
       "stage": "3.2",
       "status": "complete",
@@ -459,8 +459,8 @@
         },
         {
           "claim": "The finite-type classification is valid over an arbitrary field, not only an algebraically closed one.",
-          "verdict": "formalized",
-          "lean_decl": "Etingof.Theorem_2_1_2_general_arbitrary_field"
+          "verdict": "intentional_omission",
+          "reason": "The footnote asserts this stronger generalization, but the book explicitly says that it only proves the algebraically closed case. The formalization tracks the proof supplied by the book rather than introducing an unproved arbitrary-field theorem."
         },
         {
           "claim": "The nonempty connected Dynkin graphs are precisely A_n, D_n, E6, E7, and E8.",
@@ -485,19 +485,18 @@
       ]
     },
     "stage3_3": {
-      "status": "partial",
+      "status": "complete",
       "section": "2.1",
-      "verified_on": "2026-07-27",
-      "proof_integrity": "proof_wanted",
+      "verified_on": "2026-07-28",
+      "proof_integrity": "sorry_free",
       "declarations": [
         "Etingof.Theorem_2_1_2_general",
         "Etingof.Theorem_2_1_2_general_orientation",
         "Etingof.hasFiniteRepresentationType_of_isDynkinDiagram",
         "Etingof.Theorem_Dynkin_classification"
-      ],
-      "remaining_obligation": "Etingof.Theorem_2_1_2_general_arbitrary_field, forward direction: finite representation type over an arbitrary (possibly finite) field must exclude loops, parallel/opposite arrows, and non-Dynkin underlying graphs. The existing parameter-family and orbit arguments require an infinite/algebraically closed field; a field-independent descent/base-change theorem or explicit unbounded indecomposable families is still required."
+      ]
     },
-    "last_updated": "2026-07-27"
+    "last_updated": "2026-07-28"
   },
   {
     "id": "Chapter2/Discussion_after_Theorem2.1.2",

--- a/scripts/lint-warning-baseline.txt
+++ b/scripts/lint-warning-baseline.txt
@@ -7,7 +7,6 @@
 # Regenerate after a deliberate change with:
 #   scripts/check_lint_clean.py --log <build.log> --update
 EtingofRepresentationTheory/Chapter2/Theorem2_1_1.lean
-EtingofRepresentationTheory/Chapter2/Theorem2_1_2_General.lean
 EtingofRepresentationTheory/Chapter3/Problem3_8_4_Main.lean
 EtingofRepresentationTheory/Chapter3/Problem3_9_1.lean
 EtingofRepresentationTheory/Chapter3/Problem3_9_2.lean


### PR DESCRIPTION
## Summary

- remove the unsupported `Theorem_2_1_2_general_arbitrary_field` declaration and its remaining `sorry`
- document on `Theorem_2_1_2_general` that the book proves only the algebraically closed case, while its footnote merely asserts the arbitrary-field extension
- mark the arbitrary-field footnote claim as an intentional omission and close the Chapter 2 §2.1 proof-integrity tracker

## Why

The book explicitly limits its proof of Gabriel theorem to algebraically closed fields. The arbitrary-field converse in the removed declaration was not proved by the book or by the repository, so keeping a theorem with `sorry` overstated the formalized proof coverage.

## Validation

- `lake build EtingofRepresentationTheory.Chapter2.Theorem2_1_2_General`
- `lake build` (9411 jobs)
- `jq empty progress/items.json`
- scoped source admission and stale-reference scans
- `git diff --check`