### PR TITLE
docs(scope): make Ado–Iwasawa intentionally non-blocking

### DIFF
--- a/.claude/commands/summarize.md
+++ b/.claude/commands/summarize.md
@@ -62,6 +62,10 @@ Understand what the project currently claims to have achieved.
 - List source files and read their module-level docstrings
 - Read key top-level declarations/signatures (not full implementations)
 - Record current quality metrics as described in the project's CLAUDE.md
+- Run `scripts/check_proof_placeholders.py`. Report its blocking placeholders
+  separately from approved non-blocking wanted-theorem markers. An item with
+  `scope_approved_proof_wanted` is not active mathematical work; every other
+  wanted marker or ambiguous bare `proof_wanted` status is blocking.
 
 ### Step 5: Produce an updated progress document
 

--- a/.claude/skills/lean-formalization/SKILL.md
+++ b/.claude/skills/lean-formalization/SKILL.md
@@ -5175,14 +5175,33 @@ example : reflectionResult₁ = expected₁ := by decide
 
 **"An order-`n` subgroup `H ≤ A₅` is conjugate to a concrete point stabilizer" — use the orbit/fixed-point route, not the Sylow-normalizer route, when `H` is a point stabilizer of `natHom` (Problem 5.11.1 (d), `exists_conj_H12`, PR #6671).** The issue sketched a Sylow-`2`-normalizer argument for order-`12` `H`; a much shorter route proves `H` **fixes a point** of the natural `5`-point action and hence equals `stabSub natHom i`, then conjugates `stab i` to `stab 0 = A4std` by transitivity (`natHom_trans`, one `fin_cases i <;> fin_cases j <;> decide`) + `Subgroup.eq_of_le_of_card_ge` (with `card_stab_i : Nat.card (stabSub natHom i) = 12`). The fixed-point lemma `H12_fixes_point`: put `MulAction A5 (Fin 5)` via `MulAction.compHom (Fin 5) natHom` (subgroups act automatically, `Subgroup.instMulAction`), take the `H`-orbit `O` of `0`, get `|O| ∣ |H|` from the **existing** `Problem4_12_5.orbit_fiber_card` fiber-count + `Finset.card_eq_sum_card_fiberwise` (all fibers = stabilizer size), then case on `|O|` (`∣ 12`, `1 ≤ |O| ≤ 5`): size `5` impossible; size `4` ⟹ singleton complement is fixed; size `2`/`3` ⟹ all of `H` sits in the setwise stabilizer of `O`, which has **≤ 6 even permutations** — the parity obstruction to a `2 + 3` split, a `decide` `∀ O : Finset (Fin 5), 2 ≤ O.card → O.card ≤ 3 → (univ.filter (fun g : A5 => ∀ i ∈ O, natHom g i ∈ O)).card ≤ 6` (`revert`-then-`decide`, ~30 s). Burnside/character sums **cannot** separate `1+4` from `2+3` (both give the same orbit count and the same `∑ᵢ |Stab_H(i)|`) — the evenness `decide` is essential. **`decide` gotcha:** for `(univ.filter (· ∈ stabSub natHom i)).card = 12`, do NOT hand `decide` a local `haveI : DecidablePred (· ∈ stabSub natHom i) := decidable_of_iff …` instance — the kernel can't reduce it and errors "Expected type must not contain free variables". Instead `Finset.filter_congr` to the concrete predicate `fun a => natHom a i = i` (whose `Fin.decEq` decidability the kernel *can* reduce), then `fin_cases i <;> decide`.
 
-## FORBIDDEN: `sorry` for theorems the book states without proof — use `proof_wanted`
+## Book-stated external results require an explicit scope decision
 
-**When the book explicitly cites a deep theorem without proving it (Ado's theorem in Remark 2.9.3, and any "this is a famous result, we omit the proof" remark), do NOT formalize it as a `theorem … := by sorry`.** A `sorry` is a broken proof obligation that pollutes the project's sorry count and reads as "we tried and failed", when the truth is "the book deliberately does not prove this". State it instead with one of:
+**When the book cites or states a deep theorem without proving it, do not
+automatically turn it into either `sorry` or `proof_wanted`.** A `sorry` creates
+a blocking proof obligation, while a wanted-theorem marker is non-blocking only
+after a reviewed project-scope decision.
 
-- **`proof_wanted name (binders) : statement`** (from `import Batteries.Util.ProofWanted`) — elaborates and typechecks the statement as a genuine `Prop`, but introduces **no proof term, no `sorry`, no axiom**. This is the idiomatic Mathlib marker for "this theorem is wanted but unproved". Put any extra hypothesis in a `variable` so the `proof_wanted` signature is just `name : statement` (its pre-colon binder handling is fussier than `theorem`'s). Mirror `Chapter2/Remark2_9_3.lean` (Ado): pre-declare `k`/`L` + instances via `variable`, then `proof_wanted ado [FiniteDimensional k L] : ∃ V …`.
-- **`def StatementOfFooTheorem : Prop := …`** — names the proposition as data (no proof needed, no `sorry`), when you want a referenceable handle rather than a wanted-marker.
+- The currently approved example is `proof_wanted ado` in Remark 2.9.3. It
+  elaborates and typechecks the Ado–Iwasawa proposition but introduces no proof
+  term, `sorry`, or project axiom.
+- Adding `proof_wanted` or its Batteries synonym `theorem_wanted` requires, in
+  the same PR, an individual entry under the wanted-theorem section of
+  `skipped-exercises.md`, `scope_approved_proof_wanted` metadata in
+  `progress/items.json`, and an explicit entry in the checker's reviewed
+  allowlist. Run `scripts/check_proof_placeholders.py`; an unapproved marker is
+  a CI failure.
+- `def_wanted` and `instance_wanted` are forbidden: definitions and instances
+  must contain constructed data, not wanted placeholders.
+- Without a reviewed exception, either prove the theorem as part of the project
+  or record only its proposition as data (`def StatementOfFooTheorem : Prop :=
+  …`) while the scope decision is reviewed. Do not mint a new exception by
+  analogy with Ado.
 
-The distinction matters: **proof sorries** (claims the book *proves*, which we discharge) must go to zero; **citation sorries must never exist at all** — they become `proof_wanted`. A reviewer scanning for `sorry` should find only genuine in-progress proof work, never a deliberately-unproved book citation. The forbidden-`native_decide` discipline and this one share a root: the sorry/axiom/native_decide count is the project's trust ledger, and nothing should sit in it that isn't a real, in-progress obligation.
+The distinction matters: proof sorries for in-scope claims must go to zero, and
+the sole non-blocking wanted marker must remain a narrow, machine-checked scope
+exception. A reviewer scanning the trust ledger should see ordinary proof gaps
+and approved external-result markers reported separately.
 
 ## FORBIDDEN: vacuous "certificate" statements for tables / classifications
 

--- a/.claude/skills/parallel-agent-coordination/SKILL.md
+++ b/.claude/skills/parallel-agent-coordination/SKILL.md
@@ -199,7 +199,12 @@ Phase 3 work must respect the dependency DAG — you can't formalize an item unt
 **Finding ready work:**
 1. Query `progress/items.json` for items with status `statement_formalized`
 2. Check each item's dependencies in `dependencies/internal.json`
-3. An item is "ready" when all its direct dependencies have status `sorry_free`
+3. An item is "ready" when all its direct dependencies have status `sorry_free`,
+   except that the individually reviewed terminal status
+   `scope_approved_proof_wanted` is also ready. That exception is valid only
+   when `scripts/check_proof_placeholders.py` confirms the exact marker's scope
+   entry and approval metadata; do not treat a bare `proof_wanted` status as
+   ready.
 4. Prefer items with many dependents (unblocks more downstream work)
 
 **Planners should:**

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -31,8 +31,10 @@ jobs:
       - uses: actions/checkout@v5
       - name: Classify proof placeholders
         run: |
+          set -o pipefail
           python3 scripts/test_check_proof_placeholders.py
           scripts/check_proof_placeholders.py
+          python3 scripts/validate_items.py | tail -4
       - name: Forbid native_decide (trust-hole guard)
         run: |
           # native_decide compiles the goal to native code and trusts the Lean

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -29,6 +29,10 @@ jobs:
         with:
           size: 8G
       - uses: actions/checkout@v5
+      - name: Classify proof placeholders
+        run: |
+          python3 scripts/test_check_proof_placeholders.py
+          scripts/check_proof_placeholders.py
       - name: Forbid native_decide (trust-hole guard)
         run: |
           # native_decide compiles the goal to native code and trusts the Lean

--- a/EtingofRepresentationTheory/Chapter2/Remark2_9_3.lean
+++ b/EtingofRepresentationTheory/Chapter2/Remark2_9_3.lean
@@ -22,10 +22,12 @@ We state the Ado–Iwasawa theorem over an arbitrary field, matching the unquali
 in the chapter.  The characteristic-zero case is Ado's original theorem; the extension to
 positive characteristic is due to Iwasawa.  Etingof states the result without proof, and it is
 not available in
-Mathlib. Since the book explicitly disavows a proof, we record it with `proof_wanted`: the
-statement is elaborated and typechecked as a proposition, but no proof term, `sorry`, or
-axiom is introduced. The mathematical content captured here is the existence of a
-finite-dimensional faithful representation of an arbitrary finite-dimensional Lie algebra.
+Mathlib. This project deliberately leaves that external result outside its proof boundary and
+records it with `proof_wanted`: the statement is elaborated and typechecked as a proposition,
+but no proof term, `sorry`, or axiom is introduced. This reviewed scope exception is documented in
+`skipped-exercises.md`; it is non-blocking for project completion. The mathematical content
+captured here is the existence of a finite-dimensional faithful representation of an arbitrary
+finite-dimensional Lie algebra.
 -/
 
 namespace Etingof

--- a/PLAN.md
+++ b/PLAN.md
@@ -307,6 +307,24 @@ These files are read by formalization agents when they work on the corresponding
 
 Phase 3 is where the bulk of the project happens: every formalizable item needs a Lean file with correct definitions and eventually a complete proof. Each stage is parallelized **per item** via GitHub issues and PRs — one issue per item, one agent per item. Stages can overlap: an item can progress through scaffolding, review, and proof work while other items are still in earlier stages.
 
+#### Phase 3 completion criteria
+
+The book formalization may be declared complete only when all of the following
+hold:
+
+1. The Lean sources contain no accidental `sorry` or `admit` terms and no
+   project `axiom` declarations.
+2. Every `proof_wanted` is individually enumerated and justified in
+   `skipped-exercises.md`, with matching `scope_approved_proof_wanted` metadata
+   in `progress/items.json` that names the exact source and declaration.
+3. `scripts/check_proof_placeholders.py --enforce-completion` succeeds.
+
+An approved `proof_wanted` is a reviewed project-scope decision, not an active
+proof gap. The Ado–Iwasawa statement `Etingof.ado` in Remark 2.9.3 is currently
+the sole such marker and is non-blocking. This exception does not generalize:
+adding another non-blocking marker requires an explicit scope-document entry,
+matching metadata, and review.
+
 #### PR lifecycle
 
 PRs must be merged to `main` without human intervention to avoid blocking downstream agents. Every PR should have auto-merge enabled at creation time:
@@ -799,6 +817,7 @@ Special statuses (set during review):
 - `needs_definition` — the item has a definition-level sorry or coverage gap that must be resolved before downstream theorems are meaningful
 - `attention_needed` — requires specialized agent attention (e.g., wrong statement, repeated failures)
 - `non_formalizable` — discussion blob assessed as containing no formalizable claims (must include enumerated claims and exclusion reasons; subject to Stage 3.2 review; terminal status if review confirms)
+- `scope_approved_proof_wanted` — terminal, non-blocking scope exception for an individually enumerated book-stated external result; requires a complete `proof_wanted_approval` record and explicit review
 
 ```json
 {

--- a/PLAN.md
+++ b/PLAN.md
@@ -307,24 +307,6 @@ These files are read by formalization agents when they work on the corresponding
 
 Phase 3 is where the bulk of the project happens: every formalizable item needs a Lean file with correct definitions and eventually a complete proof. Each stage is parallelized **per item** via GitHub issues and PRs — one issue per item, one agent per item. Stages can overlap: an item can progress through scaffolding, review, and proof work while other items are still in earlier stages.
 
-#### Phase 3 completion criteria
-
-The book formalization may be declared complete only when all of the following
-hold:
-
-1. The Lean sources contain no accidental `sorry` or `admit` terms and no
-   project `axiom` declarations.
-2. Every `proof_wanted` is individually enumerated and justified in
-   `skipped-exercises.md`, with matching `scope_approved_proof_wanted` metadata
-   in `progress/items.json` that names the exact source and declaration.
-3. `scripts/check_proof_placeholders.py --enforce-completion` succeeds.
-
-An approved `proof_wanted` is a reviewed project-scope decision, not an active
-proof gap. The Ado–Iwasawa statement `Etingof.ado` in Remark 2.9.3 is currently
-the sole such marker and is non-blocking. This exception does not generalize:
-adding another non-blocking marker requires an explicit scope-document entry,
-matching metadata, and review.
-
 #### PR lifecycle
 
 PRs must be merged to `main` without human intervention to avoid blocking downstream agents. Every PR should have auto-merge enabled at creation time:
@@ -817,7 +799,6 @@ Special statuses (set during review):
 - `needs_definition` — the item has a definition-level sorry or coverage gap that must be resolved before downstream theorems are meaningful
 - `attention_needed` — requires specialized agent attention (e.g., wrong statement, repeated failures)
 - `non_formalizable` — discussion blob assessed as containing no formalizable claims (must include enumerated claims and exclusion reasons; subject to Stage 3.2 review; terminal status if review confirms)
-- `scope_approved_proof_wanted` — terminal, non-blocking scope exception for an individually enumerated book-stated external result; requires a complete `proof_wanted_approval` record and explicit review
 
 ```json
 {

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,16 @@
 
 Progress is recorded here as stages from PLAN.md are completed.
 
+## Completion policy
+
+Completion requires zero blocking proof placeholders: no `sorry`, `admit`, or
+project axiom declarations. A `proof_wanted` is non-blocking only when its item
+has `scope_approved_proof_wanted` status in `progress/items.json` and is
+individually justified in `skipped-exercises.md`. Remark 2.9.3's Ado–Iwasawa
+marker is the sole current approval and is outside the project's proof
+obligation; it must not be counted as active mathematical work. New approvals
+require an explicit scope entry, matching metadata, and review.
+
 ## Stage 1.1: Page Extraction
 - **Status:** Complete
 - **Date:** 2026-03-14
@@ -75,5 +85,5 @@ Progress is recorded here as stages from PLAN.md are completed.
 ## Stage 3.2: Proof Filling
 - **Status:** In progress (project tail)
 - **Date started:** 2026-03-16
-- **Latest update:** 2026-07-18 (sorry-landscape refresh #6976, HEAD `7337d8e3`)
-- **Notes:** 559/592 items `sorry_free` in `progress/items.json`. Comment-stripped scan of `EtingofRepresentationTheory/**/*.lean` finds only **4 genuine `sorry` proof terms across 3 files**, all covered by claimed or in-flight work: `Chapter2/Problem2_16_3.lean` `finrank_g_three` (G₂ positive part, #6340, claimed); `Chapter4/Problem4_12_8.lean` `so3_octahedral_of_poleData` and `so3_icosahedral_of_poleData` (the two hardest SO(3) polyhedral cruxes, #6972/#6971 with reduction PRs #6973/#6974/#6977); `Chapter8/Problem8_2_8.lean` `Problem_8_2_8_ext` (Ext Künneth final assembly, #6898, claimed). No `axiom`/`admit`; 2 book-disavowed `proof_wanted` (`Remark2_9_3` `ado`, `Remark5_23_3` `sl_finiteDimensional_completely_reducible`). Chapters 1,3,5,6,7,9 are source-sorry-free. See `progress/2026-07-18T16-29-26Z-sorry-landscape.md` for the full per-file/per-chapter analysis and the status-reconciliation audit (5 items reclassified to `sorry_free`; 5 sorry-free-source items confirmed as genuine deliberate holds).
+- **Latest update:** 2026-07-28 (scope-policy and placeholder-classification refresh, #8110)
+- **Notes:** The automated comment/string-aware scan reports one blocking `sorry` (`Chapter2/Theorem2_1_2_General.lean`) and no `admit` or project axiom declarations. It separately reports one approved, non-blocking `proof_wanted`: `Chapter2/Remark2_9_3.lean` `ado`. The Ado–Iwasawa marker is scope-complete rather than part of the active proof frontier. Run `scripts/check_proof_placeholders.py` for the current classification and add `--enforce-completion` for the release gate.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ the scope of a particular issue. Exercises deferred to a later import point, wit
 partial results recorded now, are tracked separately in
 [Deferred reprises](deferred-reprises.md).
 
+Project completion requires zero accidental `sorry` or `admit` terms and zero
+project axioms. Every `proof_wanted` must instead be individually enumerated and
+justified in the scope document, with matching machine-readable approval metadata
+in `progress/items.json`. The currently approved Ado–Iwasawa marker in Remark
+2.9.3 is non-blocking; no future marker inherits that exception automatically.
+Run `scripts/check_proof_placeholders.py --enforce-completion` to check these
+release criteria.
+
 ## GitHub configuration
 
 To set up your new GitHub repository, follow these steps:

--- a/progress/2026-07-28T23-04-30Z.md
+++ b/progress/2026-07-28T23-04-30Z.md
@@ -1,0 +1,33 @@
+## Accomplished
+
+- Claimed #8110 and made the Ado–Iwasawa scope decision explicit in the root
+  documentation and `Remark2_9_3.lean`.
+- Reclassified `Chapter2/Remark2.9.3` as the terminal, non-blocking
+  `scope_approved_proof_wanted` status while preserving `covered_full`,
+  `Etingof.ado`, and the constructive reduction declarations.
+- Added a machine-readable approval record and a comment/string-aware scanner
+  that reports blocking placeholders separately from approved non-blocking
+  `proof_wanted` markers. CI now runs the scanner and its unit tests.
+- Verified the scanner, its tests, `scripts/validate_items.py`, the touched Lean
+  module, and the full 9411-job `lake build`.
+
+## Current frontier
+
+The #8110 implementation is locally complete and ready to publish. The requested
+post-PR Claude Opus review and GitHub CI/rebase loop remain to be performed.
+
+## Overall project progress
+
+The source scan currently finds one blocking `sorry` in
+`Chapter2/Theorem2_1_2_General.lean`, zero `admit` or project axiom declarations,
+and one approved non-blocking `proof_wanted`, `Etingof.ado`.
+
+## Next step
+
+Open the PR, request the independent second opinion while CI runs, address any
+validated findings, then rebase/check CI and merge according to the issue
+instructions.
+
+## Blockers
+
+None.

--- a/progress/2026-07-28T23-04-30Z.md
+++ b/progress/2026-07-28T23-04-30Z.md
@@ -7,14 +7,24 @@
   `Etingof.ado`, and the constructive reduction declarations.
 - Added a machine-readable approval record and a comment/string-aware scanner
   that reports blocking placeholders separately from approved non-blocking
-  `proof_wanted` markers. CI now runs the scanner and its unit tests.
+  wanted-theorem markers. The approval is an exact item/source/declaration
+  allowlist entry shared by the scanner and metadata validator. CI runs both
+  validators and scanner regression tests.
+- Classified all Batteries wanted-command variants: `proof_wanted` and
+  `theorem_wanted` need an exact scope approval, while `def_wanted` and
+  `instance_wanted` remain blocking. The scan also fails closed on `sorryAx`,
+  project `axiom`/`constant` declarations, and malformed string/comment input.
+- Corrected the unrelated `Chapter2/Theorem2.1.2` metadata to record its actual
+  active `sorry` obligation instead of the ambiguous legacy `proof_wanted`
+  status, and made dependency/reporting guidance recognize only the exact
+  scope-approved terminal status.
 - Verified the scanner, its tests, `scripts/validate_items.py`, the touched Lean
   module, and the full 9411-job `lake build`.
 
 ## Current frontier
 
-The #8110 implementation is locally complete and ready to publish. The requested
-post-PR Claude Opus review and GitHub CI/rebase loop remain to be performed.
+The revised #8110 implementation is ready for final local validation and a PR
+update. The GitHub CI/rebase loop remains to be completed.
 
 ## Overall project progress
 
@@ -24,9 +34,8 @@ and one approved non-blocking `proof_wanted`, `Etingof.ado`.
 
 ## Next step
 
-Open the PR, request the independent second opinion while CI runs, address any
-validated findings, then rebase/check CI and merge according to the issue
-instructions.
+Run the expanded regression suite and metadata validators, push the PR update,
+then rebase/check CI and merge according to the issue instructions.
 
 ## Blockers
 

--- a/progress/items.json
+++ b/progress/items.json
@@ -5168,11 +5168,20 @@
     "end_page": "23",
     "start_line": 2,
     "end_line": 3,
-    "status": "proof_wanted",
+    "status": "scope_approved_proof_wanted",
     "fidelity": "verified",
-    "fidelity_note": "Ado–Iwasawa is asserted in Lean as Etingof.ado (Chapter2/Remark2_9_3.lean): for a finite-dimensional Lie algebra L over the chapter's arbitrary field k, there exists a finite-dimensional V and an injective LieHom L →ₗ⁅k⁆ Module.End k V (a faithful finite-dimensional representation). Statement faithful to the book claim. Recorded via `proof_wanted` (no `sorry` term, no axiom): the book states the theorem without proof and it is not available in Mathlib. Stage 3.3 proves the constructive reduction and converse: a faithful embedding into a finite-dimensional associative algebra, equivalently a finite-dimensional target of U(L) that remains injective on L, supplies the required representation by left multiplication; every faithful representation extends to such a U(L) target. This is NOT a codebase sorry — status corrected from the misleading `sorry` in audit #7001.",
+    "fidelity_note": "Ado–Iwasawa is asserted in Lean as Etingof.ado (Chapter2/Remark2_9_3.lean): for a finite-dimensional Lie algebra L over the chapter's arbitrary field k, there exists a finite-dimensional V and an injective LieHom L →ₗ⁅k⁆ Module.End k V (a faithful finite-dimensional representation). The statement is faithful to the book claim. The book states the theorem without proof; this project intentionally excludes the arbitrary-characteristic Ado–Iwasawa proof from its proof obligation and records the proposition via an approved, non-blocking `proof_wanted` (no `sorry` term or project axiom). Stage 3.3 proves the constructive reduction and converse: a faithful embedding into a finite-dimensional associative algebra, equivalently a finite-dimensional target of U(L) that remains injective on L, supplies the required representation by left multiplication; every faithful representation extends to such a U(L) target.",
     "fidelity_decl": "Etingof.ado",
     "fidelity_issue": 5367,
+    "proof_wanted_approval": {
+      "classification": "approved_nonblocking",
+      "declaration": "Etingof.ado",
+      "source": "EtingofRepresentationTheory/Chapter2/Remark2_9_3.lean",
+      "scope_document": "skipped-exercises.md",
+      "scope_heading": "Book-stated external results intentionally left as `proof_wanted`",
+      "reason": "The book states Ado's theorem without proof, and the arbitrary-characteristic Ado–Iwasawa proof requires substantial characteristic-dependent Lie-theoretic and universal-enveloping-algebra machinery outside this project's chosen representation-theory boundary.",
+      "approved_by_issue": 8110
+    },
     "claim_coverage": {
       "stage": "3.2",
       "status": "complete",
@@ -5186,25 +5195,25 @@
           "claim": "Every finite-dimensional Lie algebra over the chapter's field admits an injective finite-dimensional representation into gl(V) (Ado-Iwasawa).",
           "verdict": "formalized",
           "lean_decl": "Etingof.ado",
-          "proof_status": "stage3_3_gap"
+          "proof_status": "scope_approved_nonblocking"
         }
       ]
     },
-    "last_updated": "2026-07-27",
+    "last_updated": "2026-07-28",
     "coverage": "covered_full",
     "sorry_free": true,
     "stage3_3": {
-      "status": "partial",
+      "status": "scope_complete",
       "section": "2.9",
-      "verified_on": "2026-07-27",
-      "proof_integrity": "proof_wanted",
+      "verified_on": "2026-07-28",
+      "proof_integrity": "scope_approved_proof_wanted",
       "declarations": [
         "Etingof.ado_of_finiteAssociativeEmbedding",
         "Etingof.ado_of_finiteEnvelopingTarget",
         "Etingof.finiteEnvelopingTarget_of_faithfulRepresentation",
         "Etingof.faithfulRepresentation_iff_finiteEnvelopingTarget"
       ],
-      "remaining_obligation": "Etingof.ado (arbitrary-field Ado–Iwasawa theorem): construct a finite-dimensional target of U(L) that is injective on the canonical copy of L. Mathlib currently lacks the general PBW/injectivity theorem and the characteristic-dependent finite-quotient or Iwasawa-splitting machinery needed for that construction."
+      "scope_decision": "Etingof.ado itself has no project proof. Its reviewed `proof_wanted` records the book-stated external Ado–Iwasawa theorem and is non-blocking; the proved declarations above retain the constructive reduction API."
     }
   },
   {

--- a/progress/items.json
+++ b/progress/items.json
@@ -5213,7 +5213,8 @@
         "Etingof.finiteEnvelopingTarget_of_faithfulRepresentation",
         "Etingof.faithfulRepresentation_iff_finiteEnvelopingTarget"
       ],
-      "scope_decision": "Etingof.ado itself has no project proof. Its reviewed `proof_wanted` records the book-stated external Ado–Iwasawa theorem and is non-blocking; the proved declarations above retain the constructive reduction API."
+      "scope_decision": "Etingof.ado itself has no project proof. Its reviewed `proof_wanted` records the book-stated external Ado–Iwasawa theorem and is non-blocking; the proved declarations above retain the constructive reduction API.",
+      "unproved_theorem_note": "If the project boundary were ever reconsidered, proving arbitrary-field Ado–Iwasawa would require a finite-dimensional target of U(L) that remains injective on the canonical copy of L, including characteristic-dependent finite-quotient or Iwasawa-splitting machinery currently absent from Mathlib. This is context, not a current project obligation."
     }
   },
   {

--- a/scripts/check_proof_placeholders.py
+++ b/scripts/check_proof_placeholders.py
@@ -16,26 +16,29 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from proof_wanted_policy import (
+    APPROVAL_CLASSIFICATION,
+    APPROVAL_FIELD,
+    APPROVED_STATUS,
+    approval_identity,
+    validate_item_approval,
+)
 
-APPROVED_STATUS = "scope_approved_proof_wanted"
-APPROVAL_FIELD = "proof_wanted_approval"
-APPROVAL_CLASSIFICATION = "approved_nonblocking"
-APPROVAL_REQUIRED_FIELDS = {
-    "classification",
-    "declaration",
-    "source",
-    "scope_document",
-    "scope_heading",
-    "reason",
-    "approved_by_issue",
-}
-
-TOKEN_RE = re.compile(r"\b(sorry|admit|proof_wanted)\b")
-PROOF_WANTED_RE = re.compile(r"\bproof_wanted\s+([A-Za-z_][A-Za-z0-9_'.]*)")
-AXIOM_RE = re.compile(
-    r"(?m)^[ \t]*(?:(?:private|protected)\s+)*(axiom|constant)\s+"
+THEOREM_WANTED_KINDS = {"proof_wanted", "theorem_wanted"}
+DATA_WANTED_KINDS = {"def_wanted", "instance_wanted"}
+WANTED_KINDS = THEOREM_WANTED_KINDS | DATA_WANTED_KINDS
+TOKEN_RE = re.compile(
+    r"\b(sorryAx|sorry|admit|proof_wanted|theorem_wanted|def_wanted|instance_wanted)\b"
+)
+WANTED_RE = re.compile(
+    r"\b(proof_wanted|theorem_wanted|def_wanted|instance_wanted)\s+"
     r"([A-Za-z_][A-Za-z0-9_'.]*)"
 )
+AXIOM_RE = re.compile(
+    r"(?<![A-Za-z0-9_'.])(axiom|constant)\s+"
+    r"([A-Za-z_][A-Za-z0-9_'.]*)"
+)
+CHAR_RE = re.compile(r"'(?:\\(?:u\{[0-9A-Fa-f]+\}|.)|[^\\'\n])'")
 
 
 @dataclass(frozen=True)
@@ -56,6 +59,7 @@ def code_without_comments_or_strings(source: str) -> str:
     index = 0
     block_depth = 0
     in_string = False
+    raw_string_end: str | None = None
     in_line_comment = False
 
     def blank(position: int) -> None:
@@ -99,6 +103,17 @@ def code_without_comments_or_strings(source: str) -> str:
                 index += 1
             continue
 
+        if raw_string_end is not None:
+            if source.startswith(raw_string_end, index):
+                for position in range(index, index + len(raw_string_end)):
+                    blank(position)
+                index += len(raw_string_end)
+                raw_string_end = None
+            else:
+                blank(index)
+                index += 1
+            continue
+
         if source.startswith("--", index):
             blank(index)
             blank(index + 1)
@@ -109,6 +124,21 @@ def code_without_comments_or_strings(source: str) -> str:
             blank(index + 1)
             block_depth = 1
             index += 2
+        elif (
+            source[index] == "r"
+            and (index == 0 or not (source[index - 1].isalnum() or source[index - 1] in "_'."))
+            and (raw_match := re.match(r'r(?P<hashes>#{0,16})"', source[index:]))
+        ):
+            hashes = raw_match.group("hashes")
+            opening_length = len(hashes) + 2
+            for position in range(index, index + opening_length):
+                blank(position)
+            index += opening_length
+            raw_string_end = '"' + hashes
+        elif char_match := CHAR_RE.match(source, index):
+            for position in range(index, char_match.end()):
+                blank(position)
+            index = char_match.end()
         elif source[index] == '"':
             blank(index)
             in_string = True
@@ -116,6 +146,10 @@ def code_without_comments_or_strings(source: str) -> str:
         else:
             index += 1
 
+    if block_depth:
+        raise ValueError("unterminated block comment")
+    if in_string or raw_string_end is not None:
+        raise ValueError("unterminated string literal")
     return "".join(output)
 
 
@@ -130,7 +164,7 @@ def scan_lean_file(root: Path, path: Path) -> list[Marker]:
 
     for match in TOKEN_RE.finditer(code):
         kind = match.group(1)
-        if kind == "proof_wanted":
+        if kind in WANTED_KINDS:
             continue
         markers.append(Marker(kind, relative, line_number(code, match.start())))
 
@@ -144,17 +178,32 @@ def scan_lean_file(root: Path, path: Path) -> list[Marker]:
             )
         )
 
-    for match in PROOF_WANTED_RE.finditer(code):
+    for match in WANTED_RE.finditer(code):
         markers.append(
             Marker(
-                "proof_wanted",
+                match.group(1),
                 relative,
                 line_number(code, match.start()),
-                match.group(1),
+                match.group(2),
             )
         )
 
     return sorted(markers, key=lambda marker: (marker.line, marker.kind))
+
+
+def markdown_section(text: str, heading: str) -> str | None:
+    """Return the Markdown section under an exact heading, including subsections."""
+    heading_match = re.search(
+        rf"(?m)^(?P<marks>#{{1,6}})[ \t]+{re.escape(heading)}[ \t]*$", text
+    )
+    if heading_match is None:
+        return None
+    level = len(heading_match.group("marks"))
+    next_heading = re.search(
+        rf"(?m)^#{{1,{level}}}[ \t]+", text[heading_match.end() :]
+    )
+    end = len(text) if next_heading is None else heading_match.end() + next_heading.start()
+    return text[heading_match.end() : end]
 
 
 def load_approvals(root: Path, items_path: Path) -> tuple[dict[tuple[str, str], dict], list[str]]:
@@ -172,37 +221,12 @@ def load_approvals(root: Path, items_path: Path) -> tuple[dict[tuple[str, str], 
         if not isinstance(item, dict):
             continue
         item_id = item.get("id", "<unknown item>")
+        item_errors = validate_item_approval(item)
+        errors.extend(item_errors)
         approval = item.get(APPROVAL_FIELD)
         if item.get("status") != APPROVED_STATUS:
-            if approval is not None:
-                errors.append(
-                    f"{item_id}: {APPROVAL_FIELD} requires status {APPROVED_STATUS!r}"
-                )
             continue
-        if not isinstance(approval, dict):
-            errors.append(f"{item_id}: missing object field {APPROVAL_FIELD}")
-            continue
-
-        missing = APPROVAL_REQUIRED_FIELDS - approval.keys()
-        if missing:
-            errors.append(f"{item_id}: approval is missing {sorted(missing)}")
-            continue
-        if approval["classification"] != APPROVAL_CLASSIFICATION:
-            errors.append(
-                f"{item_id}: approval classification must be {APPROVAL_CLASSIFICATION!r}"
-            )
-        for field in (
-            "declaration",
-            "source",
-            "scope_document",
-            "scope_heading",
-            "reason",
-        ):
-            if not isinstance(approval[field], str) or not approval[field].strip():
-                errors.append(f"{item_id}: approval field {field!r} must be nonempty text")
-        if not isinstance(approval["approved_by_issue"], int) or approval["approved_by_issue"] <= 0:
-            errors.append(f"{item_id}: approved_by_issue must be a positive issue number")
-        if errors and any(error.startswith(f"{item_id}:") for error in errors):
+        if item_errors or not isinstance(approval, dict):
             continue
 
         source = approval["source"]
@@ -213,8 +237,12 @@ def load_approvals(root: Path, items_path: Path) -> tuple[dict[tuple[str, str], 
             errors.append(f"{item_id}: duplicate approval for {source} ({declaration})")
             continue
 
-        source_path = root / source
-        if not source_path.is_file() or source_path.suffix != ".lean":
+        source_path = (root / source).resolve()
+        if (
+            not source_path.is_relative_to(root)
+            or not source_path.is_file()
+            or source_path.suffix != ".lean"
+        ):
             errors.append(f"{item_id}: approved source does not exist as a Lean file: {source}")
 
         scope_path = root / approval["scope_document"]
@@ -223,18 +251,28 @@ def load_approvals(root: Path, items_path: Path) -> tuple[dict[tuple[str, str], 
         except OSError as error:
             errors.append(f"{item_id}: cannot read scope document {scope_path}: {error}")
         else:
+            section = markdown_section(scope_text, approval["scope_heading"])
+            if section is None:
+                errors.append(
+                    f"{item_id}: scope heading {approval['scope_heading']!r} is absent "
+                    f"from {approval['scope_document']}"
+                )
+                section = ""
             for expected, label in (
                 (item_id, "item id"),
                 (declaration, "declaration"),
-                (approval["scope_heading"], "scope heading"),
             ):
-                if expected not in scope_text:
+                if expected not in section:
                     errors.append(
                         f"{item_id}: {label} {expected!r} is absent from "
                         f"{approval['scope_document']}"
                     )
 
-        approvals[key] = {"item_id": item_id, **approval}
+        approvals[key] = {
+            "item_id": item_id,
+            "identity": approval_identity(item, approval),
+            **approval,
+        }
 
     return approvals, errors
 
@@ -270,19 +308,22 @@ def main() -> int:
     approvals, metadata_errors = load_approvals(root, items_path)
 
     source_root = root / "EtingofRepresentationTheory"
-    markers = [
-        marker
-        for path in sorted(source_root.rglob("*.lean"))
-        for marker in scan_lean_file(root, path)
-    ]
-    proof_wanted = [marker for marker in markers if marker.kind == "proof_wanted"]
-    blocking = [marker for marker in markers if marker.kind != "proof_wanted"]
+    source_paths = sorted(root.glob("*.lean")) + sorted(source_root.rglob("*.lean"))
+    markers: list[Marker] = []
+    for path in source_paths:
+        try:
+            markers.extend(scan_lean_file(root, path))
+        except (OSError, ValueError) as error:
+            metadata_errors.append(f"{path.relative_to(root)}: lexical scan failed: {error}")
+    proof_wanted = [marker for marker in markers if marker.kind in THEOREM_WANTED_KINDS]
+    blocking = [marker for marker in markers if marker.kind not in THEOREM_WANTED_KINDS]
     approved: list[Marker] = []
     unapproved: list[Marker] = []
 
     matched_approvals: set[tuple[str, str]] = set()
     for marker in proof_wanted:
-        key = (marker.source, marker.declaration or "")
+        local_declaration = (marker.declaration or "").rsplit(".", 1)[-1]
+        key = (marker.source, local_declaration)
         if key in approvals:
             approved.append(marker)
             matched_approvals.add(key)
@@ -297,20 +338,21 @@ def main() -> int:
             )
 
     report_group("Blocking proof placeholders", blocking)
-    report_group("Approved non-blocking proof_wanted markers", approved)
-    report_group("Unapproved proof_wanted markers (blocking)", unapproved)
+    report_group("Approved non-blocking wanted-theorem markers", approved)
+    report_group("Unapproved wanted-theorem markers (blocking)", unapproved)
 
     if metadata_errors:
         print(f"Approval metadata errors: {len(metadata_errors)}", file=sys.stderr)
         for error in metadata_errors:
             print(f"  {error}", file=sys.stderr)
     else:
-        print(f"Approval metadata errors: 0")
+        print("Approval metadata errors: 0")
 
     always_forbidden = [
         marker
         for marker in blocking
-        if marker.kind == "admit" or marker.kind.startswith("project_")
+        if marker.kind in {"admit", "sorryAx", *DATA_WANTED_KINDS}
+        or marker.kind.startswith("project_")
     ]
     if metadata_errors or unapproved or always_forbidden:
         return 1

--- a/scripts/check_proof_placeholders.py
+++ b/scripts/check_proof_placeholders.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Classify Lean proof placeholders and enforce reviewed `proof_wanted` approvals.
+
+The default mode is suitable while formalization is still in progress: it reports
+ordinary `sorry` gaps as blocking completion, and fails for metadata errors, an
+unapproved `proof_wanted`, any `admit`, or any project `axiom`/`constant`
+declaration. `--enforce-completion` additionally fails while a `sorry` remains.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+APPROVED_STATUS = "scope_approved_proof_wanted"
+APPROVAL_FIELD = "proof_wanted_approval"
+APPROVAL_CLASSIFICATION = "approved_nonblocking"
+APPROVAL_REQUIRED_FIELDS = {
+    "classification",
+    "declaration",
+    "source",
+    "scope_document",
+    "scope_heading",
+    "reason",
+    "approved_by_issue",
+}
+
+TOKEN_RE = re.compile(r"\b(sorry|admit|proof_wanted)\b")
+PROOF_WANTED_RE = re.compile(r"\bproof_wanted\s+([A-Za-z_][A-Za-z0-9_'.]*)")
+AXIOM_RE = re.compile(
+    r"(?m)^[ \t]*(?:(?:private|protected)\s+)*(axiom|constant)\s+"
+    r"([A-Za-z_][A-Za-z0-9_'.]*)"
+)
+
+
+@dataclass(frozen=True)
+class Marker:
+    kind: str
+    source: str
+    line: int
+    declaration: str | None = None
+
+    def render(self) -> str:
+        suffix = f" ({self.declaration})" if self.declaration else ""
+        return f"{self.source}:{self.line}: {self.kind}{suffix}"
+
+
+def code_without_comments_or_strings(source: str) -> str:
+    """Replace Lean comments and strings with spaces while preserving newlines."""
+    output = list(source)
+    index = 0
+    block_depth = 0
+    in_string = False
+    in_line_comment = False
+
+    def blank(position: int) -> None:
+        if output[position] != "\n":
+            output[position] = " "
+
+    while index < len(source):
+        if in_line_comment:
+            if source[index] == "\n":
+                in_line_comment = False
+            else:
+                blank(index)
+            index += 1
+            continue
+
+        if block_depth:
+            if source.startswith("/-", index):
+                blank(index)
+                blank(index + 1)
+                block_depth += 1
+                index += 2
+            elif source.startswith("-/", index):
+                blank(index)
+                blank(index + 1)
+                block_depth -= 1
+                index += 2
+            else:
+                blank(index)
+                index += 1
+            continue
+
+        if in_string:
+            if source[index] == "\\" and index + 1 < len(source):
+                blank(index)
+                blank(index + 1)
+                index += 2
+            else:
+                if source[index] == '"':
+                    in_string = False
+                blank(index)
+                index += 1
+            continue
+
+        if source.startswith("--", index):
+            blank(index)
+            blank(index + 1)
+            in_line_comment = True
+            index += 2
+        elif source.startswith("/-", index):
+            blank(index)
+            blank(index + 1)
+            block_depth = 1
+            index += 2
+        elif source[index] == '"':
+            blank(index)
+            in_string = True
+            index += 1
+        else:
+            index += 1
+
+    return "".join(output)
+
+
+def line_number(source: str, offset: int) -> int:
+    return source.count("\n", 0, offset) + 1
+
+
+def scan_lean_file(root: Path, path: Path) -> list[Marker]:
+    relative = path.relative_to(root).as_posix()
+    code = code_without_comments_or_strings(path.read_text(encoding="utf-8"))
+    markers: list[Marker] = []
+
+    for match in TOKEN_RE.finditer(code):
+        kind = match.group(1)
+        if kind == "proof_wanted":
+            continue
+        markers.append(Marker(kind, relative, line_number(code, match.start())))
+
+    for match in AXIOM_RE.finditer(code):
+        markers.append(
+            Marker(
+                f"project_{match.group(1)}",
+                relative,
+                line_number(code, match.start()),
+                match.group(2),
+            )
+        )
+
+    for match in PROOF_WANTED_RE.finditer(code):
+        markers.append(
+            Marker(
+                "proof_wanted",
+                relative,
+                line_number(code, match.start()),
+                match.group(1),
+            )
+        )
+
+    return sorted(markers, key=lambda marker: (marker.line, marker.kind))
+
+
+def load_approvals(root: Path, items_path: Path) -> tuple[dict[tuple[str, str], dict], list[str]]:
+    errors: list[str] = []
+    try:
+        items = json.loads(items_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        return {}, [f"cannot read {items_path}: {error}"]
+
+    if not isinstance(items, list):
+        return {}, [f"{items_path} must contain a JSON array"]
+
+    approvals: dict[tuple[str, str], dict] = {}
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        item_id = item.get("id", "<unknown item>")
+        approval = item.get(APPROVAL_FIELD)
+        if item.get("status") != APPROVED_STATUS:
+            if approval is not None:
+                errors.append(
+                    f"{item_id}: {APPROVAL_FIELD} requires status {APPROVED_STATUS!r}"
+                )
+            continue
+        if not isinstance(approval, dict):
+            errors.append(f"{item_id}: missing object field {APPROVAL_FIELD}")
+            continue
+
+        missing = APPROVAL_REQUIRED_FIELDS - approval.keys()
+        if missing:
+            errors.append(f"{item_id}: approval is missing {sorted(missing)}")
+            continue
+        if approval["classification"] != APPROVAL_CLASSIFICATION:
+            errors.append(
+                f"{item_id}: approval classification must be {APPROVAL_CLASSIFICATION!r}"
+            )
+        for field in (
+            "declaration",
+            "source",
+            "scope_document",
+            "scope_heading",
+            "reason",
+        ):
+            if not isinstance(approval[field], str) or not approval[field].strip():
+                errors.append(f"{item_id}: approval field {field!r} must be nonempty text")
+        if not isinstance(approval["approved_by_issue"], int) or approval["approved_by_issue"] <= 0:
+            errors.append(f"{item_id}: approved_by_issue must be a positive issue number")
+        if errors and any(error.startswith(f"{item_id}:") for error in errors):
+            continue
+
+        source = approval["source"]
+        declaration = approval["declaration"]
+        local_declaration = declaration.rsplit(".", 1)[-1]
+        key = (source, local_declaration)
+        if key in approvals:
+            errors.append(f"{item_id}: duplicate approval for {source} ({declaration})")
+            continue
+
+        source_path = root / source
+        if not source_path.is_file() or source_path.suffix != ".lean":
+            errors.append(f"{item_id}: approved source does not exist as a Lean file: {source}")
+
+        scope_path = root / approval["scope_document"]
+        try:
+            scope_text = scope_path.read_text(encoding="utf-8")
+        except OSError as error:
+            errors.append(f"{item_id}: cannot read scope document {scope_path}: {error}")
+        else:
+            for expected, label in (
+                (item_id, "item id"),
+                (declaration, "declaration"),
+                (approval["scope_heading"], "scope heading"),
+            ):
+                if expected not in scope_text:
+                    errors.append(
+                        f"{item_id}: {label} {expected!r} is absent from "
+                        f"{approval['scope_document']}"
+                    )
+
+        approvals[key] = {"item_id": item_id, **approval}
+
+    return approvals, errors
+
+
+def report_group(title: str, markers: list[Marker]) -> None:
+    print(f"{title}: {len(markers)}")
+    for marker in markers:
+        print(f"  {marker.render()}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help="repository root (default: parent of scripts/)",
+    )
+    parser.add_argument(
+        "--items",
+        type=Path,
+        help="progress metadata (default: ROOT/progress/items.json)",
+    )
+    parser.add_argument(
+        "--enforce-completion",
+        action="store_true",
+        help="fail if any blocking proof placeholder remains",
+    )
+    args = parser.parse_args()
+
+    root = args.root.resolve()
+    items_path = args.items or root / "progress" / "items.json"
+    approvals, metadata_errors = load_approvals(root, items_path)
+
+    source_root = root / "EtingofRepresentationTheory"
+    markers = [
+        marker
+        for path in sorted(source_root.rglob("*.lean"))
+        for marker in scan_lean_file(root, path)
+    ]
+    proof_wanted = [marker for marker in markers if marker.kind == "proof_wanted"]
+    blocking = [marker for marker in markers if marker.kind != "proof_wanted"]
+    approved: list[Marker] = []
+    unapproved: list[Marker] = []
+
+    matched_approvals: set[tuple[str, str]] = set()
+    for marker in proof_wanted:
+        key = (marker.source, marker.declaration or "")
+        if key in approvals:
+            approved.append(marker)
+            matched_approvals.add(key)
+        else:
+            unapproved.append(marker)
+
+    for key, approval in approvals.items():
+        if key not in matched_approvals:
+            metadata_errors.append(
+                f"{approval['item_id']}: approval has no matching proof_wanted marker "
+                f"at {key[0]} ({approval['declaration']})"
+            )
+
+    report_group("Blocking proof placeholders", blocking)
+    report_group("Approved non-blocking proof_wanted markers", approved)
+    report_group("Unapproved proof_wanted markers (blocking)", unapproved)
+
+    if metadata_errors:
+        print(f"Approval metadata errors: {len(metadata_errors)}", file=sys.stderr)
+        for error in metadata_errors:
+            print(f"  {error}", file=sys.stderr)
+    else:
+        print(f"Approval metadata errors: 0")
+
+    always_forbidden = [
+        marker
+        for marker in blocking
+        if marker.kind == "admit" or marker.kind.startswith("project_")
+    ]
+    if metadata_errors or unapproved or always_forbidden:
+        return 1
+    if args.enforce_completion and blocking:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/proof_wanted_policy.py
+++ b/scripts/proof_wanted_policy.py
@@ -1,0 +1,89 @@
+"""Shared metadata policy for approved, non-blocking wanted theorems."""
+
+from __future__ import annotations
+
+
+APPROVED_STATUS = "scope_approved_proof_wanted"
+APPROVAL_FIELD = "proof_wanted_approval"
+APPROVAL_CLASSIFICATION = "approved_nonblocking"
+APPROVAL_REQUIRED_FIELDS = {
+    "classification",
+    "declaration",
+    "source",
+    "scope_document",
+    "scope_heading",
+    "reason",
+    "approved_by_issue",
+}
+
+# This is deliberately an exact ratchet, not a count. Adding or replacing an
+# exception requires an explicit code change as well as scope documentation and
+# item metadata, so a future wanted marker cannot inherit Ado's approval.
+APPROVED_WANTED_ALLOWLIST = frozenset(
+    {
+        (
+            "Chapter2/Remark2.9.3",
+            "EtingofRepresentationTheory/Chapter2/Remark2_9_3.lean",
+            "Etingof.ado",
+        )
+    }
+)
+
+
+def approval_identity(item: dict, approval: dict) -> tuple[str, str, str]:
+    """The exact item/source/declaration identity reviewed by the policy."""
+    return (item["id"], approval["source"], approval["declaration"])
+
+
+def validate_item_approval(item: dict) -> list[str]:
+    """Validate the approval-related fields of one progress item."""
+    errors: list[str] = []
+    item_id = item.get("id", "<unknown item>")
+    status = item.get("status")
+    approval = item.get(APPROVAL_FIELD)
+
+    if status == "proof_wanted":
+        errors.append(
+            f"{item_id}: legacy status 'proof_wanted' is ambiguous; use an active "
+            "proof status or the reviewed scope_approved_proof_wanted status"
+        )
+
+    if status != APPROVED_STATUS:
+        if approval is not None:
+            errors.append(f"{item_id}: {APPROVAL_FIELD} requires status {APPROVED_STATUS!r}")
+        return errors
+
+    if not isinstance(approval, dict):
+        errors.append(f"{item_id}: missing object field {APPROVAL_FIELD}")
+        return errors
+
+    missing = APPROVAL_REQUIRED_FIELDS - approval.keys()
+    if missing:
+        errors.append(f"{item_id}: approval is missing {sorted(missing)}")
+        return errors
+
+    if approval["classification"] != APPROVAL_CLASSIFICATION:
+        errors.append(
+            f"{item_id}: approval classification must be {APPROVAL_CLASSIFICATION!r}"
+        )
+    for field in (
+        "declaration",
+        "source",
+        "scope_document",
+        "scope_heading",
+        "reason",
+    ):
+        if not isinstance(approval[field], str) or not approval[field].strip():
+            errors.append(f"{item_id}: approval field {field!r} must be nonempty text")
+    if not isinstance(approval["approved_by_issue"], int) or approval["approved_by_issue"] <= 0:
+        errors.append(f"{item_id}: approved_by_issue must be a positive issue number")
+    if item.get("coverage") != "covered_full":
+        errors.append(f"{item_id}: approved proof_wanted must retain coverage 'covered_full'")
+    if item.get("sorry_free") is not True:
+        errors.append(f"{item_id}: approved proof_wanted must record sorry_free: true")
+
+    if not errors and approval_identity(item, approval) not in APPROVED_WANTED_ALLOWLIST:
+        errors.append(
+            f"{item_id}: approval identity is not in the explicit reviewed allowlist"
+        )
+    return errors

--- a/scripts/test_check_proof_placeholders.py
+++ b/scripts/test_check_proof_placeholders.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Tests for check_proof_placeholders.py."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import check_proof_placeholders as checker
+
+
+class ProofPlaceholderTests(unittest.TestCase):
+    def test_scan_ignores_comments_and_strings(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "EtingofRepresentationTheory" / "Test.lean"
+            source.parent.mkdir()
+            source.write_text(
+                "/- sorry /- proof_wanted hidden -/ axiom hidden -/\n"
+                "def prose := \"admit constant hidden\"\n"
+                "-- proof_wanted alsoHidden\n"
+                "axiom realAxiom : True\n"
+                "constant realConstant : Nat\n"
+                "example : True := by\n"
+                "  sorry\n"
+                "proof_wanted approved : True\n",
+                encoding="utf-8",
+            )
+
+            markers = checker.scan_lean_file(root, source)
+
+        self.assertEqual(
+            [(marker.kind, marker.line, marker.declaration) for marker in markers],
+            [
+                ("project_axiom", 4, "realAxiom"),
+                ("project_constant", 5, "realConstant"),
+                ("sorry", 7, None),
+                ("proof_wanted", 8, "approved"),
+            ],
+        )
+
+    def test_load_approvals_requires_scope_entry(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source_name = "EtingofRepresentationTheory/Test.lean"
+            source = root / source_name
+            source.parent.mkdir()
+            source.write_text("proof_wanted approved : True\n", encoding="utf-8")
+            heading = "Book-stated external results intentionally left as `proof_wanted`"
+            (root / "skipped-exercises.md").write_text(
+                f"## {heading}\n\nItem/Test records `Etingof.approved`.\n",
+                encoding="utf-8",
+            )
+            items_path = root / "items.json"
+            items_path.write_text(
+                json.dumps(
+                    [
+                        {
+                            "id": "Item/Test",
+                            "status": checker.APPROVED_STATUS,
+                            checker.APPROVAL_FIELD: {
+                                "classification": checker.APPROVAL_CLASSIFICATION,
+                                "declaration": "Etingof.approved",
+                                "source": source_name,
+                                "scope_document": "skipped-exercises.md",
+                                "scope_heading": heading,
+                                "reason": "Reviewed external-result boundary.",
+                                "approved_by_issue": 8110,
+                            },
+                        }
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            approvals, errors = checker.load_approvals(root, items_path)
+
+        self.assertEqual(errors, [])
+        self.assertIn((source_name, "approved"), approvals)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_proof_placeholders.py
+++ b/scripts/test_check_proof_placeholders.py
@@ -2,15 +2,64 @@
 """Tests for check_proof_placeholders.py."""
 
 import json
+import sys
 import tempfile
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
 from pathlib import Path
+from unittest.mock import patch
 
 import check_proof_placeholders as checker
 
 
+ADO_ITEM_ID = "Chapter2/Remark2.9.3"
+ADO_SOURCE = "EtingofRepresentationTheory/Chapter2/Remark2_9_3.lean"
+ADO_DECLARATION = "Etingof.ado"
+SCOPE_HEADING = "Book-stated external results intentionally left as `proof_wanted`"
+
+
 class ProofPlaceholderTests(unittest.TestCase):
-    def test_scan_ignores_comments_and_strings(self) -> None:
+    def run_checker(self, root: Path, *, enforce_completion: bool = False) -> int:
+        arguments = ["check_proof_placeholders.py", "--root", str(root)]
+        if enforce_completion:
+            arguments.append("--enforce-completion")
+        with (
+            patch.object(sys, "argv", arguments),
+            redirect_stdout(StringIO()),
+            redirect_stderr(StringIO()),
+        ):
+            return checker.main()
+
+    def write_items(self, root: Path, items: list[dict]) -> None:
+        progress = root / "progress"
+        progress.mkdir(parents=True, exist_ok=True)
+        (progress / "items.json").write_text(json.dumps(items), encoding="utf-8")
+
+    def approved_ado_item(self) -> dict:
+        return {
+            "id": ADO_ITEM_ID,
+            "status": checker.APPROVED_STATUS,
+            "coverage": "covered_full",
+            "sorry_free": True,
+            checker.APPROVAL_FIELD: {
+                "classification": checker.APPROVAL_CLASSIFICATION,
+                "declaration": ADO_DECLARATION,
+                "source": ADO_SOURCE,
+                "scope_document": "skipped-exercises.md",
+                "scope_heading": SCOPE_HEADING,
+                "reason": "Reviewed external-result boundary.",
+                "approved_by_issue": 8110,
+            },
+        }
+
+    def write_ado_scope_entry(self, root: Path) -> None:
+        (root / "skipped-exercises.md").write_text(
+            f"## {SCOPE_HEADING}\n\n{ADO_ITEM_ID} records `{ADO_DECLARATION}`.\n",
+            encoding="utf-8",
+        )
+
+    def test_scan_ignores_comments_and_string_forms(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             source = root / "EtingofRepresentationTheory" / "Test.lean"
@@ -18,12 +67,14 @@ class ProofPlaceholderTests(unittest.TestCase):
             source.write_text(
                 "/- sorry /- proof_wanted hidden -/ axiom hidden -/\n"
                 "def prose := \"admit constant hidden\"\n"
+                "def quote := '\"'\n"
+                "def raw := r###\"sorryAx theorem_wanted hidden\"###\n"
                 "-- proof_wanted alsoHidden\n"
                 "axiom realAxiom : True\n"
                 "constant realConstant : Nat\n"
                 "example : True := by\n"
                 "  sorry\n"
-                "proof_wanted approved : True\n",
+                "theorem_wanted approved : True\n",
                 encoding="utf-8",
             )
 
@@ -32,51 +83,84 @@ class ProofPlaceholderTests(unittest.TestCase):
         self.assertEqual(
             [(marker.kind, marker.line, marker.declaration) for marker in markers],
             [
-                ("project_axiom", 4, "realAxiom"),
-                ("project_constant", 5, "realConstant"),
-                ("sorry", 7, None),
-                ("proof_wanted", 8, "approved"),
+                ("project_axiom", 6, "realAxiom"),
+                ("project_constant", 7, "realConstant"),
+                ("sorry", 9, None),
+                ("theorem_wanted", 10, "approved"),
             ],
         )
 
-    def test_load_approvals_requires_scope_entry(self) -> None:
+    def test_unterminated_lexical_form_fails_closed(self) -> None:
+        for source in ('def text := "unterminated', "/- unterminated"):
+            with self.subTest(source=source):
+                with self.assertRaises(ValueError):
+                    checker.code_without_comments_or_strings(source)
+
+    def test_sorry_is_reported_by_default_and_enforced_at_completion(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            source_name = "EtingofRepresentationTheory/Test.lean"
-            source = root / source_name
+            self.write_items(root, [])
+            source = root / "EtingofRepresentationTheory" / "Test.lean"
             source.parent.mkdir()
-            source.write_text("proof_wanted approved : True\n", encoding="utf-8")
-            heading = "Book-stated external results intentionally left as `proof_wanted`"
-            (root / "skipped-exercises.md").write_text(
-                f"## {heading}\n\nItem/Test records `Etingof.approved`.\n",
-                encoding="utf-8",
+            source.write_text("example : True := by sorry\n", encoding="utf-8")
+
+            self.assertEqual(self.run_checker(root), 0)
+            self.assertEqual(self.run_checker(root, enforce_completion=True), 1)
+
+    def test_forbidden_placeholders_fail_in_default_mode(self) -> None:
+        forbidden_sources = {
+            "admit": "example : True := by admit\n",
+            "sorryAx": "example : True := sorryAx True true\n",
+            "axiom": "open Foo in axiom hiddenAxiom : True\n",
+            "constant": "namespace N\nconstant hiddenConstant : Nat\nend N\n",
+            "def_wanted": "def_wanted missingData : Nat\n",
+            "instance_wanted": "instance_wanted missingInstance : Inhabited Nat\n",
+        }
+        for name, content in forbidden_sources.items():
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                self.write_items(root, [])
+                source = root / "EtingofRepresentationTheory" / "Test.lean"
+                source.parent.mkdir()
+                source.write_text(content, encoding="utf-8")
+                self.assertEqual(self.run_checker(root), 1)
+
+    def test_unapproved_wanted_theorem_in_root_module_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_items(root, [])
+            (root / "EtingofRepresentationTheory.lean").write_text(
+                "proof_wanted unapproved : True\n", encoding="utf-8"
             )
-            items_path = root / "items.json"
-            items_path.write_text(
-                json.dumps(
-                    [
-                        {
-                            "id": "Item/Test",
-                            "status": checker.APPROVED_STATUS,
-                            checker.APPROVAL_FIELD: {
-                                "classification": checker.APPROVAL_CLASSIFICATION,
-                                "declaration": "Etingof.approved",
-                                "source": source_name,
-                                "scope_document": "skipped-exercises.md",
-                                "scope_heading": heading,
-                                "reason": "Reviewed external-result boundary.",
-                                "approved_by_issue": 8110,
-                            },
-                        }
-                    ]
-                ),
-                encoding="utf-8",
+            self.assertEqual(self.run_checker(root), 1)
+
+    def test_approved_ado_marker_succeeds(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / ADO_SOURCE
+            source.parent.mkdir(parents=True)
+            source.write_text("proof_wanted ado : True\n", encoding="utf-8")
+            self.write_ado_scope_entry(root)
+            self.write_items(root, [self.approved_ado_item()])
+
+            approvals, errors = checker.load_approvals(
+                root, root / "progress" / "items.json"
             )
 
-            approvals, errors = checker.load_approvals(root, items_path)
+            self.assertEqual(errors, [])
+            self.assertIn((ADO_SOURCE, "ado"), approvals)
+            self.assertEqual(self.run_checker(root), 0)
 
-        self.assertEqual(errors, [])
-        self.assertIn((source_name, "approved"), approvals)
+    def test_orphaned_approval_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / ADO_SOURCE
+            source.parent.mkdir(parents=True)
+            source.write_text("theorem unrelated : True := True.intro\n", encoding="utf-8")
+            self.write_ado_scope_entry(root)
+            self.write_items(root, [self.approved_ado_item()])
+
+            self.assertEqual(self.run_checker(root), 1)
 
 
 if __name__ == "__main__":

--- a/scripts/validate_items.py
+++ b/scripts/validate_items.py
@@ -11,6 +11,8 @@ import json
 import sys
 from pathlib import Path
 
+from proof_wanted_policy import validate_item_approval
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PAGES_DIR = REPO_ROOT / "pages"
 ITEMS_PATH = REPO_ROOT / "progress" / "items.json"
@@ -37,23 +39,6 @@ VALID_EXERCISE_COVERAGE = {
     "covered_partial",
     "not_started",
     "non_formalizable",
-}
-
-# A `proof_wanted` is non-blocking only when an item carries this terminal
-# status and a complete, reviewable approval record.  The source-level checker
-# additionally verifies that this metadata matches the exact marker in Lean and
-# an entry in skipped-exercises.md.
-APPROVED_PROOF_WANTED_STATUS = "scope_approved_proof_wanted"
-APPROVED_PROOF_WANTED_CLASSIFICATION = "approved_nonblocking"
-PROOF_WANTED_APPROVAL_FIELD = "proof_wanted_approval"
-PROOF_WANTED_APPROVAL_REQUIRED_FIELDS = {
-    "classification",
-    "declaration",
-    "source",
-    "scope_document",
-    "scope_heading",
-    "reason",
-    "approved_by_issue",
 }
 
 # Files in pages/ that are not actual page content
@@ -265,40 +250,9 @@ def validate(items_path):
                     f"{sorted(VALID_EXERCISE_COVERAGE)}, got {exercise_coverage!r}"
                 )
 
-        # Scope-approved `proof_wanted` is deliberately a narrow exception,
-        # not a general synonym for unfinished work.
-        approval = item.get(PROOF_WANTED_APPROVAL_FIELD)
-        if item.get("status") == APPROVED_PROOF_WANTED_STATUS:
-            if not isinstance(approval, dict):
-                errors.append(
-                    f"{prefix}: status {APPROVED_PROOF_WANTED_STATUS!r} requires "
-                    f"an object field {PROOF_WANTED_APPROVAL_FIELD!r}"
-                )
-            else:
-                missing_approval = PROOF_WANTED_APPROVAL_REQUIRED_FIELDS - set(approval)
-                if missing_approval:
-                    errors.append(
-                        f"{prefix}: {PROOF_WANTED_APPROVAL_FIELD} is missing fields: "
-                        f"{sorted(missing_approval)}"
-                    )
-                if approval.get("classification") != APPROVED_PROOF_WANTED_CLASSIFICATION:
-                    errors.append(
-                        f"{prefix}: approval classification must be "
-                        f"{APPROVED_PROOF_WANTED_CLASSIFICATION!r}"
-                    )
-                if item.get("coverage") != "covered_full":
-                    errors.append(
-                        f"{prefix}: approved proof_wanted must retain coverage 'covered_full'"
-                    )
-                if item.get("sorry_free") is not True:
-                    errors.append(
-                        f"{prefix}: approved proof_wanted must record sorry_free: true"
-                    )
-        elif approval is not None:
-            errors.append(
-                f"{prefix}: {PROOF_WANTED_APPROVAL_FIELD!r} is only valid with status "
-                f"{APPROVED_PROOF_WANTED_STATUS!r}"
-            )
+        # Scope-approved wanted theorems use the same narrow metadata policy as
+        # the source scanner. A bare legacy `proof_wanted` status is rejected.
+        errors.extend(validate_item_approval(item))
 
         # Line number types
         if not isinstance(item["start_line"], int):

--- a/scripts/validate_items.py
+++ b/scripts/validate_items.py
@@ -39,6 +39,23 @@ VALID_EXERCISE_COVERAGE = {
     "non_formalizable",
 }
 
+# A `proof_wanted` is non-blocking only when an item carries this terminal
+# status and a complete, reviewable approval record.  The source-level checker
+# additionally verifies that this metadata matches the exact marker in Lean and
+# an entry in skipped-exercises.md.
+APPROVED_PROOF_WANTED_STATUS = "scope_approved_proof_wanted"
+APPROVED_PROOF_WANTED_CLASSIFICATION = "approved_nonblocking"
+PROOF_WANTED_APPROVAL_FIELD = "proof_wanted_approval"
+PROOF_WANTED_APPROVAL_REQUIRED_FIELDS = {
+    "classification",
+    "declaration",
+    "source",
+    "scope_document",
+    "scope_heading",
+    "reason",
+    "approved_by_issue",
+}
+
 # Files in pages/ that are not actual page content
 EXCLUDED_FILES = {"CONVENTIONS.md"}
 
@@ -247,6 +264,41 @@ def validate(items_path):
                     f"{prefix}: exercise coverage must be one of "
                     f"{sorted(VALID_EXERCISE_COVERAGE)}, got {exercise_coverage!r}"
                 )
+
+        # Scope-approved `proof_wanted` is deliberately a narrow exception,
+        # not a general synonym for unfinished work.
+        approval = item.get(PROOF_WANTED_APPROVAL_FIELD)
+        if item.get("status") == APPROVED_PROOF_WANTED_STATUS:
+            if not isinstance(approval, dict):
+                errors.append(
+                    f"{prefix}: status {APPROVED_PROOF_WANTED_STATUS!r} requires "
+                    f"an object field {PROOF_WANTED_APPROVAL_FIELD!r}"
+                )
+            else:
+                missing_approval = PROOF_WANTED_APPROVAL_REQUIRED_FIELDS - set(approval)
+                if missing_approval:
+                    errors.append(
+                        f"{prefix}: {PROOF_WANTED_APPROVAL_FIELD} is missing fields: "
+                        f"{sorted(missing_approval)}"
+                    )
+                if approval.get("classification") != APPROVED_PROOF_WANTED_CLASSIFICATION:
+                    errors.append(
+                        f"{prefix}: approval classification must be "
+                        f"{APPROVED_PROOF_WANTED_CLASSIFICATION!r}"
+                    )
+                if item.get("coverage") != "covered_full":
+                    errors.append(
+                        f"{prefix}: approved proof_wanted must retain coverage 'covered_full'"
+                    )
+                if item.get("sorry_free") is not True:
+                    errors.append(
+                        f"{prefix}: approved proof_wanted must record sorry_free: true"
+                    )
+        elif approval is not None:
+            errors.append(
+                f"{prefix}: {PROOF_WANTED_APPROVAL_FIELD!r} is only valid with status "
+                f"{APPROVED_PROOF_WANTED_STATUS!r}"
+            )
 
         # Line number types
         if not isinstance(item["start_line"], int):

--- a/skipped-exercises.md
+++ b/skipped-exercises.md
@@ -10,6 +10,41 @@ describe what is and is not formalized, link to this document, and contain no
 `sorry`, `admit`, axiom, or proof-placeholder declaration for the omitted material.
 Progress metadata should record partial coverage and the scope decision explicitly.
 
+## Book-stated external results intentionally left as `proof_wanted`
+
+This section is a narrow exception to the omission policy above. A
+`proof_wanted` records and typechecks a proposition but creates no proof term,
+`sorryAx`, or project axiom. Such a marker is non-blocking only when it is
+individually enumerated here and has matching `scope_approved_proof_wanted`
+metadata in `progress/items.json`. Adding another exception requires a new entry
+in both places and explicit review; unapproved `proof_wanted` markers remain
+blocking proof gaps. `scripts/check_proof_placeholders.py` enforces that
+correspondence.
+
+### Remark 2.9.3 — Ado–Iwasawa theorem
+
+The book states Ado's theorem—that every finite-dimensional Lie algebra has a
+faithful finite-dimensional representation—but supplies no proof. Because the
+chapter works over an arbitrary field, the faithful Lean statement
+`Etingof.ado` records the arbitrary-characteristic Ado–Iwasawa theorem, not only
+the characteristic-zero case.
+
+The project intentionally does not undertake the Ado–Iwasawa proof. Its
+arbitrary-characteristic proof requires substantial Lie-theoretic machinery
+beyond the representation-theory development selected for this book, including
+the characteristic-dependent construction of a finite-dimensional quotient of
+the universal enveloping algebra that remains faithful on the Lie algebra.
+Building that theory solely to prove a result the book invokes without proof is
+outside this formalization's boundary.
+
+Accordingly, the sole `proof_wanted ado` in
+`EtingofRepresentationTheory/Chapter2/Remark2_9_3.lean`, tracked by
+`Chapter2/Remark2.9.3`, is an approved non-blocking marker. The file still proves
+the useful constructive reductions between a faithful finite-dimensional
+representation and a finite-dimensional enveloping-algebra target. Its
+`proof_wanted` records that the theorem itself has no project proof; it is not
+active mathematical work and does not prevent completion.
+
 ## Current intentional omissions
 
 ### Problem 2.11.6 — standalone bimodule tensor calculus


### PR DESCRIPTION
## Summary

- document Ado–Iwasawa as the sole reviewed, non-blocking `proof_wanted` scope exception
- give Remark 2.9.3 machine-readable approval metadata without changing its faithful statement or constructive reduction API
- add a comment/string-aware placeholder classifier, metadata validation, unit tests, and a CI check
- correct the claim that the book explicitly disavows the proof: it states the theorem without providing one

## Completion policy

Completion still requires zero `sorry`, `admit`, and project axioms. Every non-blocking `proof_wanted` must have an explicit scope entry and reviewed metadata; future markers are blocking by default.

Closes #8110.

## Validation

- `python3 scripts/test_check_proof_placeholders.py`
- `scripts/check_proof_placeholders.py`
- `python3 scripts/validate_items.py`
- `lake build EtingofRepresentationTheory.Chapter2.Remark2_9_3`
- `lake build` (9411 jobs, successful)