### PR TITLE
Repair lossy Chapter 6 diagram transcriptions

### DIFF
--- a/blobs/Chapter6/Definition6.6.1.md
+++ b/blobs/Chapter6/Definition6.6.1.md
@@ -1,12 +1,12 @@
 **Definition 6.6.1.** Let $Q$ be any quiver. We call a vertex $i \in Q$ a **sink** if all edges connected to $i$ point towards $i$:
 
 $$
-\longrightarrow \overset{i}{\bullet} \longleftarrow
+\begin{array}{ccc} \longrightarrow & \overset{i}{\bullet} & \longleftarrow \\ & \uparrow & \end{array}.
 $$
 
 We call a vertex $i \in Q$ a **source** if all edges connected to $i$ point away from $i$:
 
 $$
-\longleftarrow \overset{i}{\bullet} \longrightarrow
+\begin{array}{ccc} \longleftarrow & \overset{i}{\bullet} & \longrightarrow \\ & \downarrow & \end{array}.
 $$
 

--- a/blobs/Chapter6/Example6.3.1.md
+++ b/blobs/Chapter6/Example6.3.1.md
@@ -1,104 +1,84 @@
 **Example 6.3.1** ($D_4$). We restrict ourselves to the orientation
 
 $$
-\begin{array}{ccc}
-& \bullet & \\
-\bullet \longrightarrow & \bullet & \longleftarrow \bullet \\
-& \uparrow & \\
-& \bullet &
+\begin{array}{ccccc}
+\bullet & \longrightarrow & \bullet & \longleftarrow & \bullet \\
+&& \uparrow && \\
+&& \bullet &&
 \end{array}.
 $$
 
 So a representation of this quiver looks like
 
 $$
-\begin{array}{ccc}
-& V & \\
-V_1 \xrightarrow{A_1} & \bullet & \xleftarrow{A_3} V_3 \\
-& \uparrow A_2 & \\
-& V_2 &
+\begin{array}{ccccc}
+\underset{V_1}{\bullet} & \xrightarrow{A_1} & \overset{V}{\bullet} &
+\xleftarrow{A_3} & \underset{V_3}{\bullet} \\
+&& \uparrow^{A_2} && \\
+&& \underset{V_2}{\bullet} &&
 \end{array}.
 $$
 
 The first thing we can do is — as usual — split away the kernels of the maps $A_1$, $A_2$, $A_3$. More precisely, we split away the representations
 
 $$
-\begin{array}{ccc}
-& 0 & \\
-\ker A_1 \xrightarrow{0} & \bullet & \longleftarrow 0 \\
-& \uparrow & \\
-& 0 &
+\begin{array}{ccccc}
+\underset{\ker A_1}{\bullet} & \xrightarrow{0} & \overset{0}{\bullet} &
+\longleftarrow & \underset{0}{\bullet} \\
+&& \uparrow && \\
+&& \underset{0}{\bullet} &&
 \end{array},
 \quad
-\begin{array}{ccc}
-& 0 & \\
-0 \longrightarrow & \bullet & \longleftarrow 0 \\
-& \uparrow 0 & \\
-& \ker A_2 &
+\begin{array}{ccccc}
+\underset{0}{\bullet} & \longrightarrow & \overset{0}{\bullet} &
+\longleftarrow & \underset{0}{\bullet} \\
+&& \overset{0}{\uparrow} && \\
+&& \underset{\ker A_2}{\bullet} &&
 \end{array},
 $$
 $$
-\overset{0}{\bullet} \to \overset{0}{\bullet} \leftarrow \overset{\ker A_3}{\bullet}
-$$
-
-$$
-\uparrow
-$$
-
-$$
-\overset{0}{\bullet}
+\begin{array}{ccccc}
+\underset{0}{\bullet} & \longrightarrow & \overset{0}{\bullet} &
+\xleftarrow{0} & \underset{\ker A_3}{\bullet} \\
+&& \uparrow && \\
+&& \underset{0}{\bullet} &&
+\end{array}.
 $$
 
 These representations are multiples of the indecomposable objects
 
 $$
-\overset{1}{\bullet} \xrightarrow{0} \overset{0}{\bullet} \leftarrow \overset{0}{\bullet}
-$$
-
-$$
-\uparrow
-$$
-
-$$
-\overset{0}{\bullet}
-$$
-
-$$
-\overset{0}{\bullet} \to \overset{0}{\bullet} \leftarrow \overset{0}{\bullet}
-$$
-
-$$
-\uparrow 0
-$$
-
-$$
-\overset{1}{\bullet}
-$$
-
-$$
-\overset{0}{\bullet} \to \overset{0}{\bullet} \xleftarrow{0} \overset{1}{\bullet}
-$$
-
-$$
-\uparrow
-$$
-
-$$
-\overset{0}{\bullet}
+\begin{array}{ccccc}
+\underset{1}{\bullet} & \xrightarrow{0} & \overset{0}{\bullet} &
+\longleftarrow & \underset{0}{\bullet} \\
+&& \uparrow && \\
+&& \underset{0}{\bullet} &&
+\end{array},
+\qquad
+\begin{array}{ccccc}
+\underset{0}{\bullet} & \longrightarrow & \overset{0}{\bullet} &
+\longleftarrow & \underset{0}{\bullet} \\
+&& \overset{0}{\uparrow} && \\
+&& \underset{1}{\bullet} &&
+\end{array},
+\qquad
+\begin{array}{ccccc}
+\underset{0}{\bullet} & \longrightarrow & \overset{0}{\bullet} &
+\xleftarrow{0} & \underset{1}{\bullet} \\
+&& \uparrow && \\
+&& \underset{0}{\bullet} &&
+\end{array}.
 $$
 
 So we get to a situation where all of the maps $A_1, A_2, A_3$ are injective:
 
 $$
-\overset{V_1}{\bullet} \xrightarrow{A_1} \overset{V}{\bullet} \xleftarrow{A_3} \overset{V_3}{\bullet}
-$$
-
-$$
-\uparrow A_2
-$$
-
-$$
-\overset{V_2}{\bullet}
+\begin{array}{ccccc}
+\underset{V_1}{\bullet} & \xrightarrow{A_1} & \overset{V}{\bullet} &
+\xleftarrow{A_3} & \underset{V_3}{\bullet} \\
+&& \uparrow^{A_2} && \\
+&& \underset{V_2}{\bullet} &&
+\end{array}.
 $$
 
 As in Example 6.2.4, we can then identify the spaces $V_1, V_2, V_3$ with subspaces of $V$. So we get to the **triple of subspaces problem** of classifying triples of subspaces of a given space $V$.

--- a/blobs/Chapter6/Lemma6.4.6.md
+++ b/blobs/Chapter6/Lemma6.4.6.md
@@ -3,13 +3,28 @@
 **Proof.** Assume the contrary, i.e., $k_i > 0$, $k_j < 0$. Without loss of generality, we can also assume that $k_s = 0$ for all $s$ between $i$ and $j$. We can identify the indices $i, j$ with vertices of the graph $\Gamma$:
 
 $$
-\bullet \longrightarrow \bullet_i \xrightarrow{\epsilon} \bullet^{i'} \longrightarrow \bullet \longrightarrow \bullet_j \longrightarrow \bullet \longrightarrow \bullet
+\begin{array}{ccccccccccccc}
+\bullet & \text{---} & \underset{i}{\bullet} & \overset{\epsilon}{\text{---}} &
+\overset{i'}{\bullet} & \text{---} & \bullet & \text{---} &
+\underset{j}{\bullet} & \text{---} & \bullet & \text{---} & \bullet \\
+&&&& \vert &&&&&&&& \\
+&&&& \bullet &&&&&&&&
+\end{array}
 $$
 
 Next, let $\epsilon$ be the edge connecting $i$ with the next vertex towards $j$ and let $i'$ be the vertex on the other end of $\epsilon$. We then let $\Gamma_1, \Gamma_2$ be the graphs obtained from $\Gamma$ by removing $\epsilon$. Since $\Gamma$ is supposed to be a Dynkin diagram — and therefore has no cycles or loops — both $\Gamma_1$ and $\Gamma_2$ will be connected graphs which are not connected to each other:
 
 $$
-\boxed{\bullet \longrightarrow \bullet_i}_{\Gamma_1} \qquad \boxed{\bullet \longrightarrow \bullet \longrightarrow \bullet_j \longrightarrow \bullet \longrightarrow \bullet}_{\Gamma_2}
+\boxed{\begin{array}{ccc}
+\bullet & \text{---} & \underset{i}{\bullet}
+\end{array}}_{\Gamma_1}
+\qquad
+\boxed{\begin{array}{ccccccccc}
+\bullet & \text{---} & \bullet & \text{---} & \underset{j}{\bullet} &
+\text{---} & \bullet & \text{---} & \bullet \\
+\vert &&&&&&&& \\
+\bullet &&&&&&&&
+\end{array}}_{\Gamma_2}
 $$
 
 Then we have $i \in \Gamma_1$, $j \in \Gamma_2$. We define

--- a/pages/158.md
+++ b/pages/158.md
@@ -15,39 +15,38 @@ As the last — slightly more complicated — example we consider the quiver $D_
 **Example 6.3.1** ($D_4$). We restrict ourselves to the orientation
 
 $$
-\begin{array}{ccc}
-& \bullet & \\
-\bullet \longrightarrow & \bullet & \longleftarrow \bullet \\
-& \uparrow & \\
-& \bullet &
+\begin{array}{ccccc}
+\bullet & \longrightarrow & \bullet & \longleftarrow & \bullet \\
+&& \uparrow && \\
+&& \bullet &&
 \end{array}.
 $$
 
 So a representation of this quiver looks like
 
 $$
-\begin{array}{ccc}
-& V & \\
-V_1 \xrightarrow{A_1} & \bullet & \xleftarrow{A_3} V_3 \\
-& \uparrow A_2 & \\
-& V_2 &
+\begin{array}{ccccc}
+\underset{V_1}{\bullet} & \xrightarrow{A_1} & \overset{V}{\bullet} &
+\xleftarrow{A_3} & \underset{V_3}{\bullet} \\
+&& \uparrow^{A_2} && \\
+&& \underset{V_2}{\bullet} &&
 \end{array}.
 $$
 
 The first thing we can do is — as usual — split away the kernels of the maps $A_1$, $A_2$, $A_3$. More precisely, we split away the representations
 
 $$
-\begin{array}{ccc}
-& 0 & \\
-\ker A_1 \xrightarrow{0} & \bullet & \longleftarrow 0 \\
-& \uparrow & \\
-& 0 &
+\begin{array}{ccccc}
+\underset{\ker A_1}{\bullet} & \xrightarrow{0} & \overset{0}{\bullet} &
+\longleftarrow & \underset{0}{\bullet} \\
+&& \uparrow && \\
+&& \underset{0}{\bullet} &&
 \end{array},
 \quad
-\begin{array}{ccc}
-& 0 & \\
-0 \longrightarrow & \bullet & \longleftarrow 0 \\
-& \uparrow 0 & \\
-& \ker A_2 &
+\begin{array}{ccccc}
+\underset{0}{\bullet} & \longrightarrow & \overset{0}{\bullet} &
+\longleftarrow & \underset{0}{\bullet} \\
+&& \overset{0}{\uparrow} && \\
+&& \underset{\ker A_2}{\bullet} &&
 \end{array},
 $$

--- a/pages/159.md
+++ b/pages/159.md
@@ -1,65 +1,46 @@
 $$
-\overset{0}{\bullet} \to \overset{0}{\bullet} \leftarrow \overset{\ker A_3}{\bullet}
-$$
-
-$$
-\uparrow
-$$
-
-$$
-\overset{0}{\bullet}
+\begin{array}{ccccc}
+\underset{0}{\bullet} & \longrightarrow & \overset{0}{\bullet} &
+\xleftarrow{0} & \underset{\ker A_3}{\bullet} \\
+&& \uparrow && \\
+&& \underset{0}{\bullet} &&
+\end{array}.
 $$
 
 These representations are multiples of the indecomposable objects
 
 $$
-\overset{1}{\bullet} \xrightarrow{0} \overset{0}{\bullet} \leftarrow \overset{0}{\bullet}
-$$
-
-$$
-\uparrow
-$$
-
-$$
-\overset{0}{\bullet}
-$$
-
-$$
-\overset{0}{\bullet} \to \overset{0}{\bullet} \leftarrow \overset{0}{\bullet}
-$$
-
-$$
-\uparrow 0
-$$
-
-$$
-\overset{1}{\bullet}
-$$
-
-$$
-\overset{0}{\bullet} \to \overset{0}{\bullet} \xleftarrow{0} \overset{1}{\bullet}
-$$
-
-$$
-\uparrow
-$$
-
-$$
-\overset{0}{\bullet}
+\begin{array}{ccccc}
+\underset{1}{\bullet} & \xrightarrow{0} & \overset{0}{\bullet} &
+\longleftarrow & \underset{0}{\bullet} \\
+&& \uparrow && \\
+&& \underset{0}{\bullet} &&
+\end{array},
+\qquad
+\begin{array}{ccccc}
+\underset{0}{\bullet} & \longrightarrow & \overset{0}{\bullet} &
+\longleftarrow & \underset{0}{\bullet} \\
+&& \overset{0}{\uparrow} && \\
+&& \underset{1}{\bullet} &&
+\end{array},
+\qquad
+\begin{array}{ccccc}
+\underset{0}{\bullet} & \longrightarrow & \overset{0}{\bullet} &
+\xleftarrow{0} & \underset{1}{\bullet} \\
+&& \uparrow && \\
+&& \underset{0}{\bullet} &&
+\end{array}.
 $$
 
 So we get to a situation where all of the maps $A_1, A_2, A_3$ are injective:
 
 $$
-\overset{V_1}{\bullet} \xrightarrow{A_1} \overset{V}{\bullet} \xleftarrow{A_3} \overset{V_3}{\bullet}
-$$
-
-$$
-\uparrow A_2
-$$
-
-$$
-\overset{V_2}{\bullet}
+\begin{array}{ccccc}
+\underset{V_1}{\bullet} & \xrightarrow{A_1} & \overset{V}{\bullet} &
+\xleftarrow{A_3} & \underset{V_3}{\bullet} \\
+&& \uparrow^{A_2} && \\
+&& \underset{V_2}{\bullet} &&
+\end{array}.
 $$
 
 As in Example 6.2.4, we can then identify the spaces $V_1, V_2, V_3$ with subspaces of $V$. So we get to the **triple of subspaces problem** of classifying triples of subspaces of a given space $V$.

--- a/pages/165.md
+++ b/pages/165.md
@@ -13,13 +13,28 @@ The $\alpha_i$ naturally form a basis of the lattice $\mathbb{Z}^n$.
 **Proof.** Assume the contrary, i.e., $k_i > 0$, $k_j < 0$. Without loss of generality, we can also assume that $k_s = 0$ for all $s$ between $i$ and $j$. We can identify the indices $i, j$ with vertices of the graph $\Gamma$:
 
 $$
-\bullet \longrightarrow \bullet_i \xrightarrow{\epsilon} \bullet^{i'} \longrightarrow \bullet \longrightarrow \bullet_j \longrightarrow \bullet \longrightarrow \bullet
+\begin{array}{ccccccccccccc}
+\bullet & \text{---} & \underset{i}{\bullet} & \overset{\epsilon}{\text{---}} &
+\overset{i'}{\bullet} & \text{---} & \bullet & \text{---} &
+\underset{j}{\bullet} & \text{---} & \bullet & \text{---} & \bullet \\
+&&&& \vert &&&&&&&& \\
+&&&& \bullet &&&&&&&&
+\end{array}
 $$
 
 Next, let $\epsilon$ be the edge connecting $i$ with the next vertex towards $j$ and let $i'$ be the vertex on the other end of $\epsilon$. We then let $\Gamma_1, \Gamma_2$ be the graphs obtained from $\Gamma$ by removing $\epsilon$. Since $\Gamma$ is supposed to be a Dynkin diagram — and therefore has no cycles or loops — both $\Gamma_1$ and $\Gamma_2$ will be connected graphs which are not connected to each other:
 
 $$
-\boxed{\bullet \longrightarrow \bullet_i}_{\Gamma_1} \qquad \boxed{\bullet \longrightarrow \bullet \longrightarrow \bullet_j \longrightarrow \bullet \longrightarrow \bullet}_{\Gamma_2}
+\boxed{\begin{array}{ccc}
+\bullet & \text{---} & \underset{i}{\bullet}
+\end{array}}_{\Gamma_1}
+\qquad
+\boxed{\begin{array}{ccccccccc}
+\bullet & \text{---} & \bullet & \text{---} & \underset{j}{\bullet} &
+\text{---} & \bullet & \text{---} & \bullet \\
+\vert &&&&&&&& \\
+\bullet &&&&&&&&
+\end{array}}_{\Gamma_2}
 $$
 
 Then we have $i \in \Gamma_1$, $j \in \Gamma_2$. We define

--- a/pages/168.md
+++ b/pages/168.md
@@ -5,13 +5,13 @@
 **Definition 6.6.1.** Let $Q$ be any quiver. We call a vertex $i \in Q$ a **sink** if all edges connected to $i$ point towards $i$:
 
 $$
-\longrightarrow \overset{i}{\bullet} \longleftarrow
+\begin{array}{ccc} \longrightarrow & \overset{i}{\bullet} & \longleftarrow \\ & \uparrow & \end{array}.
 $$
 
 We call a vertex $i \in Q$ a **source** if all edges connected to $i$ point away from $i$:
 
 $$
-\longleftarrow \overset{i}{\bullet} \longrightarrow
+\begin{array}{ccc} \longleftarrow & \overset{i}{\bullet} & \longrightarrow \\ & \downarrow & \end{array}.
 $$
 
 **Definition 6.6.2.** Let $Q$ be any quiver and let $i \in Q$ be a sink (respectively, a source). Then we let $\overline{Q}_i$ be the quiver obtained from $Q$ by reversing all arrows pointing into (respectively, pointing out of) $i$.

--- a/progress/2026-08-02T11-10-17Z.md
+++ b/progress/2026-08-02T11-10-17Z.md
@@ -1,0 +1,33 @@
+## Accomplished
+
+- Resolved issue #8541 by checking the diagrams on pp. 158, 165, and 168 directly against
+  the source PDFs and replacing lossy Markdown renderings with faithful LaTeX arrays.
+- Corrected the D₄ orientation and all adjacent representation diagrams in Example 6.3.1,
+  including the split displays on p. 159.
+- Restored the omitted branch at `i'` in Lemma 6.4.6 and in its `Γ₂` component, using
+  undirected Dynkin edges rather than quiver arrows.
+- Restored the vertical incoming/outgoing arrows in the sink and source diagrams of
+  Definition 6.6.1.
+- Regenerated the three affected blobs, verified exact page/blob concatenation, validated
+  item coverage, compiled every new diagram with LaTeX, and incorporated a fresh independent
+  Claude review.
+
+## Current frontier
+
+Issue #8541 is complete locally on branch `codex/issue-8541`. PR #8538 has merged while this
+work was in progress, so this branch must be rebased onto current `main` before publication.
+
+## Overall project progress
+
+The tracked batch is #8523--#8536 plus #8541. Issue #8532 is merged; #8528, #8536, and
+#8526 have open PRs in CI. The transcription and derived blobs now preserve the topology of
+all diagrams touched by #8541.
+
+## Next step
+
+Rebase onto current `main`, rerun the page/blob and item validators, publish the #8541 PR,
+and enable squash auto-merge. Continue the remaining issue batch from fresh `/tmp` clones.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -41393,7 +41393,7 @@
     "sorry_free": true,
     "coverage_note": "The concrete triple-of-subspaces model is equivalent to the inward D₄ quiver model for indecomposability and isomorphism. Twelve canonical representatives are constructed, proved indecomposable and pairwise nonisomorphic, and every concrete indecomposable belongs to exactly one class.",
     "lean_ref": "EtingofRepresentationTheory/Chapter6/Example6_3_1.lean :: Etingof.Example_6_3_1; EtingofRepresentationTheory/Chapter6/Example6_3_1_Classification.lean :: D₄Rep.canonicalRepresentation, D₄Rep.canonicalRepresentation_indecomposable, D₄Rep.canonical_pairwise_nonisomorphic, D₄Rep.classification, D₄Rep.classIndex_card",
-    "last_updated": "2026-08-01",
+    "last_updated": "2026-08-02",
     "claim_coverage": {
       "stage": "3.2",
       "status": "complete",
@@ -42105,7 +42105,7 @@
     "sorry_free": true,
     "coverage": "covered_full",
     "coverage_note": "The public lemma proves the exact all-nonnegative or all-nonpositive coordinate dichotomy.",
-    "last_updated": "2026-08-01",
+    "last_updated": "2026-08-02",
     "claim_coverage": {
       "stage": "3.2",
       "status": "complete",
@@ -43019,7 +43019,7 @@
     "fidelity": "verified",
     "sorry_free": true,
     "coverage": "covered_full",
-    "last_updated": "2026-08-01",
+    "last_updated": "2026-08-02",
     "claim_coverage": {
       "stage": "3.2",
       "status": "complete",


### PR DESCRIPTION
Closes #8541.

## Summary
- restore the four-vertex D₄ orientation and consistently render every adjacent representation diagram in Example 6.3.1
- restore the branch at `i′` in Lemma 6.4.6 and its `Γ₂` component, using undirected Dynkin edges
- restore the vertical incoming/outgoing edges in the sink and source diagrams
- regenerate the affected blobs from the corrected page transcriptions

## Validation
- direct visual comparison with `pdf/pages/158.pdf`, `159.pdf`, `165.pdf`, and `168.pdf`
- all new formulas compiled with `pdflatex`
- `python3 scripts/verify_blobs.py`
- `python3 scripts/validate_items.py`
- `python3 scripts/validate_dependencies.py`
- `python3 scripts/validate_external_deps.py`
- `python3 scripts/validate_postformalization_reviews.py`
- fresh independent Claude Opus review; findings incorporated