### PR TITLE
Correct the induced-representation claim ledger

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -60,6 +60,8 @@ jobs:
           # mechanically synchronized. These checks are intentionally ahead of
           # the expensive Lean build so metadata drift fails fast.
           python3 scripts/validate_items.py
+          python3 scripts/test_validate_items_sections.py
+          python3 scripts/test_validate_items_scope_refs.py
           python3 scripts/validate_dependencies.py
           python3 scripts/test_validate_dependencies.py
           python3 scripts/validate_external_deps.py

--- a/progress/2026-08-02T16-25-37Z_issue-8535.md
+++ b/progress/2026-08-02T16-25-37Z_issue-8535.md
@@ -20,20 +20,21 @@
 
 ## Current frontier
 
-The §5.17 record is supplied by the complete Frobenius-determinant and
-hook-length work for issue #8524.  This branch will be rebased after that PR
-lands so the combined ledger has correct records for both discussions.
+Stacked through the prepared proof branches from #8524 through #8533, the combined ledger has
+correct records for both the §5.8 induction verification and §5.17 hook-length derivation. The
+complete metadata suite passes with zero source-hash drift, and the Stage 3.5 record remains
+`complete` for the now-formalized local provider while carrying the corrected section `5.8`.
 
 ## Overall project progress
 
-The tracked batch is #8523--#8536 plus #8541.  Issues #8526, #8528, #8529,
-#8532, #8536, and #8541 are complete or in their final merge queue; the other
-prepared branches continue independently.
+Issues #8526, #8528, #8529, #8532, #8534, #8536, and #8541 are merged. PR #8547 (#8524) has
+squash auto-merge armed and is in exact CI; the remaining proof branches are fully prepared in
+sequence above its exact tree.
 
 ## Next step
 
-Run the full metadata suite and a fresh independent review, then rebase onto
-the merged #8524 result before opening this PR.
+After the prepared proof PRs merge in sequence, move only the #8535 commit onto main, rerun the
+metadata suite, and open the one-issue PR with exact CI and squash auto-merge.
 
 ## Blockers
 

--- a/progress/2026-08-02T16-25-37Z_issue-8535.md
+++ b/progress/2026-08-02T16-25-37Z_issue-8535.md
@@ -1,0 +1,40 @@
+## Accomplished
+
+- Replaced the misfiled §5.17 hook-length claims on
+  `Chapter5/Discussion_verification_of_Ind` with the two claims actually made
+  in §5.8: preservation of the covariance condition and the representation
+  multiplication law.
+- Recorded both claims as `covered_elsewhere` by Mathlib's literal
+  function-space construction `Representation.coindV` and its right-translation
+  action `Representation.coind`.
+- Strengthened `validate_items.py` so editorial item IDs inherit the current
+  numbered section from source order, while chapter boundaries reset that
+  context.  The validator now also enforces source ordering, preserves the
+  physical context across back-referencing IDs, and checks chapter consistency
+  before the first numbered item. Added focused regression tests and wired
+  them, plus the existing scope-reference tests, into CI.
+- Incorporated the fresh independent review: corrected two unrelated stale
+  hook-length coverage notes pasted onto Chapter 4 introductions, synchronized
+  the §5.8 Stage 3.4/3.5 section metadata, and narrowed the second §5.8 claim
+  to exactly the multiplication identity displayed by the source.
+
+## Current frontier
+
+The §5.17 record is supplied by the complete Frobenius-determinant and
+hook-length work for issue #8524.  This branch will be rebased after that PR
+lands so the combined ledger has correct records for both discussions.
+
+## Overall project progress
+
+The tracked batch is #8523--#8536 plus #8541.  Issues #8526, #8528, #8529,
+#8532, #8536, and #8541 are complete or in their final merge queue; the other
+prepared branches continue independently.
+
+## Next step
+
+Run the full metadata suite and a fresh independent review, then rebase onto
+the merged #8524 result before opening this PR.
+
+## Blockers
+
+None.

--- a/progress/items.json
+++ b/progress/items.json
@@ -20027,8 +20027,8 @@
     "end_line": 10,
     "status": "not_applicable",
     "coverage": "covered_full",
-    "coverage_note": "The section's hook-length derivation and theorem are fully formalized in CharValueHookFormula.lean and Theorem5_17_1.lean.",
-    "last_updated": "2026-08-01",
+    "coverage_note": "The mathematical content is covered by Representation and Rep.equivalenceModuleMonoidAlgebra; the chapter title, roadmap, and section heading are organizational prose.",
+    "last_updated": "2026-08-02",
     "claim_coverage": {
       "stage": "3.2",
       "status": "complete",
@@ -21729,8 +21729,8 @@
     "end_line": 2,
     "status": "not_applicable",
     "coverage": "covered_full",
-    "coverage_note": "The book's Frobenius/Vandermonde derivation, Young-diagram hook bookkeeping, determinant evaluation, and cancellation are formalized in CharValueHookFormula.lean.",
-    "last_updated": "2026-08-01",
+    "coverage_note": "The normalized Hermitian pairing and irreducible-character orthogonality are formalized by Theorem4_5_1_i and Theorem4_5_1_ii; spanning is supplied by Theorem4_2_1_span_eq_classFunctionSubmodule.",
+    "last_updated": "2026-08-02",
     "claim_coverage": {
       "stage": "3.2",
       "status": "complete",
@@ -29557,14 +29557,14 @@
       "nonvacuity": "verified",
       "claims": [
         {
-          "claim": "Right translation preserves the covariance condition f(hx)=rho(h)f(x).",
-          "verdict": "formalized",
-          "lean_decl": "Etingof.mem_Definition5_8_1_functionSpace; Etingof.Definition5_8_1_functionSpace_condition; Etingof.Definition5_8_1_functionSpace_apply"
+          "claim": "Right translation preserves the covariance condition f(hx) = ρ_V(h)f(x), so the displayed action sends the induced function space to itself.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Representation.coindV; Representation.coind"
         },
         {
-          "claim": "Successive right translations by g and g' equal right translation by gg', so the construction is a G-representation.",
-          "verdict": "formalized",
-          "lean_decl": "Etingof.Definition5_8_1_functionSpace_one; Etingof.Definition5_8_1_functionSpace_mul"
+          "claim": "The right-translation operators satisfy g(g'(f)) = (gg')(f), the displayed multiplication law required of a representation of G.",
+          "verdict": "covered_elsewhere",
+          "lean_decl": "Representation.coind"
         }
       ]
     },
@@ -29572,7 +29572,7 @@
       "supplemental_provider_dependencies": [],
       "explicit_source_references": [],
       "status": "complete",
-      "section": null,
+      "section": "5.8",
       "verified_on": "2026-08-01",
       "actual_internal_dependencies": [],
       "forward_internal_dependencies": [],
@@ -29598,7 +29598,7 @@
     },
     "stage3_5": {
       "status": "complete",
-      "section": null,
+      "section": "5.8",
       "reviewed_on": "2026-08-01",
       "mathlib_quality": "linter_screened",
       "provider_modules": [

--- a/scripts/test_validate_items_sections.py
+++ b/scripts/test_validate_items_sections.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Focused tests for source-order section inference in validate_items.py."""
+
+from validate_items import partition_order_errors, sections_from_item_order
+
+
+def test_editorial_item_inherits_current_section() -> None:
+    sections = sections_from_item_order([
+        {"id": "Chapter5/Definition5.8.1"},
+        {"id": "Chapter5/Discussion_verification_of_Ind"},
+        {"id": "Chapter5/Theorem5.9.1"},
+    ])
+    assert sections["Chapter5/Discussion_verification_of_Ind"] == "5.8"
+
+
+def test_filename_style_section_updates_context() -> None:
+    sections = sections_from_item_order([
+        {"id": "Chapter4/Example4_3_Q8"},
+        {"id": "Chapter4/Discussion_after_example"},
+    ])
+    assert sections["Chapter4/Discussion_after_example"] == "4.3"
+
+
+def test_chapter_boundary_resets_context() -> None:
+    sections = sections_from_item_order([
+        {"id": "Chapter4/Theorem4.10.1"},
+        {"id": "Chapter5/Introduction"},
+        {"id": "Chapter5/Definition5.1.1"},
+    ])
+    assert sections["Chapter5/Introduction"] is None
+    assert sections["Chapter5/Definition5.1.1"] == "5.1"
+
+
+def test_back_reference_does_not_regress_source_context() -> None:
+    sections = sections_from_item_order([
+        {"id": "Chapter5/Definition5.13.1"},
+        {"id": "Chapter5/Discussion_proof_of_Theorem5.12.2"},
+        {"id": "Chapter5/Discussion_following_proof"},
+    ])
+    assert sections["Chapter5/Discussion_following_proof"] == "5.13"
+
+
+def test_partition_order_is_checked() -> None:
+    ordered = [
+        {"id": "Chapter1/First", "start_page": "1", "start_line": 1},
+        {"id": "Chapter1/Second", "start_page": "2", "start_line": 1},
+    ]
+    assert partition_order_errors(ordered, ["1", "2"]) == []
+    assert partition_order_errors(list(reversed(ordered)), ["1", "2"])
+
+
+if __name__ == "__main__":
+    test_editorial_item_inherits_current_section()
+    test_filename_style_section_updates_context()
+    test_chapter_boundary_resets_context()
+    test_back_reference_does_not_regress_source_context()
+    test_partition_order_is_checked()

--- a/scripts/validate_items.py
+++ b/scripts/validate_items.py
@@ -171,6 +171,68 @@ def section_from_item_id(item_id):
     return f"{chapter}.{section_match.group(1)}"
 
 
+def sections_from_item_order(items):
+    """Infer each partition item's section from the ordered source partition.
+
+    Many editorial item IDs do not contain a section number.  Such an item
+    belongs to the most recent numbered section in its chapter; resetting at a
+    chapter boundary prevents an introduction from inheriting the preceding
+    chapter's last section.
+    """
+    result = {}
+    current_chapter = None
+    current_section = None
+    for item in items:
+        if not isinstance(item, dict) or not isinstance(item.get("id"), str):
+            continue
+        item_id = item["id"]
+        chapter_match = re.match(r"^Chapter(\d+)/", item_id)
+        chapter = chapter_match.group(1) if chapter_match is not None else None
+        if chapter != current_chapter:
+            current_chapter = chapter
+            current_section = None
+        explicit_section = section_from_item_id(item_id)
+        # An editorial ID can refer back to an earlier theorem (for example a
+        # proof of Theorem 5.12.2 printed in §5.13).  Such a reference must not
+        # move the physical source context backwards.
+        inferred_section = current_section
+        if explicit_section is not None and (
+            current_section is None
+            or int(explicit_section.split(".")[1]) >= int(current_section.split(".")[1])
+        ):
+            current_section = explicit_section
+        # Validate an explicitly numbered back-reference against its own ID,
+        # while retaining the physical section for following editorial items.
+        if explicit_section is not None:
+            inferred_section = explicit_section
+        else:
+            inferred_section = current_section
+        result[item_id] = inferred_section
+    return result
+
+
+def partition_order_errors(items, page_order):
+    """Return errors when partition records are not ordered by source position."""
+    errors = []
+    page_indices = {page: index for index, page in enumerate(page_order)}
+    previous = None
+    for item in items:
+        if not isinstance(item, dict) or "id" not in item:
+            continue
+        page = item.get("start_page")
+        line = item.get("start_line")
+        if page not in page_indices or not isinstance(line, int):
+            continue
+        position = (page_indices[page], line)
+        if previous is not None and position < previous[0]:
+            errors.append(
+                f"Item '{item['id']}': source position {page}:{line} precedes "
+                f"the previous partition item '{previous[1]}'"
+            )
+        previous = (position, item["id"])
+    return errors
+
+
 def expand_item_lines(item, page_order):
     """Expand an item into a set of (page, line) tuples it covers.
 
@@ -255,6 +317,7 @@ def validate(items_path):
     global page_order_set
     page_order_set = set(page_order)
     page_files = get_page_files()
+    errors.extend(partition_order_errors(items, page_order))
 
     # --- Schema-level checks per item ---
     required_fields = {"id", "type", "title", "start_page", "end_page", "start_line", "end_line"}
@@ -266,6 +329,7 @@ def validate(items_path):
         item["id"] for item in items
         if isinstance(item, dict) and "id" in item
     }
+    inferred_sections = sections_from_item_order(items)
     derived_count = 0
 
     for i, item in enumerate(items):
@@ -340,7 +404,7 @@ def validate(items_path):
         # failure mode where a broad JSON patch lands on an earlier item with
         # the same generic fields.
         claim_coverage = item.get("claim_coverage")
-        expected_section = section_from_item_id(item_id)
+        expected_section = inferred_sections.get(item_id)
         if isinstance(claim_coverage, dict) and expected_section is not None:
             actual_section = claim_coverage.get("section")
             if actual_section is not None and str(actual_section) != expected_section:
@@ -348,6 +412,16 @@ def validate(items_path):
                     f"{prefix}: claim_coverage.section is {actual_section!r}, "
                     f"expected {expected_section!r} from the item id"
                 )
+        elif isinstance(claim_coverage, dict):
+            actual_section = claim_coverage.get("section")
+            chapter_match = re.match(r"^Chapter(\d+)/", item_id)
+            if actual_section is not None and chapter_match is not None:
+                actual_chapter = str(actual_section).partition(".")[0]
+                if actual_chapter != chapter_match.group(1):
+                    errors.append(
+                        f"{prefix}: claim_coverage.section is {actual_section!r}, "
+                        f"but the item belongs to Chapter {chapter_match.group(1)}"
+                    )
 
         # Every deliberate omission must resolve to the project-wide scope
         # register. This keeps the prose policy and the machine ledger in sync.


### PR DESCRIPTION
Closes #8535.

## Summary

- replace the misfiled §5.17 hook-length claims under `Discussion_verification_of_Ind` with the two actual §5.8 verification claims
- cite the exact induction/coinduction declarations that provide the book's equivariant-function model and its action
- harden source-order validation so back-referenced item IDs cannot regress physical book context
- check chapter-introduction consistency and keep scope-reference tests wired into CI
- repair the two stale hook-length coverage notes exposed by the audit and synchronize the Stage 3.4/3.5 §5.8 records

## Verification

- complete repository `lake build` on current `main` — 9,495 jobs, successful
- complete metadata and postformalization validator suite
- section-order and scope-reference regression tests
- all validators pass with zero source-hash drift
- independent review completed with no remaining blockers
